### PR TITLE
fix(client): route GossipAgent logs to stderr — stops MCP server crashes

### DIFF
--- a/packages/client/src/gossip-agent.ts
+++ b/packages/client/src/gossip-agent.ts
@@ -233,7 +233,7 @@ export class GossipAgent extends EventEmitter {
     this._connected = false;
     this.ws = null;
     const label = WS_CLOSE_LABELS[code] ?? 'UNKNOWN';
-    console.log(`[GossipAgent] Closed: ${label} (${code}) ${reason?.toString() || ''}`);
+    console.warn(`[GossipAgent] Closed: ${label} (${code}) ${reason?.toString() || ''}`);
     if (!this.intentionalDisconnect) {
       this.emit('disconnect', code);
       this.attemptReconnect();
@@ -252,13 +252,13 @@ export class GossipAgent extends EventEmitter {
       30000
     );
     this.reconnectAttempts++;
-    console.log(`[GossipAgent] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts})`);
+    console.warn(`[GossipAgent] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts})`);
 
     this.reconnectTimer = setTimeout(async () => {
       if (this.intentionalDisconnect) return;
       try {
         await this.connect();
-        console.log('[GossipAgent] Reconnected');
+        console.warn('[GossipAgent] Reconnected');
         // Re-subscribe to all channels after reconnection
         for (const ch of this.subscribedChannels) {
           const msg = Message.createSubscription(this.config.agentId, ch, undefined, { seq: this.seq++ });


### PR DESCRIPTION
## Summary
- `GossipAgent.handleClose` / `attemptReconnect` / reconnected callback used `console.log` (`packages/client/src/gossip-agent.ts:236, 255, 261`), which writes to **stdout**. `GossipAgent` is instantiated inside the MCP server process at five sites (publisher in `mcp-server-sdk.ts`, `tool-server.ts`, `worker-agent.ts`, `main-agent.ts`). The MCP server uses `StdioServerTransport` — **stdout is the JSON-RPC pipe to Claude Code**.
- Any `[GossipAgent] Closed/Reconnecting/Reconnected` line corrupted the JSON stream → Claude Code killed and restarted the MCP server. Reproduced twice in a single session during dispatches that coincided with relay-worker reconnect events: silent 9.7-second gaps in `.gossip/mcp.log`, no error trace (writes went to stdout, not stderr — that's why they weren't logged).
- The codebase already redirects `process.stderr.write` to `.gossip/mcp.log` "BEFORE any other imports" (mcp-server-sdk.ts header comment) because Claude Code interprets MCP stderr as server errors. `console.warn` writes to stderr in Node, so it routes through that existing redirect into `mcp.log` unchanged.

3-line change. Lines 246 and 268 in the same file already used `console.warn` correctly — this just brings the other 3 in line.

## Test plan
- [x] `npx jest tests/client tests/cli` — 241/241 pass
- [x] `npm run build:mcp` — bundle rebuilt; verified `console.warn("[GossipAgent] Reconnected")` and the two backtick variants are present in `dist-mcp/mcp-server.js`; zero `console.log` mentions of `[GossipAgent` remain
- [x] No semantic change — the message text is identical, only the stream is different

🤖 Generated with [Claude Code](https://claude.com/claude-code)