### PR TITLE
fix(version): single source of truth for gossipcat's own version

### DIFF
--- a/apps/cli/src/handlers/gossip-update.ts
+++ b/apps/cli/src/handlers/gossip-update.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync } from 'fs';
 import { join, resolve } from 'path';
+import { getGossipcatVersion } from '../version';
 
 interface UpdateOptions {
   check_only: boolean;
@@ -13,14 +14,13 @@ interface UpdateResult {
 }
 
 function getCurrentVersion(): string {
-  try {
-    // Walk up from this file to find package.json at the package root
-    const pkgPath = resolve(__dirname, '..', '..', '..', '..', 'package.json');
-    if (existsSync(pkgPath)) {
-      return JSON.parse(readFileSync(pkgPath, 'utf-8')).version ?? '0.0.0';
-    }
-  } catch { /* fall through */ }
-  return '0.0.0';
+  // Delegate to the shared helper — it walks up from __dirname until it finds
+  // a package.json with name === 'gossipcat', which works across dev, global
+  // install, local dep, and bundled layouts. The old 4-up path walk fell
+  // through to '0.0.0' whenever the install layout was anything other than
+  // the monorepo dev checkout.
+  const v = getGossipcatVersion();
+  return v === 'unknown' ? '0.0.0' : v;
 }
 
 async function getLatestVersion(): Promise<string> {

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -27,6 +27,7 @@ import { createServer as createHttpServer, IncomingMessage, ServerResponse } fro
 
 // ── Extracted modules ────────────────────────────────────────────────────
 import { ctx, NATIVE_TASK_TTL_MS } from './mcp-context';
+import { getGossipcatVersion } from './version';
 import { evictStaleNativeTasks, persistNativeTaskMap, restoreNativeTaskMap, handleNativeRelay, spawnTimeoutWatcher } from './handlers/native-tasks';
 import { handleDispatchSingle, handleDispatchParallel, handleDispatchConsensus } from './handlers/dispatch';
 import { handleCollect } from './handlers/collect';
@@ -833,7 +834,7 @@ ctx.getModules = getModules;
 const server = new McpServer(
   {
     name: 'gossipcat',
-    version: '0.1.0',
+    version: getGossipcatVersion(),
   },
   {
     instructions:
@@ -3143,13 +3144,10 @@ server.tool(
     }
 
     // 2. Gather context (each wrapped in try/catch, swallow errors)
-    let version = 'unknown';
-    try {
-      const { readFileSync } = await import('fs');
-      const { join } = await import('path');
-      const pkgRaw = readFileSync(join(process.cwd(), 'package.json'), 'utf-8');
-      version = JSON.parse(pkgRaw).version ?? 'unknown';
-    } catch { /* swallow */ }
+    // Use the shared helper — reads gossipcat's own package.json, not the
+    // calling project's (which is what the old process.cwd() path returned).
+    const { getGossipcatVersion } = await import('./version');
+    const version = getGossipcatVersion();
 
     let gitHead = 'unknown';
     try {

--- a/apps/cli/src/version.ts
+++ b/apps/cli/src/version.ts
@@ -1,0 +1,46 @@
+/**
+ * Single source of truth for gossipcat's own version.
+ *
+ * Previously, three code paths each read the version independently:
+ *   - mcp-server-sdk.ts had a hardcoded literal (lied after every release)
+ *   - gossip-update.ts walked `__dirname + ../../../../package.json` (fragile to
+ *     install layout — fell through to '0.0.0' when globally installed)
+ *   - gossip_bug_feedback read `process.cwd()/package.json` (wrong package
+ *     entirely — returned the CALLING project's version when gossipcat was
+ *     used via MCP from another repo)
+ *
+ * This helper walks up from __dirname until it finds a package.json whose
+ * `name` is "gossipcat", which works across dev, global install, local dep,
+ * and bundled layouts. Cached after first resolution.
+ */
+import { existsSync, readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+
+let cached: string | null = null;
+
+export function getGossipcatVersion(): string {
+  if (cached !== null) return cached;
+  cached = resolveVersion();
+  return cached;
+}
+
+function resolveVersion(): string {
+  let dir = __dirname;
+  const root = resolve('/');
+  // Hard cap on walk depth as a safety net against pathological layouts
+  for (let i = 0; i < 20 && dir !== root; i++) {
+    const candidate = resolve(dir, 'package.json');
+    if (existsSync(candidate)) {
+      try {
+        const pkg = JSON.parse(readFileSync(candidate, 'utf-8'));
+        if (pkg && pkg.name === 'gossipcat' && typeof pkg.version === 'string') {
+          return pkg.version;
+        }
+      } catch { /* keep walking — malformed package.json shouldn't stop us */ }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return 'unknown';
+}


### PR DESCRIPTION
## Summary

Three code paths independently reported gossipcat's version and all three were broken:

1. **\`mcp-server-sdk.ts:836\`** — hardcoded literal \`'0.1.0'\`. Did not update when package.json bumped to \`0.1.1\` in commit \`a7f6baa\`, so \`gossip_status\` has been lying ever since.
2. **\`handlers/gossip-update.ts\`** — walked \`__dirname + 4 .. segments\` to find package.json. Assumed a fixed directory depth that only holds in the monorepo dev checkout. In any other install layout (global npm, local dep, release tarball, bundled esbuild output) the walk missed and fell through to \`'0.0.0'\`. This is why a user running v0.1.1 from a GitHub release saw \`gossip_update\` report \`"v0.0.0 → v0.1.0 available"\`.
3. **\`gossip_bug_feedback\` context gather** — read \`process.cwd()/package.json\`, which returns the CALLING project's version, not gossipcat's. Bug reports filed from another repo carried that repo's version number instead of gossipcat's.

## Fix

New \`apps/cli/src/version.ts\` walks up from \`__dirname\` until it finds a package.json whose \`name === 'gossipcat'\`. The name check skips the workspace \`apps/cli/package.json\` in dev and only matches the real package root. Hard-capped at 20 parent levels as a safety net. Cached after first resolution.

## Install layout matrix

| Layout | \`__dirname\` | Walk finds package.json at |
|---|---|---|
| GitHub release tarball | \`<install>/dist-mcp/\` | \`<install>/package.json\` ✓ |
| \`npm install -g gossipcat\` | \`<prefix>/lib/node_modules/gossipcat/dist-mcp/\` | one level up ✓ |
| Local npm dep | \`<proj>/node_modules/gossipcat/dist-mcp/\` | one level up ✓ |
| Dev checkout (ts-node) | \`<repo>/apps/cli/src/\` | skips \`apps/cli/package.json\`, hits repo root ✓ |
| Dev checkout (tsc dist) | \`<repo>/apps/cli/dist/\` | same ✓ |

## Test plan

- [x] \`npx tsc -p apps/cli --noEmit\` clean
- [x] \`npm run build:mcp\` bundles cleanly, \`getGossipcatVersion\` appears 8× in bundle
- [x] Simulated walk from \`dist-mcp/\` in this repo returns \`0.1.1\` ✓
- [x] Full suite: 7 failed → 7 failed on master, no regressions
- [ ] Manual after merge: reinstall release tarball on the other project, confirm \`gossip_status\` and \`gossip_update\` both report the real version

🤖 Generated with [Claude Code](https://claude.com/claude-code)