### PR TITLE
fix(agent-memory): escape regex metacharacters in keyword scoring

### DIFF
--- a/packages/orchestrator/src/agent-memory.ts
+++ b/packages/orchestrator/src/agent-memory.ts
@@ -132,7 +132,10 @@ export class AgentMemoryReader {
 
   /** Simple word-boundary keyword overlap scoring (no LLM). */
   private extractKeywords(taskText: string): string[] {
-    const words = taskText.toLowerCase().split(/[\s,/.;:!?()\[\]{}]+/);
+    // Split on whitespace, punctuation, and markdown/code emphasis markers so
+    // `**bold**`, `_italic_`, and `` `code` `` yield the inner word alone,
+    // not leaking asterisks/underscores/backticks into the keyword token.
+    const words = taskText.toLowerCase().split(/[\s,/.;:!?()\[\]{}*_~`"'<>|]+/);
     const seen = new Set<string>();
     const result: string[] = [];
     for (const w of words) {
@@ -148,8 +151,13 @@ export class AgentMemoryReader {
     const lower = text.toLowerCase();
     let score = 0;
     for (const kw of keywords) {
-      // Word-boundary match (whole word = 2 pts, substring = 1 pt)
-      const re = new RegExp(`\\b${kw}\\b`);
+      // Word-boundary match (whole word = 2 pts, substring = 1 pt).
+      // Escape regex metacharacters — keywords come from untrusted task text,
+      // so a token containing '**', '(', '[' etc. (e.g. markdown `**bold**`
+      // leaking through the split) would throw "Invalid regular expression"
+      // and crash the whole task dispatch.
+      const escaped = kw.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const re = new RegExp(`\\b${escaped}\\b`);
       if (re.test(lower)) score += 2;
       else if (lower.includes(kw)) score += 1;
     }

--- a/tests/orchestrator/agent-memory-prefetch.test.ts
+++ b/tests/orchestrator/agent-memory-prefetch.test.ts
@@ -141,4 +141,41 @@ describe('AgentMemoryReader.prefetchConsensusFindingsText', () => {
 
     expect(results[0]).toContain('dispatch pipeline consensus relay memory');
   });
+
+  // Regression guard: a task containing markdown emphasis markers (**, _, ~, `)
+  // was crashing the whole dispatch with "Invalid regular expression" because
+  // extractKeywords didn't split on those characters and scoreKeywords passed the
+  // raw token into `new RegExp`. Observed live as `/\b**what\b/: Nothing to repeat`.
+  it('does not throw when task text contains markdown emphasis markers', () => {
+    const now = new Date().toISOString();
+    const finding = JSON.stringify({ finding: 'dispatch pipeline memory eviction', timestamp: now, confirmedBy: ['gemini-tester'] });
+    writeFileSync(findingsPath, finding + '\n');
+
+    const reader = new AgentMemoryReader(testDir);
+
+    // Each of these would have thrown "Invalid regular expression" pre-fix
+    expect(() => reader.prefetchConsensusFindingsText('**what** is dispatch pipeline')).not.toThrow();
+    expect(() => reader.prefetchConsensusFindingsText('_italic_ dispatch pipeline')).not.toThrow();
+    expect(() => reader.prefetchConsensusFindingsText('`code` dispatch pipeline')).not.toThrow();
+    expect(() => reader.prefetchConsensusFindingsText('~strike~ dispatch pipeline')).not.toThrow();
+    // Regex metachars embedded mid-token must also not escape the splitter
+    expect(() => reader.prefetchConsensusFindingsText('foo(bar dispatch pipeline')).not.toThrow();
+    expect(() => reader.prefetchConsensusFindingsText('a[b dispatch pipeline')).not.toThrow();
+  });
+
+  it('still matches the inner word when wrapped in markdown emphasis', () => {
+    const now = new Date().toISOString();
+    const finding = JSON.stringify({
+      finding: 'dispatch pipeline memory eviction',
+      timestamp: now,
+      confirmedBy: ['gemini-tester'],
+    });
+    writeFileSync(findingsPath, finding + '\n');
+
+    const reader = new AgentMemoryReader(testDir);
+    // `**dispatch**` should yield keyword `dispatch`, matching the finding text
+    const results = reader.prefetchConsensusFindingsText('**dispatch** **pipeline** memory');
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]).toContain('dispatch pipeline');
+  });
 });


### PR DESCRIPTION
## Summary
`AgentMemoryReader.scoreKeywords` at `packages/orchestrator/src/agent-memory.ts:152` built a word-boundary regex directly from task-text tokens: ``new RegExp(`\\b${kw}\\b`)``. `extractKeywords` split on whitespace and common punctuation but **not** on markdown emphasis markers (`*`, `_`, `~`, `` ` ``), so a task containing `**bold**` produced the raw token `**bold`. `**` is an invalid repetition quantifier in JavaScript regex, so the whole dispatch crashed with `Invalid regular expression: /\b**what\b/: Nothing to repeat` — silently dropping any task whose prompt contained markdown formatting.

**Reproduced live** in this session: two parallel relay dispatches with `**bold**` emphasis in the task text both failed with the exact error.

## Two-layer fix

1. **Escape metachars defensively** at :152 using the project's standard pattern (`/[.*+?^${}()|[\]\\]/g → \\$&`). Same pattern already used at `skill-catalog.ts:59`, `worker-agent.ts:62`, `skill-loader.ts:128`. Crash-proof even if the splitter misses a future metacharacter.
2. **Extend the splitter** at :135 to include `*`, `_`, `~`, `` ` ``, quotes, and angle/pipe so tokens match semantic intent: `**dispatch**` now yields `dispatch` (matches the finding corpus) instead of `**dispatch` (no match + previously a crash).

## Audit of other word-boundary regex sites
- `agent-memory.ts:152` — **was vulnerable** (fixed)
- `skill-catalog.ts:60` — already escapes ✓
- `worker-agent.ts:63` — already escapes ✓
- `skill-loader.ts:129` — already escapes ✓
- `memory-writer.ts:694` — hardcoded pre-escaped keyword list (safe) ✓

## Test plan
- [x] `npx jest tests/orchestrator/agent-memory-prefetch.test.ts` — 14/14 pass, including 2 new regression tests (no-throw on 6 metachar variants; inner word still matched when wrapped)
- [x] `npx jest tests/orchestrator` — 937/937 pass
- [x] `npx tsc --noEmit` on orchestrator + apps/cli — clean
- [x] `npm run build:mcp` — bundle rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)