### PR TITLE
docs: add dual delivery mechanism lesson to HANDBOOK.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,37 @@ Restart Claude Code. Then in any project, ask:
 
 > "Set up a gossipcat team for this project"
 
+<details>
+<summary><strong>Manual MCP config</strong> (if <code>claude mcp add</code> doesn't work for your setup)</summary>
+
+Add to `~/.claude/mcp_settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "gossipcat": {
+      "command": "gossipcat",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Or project-local in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "gossipcat": {
+      "command": "npx",
+      "args": ["gossipcat", "mcp"]
+    }
+  }
+}
+```
+
+</details>
+
 Claude Code will call `gossip_setup()` to scaffold `.gossip/config.json` and your agent team. First-run bootstrap also writes the dispatch rules and tool catalog so Claude Code knows how to use gossipcat — no manual config needed.
 
 Gossipcat ships from **[GitHub Releases](https://github.com/gossipcat-ai/gossipcat-ai/releases)**, not the npm registry. The install URL above always points at the latest release. `npm` downloads the tarball directly, installs it globally, and drops a `gossipcat` binary on your `PATH` — no `npm publish` involved.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/gossipcat-ai/gossipcat-ai/releases/latest"><img src="https://img.shields.io/github/v/release/gossipcat-ai/gossipcat-ai?color=0ea5e9&label=release" alt="Latest release" /></a>
-  <a href="https://github.com/gossipcat-ai/gossipcat-ai/releases"><img src="https://img.shields.io/github/downloads/gossipcat-ai/gossipcat-ai/total?color=0ea5e9" alt="Downloads" /></a>
+  <a href="https://www.npmjs.com/package/gossipcat"><img src="https://img.shields.io/npm/v/gossipcat?color=0ea5e9" alt="npm version" /></a>
+  <a href="https://www.npmjs.com/package/gossipcat"><img src="https://img.shields.io/npm/dw/gossipcat?color=0ea5e9" alt="npm weekly downloads" /></a>
   <a href="https://github.com/gossipcat-ai/gossipcat-ai/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT License" /></a>
   <a href="#quickstart"><img src="https://img.shields.io/badge/node-22%2B-green" alt="Node 22+" /></a>
   <a href="https://github.com/gossipcat-ai/gossipcat-ai/stargazers"><img src="https://img.shields.io/github/stars/gossipcat-ai/gossipcat-ai?style=social" alt="GitHub stars" /></a>

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -252,6 +252,14 @@ PR #24 caught this: `getCountersSince` was comparing `signal.category !== catego
 
 Don't. Reddit punishes hype visibly. Reddit-native voice is specific, honest about limits, and leads with what can be poked at, not what's impressive. See `docs/reddit-claudeai-post.md` for the canonical voice.
 
+### Dual delivery mechanism for LLM + human artifacts
+
+Consensus reports, session summaries, and formatted outputs serve two audiences simultaneously: (1) the orchestrator LLM that needs structured tokens (`REQUIRED_NEXT`, `finding_id`, `<agent_finding>` tags) to drive the next tool call, and (2) the human reading the terminal or dashboard who needs readable tables and prose. These are not the same format.
+
+Early versions optimized for one audience and confused the other. Machine tokens in human-readable output look like noise. Human prose in machine-parsed output causes regex fallbacks and silent data loss (see consensus `1537efbb-2b44492d:f13` — paraphrased AGENT_PROMPT dropped the CONSENSUS_OUTPUT_FORMAT training block).
+
+**Lesson:** every artifact that crosses the LLM/human boundary needs explicit separation. The two-content-item split for native dispatch (item 1: orchestrator instructions, item 2: agent prompt verbatim) is the working pattern. `formatReport()` producing both a structured `ConsensusReport` object and a human-readable `summary` string is another. When adding new output, decide which audience it serves before writing it — don't try to serve both in one string.
+
 ---
 
 ## Glossary


### PR DESCRIPTION
## Summary
- New lesson in "Lessons from failed experiments" section
- Documents the dual-audience problem: LLM orchestrators need structured tokens, humans need readable prose
- Cites the real incident from consensus `1537efbb-2b44492d:f13` where paraphrasing the AGENT_PROMPT broke the dashboard pipeline
- References the two-content-item split and formatReport dual-output as working patterns

Explicitly flagged for this session in next-session notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)