### PR TITLE
chore(release): v0.2.1 — MCP registry publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
   "name": "gossipcat",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
+  "mcpName": "io.github.ataberk-xyz/gossipcat",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gossipcat-ai/gossipcat-ai.git"
+  },
   "license": "MIT",
   "main": "dist-mcp/mcp-server.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.ataberk-xyz/gossipcat",
+  "description": "Multi-agent orchestration for Claude Code — consensus review, adaptive dispatch, skill learning",
+  "repository": {
+    "url": "https://github.com/gossipcat-ai/gossipcat-ai",
+    "source": "github"
+  },
+  "version": "0.2.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "gossipcat",
+      "version": "0.2.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "description": "Google Gemini API key for relay agents (optional — native agents need no API key)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true,
+          "name": "GOOGLE_API_KEY"
+        },
+        {
+          "description": "Fixed port for the relay/dashboard server (optional — defaults to OS-assigned with sticky file)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false,
+          "name": "GOSSIPCAT_PORT"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Added `mcpName` and `repository` to package.json for MCP registry validation
- Added `server.json` manifest for `mcp-publisher` CLI
- Published v0.2.1 to npm and MCP registry (`io.github.ataberk-xyz/gossipcat`)

Gossipcat is now listed on the official MCP registry at registry.modelcontextprotocol.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)