### PR TITLE
feat(http-bridge): PR-A foundation — extract scope + generic RateLimiter

### DIFF
--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -8,7 +8,8 @@
       "performance-reader": ["dist/performance-reader.d.ts"],
       "skill-index": ["dist/skill-index.d.ts"],
       "consensus-types": ["dist/consensus-types.d.ts"],
-      "bootstrap": ["dist/bootstrap.d.ts"]
+      "bootstrap": ["dist/bootstrap.d.ts"],
+      "rate-limiter": ["dist/rate-limiter.d.ts"]
     }
   },
   "scripts": { "build": "tsc" },

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -40,6 +40,7 @@ export { GossipPublisher } from './gossip-publisher';
 export { DispatchPipeline } from './dispatch-pipeline';
 export type { DispatchPipelineConfig, ToolServerCallbacks, SkillGapSuggestionResult } from './dispatch-pipeline';
 export { ScopeTracker } from './scope-tracker';
+export { RateLimiter } from './rate-limiter';
 export { WorktreeManager } from './worktree-manager';
 export { BootstrapGenerator } from './bootstrap';
 export type { BootstrapResult } from './bootstrap';

--- a/packages/orchestrator/src/rate-limiter.ts
+++ b/packages/orchestrator/src/rate-limiter.ts
@@ -1,0 +1,108 @@
+/**
+ * Generic sliding-window rate limiter.
+ *
+ * Supports both COUNT mode (each event has weight=1, e.g. relay message rate
+ * gate) and WEIGHTED-SUM mode (each event has a numeric weight, e.g. HTTP
+ * bridge in-flight-bytes quota where weight = request size in bytes).
+ *
+ * Per-key state is a list of `{ ts, weight }` records inside the current
+ * window. Records older than `windowMs` are purged on every access — this
+ * keeps the per-key Map bounded by the window's request rate, not by total
+ * lifetime activity.
+ *
+ * Time source is `Date.now()` to match the existing
+ * `MessageRateLimiter` behaviour and the spec's 60-second window semantics.
+ */
+
+interface Entry {
+  ts: number;
+  weight: number;
+}
+
+export class RateLimiter {
+  private entries = new Map<string, Entry[]>();
+  private readonly windowMs: number;
+  private readonly maxWeight: number;
+
+  /**
+   * @param windowMs Sliding window size in milliseconds.
+   * @param maxWeight Cap on the SUM of weights inside the window. For
+   *   count-mode use `weight=1` per call and pass the count cap here.
+   */
+  constructor(windowMs: number, maxWeight: number) {
+    if (!Number.isFinite(windowMs) || windowMs <= 0) {
+      throw new Error(`RateLimiter: windowMs must be > 0, got ${windowMs}`);
+    }
+    if (!Number.isFinite(maxWeight) || maxWeight <= 0) {
+      throw new Error(`RateLimiter: maxWeight must be > 0, got ${maxWeight}`);
+    }
+    this.windowMs = windowMs;
+    this.maxWeight = maxWeight;
+  }
+
+  /**
+   * Record an event of `weight` (default 1) for `key`.
+   * Returns `true` if the new event fits inside the window's budget,
+   * `false` if it would exceed `maxWeight` (in which case the event is NOT
+   * recorded — callers can retry later when the window rolls).
+   *
+   * A single event whose own weight already exceeds `maxWeight` is rejected
+   * outright (returns `false`, nothing recorded). This matches the spec's
+   * intent: a 60MB single read should not pass a 50MB/min budget by being
+   * the first request of a new window.
+   */
+  record(key: string, weight: number = 1): boolean {
+    if (!Number.isFinite(weight) || weight < 0) {
+      throw new Error(`RateLimiter: weight must be a non-negative finite number, got ${weight}`);
+    }
+    if (weight > this.maxWeight) return false;
+
+    const now = Date.now();
+    const list = this.purge(key, now);
+    const currentSum = list.reduce((acc, e) => acc + e.weight, 0);
+    if (currentSum + weight > this.maxWeight) return false;
+
+    list.push({ ts: now, weight });
+    this.entries.set(key, list);
+    return true;
+  }
+
+  /**
+   * Sum of weights inside the current window for `key`. Purges expired
+   * entries as a side effect to keep the Map bounded under read-only access.
+   */
+  currentWeight(key: string): number {
+    const now = Date.now();
+    const list = this.purge(key, now);
+    return list.reduce((acc, e) => acc + e.weight, 0);
+  }
+
+  /** Drop all tracking state. Test helper. */
+  clear(): void {
+    this.entries.clear();
+  }
+
+  private purge(key: string, now: number): Entry[] {
+    const cutoff = now - this.windowMs;
+    const list = this.entries.get(key);
+    if (!list || list.length === 0) {
+      const fresh: Entry[] = [];
+      this.entries.set(key, fresh);
+      return fresh;
+    }
+    // Entries are appended in `now`-order, so the expired prefix is contiguous.
+    let firstLive = 0;
+    while (firstLive < list.length && list[firstLive].ts <= cutoff) firstLive++;
+    if (firstLive === 0) return list;
+    const trimmed = list.slice(firstLive);
+    if (trimmed.length === 0) {
+      // Don't accumulate empty arrays for keys that have gone quiet.
+      this.entries.delete(key);
+      const fresh: Entry[] = [];
+      this.entries.set(key, fresh);
+      return fresh;
+    }
+    this.entries.set(key, trimmed);
+    return trimmed;
+  }
+}

