### PR TITLE
test(performance-reader): bump sample sizes to meet MIN_CATEGORY_N=5 gate

### DIFF
--- a/tests/orchestrator/performance-reader-category-accuracy.test.ts
+++ b/tests/orchestrator/performance-reader-category-accuracy.test.ts
@@ -14,16 +14,22 @@ function makeSignal(over: Partial<ConsensusSignal>): ConsensusSignal {
 }
 
 describe('PerformanceReader — per-category accuracy', () => {
+  // Sample sizes here are ≥ MIN_CATEGORY_N (5) so that categoryAccuracy is
+  // populated — below the gate, per-category accuracy is intentionally left
+  // undefined to avoid skew on sparse data (see performance-reader.ts).
+
   it('counts agreement signals as categoryCorrect', () => {
     const reader = new PerformanceReader('');
     const signals = [
       makeSignal({ signal: 'agreement', category: 'injection_vectors', taskId: 't1' }),
       makeSignal({ signal: 'agreement', category: 'injection_vectors', taskId: 't2' }),
       makeSignal({ signal: 'agreement', category: 'injection_vectors', taskId: 't3' }),
+      makeSignal({ signal: 'agreement', category: 'injection_vectors', taskId: 't4' }),
+      makeSignal({ signal: 'agreement', category: 'injection_vectors', taskId: 't5' }),
     ];
     const scores = (reader as any).computeScores(signals);
     const score = scores.get('agent-x');
-    expect(score.categoryCorrect.injection_vectors).toBe(3);
+    expect(score.categoryCorrect.injection_vectors).toBe(5);
     expect(score.categoryHallucinated.injection_vectors ?? 0).toBe(0);
     expect(score.categoryAccuracy.injection_vectors).toBe(1.0);
   });
@@ -32,14 +38,17 @@ describe('PerformanceReader — per-category accuracy', () => {
     const reader = new PerformanceReader('');
     const signals = [
       makeSignal({ signal: 'agreement', category: 'concurrency', taskId: 't1' }),
-      makeSignal({ signal: 'hallucination_caught', category: 'concurrency', taskId: 't2' }),
-      makeSignal({ signal: 'disagreement', category: 'concurrency', taskId: 't3' }),
+      makeSignal({ signal: 'agreement', category: 'concurrency', taskId: 't2' }),
+      makeSignal({ signal: 'hallucination_caught', category: 'concurrency', taskId: 't3' }),
+      makeSignal({ signal: 'hallucination_caught', category: 'concurrency', taskId: 't4' }),
+      makeSignal({ signal: 'disagreement', category: 'concurrency', taskId: 't5' }),
+      makeSignal({ signal: 'disagreement', category: 'concurrency', taskId: 't6' }),
     ];
     const scores = (reader as any).computeScores(signals);
     const score = scores.get('agent-x');
-    expect(score.categoryCorrect.concurrency).toBe(1);
-    expect(score.categoryHallucinated.concurrency).toBe(2);
-    expect(score.categoryAccuracy.concurrency).toBeCloseTo(1 / 3, 4);
+    expect(score.categoryCorrect.concurrency).toBe(2);
+    expect(score.categoryHallucinated.concurrency).toBe(4);
+    expect(score.categoryAccuracy.concurrency).toBeCloseTo(2 / 6, 4);
   });
 
   it('excludes signals without a category from per-category counters', () => {
@@ -60,14 +69,17 @@ describe('PerformanceReader — per-category accuracy', () => {
       makeSignal({ signal: 'agreement', category: 'concurrency', taskId: 't1' }),
       makeSignal({ signal: 'agreement', category: 'concurrency', taskId: 't2' }),
       makeSignal({ signal: 'agreement', category: 'concurrency', taskId: 't3' }),
+      makeSignal({ signal: 'agreement', category: 'concurrency', taskId: 't4' }),
+      makeSignal({ signal: 'agreement', category: 'concurrency', taskId: 't5' }),
       makeSignal({ signal: 'signal_retracted', category: 'concurrency', taskId: 't1' }), // retracts t1
-      makeSignal({ signal: 'hallucination_caught', category: 'concurrency', taskId: 't4' }),
+      makeSignal({ signal: 'hallucination_caught', category: 'concurrency', taskId: 't6' }),
+      makeSignal({ signal: 'hallucination_caught', category: 'concurrency', taskId: 't7' }),
     ];
     const scores = (reader as any).computeScores(signals);
     const score = scores.get('agent-x');
-    // After retraction of t1: 2 correct (t2, t3), 1 hallucinated (t4)
-    expect(score.categoryCorrect.concurrency).toBe(2);
-    expect(score.categoryHallucinated.concurrency).toBe(1);
-    expect(score.categoryAccuracy.concurrency).toBeCloseTo(2 / 3, 4);
+    // After retraction of t1: 4 correct (t2..t5), 2 hallucinated (t6, t7). Total 6 ≥ MIN_CATEGORY_N.
+    expect(score.categoryCorrect.concurrency).toBe(4);
+    expect(score.categoryHallucinated.concurrency).toBe(2);
+    expect(score.categoryAccuracy.concurrency).toBeCloseTo(4 / 6, 4);
   });
 });


### PR DESCRIPTION
## Summary

Hotfix after the 4-PR merge sequence landed earlier today. PR #26 (dashboard signal parity) introduced \`MIN_CATEGORY_N=5\` in \`performance-reader.ts\` as a production-sensible gate to prevent sparse per-category counts from skewing \`categoryStrengths\` at the dashboard layer. Three existing tests in \`tests/orchestrator/performance-reader-category-accuracy.test.ts\` were written with N=3-4 signals and asserted on \`categoryAccuracy.<category>\` — which now returns \`undefined\` for sub-threshold categories.

**The gate is working as designed.** This is a test-data-vs-threshold drift, not a regression in the gate.

Each PR in the merge sequence passed its own test subset in isolation (I verified each branch locally before opening PRs), but no single PR ran this specific test file, so the drift surfaced only after all four landed on master together.

### What the tests are asserting

The three failing tests each verify a different aspect of per-category accuracy accumulation:

1. \`counts agreement signals as categoryCorrect\` — pure-positive case, all \`agreement\` signals
2. \`counts hallucination_caught and disagreement as categoryHallucinated\` — mixed signal types
3. \`Test 3 — excludes retracted signals from per-category counters\` — verifies the retract path correctly removes a signal from the counter

### Fix

Bump each test's sample size to ≥ \`MIN_CATEGORY_N\` while **preserving the accuracy ratios** the tests were communicating:

| Test | Before (N) | After (N) | Ratio preserved |
|---|---|---|---|
| injection_vectors all-agreements | 3 | 5 | 1.0 |
| concurrency mixed | 3 (1/3) | 6 (2/6) | 1/3 |
| concurrency with retraction | 5 eff. 4 | 8 eff. 6 | 2/3 → 4/6 |

Also added a leading comment block explaining the coupling so future edits to either the gate or the test data don't recreate the same drift.

### Verification

- \`jest tests/orchestrator/performance-reader tests/orchestrator/skill-engine tests/orchestrator/check-effectiveness tests/orchestrator/skill-loader\` — **133/133 pass** across 13 suites
- \`tsc --noEmit\` unchanged (test-only edit)
- No production code touched; the gate in \`performance-reader.ts\` stays exactly as landed in PR #26

### Process note

This is the kind of multi-PR test drift that a CI pipeline would have caught immediately. Worth adding a minimal GitHub Actions workflow (\`jest\`, \`tsc --noEmit\`) as a follow-up so the repo has automated coverage before the Reddit post drives contributors who open their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)