### PR TITLE
fix: unify agent-state refresh + emit format_compliance on native path

### DIFF
--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -295,6 +295,35 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
     } catch { /* best-effort */ }
   }
 
+  // 0c. Emit format_compliance meta signal — parity with the relay path at
+  // dispatch-pipeline.ts:398. Without this, native agents' tag-emission
+  // compliance is never scored, and skill-development loops can't detect
+  // schema drift in sonnet/haiku output. After PR #59 + #60 native agents
+  // receive FINDING_TAG_SCHEMA, so they can and should be measured.
+  if (!error && !taskInfo.utilityType && agentId !== '_utility') {
+    try {
+      const { PerformanceWriter, detectFormatCompliance } = await import('@gossip/orchestrator');
+      const compliance = detectFormatCompliance(result ?? '');
+      const metaWriter = new PerformanceWriter(process.cwd());
+      metaWriter.appendSignals([{
+        type: 'meta' as const,
+        signal: 'format_compliance',
+        agentId,
+        taskId: task_id,
+        value: compliance.formatCompliant ? 1 : 0,
+        metadata: {
+          findingCount: compliance.findingCount,
+          citationCount: compliance.citationCount,
+          tags_total: compliance.tags_total,
+          tags_accepted: compliance.tags_accepted,
+          tags_dropped_unknown_type: compliance.tags_dropped_unknown_type,
+          tags_dropped_short_content: compliance.tags_dropped_short_content,
+        },
+        timestamp: new Date().toISOString(),
+      } as any]);
+    } catch { /* best-effort */ }
+  }
+
   // 0b. Record plan step result so subsequent steps get chain context
   if (taskInfo.planId && taskInfo.step && !error) {
     try { ctx.mainAgent.recordPlanStepResult(taskInfo.planId, taskInfo.step, result); } catch { /* best-effort */ }

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -830,6 +830,18 @@ async function doSyncWorkers() {
       }
       process.stderr.write(`[gossipcat] 🔄 Synced: ${ctx.workers.size} relay workers + ${ctx.nativeAgentConfigs.size} native agents\n`);
     }
+
+    // Push the merged agent list to the dashboard so the Team page reflects
+    // the current roster. Covers both gossip_setup (which calls us directly)
+    // and hand-edits to .gossip/config.json / .claude/agents/*.md (picked up
+    // at the next auto-dispatch via the lazy syncWorkersViaKeychain call).
+    // Without this, the boot-time snapshot at :365 is the ONLY agent source
+    // the dashboard ever sees — PR #59 fixed it for gossip_setup, but
+    // hand-edits stayed stale.
+    try {
+      const merged = [...agentConfigs, ...claudeSubagentsToConfigs(claudeSubagents)];
+      ctx.relay?.setAgentConfigs(merged);
+    } catch { /* dashboard refresh is best-effort */ }
   } catch (err) {
     process.stderr.write(`[gossipcat] ❌ syncWorkers failed: ${(err as Error).message}\n`);
   }
