### PR TITLE
fix(relay): surface cross-review entry rejection instead of silent drop

### DIFF
--- a/apps/cli/src/handlers/relay-cross-review.ts
+++ b/apps/cli/src/handlers/relay-cross-review.ts
@@ -124,6 +124,10 @@ export async function handleRelayCrossReview(
   process.stderr.write(`[gossipcat] 📨 Cross-review received from ${agent_id}. Remaining: ${round.pendingNativeAgents.size}\n`);
 
   // Parse the cross-review response (parseCrossReviewResponse is stateless, llm not used)
+  let parsedCount = 0;
+  let acceptedCount = 0;
+  const rejectedPeerIds = new Set<string>();
+  let parseError: string | null = null;
   try {
     const { ConsensusEngine } = await import('@gossip/orchestrator');
     const parseLlm = ctx.mainAgent.getLlm();
@@ -134,16 +138,60 @@ export async function handleRelayCrossReview(
       projectRoot: process.cwd(),
     });
     const entries = engine.parseCrossReviewResponse(agent_id, result, 50);
+    parsedCount = entries.length;
     // Filter to round members only — prevents fabricated peerAgentId targeting agents outside the round
     const validPeerIds = new Set(round.allResults.map((r: any) => r.agentId));
-    const filtered = entries.filter(e => e.peerAgentId !== agent_id && validPeerIds.has(e.peerAgentId));
+    const filtered = entries.filter(e => {
+      const selfReview = e.peerAgentId === agent_id;
+      const unknownPeer = !validPeerIds.has(e.peerAgentId);
+      if (selfReview || unknownPeer) {
+        if (e.peerAgentId) rejectedPeerIds.add(e.peerAgentId);
+        return false;
+      }
+      return true;
+    });
+    acceptedCount = filtered.length;
     round.nativeCrossReviewEntries.push(...filtered);
+    if (parsedCount > 0 && acceptedCount === 0) {
+      process.stderr.write(
+        `[gossipcat] ⚠️  Cross-review from ${agent_id}: all ${parsedCount} entries rejected. ` +
+        `Bad peer IDs: [${[...rejectedPeerIds].join(', ')}]. ` +
+        `Valid round members: [${[...validPeerIds].join(', ')}]. ` +
+        `Expected findingId format "<peerAgentId>:f<N>".\n`
+      );
+    } else if (parsedCount > acceptedCount) {
+      process.stderr.write(
+        `[gossipcat] ⚠️  Cross-review from ${agent_id}: ${parsedCount - acceptedCount}/${parsedCount} entries rejected ` +
+        `(bad peer IDs: [${[...rejectedPeerIds].join(', ')}]).\n`
+      );
+    }
   } catch (err) {
-    process.stderr.write(`[gossipcat] Failed to parse cross-review from ${agent_id}: ${(err as Error).message}\n`);
+    parseError = (err as Error).message;
+    process.stderr.write(`[gossipcat] Failed to parse cross-review from ${agent_id}: ${parseError}\n`);
   }
 
   // Persist after each arrival so /mcp reconnect doesn't lose partial cross-reviews
   persistPendingConsensus();
+
+  // Build a diagnostic line so the orchestrator can see when entries were silently
+  // dropped by the peer-ID filter — previously this was stderr-only, so malformed
+  // findingIds like "cr:f1" / "sa:f1" would vanish without any visible signal.
+  const validPeerList = [...new Set(round.allResults.map((r: any) => r.agentId))].join(', ');
+  let diagnostic = '';
+  if (parseError) {
+    diagnostic = `\n⚠️  Parse error: ${parseError}`;
+  } else if (parsedCount > 0 && acceptedCount === 0) {
+    diagnostic =
+      `\n⚠️  All ${parsedCount} entries were REJECTED. Bad peer IDs: [${[...rejectedPeerIds].join(', ')}]. ` +
+      `Valid round members: [${validPeerList}]. ` +
+      `Expected findingId format "<peerAgentId>:f<N>" using exact agent IDs from the round.`;
+  } else if (parsedCount > acceptedCount) {
+    diagnostic =
+      `\n⚠️  ${parsedCount - acceptedCount}/${parsedCount} entries rejected (bad peer IDs: [${[...rejectedPeerIds].join(', ')}]). ` +
+      `Valid round members: [${validPeerList}].`;
+  } else if (parsedCount > 0) {
+    diagnostic = `\n✅ ${acceptedCount}/${parsedCount} entries accepted.`;
+  }
 
   // Check if all native agents have responded
   if (round.pendingNativeAgents.size > 0) {
@@ -157,7 +205,7 @@ export async function handleRelayCrossReview(
     return {
       content: [{
         type: 'text' as const,
-        text: `Cross-review from ${agent_id} received. Waiting for ${round.pendingNativeAgents.size} more agent(s): ${[...round.pendingNativeAgents].join(', ')}`,
+        text: `Cross-review from ${agent_id} received. Waiting for ${round.pendingNativeAgents.size} more agent(s): ${[...round.pendingNativeAgents].join(', ')}${diagnostic}`,
       }],
     };
   }


### PR DESCRIPTION
## Summary

When an agent submits a cross-review via \`gossip_relay_cross_review\`, entries with an unknown \`peerAgentId\` (or self-review) are filtered out at \`handlers/relay-cross-review.ts:139\` to prevent fabricated peer references. Previously this filter was silent — if ALL entries were malformed (e.g. the reviewer invented findingId prefixes like \`cr:f1\` or \`sa:f1\` instead of using the exact \`<peerAgentId>:f<N>\` IDs from the round), the relay would ack the submission, mark the agent as responded, and advance synthesis with zero signal from that reviewer.

Caught dogfooding on a smart contract audit project — \`solidity-auditor\` sent 19 entries, all were rejected, zero signal recorded, diagnosis required cross-referencing \`mcp.log\` against the consensus report.

## Changes

- stderr logs the rejected peer IDs + the set of valid round members, distinguishing "all dropped" (hard warning) from "partial drop"
- the MCP tool response itself now includes a ⚠️ diagnostic line so the orchestrator sees the rejection immediately in the same turn it relayed the result
- happy path gets a ✅ \`N/M accepted\` line for symmetry

No behavior change on valid cross-reviews — the filter still drops the same entries, it just tells you about it now.

## Test plan

- [x] \`npx tsc -p apps/cli --noEmit\` clean
- [x] Full suite unchanged (7 failed → 7 failed on master, no regressions)
- [ ] Manual: dispatch a consensus round, deliberately relay a malformed cross-review, confirm ⚠️ appears in tool response + mcp.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)