### PR TITLE
fix(signals): stop conflating taskId with findingId on provisional signals

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -625,16 +625,17 @@ export async function handleCollect(
           : undefined;
 
       // Only record provisional signals for finding authors NOT already covered.
-      // CRITICAL: populate findingId (not just taskId) so dashboard back-search
-      // can resolve signal → consensus round → score adjustment. The previous
-      // writer set taskId = f.id but left findingId undefined, leaving these
-      // signals invisible to the dashboard pipeline (consensus round 4c88bcd3
-      // confirmed this gap, sonnet-reviewer:f3).
+      // CRITICAL: taskId and findingId must have DISTINCT semantics for the
+      // dashboard back-search. Prior writer set taskId = f.id (same as findingId),
+      // conflating the two — gemini-reviewer:f1 in drift audit b0cc4995-0cd34dc7
+      // caught this. Fix: taskId groups signals by consensus round (not the
+      // specific finding), findingId points at the specific finding using the
+      // full <consensusId>:<agentId>:fN format that f.id already carries.
       const provisionalSignals = allFindings
         .filter((f: any) => !alreadySignaled.has(f.originalAgentId))
         .map((f: any) => ({
           type: 'consensus' as const,
-          taskId: f.id || '',
+          taskId: provisionalConsensusId || '',
           consensusId: provisionalConsensusId,
           findingId: typeof f.id === 'string' ? f.id : undefined,
           signal: tagToSignal[f.tag] || 'unique_unconfirmed',


### PR DESCRIPTION
## Summary

`gemini-reviewer` flagged in drift audit consensus `b0cc4995-0cd34dc7:f1` that provisional consensus signals at `collect.ts:633-646` set BOTH `taskId` and `findingId` to `f.id` (which is the full `<consensusId>:<agentId>:fN` finding identifier). The two fields have different semantics and were conflated.

**Before:** `taskId: f.id || ''` and `findingId: f.id` — same value in both slots.

**After:** `taskId: provisionalConsensusId || ''` (groups by round) and `findingId: f.id` (specific finding). Dashboard back-search `signal → task → score` works correctly.

No migration needed — existing consumers that read `findingId` keep working.

## Originally planned as PR #62 (provisional findingId + Phase 2 schema)

After reading the Phase 2 cross-review prompt builder at `consensus-engine.ts:272-481`, Phase 2 returns JSON (`action: agree|disagree|unverified|new`), not `<agent_finding>` tags — different output contract. The real gap is missing skill injection (memory-retrieval would help reviewers check prior findings before re-examining). That's a larger change and deferred to a follow-up.

## Tests

- 120 suites / 1463 pass / 1 pre-existing skip / 0 fail
- `npm run build` clean across all workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)