### PR TITLE
cli(session_save): refuse-gate for pending native tasks and consensus rounds

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2516,9 +2516,10 @@ server.tool(
   'Save a cognitive session summary to project memory. The next session will load this context automatically on MCP connect. Call before ending your session to preserve what was learned.',
   {
     notes: z.string().optional().describe('Optional freeform user context (e.g., "focusing on security hardening")'),
+    force: z.boolean().optional().describe('Bypass the refuse-gate for pending native tasks / consensus rounds. Audited to .gossip/forced-saves.jsonl.'),
     _utility_task_id: z.string().optional().describe('Internal: utility task ID for re-entry after native session summary'),
   },
-  async ({ notes, _utility_task_id }) => {
+  async ({ notes, force, _utility_task_id }) => {
     await boot();
 
     // Re-entry fast path: retrieve stashed data, skip re-gathering
@@ -2609,6 +2610,51 @@ server.tool(
       } catch { /* best-effort */ }
 
       return { content: [{ type: 'text' as const, text: `Session saved.\n\n${summary}` }] };
+    }
+
+    // Refuse-gate: block session_save while native tasks or consensus rounds are still in flight.
+    // Saving now would freeze a snapshot that omits results still landing, and next-session.md would
+    // misrepresent what shipped. `force: true` bypasses and is audited to .gossip/forced-saves.jsonl.
+    {
+      const pendingNative: string[] = [];
+      for (const [taskId, info] of ctx.nativeTaskMap) {
+        if (!ctx.nativeResultMap.has(taskId)) pendingNative.push(`${taskId} (${info.agentId})`);
+      }
+      const pendingConsensus: string[] = [];
+      const now = Date.now();
+      for (const [cid, round] of ctx.pendingConsensusRounds) {
+        // Skip rounds past their deadline — timer was lost or never fired (e.g. restart without
+        // re-arm). Without this, a stale round permanently blocks session_save.
+        if (round.deadline && now > round.deadline) continue;
+        if (round.pendingNativeAgents && round.pendingNativeAgents.size > 0) {
+          pendingConsensus.push(`${cid} (${round.pendingNativeAgents.size} agents)`);
+        }
+      }
+      if ((pendingNative.length > 0 || pendingConsensus.length > 0) && !force) {
+        const lines: string[] = ['⛔ session_save refused — work still in flight.\n'];
+        if (pendingNative.length > 0) {
+          lines.push(`Pending native tasks (${pendingNative.length}):`);
+          for (const t of pendingNative.slice(0, 10)) lines.push(`  - ${t}`);
+          lines.push('');
+        }
+        if (pendingConsensus.length > 0) {
+          lines.push(`Pending consensus rounds (${pendingConsensus.length}):`);
+          for (const c of pendingConsensus.slice(0, 10)) lines.push(`  - ${c}`);
+          lines.push('');
+        }
+        lines.push('Relay the results via gossip_relay / gossip_relay_cross_review, then re-call gossip_session_save.');
+        lines.push('To override (snapshot is intentional / tasks are abandoned): gossip_session_save(force: true).');
+        return { content: [{ type: 'text' as const, text: lines.join('\n') }], isError: true };
+      }
+      if (force && (pendingNative.length > 0 || pendingConsensus.length > 0)) {
+        try {
+          const { appendFileSync: af, mkdirSync: md } = require('fs');
+          const { join: j } = require('path');
+          md(j(process.cwd(), '.gossip'), { recursive: true });
+          af(j(process.cwd(), '.gossip', 'forced-saves.jsonl'),
+            JSON.stringify({ at: new Date().toISOString(), pendingNative, pendingConsensus, notes: notes || null }) + '\n');
+        } catch { /* best-effort audit */ }
+      }
     }
 
     // 1. Gather session gossip from disk (crash-safe)


### PR DESCRIPTION
## Summary

Blocks \`gossip_session_save\` from running while native tasks or consensus rounds are still in flight. Saving mid-flight freezes \`next-session.md\` in a state that omits results still landing — which is how backlog memories decay. Gate-before-work keeps the save atomic relative to in-flight work.

### Mechanism

In \`apps/cli/src/mcp-server-sdk.ts\`, added a pre-flight check at the top of \`gossip_session_save\` (after the \`_utility_task_id\` re-entry fast path so re-entries are never re-gated):

1. Walk \`ctx.nativeTaskMap\` — any task ID without a corresponding \`ctx.nativeResultMap\` entry is counted as pending.
2. Walk \`ctx.pendingConsensusRounds\` — any round where \`round.pendingNativeAgents.size > 0\` **and** \`Date.now() <= round.deadline\` is counted as pending.
3. If anything is pending and \`force: true\` was not passed, return \`isError: true\` with a human-readable blocker list and the exact relay instructions to unblock (via \`gossip_relay\` or \`gossip_relay_cross_review\`).
4. If \`force: true\` is passed with pending work, append an audit entry to \`.gossip/forced-saves.jsonl\` with the timestamp, pending items, and notes — the snapshot is never silently wrong.

### The deadline check on consensus rounds

The first version of this gate had a subtle bug caught in the review session: \`pendingConsensusRounds\` has no TTL eviction separate from \`nativeTaskMap\`. A round where \`startConsensusTimeout\` was lost (e.g. process restart without \`persistPendingConsensus\` re-arm) could linger with \`pendingNativeAgents.size > 0\` forever, permanently blocking \`session_save\` without \`force: true\`. \`PendingConsensusRound.deadline\` already exists at \`mcp-context.ts:22\` — this PR uses it to skip stale rounds in the gate loop.

### \`force: true\` semantics

- Bypasses the gate and proceeds with \`session_save\`.
- Writes an audit entry to \`.gossip/forced-saves.jsonl\` with the list of pending items at override time — operators can always trace back what the snapshot was missing.
- No audit entry when nothing was pending (force-save with clean state is indistinguishable from a normal save).

### Non-goals

- Not signal-gating (separate concern — session_save does not need signal freshness to be safe)
- Not touching the re-entry fast path, which correctly runs before the gate so utility re-entries stay exempt
- Not adding \`pendingRelayAgents\` — relay cross-reviews are awaited synchronously before \`pendingConsensusRounds.set()\` per the design in \`collect.ts\`, so the native-only scope is correct

### Verification

- \`tsc --noEmit\` clean on \`apps/cli\`
- Reviewed in a 2-agent consensus round (sonnet-reviewer + orchestrator direct verification); deadline-check bug was caught and fixed before this PR was cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)