### PR TITLE
ci: build workspace packages before typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Build workspace packages first so downstream typecheck / test / bundle
+      # steps can resolve @gossip/* imports against compiled dist/ output.
+      # Locally this works because prior builds leave dist/ around; on a cold
+      # CI runner we must build explicitly.
+      - name: Build workspace packages
+        run: npm run build --workspaces --if-present
+
       - name: Typecheck — apps/cli
         run: npx tsc --noEmit
         working-directory: apps/cli


### PR DESCRIPTION
## Summary

Hotfix for PR #31. The first CI run failed because \`apps/cli\`'s \`tsc --noEmit\` could not resolve \`@gossip/orchestrator\` imports — workspace packages need to be built first so their \`dist/\` output exists for downstream consumers.

## What happened

Locally, workspace typechecks "just work" because prior builds leave \`packages/*/dist/\` directories around. On a cold CI runner with only \`npm ci\`, those \`dist/\` directories don't exist, so TypeScript can't resolve the \`@gossip/orchestrator\` package specifier.

First run logs showed 40+ errors of the form:
\`\`\`
error TS2307: Cannot find module '@gossip/orchestrator' or its corresponding type declarations.
\`\`\`

cascading into downstream:
\`\`\`
error TS18046: 's' is of type 'unknown'.
\`\`\`

— TypeScript loses type information for anything imported from the unresolved module, so \`Map.get()\` results become \`unknown\` and every \`.foo\` access fails. Single root cause, 40+ symptoms.

## Fix

Add an explicit build step between \`npm ci\` and the typecheck steps:

\`\`\`yaml
- name: Build workspace packages
  run: npm run build --workspaces --if-present
\`\`\`

- \`--workspaces\` runs \`build\` in each workspace
- \`--if-present\` skips workspaces without a \`build\` script so this doesn't fail on packages that don't need compilation (e.g. \`apps/cli\` itself, which uses \`ts-node\` at runtime)
- Runs before typecheck, test, and \`build:mcp\` so all three get compiled \`dist/\` to work against

## Verification

Once merged, the post-merge CI run on master will be the source of truth. Locally this change is just a YAML edit — the workflow can only be validated by actually running.

## Meta

This is **exactly** the class of issue CI exists to catch. The irony is that CI itself tripped on it first — which is fine, this is the expected first-landing shakedown. One more iteration to get the workflow green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)