### PR TITLE
fix(signals): record per-signal timestamps so circuit breaker reflects true chronology

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -147,8 +147,8 @@ export async function handleCollect(
     if (failedResults.length > 0) {
       const { PerformanceWriter } = await import('@gossip/orchestrator');
       const writer = new PerformanceWriter(process.cwd());
-      const timestamp = new Date().toISOString();
-      const autoSignals = failedResults.map((r: any) => ({
+      const now = Date.now();
+      const autoSignals = failedResults.map((r: any, i: number) => ({
         type: 'consensus' as const,
         taskId: r.id || '',
         // Use disagreement for empty/timeout (reliability failure), hallucination only for actual errors
@@ -157,7 +157,11 @@ export async function handleCollect(
         evidence: r.status === 'failed' ? `Task failed: ${r.error || 'unknown error'}`
           : r.status === 'timed_out' ? 'Task timed out — no response'
           : 'Empty response — agent produced no output',
-        timestamp,
+        // Per-signal timestamp: prefer real task completion time when available, else
+        // a strictly-increasing per-index time so sort tiebreaker is deterministic.
+        timestamp: r.completedAt
+          ? new Date(r.completedAt).toISOString()
+          : new Date(now + i).toISOString(),
       }));
       writer.appendSignals(autoSignals);
       process.stderr.write(`[gossipcat] ⚠️  Auto-recorded ${autoSignals.length} failure signal(s): ${autoSignals.map((s: any) => s.agentId).join(', ')}\n`);

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1769,6 +1769,7 @@ server.tool(
     action: z.enum(['record', 'retract']).default('record').describe('Action: "record" to add signals, "retract" to undo a previous signal'),
     // record params
     task_id: z.string().optional().describe('Task ID to link signals to. For record: optional (synthetic ID if omitted). For retract: required.'),
+    task_start_time: z.string().optional().describe('ISO-8601 timestamp of the underlying task/consensus round. Used as the per-batch fallback timestamp so bulk-recording from a backlog preserves true chronology. Falls back to wall-clock if omitted.'),
     signals: z.array(z.object({
       signal: z.enum(['agreement', 'disagreement', 'unique_confirmed', 'unique_unconfirmed', 'new_finding', 'hallucination_caught', 'impl_test_pass', 'impl_test_fail', 'impl_peer_approved', 'impl_peer_rejected'])
         .describe('Signal type: agreement (both agree), disagreement (one wrong), unique_confirmed (only one found it + verified), unique_unconfirmed (only one found it, unverified), new_finding (discovered during cross-review), hallucination_caught (fabricated finding), impl_test_pass/fail (write-mode task outcome), impl_peer_approved/rejected (peer code review verdict)'),
@@ -1779,12 +1780,13 @@ server.tool(
       severity: z.enum(['critical', 'high', 'medium', 'low']).optional().describe('Finding severity for impact scoring. If omitted, defaults to medium.'),
       category: z.string().optional().describe('Finding category for ATI competency profiles (e.g., concurrency, trust_boundaries, injection_vectors, resource_exhaustion, type_safety, error_handling, data_integrity, input_validation)'),
       evidence: z.string().optional().describe('Supporting evidence or reasoning'),
+      timestamp: z.string().optional().describe('ISO-8601 timestamp of when this specific finding occurred. Highest precedence; overrides task_start_time. Use for per-finding chronology when known.'),
     })).optional().describe('Array of consensus signals (required for action: "record")'),
     // retract params
     agent_id: z.string().optional().describe('Agent whose signal to retract (required for action: "retract")'),
     reason: z.string().optional().describe('Why this signal is being retracted (required for action: "retract")'),
   },
-  async ({ action, task_id, signals, agent_id, reason }) => {
+  async ({ action, task_id, task_start_time, signals, agent_id, reason }) => {
     await boot();
 
     if (action === 'retract') {
@@ -1823,12 +1825,29 @@ server.tool(
     try {
       const { PerformanceWriter } = await import('@gossip/orchestrator');
       const writer = new PerformanceWriter(process.cwd());
-      const timestamp = new Date().toISOString();
+      const wallClockMs = Date.now();
+      const wallClock = new Date(wallClockMs).toISOString();
+      // Sanity window for caller-provided timestamps: 30 days back, 1 hour forward.
+      // Anything outside this is rejected to prevent score manipulation via spoofed
+      // timestamps (parking the tail far in the future, or burying negatives in the past).
+      const MIN_TS_MS = wallClockMs - 30 * 24 * 60 * 60 * 1000;
+      const MAX_TS_MS = wallClockMs + 60 * 60 * 1000;
+      const validateTimestamp = (ts: string | undefined, label: string): string | null => {
+        if (!ts) return null;
+        const parsed = new Date(ts).getTime();
+        if (!Number.isFinite(parsed)) return `Error: ${label} is not a valid ISO-8601 date: ${ts}`;
+        if (parsed < MIN_TS_MS) return `Error: ${label} is more than 30 days in the past (${ts}). Rejecting to prevent score manipulation.`;
+        if (parsed > MAX_TS_MS) return `Error: ${label} is more than 1 hour in the future (${ts}). Rejecting to prevent score manipulation.`;
+        return null;
+      };
+      const tstErr = validateTimestamp(task_start_time, 'task_start_time');
+      if (tstErr) return { content: [{ type: 'text' as const, text: tstErr }] };
+      const batchFallback = task_start_time || wallClock;
       const MAX_EVIDENCE_LENGTH = 2000;
       const PUNITIVE_SIGNALS = new Set(['hallucination_caught', 'disagreement']);
       const COUNTERPART_REQUIRED = new Set(['agreement', 'disagreement', 'impl_peer_approved', 'impl_peer_rejected']);
 
-      // Validate: punitive signals require evidence
+      // Validate: punitive signals require evidence; per-signal timestamps must be in range
       for (const s of signals) {
         if (PUNITIVE_SIGNALS.has(s.signal) && (!s.evidence || s.evidence.trim().length === 0)) {
           return { content: [{ type: 'text' as const, text: `Error: ${s.signal} signals require non-empty evidence for audit trail. Agent: ${s.agent_id}` }] };
@@ -1836,6 +1855,8 @@ server.tool(
         if (COUNTERPART_REQUIRED.has(s.signal) && (!s.counterpart_id || s.counterpart_id.trim().length === 0)) {
           return { content: [{ type: 'text' as const, text: `Error: ${s.signal} signals require counterpart_id. Agent: ${s.agent_id}` }] };
         }
+        const sigTsErr = validateTimestamp(s.timestamp, `signal[${s.agent_id}].timestamp`);
+        if (sigTsErr) return { content: [{ type: 'text' as const, text: sigTsErr }] };
       }
 
       const IMPL_SIGNALS = new Set(['impl_test_pass', 'impl_test_fail', 'impl_peer_approved', 'impl_peer_rejected']);
@@ -1859,8 +1880,18 @@ server.tool(
       };
 
       type PS = import('@gossip/orchestrator').PerformanceSignal;
+      // Per-signal timestamp resolution (highest → lowest precedence):
+      //   1. s.timestamp — caller-provided per-finding precision
+      //   2. task_start_time — caller-provided per-batch precision
+      //   3. wallClock + i ms — fallback, +i offset keeps batch order deterministic
+      const resolveTs = (s: { timestamp?: string }, i: number): string => {
+        if (s.timestamp) return s.timestamp;
+        if (task_start_time) return new Date(new Date(task_start_time).getTime() + i).toISOString();
+        return new Date(wallClockMs + i).toISOString();
+      };
       const formatted: PS[] = signals.map((s, i): PS => {
-        const taskId = task_id || `manual-${timestamp.replace(/[:.]/g, '')}-${i}`;
+        const ts = resolveTs(s, i);
+        const taskId = task_id || `manual-${batchFallback.replace(/[:.]/g, '')}-${i}`;
         const evidence = ((s.evidence || s.finding) ?? '').slice(0, MAX_EVIDENCE_LENGTH);
         if (IMPL_SIGNALS.has(s.signal)) {
           return {
@@ -1870,7 +1901,7 @@ server.tool(
             taskId,
             source: 'manual',
             evidence,
-            timestamp,
+            timestamp: ts,
           };
         }
         return {
@@ -1883,7 +1914,7 @@ server.tool(
           severity: s.severity,
           category: s.category ?? inferCategory(s),
           evidence,
-          timestamp,
+          timestamp: ts,
         };
       });
 

--- a/docs/specs/2026-04-08-signal-timestamp-from-task-time.md
+++ b/docs/specs/2026-04-08-signal-timestamp-from-task-time.md
@@ -1,0 +1,262 @@
+# Spec — Signal timestamp must reflect task time, not record time
+
+**Date:** 2026-04-08
+**Owner:** orchestrator session
+**Status:** v2 — implemented, includes consensus review feedback (haiku + gemini)
+**Branch:** `fix/signal-timestamp-from-task-time`
+
+## Problem
+
+The circuit breaker in `packages/orchestrator/src/performance-reader.ts`
+(`CIRCUIT_BREAKER_THRESHOLD = 3`, line 36; `circuitOpen` calc at line 510)
+trips on **3 consecutive negative signals at the tail of an agent's signal
+stream**. Negative signals are `hallucination_caught`, `disagreement`,
+`unique_unconfirmed`.
+
+The reader at `performance-reader.ts:434` already sorts each agent's
+signals by `signal.timestamp` via `localeCompare` before walking the tail.
+**That sort is currently a no-op for bulk-recorded signals.**
+
+### Root cause
+
+`apps/cli/src/mcp-server-sdk.ts:1826` (the `gossip_signals(action:"record")`
+handler):
+
+```ts
+const timestamp = new Date().toISOString();   // ← ONCE, before the loop
+const formatted = signals.map(s => ({
+  ...s,
+  timestamp,                                   // ← every signal gets the same value
+}));
+writer.appendSignals(formatted);
+```
+
+When the orchestrator bulk-records 5 backlogged consensus rounds in 30
+seconds, all signals across all 5 rounds get the **same** ISO timestamp.
+`localeCompare` returns 0 for every comparison, so the sort becomes a
+no-op and append order determines the tail.
+
+### Concrete incident
+
+Session 2026-04-08, after manually triaging 5 stale consensus rounds:
+1. I read the reports newest-first (`38ceed43` → ... → `c8dae78e`).
+2. I recorded signals batch-by-batch in that read order.
+3. The actual oldest round (`c8dae78e`, where sonnet-reviewer lost 2
+   disputes) ended up at the tail of the append stream.
+4. sonnet-reviewer's circuit breaker tripped: 5 consecutive negatives.
+5. Dispatch weight collapsed from baseline to 0.30
+   (`performance-reader.ts:99`).
+
+The agent didn't degrade — the recorder's batched timestamp made the
+chronology unrecoverable.
+
+## Goal
+
+Make the recorded `signal.timestamp` reflect the **time the underlying
+task/consensus round actually happened**, not the wall-clock time at the
+moment of recording, so the circuit breaker reflects real chronology.
+
+## Non-goals
+
+- Backfilling historical signals already in `agent-performance.jsonl`
+  (deferred — see "Follow-ups" below).
+- Changing `CIRCUIT_BREAKER_THRESHOLD` or the negative-signal set.
+- Reworking the dispatch-weight formula.
+
+## Design
+
+### 1. Recorder change (primary fix)
+
+**File:** `apps/cli/src/mcp-server-sdk.ts`
+**Tool:** `gossip_signals` (action `record`)
+
+#### Schema additions
+
+Add two **optional** fields to the `gossip_signals` tool input schema:
+
+- `task_start_time?: string` — ISO-8601, batch-level fallback. The
+  orchestrator passes the consensus round's `report.timestamp` here when
+  bulk-recording from a backlog.
+- Per-signal `timestamp?: string` (already accepted on the
+  `ConsensusSignal` type at `packages/orchestrator/src/consensus-types.ts:104`,
+  but currently overwritten by the handler). Stop overwriting it.
+
+#### Handler change
+
+Replace lines around 1826 / 1862-1888:
+
+```ts
+// Before
+const timestamp = new Date().toISOString();
+const formatted = signals.map(s => ({ ...s, timestamp, /* ... */ }));
+
+// After
+const fallback = task_start_time ?? new Date().toISOString();
+const formatted = signals.map(s => ({
+  ...s,
+  timestamp: s.timestamp ?? fallback,
+  /* ... */
+}));
+```
+
+Resolution priority per signal:
+1. `s.timestamp` if the caller passed one (per-finding precision).
+2. `task_start_time` if the caller passed one (per-batch precision).
+3. `new Date().toISOString()` as last resort (live one-off corrections).
+
+### 2. Reader tiebreaker (defensive)
+
+**File:** `packages/orchestrator/src/performance-reader.ts:434`
+
+```ts
+// Before
+agentSignals.sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
+
+// After
+agentSignals.sort((a, b) => {
+  const t = (a.timestamp || '').localeCompare(b.timestamp || '');
+  if (t !== 0) return t;
+  return (a.consensusId || '').localeCompare(b.consensusId || '');
+});
+```
+
+When timestamps tie (e.g. legacy data, or two signals from the same
+consensus round), break the tie by `consensusId` lexicographically. This
+gives deterministic ordering within a round and is a no-op when
+timestamps already differ.
+
+### 3. Other batch-record sites — IN SCOPE (added in v2)
+
+Spec v1 declared 5 paths "safe" because they record at the moment the
+underlying event happens. Consensus review (haiku) caught that 3 of the
+5 share the same root cause as the recorder bug — they batch-write
+multiple signals with one shared `now`, so the reader's chronological
+sort becomes a no-op for collisions in the same batch:
+
+- **`apps/cli/src/handlers/collect.ts:150`** — auto-failure loop reused
+  one `timestamp` across all failed-results signals. **FIXED:** prefer
+  `r.completedAt` per result; fall back to `now + i ms` for strict
+  ordering.
+- **`packages/orchestrator/src/consensus-coordinator.ts:105`** —
+  category-extraction loop reused one `now` for every category emitted
+  in a single `synthesize()` call. **FIXED:** lift `baseMs` outside,
+  emit each signal at `baseMs + i ms`.
+- **`packages/tools/src/tool-server.ts:531`** — impl test signal +
+  peer-review signal pair shared one `now`. **FIXED:** test signal at
+  `baseMs`, peer-review signal at `baseMs + 1 ms` (test happens before
+  review).
+
+**Genuinely safe (unchanged):**
+
+- `apps/cli/src/handlers/native-tasks.ts:77` — single signal per timeout
+  event; no batch loop.
+- `apps/cli/src/handlers/relay-cross-review.ts:40` — single signal per
+  consensus-timeout event; no batch loop.
+
+### 4. Timestamp validation — spoof rejection (added in v2)
+
+Consensus review (gemini) caught that exposing `task_start_time` and
+per-signal `timestamp` to callers without validation creates a
+score-manipulation surface:
+
+- **Park the tail:** record a positive signal with a far-future
+  timestamp → permanent "good" tail → circuit breaker effectively
+  disabled.
+- **Bury negatives:** record negatives with very old timestamps → push
+  them outside `SIGNAL_EXPIRY_DAYS` (30d) window or shift them away
+  from the tail.
+
+**Mitigation:** in the recorder, validate every caller-provided
+timestamp against a sanity window of `[now - 30d, now + 1h]`. Reject
+out-of-range or unparseable values with a clear error citing the field
+and the bound that was violated. Implemented as a single
+`validateTimestamp(ts, label)` helper applied to `task_start_time` and
+each `signals[i].timestamp`.
+
+## Test plan
+
+### New tests
+
+`tests/cli/mcp-signals-validation.test.ts` (additions):
+
+1. **Per-signal timestamp respected:** record 3 signals with explicit
+   `timestamp` fields → assert each row in JSONL has its own timestamp.
+2. **`task_start_time` fallback applied:** record 3 signals without
+   per-signal timestamp, with `task_start_time` set → all 3 get
+   `task_start_time` (same value, but distinguishable from wall-clock).
+3. **Wall-clock fallback last resort:** record 1 signal with no timestamp
+   and no `task_start_time` → row gets a recent ISO timestamp.
+
+`tests/orchestrator/performance-reader.test.ts` (additions):
+
+4. **Bulk-record chronology bug regression:** seed 5 signals for one
+   agent — 3 positive with old timestamps, 2 negative with newer
+   timestamps → assert circuit is OPEN.
+5. **Inverse:** seed 5 signals — 2 negative old, 3 positive new →
+   assert circuit is CLOSED. (Today this fails because identical
+   timestamps fall back to file order.)
+6. **Tiebreaker:** seed signals with identical timestamps but different
+   `consensusId` → sort is deterministic.
+
+### Manual regression
+
+After landing, retract this session's misordered sonnet-reviewer
+hallucination/disagreement signals via `gossip_signals(action:retract)`
+and re-record them with explicit `task_start_time` pulled from each
+round's `consensus-reports/<id>.json` `timestamp` field. Verify
+sonnet-reviewer's circuit re-closes via `gossip_scores`.
+
+## Edge cases (already considered)
+
+- **`signal_retracted`** at `mcp-server-sdk.ts:1810` continues to use
+  wall-clock. It's not in `NEGATIVE_SIGNALS`, so it acts as a streak
+  breaker — wall-clock is correct here.
+- **Cross-round signals with same `taskId`** sort by their own
+  timestamp; minor non-intuitive interleaving is acceptable.
+- **Live one-off corrections** with no `task_start_time` and no
+  `s.timestamp` continue to use wall-clock — correct.
+- **Historical signals already in `agent-performance.jsonl`** still have
+  collided timestamps from past bulk-records. Not fixed by this change;
+  see Follow-ups.
+
+## Follow-ups (out of scope)
+
+- **F1.** Reader-side backfill: join `signal.consensusId` →
+  `consensus-reports/<id>.json::timestamp` to retroactively fix
+  historical collisions. Adds FS read per signal in the scoring hot
+  path; only worth it if historical chronology matters.
+- **F2.** Audit the 11 other signal-recording paths to confirm none are
+  also vulnerable to bulk-import chronology drift.
+- **F3.** Add a `gossip_signals(action:rewrite_timestamps)` admin tool
+  to repair existing JSONL data once F1 is implemented.
+- **F4.** Memory entry: structural lesson — bulk-recording skews
+  chronology; live recording is preferable.
+
+## Acceptance criteria
+
+- [ ] `gossip_signals` tool schema accepts `task_start_time` and
+      per-signal `timestamp`.
+- [ ] Recorder no longer overwrites caller-provided per-signal
+      timestamps.
+- [ ] Reader sort has deterministic tiebreaker on `consensusId`.
+- [ ] All 6 new tests pass; existing tests still pass.
+- [ ] Sonnet-reviewer's circuit can be re-closed by retract +
+      re-record with proper timestamps.
+- [ ] PR opened against `master` from `fix/signal-timestamp-from-task-time`.
+
+## Estimated diff size (v2 actual)
+
+~95 LOC across 5 source files + ~180 LOC of tests:
+
+- `apps/cli/src/mcp-server-sdk.ts` — schema additions, validation helper,
+  resolver, per-signal timestamp wiring (~50 LOC)
+- `packages/orchestrator/src/performance-reader.ts` — secondary sort key
+  (~5 LOC)
+- `apps/cli/src/handlers/collect.ts` — per-result timestamp (~6 LOC)
+- `packages/orchestrator/src/consensus-coordinator.ts` — per-category
+  offset (~5 LOC)
+- `packages/tools/src/tool-server.ts` — distinct test/peer-review
+  timestamps (~5 LOC)
+
+No schema changes to `agent-performance.jsonl` (the `timestamp` field
+already exists as a free-form `string`).

--- a/packages/orchestrator/src/consensus-coordinator.ts
+++ b/packages/orchestrator/src/consensus-coordinator.ts
@@ -102,7 +102,12 @@ export class ConsensusCoordinator {
 
       // Extract categories from confirmed findings
       if (consensusReport.confirmed.length > 0) {
-        const now = new Date().toISOString();
+        // synthesize() runs at the time the consensus actually completes, so wall-clock
+        // IS the task time here. The +i ms offset on each emitted signal keeps the
+        // chronological sort tiebreaker deterministic when many categories fire in one
+        // synthesize() call (otherwise they would all share one timestamp).
+        const baseMs = Date.now();
+        let i = 0;
         for (const finding of consensusReport.confirmed) {
           const categories = extractCategories(finding.finding);
           for (const category of categories) {
@@ -114,9 +119,10 @@ export class ConsensusCoordinator {
               taskId: finding.id || '',
               category,
               evidence: finding.finding,
-              timestamp: now,
+              timestamp: new Date(baseMs + i).toISOString(),
               severity: finding.severity,
             } as any);
+            i++;
           }
         }
       }

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -430,8 +430,14 @@ export class PerformanceReader {
       signalsByAgent.set(signal.agentId, list);
     }
     for (const [agentId, agentSignals] of signalsByAgent) {
-      // Sort chronologically so "tail" means most recent
-      agentSignals.sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
+      // Sort chronologically so "tail" means most recent.
+      // Tiebreaker on consensusId keeps order deterministic when timestamps collide
+      // (legacy bulk-recorded data, or signals from the same consensus round).
+      agentSignals.sort((a, b) => {
+        const t = (a.timestamp || '').localeCompare(b.timestamp || '');
+        if (t !== 0) return t;
+        return ((a as any).consensusId || '').localeCompare((b as any).consensusId || '');
+      });
       let streak = 0;
       // Walk from newest to oldest — count consecutive negatives at tail
       for (let i = agentSignals.length - 1; i >= 0; i--) {

--- a/packages/tools/src/tool-server.ts
+++ b/packages/tools/src/tool-server.ts
@@ -528,14 +528,16 @@ export class ToolServer {
     // Emit impl signals
     const testStatus = testResult.includes('FAIL') ? 'FAIL' : 'PASS';
     if (this.perfWriter) {
-      const now = new Date().toISOString();
+      // Distinct per-signal timestamps so the test signal and the peer-review signal
+      // are deterministically ordered (test result happens before peer review).
+      const baseMs = Date.now();
       this.perfWriter.appendSignal({
         type: 'impl',
         signal: testStatus === 'PASS' ? 'impl_test_pass' : 'impl_test_fail',
         agentId: callerId,
         taskId: callerId,
         evidence: testStatus === 'FAIL' ? testResult.slice(-500) : undefined,
-        timestamp: now,
+        timestamp: new Date(baseMs).toISOString(),
       });
 
       if (reviewResult && !reviewResult.includes('unavailable')) {
@@ -546,7 +548,7 @@ export class ToolServer {
           agentId: callerId,
           taskId: callerId,
           evidence: reviewResult.slice(0, 500),
-          timestamp: now,
+          timestamp: new Date(baseMs + 1).toISOString(),
         });
       }
     }

--- a/tests/cli/mcp-signals-validation.test.ts
+++ b/tests/cli/mcp-signals-validation.test.ts
@@ -579,3 +579,136 @@ describe('gossip_signals retraction validation', () => {
     }
   });
 });
+
+// ── Timestamp resolution & validation (signal-timestamp-from-task-time spec) ──
+//
+// Replicates the resolution + validation logic from mcp-server-sdk.ts so we can
+// exercise it without spinning up the full server. Mirrors the production code:
+// per-signal `timestamp` (highest precedence) → `task_start_time` (batch) →
+// wall-clock + i ms fallback. Caller-provided timestamps are clamped to a sane
+// 30-day-back / 1-hour-forward window to prevent score manipulation.
+
+describe('gossip_signals timestamp resolution + spoofing rejection', () => {
+  function resolveTimestamps(opts: {
+    taskStartTime?: string;
+    signals: Array<{ timestamp?: string }>;
+    nowMs: number;
+  }): { error?: string; timestamps?: string[] } {
+    const wallClockMs = opts.nowMs;
+    const MIN_TS_MS = wallClockMs - 30 * 24 * 60 * 60 * 1000;
+    const MAX_TS_MS = wallClockMs + 60 * 60 * 1000;
+    const validateTimestamp = (ts: string | undefined, label: string): string | null => {
+      if (!ts) return null;
+      const parsed = new Date(ts).getTime();
+      if (!Number.isFinite(parsed)) return `Error: ${label} is not a valid ISO-8601 date: ${ts}`;
+      if (parsed < MIN_TS_MS) return `Error: ${label} is more than 30 days in the past (${ts}). Rejecting to prevent score manipulation.`;
+      if (parsed > MAX_TS_MS) return `Error: ${label} is more than 1 hour in the future (${ts}). Rejecting to prevent score manipulation.`;
+      return null;
+    };
+    const tstErr = validateTimestamp(opts.taskStartTime, 'task_start_time');
+    if (tstErr) return { error: tstErr };
+    for (let i = 0; i < opts.signals.length; i++) {
+      const err = validateTimestamp(opts.signals[i].timestamp, `signal[${i}].timestamp`);
+      if (err) return { error: err };
+    }
+    const timestamps = opts.signals.map((s, i) => {
+      if (s.timestamp) return s.timestamp;
+      if (opts.taskStartTime) return new Date(new Date(opts.taskStartTime).getTime() + i).toISOString();
+      return new Date(wallClockMs + i).toISOString();
+    });
+    return { timestamps };
+  }
+
+  const NOW_MS = new Date('2026-04-08T12:00:00.000Z').getTime();
+
+  it('per-signal timestamps win over task_start_time', () => {
+    const r = resolveTimestamps({
+      taskStartTime: '2026-04-01T00:00:00.000Z',
+      signals: [
+        { timestamp: '2026-04-05T10:00:00.000Z' },
+        { timestamp: '2026-04-06T10:00:00.000Z' },
+      ],
+      nowMs: NOW_MS,
+    });
+    expect(r.error).toBeUndefined();
+    expect(r.timestamps).toEqual([
+      '2026-04-05T10:00:00.000Z',
+      '2026-04-06T10:00:00.000Z',
+    ]);
+  });
+
+  it('task_start_time used as fallback when per-signal omitted, with +i ms offsets', () => {
+    const r = resolveTimestamps({
+      taskStartTime: '2026-04-04T14:08:13.631Z',
+      signals: [{}, {}, {}],
+      nowMs: NOW_MS,
+    });
+    expect(r.error).toBeUndefined();
+    expect(r.timestamps).toEqual([
+      '2026-04-04T14:08:13.631Z',
+      '2026-04-04T14:08:13.632Z',
+      '2026-04-04T14:08:13.633Z',
+    ]);
+  });
+
+  it('wall-clock fallback when both omitted, distinct per signal', () => {
+    const r = resolveTimestamps({
+      signals: [{}, {}, {}],
+      nowMs: NOW_MS,
+    });
+    expect(r.error).toBeUndefined();
+    expect(r.timestamps).toEqual([
+      '2026-04-08T12:00:00.000Z',
+      '2026-04-08T12:00:00.001Z',
+      '2026-04-08T12:00:00.002Z',
+    ]);
+    // Critical: distinct so the reader's chronological sort is meaningful.
+    expect(new Set(r.timestamps).size).toBe(r.timestamps!.length);
+  });
+
+  it('rejects task_start_time more than 1 hour in the future', () => {
+    const r = resolveTimestamps({
+      taskStartTime: '3026-01-01T00:00:00.000Z',
+      signals: [{}],
+      nowMs: NOW_MS,
+    });
+    expect(r.error).toMatch(/more than 1 hour in the future/);
+    expect(r.error).toMatch(/task_start_time/);
+  });
+
+  it('rejects task_start_time more than 30 days in the past', () => {
+    const r = resolveTimestamps({
+      taskStartTime: '1970-01-01T00:00:00.000Z',
+      signals: [{}],
+      nowMs: NOW_MS,
+    });
+    expect(r.error).toMatch(/more than 30 days in the past/);
+  });
+
+  it('rejects per-signal timestamp far in the future', () => {
+    const r = resolveTimestamps({
+      signals: [{ timestamp: '3026-01-01T00:00:00.000Z' }],
+      nowMs: NOW_MS,
+    });
+    expect(r.error).toMatch(/more than 1 hour in the future/);
+    expect(r.error).toMatch(/signal\[0\]/);
+  });
+
+  it('rejects garbage timestamp', () => {
+    const r = resolveTimestamps({
+      taskStartTime: 'not a date',
+      signals: [{}],
+      nowMs: NOW_MS,
+    });
+    expect(r.error).toMatch(/not a valid ISO-8601 date/);
+  });
+
+  it('accepts task_start_time exactly 1 hour in the future (boundary)', () => {
+    const r = resolveTimestamps({
+      taskStartTime: new Date(NOW_MS + 60 * 60 * 1000).toISOString(),
+      signals: [{}],
+      nowMs: NOW_MS,
+    });
+    expect(r.error).toBeUndefined();
+  });
+});

--- a/tests/orchestrator/performance-reader.test.ts
+++ b/tests/orchestrator/performance-reader.test.ts
@@ -334,3 +334,94 @@ describe('PerformanceReader.getCountersSince', () => {
     expect(counters2).toEqual({ correct: 0, hallucinated: 1 });
   });
 });
+
+describe('PerformanceReader — circuit breaker chronology (signal-timestamp-from-task-time)', () => {
+  // Regression suite for the bulk-record bug. Before the fix, every signal in a
+  // bulk-record call shared one timestamp; the reader's localeCompare sort
+  // returned 0 for every pair, making the sort a no-op and letting append order
+  // determine the tail. The reader was always correct in intent — these tests
+  // pin its behavior so a future regression to "single batch timestamp"
+  // recording immediately fails.
+
+  function ts(daysAgo: number, ms = 0): string {
+    return new Date(Date.now() - daysAgo * 86400000 + ms).toISOString();
+  }
+
+  it('circuit OPEN when 3 newest signals are negative (true chronology)', () => {
+    writeSignals([
+      // 3 positives in the past
+      { type: 'consensus', signal: 'agreement', agentId: 'rev', counterpartId: 'p', taskId: 't1', evidence: 'x', timestamp: ts(5) },
+      { type: 'consensus', signal: 'agreement', agentId: 'rev', counterpartId: 'p', taskId: 't2', evidence: 'x', timestamp: ts(4) },
+      { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', taskId: 't3', evidence: 'x', timestamp: ts(3) },
+      // 3 negatives more recent
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', counterpartId: 'p', taskId: 't4', evidence: 'bad', timestamp: ts(2) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', taskId: 't5', evidence: 'bad', timestamp: ts(1) },
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'rev', taskId: 't6', evidence: 'bad', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    expect(reader.isCircuitOpen('rev')).toBe(true);
+  });
+
+  it('circuit CLOSED when newest signal is positive even though older negatives exist', () => {
+    writeSignals([
+      // 3 negatives in the past
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', counterpartId: 'p', taskId: 't1', evidence: 'bad', timestamp: ts(5) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', taskId: 't2', evidence: 'bad', timestamp: ts(4) },
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'rev', taskId: 't3', evidence: 'bad', timestamp: ts(3) },
+      // Newest is positive — must break the streak
+      { type: 'consensus', signal: 'agreement', agentId: 'rev', counterpartId: 'p', taskId: 't4', evidence: 'x', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    expect(reader.isCircuitOpen('rev')).toBe(false);
+  });
+
+  it('circuit CLOSED when negatives are recorded in append order but timestamps put them in the past', () => {
+    // Simulates the exact bug from session 2026-04-08: orchestrator bulk-records
+    // 5 backlogged rounds in newest-first read order, so the JSONL tail is the
+    // OLDEST round. With per-signal timestamps from the consensus reports, the
+    // reader's chronological sort must put the actually-newest round at the tail.
+    writeSignals([
+      // Append order = newest-first (file tail = oldest)
+      { type: 'consensus', signal: 'agreement', agentId: 'rev', counterpartId: 'p', taskId: 'newest', evidence: 'x', timestamp: ts(0) },
+      { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', taskId: 'newer', evidence: 'x', timestamp: ts(1) },
+      { type: 'consensus', signal: 'agreement', agentId: 'rev', counterpartId: 'p', taskId: 'mid', evidence: 'x', timestamp: ts(2) },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', counterpartId: 'p', taskId: 'old', evidence: 'bad', timestamp: ts(3) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', taskId: 'oldest1', evidence: 'bad', timestamp: ts(4) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', taskId: 'oldest2', evidence: 'bad', timestamp: ts(5) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    // True chronology: 3 negatives (oldest) → 3 positives (newest). Tail is positive.
+    expect(reader.isCircuitOpen('rev')).toBe(false);
+  });
+
+  it('circuit OPEN when negatives appended first but timestamps make them newest', () => {
+    // The exact incident: even though file order looks "good then bad",
+    // the bad signals are CHRONOLOGICALLY NEWER and must trip the breaker.
+    writeSignals([
+      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', taskId: 'oldest', evidence: 'bad', timestamp: ts(2) },
+      { type: 'consensus', signal: 'agreement', agentId: 'rev', counterpartId: 'p', taskId: 'mid', evidence: 'x', timestamp: ts(5) },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', counterpartId: 'p', taskId: 'newer', evidence: 'bad', timestamp: ts(1) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', taskId: 'newest', evidence: 'bad', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    expect(reader.isCircuitOpen('rev')).toBe(true);
+  });
+
+  it('consensusId tiebreaker keeps order deterministic when timestamps collide', () => {
+    // Two signals with the SAME timestamp — tiebreaker on consensusId.
+    // Without the tiebreaker, sort order would depend on file order; with it,
+    // 'aaa' always sorts before 'bbb' so the tail is deterministic.
+    const sameTime = ts(0);
+    writeSignals([
+      { type: 'consensus', signal: 'agreement', agentId: 'rev', counterpartId: 'p', consensusId: 'bbb', taskId: 't1', evidence: 'x', timestamp: sameTime },
+      { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', consensusId: 'aaa', taskId: 't2', evidence: 'x', timestamp: sameTime },
+      { type: 'consensus', signal: 'agreement', agentId: 'rev', counterpartId: 'p', consensusId: 'aaa', taskId: 't3', evidence: 'x', timestamp: ts(1) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    // The tail is the bbb-tagged signal (positive) — circuit closed.
+    // What we're really testing: the reader doesn't crash, returns deterministic state.
+    expect(reader.isCircuitOpen('rev')).toBe(false);
+    // Run twice to confirm idempotence under tiebreaker.
+    expect(reader.isCircuitOpen('rev')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes the **circuit-breaker chronology bug**: bulk-recording 5 backlogged consensus rounds in this session tripped sonnet-reviewer's circuit because every signal in a batch shared one `new Date()` timestamp, the reader's `localeCompare` sort became a no-op, and append order decided the tail.
- Adds optional `task_start_time` (per-batch) and per-signal `timestamp` to `gossip_signals`, with a 3-tier resolution: per-signal → batch → wall-clock + `i` ms.
- Validates caller-provided timestamps against a `[now-30d, now+1h]` window to prevent score manipulation via spoofed timestamps (parking the tail in the future, burying negatives in the past).
- Fixes 3 additional batch-record sites caught by spec consensus review (`collect.ts` auto-failure loop, `consensus-coordinator.ts` category emit, `tool-server.ts` impl signals).
- Reader gets a `consensusId` secondary sort so tied timestamps stay deterministic.

## Spec

Full design + consensus review notes: `docs/specs/2026-04-08-signal-timestamp-from-task-time.md` (v2 — includes haiku + gemini review feedback).

## Test plan
- [x] `npx jest tests/cli/mcp-signals-validation.test.ts tests/orchestrator/performance-reader.test.ts` → 69 passed (1 pre-existing failure unrelated to this PR — see PR #4)
- [x] Pre-existing typecheck baseline verified against master — zero new errors introduced
- [ ] After merge: retract this session's misordered sonnet-reviewer signals via `gossip_signals(action:retract)` and re-record with explicit `task_start_time` from each `consensus-reports/<id>.json`. Verify circuit re-closes via `gossip_scores`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)