### PR TITLE
docs(handbook): tighten signal-recording discipline — verify → signal → synthesize

### DIFF
--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -124,6 +124,8 @@ The server selects cross-reviewers via `selectCrossReviewers` (epsilon-greedy, s
 
 When you verify a finding as real (or catch a hallucination), **record the signal immediately** via `gossip_signals`. Don't batch signals at session end. Don't ask the user permission to record. This is the action immediately after verification.
 
+**Strict order: verify → signal → synthesize.** Not the other way. The common failure mode is recognizing that the signal step is owed, but deciding the synthesis deliverable (a decision table, a PR description, a summary back to the user) feels more urgent — so signals get pushed to "after I present this." That reordering is how signal recording silently stops happening. If you catch yourself writing the summary before signals are recorded, stop and record first. "This deliverable is cleaner" is the disguise the failure mode wears.
+
 **Every signal must include `finding_id`** in the format `<consensusId>:<agentId>:fN`. Without it, the dashboard can't trace back from signal → finding → agent and scoring becomes opaque.
 
 ### Verifying UNVERIFIED findings


### PR DESCRIPTION
## Summary
The existing \"Signal recording is mandatory, not deferrable\" section in the HANDBOOK captures the rule but not the specific failure mode that surfaced twice in two recent sessions:

- **2026-04-07**: skipped signal recording for two consecutive consensus rounds while keeping momentum on a design discussion.
- **2026-04-14**: completed a 3-agent consensus round (16 findings across verified, disputed, unverified, unique), then immediately synthesized a 10-row revised-decisions table for the user — without recording a single signal. Caught by the user asking \"have we recorded any signals?\"

Same root cause, different disguise. The orchestrator recognizes the signal step is owed, then decides presenting the synthesis (a decision table, a PR description, a summary back to the user) feels *more urgent* — so signals get reordered to \"after I present this.\" That reordering is how signal recording silently stops happening. The fix is to name the pattern in the canonical operator's manual so future sessions can self-catch it.

## What changes
One paragraph added to `docs/HANDBOOK.md:125` making the strict order explicit and naming the failure-mode disguise. ~5 lines, no structural change.

## Why the HANDBOOK (not just per-user memory)
The orchestrator's personal auto-memory lives in per-user state and is invisible to fresh users installing gossipcat. `docs/HANDBOOK.md` is auto-loaded by `gossip_status()` every session, so this discipline refinement reaches anyone orchestrating the system — not just my own future sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)