### PR TITLE
fix(sync): close 6 cache-drift gaps in syncWorkersViaKeychain

### DIFF
--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -295,33 +295,43 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
     } catch { /* best-effort */ }
   }
 
-  // 0c. Emit format_compliance meta signal — parity with the relay path at
-  // dispatch-pipeline.ts:398. Without this, native agents' tag-emission
-  // compliance is never scored, and skill-development loops can't detect
-  // schema drift in sonnet/haiku output. After PR #59 + #60 native agents
-  // receive FINDING_TAG_SCHEMA, so they can and should be measured.
+  // 0c. Emit task_completed + task_tool_turns + format_compliance meta signals.
+  // Closes the metrics-asymmetry gap haiku flagged on PR #61: relay dispatches
+  // emit all three at dispatch-pipeline.ts:395-399 but the native completion
+  // path only had format_compliance. Without task_completed (durationMs) and
+  // task_tool_turns (toolCalls), native agents are invisible in dispatcher
+  // performance analytics. Native tool-call count isn't observable from
+  // gossipcat (the Agent() tool runs out-of-process), so we emit 0 — the
+  // signal still slots into the time series even if its value is unknown.
   if (!error && !taskInfo.utilityType && agentId !== '_utility') {
     try {
       const { PerformanceWriter, detectFormatCompliance } = await import('@gossip/orchestrator');
       const compliance = detectFormatCompliance(result ?? '');
       const metaWriter = new PerformanceWriter(process.cwd());
-      metaWriter.appendSignals([{
-        type: 'meta' as const,
-        signal: 'format_compliance',
-        agentId,
-        taskId: task_id,
-        value: compliance.formatCompliant ? 1 : 0,
-        metadata: {
-          findingCount: compliance.findingCount,
-          citationCount: compliance.citationCount,
-          tags_total: compliance.tags_total,
-          tags_accepted: compliance.tags_accepted,
-          tags_dropped_unknown_type: compliance.tags_dropped_unknown_type,
-          tags_dropped_short_content: compliance.tags_dropped_short_content,
-        },
-        timestamp: new Date().toISOString(),
-      } as any]);
-    } catch { /* best-effort */ }
+      const now = new Date().toISOString();
+      metaWriter.appendSignals([
+        { type: 'meta' as const, signal: 'task_completed', agentId, taskId: task_id, value: elapsed, timestamp: now } as any,
+        { type: 'meta' as const, signal: 'task_tool_turns', agentId, taskId: task_id, value: 0, timestamp: now } as any,
+        {
+          type: 'meta' as const,
+          signal: 'format_compliance',
+          agentId,
+          taskId: task_id,
+          value: compliance.formatCompliant ? 1 : 0,
+          metadata: {
+            findingCount: compliance.findingCount,
+            citationCount: compliance.citationCount,
+            tags_total: compliance.tags_total,
+            tags_accepted: compliance.tags_accepted,
+            tags_dropped_unknown_type: compliance.tags_dropped_unknown_type,
+            tags_dropped_short_content: compliance.tags_dropped_short_content,
+          },
+          timestamp: now,
+        } as any,
+      ]);
+    } catch (err) {
+      process.stderr.write(`[gossipcat] native meta signals: ${(err as Error).message}\n`);
+    }
   }
 
   // 0b. Record plan step result so subsequent steps get chain context

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -59,9 +59,18 @@ export interface McpContext {
   nativeTaskMap: Map<string, NativeTaskInfo>;
   nativeResultMap: Map<string, NativeResultInfo>;
   nativeAgentConfigs: Map<string, { model: string; instructions: string; description: string; skills: string[] }>;
+  /**
+   * Identity registry — agentId → runtime/provider/model. Read by the
+   * ToolServer's self_identity tool for relay agents (native agents get
+   * the identity block injected directly into their prompt). Mutated at
+   * boot AND on every syncWorkersViaKeychain so newly-added agents are
+   * visible to self_identity without /mcp reconnect.
+   */
+  identityRegistry: Map<string, { agent_id: string; runtime: 'native' | 'relay'; provider: string; model: string }>;
   pendingConsensusRounds: Map<string, PendingConsensusRound>;
   nativeUtilityConfig: { model: string } | null;
   mainProvider: string;
+  mainModel: string;
   /** Actual bound HTTP MCP port (0/null if transport disabled). Set after listen(). */
   httpMcpPort: number | null;
   /** Source of the relay port: 'env' | 'sticky' | 'auto'. Used by gossip_status. */
@@ -84,9 +93,11 @@ export const ctx: McpContext = {
   nativeTaskMap: new Map(),
   nativeResultMap: new Map(),
   nativeAgentConfigs: new Map(),
+  identityRegistry: new Map(),
   pendingConsensusRounds: new Map(),
   nativeUtilityConfig: null,
   mainProvider: 'google',
+  mainModel: 'gemini-2.5-pro',
   httpMcpPort: null,
   relayPortSource: null,
   httpMcpPortSource: null,

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -402,16 +402,20 @@ async function doBoot() {
   // (Claude Code Agent()) don't go through ToolServer, so this registry only
   // serves relay workers — but we record both runtimes here for symmetry with
   // the dispatch-time prompt injection.
-  const identityRegistry = new Map<string, { agent_id: string; runtime: 'native' | 'relay'; provider: string; model: string }>();
+  // Use ctx.identityRegistry so syncWorkersViaKeychain can refresh it for
+  // agents added after boot (e.g. via gossip_setup or hand-edits to
+  // .claude/agents/*.md). Without this, newly-added relay agents calling
+  // self_identity get undefined — drift audit haiku #5.
+  ctx.identityRegistry.clear();
   for (const a of agentConfigs as Array<{ id: string; provider: string; model: string; native?: boolean }>) {
-    identityRegistry.set(a.id, {
+    ctx.identityRegistry.set(a.id, {
       agent_id: a.id,
       runtime: a.native ? 'native' : 'relay',
       provider: a.provider,
       model: a.model,
     });
   }
-  const agentLookup = (id: string) => identityRegistry.get(id);
+  const agentLookup = (id: string) => ctx.identityRegistry.get(id);
 
   ctx.toolServer = new m.ToolServer({
     relayUrl: ctx.relay.url,
@@ -453,7 +457,7 @@ async function doBoot() {
     // Prepend identity block so the agent knows its own agentId/runtime/model
     // without needing to call self_identity. self_identity remains available
     // for re-checks after context summarization.
-    const identity = identityRegistry.get(ac.id);
+    const identity = ctx.identityRegistry.get(ac.id);
     const identityBlock = identity ? m.formatIdentityBlock(identity) + '\n' : '';
     const instructions = (identityBlock + baseInstructions).trim() || undefined;
     const enableWebSearch = ac.preset === 'researcher' || (ac.skills ?? []).includes('research');
@@ -485,6 +489,8 @@ async function doBoot() {
       // Map model tier for Agent tool dispatch
       const modelTier = sa.model.includes('opus') ? 'opus' : sa.model.includes('haiku') ? 'haiku' : 'sonnet';
       ctx.nativeAgentConfigs.set(ac.id, { model: modelTier, instructions: sa.instructions, description: sa.description, skills: ac.skills || [] });
+      // Register in identityRegistry so self_identity returns runtime/provider/model
+      ctx.identityRegistry.set(ac.id, { agent_id: ac.id, runtime: 'native', provider: ac.provider, model: ac.model });
       process.stderr.write(`[gossipcat] 🤖 Registered native agent: ${sa.id} (${modelTier})\n`);
     }
   }
@@ -524,6 +530,7 @@ async function doBoot() {
     }
   }
   ctx.mainProvider = mainProvider;
+  ctx.mainModel = mainModel;
   const supaKey = await ctx.keychain.getKey('supabase');
   const supaTeamSalt = await ctx.keychain.getKey('supabase-team-salt');
   ctx.mainAgent = new m.MainAgent({
@@ -783,9 +790,30 @@ async function doSyncWorkers() {
     const config = m.loadConfig(configPath);
     const agentConfigs = m.configToAgentConfigs(config);
 
+    // Warn if main_agent provider/model has been changed in config since boot.
+    // ctx.mainAgent is constructed once at boot with a baked-in provider; we
+    // can't hot-swap the LLM live (too risky — MainAgent has provider state
+    // throughout). Surface the divergence so the user knows /mcp reconnect
+    // is required for the new orchestrator LLM to take effect. Drift audit
+    // haiku #4. Skip on first call from boot when ctx.mainProvider matches.
+    if (config.main_agent && (config.main_agent.provider !== ctx.mainProvider || config.main_agent.model !== ctx.mainModel)) {
+      process.stderr.write(
+        `[gossipcat] ⚠ main_agent changed in config: ${ctx.mainProvider}/${ctx.mainModel} → ${config.main_agent.provider}/${config.main_agent.model}. ` +
+        `Restart Claude Code (/mcp reconnect) for the new orchestrator LLM to take effect.\n`
+      );
+    }
+
     // Register any new agent configs (including native flag)
     for (const ac of agentConfigs) {
       ctx.mainAgent.registerAgent(ac);
+      // Refresh identityRegistry — without this, newly-added relay agents
+      // get undefined from the self_identity tool. Drift audit haiku #5.
+      ctx.identityRegistry.set(ac.id, {
+        agent_id: ac.id,
+        runtime: ac.native ? 'native' : 'relay',
+        provider: ac.provider,
+        model: ac.model,
+      });
       // [H2 fix] Populate nativeAgentConfigs for config-defined native agents
       if (ac.native && !ctx.nativeAgentConfigs.has(ac.id)) {
         const { existsSync: ex, readFileSync: rf } = require('fs');
@@ -815,6 +843,7 @@ async function doSyncWorkers() {
         // [H2 fix] Populate nativeAgentConfigs for hot-reloaded subagents
         const modelTier = sa.model.includes('opus') ? 'opus' : sa.model.includes('haiku') ? 'haiku' : 'sonnet';
         ctx.nativeAgentConfigs.set(ac.id, { model: modelTier, instructions: sa.instructions, description: sa.description, skills: ac.skills || [] });
+        ctx.identityRegistry.set(ac.id, { agent_id: ac.id, runtime: 'native', provider: ac.provider, model: ac.model });
       }
     }
 
@@ -830,6 +859,30 @@ async function doSyncWorkers() {
       }
       process.stderr.write(`[gossipcat] 🔄 Synced: ${ctx.workers.size} relay workers + ${ctx.nativeAgentConfigs.size} native agents\n`);
     }
+
+    // Re-seed the skill index for any newly-added agents so they get the
+    // global permanent defaults (memory-retrieval) AND their config skills
+    // bound. Without this, agents added via gossip_setup don't have any
+    // skill slots and loadSkills() falls back to the agent's bare config
+    // skills list — missing memory-retrieval and any future global default.
+    // Drift audit haiku #6.
+    try {
+      const skillIndex = ctx.mainAgent.getSkillIndex?.();
+      if (skillIndex) {
+        const merged = [...agentConfigs, ...claudeSubagentsToConfigs(claudeSubagents)];
+        skillIndex.seedFromConfigs(merged.map((ac: any) => ({ id: ac.id, skills: ac.skills || [] })));
+        const allIds = merged.map((ac: any) => ac.id).filter((id: any) => typeof id === 'string' && id.length > 0);
+        if (allIds.length > 0) skillIndex.ensureBoundWithMode(['memory-retrieval'], allIds, 'permanent');
+      }
+    } catch { /* skill re-seed is best-effort */ }
+
+    // Invalidate the project-structure cache so prompts regenerate against
+    // the current layout. New agents typically arrive together with new
+    // packages/dirs (e.g. gossip_setup for a fresh project) — without this,
+    // every dispatch sees the boot-time-cached layout. Drift audit haiku #8.
+    try {
+      ctx.mainAgent.invalidateProjectStructureCache?.();
+    } catch { /* cache invalidate is best-effort */ }
 
     // Push the merged agent list to the dashboard so the Team page reflects
     // the current roster. Covers both gossip_setup (which calls us directly)

--- a/packages/orchestrator/src/dispatch-pipeline.ts
+++ b/packages/orchestrator/src/dispatch-pipeline.ts
@@ -149,6 +149,17 @@ export class DispatchPipeline {
     return this.projectStructureCache || undefined;
   }
 
+  /**
+   * Invalidate the cached project structure so the next prompt regenerates it.
+   * Call this when the project layout has changed mid-session (e.g. new
+   * top-level packages, agent scaffold, gossip_setup adding agent dirs).
+   * Without this, every prompt sees the boot-time-cached layout and agents
+   * reason against stale structure. Drift audit haiku #8.
+   */
+  public invalidateProjectStructureCache(): void {
+    this.projectStructureCache = null;
+  }
+
   constructor(config: DispatchPipelineConfig) {
     this.projectRoot = config.projectRoot;
     this.workers = config.workers;

--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -239,6 +239,7 @@ export class MainAgent {
   setDispatchDifferentiator(differ: any): void { this.pipeline.setDispatchDifferentiator(differ); }
   getSkillGapSuggestions() { return this.pipeline.getSkillGapSuggestions(); }
   setSkillIndex(index: any): void { this.pipeline.setSkillIndex(index); }
+  invalidateProjectStructureCache(): void { this.pipeline.invalidateProjectStructureCache(); }
   setSummaryLlm(llm: any): void { this.pipeline.setSummaryLlm(llm); }
   getSessionConsensusHistory() { return this.pipeline.getSessionConsensusHistory(); }
   getSessionStartTime() { return this.pipeline.getSessionStartTime(); }


### PR DESCRIPTION
## Summary

Drift audit (session 2026-04-14) identified shared invariants cached at boot but never refreshed when agents are added/removed via `gossip_setup` or hand-edits to `.gossip/config.json`. These surface as stale state minutes or hours into a session.

## Fixes

- **identityRegistry refresh** — lifted from local module state onto `ctx.identityRegistry`; re-populated in `syncWorkersViaKeychain` so `self_identity` works for newly-added relay agents without `/mcp reconnect`.
- **main_agent change warning** — if `config.main_agent` provider/model differs from boot values, log a stderr warning prompting the user to reconnect.
- **SkillIndex re-seed** — call `seedFromConfigs` + `ensureBoundWithMode(['memory-retrieval'], …, 'permanent')` on sync so new agents get the baseline skill.
- **projectStructureCache invalidate** — add `DispatchPipeline.invalidateProjectStructureCache()` (delegated via `MainAgent`); clear on every sync so prompts regenerate against current layout.
- **Native meta signals** — emit `task_completed` + `task_tool_turns` alongside existing `format_compliance` on native task finish (matches relay).
- **Stderr log on silent catch** — native meta-signal write failures now surface to stderr instead of disappearing.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1463 passed, 1 skipped (all 120 suites green)
- [ ] Manual: fresh install → `gossip_setup` → verify Team page updates + new relay agent answers `self_identity`
- [ ] Manual: edit `.gossip/config.json` main_agent → next dispatch shows stderr warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)