### PR TITLE
fix(signals): persist source:'manual' so pending-signals detector clears

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1990,6 +1990,7 @@ server.tool(
             taskId: batchTaskId,
             findingId: fid,
             severity: f.severity,
+            source: 'manual',
             evidence: (f.finding || '').slice(0, 2000),
             timestamp: batchTs,
           } as Extract<PS, { type: 'consensus' }>);
@@ -2106,6 +2107,7 @@ server.tool(
           findingId: s.finding_id,
           severity: s.severity,
           category: s.category ?? inferCategory(s),
+          source: 'manual',
           evidence,
           timestamp: ts,
         };

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -120,6 +120,7 @@ export interface ConsensusSignal {
   severity?: 'critical' | 'high' | 'medium' | 'low';
   claimedSeverity?: 'critical' | 'high' | 'medium' | 'low';
   retractedSignal?: string;
+  source?: 'auto' | 'manual';
   evidence: string;
   timestamp: string;
 }

--- a/tests/cli/mcp-signals-validation.test.ts
+++ b/tests/cli/mcp-signals-validation.test.ts
@@ -384,6 +384,7 @@ describe('gossip_signals formatting — taskId synthesis, evidence truncation, t
       counterpartId: s.counterpart_id,
       findingId: s.finding_id,
       severity: s.severity,
+      source: 'manual' as const,
       evidence: ((s.evidence || s.finding) ?? '').slice(0, MAX_EVIDENCE_LENGTH),
       timestamp,
     }));
@@ -481,9 +482,41 @@ describe('gossip_signals formatting — taskId synthesis, evidence truncation, t
       expect(line.agentId).toBe('gemini-reviewer');
       expect(line.signal).toBe('unique_confirmed');
       expect(line.taskId).toBe('write-task-001');
+      // Regression: source='manual' must persist so gossip_status pending-signals
+      // detector (mcp-server-sdk.ts filters sig.source !== 'manual') sees coverage.
+      expect(line.source).toBe('manual');
     } finally {
       rmSync(testDir, { recursive: true, force: true });
     }
+  });
+
+  // Regression guards for the real handler in mcp-server-sdk.ts — the handler is
+  // not unit-testable (inline registerTool callback), so we grep the source to
+  // ensure both write sites set source:'manual'. If either regresses, the
+  // pending-signals detector silently stops clearing after signal recording.
+  it('handler sets source:"manual" in the record-consensus branch', () => {
+    const src = readFileSync(
+      join(__dirname, '..', '..', 'apps', 'cli', 'src', 'mcp-server-sdk.ts'),
+      'utf-8',
+    );
+    // Match the consensus-type return object in the record handler (not the IMPL branch)
+    const consensusReturn = src.match(
+      /return \{\s*type: 'consensus',[\s\S]{0,600}?timestamp: ts,\s*\};/,
+    );
+    expect(consensusReturn).not.toBeNull();
+    expect(consensusReturn![0]).toContain("source: 'manual'");
+  });
+
+  it('handler sets source:"manual" in the bulk_from_consensus branch', () => {
+    const src = readFileSync(
+      join(__dirname, '..', '..', 'apps', 'cli', 'src', 'mcp-server-sdk.ts'),
+      'utf-8',
+    );
+    const bulkPush = src.match(
+      /toRecord\.push\(\{\s*type: 'consensus',[\s\S]{0,600}?timestamp: batchTs,\s*\}/,
+    );
+    expect(bulkPush).not.toBeNull();
+    expect(bulkPush![0]).toContain("source: 'manual'");
   });
 });
 


### PR DESCRIPTION
## Summary
- `gossip_status` pending-signals detector at `apps/cli/src/mcp-server-sdk.ts:1158` filters `sig.source !== 'manual'`, but the `record` handler's consensus branch and the `bulk_from_consensus` handler never set that field (only the IMPL branch did). Review rounds stayed flagged as "Signals pending" regardless of how many signals were recorded — silently undermining the back-search discipline documented in CLAUDE.md.
- Adds `source: 'manual'` to both consensus write sites and extends `ConsensusSignal` with the optional field (parity with `ImplSignal`). Fix scope: 3 fields added.
- Verified live: pending list went from 2 rounds → 1 round immediately after recording a single post-fix signal. The remaining round is pre-fix data with no `source` field, as expected.

## Test plan
- [x] Typecheck clean on `apps/cli` and `packages/orchestrator`
- [x] `npx jest tests/cli` — 241/241 pass (default config)
- [x] `RUN_KNOWN_BROKEN=1 npx jest tests/cli/mcp-signals-validation.test.ts` — 3 new/modified tests pass (the pre-existing keyword-matching failure on line 330 is unrelated and why the file is on `KNOWN_BROKEN_SUITES`)
- [x] MCP bundle rebuilt (`npm run build:mcp`), live `gossip_status` confirms pending round drops off after recording a signal
- [x] Tests include regression guards that grep the handler source for `source: 'manual'` at both write sites — so future refactors can't silently drop the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)