### PR TITLE
fix(fresh-install): team page refresh + native agent schema injection

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -5,7 +5,7 @@
 import { randomUUID } from 'crypto';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { CONSENSUS_OUTPUT_FORMAT, loadSkills } from '@gossip/orchestrator';
+import { assemblePrompt, loadSkills } from '@gossip/orchestrator';
 import { formatIdentityBlock } from '@gossip/tools';
 import { ctx, NATIVE_TASK_TTL_MS } from '../mcp-context';
 
@@ -182,18 +182,17 @@ export async function handleDispatchSingle(
       task,
     );
 
-    const identityBlock = buildNativeIdentity(agent_id, nativeConfig.model);
-    let agentPrompt = [
-      identityBlock,
-      nativeConfig.instructions || '',
-      skillResult.content,
-      chainContext ? `\n${chainContext}\n` : '',
-      `\n---\n\nTask: ${task}`,
-    ].filter(Boolean).join('').trim();
-    const MAX_AGENT_PROMPT_CHARS = 30_000;
-    if (agentPrompt.length > MAX_AGENT_PROMPT_CHARS) {
-      agentPrompt = agentPrompt.slice(0, MAX_AGENT_PROMPT_CHARS) + '\n\n[Context truncated to fit budget]';
-    }
+    // Route through assemblePrompt() so the FINDING TAG SCHEMA (PR #56) and
+    // block ordering stay in lock-step with the relay dispatch path — prior
+    // to this change native dispatch built its prompt via manual concat and
+    // silently missed every schema update made to prompt-assembler.ts.
+    let agentPrompt = assemblePrompt({
+      identity: buildNativeIdentity(agent_id, nativeConfig.model),
+      instructions: nativeConfig.instructions || undefined,
+      skills: skillResult.content || undefined,
+      chainContext: chainContext || undefined,
+      task,
+    });
     if (sanitizeResult.sanitized) agentPrompt = prependScopeNote(agentPrompt);
 
     // Record dispatch metadata for the post-task audit
@@ -368,17 +367,18 @@ export async function handleDispatchParallel(
       def.task,
     );
 
