### PR TITLE
chore(publish): prep gossipcat for npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,29 +162,35 @@ Both types participate equally in consensus, cross-review, and skill development
 
 **Requirements:** Node.js 22+
 
-### 1. Clone and build
+### 1. Install
 
+```bash
+npm install -g gossipcat
+```
+
+That's it. The install drops a `gossipcat` binary on your `PATH` and ships both the MCP server bundle and the dashboard assets. No clone, no build step.
+
+If you prefer project-local install:
+```bash
+npm install --save-dev gossipcat
+```
+The postinstall will write a `.mcp.json` into your project root automatically. Open Claude Code in that directory and gossipcat connects.
+
+### 2. Register with Claude Code
+
+For global registration (available in every project):
+```bash
+claude mcp add gossipcat -s user -- gossipcat
+```
+
+The dashboard launches automatically on port `24420` when the relay starts — no extra setup needed.
+
+**From source** (contributors only):
 ```bash
 git clone https://github.com/ataberk-xyz/gossipcat-ai.git
-cd gossipcat-ai
-npm install
-npm run build:mcp
+cd gossipcat-ai && npm install && npm run build:mcp
+claude mcp add gossipcat -s user -- node "$PWD/dist-mcp/mcp-server.js"
 ```
-
-`npm install` generates `.mcp.json` with the correct paths for your machine. `build:mcp` bundles the MCP server. Open Claude Code in this directory and gossipcat connects automatically.
-
-To register globally (available in all projects):
-```bash
-claude mcp add gossipcat -s user -- node /absolute/path/to/gossipcat-ai/dist-mcp/mcp-server.js
-```
-
-### 2. Build the dashboard (optional)
-
-```bash
-npm run build:dashboard
-```
-
-Launches automatically on port `24420`. Skip this if you don't need the visual dashboard.
 
 ### 3. API keys
 
@@ -203,7 +209,7 @@ Add env vars for the providers you want to use. Pass them with `-e` when registe
 
 **Native only** (zero API keys — everything runs through Claude Code):
 ```bash
-claude mcp add gossipcat -s user -- node /path/to/gossipcat/dist-mcp/mcp-server.js
+claude mcp add gossipcat -s user -- gossipcat
 ```
 Then in session ask for a team built from `sonnet-reviewer` / `haiku-researcher` / `opus-implementer`. Native agents dispatch through `Agent()` and relay back. Good zero-config starting point.
 
@@ -211,7 +217,7 @@ Then in session ask for a team built from `sonnet-reviewer` / `haiku-researcher`
 ```bash
 claude mcp add gossipcat -s user \
   -e ANTHROPIC_API_KEY=sk-ant-... \
-  -- node /path/to/gossipcat/dist-mcp/mcp-server.js
+  -- gossipcat
 ```
 Use this if you want relay agents running Claude models without going through the Claude Code subscription path — e.g. for parallelism beyond Claude Code's concurrency cap, or for running long background reviews while you keep working.
 
@@ -219,7 +225,7 @@ Use this if you want relay agents running Claude models without going through th
 ```bash
 claude mcp add gossipcat -s user \
   -e GOOGLE_API_KEY=AIza... \
-  -- node /path/to/gossipcat/dist-mcp/mcp-server.js
+  -- gossipcat
 ```
 Enables `gemini-reviewer`, `gemini-tester`, `gemini-implementer` on the relay. Watch the quota — gossipcat has a built-in 429 watcher that falls back to native agents when Gemini is cooling down.
 
@@ -227,20 +233,20 @@ Enables `gemini-reviewer`, `gemini-tester`, `gemini-implementer` on the relay. W
 ```bash
 claude mcp add gossipcat -s user \
   -e OPENAI_API_KEY=sk-... \
-  -- node /path/to/gossipcat/dist-mcp/mcp-server.js
+  -- gossipcat
 ```
 For Azure / Together / Groq / OpenRouter, add `OPENAI_BASE_URL`:
 ```bash
 claude mcp add gossipcat -s user \
   -e OPENAI_API_KEY=your-key \
   -e OPENAI_BASE_URL=https://api.groq.com/openai/v1 \
-  -- node /path/to/gossipcat/dist-mcp/mcp-server.js
+  -- gossipcat
 ```
 
 **OpenClaw** (local gateway):
 ```bash
 # Start the OpenClaw daemon first (see openclaw docs), default port 18789
-claude mcp add gossipcat -s user -- node /path/to/gossipcat/dist-mcp/mcp-server.js
+claude mcp add gossipcat -s user -- gossipcat
 ```
 No env vars. Configure an agent with `provider: "openclaw"` in `.gossip/config.json` and gossipcat talks to the local gateway automatically. Override the port with `base_url` in the agent config if your daemon runs elsewhere.
 
