### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gossipcat",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gossipcat",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossipcat",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
   "license": "MIT",
   "main": "dist-mcp/mcp-server.js",


### PR DESCRIPTION
Version bump for v0.2.0. After merging this PR, run `./scripts/release.sh` (no args) from master to build, tag, and publish the GitHub release.