### PR TITLE
dashboard(team-hero): 2x2 grid sorted by last dispatch

### DIFF
--- a/packages/dashboard-v2/src/components/TeamHero.tsx
+++ b/packages/dashboard-v2/src/components/TeamHero.tsx
@@ -6,9 +6,19 @@ interface TeamHeroProps {
 }
 
 export function TeamHero({ agents }: TeamHeroProps) {
-  const sorted = [...agents].sort((a, b) => (b.scores?.dispatchWeight || 0) - (a.scores?.dispatchWeight || 0));
-  const visible = sorted.slice(0, 6);
-  const hasMore = sorted.length > 6;
+  // Sort by most recent dispatch first (lastTask.timestamp desc), with signal count as tie-break
+  // so agents with no tasks sink to the bottom deterministically.
+  const sorted = [...agents].sort((a, b) => {
+    const aTs = a.lastTask?.timestamp ?? '';
+    const bTs = b.lastTask?.timestamp ?? '';
+    if (aTs !== bTs) return bTs.localeCompare(aTs);
+    const aSig = a.scores?.signals || 0;
+    const bSig = b.scores?.signals || 0;
+    if (aSig !== bSig) return bSig - aSig;
+    return a.id.localeCompare(b.id);
+  });
+  const visible = sorted.slice(0, 4);
+  const hasMore = sorted.length > 4;
 
   return (
     <section>
@@ -22,7 +32,7 @@ export function TeamHero({ agents }: TeamHeroProps) {
           </a>
         )}
       </div>
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         {visible.map((agent) => (
           <AgentCardBig key={agent.id} agent={agent} />
         ))}


### PR DESCRIPTION
## Summary
- TeamHero goes from 3x2 (6 cards) to 2x2 (4 cards at md+) per the dashboard v3 next-session plan
- Sort is \`lastTask.timestamp\` desc with signal count and agent id as tie-breakers
- Agents with no tasks sink to the bottom via empty-string ordering
- View-all threshold drops from >6 to >4 so the overflow link appears sooner

## Context
Anchor task from \`project_dashboard_next_session_plan.md\`. No backend change — the \`lastTask.timestamp\` field is already exposed via \`api-agents.ts:119-122\` where the task-graph.jsonl walker computes the most recent task per agent. Pure frontend change, ~15 lines in one file.

## Deferred to follow-ups
- Avatar bump (72px → 96px/108px) pending Vortex performance profile at the new card size
- Metric bar rescaling in \`AgentCardBig.tsx\` if the bigger footprint breaks typography
- Data fixes (gemini score, relay-task invisibility, impl signals) and other visual corrections ship as separate PRs

## Test plan
- [ ] \`npx tsc --noEmit -p packages/dashboard-v2/tsconfig.json\` passes (verified locally)
- [ ] Open dashboard, confirm 4 cards visible sorted by most recent dispatch
- [ ] Confirm view-all link appears when team has >4 agents
- [ ] Sanity-check agents with no \`lastTask\` render at the bottom, not hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)