### PR TITLE
feat(gossip_guide): human-facing handbook reader tool

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1321,6 +1321,60 @@ server.tool(
   }
 );
 
+// ── Tool: guide — human-facing handbook reader ──────────────────────────
+// This is the human-visible counterpart to the LLM-facing handbook auto-load
+// in gossip_status(). Users call this explicitly when they want to READ the
+// handbook; gossip_status injects it invisibly for orchestrator context.
+// Different audiences, different delivery mechanisms — same source artifact.
+server.tool(
+  'gossip_guide',
+  'Show the gossipcat handbook for humans — architectural invariants, operator playbook, caveats, hallucination patterns, glossary. Call this when you want to READ the docs, not when you need LLM context. The LLM-facing auto-load lives in gossip_status().',
+  {},
+  async () => {
+    try {
+      const { readFileSync: rfG, existsSync: exG } = require('fs');
+      const { join: jG, dirname: dG } = require('path');
+      // Prefer the current project's customized handbook
+      const projectHandbook = jG(process.cwd(), 'docs', 'HANDBOOK.md');
+      if (exG(projectHandbook)) {
+        const body = rfG(projectHandbook, 'utf-8');
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `# Gossipcat Handbook (from ${projectHandbook})\n\n${body}`,
+          }],
+        };
+      }
+      // Fallback to the bundled default handbook shipped with gossipcat
+      // (resolved relative to the running MCP bundle)
+      const bundleRoot = dG(require.resolve('../../dist-mcp/mcp-server.js').replace(/\/dist-mcp\/mcp-server\.js$/, '/dist-mcp/mcp-server.js'));
+      const defaultHandbook = jG(bundleRoot, '..', 'docs', 'HANDBOOK.md');
+      if (exG(defaultHandbook)) {
+        const body = rfG(defaultHandbook, 'utf-8');
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `# Gossipcat Handbook (bundled default — your project has no docs/HANDBOOK.md yet)\n\n${body}`,
+          }],
+        };
+      }
+      return {
+        content: [{
+          type: 'text' as const,
+          text: 'No handbook found. Expected at docs/HANDBOOK.md in the current project or bundled with gossipcat. If you are inside a gossipcat project, run `gossip_setup` first.',
+        }],
+      };
+    } catch (err) {
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `Error reading handbook: ${(err as Error).message}`,
+        }],
+      };
+    }
+  }
+);
+
 // ── Tool: update — check or apply gossipcat updates ──────────────────────
 server.tool(
   'gossip_update',
@@ -3162,6 +3216,7 @@ server.tool(
       { name: 'gossip_remember', desc: 'Search an agent\'s archived knowledge files by keyword query.' },
       { name: 'gossip_verify_memory', desc: 'On-demand staleness check for a memory file claim. Returns FRESH | STALE | CONTRADICTED | INCONCLUSIVE with file:line evidence.' },
       { name: 'gossip_tools', desc: 'List available tools (this command).' },
+      { name: 'gossip_guide', desc: 'Show the gossipcat handbook for humans — invariants, operator playbook, caveats, hallucination patterns, glossary. Read the docs, not LLM context.' },
       { name: 'gossip_progress', desc: 'Show active task progress and consensus phase. No params.' },
       { name: 'gossip_format', desc: 'Return the CONSENSUS_OUTPUT_FORMAT block to paste into ad-hoc Agent() prompts so native subagents emit parseable <agent_finding> tags.' },
       { name: 'gossip_bug_feedback', desc: 'File a GitHub issue on the gossipcat repo from an in-session bug report. Dedupes against open issues.' },


### PR DESCRIPTION
## Summary

Adds \`gossip_guide\` — a human-visible MCP tool that returns \`docs/HANDBOOK.md\` as a readable text response. Complements PR #29's LLM-facing auto-load without replacing it.

### Two audiences, two delivery mechanisms

| Audience | Mechanism | Visibility | Truncation | Called when |
|---|---|---|---|---|
| Orchestrator LLM | \`gossip_status()\` auto-inject | Invisible to user (correct) | 24KB cap | Every session start |
| **Human user** | **\`gossip_guide()\` tool call** | **Visible tool response** | **No cap** | **On demand** |

Before this PR, a human who wanted to read the handbook had to either open \`docs/HANDBOOK.md\` in their editor or scroll through a collapsed \`gossip_status\` tool result (Claude Code collapses ~13KB tool outputs by default). Neither is discoverable for a new user.

### What the tool does

- Reads \`docs/HANDBOOK.md\` from \`process.cwd()\`
- If the project has no customized handbook yet, falls back to the bundled default (shipped with gossipcat at \`dist-mcp/docs/HANDBOOK.md\` or equivalent resolution)
- Returns the full handbook as a single text content item — no cap, because the user is consciously asking to read it
- Tool description explicitly marked "for humans": *"Show the gossipcat handbook for humans — invariants, operator playbook, caveats, hallucination patterns, glossary. Read the docs, not LLM context."*

### Why a separate tool instead of reusing gossip_status

- **Tool names become search affordances.** A user typing \`gossip_\` in Claude Code's tool picker sees \`gossip_guide\` and immediately knows "that's where the docs live."
- **\`gossip_status\` is called every session start.** Users also calling it for docs would mean getting the entire orchestrator bootstrap every time they wanted to read the glossary — wasteful and confusing.
- **Different truncation policies.** \`gossip_status\` caps at 24KB for context-window hygiene; \`gossip_guide\` returns the whole file.
- **Zero dependency coupling.** They can diverge later without risk.

### Registered in gossip_tools

The tool is added to the \`gossip_tools\` registry so it's discoverable via "list tools" browsing, sitting next to \`gossip_tools\` itself.

### Implementation

Single file edit in \`apps/cli/src/mcp-server-sdk.ts\` — 55 LOC added, no subtractions. Follows the same tool-registration pattern as the rest of the MCP handlers. Typecheck clean.

### Non-goals

- Not replacing the \`gossip_status\` auto-load — both coexist intentionally
- Not rendering markdown — clients can render if they want, the tool returns raw markdown text
- Not watching the file — one read per call, no caching, no staleness concerns

### Follow-ups worth considering (not in this PR)

- \`gossip_tools\` currently lists tool names only. Could be extended to show a one-line purpose for each so users browsing can tell tools apart at a glance. (Actually, that happens to be what it already does — just noting it for future attention.)
- README should point at \`gossip_guide\` as the "type this to learn how to use gossipcat" entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)