### PR TITLE
fix(collect,prompt): validate provisional consensus id + cap suffix overflow

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -8,6 +8,30 @@ import { persistRelayTasks } from './relay-tasks';
 import { FILE_TOOLS, FileTools, GitTools, Sandbox } from '@gossip/tools';
 import { MemorySearcher } from '@gossip/orchestrator';
 
+/**
+ * Canonical shape for a consensus round identifier. `<8hex>-<8hex>`.
+ * Exported so handlers and tests share one source of truth.
+ */
+export const CONSENSUS_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{8}$/;
+
+/** True when `id` is a valid `<8hex>-<8hex>` consensus ID string. */
+export function isValidConsensusId(id: unknown): id is string {
+  return typeof id === 'string' && CONSENSUS_ID_RE.test(id);
+}
+
+/**
+ * Extract the consensus round ID from a finding ID. Findings carry IDs in
+ * "<consensusId>:<agentId>:fN" (modern) or "<consensusId>:fN" (legacy) shape.
+ * Returns undefined if the first segment doesn't match the canonical shape —
+ * callers must fall back rather than silently attributing signals to a
+ * malformed ID. F13 hardening from consensus 20c17ac3-03bb4f25.
+ */
+export function extractConsensusIdFromFindingId(findingId: unknown): string | undefined {
+  if (typeof findingId !== 'string') return undefined;
+  const first = findingId.split(':')[0];
+  return isValidConsensusId(first) ? first : undefined;
+}
+
 export async function handleCollect(
   task_ids: string[],
   timeout_ms: number,
@@ -619,10 +643,19 @@ export async function handleCollect(
       // shape. The consensusId is itself a single token "<8hex>-<8hex>" where
       // the dash is NOT a colon, so the first colon-segment is the full
       // consensusId in both shapes.
+      //
+      // Validate the shape before accepting it — malformed first-finding IDs
+      // (e.g. free-form strings from a legacy/custom producer) would otherwise
+      // silently route provisional signals under the wrong consensusId.
+      // Prefer the authoritative consensusId emitted on the report's signals
+      // (same source formatReport and the report file use); fall back to
+      // parsing findings only when the report has no signals. F13 hardening
+      // from consensus 20c17ac3-03bb4f25. Helpers are exported from this
+      // module — see isValidConsensusId + extractConsensusIdFromFindingId.
+      const authoritativeId = consensusReport?.signals?.[0]?.consensusId;
       const provisionalConsensusId =
-        allFindings.length > 0 && typeof allFindings[0].id === 'string'
-          ? allFindings[0].id.split(':')[0]
-          : undefined;
+        (isValidConsensusId(authoritativeId) ? authoritativeId : undefined) ??
+        (allFindings.length > 0 ? extractConsensusIdFromFindingId(allFindings[0].id) : undefined);
 
       // Only record provisional signals for finding authors NOT already covered.
       // CRITICAL: taskId and findingId must have DISTINCT semantics for the

--- a/packages/orchestrator/src/prompt-assembler.ts
+++ b/packages/orchestrator/src/prompt-assembler.ts
@@ -169,7 +169,13 @@ export function assemblePrompt(parts: {
   task?: string;
 }): string {
   const prefix: string[] = [];
-  const suffix: string[] = [];
+  // Suffix segments carry a priority: lower number = keep-first when over
+  // budget. PRIORITY 0 is mandatory (TASK + SCHEMA) and never dropped.
+  // See F14 (consensus 20c17ac3-03bb4f25) — earlier versions only truncated
+  // the prefix, so oversized MEMORY/SPEC blocks silently exceeded the 30K
+  // cap. The output order below is fixed; priority controls drop-order, not
+  // insertion order.
+  const suffix: Array<{ priority: number; text: string }> = [];
 
   // ── PREFIX (truncatable) ───────────────────────────────────────────────
   if (parts.identity) {
@@ -196,10 +202,17 @@ export function assemblePrompt(parts: {
     prefix.push(`\n\n--- SKILLS ---\n${parts.skills}\n--- END SKILLS ---`);
   }
 
-  // ── SUFFIX (preserved under truncation) ────────────────────────────────
+  // ── SUFFIX (preserved under truncation, priority-ordered drop) ─────────
+  // Priority 0: schema + task (mandatory).
+  // Priority 1: LENS (directs the review).
+  // Priority 2: SPEC REVIEW (spec-specific framing).
+  // Priority 3: MEMORY + consensus findings.
+  // Priority 4: AGENT MEMORY (generic write pointer).
+  // Priority 5: sessionContext.
+  // Priority 6: context (freeform — least critical).
   if (parts.consensusSummary) {
     // Consensus dispatches need the full cross-review framing.
-    suffix.push(`\n\n--- CONSENSUS OUTPUT FORMAT ---\n${CONSENSUS_OUTPUT_FORMAT}\n\nThis section will be used for cross-review with peer agents.\n--- END CONSENSUS OUTPUT FORMAT ---`);
+    suffix.push({ priority: 0, text: `\n\n--- CONSENSUS OUTPUT FORMAT ---\n${CONSENSUS_OUTPUT_FORMAT}\n\nThis section will be used for cross-review with peer agents.\n--- END CONSENSUS OUTPUT FORMAT ---` });
   } else {
     // Non-consensus dispatches still need the type enum + anti-invention rule
     // so agent output is parseable when the dashboard retroactively shows it.
@@ -216,16 +229,16 @@ export function assemblePrompt(parts: {
       (parts.consensusFindings && parts.consensusFindings.length > 0)
     );
     if (hasAnyMeaningfulPart) {
-      suffix.push(`\n\n--- FINDING TAG SCHEMA ---\n${FINDING_TAG_SCHEMA}\n--- END FINDING TAG SCHEMA ---`);
+      suffix.push({ priority: 0, text: `\n\n--- FINDING TAG SCHEMA ---\n${FINDING_TAG_SCHEMA}\n--- END FINDING TAG SCHEMA ---` });
     }
   }
 
   if (parts.lens) {
-    suffix.push(`\n\n--- LENS ---\n${parts.lens}\n--- END LENS ---`);
+    suffix.push({ priority: 1, text: `\n\n--- LENS ---\n${parts.lens}\n--- END LENS ---` });
   }
 
   if (parts.specReviewContext) {
-    suffix.push(`\n\n--- SPEC REVIEW ---\n${parts.specReviewContext}\n--- END SPEC REVIEW ---`);
+    suffix.push({ priority: 2, text: `\n\n--- SPEC REVIEW ---\n${parts.specReviewContext}\n--- END SPEC REVIEW ---` });
   }
 
   if (parts.memory || (parts.consensusFindings && parts.consensusFindings.length > 0)) {
@@ -239,40 +252,63 @@ export function assemblePrompt(parts: {
         parts.consensusFindings.map((f, i) => `${i + 1}. ${f}`).join('\n');
       memParts.push(findingsBlock);
     }
-    suffix.push(`\n\n--- MEMORY ---\n${memParts.join('\n\n')}\n--- END MEMORY ---`);
+    suffix.push({ priority: 3, text: `\n\n--- MEMORY ---\n${memParts.join('\n\n')}\n--- END MEMORY ---` });
   }
 
   if (parts.memoryDir) {
-    suffix.push(`\n\n--- AGENT MEMORY ---
+    suffix.push({ priority: 4, text: `\n\n--- AGENT MEMORY ---
 Your persistent memory directory: ${parts.memoryDir}
 Save important learnings using file_write to this directory.
 What to save: technology choices, file structure, key patterns, architectural decisions, gotchas.
 Use descriptive filenames like: tech-stack.md, project-structure.md, patterns.md
 Keep entries concise (5-10 lines each). Update existing files rather than creating new ones.
---- END AGENT MEMORY ---`);
+--- END AGENT MEMORY ---` });
   }
 
   if (parts.sessionContext) {
-    suffix.push(`\n\n${parts.sessionContext}`);
+    suffix.push({ priority: 5, text: `\n\n${parts.sessionContext}` });
   }
 
   if (parts.context) {
-    suffix.push(`\n\nContext:\n${parts.context}`);
+    suffix.push({ priority: 6, text: `\n\nContext:\n${parts.context}` });
   }
 
-  // TASK last — the most important surviving element.
+  // TASK last — the most important surviving element, mandatory priority.
   if (parts.task) {
-    suffix.push(`\n\n---\n\nTask: ${parts.task}`);
+    suffix.push({ priority: 0, text: `\n\n---\n\nTask: ${parts.task}` });
   }
 
   // Cap total prompt size to prevent context window overflow.
   // ~30K chars ≈ ~8K tokens — leaves room for system prompt + tool results.
-  // Truncate only the prefix so the suffix (schema + task) always survives.
-  // See consensus finding 12827629-fa9a4660:f8 (native consensus block-order
-  // regression) — concatenating then truncating could sever CONSENSUS OUTPUT
-  // FORMAT, causing silent consensus degradation.
-  const suffixStr = suffix.join('');
+  //
+  // F14 hardening (consensus 20c17ac3-03bb4f25): the suffix is ALSO capped.
+  // Earlier versions only truncated the prefix on the theory that "the suffix
+  // fits by construction", but MEMORY and SPEC REVIEW can each carry many KB
+  // of agent-supplied or consensus-injected content. When they don't fit,
+  // drop the lowest-priority optional suffix blocks (highest `priority`
+  // value first) until the suffix is under its reserved budget. Priority-0
+  // segments (SCHEMA + TASK) always survive.
+  const SUFFIX_RESERVE = Math.floor(MAX_ASSEMBLED_PROMPT_CHARS * 0.6);
+  const dropOrderDesc = [...suffix].sort((a, b) => b.priority - a.priority);
+  const dropped = new Set<number>();
+  const suffixLen = () => suffix
+    .filter((_, i) => !dropped.has(i))
+    .reduce((acc, seg) => acc + seg.text.length, 0);
+  for (const seg of dropOrderDesc) {
+    if (seg.priority === 0) break;
+    if (suffixLen() <= SUFFIX_RESERVE) break;
+    const idx = suffix.indexOf(seg);
+    if (idx >= 0) dropped.add(idx);
+  }
+  const suffixStr = suffix
+    .filter((_, i) => !dropped.has(i))
+    .map(seg => seg.text)
+    .join('');
   let prefixStr = prefix.join('');
+  // After suffix is finalized, truncate the prefix to whatever budget remains.
+  // Past consensus 12827629-fa9a4660:f8 flagged the prefix-truncation risk
+  // of severing CONSENSUS OUTPUT FORMAT; that's handled here by reserving
+  // suffix first, then shrinking the prefix.
   const budget = Math.max(0, MAX_ASSEMBLED_PROMPT_CHARS - suffixStr.length);
   if (prefixStr.length > budget) {
     prefixStr = prefixStr.slice(0, budget) + '\n\n[Context truncated to fit budget]';

--- a/tests/cli/collect-consensus-id.test.ts
+++ b/tests/cli/collect-consensus-id.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for F13 hardening (consensus 20c17ac3-03bb4f25): the provisional
+ * signal pipeline in handleCollect used to derive the consensus round ID
+ * with `allFindings[0].id.split(':')[0]` without validating the shape.
+ * Malformed first-finding IDs silently routed signals under the wrong ID.
+ * These tests lock in the canonical validator + extractor.
+ */
+import {
+  CONSENSUS_ID_RE,
+  isValidConsensusId,
+  extractConsensusIdFromFindingId,
+} from '../../apps/cli/src/handlers/collect';
+
+describe('CONSENSUS_ID_RE', () => {
+  it('matches canonical <8hex>-<8hex> shape', () => {
+    expect(CONSENSUS_ID_RE.test('0a7c34cb-91624bd4')).toBe(true);
+    expect(CONSENSUS_ID_RE.test('abcdef01-23456789')).toBe(true);
+  });
+
+  it('rejects shorter or longer segments', () => {
+    expect(CONSENSUS_ID_RE.test('0a7c34c-91624bd4')).toBe(false);
+    expect(CONSENSUS_ID_RE.test('0a7c34cb1-91624bd4')).toBe(false);
+    expect(CONSENSUS_ID_RE.test('0a7c34cb-91624bd')).toBe(false);
+  });
+
+  it('rejects uppercase / non-hex characters', () => {
+    expect(CONSENSUS_ID_RE.test('0A7C34CB-91624BD4')).toBe(false);
+    expect(CONSENSUS_ID_RE.test('0a7c34cg-91624bd4')).toBe(false);
+    expect(CONSENSUS_ID_RE.test('0a7c34cb_91624bd4')).toBe(false);
+  });
+});
+
+describe('isValidConsensusId', () => {
+  it('accepts a valid consensus ID', () => {
+    expect(isValidConsensusId('0a7c34cb-91624bd4')).toBe(true);
+  });
+
+  it('rejects non-string inputs', () => {
+    expect(isValidConsensusId(undefined)).toBe(false);
+    expect(isValidConsensusId(null)).toBe(false);
+    expect(isValidConsensusId(42)).toBe(false);
+    expect(isValidConsensusId({})).toBe(false);
+  });
+
+  it('rejects malformed strings', () => {
+    expect(isValidConsensusId('')).toBe(false);
+    expect(isValidConsensusId('not-a-consensus-id')).toBe(false);
+    expect(isValidConsensusId('12345')).toBe(false);
+  });
+});
+
+describe('extractConsensusIdFromFindingId', () => {
+  it('extracts the consensus ID from a modern three-segment finding ID', () => {
+    expect(extractConsensusIdFromFindingId('0a7c34cb-91624bd4:sonnet-reviewer:f11')).toBe('0a7c34cb-91624bd4');
+  });
+
+  it('extracts the consensus ID from a legacy two-segment finding ID', () => {
+    expect(extractConsensusIdFromFindingId('abcdef01-23456789:f1')).toBe('abcdef01-23456789');
+  });
+
+  it('returns undefined when the first segment is not a valid consensus ID', () => {
+    expect(extractConsensusIdFromFindingId('not-an-id:agent-x:f1')).toBeUndefined();
+    expect(extractConsensusIdFromFindingId('short:f1')).toBeUndefined();
+    expect(extractConsensusIdFromFindingId('totally-freeform-finding')).toBeUndefined();
+  });
+
+  it('returns undefined for non-string inputs', () => {
+    expect(extractConsensusIdFromFindingId(undefined)).toBeUndefined();
+    expect(extractConsensusIdFromFindingId(null)).toBeUndefined();
+    expect(extractConsensusIdFromFindingId(123)).toBeUndefined();
+  });
+
+  it('returns undefined when split yields a would-be-valid-looking but malformed segment', () => {
+    // Missing dash in what would otherwise be an 8+8 hex prefix.
+    expect(extractConsensusIdFromFindingId('0a7c34cb91624bd4:f1')).toBeUndefined();
+  });
+});

--- a/tests/orchestrator/prompt-assembler.test.ts
+++ b/tests/orchestrator/prompt-assembler.test.ts
@@ -213,3 +213,79 @@ describe('MAX_ASSEMBLED_PROMPT_CHARS', () => {
     expect(MAX_ASSEMBLED_PROMPT_CHARS).toBeLessThan(100_000);
   });
 });
+
+describe('assemblePrompt suffix cap (F14 — priority-ordered drop)', () => {
+  const BIG = (label: string) => `${label}:` + 'x'.repeat(25_000);
+
+  it('preserves TASK and SCHEMA even when lower-priority blocks are dropped', () => {
+    const result = assemblePrompt({
+      task: 'do the thing',
+      memory: BIG('huge memory'),
+      context: BIG('huge context'),
+      sessionContext: BIG('huge session'),
+    });
+    expect(result).toContain('Task: do the thing');
+    expect(result).toContain('--- FINDING TAG SCHEMA ---');
+    expect(result.length).toBeLessThanOrEqual(MAX_ASSEMBLED_PROMPT_CHARS + 100);
+  });
+
+  it('drops lowest-priority suffix first when suffix exceeds its reserve', () => {
+    // context is priority 6 (lowest), memory is priority 3.
+    const result = assemblePrompt({
+      task: 'do the thing',
+      memory: 'small memory block',
+      context: BIG('oversized context'),
+    });
+    // Small memory must survive; oversized freeform context must be dropped.
+    expect(result).toContain('small memory block');
+    expect(result).not.toContain('oversized context');
+  });
+
+  it('drops AGENT MEMORY before MEMORY when only one drop is needed (priority 4 > priority 3)', () => {
+    // Size MEMORY just over the reserve budget so AGENT_MEMORY's removal
+    // alone brings total back under reserve. Schema ~600 + AGENT_MEMORY ~500
+    // + task tiny → memory body of ~17100 pushes total just over 18K reserve.
+    const memoryBlock = 'actual memory: ' + 'y'.repeat(17_100);
+    const result = assemblePrompt({
+      task: 'x',
+      memory: memoryBlock,
+      memoryDir: '/tmp/agent-dir',
+    });
+    expect(result).toContain('actual memory:');
+    expect(result).not.toContain('--- AGENT MEMORY ---');
+  });
+
+  it('drops multiple suffix blocks in priority order when one drop is insufficient', () => {
+    // Oversized memory forces BOTH AGENT_MEMORY and MEMORY to drop.
+    // MEMORY is still dropped AFTER lower-priority blocks try first.
+    const result = assemblePrompt({
+      task: 'x',
+      memory: 'm'.repeat(25_000),
+      memoryDir: '/tmp/agent-dir',
+      context: 'small context',
+      sessionContext: 'small session',
+    });
+    // task + schema always survive
+    expect(result).toContain('Task: x');
+    expect(result).toContain('--- FINDING TAG SCHEMA ---');
+    // Oversized MEMORY cannot be kept
+    expect(result).not.toContain('m'.repeat(100));
+    // AGENT_MEMORY (priority 4) was dropped before us getting here
+    expect(result).not.toContain('--- AGENT MEMORY ---');
+  });
+
+  it('keeps everything when combined size fits the budget', () => {
+    const result = assemblePrompt({
+      task: 'x',
+      memory: 'small',
+      context: 'small',
+      sessionContext: 'small',
+      memoryDir: '/tmp/d',
+      lens: 'focus',
+    });
+    expect(result).toContain('--- MEMORY ---');
+    expect(result).toContain('--- AGENT MEMORY ---');
+    expect(result).toContain('--- LENS ---');
+    expect(result).toContain('Context:');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up from consensus `20c17ac3-03bb4f25` which reviewed already-merged PRs #59 and #62. Two MEDIUM silent-failure modes earlier reviews missed.

Note: this PR stacks on #63 and #64. CI builds against master; all three can be merged in order.

## Fixes

### F13: `provisionalConsensusId` had no shape validation (collect.ts)
`allFindings[0].id.split(':')[0]` silently accepted any string. Free-form finding IDs from legacy or custom producers routed provisional signals under the wrong consensus round.

- Extracted exported helpers: \`CONSENSUS_ID_RE\`, \`isValidConsensusId\`, \`extractConsensusIdFromFindingId\`
- Prefer the authoritative consensusId from \`consensusReport.signals[0]\` (same source formatReport uses)
- Fall back to parsing findings only when the report has no signals — validated either way

### F14: Suffix bypassed the 30K cap (prompt-assembler.ts)
Only the prefix was truncated. Oversized MEMORY / SPEC REVIEW / session blocks silently exceeded the budget.

- Suffix segments now carry priority 0-6 (0 = mandatory: TASK + schema)
- 60% of the total budget reserved for suffix (18K)
- When suffix exceeds reserve, drop lowest-priority segments first until it fits
- Schema + task always survive; prefix truncation runs after suffix is finalized

## Tests

- \`tests/cli/collect-consensus-id.test.ts\` — 11 tests for the validator/extractor helpers
- \`tests/orchestrator/prompt-assembler.test.ts\` — 5 tests for priority-ordered drop

\`npm test\`: 1495 passed (was 1479), 1 skipped, all 121 suites green.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1495/1 skipped
- [ ] Manual: dispatch consensus with a large MEMORY block → confirm suffix doesn't exceed 30K
- [ ] Manual: consensus round with legacy finding IDs → confirm provisional signals route correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)