### PR TITLE
fix(release): two-stage flow that respects branch protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,6 +858,24 @@ Gossipcat is open source and early-stage — bug reports, feature ideas, and PRs
 
 See `CLAUDE.md` in the repo for the operational rules gossipcat's own agents follow during development — it's a useful read if you want to understand the signal pipeline and consensus workflow from the inside.
 
+### Cutting a release (maintainers)
+
+Releases go to GitHub Releases via a two-stage script that respects branch protection — no direct commits to master.
+
+```bash
+# Stage 1 — open the version bump PR
+./scripts/release.sh 0.1.2
+
+# review + merge the PR via gh or web UI
+gh pr merge <pr-number> --squash --delete-branch
+
+# Stage 2 — build, tag, release (from master, after the PR is merged)
+git checkout master && git pull
+./scripts/release.sh   # no args
+```
+
+Stage 1 creates `chore/release-X.Y.Z`, bumps `package.json`, opens the PR, exits. Stage 2 reads the version from `package.json`, builds the MCP bundle + dashboard, packs the tarball, tags, pushes the tag, and creates the GitHub release with auto-generated notes from commits since the last tag.
+
 <br/>
 
 ## Star History

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,39 +1,35 @@
 #!/usr/bin/env bash
-# Usage: ./scripts/release.sh <version>     (e.g. 0.1.1)
-# Publishes gossipcat to GitHub Releases — no npm publish required.
+# Release gossipcat to GitHub Releases. NO direct commits to master.
 #
-# What this does:
-#   1. Bumps package.json version (no git tag — we tag at the end)
-#   2. Builds MCP bundle + dashboard
-#   3. Packs a tarball
-#   4. Creates a GitHub release with the tarball + auto-generated notes
-#   5. Commits the version bump, tags, pushes
+# Two-stage flow that respects branch protection:
 #
-# After this runs, users install via:
-#   npm install -g https://github.com/gossipcat-ai/gossipcat-ai/releases/latest/download/gossipcat.tgz
+#   Stage 1 — bump version via PR (call once with the new version):
+#     ./scripts/release.sh 0.1.2
+#     ↓
+#     creates branch chore/release-0.1.2, bumps package.json,
+#     pushes, opens PR. You merge it via gh/web UI as normal.
 #
-# Requirements: gh (GitHub CLI) authenticated, clean git working tree on master.
+#   Stage 2 — tag + release from master (call again, no args, after merge):
+#     git checkout master && git pull
+#     ./scripts/release.sh
+#     ↓
+#     reads version from package.json, builds, packs, tags v<version>,
+#     pushes tag, creates GitHub release with auto-generated notes.
+#
+# The script auto-detects which stage to run based on whether you pass
+# a version arg. No state file, no surprises, no direct push to master.
+#
+# Requirements: gh (GitHub CLI) authenticated, clean git working tree.
 
 set -euo pipefail
 