--- a/packages/relay/src/message-rate-limiter.ts
+++ b/packages/relay/src/message-rate-limiter.ts
@@ -1,9 +1,14 @@
 /**
  * Message Rate Limiter
  *
- * Prevents a single agent from flooding the server with too many messages
- * in a short period. Uses a sliding window algorithm.
+ * Per-agent message-count gate on a sliding window. This is now a thin
+ * adapter over the generic `RateLimiter` in `@gossip/orchestrator` so the
+ * relay's count-mode gate and the HTTP file bridge's weighted-sum quota
+ * share one substrate. Public API is preserved so existing test importers
+ * and any future relay wiring continue to work without changes.
  */
+
+import { RateLimiter } from '@gossip/orchestrator/rate-limiter';
 
 export interface RateLimiterConfig {
   maxMessages: number;
@@ -11,42 +16,23 @@ export interface RateLimiterConfig {
 }
 
 export class MessageRateLimiter {
-  private messageTimestamps = new Map<string, number[]>();
-  private readonly maxMessages: number;
-  private readonly windowMs: number;
+  private readonly inner: RateLimiter;
 
   constructor(config: RateLimiterConfig) {
-    this.maxMessages = config.maxMessages;
-    this.windowMs = config.windowMs;
+    this.inner = new RateLimiter(config.windowMs, config.maxMessages);
   }
 
   /**
-   * Records a message from an agent and checks if they have exceeded the rate limit.
-   *
-   * @param agentId The ID of the agent sending the message.
-   * @returns True if the agent is allowed to send the message, false otherwise.
+   * Records a message from an agent and checks whether they are within the
+   * rate limit. Returns `true` if the message is allowed, `false` if the
+   * agent has exceeded their quota for the current window.
    */
   public isAllowed(agentId: string): boolean {
-    const now = Date.now();
-    const timestamps = this.messageTimestamps.get(agentId) || [];
-
-    // Remove timestamps older than the window
-    const windowStart = now - this.windowMs;
-    const recentTimestamps = timestamps.filter(ts => ts > windowStart);
-
-    if (recentTimestamps.length >= this.maxMessages) {
-      return false; // Limit exceeded
-    }
-
-    recentTimestamps.push(now);
-    this.messageTimestamps.set(agentId, recentTimestamps);
-    return true;
+    return this.inner.record(agentId, 1);
   }
 
-  /**
-   * Clears all tracking data (for testing).
-   */
+  /** Clears all tracking data (for testing). */
   public clear(): void {
-    this.messageTimestamps.clear();
+    this.inner.clear();
   }
 }

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -7,5 +7,6 @@ export { GitTools } from './git-tools';
 export { ALL_TOOLS, FILE_TOOLS, SHELL_TOOLS, GIT_TOOLS, SKILL_TOOLS, MEMORY_TOOLS, IDENTITY_TOOLS } from './definitions';
 export type { MemorySearcherLike, AgentIdentity, AgentLookup } from './tool-server';
 export { formatIdentityBlock } from './tool-server';
+export { canonicalizeForBoundary, validatePathInScope, CASE_INSENSITIVE_FS } from './scope';
 export { SkillTools } from './skill-tools';
 export type { SuggestSkillArgs, GapSuggestion, GapResolution, GapEntry } from './skill-tools';

--- a/packages/tools/src/scope.ts
+++ b/packages/tools/src/scope.ts
@@ -1,0 +1,56 @@
+import { dirname, basename, join } from 'path';
+import { realpathSync, existsSync } from 'fs';
+
+/**
+ * Case-insensitive filesystems (darwin/win32) require case-folded path
+ * compares — otherwise a scope of `packages/relay/` can be bypassed by a path
+ * like `packages/RELAY/evil.ts` since the OS treats them as the same directory
+ * but `startsWith` is case-sensitive.
+ */
+export const CASE_INSENSITIVE_FS =
+  process.platform === 'darwin' || process.platform === 'win32';
+
+/**
+ * Resolve a path to its canonical form for boundary comparison:
+ *   1. Follow symlinks via realpathSync so a planted symlink in-scope cannot
+ *      escape to an out-of-scope target. If the target does not exist yet
+ *      (common for file_write), resolve the parent and re-attach the basename.
+ *   2. Case-fold on case-insensitive filesystems.
+ *   3. Append a trailing slash so sibling-prefix bypass (e.g. `packages/relay2/`
+ *      matching scope `packages/relay/`) is impossible.
+ *
+ * The non-existent-path branch is SECURITY-CRITICAL for `/file-write` on new
+ * paths: without it, planted symlinks in ancestor directories could hide an
+ * escape during the write. Both branches must be preserved verbatim.
+ *
+ * @param p Absolute path to canonicalize. Caller is expected to have already
+ *   joined the path against its scope root (e.g. via `resolve(root, rel)`).
+ */
+export function canonicalizeForBoundary(p: string): string {
+  let out = p;
+  if (existsSync(out)) {
+    try { out = realpathSync(out); } catch { /* best-effort */ }
+  } else {
+    // Path does not exist — resolve symlinks in the parent directory instead,
+    // then reattach the basename. This prevents symlinks in ancestor dirs from
+    // hiding an escape during file_write.
+    const parent = dirname(out);
+    if (parent !== out && existsSync(parent)) {
+      try { out = join(realpathSync(parent), basename(out)); } catch { /* best-effort */ }
+    }
+  }
+  if (CASE_INSENSITIVE_FS) out = out.toLowerCase();
+  return out.endsWith('/') ? out : out + '/';
+}
+
+/**
+ * Membership check — does a canonicalized path fall inside a canonicalized
+ * scope? Both arguments MUST already have been passed through
+ * `canonicalizeForBoundary` (or be a stored canonical scope from
+ * `assignScope`/`assignRoot`). This helper exists so the five inline
+ * `startsWith(scope)` checks in `tool-server.ts` and any future bridge
+ * endpoints share a single primitive.
+ */
+export function validatePathInScope(scope: string, canonicalPath: string): boolean {
+  return canonicalPath.startsWith(scope);
+}

--- a/packages/tools/src/tool-server.ts
+++ b/packages/tools/src/tool-server.ts
@@ -8,40 +8,8 @@ import { GitTools } from './git-tools';
 import { SkillTools } from './skill-tools';
 import { Sandbox } from './sandbox';
 import { isKnownTool, validateToolArgs } from './tool-schemas';
-import { resolve, dirname, basename, join } from 'path';
-import { realpathSync, existsSync } from 'fs';
-
-// Case-insensitive filesystems (darwin/win32) require case-folded path compares,
-// otherwise a scope of `packages/relay/` can be bypassed by a path like
-// `packages/RELAY/evil.ts` — the OS treats them as the same directory but
-// `startsWith` is case-sensitive.
-const CASE_INSENSITIVE_FS = process.platform === 'darwin' || process.platform === 'win32';
-
-/**
- * Resolve a path to its canonical form for boundary comparison:
- *   1. Follow symlinks via realpathSync so a planted symlink in-scope cannot
- *      escape to an out-of-scope target. If the target does not exist yet
- *      (common for file_write), resolve the parent and re-attach the basename.
- *   2. Case-fold on case-insensitive filesystems.
- *   3. Append a trailing slash so sibling-prefix bypass (e.g. `packages/relay2/`
- *      matching scope `packages/relay/`) is impossible.
- */
-function canonicalizeForBoundary(p: string): string {
-  let out = p;
-  if (existsSync(out)) {
-    try { out = realpathSync(out); } catch { /* best-effort */ }
-  } else {
-    // Path does not exist — resolve symlinks in the parent directory instead,
-    // then reattach the basename. This prevents symlinks in ancestor dirs from
-    // hiding an escape during file_write.
-    const parent = dirname(out);
-    if (parent !== out && existsSync(parent)) {
-      try { out = join(realpathSync(parent), basename(out)); } catch { /* best-effort */ }
-    }
-  }
-  if (CASE_INSENSITIVE_FS) out = out.toLowerCase();
-  return out.endsWith('/') ? out : out + '/';
-}
+import { resolve } from 'path';
+import { canonicalizeForBoundary, validatePathInScope } from './scope';
 
 /**
  * Structural shape of MemorySearcher from @gossip/orchestrator. Defined here as
@@ -242,13 +210,13 @@ export class ToolServer {
         // case-insensitive filesystems, and appends a trailing slash so
         // sibling-prefix bypass is impossible. scope is already canonical.
         const canonical = canonicalizeForBoundary(resolve(this.sandbox.projectRoot, filePath));
-        if (!canonical.startsWith(scope)) {
+        if (!validatePathInScope(scope, canonical)) {
           throw new Error(`Write blocked: "${filePath}" is outside scope "${scope}"`);
         }
       }
       if (root) {
         const canonical = canonicalizeForBoundary(resolve(root, filePath));
-        if (!canonical.startsWith(root)) {
+        if (!validatePathInScope(root, canonical)) {
           throw new Error(`Write blocked: "${filePath}" is outside worktree root "${root}"`);
         }
       }
@@ -289,7 +257,7 @@ export class ToolServer {
       const filePath = args.path as string;
       if (scope) {
         const canonical = canonicalizeForBoundary(resolve(this.sandbox.projectRoot, filePath));
-        if (!canonical.startsWith(scope)) {
+        if (!validatePathInScope(scope, canonical)) {
           throw new Error(`Delete blocked: "${filePath}" is outside scope "${scope}"`);
         }
       }
@@ -297,7 +265,7 @@ export class ToolServer {
         // Match file_write hardening: resolve symlinks + trailing-slash guard
         // so planted symlinks and sibling-prefix roots cannot escape.
         const canonical = canonicalizeForBoundary(resolve(root, filePath));
-        if (!canonical.startsWith(root)) {
+        if (!validatePathInScope(root, canonical)) {
           throw new Error(`Delete blocked: "${filePath}" is outside worktree root "${root}"`);
         }
       }
@@ -350,7 +318,7 @@ export class ToolServer {
           // canonicalizeForBoundary follows symlinks so a planted symlink
           // inside scope cannot redirect the read to an out-of-scope target.
           const canonical = canonicalizeForBoundary(resolve(this.sandbox.projectRoot, args.path as string));
-          if (!canonical.startsWith(readScope)) {
+          if (!validatePathInScope(readScope, canonical)) {
             throw new Error(`Read blocked: "${args.path}" is outside scope "${readScope}"`);
           }
         }

--- a/tests/orchestrator/rate-limiter.test.ts
+++ b/tests/orchestrator/rate-limiter.test.ts
@@ -1,0 +1,146 @@
+import { RateLimiter } from '@gossip/orchestrator/rate-limiter';
+
+describe('RateLimiter', () => {
+  describe('count mode (weight=1)', () => {
+    it('allows events up to maxWeight, then rejects', () => {
+      const lim = new RateLimiter(1000, 5);
+      for (let i = 0; i < 5; i++) {
+        expect(lim.record('agent-a')).toBe(true);
+      }
+      expect(lim.record('agent-a')).toBe(false);
+      expect(lim.record('agent-a')).toBe(false);
+    });
+
+    it('does not record events that exceed the cap (no consumed quota on rejection)', () => {
+      const lim = new RateLimiter(1000, 3);
+      for (let i = 0; i < 3; i++) lim.record('agent-a');
+      expect(lim.currentWeight('agent-a')).toBe(3);
+      expect(lim.record('agent-a')).toBe(false);
+      // Rejected event must NOT show up in currentWeight.
+      expect(lim.currentWeight('agent-a')).toBe(3);
+    });
+  });
+
+  describe('weighted-sum mode', () => {
+    it('caps the SUM of weights, not the count of events', () => {
+      const lim = new RateLimiter(60_000, 100); // 100 byte budget
+      expect(lim.record('token-a', 30)).toBe(true);
+      expect(lim.record('token-a', 30)).toBe(true);
+      expect(lim.record('token-a', 30)).toBe(true); // sum=90
+      expect(lim.record('token-a', 20)).toBe(false); // 90+20=110 > 100
+      expect(lim.record('token-a', 10)).toBe(true);  // 90+10=100, fits
+      expect(lim.record('token-a', 1)).toBe(false);
+    });
+
+    it('rejects a single event whose weight alone exceeds maxWeight', () => {
+      const lim = new RateLimiter(60_000, 50);
+      expect(lim.record('token-a', 51)).toBe(false);
+      // No quota was consumed.
+      expect(lim.currentWeight('token-a')).toBe(0);
+      // And subsequent fitting events still work.
+      expect(lim.record('token-a', 25)).toBe(true);
+    });
+
+    it('rejects negative or non-finite weights', () => {
+      const lim = new RateLimiter(1000, 100);
+      expect(() => lim.record('k', -1)).toThrow();
+      expect(() => lim.record('k', NaN)).toThrow();
+      expect(() => lim.record('k', Infinity)).toThrow();
+    });
+  });
+
+  describe('window rollover', () => {
+    it('purges entries older than windowMs so quota frees up', async () => {
+      const lim = new RateLimiter(150, 2);
+      expect(lim.record('a')).toBe(true);
+      expect(lim.record('a')).toBe(true);
+      expect(lim.record('a')).toBe(false);
+      await new Promise((r) => setTimeout(r, 200));
+      // Window fully rolled — both old entries are expired.
+      expect(lim.currentWeight('a')).toBe(0);
+      expect(lim.record('a')).toBe(true);
+      expect(lim.record('a')).toBe(true);
+      expect(lim.record('a')).toBe(false);
+    });
+
+    it('partial-window rollover frees only the expired prefix', async () => {
+      const lim = new RateLimiter(200, 4);
+      lim.record('a'); // t0
+      lim.record('a'); // t0
+      await new Promise((r) => setTimeout(r, 120));
+      lim.record('a'); // t≈120
+      lim.record('a'); // t≈120
+      expect(lim.record('a')).toBe(false);
+      // Wait for the first two to expire but not the second pair.
+      await new Promise((r) => setTimeout(r, 120));
+      expect(lim.currentWeight('a')).toBe(2);
+      expect(lim.record('a')).toBe(true);
+      expect(lim.record('a')).toBe(true);
+      expect(lim.record('a')).toBe(false);
+    });
+  });
+
+  describe('currentWeight accessor', () => {
+    it('reports the live sum without recording anything', () => {
+      const lim = new RateLimiter(60_000, 100);
+      expect(lim.currentWeight('k')).toBe(0);
+      lim.record('k', 25);
+      expect(lim.currentWeight('k')).toBe(25);
+      lim.record('k', 30);
+      expect(lim.currentWeight('k')).toBe(55);
+      // Calling currentWeight repeatedly is a pure read (no consumption).
+      expect(lim.currentWeight('k')).toBe(55);
+      expect(lim.currentWeight('k')).toBe(55);
+    });
+  });
+
+  describe('multi-key isolation', () => {
+    it('counts each key independently', () => {
+      const lim = new RateLimiter(1000, 2);
+      expect(lim.record('a')).toBe(true);
+      expect(lim.record('a')).toBe(true);
+      expect(lim.record('a')).toBe(false);
+      // Key 'b' has its own quota.
+      expect(lim.record('b')).toBe(true);
+      expect(lim.record('b')).toBe(true);
+      expect(lim.record('b')).toBe(false);
+      expect(lim.currentWeight('a')).toBe(2);
+      expect(lim.currentWeight('b')).toBe(2);
+    });
+
+    it('weighted mode isolates keys too', () => {
+      const lim = new RateLimiter(60_000, 100);
+      lim.record('token-a', 80);
+      lim.record('token-b', 80);
+      expect(lim.currentWeight('token-a')).toBe(80);
+      expect(lim.currentWeight('token-b')).toBe(80);
+      expect(lim.record('token-a', 30)).toBe(false); // a is full
+      expect(lim.record('token-b', 20)).toBe(true);  // b still has room
+    });
+  });
+
+  describe('constructor validation', () => {
+    it('rejects non-positive windowMs', () => {
+      expect(() => new RateLimiter(0, 1)).toThrow();
+      expect(() => new RateLimiter(-1, 1)).toThrow();
+      expect(() => new RateLimiter(NaN, 1)).toThrow();
+    });
+    it('rejects non-positive maxWeight', () => {
+      expect(() => new RateLimiter(1000, 0)).toThrow();
+      expect(() => new RateLimiter(1000, -1)).toThrow();
+      expect(() => new RateLimiter(1000, NaN)).toThrow();
+    });
+  });
+
+  describe('clear', () => {
+    it('drops all tracking', () => {
+      const lim = new RateLimiter(1000, 2);
+      lim.record('a');
+      lim.record('a');
+      expect(lim.record('a')).toBe(false);
+      lim.clear();
+      expect(lim.currentWeight('a')).toBe(0);
+      expect(lim.record('a')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Prep work for the HTTP File Bridge feature (docs/specs/2026-04-14-http-file-bridge.md). No behavior change — only refactors existing primitives into shared modules so PR-B can wire them into the new HTTP bridge without duplication.
- Stacked on #53 (spec corrections).

## What changed

**New modules:**
- `packages/tools/src/scope.ts` (56 LOC) — `canonicalizeForBoundary` + `validatePathInScope` + `CASE_INSENSITIVE_FS`. Both canonicalize branches preserved verbatim including the security-critical non-existent-path branch.
- `packages/orchestrator/src/rate-limiter.ts` (108 LOC) — generic sliding-window `RateLimiter` with count + weighted-sum modes. Purges expired entries on access. Rejects single events whose weight exceeds maxWeight (strict interpretation for bytes quota).

**Refactored (same behavior):**
- `tool-server.ts`: 5 inline `startsWith(scope)` checks → `validatePathInScope` calls. Net -33 LOC.
- `message-rate-limiter.ts`: rewritten as 38-LOC adapter over `RateLimiter`. Public API unchanged.

## Test plan

- [x] Full suite: 116 suites pass, 1384/1385 tests pass (1 pre-existing KNOWN_BROKEN skip)
- [x] New `rate-limiter.test.ts`: 13/13 pass (count mode, weighted-sum, window rollover, currentWeight, multi-key isolation, constructor validation, single-event oversize rejection)
- [x] `tool-server-scope.test.ts` + `tool-server-verify.test.ts` pass (exercise the delegated boundary checks)
- [x] `router.test.ts` passes (MessageRateLimiter adapter drop-in verified)
- [x] `npm run build` clean across all 7 workspaces

## Review notes / follow-ups (non-blocking)

1. **Single-event-exceeds-cap behavior is opinionated.** `record(key, w)` returns false AND consumes nothing when `w > maxWeight`. If you'd prefer the limiter to accept oversized single events, that's a 2-line change. I chose strict for the upcoming in-flight-bytes quota (a single 60MB read should not slip through a 50MB/min budget as the first call of a fresh window).
2. **Time source is `Date.now()`** to match `MessageRateLimiter` historical behavior. Injectable `nowFn` would let us retire the KNOWN_BROKEN timing test — follow-up.
3. **`typesVersions` pattern is inconsistent** across the orchestrator package (only 5 subpaths listed). Long-term it should be all-or-none. I followed the existing pattern to keep this PR focused.
4. **`sandbox.ts` parallel canonicalization** (lines 8 + 31) was explicitly NOT touched per spec §Scope enforcement. Will get addressed separately; spec acknowledges the dual-source state.

## Pre-impl review provenance

Findings that shaped this PR's design came from a 2-agent consensus round (sonnet-reviewer + haiku-researcher, 2026-04-14) that validated the spec's Implementation scope table against actual master state. See #53 for the full finding set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)