### PR TITLE
chore(release): v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ## [Unreleased]
 
+## [0.1.2] — 2026-04-09
+
+### Native Claude Code as a first-class orchestrator (#12)
+
+New users on fresh Claude Code projects previously hit two friction points that contradicted the README's zero-config promise:
+
+- `gossip_setup` defaulted the `main_agent` to Gemini even when the host was Claude Code, because the wizard only considered keyed providers and never saw native as an option.
+- Boot with no API keys printed `❌ No API keys available — orchestrator LLM disabled, features degrade to profile-based`, scaring users away from what is in fact the expected zero-config state on Claude Code (the host classifies tasks via natural language through the existing `isNullLlm` path).
+
+Both are fixed. The wizard now injects `none: none (native Claude Code orchestration)` at the top of the available-models list when `CLAUDECODE=1` and explicitly instructs the LLM to PREFER `{ provider: "none", model: "none" }` for `main_agent` on Claude Code hosts. The boot fallback now prints `✅ Native Claude Code orchestration enabled` instead of the old error. The session-summary validation was also relaxed — it no longer requires a strict `SUMMARY:` prefix (the downstream extraction fallback already synthesizes one), and on true malformed output the raw LLM text is persisted to `.gossip/memory/last-malformed-summary.txt` for diagnosis.
+
+### Cross-review silent-drop diagnostics (#13)
+
+`gossip_relay_cross_review` filters entries whose `peerAgentId` is not a real round member (anti-fabrication guard at `relay-cross-review.ts:139`). This filter was previously silent — if ALL entries were malformed (e.g. a reviewer invented findingId prefixes like `cr:f1` or `sa:f1` instead of using `<peerAgentId>:f<N>`), the relay would ack the submission, mark the agent as responded, and advance synthesis with zero signal from that reviewer. Diagnosis required cross-referencing `mcp.log` against the consensus report.
+
+Now both stderr and the MCP tool response itself carry a ⚠️ diagnostic line showing rejected peer IDs and the set of valid round members when any entry is filtered out. Happy path gets a ✅ `N/M entries accepted` confirmation for symmetry.
+
+### Single source of truth for version reporting (#14)
+
+Three independent code paths reported gossipcat's version and all three were broken: `gossip_status` returned a hardcoded literal `'0.1.0'`, `gossip_update` walked a fixed 4-level `__dirname` path that only held in the monorepo dev checkout (falling through to `'0.0.0'` on global installs and release tarballs), and `gossip_bug_feedback` read `process.cwd()/package.json` which returned the CALLING project's version instead of gossipcat's.
+
+New `apps/cli/src/version.ts` walks up from `__dirname` until it finds a `package.json` with `name === 'gossipcat'`. The name check is what makes it layout-agnostic — it skips the workspace `apps/cli/package.json` in dev and only matches the real package root. Cached after first resolution, capped at 20 parent levels. Verified across dev checkout, global install, local dep, and GitHub release tarball layouts.
+
 ### checkEffectiveness Option A v2 (commit `048077e`, 2026-04-08)
 
 The skill effectiveness gate has been rewritten to eliminate the `postTotal < 0` failure mode that caused skills to silently freeze in `pending` state for up to 90 days. Effectiveness evaluation now operates on **anchored deltas** rather than subtracting cumulative counters that drift independently.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gossipcat",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gossipcat",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossipcat",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
   "license": "MIT",
   "main": "dist-mcp/mcp-server.js",


### PR DESCRIPTION
Version bump + CHANGELOG entry for v0.1.2, bundling three fixes shipped today:

- #12 — Native Claude Code as a first-class orchestrator. Fixes the two friction points reported from fresh projects: wizard defaulting to Gemini and the scary ❌ error on zero-config boot. Also relaxes session-summary validation and persists raw LLM output on true malformed responses for diagnosis.
- #13 — Cross-review entry rejection diagnostics. Malformed findingIds (invented peer IDs like \`cr:f1\`) no longer silently drop — stderr and the tool response both carry a ⚠️ line showing rejected peer IDs and valid round members.
- #14 — Single source of truth for version reporting. Fixes \`gossip_status\` returning a hardcoded \`'0.1.0'\`, \`gossip_update\` walking a fragile 4-up \`__dirname\` path (fell through to \`'0.0.0'\` on release tarball / global install layouts), and \`gossip_bug_feedback\` reading the CALLING project's package.json.

## Release plan after merge

1. \`git checkout master && git pull --ff-only\`
2. \`./scripts/release.sh\` — Stage 2, builds + tags + creates GitHub release
3. **\`npm publish\`** — manual step, release.sh does not currently push to npm. Tracked as a follow-up PR to wire npm publish into the script and optionally add a GitHub Releases fallback in \`gossip-update.ts\`.

Without the manual \`npm publish\`, the other gossipcat instance's \`gossip_update\` (which queries \`registry.npmjs.org\`) will still see v0.1.0 as latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)