-    const parallelIdentityBlock = buildNativeIdentity(def.agent_id, nativeConfig.model);
-    let agentPrompt = [
-      parallelIdentityBlock,
-      nativeConfig.instructions || '',
-      skillResult.content,
-      `\n---\n\nTask: ${def.task}`,
-    ].filter(Boolean).join('').trim();
-    const MAX_AGENT_PROMPT_CHARS = 30_000;
-    if (agentPrompt.length > MAX_AGENT_PROMPT_CHARS) {
-      agentPrompt = agentPrompt.slice(0, MAX_AGENT_PROMPT_CHARS) + '\n\n[Context truncated to fit budget]';
-    }
+    // Route through assemblePrompt() so the FINDING TAG SCHEMA (PR #56) and
+    // block ordering stay in lock-step with relay dispatch. When the caller
+    // flags this batch as consensus (via the outer `consensus` param), use
+    // the full CONSENSUS_OUTPUT_FORMAT instead of the slim schema — peer
+    // cross-review expects the same framing relay agents see.
+    let agentPrompt = assemblePrompt({
+      identity: buildNativeIdentity(def.agent_id, nativeConfig.model),
+      instructions: nativeConfig.instructions || undefined,
+      skills: skillResult.content || undefined,
+      consensusSummary: consensus || undefined,
+      task: def.task,
+    });
     if ((def as any)._sandboxSanitized) agentPrompt = prependScopeNote(agentPrompt);
 
     recordDispatchMetadata(process.cwd(), {
@@ -515,8 +515,11 @@ export async function handleDispatchConsensus(
     if (errors.length) lines.push(`Relay errors: ${errors.join(', ')}`);
   }
 
-  // Native tasks — inject consensus output format into the prompt (same as relay agents via prompt-assembler)
-  const consensusInstruction = `\n\n--- CONSENSUS OUTPUT FORMAT ---\n${CONSENSUS_OUTPUT_FORMAT}\n--- END CONSENSUS OUTPUT FORMAT ---`;
+  // Native tasks — route through assemblePrompt() so the CONSENSUS OUTPUT
+  // FORMAT block + block ordering stay in lock-step with relay agents. Prior
+  // to this refactor the native consensus path hand-concatenated its prompt
+  // and silently diverged from prompt-assembler.ts every time a new block
+  // was added there (see PR #56 FINDING TAG SCHEMA miss).
   const nativeInstructions: string[] = [];
   const nativePrompts: Array<{ taskId: string; agentId: string; prompt: string }> = [];
   for (const def of nativeTasks) {
@@ -531,9 +534,11 @@ export async function handleDispatchConsensus(
     process.stderr.write(`[gossipcat] dispatch → ${def.agent_id} (${nativeConfig.model}) [${taskId}]\n`);
 
     const rawLens = precomputedLenses?.get(def.agent_id);
-    const lensSection = rawLens
-      ? `\n\n--- LENS ---\n${rawLens.replace(/---\s*(END )?LENS\s*---/gi, '')}\n--- END LENS ---`
-      : '';
+    // Strip any LENS delimiters the generator may have emitted — assemblePrompt
+    // wraps the lens itself so a nested block would produce duplicate markers.
+    const lensContent = rawLens
+      ? rawLens.replace(/---\s*(END )?LENS\s*---/gi, '').trim()
+      : undefined;
 
     let consensusSkillIndex: ReturnType<typeof ctx.mainAgent.getSkillIndex> | undefined;
     try { consensusSkillIndex = ctx.mainAgent.getSkillIndex() ?? undefined; } catch { /* best-effort */ }
@@ -545,26 +550,19 @@ export async function handleDispatchConsensus(
       def.task,
     );
 
-    // Truncation reserves CONSENSUS_OUTPUT_FORMAT + lens + task — those must survive
-    // or the agent will emit prose instead of <agent_finding> tags (silent consensus
-    // round degradation). Per bench review finding 12827629-fa9a4660:f8, the old
-    // behavior concatenated everything THEN truncated, which could sever the format
-    // block entirely when skill content was large. Now we apply the cap only to the
-    // [instructions + skills] prefix and always append consensusInstruction + lens +
-    // task at full length afterward.
-    const MAX_AGENT_PROMPT_CHARS = 30_000;
-    const suffix = consensusInstruction + lensSection + `\n\n---\n\nTask: ${def.task}`;
-    const prefixBudget = Math.max(0, MAX_AGENT_PROMPT_CHARS - suffix.length);
-    const consensusIdentityBlock = buildNativeIdentity(def.agent_id, nativeConfig.model);
-    let prefix = [
-      consensusIdentityBlock,
-      nativeConfig.instructions || '',
-      skillResultC.content,
-    ].filter(Boolean).join('').trim();
-    if (prefix.length > prefixBudget) {
-      prefix = prefix.slice(0, prefixBudget) + '\n\n[Context truncated to fit budget]';
-    }
-    let agentPrompt = prefix + suffix;
+    // Truncation reserves CONSENSUS OUTPUT FORMAT + lens + task — those must
+    // survive or the agent emits prose instead of <agent_finding> tags (silent
+    // consensus degradation). assemblePrompt() keeps them in the preserved
+    // suffix automatically; the truncatable prefix is [identity + instructions
+    // + skills]. See consensus 12827629-fa9a4660:f8 for the original regression.
+    let agentPrompt = assemblePrompt({
+      identity: buildNativeIdentity(def.agent_id, nativeConfig.model),
+      instructions: nativeConfig.instructions || undefined,
+      skills: skillResultC.content || undefined,
+      consensusSummary: true,
+      lens: lensContent || undefined,
+      task: def.task,
+    });
     lines.push(`  ${taskId} → ${def.agent_id} (native — dispatch via Agent tool)`);
     nativeInstructions.push(
       `[${taskId}] Agent(model: "${nativeConfig.model}", prompt: <AGENT_PROMPT:${taskId} below>, run_in_background: true)` +

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1629,6 +1629,20 @@ server.tool(
     mkdirSync(join(root, '.gossip'), { recursive: true });
     writeFileSync(join(root, '.gossip', 'config.json'), JSON.stringify(config, null, 2));
 
+    // Refresh dashboard's cached agent configs so the Team page reflects the
+    // new team without requiring /mcp reconnect. The boot-time snapshot at
+    // :365 still wins on initial boot — this is a post-setup override for
+    // the common "boot before setup" fresh-install flow. Only fires on create
+    // modes (merge/replace); update_instructions returns earlier at :1504.
+    try {
+      const m = await getModules();
+      const freshConfig = m.loadConfig(join(root, '.gossip', 'config.json'));
+      const freshAgentConfigs = m.configToAgentConfigs(freshConfig);
+      ctx.relay?.setAgentConfigs(freshAgentConfigs);
+    } catch (e) {
+      process.stderr.write(`[gossipcat] gossip_setup: failed to refresh dashboard agent configs: ${e}\n`);
+    }
+
     // Generate host-appropriate rules file so the IDE knows about the team
     const agentList = Object.entries(config.agents)
       .map(([id, a]: [string, any]) => `- ${id}: ${a.provider}/${a.model} (${a.preset || 'custom'})${a.native ? ' — native' : ''}`)

--- a/packages/orchestrator/src/prompt-assembler.ts
+++ b/packages/orchestrator/src/prompt-assembler.ts
@@ -125,16 +125,34 @@ Before completing:
 
 /**
  * Assemble memory, lens, skills, context, and gossip into a single prompt string.
- * Priority order (highest first — survives truncation):
- *   PROJECT → CHAIN CONTEXT → SKILLS → [CONSENSUS FORMAT | FINDING SCHEMA] → [LENS] → [SPEC REVIEW] → MEMORY → SESSION → context
- * Bracketed items are optional — only present when relevant to the task. The
- * slim FINDING TAG SCHEMA is injected for non-consensus dispatches that carry
- * any meaningful content (so the agent's <agent_finding> tags parse correctly
- * when surfaced retroactively by tools like gossip_dispatch).
- * Skills are behavioral methodology (iron laws, methodology, quality gates) — they define
- * HOW the agent thinks. They must survive truncation over supplementary context like memory/session.
+ *
+ * Block order (truncation-aware):
+ *   PREFIX (truncatable):  IDENTITY → PROJECT → CHAIN CONTEXT → INSTRUCTIONS → SKILLS
+ *   SUFFIX (preserved):    [CONSENSUS FORMAT | FINDING SCHEMA] → [LENS] →
+ *                          [SPEC REVIEW] → MEMORY → AGENT MEMORY → SESSION →
+ *                          context → TASK
+ *
+ * Bracketed items are optional — only present when relevant to the task.
+ *
+ * The slim FINDING TAG SCHEMA is injected for non-consensus dispatches that
+ * carry any meaningful content, so the agent's <agent_finding> tags parse
+ * correctly when surfaced retroactively by tools like gossip_dispatch.
+ *
+ * Skills are behavioral methodology (iron laws, methodology, quality gates) —
+ * they define HOW the agent thinks. They go in the truncatable prefix on the
+ * theory that they are large but also the most expendable single block: we'd
+ * rather truncate skills than lose the output schema or the task.
+ *
+ * The `task` and schema blocks are in the always-preserved suffix because if
+ * they are severed the agent cannot do its job — with no task it has nothing
+ * to do, and without the schema it emits prose that the consensus parser
+ * silently drops.
  */
 export function assemblePrompt(parts: {
+  /** Identity block (## Identity ...) — placed first, truncatable under memory pressure. */
+  identity?: string;
+  /** Raw instructions text (agent role/system prompt body). Placed after SKILLS in the truncatable prefix. */
+  instructions?: string;
   memory?: string;
   memoryDir?: string;
   lens?: string;
@@ -147,26 +165,41 @@ export function assemblePrompt(parts: {
   projectStructure?: string;
   /** Pre-fetched consensus finding snippets to inject under MEMORY block. */
   consensusFindings?: string[];
+  /** The actual task to perform — placed last, always preserved under truncation. */
+  task?: string;
 }): string {
-  const blocks: string[] = [];
+  const prefix: string[] = [];
+  const suffix: string[] = [];
 
-  // HIGH PRIORITY — project layout and chain context for plan continuity
+  // ── PREFIX (truncatable) ───────────────────────────────────────────────
+  if (parts.identity) {
+    // Identity block is already self-delimited with "## Identity" heading.
+    prefix.push(parts.identity);
+  }
+
   if (parts.projectStructure) {
-    blocks.push(`\n\n--- PROJECT ---\n${parts.projectStructure}\n--- END PROJECT ---`);
+    prefix.push(`\n\n--- PROJECT ---\n${parts.projectStructure}\n--- END PROJECT ---`);
   }
 
   if (parts.chainContext) {
-    blocks.push(`\n\n${parts.chainContext}`);
+    prefix.push(`\n\n${parts.chainContext}`);
   }
 
-  // BEHAVIORAL — skills define how the agent thinks, must survive truncation
+  if (parts.instructions) {
+    // Instructions are raw prose (agent role / system prompt body). Kept raw
+    // to avoid breaking tests that match on existing instruction substrings.
+    prefix.push(`\n\n${parts.instructions}`);
+  }
+
+  // BEHAVIORAL — skills define how the agent thinks
   if (parts.skills) {
-    blocks.push(`\n\n--- SKILLS ---\n${parts.skills}\n--- END SKILLS ---`);
+    prefix.push(`\n\n--- SKILLS ---\n${parts.skills}\n--- END SKILLS ---`);
   }
 
+  // ── SUFFIX (preserved under truncation) ────────────────────────────────
   if (parts.consensusSummary) {
     // Consensus dispatches need the full cross-review framing.
-    blocks.push(`\n\n--- CONSENSUS OUTPUT FORMAT ---\n${CONSENSUS_OUTPUT_FORMAT}\n\nThis section will be used for cross-review with peer agents.\n--- END CONSENSUS OUTPUT FORMAT ---`);
+    suffix.push(`\n\n--- CONSENSUS OUTPUT FORMAT ---\n${CONSENSUS_OUTPUT_FORMAT}\n\nThis section will be used for cross-review with peer agents.\n--- END CONSENSUS OUTPUT FORMAT ---`);
   } else {
     // Non-consensus dispatches still need the type enum + anti-invention rule
     // so agent output is parseable when the dashboard retroactively shows it.
@@ -175,26 +208,26 @@ export function assemblePrompt(parts: {
     // Skip entirely when no other content is present (e.g. assemblePrompt({}))
     // so tests + callers that deliberately ask for an empty prompt still get one.
     const hasAnyMeaningfulPart = !!(
+      parts.identity || parts.instructions ||
       parts.memory || parts.memoryDir || parts.lens || parts.skills ||
       parts.context || parts.sessionContext || parts.chainContext ||
       parts.specReviewContext || parts.projectStructure ||
+      parts.task ||
       (parts.consensusFindings && parts.consensusFindings.length > 0)
     );
     if (hasAnyMeaningfulPart) {
-      blocks.push(`\n\n--- FINDING TAG SCHEMA ---\n${FINDING_TAG_SCHEMA}\n--- END FINDING TAG SCHEMA ---`);
+      suffix.push(`\n\n--- FINDING TAG SCHEMA ---\n${FINDING_TAG_SCHEMA}\n--- END FINDING TAG SCHEMA ---`);
     }
   }
 
   if (parts.lens) {
-    blocks.push(`\n\n--- LENS ---\n${parts.lens}\n--- END LENS ---`);
+    suffix.push(`\n\n--- LENS ---\n${parts.lens}\n--- END LENS ---`);
   }
 
-  // SPEC REVIEW — cross-reference material, must survive truncation over memory/session
   if (parts.specReviewContext) {
-    blocks.push(`\n\n--- SPEC REVIEW ---\n${parts.specReviewContext}\n--- END SPEC REVIEW ---`);
+    suffix.push(`\n\n--- SPEC REVIEW ---\n${parts.specReviewContext}\n--- END SPEC REVIEW ---`);
   }
 
-  // SUPPLEMENTARY — memory and session context are useful but expendable under truncation
   if (parts.memory || (parts.consensusFindings && parts.consensusFindings.length > 0)) {
     const memParts: string[] = [];
     if (parts.memory) memParts.push(parts.memory);
@@ -206,11 +239,11 @@ export function assemblePrompt(parts: {
         parts.consensusFindings.map((f, i) => `${i + 1}. ${f}`).join('\n');
       memParts.push(findingsBlock);
     }
-    blocks.push(`\n\n--- MEMORY ---\n${memParts.join('\n\n')}\n--- END MEMORY ---`);
+    suffix.push(`\n\n--- MEMORY ---\n${memParts.join('\n\n')}\n--- END MEMORY ---`);
   }
 
   if (parts.memoryDir) {
-    blocks.push(`\n\n--- AGENT MEMORY ---
+    suffix.push(`\n\n--- AGENT MEMORY ---
 Your persistent memory directory: ${parts.memoryDir}
 Save important learnings using file_write to this directory.
 What to save: technology choices, file structure, key patterns, architectural decisions, gotchas.
@@ -220,21 +253,30 @@ Keep entries concise (5-10 lines each). Update existing files rather than creati
   }
 
   if (parts.sessionContext) {
-    blocks.push(`\n\n${parts.sessionContext}`);
+    suffix.push(`\n\n${parts.sessionContext}`);
   }
 
   if (parts.context) {
-    blocks.push(`\n\nContext:\n${parts.context}`);
+    suffix.push(`\n\nContext:\n${parts.context}`);
   }
 
-  let assembled = blocks.join('');
+  // TASK last — the most important surviving element.
+  if (parts.task) {
+    suffix.push(`\n\n---\n\nTask: ${parts.task}`);
+  }
 
   // Cap total prompt size to prevent context window overflow.
-  // ~30K chars ≈ ~8K tokens — leaves room for system prompt + task + tool results.
+  // ~30K chars ≈ ~8K tokens — leaves room for system prompt + tool results.
+  // Truncate only the prefix so the suffix (schema + task) always survives.
+  // See consensus finding 12827629-fa9a4660:f8 (native consensus block-order
+  // regression) — concatenating then truncating could sever CONSENSUS OUTPUT
+  // FORMAT, causing silent consensus degradation.
   const MAX_PROMPT_CHARS = 30_000;
-  if (assembled.length > MAX_PROMPT_CHARS) {
-    assembled = assembled.slice(0, MAX_PROMPT_CHARS) + '\n\n[Context truncated to fit budget]';
+  const suffixStr = suffix.join('');
+  let prefixStr = prefix.join('');
+  const budget = Math.max(0, MAX_PROMPT_CHARS - suffixStr.length);
+  if (prefixStr.length > budget) {
+    prefixStr = prefixStr.slice(0, budget) + '\n\n[Context truncated to fit budget]';
   }
-
-  return assembled;
+  return prefixStr + suffixStr;
 }

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -299,4 +299,15 @@ export class RelayServer {
       connectedAgentIds: this.connectionManager.getAll().map(c => c.agentId),
     });
   }
+
+  /**
+   * Update the dashboard's cached agent configs. Call from the MCP server
+   * after gossip_setup writes config.json so the Team page reflects the new
+   * team without requiring /mcp reconnect. The boot-time snapshot
+   * (mcp-server-sdk.ts:365) still wins on initial boot — this method is a
+   * post-setup override, not a replacement.
+   */
+  setAgentConfigs(configs: Array<{ id: string; provider: string; model: string; preset?: string; skills: string[]; native?: boolean }>): void {
+    this.dashboardRouter?.updateContext({ agentConfigs: configs });
+  }
 }

--- a/tests/cli/dispatch-native-prompt.test.ts
+++ b/tests/cli/dispatch-native-prompt.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Regression tests for the native dispatch prompt pipeline.
+ *
+ * These exist because PR #56 added FINDING_TAG_SCHEMA injection inside
+ * assemblePrompt() — but the native dispatch path built prompts via manual
+ * concat and silently missed the update. The bug shipped to fresh installs:
+ * native agents produced markdown tables instead of <agent_finding> tags,
+ * consensus synthesis fell through to bullet parsing, and the dashboard
+ * showed 0 findings.
+ *
+ * The fix (combined PR) unifies all dispatch paths through assemblePrompt()
+ * and these tests assert the schema blocks appear in the native agent prompt
+ * output so a future drift is caught in CI.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { ctx } from '../../apps/cli/src/mcp-context';
+import {
+  handleDispatchSingle,
+  handleDispatchParallel,
+  handleDispatchConsensus,
+} from '../../apps/cli/src/handlers/dispatch';
+
+type SkillIndexStub = {
+  getAgentSlots: (agentId: string) => Array<{ slot: number }>;
+  getEnabledSkills: (agentId: string) => string[];
+  getSkillMode: (agentId: string, skill: string) => 'permanent' | 'contextual';
+};
+
+function makeSkillIndex(enabled: string[]): SkillIndexStub {
+  return {
+    getAgentSlots: () => enabled.map((_, i) => ({ slot: i })),
+    getEnabledSkills: () => enabled,
+    getSkillMode: () => 'permanent' as const,
+  };
+}
+
+function makeMainAgent(overrides: Record<string, any> = {}): any {
+  return {
+    dispatch: jest.fn().mockReturnValue({ taskId: 'default-task-id' }),
+    collect: jest.fn().mockResolvedValue({ results: [] }),
+    getAgentConfig: jest.fn().mockReturnValue(null),
+    getLlm: jest.fn().mockReturnValue(null),
+    getLLM: jest.fn().mockReturnValue(null),
+    getAgentList: jest.fn().mockReturnValue([]),
+    getSkillGapSuggestions: jest.fn().mockReturnValue([]),
+    getSkillIndex: jest.fn().mockReturnValue(null),
+    getSessionGossip: jest.fn().mockReturnValue([]),
+    getSessionConsensusHistory: jest.fn().mockReturnValue([]),
+    recordNativeTask: jest.fn(),
+    recordNativeTaskCompleted: jest.fn(),
+    recordPlanStepResult: jest.fn(),
+    publishNativeGossip: jest.fn().mockResolvedValue(undefined),
+    getChainContext: jest.fn().mockReturnValue(''),
+    generateLensesForAgents: jest.fn().mockResolvedValue(new Map()),
+    dispatchParallel: jest.fn().mockResolvedValue({ taskIds: [], errors: [] }),
+    dispatchParallelWithLenses: jest.fn().mockResolvedValue({ taskIds: [], errors: [] }),
+    getTask: jest.fn().mockReturnValue(null),
+    scopeTracker: {
+      hasOverlap: jest.fn().mockReturnValue({ overlaps: false }),
+      register: jest.fn(),
+      release: jest.fn(),
+    },
+    pipeline: null,
+    projectRoot: '/tmp/gossip-test-project',
+    ...overrides,
+  };
+}
+
+const originalCtx = {
+  mainAgent: ctx.mainAgent,
+  relay: ctx.relay,
+  workers: ctx.workers,
+  keychain: ctx.keychain,
+  skillEngine: ctx.skillEngine,
+  nativeTaskMap: ctx.nativeTaskMap,
+  nativeResultMap: ctx.nativeResultMap,
+  nativeAgentConfigs: ctx.nativeAgentConfigs,
+  pendingConsensusRounds: ctx.pendingConsensusRounds,
+  booted: ctx.booted,
+  boot: ctx.boot,
+  syncWorkersViaKeychain: ctx.syncWorkersViaKeychain,
+};
+
+function resetCtx(mainAgentOverrides: Record<string, any> = {}) {
+  ctx.mainAgent = makeMainAgent(mainAgentOverrides);
+  ctx.nativeTaskMap = new Map();
+  ctx.nativeResultMap = new Map();
+  ctx.nativeAgentConfigs = new Map();
+  ctx.pendingConsensusRounds = new Map();
+  ctx.booted = true;
+  ctx.boot = jest.fn().mockResolvedValue(undefined) as any;
+  ctx.syncWorkersViaKeychain = jest.fn().mockResolvedValue(undefined) as any;
+  (ctx as any).skillEngine = null;
+}
+
+function restoreCtx() {
+  Object.assign(ctx, originalCtx);
+}
+
+/**
+ * AGENT_PROMPT is emitted as the second content item for native dispatches.
+ * Tests use this helper so they fail loudly if the payload layout changes
+ * (instead of silently checking the wrong string).
+ */
+function extractAgentPrompt(content: Array<{ text: string }>): string {
+  const match = content.find(c => c.text.startsWith('AGENT_PROMPT:'));
+  if (!match) throw new Error(`no AGENT_PROMPT content item; got: ${content.map(c => c.text.slice(0, 40)).join(' | ')}`);
+  return match.text;
+}
+
+describe('native dispatch — FINDING TAG SCHEMA injection (non-consensus)', () => {
+  let skillDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    skillDir = mkdtempSync(join(tmpdir(), 'gossip-native-prompt-'));
+    mkdirSync(join(skillDir, '.gossip', 'skills'), { recursive: true });
+    process.chdir(skillDir);
+    resetCtx();
+  });
+
+  afterEach(() => {
+    restoreCtx();
+    process.chdir(prevCwd);
+    rmSync(skillDir, { recursive: true, force: true });
+  });
+
+  it('handleDispatchSingle injects FINDING TAG SCHEMA markers', async () => {
+    ctx.nativeAgentConfigs.set('native-claude', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Native reviewer',
+      skills: [],
+    });
+
+    const result = await handleDispatchSingle('native-claude', 'Audit the memory system');
+    const prompt = extractAgentPrompt(result.content);
+    expect(prompt).toContain('--- FINDING TAG SCHEMA ---');
+    expect(prompt).toContain('--- END FINDING TAG SCHEMA ---');
+    // The slim schema goes out on non-consensus — full cross-review framing must NOT appear.
+    expect(prompt).not.toContain('--- CONSENSUS OUTPUT FORMAT ---');
+  });
+
+  it('handleDispatchSingle places the schema AFTER skills (ordering invariant)', async () => {
+    writeFileSync(
+      join(skillDir, '.gossip', 'skills', 'memory-retrieval.md'),
+      '---\nname: memory-retrieval\nmode: permanent\n---\nRecall past findings before making new claims.\n',
+    );
+    ctx.mainAgent = makeMainAgent({
+      getSkillIndex: jest.fn().mockReturnValue(makeSkillIndex(['memory-retrieval'])),
+    });
+    ctx.nativeAgentConfigs.set('native-claude', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Native reviewer',
+      skills: ['memory-retrieval'],
+    });
+
+    const result = await handleDispatchSingle('native-claude', 'Audit memory');
+    const prompt = extractAgentPrompt(result.content);
+    const skillsIdx = prompt.indexOf('--- SKILLS ---');
+    const schemaIdx = prompt.indexOf('--- FINDING TAG SCHEMA ---');
+    const taskIdx = prompt.indexOf('Task: Audit memory');
+    expect(skillsIdx).toBeGreaterThan(-1);
+    expect(schemaIdx).toBeGreaterThan(-1);
+    expect(taskIdx).toBeGreaterThan(-1);
+    expect(skillsIdx).toBeLessThan(schemaIdx);
+    expect(schemaIdx).toBeLessThan(taskIdx);
+  });
+
+  it('handleDispatchParallel (consensus=false) injects FINDING TAG SCHEMA', async () => {
+    ctx.nativeAgentConfigs.set('native-claude', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Native reviewer',
+      skills: [],
+    });
+
+    const result = await handleDispatchParallel(
+      [{ agent_id: 'native-claude', task: 'Audit x' }],
+      false,
+    );
+    const prompt = extractAgentPrompt(result.content);
+    expect(prompt).toContain('--- FINDING TAG SCHEMA ---');
+    expect(prompt).not.toContain('--- CONSENSUS OUTPUT FORMAT ---');
+  });
+});
+
+describe('native dispatch — CONSENSUS OUTPUT FORMAT injection (consensus)', () => {
+  let skillDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    skillDir = mkdtempSync(join(tmpdir(), 'gossip-native-consensus-'));
+    mkdirSync(join(skillDir, '.gossip', 'skills'), { recursive: true });
+    process.chdir(skillDir);
+    resetCtx({
+      generateLensesForAgents: jest.fn().mockResolvedValue(new Map()),
+    });
+  });
+
+  afterEach(() => {
+    restoreCtx();
+    process.chdir(prevCwd);
+    rmSync(skillDir, { recursive: true, force: true });
+  });
+
+  it('handleDispatchConsensus injects CONSENSUS OUTPUT FORMAT markers', async () => {
+    ctx.nativeAgentConfigs.set('native-claude', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Native reviewer',
+      skills: [],
+    });
+
+    const result = await handleDispatchConsensus([
+      { agent_id: 'native-claude', task: 'Audit memory' },
+    ]);
+    const prompt = extractAgentPrompt(result.content);
+    expect(prompt).toContain('--- CONSENSUS OUTPUT FORMAT ---');
+    expect(prompt).toContain('--- END CONSENSUS OUTPUT FORMAT ---');
+    // Consensus path emits the full block, not the slim schema.
+    expect(prompt).not.toContain('--- FINDING TAG SCHEMA ---');
+  });
+
+  it('handleDispatchConsensus preserves block ordering: SKILLS < CONSENSUS FORMAT < TASK', async () => {
+    writeFileSync(
+      join(skillDir, '.gossip', 'skills', 'memory-retrieval.md'),
+      '---\nname: memory-retrieval\nmode: permanent\n---\nRecall past findings.\n',
+    );
+    ctx.mainAgent = makeMainAgent({
+      generateLensesForAgents: jest.fn().mockResolvedValue(new Map()),
+      getSkillIndex: jest.fn().mockReturnValue(makeSkillIndex(['memory-retrieval'])),
+    });
+    ctx.nativeAgentConfigs.set('native-claude', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Native reviewer',
+      skills: ['memory-retrieval'],
+    });
+
+    const result = await handleDispatchConsensus([
+      { agent_id: 'native-claude', task: 'Audit memory' },
+    ]);
+    const prompt = extractAgentPrompt(result.content);
+    const skillsIdx = prompt.indexOf('--- SKILLS ---');
+    const consensusIdx = prompt.indexOf('--- CONSENSUS OUTPUT FORMAT ---');
+    const taskIdx = prompt.indexOf('Task: Audit memory');
+    expect(skillsIdx).toBeGreaterThan(-1);
+    expect(consensusIdx).toBeGreaterThan(-1);
+    expect(taskIdx).toBeGreaterThan(-1);
+    expect(skillsIdx).toBeLessThan(consensusIdx);
+    expect(consensusIdx).toBeLessThan(taskIdx);
+  });
+});

--- a/tests/relay/dashboard-routes.test.ts
+++ b/tests/relay/dashboard-routes.test.ts
@@ -360,4 +360,64 @@ describe('RelayServer dashboard integration', () => {
     expect(data).toHaveProperty('agentsOnline');
     expect(data).toHaveProperty('totalSignals');
   });
+
+  // Regression for "Team page shows empty list on fresh install". The boot
+  // snapshot at mcp-server-sdk.ts:365 runs once; if the user calls
+  // gossip_setup AFTER boot, the dashboard stays empty until /mcp reconnect
+  // unless the MCP server calls setAgentConfigs() to push the new team.
+  it('setAgentConfigs updates /dashboard/api/agents without restart', async () => {
+    // Authenticate first so we can call the API.
+    const postBody = JSON.stringify({ key: server.dashboardKey });
+    const authRes = await new Promise<{ cookie: string }>((resolve, reject) => {
+      const req = http.request(`http://localhost:${server.port}/dashboard/api/auth`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(postBody) },
+      }, (res) => {
+        let body = '';
+        res.on('data', (chunk) => body += chunk);
+        res.on('end', () => resolve({
+          cookie: (res.headers['set-cookie']?.[0] ?? '').split(';')[0],
+        }));
+      });
+      req.on('error', reject);
+      req.write(postBody);
+      req.end();
+    });
+
+    const fetchAgents = async (): Promise<any[]> => {
+      const res = await new Promise<{ body: string }>((resolve, reject) => {
+        const req = http.request(`http://localhost:${server.port}/dashboard/api/agents`, {
+          headers: { Cookie: authRes.cookie },
+        }, (r) => {
+          let body = '';
+          r.on('data', (c) => body += c);
+          r.on('end', () => resolve({ body }));
+        });
+        req.on('error', reject);
+        req.end();
+      });
+      return JSON.parse(res.body);
+    };
+
+    // Start: empty team (boot snapshot with no agents).
+    expect(await fetchAgents()).toEqual([]);
+
+    // Simulate gossip_setup writing config.json and calling setAgentConfigs.
+    server.setAgentConfigs([
+      {
+        id: 'sonnet-reviewer',
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        preset: 'reviewer',
+        skills: ['code_review'],
+        native: true,
+      },
+    ]);
+
+    // Dashboard reflects the new team without /mcp reconnect.
+    const after = await fetchAgents();
+    expect(after).toHaveLength(1);
+    expect(after[0].id).toBe('sonnet-reviewer');
+    expect(after[0].native).toBe(true);
+  });
 });


### PR DESCRIPTION
See commit message for full detail.

## Summary

Two fresh-install bugs + a structural refactor so we don't regress again.

**Part A** — Team page staleness: `gossip_setup` now pushes fresh agentConfigs into the dashboard via new `RelayServer.setAgentConfigs()` hook. No more `/mcp` reconnect required.

**Part B1** — `assemblePrompt()` extended with `identity`/`instructions`/`task` parts + truncatable-prefix / preserved-suffix split so schema + task always survive the 30K cap.

**Part B2** — Native dispatch (3 sites in `dispatch.ts`) refactored to call `assemblePrompt()` instead of manual concat. Fixes the root cause: native agents now receive FINDING_TAG_SCHEMA / CONSENSUS_OUTPUT_FORMAT same as relay agents.

Parity confirmed: relay + native paths produce identical block sequence (SKILLS → SCHEMA → ...).

## Tests

- NEW `tests/cli/dispatch-native-prompt.test.ts` — 5 tests covering single/parallel/consensus schema markers + SKILLS<SCHEMA<TASK ordering
- +1 test in `tests/relay/dashboard-routes.test.ts` — setAgentConfigs live update
- Full suite: 120 suites / 1463 pass / 1 pre-existing skip / 0 fail
- `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)