### PR TITLE
fix(signals): gate weak-category trigger on MIN_CATEGORY_N — stops sparse-data false positives

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2350,13 +2350,23 @@ server.tool(
           const score: any = scores.get(agentId);
           if (!score) continue;
 
+          // Match the sparse-data gate used by categoryAccuracy (performance-reader.ts:528):
+          // a category needs ≥5 classified signals (correct + hallucinated) before its
+          // strength is eligible to trigger a weak flag. Without this gate the trigger
+          // fires on agents whose only accumulated strength is one decayed agreement,
+          // even when they have 10+ unique_confirmed findings in the category.
+          const MIN_CATEGORY_N_FOR_TRIGGER = 5;
           const cats = score.categoryStrengths;
+          const correctCounts = (score.categoryCorrect || {}) as Record<string, number>;
+          const hallucinatedCounts = (score.categoryHallucinated || {}) as Record<string, number>;
           let weakestCategory: string | null = null;
           let weakestValue = Infinity;
           if (cats && typeof cats === 'object') {
             for (const [k, v] of Object.entries(cats)) {
               const val = v as number;
-              if (val < 0.3 && val !== 0 && val < weakestValue) {
+              const n = (correctCounts[k] ?? 0) + (hallucinatedCounts[k] ?? 0);
+              if (n < MIN_CATEGORY_N_FOR_TRIGGER) continue;
+              if (val < 0.3 && val < weakestValue) {
                 weakestValue = val;
                 weakestCategory = k;
               }

--- a/tests/cli/mcp-signals-validation.test.ts
+++ b/tests/cli/mcp-signals-validation.test.ts
@@ -745,3 +745,88 @@ describe('gossip_signals timestamp resolution + spoofing rejection', () => {
     expect(r.error).toBeUndefined();
   });
 });
+
+// ── 8. Weak-category trigger sparse-data gate ────────────────────────────────
+
+describe('gossip_signals weak-category trigger — sparse-data gate', () => {
+  const MIN_CATEGORY_N_FOR_TRIGGER = 5;
+
+  // Replica of the trigger filter at apps/cli/src/mcp-server-sdk.ts:2353-2370.
+  // If the handler changes, keep this in sync; also see the source-grep guard below.
+  function pickWeakestCategory(score: {
+    categoryStrengths?: Record<string, number>;
+    categoryCorrect?: Record<string, number>;
+    categoryHallucinated?: Record<string, number>;
+  }): { category: string; value: number } | null {
+    const cats = score.categoryStrengths;
+    const correctCounts = score.categoryCorrect || {};
+    const hallucinatedCounts = score.categoryHallucinated || {};
+    let weakestCategory: string | null = null;
+    let weakestValue = Infinity;
+    if (cats && typeof cats === 'object') {
+      for (const [k, v] of Object.entries(cats)) {
+        const val = v as number;
+        const n = (correctCounts[k] ?? 0) + (hallucinatedCounts[k] ?? 0);
+        if (n < MIN_CATEGORY_N_FOR_TRIGGER) continue;
+        if (val < 0.3 && val < weakestValue) {
+          weakestValue = val;
+          weakestCategory = k;
+        }
+      }
+    }
+    return weakestCategory ? { category: weakestCategory, value: weakestValue } : null;
+  }
+
+  it('fires when category has ≥5 classified signals and low strength', () => {
+    const r = pickWeakestCategory({
+      categoryStrengths: { trust_boundaries: 0.15 },
+      categoryCorrect: { trust_boundaries: 4 },
+      categoryHallucinated: { trust_boundaries: 2 }, // n = 6
+    });
+    expect(r).not.toBeNull();
+    expect(r!.category).toBe('trust_boundaries');
+    expect(r!.value).toBeCloseTo(0.15);
+  });
+
+  it('stays silent when category has <5 classified signals (the sparse-data false positive we are fixing)', () => {
+    // Reproduces the sonnet-reviewer citation_grounding case: one old decayed
+    // agreement gives strength ≈ 0.002 which displays "0.00", but the total
+    // classified signals (c + h) is only 1 — not enough to flag.
+    const r = pickWeakestCategory({
+      categoryStrengths: { citation_grounding: 0.002 },
+      categoryCorrect: { citation_grounding: 1 }, // n = 1, below gate
+      categoryHallucinated: {},
+    });
+    expect(r).toBeNull();
+  });
+
+  it('does not fire when category is strong (regression guard)', () => {
+    const r = pickWeakestCategory({
+      categoryStrengths: { data_integrity: 1.2 },
+      categoryCorrect: { data_integrity: 12 },
+      categoryHallucinated: { data_integrity: 1 },
+    });
+    expect(r).toBeNull();
+  });
+
+  it('picks the lowest-strength category among multiple eligible weak ones', () => {
+    const r = pickWeakestCategory({
+      categoryStrengths: { error_handling: 0.25, type_safety: 0.10, concurrency: 0.20 },
+      categoryCorrect: { error_handling: 10, type_safety: 8, concurrency: 6 },
+      categoryHallucinated: {},
+    });
+    expect(r).not.toBeNull();
+    expect(r!.category).toBe('type_safety');
+  });
+
+  it('regression guard: handler source at mcp-server-sdk.ts keeps the MIN_CATEGORY_N gate', () => {
+    const src = readFileSync(
+      join(__dirname, '..', '..', 'apps', 'cli', 'src', 'mcp-server-sdk.ts'),
+      'utf-8',
+    );
+    // Locate the trigger block and assert it preconditions on (correct + hallucinated) >= N
+    expect(src).toMatch(/MIN_CATEGORY_N_FOR_TRIGGER/);
+    expect(src).toMatch(/const n = \(correctCounts\[k\] \?\? 0\) \+ \(hallucinatedCounts\[k\] \?\? 0\);/);
+    expect(src).toMatch(/if \(n < MIN_CATEGORY_N_FOR_TRIGGER\) continue;/);
+  });
+});


### PR DESCRIPTION
## Summary
- Post-signal skill-development trigger at `apps/cli/src/mcp-server-sdk.ts:2353-2370` flagged an agent as "weak" in any category where `categoryStrengths[cat] < 0.3 && val !== 0`. But `categoryStrengths` is only incremented by `agreement` signals (`packages/orchestrator/src/performance-reader.ts:377`); `unique_confirmed` — despite being a verified positive outcome — only touches `categoryCorrect` at :403-413. Under task-based decay (half-life 50 tasks), a single old agreement decays to ~0.001, renders as "0.00" in the trigger message, and the category gets flagged weak even when the agent has 10+ verified findings in it.
- Observed live for **sonnet-reviewer × citation_grounding**: 24 signals total (19 `unique_confirmed`, 1 `agreement`, 4 `unique_unconfirmed`), zero hallucinations. `gossip_scores()` correctly excludes the category from sonnet's weak list because the parallel metric `categoryAccuracy` applies a `MIN_CATEGORY_N=5` gate at `:528-537`. The trigger lacked the same gate.
- Fix mirrors the existing pattern: require `(categoryCorrect[cat] ?? 0) + (categoryHallucinated[cat] ?? 0) >= 5` before a category is eligible. Drops the redundant `val !== 0` guard. No scoring semantics change.

**Why narrow, not broader:** an alternative would make `unique_confirmed` also increment `categoryStrengths`. Both reviewers (gemini-reviewer + gemini-tester in consensus `c9aaf773` / `88ff9cac`) flagged that as a semantic shift — redefines "strength" from "peer-confirmed correctness" to "general correctness" — with unforeseen consequences. The narrow fix addresses the bug without touching the metric's definition.

**Dashboard impact:** none. `packages/dashboard-v2/src/components/CategoryStrengths.tsx:14,48` already has an identical `MIN_CATEGORY_N=5` gate that marks sparse rows with `opacity-40`. Only the server-side trigger notification was missing the gate.

## Test plan
- [x] `RUN_KNOWN_BROKEN=1 npx jest tests/cli/mcp-signals-validation.test.ts -t "weak-category"` — 5/5 pass
- [x] `npx jest tests/cli` — 241/241 pass (default config)
- [x] `npx tsc --noEmit -p apps/cli` — clean
- [x] `npm run build:mcp` — bundle rebuilt successfully

**Tests added:**
1. Fires when `n ≥ 5` and strength `< 0.3`
2. Silent when `n < 5` regardless of strength (the fix target — reproduces the citation_grounding sparse case)
3. Silent when category is strong (regression guard)
4. Picks lowest-strength among multiple eligible (existing selection behavior preserved)
5. Source-grep guard on the handler source — catches future refactors that drop the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)