### PR TITLE
ci: build workspace packages in explicit topological order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Build workspace packages first so downstream typecheck / test / bundle
-      # steps can resolve @gossip/* imports against compiled dist/ output.
-      # Locally this works because prior builds leave dist/ around; on a cold
-      # CI runner we must build explicitly.
-      - name: Build workspace packages
-        run: npm run build --workspaces --if-present
+      # Build workspace packages in topological order so downstream
+      # typecheck / test / bundle steps can resolve @gossip/* imports
+      # against compiled dist/ output. `npm run build --workspaces` does
+      # NOT respect dep order — it walks the workspaces array as-listed,
+      # which produces build failures when a consumer builds before its
+      # dependency. Explicit order is the simplest correct fix.
+      #
+      # Topology (see each package.json @gossip/* deps):
+      #   types  →  client  →  tools  →  orchestrator  →  relay  →  cli
+      - name: Build @gossip/types
+        run: npm run build -w @gossip/types
+      - name: Build @gossip/client
+        run: npm run build -w @gossip/client
+      - name: Build @gossip/tools
+        run: npm run build -w @gossip/tools
+      - name: Build @gossip/orchestrator
+        run: npm run build -w @gossip/orchestrator
+      - name: Build @gossip/relay
+        run: npm run build -w @gossip/relay
 
       - name: Typecheck — apps/cli
         run: npx tsc --noEmit


### PR DESCRIPTION
## Summary

Second hotfix for the CI workflow. \`npm run build --workspaces\` (added in PR #32) does NOT respect topological order — it walks the workspaces array in \`package.json\` as-listed, which produces build failures whenever a consumer builds before its dependency.

## What the second CI run showed

\`\`\`
@gossip/relay  → failed (needs @gossip/orchestrator not yet built)
@gossip/tools  → failed (needs @gossip/types not yet built)
@gossip/types  → built OK (ran last, after its consumers already failed)
@gossip/cli    → failed downstream
\`\`\`

## Fix

Replace the single \`--workspaces\` call with explicit per-package build steps in topological order derived from each package's \`@gossip/*\` dependencies:

\`\`\`
types → client → tools → orchestrator → relay
\`\`\`

(\`apps/cli\` is an app, not a library, and is built separately by \`build:mcp\` further down the pipeline.)

Each package as its own GHA step so failure output points at the exact package that broke — if future dependency drift introduces a cycle or a new out-of-order dep, the CI logs will name the culprit immediately.

## Alternatives considered

- **Turborepo / Nx** — overkill for 6 packages, introduces new tooling and config
- **Topological sort via script** — reinvents what turbo does; YAGNI
- **Reorder \`package.json\` workspaces array** — fragile, silently breaks if future packages are added out of order; also doesn't actually fix the root issue (npm doesn't guarantee order even for listed workspaces)

Explicit steps are verbose but obviously correct and trivially debuggable in CI logs.

## Meta

Two iterations to get CI green on first-land. That's about normal for a greenfield workflow — the local-works-because-dist-exists assumption is a common gotcha in monorepos. Next iteration should actually pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)