### PR TITLE
fix(gossip_run): route native dispatch through handleDispatchSingle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,46 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ## [Unreleased]
 
-## [0.3.0] — 2026-04-13
+## [0.4.0] — 2026-04-14
+
+Combines the unreleased 0.3.0 work (server-side cross-review, memory pre-fetch, scoring, dashboard polish) with three new streams: HTTP file bridge infrastructure, the consensus type-contract fix, and a long-standing test bug cleanup.
+
+> **Note:** v0.3.0 was published to npm on 2026-04-13 but never cut a matching GitHub release. Its changes are included here under 0.4.0 rather than retroactively tagged — the CHANGELOG entries below merge both cycles for a single coherent release. If you installed 0.3.0 from npm, upgrading to 0.4.0 is additive; behavior changes are called out explicitly in the "Behavior changes" subsection.
+
+### Behavior changes (read before upgrading)
+
+- **`formatCompliant` now requires `tags_accepted > 0`.** Previously an agent that emitted `<agent_finding>` tags with non-canonical `type` values (e.g. `approval`, `concern`, `risk`) was counted as format-compliant because the raw tag count was non-zero. The parser silently dropped those tags, but the meta-signal stayed positive. The new behavior is stricter: compliance requires that at least one tag survived the type-enum filter. Agents producing only invented types will now correctly fail the compliance check. Downstream consumers (signals pipeline, per-agent accuracy, dashboard) will see a short-term shift in the `format_compliance` signal distribution — this is a correction, not a regression. See PR #56.
+
+### HTTP file bridge — foundation (#54, #55)
+
+Two stacked PRs land the groundwork for live tool proxying to closed-toolchain remote agents (openclaw and future HTTP-only providers). **The bridge is dead code in this release — it ships behind the `enableHttpBridge` AgentConfig flag (default off) and is not wired into dispatch yet.** A follow-up PR will land the dispatch-pipeline integration (token issuance, cleanup paths, prompt block, sentinel detector) in a future release. What's in 0.4.0:
+
+- `packages/tools/src/scope.ts` — extracted `canonicalizeForBoundary` + `validatePathInScope` from `tool-server.ts` as a shared security primitive. Both branches of the original function (including the security-critical non-existent-path branch for `/file-write`) preserved verbatim. Exported from `@gossip/tools` barrel.
+- `packages/orchestrator/src/rate-limiter.ts` — generic sliding-window `RateLimiter` supporting both count mode (weight=1) and weighted-sum mode (variable weights for in-flight byte quotas). Purges expired entries on every access. Rejects single events whose weight exceeds `maxWeight` (strict interpretation for bytes quota).
+- `packages/relay/src/message-rate-limiter.ts` — rewritten as a thin adapter over the generic limiter. Public API (`isAllowed`, `clear`, `RateLimiterConfig`) unchanged.
+- `packages/orchestrator/src/http-bridge-server.ts` + `http-bridge-handlers.ts` — factory `createHttpBridgeServer()` returning the `HttpBridgeServer` interface (`listen`/`issueToken`/`revoke`/`close`). Seven endpoints (`/file-read`, `/file-write`, `/file-list`, `/file-grep`, `/run-tests`, `/sentinel`, `/bridge-info`), per-task bearer tokens, 127.0.0.1 binding by default, pre-body Content-Length check on writes (not `express.json`), ETag with pipe-delimited hash, per-token RPS + in-flight-bytes quotas, `BridgeConfigError` thrown when `bridgeRemoteAccess: true` without TLS cert. 32 new tests.
+- 4 new optional `AgentConfig` fields (`enableHttpBridge`, `bridgeWriteMode`, `bridgeScope`, `bridgeRemoteAccess`) — all default off.
+
+Spec at `docs/specs/2026-04-14-http-file-bridge.md`, updated from a 3-agent pre-implementation review (#53) that caught 5 HIGH spec inaccuracies before code was written.
+
+### Consensus type contract — strict parser, loud drops (#56)
+
+Fixes a silent-drop bug where agents emitted `<agent_finding type="approval|concern|risk|recommendation|confirmed">` tags and the parser silently discarded them, leaving the dashboard showing "0 findings" despite 14+ tagged observations.
+
+- New `packages/orchestrator/src/finding-tag-schema.ts` — single source of truth for the tag contract. Exports `FINDING_TAG_SCHEMA` (the ~6-line type-enum + anti-invention rule) and `CONSENSUS_OUTPUT_FORMAT` (schema + consensus-specific framing) with a prominent "⚠ UNKNOWN TYPES ARE SILENTLY DROPPED" header.
+- 10 default skills flattened — `## Output Format` sections replaced with a canonical 2-line pointer to the system-prompt schema. Skills now describe methodology only; output format is the orchestrator's responsibility.
+- `prompt-assembler.ts` now injects a format block on every skill-bearing dispatch (full `CONSENSUS_OUTPUT_FORMAT` for consensus, slim `FINDING_TAG_SCHEMA` for non-consensus) — previously non-consensus tasks had no tag-schema guidance at all.
+- New `packages/orchestrator/src/parse-findings.ts` — shared `parseAgentFindingsStrict()` helper replaces two duplicated regex sites in `consensus-engine.ts`. Preserves `findingIdx` sequential IDs (load-bearing for cross-review matching). Returns per-type drop counters via `onUnknownType` callback.
+- Per-drop `⚠ DROPPED` log + per-round `⚠ DROP_SUMMARY` log at both parser sites. Misleading "ZERO tags" warning split into three paths (zero raw tags / all invalid / missing type attribute).
+- New `droppedFindingsByType: Record<string, number>` field on `ConsensusReport`, populated in synthesis, persisted from `collect.ts` and `relay-cross-review.ts`. Dashboard surface: `FindingsMetrics.tsx` shows a "dropped findings" badge with tooltip listing offending types.
+- `format_compliance` meta-signal extended with `{tags_total, tags_accepted, tags_dropped_unknown_type, tags_dropped_short_content}` for empirical fix verification.
+- 35 new unit tests covering canonical types, unknown types, typos, missing type attr, case sensitivity, single-quote rejection, whitespace rejection, multi-line bodies, unclosed tags, nested angle brackets, short-content drops.
+
+Diagnosed via a 3-agent consensus round (sonnet-reviewer + haiku-researcher + gemini-reviewer, 26 findings confirmed). Parser enum intentionally **not broadened** — broadening would normalize bad input and invite further drift.
+
+### Message-rate-limiter windowing test fix
+
+`tests/relay/message-rate-limiter.test.ts` "should not let old messages affect the current window" had an off-by-one (sent 5 messages then asserted the 6th call returns true with `maxMessages=5`). Fix is a 1-char change: `maxMessages - 2` → `maxMessages - 3`. Suite removed from `KNOWN_BROKEN_SUITES` — no longer skipped in CI.
 
 ### Server-side cross-review with epsilon-greedy reviewer selection (#45)
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Gossipcat ships from **[GitHub Releases](https://github.com/gossipcat-ai/gossipc
 |---|---|
 | **MCP server** | Bundled binary at `dist-mcp/mcp-server.js`, wired as the `gossipcat` command on `PATH` |
 | **Dashboard** | Prebuilt static assets in `dist-dashboard/` — launches automatically on a dynamic port (ask Claude Code *"what's my gossipcat dashboard URL?"*). Override with `GOSSIPCAT_PORT=24420` if you want a stable port. |
-| **Default skills + rules + archetypes** | 18 bundled skill templates, operational rules, and project archetypes copied into the install |
+| **Default skills + rules + archetypes** | 16 bundled skill templates, operational rules, and project archetypes copied into the install |
 | **Postinstall wizard** | Writes `.mcp.json` with correct absolute paths for your machine |
 
 ### Alternative install paths

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -26,9 +26,9 @@ import { randomUUID, randomBytes, timingSafeEqual } from 'crypto';
 import { createServer as createHttpServer, IncomingMessage, ServerResponse } from 'http';
 
 // ── Extracted modules ────────────────────────────────────────────────────
-import { ctx, NATIVE_TASK_TTL_MS } from './mcp-context';
+import { ctx } from './mcp-context';
 import { getGossipcatVersion } from './version';
-import { evictStaleNativeTasks, persistNativeTaskMap, restoreNativeTaskMap, handleNativeRelay, spawnTimeoutWatcher } from './handlers/native-tasks';
+import { restoreNativeTaskMap, handleNativeRelay, spawnTimeoutWatcher } from './handlers/native-tasks';
 import { handleDispatchSingle, handleDispatchParallel, handleDispatchConsensus } from './handlers/dispatch';
 import { handleCollect } from './handlers/collect';
 import { restorePendingConsensus } from './handlers/relay-cross-review';
@@ -1756,94 +1756,19 @@ server.tool(
 
     const isNative = ctx.nativeAgentConfigs.has(agent_id);
 
-    // Sandbox mitigation 1: sanitize project paths in the task prompt
-    let _runSanitized = false;
-    try {
-      const { relativizeProjectPaths, readSandboxMode, shouldSanitize } = require('./sandbox');
-      if (readSandboxMode(process.cwd()) !== 'off') {
-        const preset = (() => {
-          try { return ctx.mainAgent.getAgentList?.().find((a: any) => a.id === agent_id)?.preset; } catch { return undefined; }
-        })();
-        if (shouldSanitize(write_mode, preset)) {
-          const { sanitized, replacements } = relativizeProjectPaths(task, process.cwd());
-          if (replacements > 0) {
-            process.stderr.write(`[gossipcat] 🧹 sanitized ${replacements} project path(s) in task for ${agent_id}\n`);
-          }
-          task = sanitized;
-          _runSanitized = true;
-        }
-      }
-    } catch { /* best-effort */ }
+    if (isNative) {
+      // Delegate to handleDispatchSingle — single source of truth for native prompt
+      // assembly (identity + skills + FINDING_TAG_SCHEMA + chainContext + memory + task)
+      // after PR #59 unified the path. Previously gossip_run manually concatenated its
+      // own bare prompt and silently skipped the schema; consensus round
+      // b0cc4995-0cd34dc7 surfaced this as the reason fresh-install agents produced
+      // prose tables instead of <agent_finding> tags.
+      return handleDispatchSingle(agent_id, task, write_mode, scope);
+    }
 
     const options: any = {};
     if (write_mode) options.writeMode = write_mode;
     if (scope) options.scope = scope;
-
-    if (isNative) {
-      // Native agent — validate scope, record task, return instructions for host
-      if (write_mode === 'scoped') {
-        if (!scope) {
-          return { content: [{ type: 'text' as const, text: 'Error: scoped write mode requires a scope path' }] };
-        }
-        const overlap = ctx.mainAgent.scopeTracker.hasOverlap(scope);
-        if (overlap.overlaps) {
-          return { content: [{ type: 'text' as const, text: `Error: Scope "${scope}" conflicts with running task ${overlap.conflictTaskId} at "${overlap.conflictScope}"` }] };
-        }
-      }
-
-      evictStaleNativeTasks();
-      const taskId = require('crypto').randomUUID().slice(0, 8);
-      const relayToken = require('crypto').randomUUID().slice(0, 12);
-      ctx.nativeTaskMap.set(taskId, { agentId: agent_id, task, startedAt: Date.now(), timeoutMs: NATIVE_TASK_TTL_MS, relayToken });
-      spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
-      persistNativeTaskMap();
-      try { ctx.mainAgent.recordNativeTask(taskId, agent_id, task); } catch { /* best-effort */ }
-
-      // Register scope so subsequent dispatches see it
-      if (write_mode === 'scoped' && scope) {
-        ctx.mainAgent.scopeTracker.register(scope, taskId);
-      }
-      const config = ctx.nativeAgentConfigs.get(agent_id)!;
-
-      // Use agent's .claude/agents/<id>.md instructions as the system prompt
-      const basePrompt = config.instructions
-        || `You are a skilled ${config.description || 'agent'}. Complete the task thoroughly.`;
-
-      // Inject scope restriction for scoped write mode
-      const scopePrefix = (write_mode === 'scoped' && scope)
-        ? `SCOPE RESTRICTION: Only modify files within ${scope}. Do not edit files outside this directory.\n\n`
-        : '';
-
-      let agentPrompt = `${scopePrefix}${basePrompt}\n\n---\n\nTask: ${task}`;
-      if (_runSanitized) {
-        try {
-          const { prependScopeNote } = require('./sandbox');
-          agentPrompt = prependScopeNote(agentPrompt);
-        } catch { /* best-effort */ }
-      }
-      // Record dispatch metadata for post-task audit
-      try {
-        const { recordDispatchMetadata } = require('./sandbox');
-        recordDispatchMetadata(process.cwd(), {
-          taskId, agentId: agent_id, writeMode: write_mode, scope, timestamp: Date.now(),
-        });
-      } catch { /* best-effort */ }
-      // config.model is already the short tier ('sonnet', 'opus', 'haiku') from boot
-      const modelShort = config.model || 'sonnet';
-
-      return {
-        content: [
-          { type: 'text' as const, text:
-            `Dispatched to ${agent_id} (native). Task ID: ${taskId}\n\n` +
-            `⚠️ EXECUTE NOW — launch this Agent and relay the result:\n\n` +
-            `1. Agent(model: "${modelShort}", prompt: <AGENT_PROMPT:${taskId} below>, run_in_background: true) — pass the AGENT_PROMPT:${taskId} content item verbatim\n` +
-            `2. When agent completes → gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<full agent output>")\n\n` +
-            `Do BOTH steps in your next response. Do not wait for user input between them.`
-          },
-          { type: 'text' as const, text: `AGENT_PROMPT:${taskId} (${agent_id})\n${agentPrompt}` },
-        ],
-      };
-    }
 
     // Relay worker — dispatch and collect in one call
     // Sync workers lazily: if this agent isn't connected yet (e.g. added after boot), spin it up now

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -73,6 +73,20 @@ Skills with `status: 'failed'` or `status: 'silent_skill'` are filtered out at `
 
 **Do not** add a second filter site. Filtering is a read-only operation at load-for-injection time; frontmatter is never mutated.
 
+### 8. `FINDING_TAG_SCHEMA` is the single source of truth — parsers are strict, prompts are explicit, drops are loud
+
+The `<agent_finding>` tag contract lives in `packages/orchestrator/src/finding-tag-schema.ts`. Type MUST be one of `finding | suggestion | insight`. Any other value (e.g. `approval`, `concern`, `risk`, `recommendation`, `confirmed`) is silently dropped by the parser, counted in `droppedFindingsByType`, logged at both `parseAgentFindingsStrict` call sites, and surfaced in the dashboard as a "dropped findings" badge with tooltip listing the offending types.
+
+**Do not** broaden the parser enum to "accept" new types. Every accepted synonym teaches the next agent the enum is negotiable. Drift is unbounded — today it's `approval`, tomorrow it's `verdict`, `observation`, `critique`. The fix is to make the contract loud, not to normalize bad input.
+
+`FINDING_TAG_SCHEMA` is injected on every skill-bearing dispatch — full `CONSENSUS_OUTPUT_FORMAT` (schema + cross-review framing) for consensus rounds, slim schema-only block for non-consensus. Default skills point to the system-prompt schema with a 2-line pointer; they do not define their own `## Output Format`. User-editable skills at `.gossip/agents/<id>/skills/*.md` are not touched automatically — if you fork a default skill, use the pointer pattern.
+
+### 9. `formatCompliant` requires accepted tags, not raw-count tags
+
+`detectFormatCompliance` in `dispatch-pipeline.ts` computes compliance as `tags_accepted > 0 && citationCount >= tags_accepted`. An agent that emits 14 `<agent_finding>` tags all with `type="approval"` is NOT compliant — the tags are dropped by the type-enum filter, `tags_accepted` is zero, and the compliance signal correctly fails. The `format_compliance` meta-signal payload includes `{tags_total, tags_accepted, tags_dropped_unknown_type, tags_dropped_short_content}` so drift can be tracked empirically.
+
+If you see an agent scoring badly on compliance despite emitting tags, check `droppedFindingsByType` on the consensus report — the invented type will be named there.
+
 ---
 
 ## Operator playbook (for orchestrator LLMs)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossipcat",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
   "mcpName": "io.github.ataberk-xyz/gossipcat",
   "repository": {


### PR DESCRIPTION
## Summary

PR #59 unified the native prompt path in `handleDispatchSingle`/`Parallel`/`Consensus` so every native dispatch receives identity + skills + FINDING_TAG_SCHEMA + chainContext + memory + task via `assemblePrompt()`.

But **`gossip_run`'s native branch had its own inline dispatch** at `mcp-server-sdk.ts:1782-1846` that manually concatenated `[scopePrefix, instructions, task]` with none of those blocks. Since `gossip_run` is the documented preferred entrypoint (per CLAUDE.md dispatch rule), the fresh-install bug was **still reachable through it** even after PR #59 shipped.

Fix: replace the native branch body with a single call to `handleDispatchSingle(agent_id, task, write_mode, scope)`. The relay branch is unchanged.

## Discovery

3-agent drift audit consensus round `b0cc4995-0cd34dc7` flagged this as CRITICAL. Sonnet-reviewer caught it; cross-verified against code; recorded as `unique_confirmed` signal.

## Diff

```
apps/cli/src/mcp-server-sdk.ts | 11 insertions(+), 86 deletions(-)
```

Net -75 LOC — removes duplicated-and-broken dispatch logic now centralized in `handleDispatchSingle` post-PR #59.

Also drops unused `_runSanitized` flag and unused imports (`NATIVE_TASK_TTL_MS`, `evictStaleNativeTasks`, `persistNativeTaskMap`) — now all handled inside `handleDispatchSingle`.

## Tests

- 119 suites / 1457 pass / 1 pre-existing skip / 0 fail
- `npm run build` clean across all workspaces
- Existing PR #59 test `tests/cli/dispatch-native-prompt.test.ts` covers `handleDispatchSingle`; `gossip_run` now delegates there so the same coverage applies

## First of 4 planned follow-up PRs

- **#60 (this)**: `gossip_run` native → `handleDispatchSingle`
- **#61**: `refreshAgentState()` helper + 5 cache-drift HIGHs (sync workers, nativeAgentConfigs, mainAgent, identityRegistry, `format_compliance` on native)
- **#62**: Phase 2 cross-review schema + `gossip_plan` native-utility re-entry + provisional-signal `findingId` fix
- **#63**: utility AGENT_PROMPT helper + named 30K cap export + mediums

🤖 Generated with [Claude Code](https://claude.com/claude-code)