### PR TITLE
fix(dashboard): render categoryAccuracy, not unbounded categoryStrengths

### DIFF
--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -180,7 +180,7 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
           <h2 className="mb-3 font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
             Category Strengths
           </h2>
-          <CategoryStrengths strengths={s.categoryStrengths} />
+          <CategoryStrengths strengths={s.categoryStrengths} accuracy={s.categoryAccuracy} />
         </div>
       </section>
 

--- a/packages/dashboard-v2/src/components/CategoryStrengths.tsx
+++ b/packages/dashboard-v2/src/components/CategoryStrengths.tsx
@@ -1,9 +1,26 @@
 interface CategoryStrengthsProps {
+  /** Raw severity-weighted accumulator from performance-reader. Unbounded — used as sort fallback only. */
   strengths: Record<string, number>;
+  /** c / (c + h) ratio in [0,1]. Preferred data source when available. */
+  accuracy?: Record<string, number>;
 }
 
-export function CategoryStrengths({ strengths }: CategoryStrengthsProps) {
-  const entries = Object.entries(strengths)
+// Clamp any score to [0, 1] before turning it into a percentage. Guards against
+// stale clients rendering categoryStrengths (unbounded) as a ratio.
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+export function CategoryStrengths({ strengths, accuracy }: CategoryStrengthsProps) {
+  // Prefer categoryAccuracy (real c/(c+h) ratio) over categoryStrengths (unbounded
+  // severity-weighted accumulator used for dispatch routing). Fall back to clamped
+  // strengths when accuracy is unavailable for back-compat with older server builds.
+  const source = accuracy && Object.keys(accuracy).length > 0 ? accuracy : strengths;
+  const entries = Object.entries(source)
+    .map(([k, v]) => [k, clamp01(v)] as [string, number])
     .sort(([, a], [, b]) => b - a);
 
   if (entries.length === 0) {

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -31,7 +31,10 @@ export interface AgentData {
     impactScore: number; dispatchWeight: number; signals: number;
     agreements: number; disagreements: number; hallucinations: number;
     consecutiveFailures: number; circuitOpen: boolean;
+    // categoryStrengths is an unbounded dispatch-routing accumulator — do not
+    // render as a percentage. categoryAccuracy = c / (c + h) is the real ratio.
     categoryStrengths: Record<string, number>;
+    categoryAccuracy?: Record<string, number>;
   };
 }
 

--- a/packages/relay/src/dashboard/api-agents.ts
+++ b/packages/relay/src/dashboard/api-agents.ts
@@ -179,7 +179,13 @@ export async function agentsHandler(
         hallucinations: score.hallucinations,
         consecutiveFailures: score.consecutiveFailures ?? 0,
         circuitOpen: score.circuitOpen ?? false,
+        // categoryStrengths is an UNBOUNDED severity-weighted accumulator used
+        // for dispatch routing (severity × decay × 0.15 per confirmed signal),
+        // not a [0,1] ratio. The dashboard must NOT render it as a percentage —
+        // it should render categoryAccuracy (c / (c + h)) which is a real ratio.
+        // See performance-reader.ts:357 (increment) vs :496-505 (accuracy).
         categoryStrengths: score.categoryStrengths ?? {},
+        categoryAccuracy: score.categoryAccuracy ?? {},
       },
     };
   });


### PR DESCRIPTION
## Summary
- \`categoryStrengths\` at \`performance-reader.ts:357\` is an **unbounded severity-weighted accumulator** used for dispatch routing (adds \`sevMul * decay * 0.15\` per confirmed signal). Rendering it as a [0,1] percentage in \`CategoryStrengths.tsx\` produced values >100% — a CRITICAL finding reviewed twice could display 120% bars.
- \`categoryAccuracy = c / (c + h)\` is already computed at \`performance-reader.ts:496-505\` as a real ratio in [0,1], but was never forwarded by \`api-agents.ts\` or consumed by any UI.
- This PR forwards \`categoryAccuracy\`, threads it through dashboard types, and prefers it in \`CategoryStrengths\` with a clamp01 fallback on \`strengths\` for back-compat.

## Root cause
Type mismatch between producer and consumer:
- **Producer** (\`performance-reader.ts:357\`): unbounded severity-weighted rank signal
- **Consumer** (\`CategoryStrengths.tsx:29,33\`): \`score * 100%\` treating it as a probability

\`categoryStrengths\` stays as-is because it's still used for dispatch weighting — clamping at source would corrupt scoring. The fix lives entirely at the display layer.

## Found via
3-agent consensus investigation — sonnet, opus, and haiku independently found the same root cause and fix shape. Part of the dashboard v3 data-corrections pass.

## Related bugs surfaced in the same investigation (separate PRs)
- **Debates/ConsensusRounds count stuck at 10** — pagination slice rendered as total (PR #20)
- **SystemPulse.consensusRuns vs consensus.runs filter mismatch** — different definitions of "consensus run" (PR #20)
- \`totalFindings\` counts signal entries not unique findings (follow-up)
- \`totalSignals\` counts all JSONL lines including impl entries (follow-up)
- \`successRate\` defaults to 100% with zero tasks (follow-up)

## Test plan
- [x] \`npx tsc --noEmit\` passes on dashboard-v2 and relay
- [ ] Open dashboard, agent detail page, verify category bars all render ≤ 100% even for agents with many CRITICAL confirmations
- [ ] Agents with no category data still show "No category data yet."
- [ ] Back-compat: older server builds without \`categoryAccuracy\` in the payload fall through to clamped \`strengths\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)