### PR TITLE
docs(readme): normalize MCP config + bump stale v0.1.1 pin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,7 @@ Add to `~/.claude/mcp_settings.json`:
 {
   "mcpServers": {
     "gossipcat": {
-      "command": "gossipcat",
-      "args": ["mcp"]
+      "command": "gossipcat"
     }
   }
 }
@@ -199,7 +198,7 @@ Or project-local in `.mcp.json`:
   "mcpServers": {
     "gossipcat": {
       "command": "npx",
-      "args": ["gossipcat", "mcp"]
+      "args": ["gossipcat"]
     }
   }
 }
@@ -224,7 +223,7 @@ Gossipcat ships from **[GitHub Releases](https://github.com/gossipcat-ai/gossipc
 
 **Pin to a specific version:**
 ```bash
-npm install -g https://github.com/gossipcat-ai/gossipcat-ai/releases/download/v0.1.1/gossipcat-0.1.1.tgz
+npm install -g https://github.com/gossipcat-ai/gossipcat-ai/releases/download/v0.4.1/gossipcat-0.4.1.tgz
 ```
 
 **Project-local install** (each project gets its own gossipcat):


### PR DESCRIPTION
Two small inconsistencies the 0.4.1 fresh-install walkthrough surfaced:

1. Manual MCP config snippets used `args: ["mcp"]` while the quickstart one-liner uses `claude mcp add ... -- gossipcat` with no args. `mcp-server.js` ignores argv, so both happened to work — but the docs were confusing. Drop the unused arg.
2. Pinned-version install example still referenced `v0.1.1`. Bumped to `v0.4.1`.

No code, no behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)