### PR TITLE
fix: allowlist .claude/worktrees/ and settings.local.json in boundary escape detector

### DIFF
--- a/apps/cli/src/sandbox.ts
+++ b/apps/cli/src/sandbox.ts
@@ -35,6 +35,20 @@ export interface DispatchMetadata {
 const METADATA_FILE = 'dispatch-metadata.jsonl';
 const BOUNDARY_ESCAPE_FILE = 'boundary-escapes.jsonl';
 
+// Paths that agents legitimately write outside their declared boundary.
+// These are infrastructure artifacts, not application code — false-positive
+// disagreements from these paths penalize agents unfairly.
+// Prefix-matched against relative paths from projectRoot.
+const BOUNDARY_ALLOWLIST = [
+  '.claude/worktrees/',       // worktree agents: git worktree config lives in main repo
+  '.claude/settings.local.json', // scoped/worktree agents: permission adjustments
+];
+
+function isBoundaryAllowed(filePath: string): boolean {
+  const f = filePath.replace(/^\.\//, '');
+  return BOUNDARY_ALLOWLIST.some(prefix => f === prefix || f.startsWith(prefix));
+}
+
 // System directories that should NEVER be rewritten, even if nested under
 // something that looks like a project path. The check is prefix-based on the
 // canonical absolute path.
@@ -245,13 +259,14 @@ export function detectBoundaryEscapes(
   if (mode === 'scoped') {
     const scope = normalizeScope(meta.scope || '', projectRoot);
     if (!scope) return []; // no scope declared → cannot evaluate
-    return modifiedFiles.filter(f => !isInsideScope(f, scope));
+    return modifiedFiles.filter(f => !isInsideScope(f, scope) && !isBoundaryAllowed(f));
   }
 
   if (mode === 'worktree') {
     // Main repo should have NO modifications — all writes should have gone to
-    // the isolated worktree. Every modified file in the main repo is a violation.
-    return [...modifiedFiles];
+    // the isolated worktree. Every modified file in the main repo is a violation,
+    // EXCEPT infrastructure paths that legitimately live in the main repo.
+    return modifiedFiles.filter(f => !isBoundaryAllowed(f));
   }
 
   return [];
@@ -356,5 +371,7 @@ function recordBoundaryEscape(
 export const __test__ = {
   normalizeScope,
   isSystemPath,
+  isBoundaryAllowed,
   SYSTEM_PREFIXES,
+  BOUNDARY_ALLOWLIST,
 };

--- a/tests/cli/sandbox.test.ts
+++ b/tests/cli/sandbox.test.ts
@@ -210,6 +210,42 @@ describe('detectBoundaryEscapes', () => {
     );
     expect(v).toEqual([]);
   });
+
+  it('worktree mode: allowlists .claude/worktrees/ paths', () => {
+    const v = detectBoundaryEscapes(
+      baseMeta({ writeMode: 'worktree', scope: undefined }),
+      ['.claude/worktrees/some-branch/HEAD', 'apps/cli/src/leaked.ts'],
+      root,
+    );
+    expect(v).toEqual(['apps/cli/src/leaked.ts']);
+  });
+
+  it('scoped mode: allowlists .claude/settings.local.json', () => {
+    const v = detectBoundaryEscapes(
+      baseMeta(),
+      ['apps/cli/src/ok.ts', '.claude/settings.local.json'],
+      root,
+    );
+    expect(v).toEqual([]);
+  });
+
+  it('scoped mode: allowlists .claude/worktrees/ paths', () => {
+    const v = detectBoundaryEscapes(
+      baseMeta(),
+      ['apps/cli/src/ok.ts', '.claude/worktrees/feat/config'],
+      root,
+    );
+    expect(v).toEqual([]);
+  });
+
+  it('worktree mode: non-allowlisted .claude paths are still violations', () => {
+    const v = detectBoundaryEscapes(
+      baseMeta({ writeMode: 'worktree', scope: undefined }),
+      ['.claude/agents/rogue/instructions.md'],
+      root,
+    );
+    expect(v).toEqual(['.claude/agents/rogue/instructions.md']);
+  });
 });
 
 describe('dispatch metadata round-trip', () => {


### PR DESCRIPTION
## Summary
- Boundary escape detector was generating false-positive `disagreement` signals for `.claude/worktrees/` (worktree config) and `.claude/settings.local.json` (agent permissions), tripping sonnet-implementer's circuit breaker and dropping its dispatch weight to 0.30
- Added `BOUNDARY_ALLOWLIST` in `sandbox.ts` that filters these infrastructure paths before recording violations, applied to both `scoped` and `worktree` write modes
- 4 new tests covering allowlist behavior in both modes + negative case (non-allowlisted `.claude` paths still flagged)

## Test plan
- [x] 37/37 sandbox tests pass (`npx jest tests/cli/sandbox.test.ts`)
- [x] `tsc --noEmit` clean
- [x] MCP bundle rebuilt
- [ ] Verify sonnet-implementer dispatch weight recovers after retraction + this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)