### PR TITLE
fix: remove hardcoded 24421 fallback for HTTP MCP port

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -3457,10 +3457,9 @@ async function startHttpMcpTransport(): Promise<void> {
   // collided across parallel Claude Code instances on the same machine —
   // matches the fix already applied to the relay port.
   const httpPick = await pickStickyPort('GOSSIPCAT_HTTP_PORT', HTTP_MCP_STICKY_FILE);
-  // Legacy default: if nothing was provided and we had no sticky file, prefer
-  // 24421 once so existing clients with that port in their config keep working.
-  // If 24421 is already busy we'll still fall through to port 0 via EADDRINUSE.
-  const port = httpPick.source === 'auto' ? 24421 : httpPick.port;
+  // OS-assigned port when no env var or sticky file — matches relay port behavior.
+  // Sticky file makes it stable across reconnects; no need for a hardcoded default.
+  const port = httpPick.port;
   ctx.httpMcpPortSource = httpPick.source;
   const token = process.env.GOSSIPCAT_HTTP_TOKEN ?? '';
   const bindHost = (process.env.GOSSIPCAT_HTTP_BIND === '0.0.0.0' && token) ? '0.0.0.0' : '127.0.0.1';


### PR DESCRIPTION
## Summary
- Removed legacy `24421` fallback when no env var or sticky file exists
- Now uses OS-assigned port (0), matching the relay port behavior
- Sticky file (`.gossip/http-mcp.port`) persists the chosen port across reconnects

1-line change. From backlog item `project_http_mcp_port_collision.md`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] MCP bundle rebuilt
- [ ] Boot two parallel instances, verify different ports in `.gossip/http-mcp.port`

🤖 Generated with [Claude Code](https://claude.com/claude-code)