### PR TITLE
fix(skill-loop): close the RL loop — name normalization + skill status filter

### DIFF
--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -8,6 +8,7 @@
 import { readFileSync, existsSync, statSync } from 'fs';
 import { join } from 'path';
 import { ConsensusSignal } from './consensus-types';
+import { normalizeSkillName } from './skill-name';
 
 export interface AgentScore {
   agentId: string;
@@ -131,10 +132,11 @@ export class PerformanceReader {
   getCountersSince(agentId: string, category: string, sinceMs: number): CategoryCounters {
     const allSignals = this.readSignalsRaw();
     const counters: CategoryCounters = { correct: 0, hallucinated: 0 };
+    const normalizedTarget = normalizeSkillName(category);
 
     for (const s of allSignals) {
       if (s.agentId !== agentId) continue;
-      if (s.category !== category) continue;
+      if (normalizeSkillName(s.category ?? '') !== normalizedTarget) continue;
       const ts = s.timestamp ? new Date(s.timestamp).getTime() : 0;
       if (!isFinite(ts) || ts === 0 || ts < sinceMs) continue;
 

--- a/packages/orchestrator/src/skill-loader.ts
+++ b/packages/orchestrator/src/skill-loader.ts
@@ -58,6 +58,19 @@ export function loadSkills(agentId: string, skills: string[], projectRoot: strin
     const content = resolveSkill(agentId, skill, projectRoot);
     if (!content) continue;
 
+    // Filter by skill effectiveness status written by checkEffectiveness().
+    // 'failed' and 'silent_skill' are suppressed — injecting a skill the RL loop
+    // has marked as harmful or silent would re-pollute the forward pass.
+    const frontmatterStatus = parseSkillFrontmatter(content)?.status;
+    if (frontmatterStatus === 'failed' || frontmatterStatus === 'silent_skill') {
+      process.stderr.write(`[gossipcat] Skipping ${frontmatterStatus} skill ${agentId}/${skill} from injection\n`);
+      dropped.push(skill);
+      continue;
+    }
+    if (frontmatterStatus === 'flagged_for_manual_review') {
+      process.stderr.write(`[gossipcat] Injecting flagged_for_manual_review skill ${agentId}/${skill} — manual review recommended\n`);
+    }
+
     const mode = index?.getSkillMode(agentId, skill) ?? 'permanent';
 
     if (mode === 'permanent') {

--- a/packages/orchestrator/src/skill-parser.ts
+++ b/packages/orchestrator/src/skill-parser.ts
@@ -1,5 +1,21 @@
 import { normalizeSkillName } from './skill-name';
 
+/** Status values written by the skill lifecycle: both the authoring-time values
+ * ('active', 'draft', 'disabled') and the effectiveness verdict values written
+ * by checkEffectiveness() ('passed', 'failed', 'pending', 'flagged_for_manual_review',
+ * 'silent_skill', 'insufficient_evidence'). Loader filters on these at dispatch time.
+ */
+export type SkillStatus =
+  | 'active'
+  | 'draft'
+  | 'disabled'
+  | 'passed'
+  | 'failed'
+  | 'pending'
+  | 'flagged_for_manual_review'
+  | 'silent_skill'
+  | 'insufficient_evidence';
+
 export interface SkillFrontmatter {
   name: string;
   description: string;
@@ -8,7 +24,7 @@ export interface SkillFrontmatter {
   mode?: 'permanent' | 'contextual';
   generated_by?: string;
   sources?: string;
-  status: 'active' | 'draft' | 'disabled';
+  status: SkillStatus;
 }
 
 export function parseSkillFrontmatter(content: string): SkillFrontmatter | null {
@@ -46,6 +62,6 @@ export function parseSkillFrontmatter(content: string): SkillFrontmatter | null 
     mode: (fields.mode === 'contextual' ? 'contextual' : fields.mode === 'permanent' ? 'permanent' : undefined),
     generated_by: fields.generated_by,
     sources: fields.sources,
-    status: fields.status as 'active' | 'draft' | 'disabled',
+    status: fields.status as SkillStatus,
   };
 }

--- a/tests/orchestrator/performance-reader-normalization.test.ts
+++ b/tests/orchestrator/performance-reader-normalization.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for category name normalization in PerformanceReader.getCountersSince().
+ *
+ * Signals on disk use underscore category names (e.g. `data_integrity`) because
+ * that's how gossip_signals records them. Skill files use hyphenated names
+ * (e.g. `data-integrity.md`) because normalizeSkillName converts underscores to
+ * hyphens. check-effectiveness-runner.ts passes the hyphenated form to
+ * getCountersSince. Without normalization on both sides, the counter always
+ * returns 0 for any multi-word category, so the z-test never fires.
+ */
+import { PerformanceReader } from '../../packages/orchestrator/src/performance-reader';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const TEST_DIR = join(__dirname, '..', '..', '.test-perf-norm');
+
+function writeSignals(signals: object[]): void {
+  mkdirSync(join(TEST_DIR, '.gossip'), { recursive: true });
+  const data = signals.map(s => JSON.stringify(s)).join('\n') + '\n';
+  writeFileSync(join(TEST_DIR, '.gossip', 'agent-performance.jsonl'), data);
+}
+
+beforeEach(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterAll(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+});
+
+const NOW = new Date().toISOString();
+
+describe('getCountersSince — category normalization', () => {
+  it('matches underscore signal category when queried with hyphen form', () => {
+    // Stored with underscore (canonical producer form)
+    writeSignals([
+      { type: 'consensus', signal: 'agreement', agentId: 'agent-1', category: 'data_integrity', taskId: 't1', timestamp: NOW },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'agent-1', category: 'data_integrity', taskId: 't2', timestamp: NOW },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    // Query with hyphen form (as check-effectiveness-runner does)
+    const counters = reader.getCountersSince('agent-1', 'data-integrity', 0);
+    expect(counters).toEqual({ correct: 1, hallucinated: 1 });
+  });
+
+  it('matches hyphen signal category when queried with underscore form', () => {
+    writeSignals([
+      { type: 'consensus', signal: 'unique_confirmed', agentId: 'agent-1', category: 'error-handling', taskId: 't1', timestamp: NOW },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const counters = reader.getCountersSince('agent-1', 'error_handling', 0);
+    expect(counters).toEqual({ correct: 1, hallucinated: 0 });
+  });
+
+  it('normalizes all 9 multi-word categories with underscores', () => {
+    const categories = [
+      'data_integrity',
+      'error_handling',
+      'injection_vectors',
+      'input_validation',
+      'resource_exhaustion',
+      'trust_boundaries',
+      'citation_grounding',
+      'type_safety',
+    ];
+    for (const cat of categories) {
+      if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+      mkdirSync(TEST_DIR, { recursive: true });
+
+      writeSignals([
+        { type: 'consensus', signal: 'agreement', agentId: 'a', category: cat, taskId: 't1', timestamp: NOW },
+      ]);
+      const reader = new PerformanceReader(TEST_DIR);
+      const hyphenForm = cat.replace(/_/g, '-');
+      const counters = reader.getCountersSince('a', hyphenForm, 0);
+      expect(counters.correct).toBe(1);
+      expect(counters.hallucinated).toBe(0);
+    }
+  });
+
+  it('single-word category concurrency matches unchanged', () => {
+    writeSignals([
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'a', category: 'concurrency', taskId: 't1', timestamp: NOW },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const counters = reader.getCountersSince('a', 'concurrency', 0);
+    expect(counters).toEqual({ correct: 0, hallucinated: 1 });
+  });
+
+  it('does not mutate signals on disk — normalization is read-time only', () => {
+    writeSignals([
+      { type: 'consensus', signal: 'agreement', agentId: 'a', category: 'type_safety', taskId: 't1', timestamp: NOW },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    reader.getCountersSince('a', 'type-safety', 0);
+
+    // Re-read raw file and verify original underscore form is preserved
+    const raw = require('fs').readFileSync(join(TEST_DIR, '.gossip', 'agent-performance.jsonl'), 'utf-8');
+    const parsed = JSON.parse(raw.trim());
+    expect(parsed.category).toBe('type_safety');
+  });
+
+  it('empty category in signal does not match non-empty query', () => {
+    writeSignals([
+      { type: 'consensus', signal: 'agreement', agentId: 'a', taskId: 't1', timestamp: NOW },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const counters = reader.getCountersSince('a', 'data-integrity', 0);
+    expect(counters).toEqual({ correct: 0, hallucinated: 0 });
+  });
+});

--- a/tests/orchestrator/skill-loader-status-filter.test.ts
+++ b/tests/orchestrator/skill-loader-status-filter.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for skill effectiveness status filtering in loadSkills().
+ *
+ * checkEffectiveness() writes a `status` field to skill frontmatter
+ * ('passed', 'failed', 'pending', 'silent_skill', etc.). The loader must
+ * filter out 'failed' and 'silent_skill' at dispatch time so the RL loop
+ * reward actually re-enters the forward pass.
+ *
+ * This is "Step 4 of the RL loop": signal → counter → verdict → policy update
+ * on next dispatch. Without this filter, failed skills keep polluting prompts
+ * regardless of their effectiveness verdict.
+ */
+import { loadSkills } from '../../packages/orchestrator/src/skill-loader';
+import { SkillIndex } from '../../packages/orchestrator/src/skill-index';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+function makeSkillFile(status: string, content = 'Secret skill body.'): string {
+  return `---
+name: test-skill
+description: A test skill
+keywords: [auth, injection, security]
+category: trust_boundaries
+mode: permanent
+status: ${status}
+---
+
+${content}
+`;
+}
+
+describe('loadSkills — effectiveness status filtering', () => {
+  let tmpDir: string;
+  let index: SkillIndex;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `gossip-status-filter-${Date.now()}`);
+    mkdirSync(join(tmpDir, '.gossip', 'agents', 'test-agent', 'skills'), { recursive: true });
+    index = new SkillIndex(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeAgentSkill(name: string, status: string, body?: string): void {
+    const skillsDir = join(tmpDir, '.gossip', 'agents', 'test-agent', 'skills');
+    writeFileSync(join(skillsDir, `${name}.md`), makeSkillFile(status, body));
+    index.bind('test-agent', name, { source: 'auto', mode: 'permanent' });
+  }
+
+  it('injects skill with status: passed', () => {
+    writeAgentSkill('passed', 'passed', 'Passed skill body.');
+    const result = loadSkills('test-agent', [], tmpDir, index);
+    expect(result.content).toContain('Passed skill body.');
+    expect(result.loaded).toContain('passed');
+  });
+
+  it('injects skill with status: pending (default — not yet evaluated)', () => {
+    writeAgentSkill('pending', 'pending', 'Pending skill body.');
+    const result = loadSkills('test-agent', [], tmpDir, index);
+    expect(result.content).toContain('Pending skill body.');
+    expect(result.loaded).toContain('pending');
+  });
+
+  it('injects skill with status: insufficient_evidence', () => {
+    writeAgentSkill('insufficient-evidence', 'insufficient_evidence', 'Insufficient skill body.');
+    const result = loadSkills('test-agent', [], tmpDir, index);
+    expect(result.content).toContain('Insufficient skill body.');
+    expect(result.loaded).toContain('insufficient-evidence');
+  });
+
+  it('injects skill with status: flagged_for_manual_review', () => {
+    writeAgentSkill('flagged', 'flagged_for_manual_review', 'Flagged skill body.');
+    const result = loadSkills('test-agent', [], tmpDir, index);
+    expect(result.content).toContain('Flagged skill body.');
+    expect(result.loaded).toContain('flagged');
+  });
+
+  it('FILTERS OUT skill with status: failed', () => {
+    writeAgentSkill('failed', 'failed', 'Failed skill body.');
+    const result = loadSkills('test-agent', [], tmpDir, index);
+    expect(result.content).not.toContain('Failed skill body.');
+    expect(result.loaded).not.toContain('failed');
+    expect(result.dropped).toContain('failed');
+  });
+
+  it('FILTERS OUT skill with status: silent_skill', () => {
+    writeAgentSkill('silent', 'silent_skill', 'Silent skill body.');
+    const result = loadSkills('test-agent', [], tmpDir, index);
+    expect(result.content).not.toContain('Silent skill body.');
+    expect(result.loaded).not.toContain('silent');
+    expect(result.dropped).toContain('silent');
+  });
+
+  it('injects passed + pending, drops failed + silent in same dispatch', () => {
+    writeAgentSkill('good-passed', 'passed', 'GOOD_PASSED_CONTENT');
+    writeAgentSkill('good-pending', 'pending', 'GOOD_PENDING_CONTENT');
+    writeAgentSkill('bad-failed', 'failed', 'BAD_FAILED_CONTENT');
+    writeAgentSkill('bad-silent', 'silent_skill', 'BAD_SILENT_CONTENT');
+
+    const result = loadSkills('test-agent', [], tmpDir, index);
+
+    expect(result.content).toContain('GOOD_PASSED_CONTENT');
+    expect(result.content).toContain('GOOD_PENDING_CONTENT');
+    expect(result.content).not.toContain('BAD_FAILED_CONTENT');
+    expect(result.content).not.toContain('BAD_SILENT_CONTENT');
+
+    expect(result.loaded).toContain('good-passed');
+    expect(result.loaded).toContain('good-pending');
+    expect(result.loaded).not.toContain('bad-failed');
+    expect(result.loaded).not.toContain('bad-silent');
+
+    expect(result.dropped).toContain('bad-failed');
+    expect(result.dropped).toContain('bad-silent');
+  });
+
+  it('includes insufficient_evidence and flagged_for_manual_review in dispatch', () => {
+    writeAgentSkill('insuf', 'insufficient_evidence', 'INSUF_CONTENT');
+    writeAgentSkill('flagged2', 'flagged_for_manual_review', 'FLAGGED_CONTENT');
+
+    const result = loadSkills('test-agent', [], tmpDir, index);
+
+    expect(result.content).toContain('INSUF_CONTENT');
+    expect(result.content).toContain('FLAGGED_CONTENT');
+    expect(result.loaded).toContain('insuf');
+    expect(result.loaded).toContain('flagged2');
+  });
+
+  it('falls back to inject when status is unknown/missing (backwards compat)', () => {
+    // A skill file with no status field should still be parsed and injected
+    const skillsDir = join(tmpDir, '.gossip', 'agents', 'test-agent', 'skills');
+    writeFileSync(join(skillsDir, 'no-status.md'), `---
+name: no-status
+description: A skill without status
+keywords: [auth]
+mode: permanent
+---
+
+NO_STATUS_CONTENT
+`);
+    index.bind('test-agent', 'no-status', { source: 'auto', mode: 'permanent' });
+    const result = loadSkills('test-agent', [], tmpDir, index);
+    // parseSkillFrontmatter returns null when required fields (status) are missing.
+    // Null frontmatter → no status → inject (backwards compat).
+    expect(result.content).toContain('NO_STATUS_CONTENT');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the skill-learning reward loop by shipping two serial fixes in one commit. Both were caught in a consensus review session earlier today by `sonnet-reviewer` and `opus-implementer` (cross-referencing each other's findings against the actual source). A third reviewer hallucinated a fabricated root cause and was auto-penalized by the signal pipeline.

### Fix #1 — Category name normalization in `getCountersSince` (~10 LOC)

`packages/orchestrator/src/performance-reader.ts`

- `.gossip/agent-performance.jsonl` stores signals with **underscore**-separated categories (`data_integrity`, `error_handling`, `injection_vectors`, etc.)
- Skill files on disk use **hyphen**-separated names via `normalizeSkillName` (`data-integrity.md`, etc.)
- `check-effectiveness-runner.ts:38` derives category from filename and passes hyphen-form to `getCountersSince`, which did exact-match `s.category !== category`
- Result: for **9 of 10 categories** (all except `concurrency`, which is single-word), the counter always returned 0 regardless of actual signal volume. The z-test never fired. Verdicts stayed `pending` forever, timing out into `silent_skill` after 90 days.
- Fix: normalize both sides of the comparison via `normalizeSkillName`. Defensive at read time so any future producer form still matches.

### Fix #2 — Wire skill status → dispatch injection (~18 LOC)

`packages/orchestrator/src/skill-loader.ts`, `packages/orchestrator/src/skill-parser.ts`

- `snapshot.status` (`passed`/`failed`/`flagged_for_manual_review`/`pending`/`silent_skill`/`insufficient_evidence`) was written to skill frontmatter but **nothing in the dispatch path read it back**. Grep for `snapshot.status === 'passed'` / `'failed'` across the codebase returned only self-reads inside `check-effectiveness.ts`.
- The reward signal never re-entered the forward pass. "Skill learning" was cosmetically closed but structurally open — writing verdicts is easy, reading them back in the next dispatch is where most agent systems quietly stay open.
- Fix: in `loadSkills()`, after reading each skill file, parse the frontmatter `status` via the existing `parseSkillFrontmatter`. Filter rules:
  - `failed` → skip injection entirely, log to stderr
  - `silent_skill` → skip injection entirely, log to stderr
  - `flagged_for_manual_review` → inject with warning log
  - `passed` / `pending` / `insufficient_evidence` / missing → inject normally
- Read-only filter, no frontmatter mutation, no file deletion. Operators can still inspect failed skills.

### Tests

- New: `tests/orchestrator/performance-reader-normalization.test.ts` (6 tests) — covers all round-trip cases between hyphen and underscore forms
- New: `tests/orchestrator/skill-loader-status-filter.test.ts` (8 tests) — covers all `SkillStatus` values, verifies `failed`/`silent_skill` are filtered and everything else passes through
- **133/133 tests pass** across 13 suites (`jest tests/orchestrator/performance-reader tests/orchestrator/skill-engine tests/orchestrator/check-effectiveness tests/orchestrator/skill-loader`)
- `tsc --noEmit` clean on `apps/cli` and `packages/orchestrator`

### Why this matters

With these two fixes, the full loop is now structurally closed:

```
signal → counter → verdict → policy update on next dispatch
```

Before: counters never moved for multi-word categories AND verdicts were never read back. Writing a skill file had no causal effect on future agent behavior.

After: counters accumulate correctly, verdicts flip `pending → passed/failed` once `MIN_EVIDENCE=120` is reached, and `failed` skills stop being injected — which is the minimal wiring needed for the "agents learn from their own failure history" claim to be true in code rather than aspirational.

### Non-goals

- Not touching `check-effectiveness.ts` (verdict logic is correct)
- Not touching `MIN_EVIDENCE=120` (intentional statistical gate per consensus `9369ebfc-a3654b51 f5`)
- Not deleting failed skill files — read-only filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)