### PR TITLE
dashboard(ux): first-impression polish for public share

### DIFF
--- a/packages/dashboard-v2/src/components/ActiveTasksBanner.tsx
+++ b/packages/dashboard-v2/src/components/ActiveTasksBanner.tsx
@@ -55,16 +55,22 @@ export function ActiveTasksBanner({ onCountChange }: { onCountChange?: (n: numbe
   if (live.length === 0) return null;
 
   return (
-    <div className="rounded-lg border border-unverified/20 bg-unverified/5 px-4 py-2.5">
-      {/* Header */}
+    <div className="rounded-lg border border-border bg-card/60 px-4 py-2.5">
+      {/* Header — uses the same confirmed-green LIVE vocabulary as SystemPulse
+          and TopBar. The previous unverified-yellow treatment collided with
+          actual "unverified finding" counts on the same page, causing users
+          to conflate running-task status with review-state. */}
       <div className="mb-2 flex items-center gap-2">
-        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-unverified" />
-        <span className="font-mono text-xs font-bold text-unverified">
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-confirmed shadow-[0_0_6px_rgba(52,211,153,0.5)]" />
+        <span className="font-mono text-xs font-bold uppercase tracking-widest text-foreground">
+          Live
+        </span>
+        <span className="font-mono text-[11px] text-muted-foreground">
           {live.length} active
         </span>
         {staleCount > 0 && (
           <span className="font-mono text-[10px] text-muted-foreground/50">
-            + {staleCount} stale
+            · {staleCount} stale
           </span>
         )}
       </div>
@@ -79,7 +85,7 @@ export function ActiveTasksBanner({ onCountChange }: { onCountChange?: (n: numbe
             <span className="min-w-0 truncate text-[11px] text-muted-foreground">
               {t.task}
             </span>
-            <span className="font-mono text-[11px] text-unverified whitespace-nowrap">
+            <span className="font-mono text-[11px] text-muted-foreground whitespace-nowrap tabular-nums">
               {elapsed(t.startedAt)}
             </span>
           </div>

--- a/packages/dashboard-v2/src/components/AgentCardBig.tsx
+++ b/packages/dashboard-v2/src/components/AgentCardBig.tsx
@@ -1,6 +1,6 @@
 import type { AgentData } from '@/lib/types';
 import { NeuralAvatar } from './NeuralAvatar';
-import { agentColor, timeAgo } from '@/lib/utils';
+import { timeAgo } from '@/lib/utils';
 
 interface AgentCardBigProps {
   agent: AgentData;
@@ -24,7 +24,6 @@ function accTier(a: number): 'good' | 'mid' | 'low' {
 
 export function AgentCardBig({ agent }: AgentCardBigProps) {
   const s = agent.scores;
-  const color = agentColor(agent.id);
   const lastTime = agent.lastTask?.timestamp ? timeAgo(agent.lastTask.timestamp) : '';
 
   const wt = weightTier(s.dispatchWeight);
@@ -40,28 +39,23 @@ export function AgentCardBig({ agent }: AgentCardBigProps) {
   return (
     <a
       href={`/dashboard/agent/${encodeURIComponent(agent.id)}`}
-      className="group relative block rounded-xl border border-border bg-gradient-to-br from-card to-card/50 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_2px_8px_rgba(0,0,0,0.35)] transition-all hover:-translate-y-0.5 hover:border-primary/30 hover:from-card/90 hover:to-card/40 hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_10px_28px_rgba(0,0,0,0.55),0_0_0_1px_rgba(117,221,221,0.14)]"
+      className="group relative block rounded-xl border border-border bg-card p-4 transition-all hover:-translate-y-0.5 hover:border-primary/30 hover:bg-card/90"
     >
-      {/* Top inner highlight line */}
-      <span className="pointer-events-none absolute inset-x-0 top-0 h-px rounded-t-xl bg-gradient-to-r from-transparent via-white/12 to-transparent" />
+      {/* Flatten pass: the card used to layer gradient + inset highlight line
+          + outer shadow + hover ring + per-agent avatar halo blur, which felt
+          skeuomorphic and fought the metric bars for attention. Single card
+          background + subtle hover lift reads cleaner in the 2x2 hero grid. */}
       <div className="mb-3.5 flex items-center gap-3">
-        {/* Avatar with halo glow */}
         <div className="relative shrink-0">
-          <div
-            className="absolute -inset-2 rounded-full opacity-[0.18] blur-xl transition group-hover:opacity-30"
-            style={{ background: color }}
+          <NeuralAvatar
+            agentId={agent.id}
+            size={60}
+            animate={agent.online}
+            signals={s.signals}
+            accuracy={s.accuracy}
+            uniqueness={s.uniqueness}
+            impact={s.impactScore}
           />
-          <div className="relative">
-            <NeuralAvatar
-              agentId={agent.id}
-              size={60}
-              animate={agent.online}
-              signals={s.signals}
-              accuracy={s.accuracy}
-              uniqueness={s.uniqueness}
-              impact={s.impactScore}
-            />
-          </div>
         </div>
 
         {/* Name + meta — full remaining width */}
@@ -90,8 +84,8 @@ export function AgentCardBig({ agent }: AgentCardBigProps) {
         </div>
       </div>
 
-      {/* Metric bars panel — inset/recessed */}
-      <div className="space-y-2 rounded-lg border border-border/40 bg-background/50 px-3.5 py-3 shadow-[inset_0_1px_3px_rgba(0,0,0,0.35)]">
+      {/* Metric bars — neutral inset panel without the extra shadow layer */}
+      <div className="space-y-2 rounded-lg border border-border/30 bg-background/40 px-3.5 py-3">
         <BarRow
           label="accuracy"
           value={s.accuracy}

--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -4,7 +4,7 @@ import { NeuralAvatar } from './NeuralAvatar';
 import { CategoryStrengths } from './CategoryStrengths';
 import { SignalTimeline } from './SignalTimeline';
 import { TaskRow } from './TaskRow';
-import { agentColor, timeAgo, cleanFindingTags } from '@/lib/utils';
+import { timeAgo, cleanFindingTags } from '@/lib/utils';
 import type { AgentData, TasksData, ConsensusData, MemoryData, MemoryFile } from '@/lib/types';
 
 interface AgentPageProps {
@@ -36,7 +36,6 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
   }
 
   const s = agent.scores;
-  const color = agentColor(agent.id);
   const agentTasks = tasks?.items.filter(t => t.agentId === agentId) || [];
   const agentRuns = consensus?.runs.filter(r => r.agents.includes(agentId)) || [];
 
@@ -92,22 +91,20 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
         </div>
       )}
 
-      {/* Header — v3 card style */}
-      <div className="relative mb-6 rounded-xl border border-border bg-gradient-to-br from-card to-card/50 p-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_2px_8px_rgba(0,0,0,0.35)]">
-        <span className="pointer-events-none absolute inset-x-0 top-0 h-px rounded-t-xl bg-gradient-to-r from-transparent via-white/12 to-transparent" />
+      {/* Header — flattened: dropped the gradient layer, inset highlight line,
+          and per-agent halo glow. The glow was hex-derived so the header tone
+          changed per agent in a way that was decorative, not informational. */}
+      <div className="relative mb-6 rounded-xl border border-border bg-card p-5">
         <div className="flex items-center gap-6">
           <div className="relative shrink-0">
-            <div className="absolute -inset-3 rounded-full opacity-[0.18] blur-xl" style={{ background: color }} />
-            <div className="relative">
-              <NeuralAvatar
-                agentId={agent.id}
-                size={120}
-                signals={s.signals}
-                accuracy={s.accuracy}
-                uniqueness={s.uniqueness}
-                impact={s.impactScore}
-              />
-            </div>
+            <NeuralAvatar
+              agentId={agent.id}
+              size={120}
+              signals={s.signals}
+              accuracy={s.accuracy}
+              uniqueness={s.uniqueness}
+              impact={s.impactScore}
+            />
           </div>
           <div className="min-w-0 flex-1">
             <h1 className="truncate font-mono text-2xl font-bold text-foreground">{agent.id}</h1>

--- a/packages/dashboard-v2/src/components/AuthGate.tsx
+++ b/packages/dashboard-v2/src/components/AuthGate.tsx
@@ -1,40 +1,18 @@
-import { useState, useEffect, useRef, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 
 interface AuthGateProps {
   onLogin: (key: string) => void;
   error: boolean;
 }
 
+// The CRT glitch effect used to fire on a random 3-12s interval — but on an
+// idle login screen, surprise flicker reads as "something is broken, can I
+// even trust this?" First-touch users don't know the glitch is intentional.
+// The `crt-logo:hover` rules in globals.css already animate on hover, so the
+// effect survives; we just stop triggering it unprompted.
+
 export function AuthGate({ onLogin, error }: AuthGateProps) {
   const [key, setKey] = useState('');
-  const [glitching, setGlitching] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const mountedRef = useRef(true);
-
-  useEffect(() => {
-    mountedRef.current = true;
-    const schedule = () => {
-      if (!mountedRef.current) return;
-      // Wait 3–12 seconds between random glitch bursts
-      const delay = 3000 + Math.random() * 9000;
-      timerRef.current = setTimeout(() => {
-        if (!mountedRef.current) return;
-        setGlitching(true);
-        // Stay glitched for 150–600ms
-        const duration = 150 + Math.random() * 450;
-        timerRef.current = setTimeout(() => {
-          if (!mountedRef.current) return;
-          setGlitching(false);
-          schedule();
-        }, duration);
-      }, delay);
-    };
-    schedule();
-    return () => {
-      mountedRef.current = false;
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, []);
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -45,7 +23,7 @@ export function AuthGate({ onLogin, error }: AuthGateProps) {
     <div className="min-h-screen flex items-center justify-center bg-background">
       <div className="w-full max-w-sm rounded-xl border border-border bg-card p-8 text-center shadow-2xl">
         {/* Logo with CRT hover effect */}
-        <div className={`crt-logo mx-auto mb-4${glitching ? ' crt-logo--glitch' : ''}`} style={{ width: 'fit-content' }}>
+        <div className="crt-logo mx-auto mb-4" style={{ width: 'fit-content' }}>
           <img
             src="/dashboard/assets/gossip-mini.png"
             alt="gossipcat"

--- a/packages/dashboard-v2/src/components/CategoryStrengths.tsx
+++ b/packages/dashboard-v2/src/components/CategoryStrengths.tsx
@@ -1,3 +1,5 @@
+import { EmptyState } from './EmptyState';
+
 interface CategoryStrengthsProps {
   /** Raw severity-weighted accumulator from performance-reader. Unbounded — used as sort fallback only. */
   strengths: Record<string, number>;
@@ -25,9 +27,11 @@ export function CategoryStrengths({ strengths, accuracy }: CategoryStrengthsProp
 
   if (entries.length === 0) {
     return (
-      <div className="py-4 text-center text-xs text-muted-foreground">
-        No category data yet.
-      </div>
+      <EmptyState
+        title="No category data yet"
+        hint="Category signals accrue after the first consensus round."
+        compact
+      />
     );
   }
 

--- a/packages/dashboard-v2/src/components/EmptyState.tsx
+++ b/packages/dashboard-v2/src/components/EmptyState.tsx
@@ -1,0 +1,28 @@
+/**
+ * Shared empty-state shell. Every panel on the dashboard used to render an
+ * empty state as a single centered muted sentence ("No memories yet."), which
+ * is indistinguishable from "broken" to a first-run user. This component adds
+ * a short next-action hint so empty panels feel intentional rather than
+ * missing data.
+ *
+ * Usage: <EmptyState title="No tasks yet" hint="Dispatch via gossip_run." />
+ */
+interface EmptyStateProps {
+  title: string;
+  hint?: string;
+  /** Override padding if the host panel is already tight. */
+  compact?: boolean;
+}
+
+export function EmptyState({ title, hint, compact = false }: EmptyStateProps) {
+  return (
+    <div className={`text-center ${compact ? 'py-3' : 'py-6'}`}>
+      <div className="font-mono text-xs text-muted-foreground">{title}</div>
+      {hint && (
+        <div className="mt-1 font-mono text-[10px] text-muted-foreground/60">
+          {hint}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import type { ConsensusData, ConsensusReportsData, ConsensusReportFinding, ConsensusReport } from '@/lib/types';
 import { api } from '@/lib/api';
 import { timeAgo, cleanFindingTags, agentInitials, agentColor } from '@/lib/utils';
+import { EmptyState } from './EmptyState';
 
 interface FindingsMetricsProps {
   consensus: ConsensusData;
@@ -387,7 +388,10 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
           )}
         </div>
       ) : runs.length === 0 ? (
-        <div className="py-8 text-center text-sm text-muted-foreground">No consensus runs yet.</div>
+        <EmptyState
+          title="No consensus runs yet"
+          hint="Dispatch a consensus round with gossip_dispatch to populate this view."
+        />
       ) : (
         <div className="space-y-2">
           {runs.map((run, i) => {

--- a/packages/dashboard-v2/src/components/RecentMemories.tsx
+++ b/packages/dashboard-v2/src/components/RecentMemories.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { MemoryFile } from '@/lib/types';
+import { EmptyState } from './EmptyState';
 
 interface RecentMemoriesProps {
   memories: MemoryFile[];
@@ -64,10 +65,15 @@ export function RecentMemories({ memories }: RecentMemoriesProps) {
   return (
     <section className="flex h-full flex-col">
       <h2 className="mb-3 font-mono text-xs font-bold uppercase tracking-widest text-foreground">
-        Recent Memories <span className="text-primary">{unique.length}</span>
+        Recent Memories <span className="text-foreground">{unique.length}</span>
       </h2>
       {display.length === 0 ? (
-        <div className="flex-1 py-6 text-center text-sm text-muted-foreground">No memories yet.</div>
+        <div className="flex-1">
+          <EmptyState
+            title="No memories yet"
+            hint="Memories populate after gossip_session_save() or consensus rounds."
+          />
+        </div>
       ) : (
         <div className="flex-1 rounded-md border border-border/40 bg-card/80">
           {display.map((mem, i) => {

--- a/packages/dashboard-v2/src/components/SignalTimeline.tsx
+++ b/packages/dashboard-v2/src/components/SignalTimeline.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { api } from '@/lib/api';
 import { timeAgo } from '@/lib/utils';
+import { EmptyState } from './EmptyState';
 
 interface SignalEntry {
   signal: string;
@@ -51,8 +52,12 @@ export function SignalTimeline({ agentId }: { agentId: string }) {
 
   if (signals.length === 0) {
     return (
-      <div className="rounded-md border border-border/40 bg-card/80 px-4 py-3 text-center text-xs text-muted-foreground">
-        No signal history yet.
+      <div className="rounded-md border border-border/40 bg-card/80 px-4 py-3">
+        <EmptyState
+          title="No signal history yet"
+          hint="Signals are recorded during consensus rounds."
+          compact
+        />
       </div>
     );
   }
@@ -60,15 +65,35 @@ export function SignalTimeline({ agentId }: { agentId: string }) {
   // Reverse so oldest is left, newest is right
   const ordered = [...signals].reverse();
 
+  // Summary counts row — lets users see the distribution without hovering
+  // every 1.5px bar. Counts are grouped by resolution bucket so the row
+  // mirrors the legend at the bottom.
+  const counts = {
+    confirmed: 0,
+    disputed: 0,
+    unique: 0,
+    unverified: 0,
+  };
+  for (const s of signals) {
+    if (s.signal === 'agreement' || s.signal === 'consensus_verified') counts.confirmed++;
+    else if (s.signal === 'disagreement' || s.signal === 'hallucination_caught') counts.disputed++;
+    else if (s.signal === 'unique_confirmed' || s.signal === 'unique_unconfirmed' || s.signal === 'new_finding') counts.unique++;
+    else if (s.signal === 'unverified') counts.unverified++;
+  }
+
   return (
     <div className="rounded-md border border-border/40 bg-card/80 px-4 py-3">
       <div className="mb-2 flex items-center justify-between">
         <span className="font-mono text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
           Signal Timeline
         </span>
-        <span className="font-mono text-[10px] text-muted-foreground/50">
-          {total} total
-        </span>
+        <div className="flex items-center gap-3 font-mono text-[10px]">
+          <span className="text-confirmed">{counts.confirmed} confirmed</span>
+          {counts.disputed > 0 && <span className="text-disputed">{counts.disputed} disputed</span>}
+          {counts.unique > 0 && <span className="text-unique">{counts.unique} unique</span>}
+          {counts.unverified > 0 && <span className="text-unverified">{counts.unverified} unverified</span>}
+          <span className="text-muted-foreground/50">· {total} total</span>
+        </div>
       </div>
       <div className="flex items-center gap-0.5">
         {ordered.map((s, i) => (

--- a/packages/dashboard-v2/src/components/TasksSection.tsx
+++ b/packages/dashboard-v2/src/components/TasksSection.tsx
@@ -1,5 +1,6 @@
 import type { TasksData } from '@/lib/types';
 import { timeAgo } from '@/lib/utils';
+import { EmptyState } from './EmptyState';
 
 const PAGE_SIZE = 8;
 
@@ -26,17 +27,20 @@ export function TasksSection({ tasks }: TasksSectionProps) {
     <section className="flex h-full flex-col">
       <div className="mb-3 flex items-center justify-between">
         <h2 className="font-mono text-xs font-bold uppercase tracking-widest text-foreground">
-          Tasks <span className="text-primary">{tasks.total}</span>
+          Tasks <span className="text-foreground">{tasks.total}</span>
         </h2>
         {hasMore && (
-          <a href="/dashboard/tasks" className="font-mono text-xs text-muted-foreground transition hover:text-primary">
+          <a href="/dashboard/tasks" className="font-mono text-xs text-muted-foreground transition hover:text-foreground">
             view all
           </a>
         )}
       </div>
       <div className="flex-1 rounded-md border border-border/40 bg-card/80">
         {visible.length === 0 ? (
-          <div className="py-6 text-center text-xs text-muted-foreground">No tasks yet.</div>
+          <EmptyState
+            title="No tasks yet"
+            hint="Dispatch with gossip_run to populate this view."
+          />
         ) : (
           visible.map((task, i) => (
             <div

--- a/packages/dashboard-v2/src/components/TopBar.tsx
+++ b/packages/dashboard-v2/src/components/TopBar.tsx
@@ -51,8 +51,6 @@ export function TopBar() {
         <span className={`inline-block h-1.5 w-1.5 rounded-full ${online ? 'bg-confirmed shadow-[0_0_6px_rgba(52,211,153,0.5)]' : 'bg-destructive'}`} />
         {online ? 'Connected' : 'Disconnected'}
       </div>
-      {/* Violet gradient accent under border */}
-      <span className="pointer-events-none absolute inset-x-0 -bottom-px h-px bg-gradient-to-r from-transparent via-primary/15 to-transparent" />
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
Seven polish items from the UX review round, all deferred from PR #21. Preparing the dashboard for a public share.

### Fixes
1. **AuthGate: drop random CRT glitch timer** — login screen was flickering on a 3–12s random interval. First-touch users read that as "something is broken". Hover-only animation preserved via existing \`.crt-logo:hover\` CSS.
2. **ActiveTasksBanner: confirmed + LIVE vocabulary** — was using unverified-yellow, colliding with actual unverified finding counts. Now matches the SystemPulse/TopBar LIVE dot pattern.
3. **EmptyState helper + 6 empty states** — new shared \`<EmptyState>\` component with title + optional next-action hint. Wired into CategoryStrengths, RecentMemories, TasksSection, FindingsMetrics, SignalTimeline. A first-run dashboard is mostly empty; plain "No X yet." was indistinguishable from broken.
4. **AgentCardBig flatten** — dropped gradient card, inset highlight line, outer shadow, hover ring shadow, and per-agent avatar halo blur. Single card bg + subtle hover lift.
5. **AgentPage header flatten** — same treatment. The per-agent halo was hex-derived so the header tone changed per agent — decorative, not informational.
6. **TopBar: delete violet gradient orphan** — one-line decorative span under the nav border that survived the theme migration. \`border-b\` already separates nav.
7. **SignalTimeline counts summary** — was 100 edge-to-edge 1.5px bars, only hoverable. Now a counts strip above (confirmed/disputed/unique/unverified) makes the panel skimmable without hovering.

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [ ] Open dashboard — confirm login screen is still (no random flicker)
- [ ] Confirm ActiveTasksBanner is green, not yellow
- [ ] Confirm every empty state has a hint line under it
- [ ] Agent team hero grid feels lighter (flattened cards)
- [ ] Agent detail page header has no per-agent color glow
- [ ] SignalTimeline shows counts row above the sparkline

## Deferred (not this PR)
- TeamRoster double-color (only /team drill-down)
- TaskDetailModal focus trap + aria (a11y, separate PR)
- MemoryCard vs RecentMemories taxonomy unification (internal consistency)
- Vortex perf profile at 72→96px bump
- Saturn Ring / Ouroboros clipping past 3500 signals
- Insights gray vs unique purple audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)