-if [ $# -ne 1 ]; then
-  echo "Usage: $0 <version>" >&2
-  echo "Example: $0 0.1.1" >&2
-  exit 1
-fi
-
-version=$1
-
-# Sanity checks
-if [ -n "$(git status --porcelain | grep -v '^?? ')" ]; then
-  echo "❌ Working tree has uncommitted changes. Commit or stash first." >&2
-  git status --short >&2
-  exit 1
-fi
-
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-if [ "$current_branch" != "master" ]; then
-  echo "❌ Releases must be cut from master (currently on $current_branch)." >&2
+# Allow .claude/settings.local.json to be dirty — it's developer-local state
+# that the script doesn't touch. Everything else must be clean.
+dirty=$(git status --porcelain | grep -v -E '^\?\? ' | grep -v '\.claude/settings\.local\.json' || true)
+if [ -n "$dirty" ]; then
+  echo "❌ Working tree has uncommitted changes (excluding .claude/settings.local.json):" >&2
+  echo "$dirty" >&2
+  echo "Commit, stash, or revert first." >&2
   exit 1
 fi
 
@@ -47,8 +43,81 @@ if ! gh auth status >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "→ Bumping version to $version"
-npm version "$version" --no-git-tag-version >/dev/null
+############################################################
+# Stage 1 — version bump via PR
+############################################################
+if [ $# -ge 1 ]; then
+  version=$1
+
+  current_version=$(node -p "require('./package.json').version")
+  if [ "$current_version" = "$version" ]; then
+    echo "ℹ️  package.json is already at v$version — skipping Stage 1." >&2
+    echo "    Run without arguments to perform Stage 2 (build + tag + release)." >&2
+    exit 1
+  fi
+
+  current_branch=$(git rev-parse --abbrev-ref HEAD)
+  if [ "$current_branch" != "master" ]; then
+    echo "❌ Stage 1 must be started from master (currently on $current_branch)." >&2
+    exit 1
+  fi
+
+  branch="chore/release-${version}"
+  echo "→ Creating branch $branch"
+  git checkout -b "$branch"
+
+  echo "→ Bumping package.json to v$version"
+  npm version "$version" --no-git-tag-version >/dev/null
+
+  git add package.json package-lock.json 2>/dev/null || git add package.json
+  git commit -m "chore(release): v${version}"
+
+  echo "→ Pushing $branch"
+  git push -u origin "$branch"
+
+  echo "→ Opening PR"
+  gh pr create \
+    --title "chore(release): v${version}" \
+    --body "Version bump for v${version}. After merging this PR, run \`./scripts/release.sh\` (no args) from master to build, tag, and publish the GitHub release."
+
+  echo ""
+  echo "✅ Stage 1 complete — version bump PR opened."
+  echo ""
+  echo "Next:"
+  echo "  1. Review and merge the PR via gh or the web UI"
+  echo "  2. git checkout master && git pull"
+  echo "  3. ./scripts/release.sh   # no args — runs Stage 2"
+  exit 0
+fi
+
+############################################################
+# Stage 2 — build + tag + release from master
+############################################################
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" != "master" ]; then
+  echo "❌ Stage 2 (release) must be run from master (currently on $current_branch)." >&2
+  echo "   Did you forget to merge the version bump PR and pull master?" >&2
+  exit 1
+fi
+
+# Make sure local master matches origin/master — never tag a stale commit
+git fetch origin master --quiet
+local_sha=$(git rev-parse HEAD)
+remote_sha=$(git rev-parse origin/master)
+if [ "$local_sha" != "$remote_sha" ]; then
+  echo "❌ Local master ($local_sha) is not in sync with origin/master ($remote_sha)." >&2
+  echo "   Run: git pull --ff-only" >&2
+  exit 1
+fi
+
+version=$(node -p "require('./package.json').version")
+tag="v${version}"
+
+# Refuse to re-release a version that's already tagged
+if git rev-parse "$tag" >/dev/null 2>&1; then
+  echo "❌ Tag $tag already exists. Bump the version (Stage 1) before releasing again." >&2
+  exit 1
+fi
 
 echo "→ Building MCP bundle"
 npm run build:mcp
@@ -66,35 +135,30 @@ if [ ! -f "$tarball" ]; then
   exit 1
 fi
 
-# Also produce a stable "latest" filename so the install URL never changes
+# Stable "latest" filename so the install URL never changes between releases
 cp "$tarball" "gossipcat.tgz"
 
-echo "→ Committing version bump"
-git add package.json package-lock.json 2>/dev/null || git add package.json
-git commit -m "chore(release): v${version}"
+echo "→ Tagging $tag"
+git tag -a "$tag" -m "gossipcat $tag"
 
-echo "→ Tagging v${version}"
-git tag -a "v${version}" -m "gossipcat v${version}"
-
-echo "→ Pushing to origin"
-git push origin master
-git push origin "v${version}"
+echo "→ Pushing tag"
+git push origin "$tag"
 
 echo "→ Creating GitHub release"
-gh release create "v${version}" \
+gh release create "$tag" \
   "$tarball" \
   "gossipcat.tgz" \
-  --title "gossipcat v${version}" \
+  --title "gossipcat $tag" \
   --generate-notes
 
-# Cleanup local tarballs (gitignored but still clutter)
+# Cleanup local tarballs
 rm -f "$tarball" "gossipcat.tgz"
 
 echo ""
-echo "✅ Released v${version}"
+echo "✅ Released $tag"
 echo ""
-echo "Install command:"
+echo "Install command (latest):"
 echo "  npm install -g https://github.com/gossipcat-ai/gossipcat-ai/releases/latest/download/gossipcat.tgz"
 echo ""
 echo "Pinned version:"
-echo "  npm install -g https://github.com/gossipcat-ai/gossipcat-ai/releases/download/v${version}/gossipcat-${version}.tgz"
+echo "  npm install -g https://github.com/gossipcat-ai/gossipcat-ai/releases/download/${tag}/gossipcat-${version}.tgz"


### PR DESCRIPTION
## Why

The previous release.sh direct-pushed the version-bump commit to master, bypassing branch protection via admin override. I caught this during the v0.1.1 release and flagged it. This PR fixes the script.

## New flow

**Stage 1 — bump version via PR:**
\`\`\`bash
./scripts/release.sh 0.1.2
# → creates chore/release-0.1.2, bumps package.json, opens PR
\`\`\`

**Maintainer reviews + merges the PR** via gh or web UI

**Stage 2 — build + tag + release from master (after merge):**
\`\`\`bash
git checkout master && git pull
./scripts/release.sh   # no args
# → reads version from package.json, builds, packs, tags, pushes tag,
#   creates GitHub release with auto-generated notes
\`\`\`

Stage detection is automatic: pass a version arg → Stage 1, no args → Stage 2. No state file, no surprise behavior. The only things pushed to master are (a) the merged PR via normal flow and (b) the release tag (which isn't a branch update so branch protection doesn't apply).

## Safety improvements over the old script

- ✅ Refuses to release if local master differs from origin/master (prevents tagging a stale commit)
- ✅ Refuses to re-release a version that's already tagged
- ✅ Refuses Stage 1 if package.json is already at the requested version
- ✅ Refuses both stages if \`gh\` is unauthenticated
- ✅ Allows \`.claude/settings.local.json\` to be dirty (developer-local state) while still rejecting any other uncommitted changes

## README

Added "Cutting a release (maintainers)" subsection under Contributing with the two-stage commands.

## Test plan

- [ ] Reviewer: dry-run Stage 1 against an unused version like 0.1.99 to verify the PR opens correctly
- [ ] Reviewer: confirm the script refuses Stage 2 if master is behind origin/master
- [ ] Real test: next time we cut a release, run \`./scripts/release.sh 0.1.2\` and verify it opens the PR instead of direct-pushing

🤖 Generated with [Claude Code](https://claude.com/claude-code)