### PR TITLE
fix(ports): sticky per-project port files for relay + HTTP MCP

### DIFF
--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -62,6 +62,12 @@ export interface McpContext {
   pendingConsensusRounds: Map<string, PendingConsensusRound>;
   nativeUtilityConfig: { model: string } | null;
   mainProvider: string;
+  /** Actual bound HTTP MCP port (0/null if transport disabled). Set after listen(). */
+  httpMcpPort: number | null;
+  /** Source of the relay port: 'env' | 'sticky' | 'auto'. Used by gossip_status. */
+  relayPortSource: 'env' | 'sticky' | 'auto' | null;
+  /** Source of the HTTP MCP port. */
+  httpMcpPortSource: 'env' | 'sticky' | 'auto' | null;
   booted: boolean;
   boot: () => Promise<void>;
   syncWorkersViaKeychain: () => Promise<void>;
@@ -81,6 +87,9 @@ export const ctx: McpContext = {
   pendingConsensusRounds: new Map(),
   nativeUtilityConfig: null,
   mainProvider: 'google',
+  httpMcpPort: null,
+  relayPortSource: null,
+  httpMcpPortSource: null,
   booted: false,
   boot: async () => { throw new Error('boot not initialized'); },
   syncWorkersViaKeychain: async () => {},

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -33,6 +33,7 @@ import { handleDispatchSingle, handleDispatchParallel, handleDispatchConsensus }
 import { handleCollect } from './handlers/collect';
 import { restorePendingConsensus } from './handlers/relay-cross-review';
 import { persistRelayTasks, restoreRelayTasksAsFailed } from './handlers/relay-tasks';
+import { pickStickyPort, writeStickyPort, RELAY_STICKY_FILE, HTTP_MCP_STICKY_FILE } from './stickyPort';
 
 // ── Environment detection ────────────────────────────────────────────────
 
@@ -343,14 +344,16 @@ async function doBoot() {
   // Generate a per-process relay key so only co-launched agents can connect.
   const relayApiKey = randomBytes(32).toString('hex');
 
-  // Port selection: try a user-provided port via GOSSIPCAT_PORT env var,
-  // otherwise let the OS assign a free port (port: 0). This lets multiple
-  // Claude Code instances run gossipcat in parallel on the same machine
-  // without fighting over 24420. Each instance gets its own port; the actual
-  // port is logged to stderr + written to .gossip/relay.pid + exposed via
-  // gossip_status() and the MCP `instructions` field after boot.
-  const envPort = process.env.GOSSIPCAT_PORT ? parseInt(process.env.GOSSIPCAT_PORT, 10) : NaN;
-  const relayPort = Number.isFinite(envPort) && envPort >= 0 && envPort <= 65535 ? envPort : 0;
+  // Port selection: env → sticky file (.gossip/relay.port) → OS-assigned.
+  // GOSSIPCAT_PORT still wins unconditionally. When unset we try to re-bind the
+  // last port this project used so dashboard URLs stay stable across reboots,
+  // then fall back to port 0 if it's busy — multiple Claude Code instances can
+  // still run gossipcat in parallel on the same machine. The actual bound port
+  // is logged to stderr, written to .gossip/relay.port, and exposed via
+  // gossip_status() + the MCP `instructions` field after boot.
+  const relayPick = await pickStickyPort('GOSSIPCAT_PORT', RELAY_STICKY_FILE);
+  const relayPort = relayPick.port;
+  ctx.relayPortSource = relayPick.source;
 
   ctx.relay = new m.RelayServer({
     port: relayPort,
@@ -362,8 +365,13 @@ async function doBoot() {
   });
   await ctx.relay.start();
 
+  // Persist the actual bound port for next boot's sticky lookup.
+  if (typeof ctx.relay.port === 'number' && ctx.relay.port > 0) {
+    writeStickyPort(RELAY_STICKY_FILE, ctx.relay.port);
+  }
+
   // Start HTTP MCP transport for remote clients
-  startHttpMcpTransport();
+  await startHttpMcpTransport();
 
   // Write PID so the next boot can clean up if we crash without releasing the port.
   try { writePid(pidFile, String(process.pid)); } catch { /* best-effort */ }
@@ -1083,13 +1091,16 @@ server.tool(
       'Status:',
       `  Host: ${env.host}${env.supportsNativeAgents ? ' (native agents supported)' : ''}`,
       `  Native agent dir: ${env.nativeAgentDir || 'n/a'}`,
-      `  Relay: ${ctx.relay ? `running :${ctx.relay.port}` : 'not started'}`,
+      `  Relay: ${ctx.relay ? `running :${ctx.relay.port}${ctx.relayPortSource === 'sticky' ? ' (sticky)' : ''}` : 'not started'}`,
       `  Tool Server: ${ctx.toolServer ? 'running' : 'not started'}`,
       `  Workers: ${ctx.workers.size} (${Array.from(ctx.workers.keys()).join(', ') || 'none'})`,
       `  Claude subagents found: ${claudeSubagentsList.length}`,
     ];
     if (ctx.relay?.dashboardUrl) {
-      lines.push(`  Dashboard: ${ctx.relay.dashboardUrl} (key: ${ctx.relay.dashboardKey})`);
+      lines.push(`  Dashboard: ${ctx.relay.dashboardUrl}${ctx.relayPortSource === 'sticky' ? ' (sticky)' : ''} (key: ${ctx.relay.dashboardKey})`);
+    }
+    if (ctx.httpMcpPort) {
+      lines.push(`  HTTP MCP: :${ctx.httpMcpPort}/mcp${ctx.httpMcpPortSource === 'sticky' ? ' (sticky)' : ''}`);
     }
 
     // Quota health
@@ -3215,8 +3226,17 @@ function touchSession(sid: string): void {
   }, HTTP_SESSION_TTL_MS);
 }
 
-function startHttpMcpTransport(): void {
-  const port = parseInt(process.env.GOSSIPCAT_HTTP_PORT ?? '24421', 10);
+async function startHttpMcpTransport(): Promise<void> {
+  // Port selection: GOSSIPCAT_HTTP_PORT env wins, then .gossip/http-mcp.port
+  // sticky file, then OS-assigned (0). Previously this hardcoded 24421 which
+  // collided across parallel Claude Code instances on the same machine —
+  // matches the fix already applied to the relay port.
+  const httpPick = await pickStickyPort('GOSSIPCAT_HTTP_PORT', HTTP_MCP_STICKY_FILE);
+  // Legacy default: if nothing was provided and we had no sticky file, prefer
+  // 24421 once so existing clients with that port in their config keep working.
+  // If 24421 is already busy we'll still fall through to port 0 via EADDRINUSE.
+  const port = httpPick.source === 'auto' ? 24421 : httpPick.port;
+  ctx.httpMcpPortSource = httpPick.source;
   const token = process.env.GOSSIPCAT_HTTP_TOKEN ?? '';
   const bindHost = (process.env.GOSSIPCAT_HTTP_BIND === '0.0.0.0' && token) ? '0.0.0.0' : '127.0.0.1';
 
@@ -3318,9 +3338,13 @@ function startHttpMcpTransport(): void {
   });
 
   httpServer.listen(port, bindHost, () => {
+    const addr = httpServer.address();
+    const bound = typeof addr === 'object' && addr ? addr.port : port;
+    ctx.httpMcpPort = bound;
+    if (bound > 0) writeStickyPort(HTTP_MCP_STICKY_FILE, bound);
     const authNote = token ? ' (token protected)' : ' (no auth — set GOSSIPCAT_HTTP_TOKEN to secure)';
     const bindNote = bindHost === '0.0.0.0' ? ' [remote]' : ' [localhost only]';
-    process.stderr.write(`[gossipcat] HTTP MCP listening on :${port}/mcp${authNote}${bindNote}\n`);
+    process.stderr.write(`[gossipcat] HTTP MCP listening on :${bound}/mcp${authNote}${bindNote}\n`);
   });
 
   httpServer.on('error', (err: NodeJS.ErrnoException) => {

--- a/apps/cli/src/stickyPort.ts
+++ b/apps/cli/src/stickyPort.ts
@@ -1,0 +1,121 @@
+// Sticky per-project port selection.
+//
+// Motivation: running multiple parallel gossipcat instances on one machine used
+// to fight over hardcoded ports (24420 relay, 24421 HTTP MCP). Relay already
+// falls back to port 0 (OS-assigned); HTTP MCP still hardcodes 24421.
+// Letting the OS assign every boot makes dashboard bookmarks and MCP client
+// configs break across restarts. Sticky port files give each project a stable
+// port that survives reboots but yields gracefully to collisions.
+//
+// Policy (see pickStickyPort):
+//   1. Env var wins unconditionally (no sticky read, no fallback).
+//   2. Else read <project>/.gossip/<file> and probe-bind that port.
+//   3. Else port 0 (OS picks a free one).
+// After a successful listen() the caller writes the bound port back via
+// writeStickyPort(), so the next boot re-uses it when possible.
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { createServer } from 'net';
+
+export const RELAY_STICKY_FILE = join('.gossip', 'relay.port');
+export const HTTP_MCP_STICKY_FILE = join('.gossip', 'http-mcp.port');
+
+function stickyPath(filename: string): string {
+  return join(process.cwd(), filename);
+}
+
+/** Read a persisted port number from the sticky file, or null if absent/invalid. */
+export function readStickyPort(filename: string): number | null {
+  const p = stickyPath(filename);
+  if (!existsSync(p)) return null;
+  try {
+    const raw = readFileSync(p, 'utf-8').trim();
+    const n = parseInt(raw, 10);
+    if (!Number.isFinite(n) || n < 1 || n > 65535) return null;
+    return n;
+  } catch {
+    return null;
+  }
+}
+
+/** Write the actual bound port back to the sticky file (best-effort). */
+export function writeStickyPort(filename: string, port: number): void {
+  if (!Number.isFinite(port) || port < 1 || port > 65535) return;
+  const p = stickyPath(filename);
+  try {
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, String(port), 'utf-8');
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Probe whether a TCP port is bindable on `host` (default 127.0.0.1).
+ * Briefly opens a listener, then closes it. Returns true if the bind
+ * succeeded, false otherwise (EADDRINUSE, EACCES, etc.).
+ *
+ * Note: there is a tiny TOCTOU window between probe and the real listen,
+ * but that's fine — the caller still has an EADDRINUSE handler as a safety
+ * net, and losing a race just means we fall back to port 0.
+ */
+export function probePort(port: number, host: string = '127.0.0.1'): Promise<boolean> {
+  return new Promise((resolve) => {
+    const srv = createServer();
+    let settled = false;
+    const done = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      try { srv.close(); } catch { /* ignore */ }
+      resolve(ok);
+    };
+    srv.once('error', () => done(false));
+    try {
+      srv.listen(port, host, () => {
+        srv.close(() => done(true));
+      });
+    } catch {
+      done(false);
+    }
+  });
+}
+
+export interface StickyPortResult {
+  /** The port to pass to the listener (0 means OS-assigned). */
+  port: number;
+  /** Where the port came from. Used by gossip_status to surface a (sticky) hint. */
+  source: 'env' | 'sticky' | 'auto';
+}
+
+/**
+ * Pick a port following the env → sticky → auto policy.
+ *
+ * @param envVar        Name of the env var that overrides everything.
+ * @param stickyFile    Project-relative sticky file path (e.g. `.gossip/relay.port`).
+ * @param probeHost     Host to probe-bind on when validating the sticky port.
+ */
+export async function pickStickyPort(
+  envVar: string,
+  stickyFile: string,
+  probeHost: string = '127.0.0.1',
+): Promise<StickyPortResult> {
+  // 1. Env var wins unconditionally.
+  const envRaw = process.env[envVar];
+  if (envRaw !== undefined && envRaw !== '') {
+    const envPort = parseInt(envRaw, 10);
+    if (Number.isFinite(envPort) && envPort >= 0 && envPort <= 65535) {
+      return { port: envPort, source: 'env' };
+    }
+  }
+
+  // 2. Sticky file → probe.
+  const sticky = readStickyPort(stickyFile);
+  if (sticky !== null) {
+    const free = await probePort(sticky, probeHost);
+    if (free) return { port: sticky, source: 'sticky' };
+  }
+
+  // 3. OS-assigned.
+  return { port: 0, source: 'auto' };
+}


### PR DESCRIPTION
## Summary
- New `apps/cli/src/stickyPort.ts` helper implements env → sticky → auto port selection
- Relay (`GOSSIPCAT_PORT`) and HTTP MCP (`GOSSIPCAT_HTTP_PORT`) now persist their bound ports to `.gossip/relay.port` and `.gossip/http-mcp.port`, reclaiming them across reconnects
- `gossip_status()` gains a `(sticky)` hint on Relay/Dashboard lines and finally surfaces HTTP MCP which had no status line before
- Legacy `24421` preserved as HTTP MCP default so existing client configs keep working

## Context
Closes `project_http_mcp_port_collision.md`. Parallel gossipcat instances fought over hardcoded 24421; relay port was fixed in a prior pass but HTTP MCP was missed. Letting the OS pick every boot (the obvious fix) broke dashboard bookmarks and cached MCP client configs. Sticky files solve both.

## Test plan
- [ ] `npm run build:mcp` succeeds (verified locally: 1.5mb, 22ms)
- [ ] `npx tsc --noEmit` passes for touched files (verified)
- [ ] Boot gossipcat once, note Relay/HTTP MCP ports in `gossip_status()`, reconnect via `/mcp reconnect`, confirm the same ports come back with `(sticky)` hint
- [ ] Boot a second gossipcat instance in a different project dir, confirm it picks different ports (falls through the probe) and writes its own sticky files
- [ ] Set `GOSSIPCAT_PORT=12345` explicitly, confirm env wins and no sticky file read happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)