@@ -249,7 +255,7 @@ No env vars. Configure an agent with `provider: "openclaw"` in `.gossip/config.j
 # Pull a model once
 ollama pull llama3.1:8b
 # Then register gossipcat
-claude mcp add gossipcat -s user -- node /path/to/gossipcat/dist-mcp/mcp-server.js
+claude mcp add gossipcat -s user -- gossipcat
 ```
 Configure the agent with `provider: "local"` and `model: "llama3.1:8b"` in `.gossip/config.json`. Good for airgapped dev, offline work, and burning-down-test-debt sessions where you don't want to spend API credits.
 
@@ -258,7 +264,7 @@ Configure the agent with `provider: "local"` and `model: "llama3.1:8b"` in `.gos
 claude mcp add gossipcat -s user \
   -e GOOGLE_API_KEY=AIza... \
   -e ANTHROPIC_API_KEY=sk-ant-... \
-  -- node /path/to/gossipcat/dist-mcp/mcp-server.js
+  -- gossipcat
 ```
 Then set up a team with `gemini-reviewer` + `haiku-researcher` (native) + `opus-implementer` (native) + `sonnet-reviewer` (native). Gossipcat dispatches by category strength from the signal pipeline.
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.0",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
   "license": "MIT",
+  "main": "dist-mcp/mcp-server.js",
+  "bin": {
+    "gossipcat": "dist-mcp/mcp-server.js"
+  },
+  "engines": {
+    "node": ">=22"
+  },
   "workspaces": [
     "packages/*",
     "apps/*"
@@ -17,7 +24,7 @@
     "test": "jest --config jest.config.base.js",
     "clean": "rm -rf packages/*/dist apps/*/dist dist-mcp/ dist-dashboard/",
     "postinstall": "node scripts/postinstall.js",
-    "build:mcp": "npx esbuild apps/cli/src/mcp-server-sdk.ts --bundle --platform=node --target=node22 --outfile=dist-mcp/mcp-server.js --external:ws --external:@modelcontextprotocol/sdk --tsconfig=tsconfig.json && rm -rf dist-mcp/default-skills dist-mcp/default-rules && cp -r packages/orchestrator/src/default-skills dist-mcp/default-skills && cp -r packages/orchestrator/src/default-rules dist-mcp/default-rules",
+    "build:mcp": "rm -rf dist-mcp && npx esbuild apps/cli/src/mcp-server-sdk.ts --bundle --platform=node --target=node22 --outfile=dist-mcp/mcp-server.js --external:ws --external:@modelcontextprotocol/sdk --tsconfig=tsconfig.json && cp -r packages/orchestrator/src/default-skills dist-mcp/default-skills && cp -r packages/orchestrator/src/default-rules dist-mcp/default-rules && chmod +x dist-mcp/mcp-server.js",
     "build:dashboard": "cd packages/dashboard-v2 && npx vite build --outDir ../../dist-dashboard --emptyOutDir",
     "prepublishOnly": "npm run build:mcp && npm run build:dashboard",
     "gossipcat": "npx ts-node -r tsconfig-paths/register -P tsconfig.json apps/cli/src/index.ts",


### PR DESCRIPTION
## Summary
- Add `bin: { gossipcat }`, `main`, `engines: node>=22` to package.json
- Fix `build:mcp` to wipe `dist-mcp/` before bundling and `chmod +x` the output
- Rewrite README Quickstart to lead with `npm install -g gossipcat`

## Why
Unblocks first npm publish. Previously the tarball shipped 180 files (3.5MB unpacked) because stale tsc artifacts from `packages/*/dist/` had leaked into `dist-mcp/apps`, `dist-mcp/packages`, `dist-mcp/tests`. After the fix: **30 files, 3.1MB unpacked**. Install flow is now a single `npm install -g gossipcat` + `claude mcp add gossipcat -s user -- gossipcat`.

## Smoke test
End-to-end in a scratch dir:
```
$ npm pack                             # → gossipcat-0.1.0.tgz (30 files)
$ cd /tmp && mkdir smoke && cd smoke
$ npm init -y && npm i <tgz>           # ✓ 103 deps, 0 vulnerabilities
$ cat .mcp.json                        # ✓ postinstall wrote correct absolute path
$ ls node_modules/.bin/ | grep gossip  # ✓ gossipcat
$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize",...}' | ./node_modules/.bin/gossipcat
# ✓ protocol 2024-11-05, serverInfo name=gossipcat v0.1.0
# ✓ tools/list returns populated catalog (gossip_plan, gossip_dispatch, ...)
```

## Test plan
- [ ] Reviewer: sanity-check `npm pack --dry-run` locally — should show 30 files, no `dist-mcp/apps|packages|tests`
- [ ] Reviewer: confirm `bin` name `gossipcat` is the preferred UX (alternative was `gossipcat-mcp`)
- [ ] After merge: `npm publish --tag next` (smoke publish), install from `next`, verify dashboard loads, then promote to `latest`

## Not in this PR
- Dashboard HTTP serving from `node_modules/gossipcat/dist-dashboard/` path — needs a real agent dispatch to exercise; deferred to post-publish canary
- Global install flow (`npm i -g`) not yet smoke-tested (local install path was)
- `--provenance` flag / CI publishing setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)