@@ -1629,18 +1641,19 @@ server.tool(
     mkdirSync(join(root, '.gossip'), { recursive: true });
     writeFileSync(join(root, '.gossip', 'config.json'), JSON.stringify(config, null, 2));
 
-    // Refresh dashboard's cached agent configs so the Team page reflects the
-    // new team without requiring /mcp reconnect. The boot-time snapshot at
-    // :365 still wins on initial boot — this is a post-setup override for
-    // the common "boot before setup" fresh-install flow. Only fires on create
-    // modes (merge/replace); update_instructions returns earlier at :1504.
+    // Refresh all runtime caches of .gossip/config.json state — dashboard,
+    // ctx.nativeAgentConfigs, ctx.workers, and ctx.mainAgent registry — so
+    // the new team is fully dispatchable without /mcp reconnect. PR #59
+    // only refreshed the dashboard; that left the dispatch pipeline stale
+    // (e.g. gossip_dispatch(agent_id: "new-agent") returned "unknown agent"
+    // until the next lazy syncWorkers). syncWorkersViaKeychain now also
+    // pushes to the dashboard at its tail, so one call refreshes everything.
+    // Only fires on create modes (merge/replace); update_instructions
+    // returns earlier at :1504.
     try {
-      const m = await getModules();
-      const freshConfig = m.loadConfig(join(root, '.gossip', 'config.json'));
-      const freshAgentConfigs = m.configToAgentConfigs(freshConfig);
-      ctx.relay?.setAgentConfigs(freshAgentConfigs);
+      await syncWorkersViaKeychain();
     } catch (e) {
-      process.stderr.write(`[gossipcat] gossip_setup: failed to refresh dashboard agent configs: ${e}\n`);
+      process.stderr.write(`[gossipcat] gossip_setup: failed to refresh agent state: ${e}\n`);
     }
 
     // Generate host-appropriate rules file so the IDE knows about the team

--- a/packages/orchestrator/src/dispatch-pipeline.ts
+++ b/packages/orchestrator/src/dispatch-pipeline.ts
@@ -72,7 +72,7 @@ type TrackedTask = TaskEntry & {
  * "agent emitted tags but all had invalid type=" — the second case points at
  * a skill/prompt-format drift that instruction edits won't fix.
  */
-function detectFormatCompliance(result: string): {
+export function detectFormatCompliance(result: string): {
   findingCount: number;
   citationCount: number;
   formatCompliant: boolean;

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -1,4 +1,5 @@
 export { MainAgent } from './main-agent';
+export { detectFormatCompliance } from './dispatch-pipeline';
 export { loadSkills, DEFAULT_KEYWORDS, resolveSkillExists } from './skill-loader';
 export type { LoadSkillsResult } from './skill-loader';
 export { SkillCounterTracker } from './skill-counters';


### PR DESCRIPTION
## Summary

Drift audit consensus round `b0cc4995-0cd34dc7` surfaced that PR #59's `setAgentConfigs` fix covered only the dashboard cache — 7 other runtime caches of `.gossip/config.json` state stayed stale. This PR consolidates the refresh into a single well-exercised code path and closes two specific HIGH drifts.

## Part A — collapse refresh paths into `syncWorkersViaKeychain`

**Before:** `gossip_setup` only called `ctx.relay?.setAgentConfigs()` (dashboard only). Hand-edits of `.claude/agents/*.md` or `.gossip/config.json` updated the runtime side (via lazy `syncWorkersViaKeychain` on next auto-dispatch) but never the dashboard. Two code paths, different subsets — classic drift.

**After:**
- `syncWorkersViaKeychain` at its tail calls `ctx.relay?.setAgentConfigs()` with the merged (config.json + `.claude/agents/*.md`) agent list
- `gossip_setup` (merge/replace modes) calls `syncWorkersViaKeychain()` instead of the ad-hoc direct push. One atomic refresh path.

Now `ctx.nativeAgentConfigs`, `ctx.workers`, `ctx.mainAgent` registry, and the dashboard all refresh together whether the trigger was `gossip_setup` or a subsequent auto-dispatch after a hand-edit. Closes haiku's findings **#1** and **#3** in the drift audit.

## Part B — `format_compliance` meta signal on native path

PR #59 gave native agents the FINDING_TAG_SCHEMA in their prompts but the native completion path at `native-tasks.ts:279-296` recorded only `task.completed` + `impl_*` signals. `detectFormatCompliance` was a private function inside `dispatch-pipeline.ts` emitted only on the relay path. Consequence: native agents' compliance was never measured; schema-drift regressions were invisible in native dispatches, which is most of the traffic on Claude Code.

**After:**
- `detectFormatCompliance` exported from `@gossip/orchestrator`
- `native-tasks.ts` emits `format_compliance` meta signal after task completion with identical payload shape to `dispatch-pipeline.ts:398`

Closes haiku's finding **#2** in the drift audit.

## Not in this PR (deferred)

- `identityRegistry` refresh (haiku #5) — relay `self_identity` stale for newly-added agents; relay agents still get identity via prompt
- `ctx.mainAgent` provider/model hot-swap (haiku #4) — risky; follow-up with stderr warning
- Skill index re-seed for new agents (haiku #6) — follow-up
- `projectStructureCache` invalidation (haiku #8) — follow-up
- `gossip_plan` native-utility re-entry — PR #62
- Phase 2 cross-review schema injection — PR #62
- Provisional signal `findingId` fix — PR #62
- Utility `assembleUtilityPrompt` helper + named cap export — PR #63

## Tests

- 120 suites / 1463 pass / 1 pre-existing skip / 0 fail
- `npm run build` clean across all workspaces
- No new tests — refresh path exercised via existing dashboard-routes.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)