### PR TITLE
fix(native): make Claude Code a first-class orchestrator + harden summary validation

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -502,7 +502,14 @@ async function doBoot() {
     if (!mainKey) {
       mainProvider = 'none';
       config.main_agent.provider = 'none';
-      process.stderr.write(`[gossipcat] ❌ No API keys available — orchestrator LLM disabled, features degrade to profile-based\n`);
+      // On Claude Code hosts with native subagents available, "none" is the
+      // expected zero-config state — the host classifies via natural language
+      // through isNullLlm path. Don't misrepresent this as an error.
+      if (env.host === 'claude-code') {
+        process.stderr.write(`[gossipcat] ✅ Native Claude Code orchestration enabled (no API LLM needed — host classifies via natural language)\n`);
+      } else {
+        process.stderr.write(`[gossipcat] ❌ No API keys available — orchestrator LLM disabled, features degrade to profile-based\n`);
+      }
     }
   }
   ctx.mainProvider = mainProvider;

--- a/packages/orchestrator/src/memory-writer.ts
+++ b/packages/orchestrator/src/memory-writer.ts
@@ -379,12 +379,19 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
     } else {
       rawLlmResponse = raw;
 
-      // Validate completeness before truncating
-      const hasSummaryLine = /^SUMMARY:\s*.+/m.test(raw);
+      // Validate completeness before truncating. We only require a ## header —
+      // the SUMMARY: line is nice-to-have, and the fallback extraction below can
+      // synthesize a one-liner from the first bullet or sentence if it's missing.
       const hasSectionHeader = /^##\s+\w/m.test(raw);
 
-      if (!hasSummaryLine || !hasSectionHeader) {
+      if (!hasSectionHeader) {
         process.stderr.write('[gossipcat] Session summary missing required structure, using raw fallback\n');
+        // Persist the raw LLM output so we can diagnose what went wrong next time,
+        // instead of throwing it away and being blind to the failure mode.
+        try {
+          const debugPath = join(memDir, 'last-malformed-summary.txt');
+          writeFileSync(debugPath, `# Malformed session summary @ ${timestamp}\n# No ## header found in LLM output.\n\n---\n${raw}`);
+        } catch {}
         summaryBody = `> ⚠️ LLM summary malformed — raw data below.\n\n${rawInput.slice(0, SESSION_SUMMARY_MAX_CHARS)}`;
       } else if (raw.length > SESSION_SUMMARY_MAX_CHARS - 100 && !/[.!)\n]$/.test(raw.trimEnd())) {
         // Likely truncated by model output limit — trim to last complete paragraph

--- a/packages/orchestrator/src/project-initializer.ts
+++ b/packages/orchestrator/src/project-initializer.ts
@@ -84,7 +84,11 @@ export class ProjectInitializer {
     for (const p of ['google', 'anthropic', 'openai']) {
       if (await this.config.keyProvider(p)) providers.push(p);
     }
-    if (!providers.length) {
+    // Native Claude Code is always available as an orchestrator when running
+    // under the Claude Code host — it needs no API key because the host
+    // classifies via natural language through the isNullLlm path.
+    const hostIsClaudeCode = process.env.CLAUDECODE === '1' || !!process.env.CLAUDE_CODE_ENTRYPOINT;
+    if (!providers.length && !hostIsClaudeCode) {
       return { text: 'No API keys available. Run gossipcat setup to configure providers.' };
     }
     const catalog = new ArchetypeCatalog(this.config.catalogPath);
@@ -98,11 +102,14 @@ export class ProjectInitializer {
       anthropic: { best: 'claude-opus-4-6', fast: 'claude-sonnet-4-6', cheapest: 'claude-haiku-4-5' },
       openai: { best: 'gpt-4o', fast: 'gpt-4o', cheapest: 'gpt-4o-mini' },
     };
-    const availableModels = providers.map(p => {
-      const tiers = MODEL_TIERS[p];
-      if (!tiers) return `${p}: (use any available model)`;
-      return `${p}: ${tiers.best} (best), ${tiers.fast} (fast), ${tiers.cheapest} (cheapest)`;
-    }).join('\n');
+    const availableModels = [
+      ...(hostIsClaudeCode ? ['none: none (native Claude Code orchestration — no API key needed, preferred for main_agent on this host)'] : []),
+      ...providers.map(p => {
+        const tiers = MODEL_TIERS[p];
+        if (!tiers) return `${p}: (use any available model)`;
+        return `${p}: ${tiers.best} (best), ${tiers.fast} (fast), ${tiers.cheapest} (cheapest)`;
+      }),
+    ].join('\n');
 
     const brainstormCtx = (signals as any).brainstormContext;
     const systemPrompt = `You are configuring an agent team for a software project.
@@ -147,7 +154,7 @@ You may add additional skills from the table above based on project needs. Do NO
 - Pick the best archetype and customize roles for this specific project
 - Use ONLY the exact model names listed above
 - Choose models based on project complexity: simple → "fast" for all, complex → "best" for critical roles
-- For the main_agent (orchestrator), use the "best" model from the primary provider
+- For the main_agent (orchestrator): ${hostIsClaudeCode ? 'PREFER { "provider": "none", "model": "none" } — native Claude Code orchestration needs no API key and is the zero-config default on this host. Only pick a keyed provider if the user explicitly asks for one.' : 'use the "best" model from the primary provider'}
 - Do NOT include agent IDs — the system generates them automatically
 - **Scale team size to project complexity.** Simple (single-page app, script, simple game) → 1-2 agents. Medium → 2-3. Complex multi-module → 4-5. NEVER duplicate roles.
 - Max 5 agents, prefer fewer. Every agent costs money.

--- a/tests/orchestrator/project-initializer.test.ts
+++ b/tests/orchestrator/project-initializer.test.ts
@@ -120,14 +120,48 @@ describe('ProjectInitializer', () => {
     expect(systemMsg.content).toContain('anthropic:');
   });
 
-  it('proposeTeam returns error when no API keys', async () => {
-    const init = new ProjectInitializer(makeConfig({ keyProvider: nullKeyProvider }));
-    const signals: ProjectSignals = { dependencies: [], directories: [], files: [] };
+  it('proposeTeam returns error when no API keys and not on Claude Code host', async () => {
+    const savedCC = process.env.CLAUDECODE;
+    const savedCCE = process.env.CLAUDE_CODE_ENTRYPOINT;
+    delete process.env.CLAUDECODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
+    try {
+      const init = new ProjectInitializer(makeConfig({ keyProvider: nullKeyProvider }));
+      const signals: ProjectSignals = { dependencies: [], directories: [], files: [] };
 
-    const result = await init.proposeTeam('test', signals);
+      const result = await init.proposeTeam('test', signals);
 
-    expect(result.text).toContain('No API keys available');
-    expect(result.choices).toBeUndefined();
+      expect(result.text).toContain('No API keys available');
+      expect(result.choices).toBeUndefined();
+    } finally {
+      if (savedCC !== undefined) process.env.CLAUDECODE = savedCC;
+      if (savedCCE !== undefined) process.env.CLAUDE_CODE_ENTRYPOINT = savedCCE;
+    }
+  });
+
+  it('proposeTeam on Claude Code host with no keys proposes native orchestration', async () => {
+    const savedCC = process.env.CLAUDECODE;
+    process.env.CLAUDECODE = '1';
+    try {
+      const llm = mockLLM(JSON.stringify({
+        archetype: 'generic',
+        reason: 'Native Claude Code host',
+        main_agent: { provider: 'none', model: 'none' },
+        agents: [],
+      }));
+      const init = new ProjectInitializer(makeConfig({ llm, keyProvider: nullKeyProvider, projectRoot: tmpDir }));
+      const signals: ProjectSignals = { dependencies: [], directories: [], files: [] };
+
+      await init.proposeTeam('test', signals);
+
+      expect(llm.generate).toHaveBeenCalledTimes(1);
+      const systemMsg = (llm.generate as jest.Mock).mock.calls[0][0].find((m: any) => m.role === 'system');
+      expect(systemMsg.content).toContain('none: none');
+      expect(systemMsg.content).toContain('native Claude Code orchestration');
+    } finally {
+      if (savedCC === undefined) delete process.env.CLAUDECODE;
+      else process.env.CLAUDECODE = savedCC;
+    }
   });
 
   it('proposeTeam returns CHOICES with team proposal', async () => {


### PR DESCRIPTION
## Summary

Three related fixes for friction reported from fresh Claude Code projects:

- **Bug A (wizard defaults to Gemini on Claude Code)** — `project-initializer.ts` now injects `none: none (native Claude Code orchestration)` at the top of the available-models list when `CLAUDECODE=1`, and tells the LLM to PREFER `{ provider: "none", model: "none" }` for `main_agent` on Claude Code hosts. Previously users with a stray Google key always landed on Gemini even though native is the documented zero-config path.
- **Bug B (scary ❌ error on zero-config Claude Code)** — `mcp-server-sdk.ts` now prints `✅ Native Claude Code orchestration enabled` when the boot key-fallback chain runs dry on a Claude Code host. The `isNullLlm` path at the call site is already designed for this state; only the message was wrong.
- **LLM summary malformed false positive** — `memory-writer.ts` drops the strict `SUMMARY:` prefix requirement (the downstream fallback already synthesizes one). On true malformed output, raw LLM text is now persisted to `.gossip/memory/last-malformed-summary.txt` so the failure mode is diagnosable instead of silently discarded. Root cause of the warning observed after a 19-minute Gemini session-summary run.

## Test plan

- [x] `tests/orchestrator/project-initializer.test.ts` — updated to cover both `CLAUDECODE=1` (prefers native) and `CLAUDECODE` unset (original negative case still returns error)
- [x] Full suite: 7 failed → was 8 on master (net −1), no regressions
- [x] Both packages typecheck clean (`tsc -p packages/orchestrator --noEmit`, `tsc -p apps/cli --noEmit`)
- [x] Independent review by second agent: confirmed `memDir` is in scope for the debug-file write, `env` is module-scoped at the mcp-server-sdk.ts call site, no downstream code branches on the old stderr text, and `proposeTeam`'s ID generation + `writeConfig` handle the `agents: []` native-only case cleanly
- [ ] Manual: fresh Claude Code project with no API keys → boot should show ✅ native line, not ❌

🤖 Generated with [Claude Code](https://claude.com/claude-code)