### PR TITLE
fix(scoring): task_timeout/task_empty signals + impl streak reset

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -177,7 +177,9 @@ export async function handleCollect(
         type: 'consensus' as const,
         taskId: r.id || '',
         // Use disagreement for empty/timeout (reliability failure), hallucination only for actual errors
-        signal: r.status === 'failed' ? 'disagreement' as const : 'unique_unconfirmed' as const,
+        signal: r.status === 'failed' ? 'disagreement' as const
+          : r.status === 'timed_out' ? 'task_timeout' as const
+          : 'task_empty' as const,
         agentId: r.agentId,
         evidence: r.status === 'failed' ? `Task failed: ${r.error || 'unknown error'}`
           : r.status === 'timed_out' ? 'Task timed out — no response'

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -111,7 +111,9 @@ export interface ConsensusSignal {
     | 'category_confirmed'
     | 'consensus_verified'
     | 'signal_retracted'
-    | 'severity_miscalibrated';
+    | 'severity_miscalibrated'
+    | 'task_timeout'
+    | 'task_empty';
   agentId: string;
   counterpartId?: string;
   skill?: string;

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -7,7 +7,7 @@
 
 import { readFileSync, existsSync, statSync } from 'fs';
 import { join } from 'path';
-import { ConsensusSignal } from './consensus-types';
+import { ConsensusSignal, ImplSignal, PerformanceSignal } from './consensus-types';
 import { normalizeSkillName } from './skill-name';
 
 export interface AgentScore {
@@ -35,7 +35,8 @@ export interface CategoryCounters {
 }
 
 const CIRCUIT_BREAKER_THRESHOLD = 3; // consecutive failures → open circuit
-const NEGATIVE_SIGNALS = new Set(['hallucination_caught', 'disagreement', 'unique_unconfirmed']);
+const NEGATIVE_SIGNALS = new Set(['hallucination_caught', 'disagreement']);
+const NEGATIVE_IMPL_SIGNALS = new Set(['impl_test_fail', 'impl_peer_rejected']);
 const SIGNAL_EXPIRY_DAYS = 30;
 
 /** Known consensus signal types — used to filter valid signals in computeScores */
@@ -51,6 +52,8 @@ const KNOWN_SIGNALS: Record<ConsensusSignal['signal'], true> = {
   consensus_verified: true,
   signal_retracted: true,
   severity_miscalibrated: true,
+  task_timeout: true,
+  task_empty: true,
 };
 
 const SEVERITY_MULTIPLIER: Record<string, number> = {
@@ -130,6 +133,7 @@ export class PerformanceReader {
     const signals = this.readSignals();
     return signals.filter(s => {
       if (s.agentId !== agentId) return false;
+      if (s.type !== 'consensus') return false;
       if (!CROSS_REVIEW_SIGNALS.has(s.signal)) return false;
       const ts = s.timestamp ? new Date(s.timestamp).getTime() : 0;
       return isFinite(ts) && ts > cutoffMs;
@@ -220,22 +224,26 @@ export class PerformanceReader {
     }
   }
 
-  private readSignals(): ConsensusSignal[] {
+  private readSignals(): PerformanceSignal[] {
     if (!existsSync(this.filePath)) return [];
     try {
       const expiryMs = Date.now() - SIGNAL_EXPIRY_DAYS * 86400000;
 
       const lines = readFileSync(this.filePath, 'utf-8').trim().split('\n').filter(Boolean);
       const all = lines.map(line => {
-        try { return JSON.parse(line) as ConsensusSignal; }
+        try { return JSON.parse(line) as PerformanceSignal; }
         catch { return null; }
-      }).filter((s): s is ConsensusSignal =>
-        s !== null && s.type === 'consensus' && typeof s.agentId === 'string' && s.agentId.length > 0
+      }).filter((s): s is PerformanceSignal =>
+        s !== null &&
+        (s.type === 'consensus' || s.type === 'impl') &&
+        typeof s.agentId === 'string' && s.agentId.length > 0
       );
 
       // Collect retraction keys: agentId + taskId + signalType combos that have been retracted
+      // Only consensus signals can carry retractions.
       const retracted = new Set<string>();
       for (const s of all) {
+        if (s.type !== 'consensus') continue;
         if (s.signal === 'signal_retracted') {
           const taskKey = s.taskId || s.timestamp;
           if (s.retractedSignal) {
@@ -250,14 +258,16 @@ export class PerformanceReader {
 
       // Filter: exclude expired, retracted, and retraction signals themselves
       return all.filter(s => {
-        if (s.signal === 'signal_retracted') return false;
+        if (s.type === 'consensus' && s.signal === 'signal_retracted') return false;
         // Expire old signals — missing/bad timestamps are treated as expired
         const ts = s.timestamp ? new Date(s.timestamp).getTime() : 0;
         if (!isFinite(ts) || ts === 0 || ts < expiryMs) return false;
-        // Skip retracted signals (check both scoped and wildcard keys)
-        const taskKey = s.taskId || s.timestamp;
-        if (retracted.has(s.agentId + ':' + taskKey + ':' + s.signal)) return false;
-        if (retracted.has(s.agentId + ':' + taskKey + ':*')) return false;
+        // Skip retracted signals (check both scoped and wildcard keys; impl signals are never retracted)
+        if (s.type === 'consensus') {
+          const taskKey = s.taskId || s.timestamp;
+          if (retracted.has(s.agentId + ':' + taskKey + ':' + s.signal)) return false;
+          if (retracted.has(s.agentId + ':' + taskKey + ':*')) return false;
+        }
         return true;
       });
     } catch {
@@ -265,11 +275,17 @@ export class PerformanceReader {
     }
   }
 
-  private computeScores(signals: ConsensusSignal[]): Map<string, AgentScore> {
+  private computeScores(signals: PerformanceSignal[]): Map<string, AgentScore> {
     const DECAY_HALF_LIFE = 50; // tasks
 
     const TIME_DECAY_HALF_LIFE_DAYS = 7; // scores drift toward neutral after a week of inactivity
     const now = Date.now();
+
+    // Split into typed arrays once so remaining code keeps narrow types.
+    // consensusSignals → scoring + streak building.
+    // implSignals      → streak building only (scoring is handled separately by getImplScore).
+    const consensusSignals = signals.filter((s): s is ConsensusSignal => s.type === 'consensus');
+    const implSignals = signals.filter((s): s is ImplSignal => s.type === 'impl');
 
     // Per-agent accumulators for ratio-based scoring
     const acc = new Map<string, {
@@ -307,7 +323,7 @@ export class PerformanceReader {
 
     // Index task order per agent for decay calculation
     // Index both agentId and counterpartId so winners get correct decay
-    for (const signal of signals) {
+    for (const signal of consensusSignals) {
       const taskKey = signal.taskId || signal.timestamp;
       const a = ensure(signal.agentId);
       if (!a.tasksSeen.has(taskKey)) {
@@ -321,12 +337,12 @@ export class PerformanceReader {
       }
     }
 
-    const peerDiversity = this.computePeerDiversity(signals);
+    const peerDiversity = this.computePeerDiversity(consensusSignals);
 
     // Build per-agent retraction index so computeScores skips retracted signals
     // even when called with a raw (unfiltered) signal array (e.g. directly from tests).
     const retractedKeys = new Set<string>();
-    for (const signal of signals) {
+    for (const signal of consensusSignals) {
       if (signal.signal === 'signal_retracted') {
         const taskKey = signal.taskId || signal.timestamp;
         if (signal.retractedSignal) {
@@ -337,7 +353,7 @@ export class PerformanceReader {
       }
     }
 
-    for (const signal of signals) {
+    for (const signal of consensusSignals) {
       const isKnown = KNOWN_SIGNALS[signal.signal];
       if (!isKnown) continue;
       if (signal.signal === 'signal_retracted') continue;
@@ -435,16 +451,28 @@ export class PerformanceReader {
           }
           break;
         }
+        case 'task_timeout':
+        case 'task_empty':
+          // Transport/provider failure — contributes nothing to any scoring accumulator.
+          // Does not affect accuracy, uniqueness, reliability, or circuit breaker.
+          break;
       }
     }
 
-    // Circuit breaker: count consecutive trailing failures per agent
+    // Circuit breaker: count consecutive trailing failures per agent.
+    // Accepts both consensus signals (using KNOWN_SIGNALS + NEGATIVE_SIGNALS) and impl
+    // signals (using NEGATIVE_IMPL_SIGNALS), so a clean impl run can reset a stale
+    // consensus-side streak and vice versa.
     const consecutiveFailures = new Map<string, number>();
-    // Group signals by agent in order, then count trailing negatives
-    const signalsByAgent = new Map<string, ConsensusSignal[]>();
-    for (const signal of signals) {
+    // Group eligible signals by agent; preserve insertion order for sort.
+    const signalsByAgent = new Map<string, (ConsensusSignal | ImplSignal)[]>();
+    for (const signal of consensusSignals) {
       if (!KNOWN_SIGNALS[signal.signal]) continue;
-      if (signal.type !== 'consensus') continue;
+      const list = signalsByAgent.get(signal.agentId) || [];
+      list.push(signal);
+      signalsByAgent.set(signal.agentId, list);
+    }
+    for (const signal of implSignals) {
       const list = signalsByAgent.get(signal.agentId) || [];
       list.push(signal);
       signalsByAgent.set(signal.agentId, list);
@@ -459,9 +487,14 @@ export class PerformanceReader {
         return ((a as any).consensusId || '').localeCompare((b as any).consensusId || '');
       });
       let streak = 0;
-      // Walk from newest to oldest — count consecutive negatives at tail
+      // Walk from newest to oldest — count consecutive negatives at tail.
+      // A non-negative signal (positive consensus or positive impl) breaks the streak.
       for (let i = agentSignals.length - 1; i >= 0; i--) {
-        if (NEGATIVE_SIGNALS.has(agentSignals[i].signal)) streak++;
+        const sig = agentSignals[i];
+        const isNegative =
+          (sig.type === 'consensus' && NEGATIVE_SIGNALS.has(sig.signal)) ||
+          (sig.type === 'impl' && NEGATIVE_IMPL_SIGNALS.has(sig.signal));
+        if (isNegative) streak++;
         else break;
       }
       consecutiveFailures.set(agentId, streak);
@@ -552,6 +585,21 @@ export class PerformanceReader {
         categoryHallucinated: { ...a.categoryHallucinated },
         categoryAccuracy,
       });
+    }
+
+    // Agents that have ONLY impl signals (no consensus signals) won't appear in `acc`
+    // but may have a non-zero consecutiveFailures from the streak loop above.
+    // Emit a neutral score entry for them so circuit-breaker state is visible.
+    for (const [agentId, consec] of consecutiveFailures) {
+      if (!scores.has(agentId)) {
+        scores.set(agentId, {
+          agentId, accuracy: 0.5, uniqueness: 0.5, reliability: 0.5, impactScore: 0.5,
+          totalSignals: 0, agreements: 0, disagreements: 0, uniqueFindings: 0, hallucinations: 0,
+          consecutiveFailures: consec,
+          circuitOpen: consec >= CIRCUIT_BREAKER_THRESHOLD,
+          categoryStrengths: {}, categoryCorrect: {}, categoryHallucinated: {}, categoryAccuracy: {},
+        });
+      }
     }
 
     return scores;

--- a/packages/orchestrator/src/performance-writer.ts
+++ b/packages/orchestrator/src/performance-writer.ts
@@ -7,6 +7,7 @@ const VALID_CONSENSUS_SIGNALS = new Set([
   'agreement', 'disagreement', 'unverified', 'unique_confirmed',
   'unique_unconfirmed', 'new_finding', 'hallucination_caught',
   'category_confirmed', 'consensus_verified', 'signal_retracted',
+  'task_timeout', 'task_empty',
 ]);
 
 const VALID_IMPL_SIGNALS = new Set([

--- a/tests/orchestrator/performance-reader.test.ts
+++ b/tests/orchestrator/performance-reader.test.ts
@@ -353,10 +353,10 @@ describe('PerformanceReader — circuit breaker chronology (signal-timestamp-fro
       { type: 'consensus', signal: 'agreement', agentId: 'rev', counterpartId: 'p', taskId: 't1', evidence: 'x', timestamp: ts(5) },
       { type: 'consensus', signal: 'agreement', agentId: 'rev', counterpartId: 'p', taskId: 't2', evidence: 'x', timestamp: ts(4) },
       { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', taskId: 't3', evidence: 'x', timestamp: ts(3) },
-      // 3 negatives more recent
+      // 3 negatives more recent (unique_unconfirmed removed from NEGATIVE_SIGNALS — use hallucination instead)
       { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', counterpartId: 'p', taskId: 't4', evidence: 'bad', timestamp: ts(2) },
       { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', taskId: 't5', evidence: 'bad', timestamp: ts(1) },
-      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'rev', taskId: 't6', evidence: 'bad', timestamp: ts(0) },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', counterpartId: 'p', taskId: 't6', evidence: 'bad', timestamp: ts(0) },
     ]);
     const reader = new PerformanceReader(TEST_DIR);
     expect(reader.isCircuitOpen('rev')).toBe(true);
@@ -423,5 +423,262 @@ describe('PerformanceReader — circuit breaker chronology (signal-timestamp-fro
     expect(reader.isCircuitOpen('rev')).toBe(false);
     // Run twice to confirm idempotence under tiebreaker.
     expect(reader.isCircuitOpen('rev')).toBe(false);
+  });
+});
+
+describe('PerformanceReader — circuit breaker: unique_unconfirmed removed from NEGATIVE_SIGNALS', () => {
+  // Change 1 from docs/specs/2026-04-14-circuit-breaker-fix.md
+  // Consensus round: 4d6406d5-b0e147a5
+  // Rationale: unique_unconfirmed covers 3 ambiguous conditions (peer couldn't verify,
+  // task timed out, empty output). None indicate hallucination. The weighted scoring
+  // loop already treats it as near-neutral. Removing it only relaxes the binary
+  // circuit-breaker streak count.
+
+  function ts(daysAgo: number, ms = 0): string {
+    return new Date(Date.now() - daysAgo * 86400000 + ms).toISOString();
+  }
+
+  it('5 consecutive unique_unconfirmed: consecutiveFailures === 0, circuitOpen === false', () => {
+    // unique_unconfirmed no longer benches — peer couldn't verify / timeout / empty
+    // output do not constitute evidence of agent error.
+    writeSignals([
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'agent-a', taskId: 't1', evidence: '', timestamp: ts(4) },
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'agent-a', taskId: 't2', evidence: '', timestamp: ts(3) },
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'agent-a', taskId: 't3', evidence: '', timestamp: ts(2) },
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'agent-a', taskId: 't4', evidence: '', timestamp: ts(1) },
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'agent-a', taskId: 't5', evidence: '', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('agent-a')!;
+    expect(score.consecutiveFailures).toBe(0);
+    expect(score.circuitOpen).toBe(false);
+  });
+
+  it('3 consecutive hallucination_caught still bench: consecutiveFailures === 3, circuitOpen === true', () => {
+    // hallucination_caught remains in NEGATIVE_SIGNALS — real correctness error.
+    writeSignals([
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'agent-b', counterpartId: 'peer', taskId: 't1', evidence: 'bad', timestamp: ts(2) },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'agent-b', counterpartId: 'peer', taskId: 't2', evidence: 'bad', timestamp: ts(1) },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'agent-b', counterpartId: 'peer', taskId: 't3', evidence: 'bad', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('agent-b')!;
+    expect(score.consecutiveFailures).toBe(3);
+    expect(score.circuitOpen).toBe(true);
+  });
+
+  it('3 consecutive disagreement (loser) still bench: circuitOpen === true', () => {
+    // disagreement remains in NEGATIVE_SIGNALS — agentId is the loser.
+    // Only the loser gets a disagreement signal record; winner gets no streak tick.
+    writeSignals([
+      { type: 'consensus', signal: 'disagreement', agentId: 'agent-c', counterpartId: 'winner', taskId: 't1', evidence: 'bad', timestamp: ts(2) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'agent-c', counterpartId: 'winner', taskId: 't2', evidence: 'bad', timestamp: ts(1) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'agent-c', counterpartId: 'winner', taskId: 't3', evidence: 'bad', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('agent-c')!;
+    expect(score.circuitOpen).toBe(true);
+    // Winner must NOT be penalized
+    const winnerScore = reader.getAgentScore('winner');
+    expect(winnerScore?.circuitOpen ?? false).toBe(false);
+  });
+
+  it('unique_unconfirmed in middle breaks the streak: only trailing 3 hallucinations count', () => {
+    // Signal sequence (oldest → newest):
+    //   hallucination, hallucination, unique_unconfirmed, hallucination, hallucination, hallucination
+    //
+    // With unique_unconfirmed no longer negative, it acts as a streak-breaker
+    // (non-negative signal stops the backwards walk). The trailing 3 hallucinations
+    // form a streak of 3, not 5 (the earlier 2 are cut off by the non-negative signal).
+    writeSignals([
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'agent-d', counterpartId: 'p', taskId: 't1', evidence: 'bad', timestamp: ts(5) },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'agent-d', counterpartId: 'p', taskId: 't2', evidence: 'bad', timestamp: ts(4) },
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'agent-d', taskId: 't3', evidence: '', timestamp: ts(3) },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'agent-d', counterpartId: 'p', taskId: 't4', evidence: 'bad', timestamp: ts(2) },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'agent-d', counterpartId: 'p', taskId: 't5', evidence: 'bad', timestamp: ts(1) },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'agent-d', counterpartId: 'p', taskId: 't6', evidence: 'bad', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('agent-d')!;
+    // Backwards walk: 3 hallucinations at tail → streak = 3. unique_unconfirmed is not
+    // negative, so it stops the walk. The two earlier hallucinations do not extend the streak.
+    expect(score.consecutiveFailures).toBe(3);
+    expect(score.circuitOpen).toBe(true);
+  });
+
+  it('positive signal after unique_unconfirmed run resets streak: consecutiveFailures === 0', () => {
+    // 3 unique_unconfirmed (now non-negative) followed by 1 agreement at tail.
+    // The tail is positive → streak walks back 0 consecutive negatives.
+    writeSignals([
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'agent-e', taskId: 't1', evidence: '', timestamp: ts(3) },
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'agent-e', taskId: 't2', evidence: '', timestamp: ts(2) },
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'agent-e', taskId: 't3', evidence: '', timestamp: ts(1) },
+      { type: 'consensus', signal: 'agreement', agentId: 'agent-e', counterpartId: 'peer', taskId: 't4', evidence: 'ok', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('agent-e')!;
+    expect(score.consecutiveFailures).toBe(0);
+    expect(score.circuitOpen).toBe(false);
+  });
+});
+
+describe('PerformanceReader — circuit breaker Changes 2 & 3 (2026-04-14-circuit-breaker-fix.md)', () => {
+  // Change 2: task_timeout and task_empty are neutral transport signals, not
+  // evidence of agent correctness failure. They must not tick the streak counter.
+  //
+  // Change 3: impl signals (impl_test_pass, impl_peer_approved, impl_test_fail,
+  // impl_peer_rejected) now participate in streak building. A positive impl signal
+  // breaks a trailing run of consensus negatives; a negative impl signal extends it.
+
+  function ts(daysAgo: number, ms = 0): string {
+    return new Date(Date.now() - daysAgo * 86400000 + ms).toISOString();
+  }
+
+  // ── Change 2 tests ──────────────────────────────────────────────────────────
+
+  it('C2-1: 5 consecutive task_timeout → consecutiveFailures === 0, circuitOpen === false', () => {
+    writeSignals([
+      { type: 'consensus', signal: 'task_timeout', agentId: 'agt', taskId: 't1', evidence: 'Task timed out — no response', timestamp: ts(4) },
+      { type: 'consensus', signal: 'task_timeout', agentId: 'agt', taskId: 't2', evidence: 'Task timed out — no response', timestamp: ts(3) },
+      { type: 'consensus', signal: 'task_timeout', agentId: 'agt', taskId: 't3', evidence: 'Task timed out — no response', timestamp: ts(2) },
+      { type: 'consensus', signal: 'task_timeout', agentId: 'agt', taskId: 't4', evidence: 'Task timed out — no response', timestamp: ts(1) },
+      { type: 'consensus', signal: 'task_timeout', agentId: 'agt', taskId: 't5', evidence: 'Task timed out — no response', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('agt')!;
+    expect(score.consecutiveFailures).toBe(0);
+    expect(score.circuitOpen).toBe(false);
+  });
+
+  it('C2-2: 5 consecutive task_empty → consecutiveFailures === 0, circuitOpen === false', () => {
+    writeSignals([
+      { type: 'consensus', signal: 'task_empty', agentId: 'agt', taskId: 't1', evidence: 'Empty response — agent produced no output', timestamp: ts(4) },
+      { type: 'consensus', signal: 'task_empty', agentId: 'agt', taskId: 't2', evidence: 'Empty response — agent produced no output', timestamp: ts(3) },
+      { type: 'consensus', signal: 'task_empty', agentId: 'agt', taskId: 't3', evidence: 'Empty response — agent produced no output', timestamp: ts(2) },
+      { type: 'consensus', signal: 'task_empty', agentId: 'agt', taskId: 't4', evidence: 'Empty response — agent produced no output', timestamp: ts(1) },
+      { type: 'consensus', signal: 'task_empty', agentId: 'agt', taskId: 't5', evidence: 'Empty response — agent produced no output', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('agt')!;
+    expect(score.consecutiveFailures).toBe(0);
+    expect(score.circuitOpen).toBe(false);
+  });
+
+  it('C2: task_timeout and task_empty contribute nothing to accuracy scoring', () => {
+    // task_timeout / task_empty must not add to weightedTotal or weightedCorrect,
+    // so accuracy stays at 0.5 (neutral) when there are no other signals.
+    writeSignals([
+      { type: 'consensus', signal: 'task_timeout', agentId: 'agt', taskId: 't1', evidence: '', timestamp: ts(1) },
+      { type: 'consensus', signal: 'task_empty',   agentId: 'agt', taskId: 't2', evidence: '', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('agt')!;
+    expect(score.accuracy).toBeCloseTo(0.5, 1);
+    expect(score.consecutiveFailures).toBe(0);
+  });
+
+  // ── Change 3 tests ──────────────────────────────────────────────────────────
+
+  it('C3-1: impl_test_pass resets a trailing consensus streak', () => {
+    // Tail order (oldest → newest): hallucination, hallucination, impl_test_pass
+    // impl_test_pass is a positive impl signal → streak walk stops at impl_test_pass → streak = 0.
+    writeSignals([
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'impl-agent', taskId: 't1', evidence: 'bad', timestamp: ts(2) },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'impl-agent', taskId: 't2', evidence: 'bad', timestamp: ts(1) },
+      { type: 'impl',      signal: 'impl_test_pass',       agentId: 'impl-agent', taskId: 't3', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('impl-agent')!;
+    expect(score.consecutiveFailures).toBe(0);
+    expect(score.circuitOpen).toBe(false);
+  });
+
+  it('C3-2: impl_test_fail extends a trailing consensus streak', () => {
+    // Tail order: hallucination, hallucination, impl_test_fail
+    // impl_test_fail is in NEGATIVE_IMPL_SIGNALS → extends the streak → streak = 3.
+    writeSignals([
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'impl-agent', taskId: 't1', evidence: 'bad', timestamp: ts(2) },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'impl-agent', taskId: 't2', evidence: 'bad', timestamp: ts(1) },
+      { type: 'impl',      signal: 'impl_test_fail',        agentId: 'impl-agent', taskId: 't3', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('impl-agent')!;
+    expect(score.consecutiveFailures).toBe(3);
+    expect(score.circuitOpen).toBe(true);
+  });
+
+  it('C3-3: impl_peer_rejected extends a trailing consensus streak', () => {
+    // Tail order: hallucination, hallucination, impl_peer_rejected
+    // impl_peer_rejected is in NEGATIVE_IMPL_SIGNALS → streak = 3.
+    writeSignals([
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'impl-agent', taskId: 't1', evidence: 'bad', timestamp: ts(2) },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'impl-agent', taskId: 't2', evidence: 'bad', timestamp: ts(1) },
+      { type: 'impl',      signal: 'impl_peer_rejected',   agentId: 'impl-agent', taskId: 't3', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('impl-agent')!;
+    expect(score.consecutiveFailures).toBe(3);
+    expect(score.circuitOpen).toBe(true);
+  });
+
+  it('C3-4: mixed recovery — agreement in middle caps trailing impl_test_fail streak at 2', () => {
+    // Tail order (oldest → newest):
+    //   hallucination, hallucination, agreement, impl_test_fail, impl_test_fail
+    // Walk: impl_test_fail (neg, streak=1) → impl_test_fail (neg, streak=2) → agreement (non-neg, STOP)
+    // consecutiveFailures = 2, circuit open (>= threshold 3) = false.
+    writeSignals([
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'agent-z', taskId: 't1', evidence: 'bad', timestamp: ts(4) },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'agent-z', taskId: 't2', evidence: 'bad', timestamp: ts(3) },
+      { type: 'consensus', signal: 'agreement',             agentId: 'agent-z', counterpartId: 'p', taskId: 't3', evidence: 'ok', timestamp: ts(2) },
+      { type: 'impl',      signal: 'impl_test_fail',        agentId: 'agent-z', taskId: 't4', timestamp: ts(1) },
+      { type: 'impl',      signal: 'impl_test_fail',        agentId: 'agent-z', taskId: 't5', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('agent-z')!;
+    expect(score.consecutiveFailures).toBe(2);
+    expect(score.circuitOpen).toBe(false);
+  });
+
+  it('C3-5: pure impl streak of 3 impl_test_fail opens the circuit', () => {
+    // Agent with no consensus history, only 3 trailing impl_test_fail signals.
+    // Each is in NEGATIVE_IMPL_SIGNALS → consecutiveFailures = 3 → circuitOpen = true.
+    writeSignals([
+      { type: 'impl', signal: 'impl_test_fail', agentId: 'impl-only', taskId: 't1', timestamp: ts(2) },
+      { type: 'impl', signal: 'impl_test_fail', agentId: 'impl-only', taskId: 't2', timestamp: ts(1) },
+      { type: 'impl', signal: 'impl_test_fail', agentId: 'impl-only', taskId: 't3', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('impl-only')!;
+    expect(score.consecutiveFailures).toBe(3);
+    expect(score.circuitOpen).toBe(true);
+  });
+
+  it('C3-6 (regression): unique_unconfirmed still does not bench (Change 1 carry-over)', () => {
+    // Regression guard: unique_unconfirmed must remain out of NEGATIVE_SIGNALS
+    // regardless of the Change 3 streak-loop rewrite.
+    writeSignals([
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'rg-agent', taskId: 't1', evidence: '', timestamp: ts(4) },
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'rg-agent', taskId: 't2', evidence: '', timestamp: ts(3) },
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'rg-agent', taskId: 't3', evidence: '', timestamp: ts(2) },
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'rg-agent', taskId: 't4', evidence: '', timestamp: ts(1) },
+      { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'rg-agent', taskId: 't5', evidence: '', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('rg-agent')!;
+    expect(score.consecutiveFailures).toBe(0);
+    expect(score.circuitOpen).toBe(false);
+  });
+
+  it('C3: impl_peer_approved resets a trailing consensus streak', () => {
+    // impl_peer_approved is a positive impl signal (not in NEGATIVE_IMPL_SIGNALS) → streak-breaker.
+    writeSignals([
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'agent-q', taskId: 't1', evidence: 'bad', timestamp: ts(2) },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'agent-q', taskId: 't2', evidence: 'bad', timestamp: ts(1) },
+      { type: 'impl',      signal: 'impl_peer_approved',   agentId: 'agent-q', taskId: 't3', timestamp: ts(0) },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('agent-q')!;
+    expect(score.consecutiveFailures).toBe(0);
+    expect(score.circuitOpen).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

**Stacked on PR #71.** Completes the circuit-breaker fix from `docs/specs/2026-04-14-circuit-breaker-fix.md` with Changes 2 + 3. Base is `fix/circuit-breaker-unique-unconfirmed` so this diff shows only the delta beyond PR #71.

## Change 2 — Dedicated timeout/empty signal types

`collect.ts` previously co-opted `unique_unconfirmed` for timed-out/empty tasks, conflating transport failure with correctness. Introduce dedicated types:

- `consensus-types.ts`: `ConsensusSignal['signal']` union extended with `task_timeout`, `task_empty`
- `performance-writer.ts`: `VALID_CONSENSUS_SIGNALS` updated
- `performance-reader.ts`: `KNOWN_SIGNALS` extended; explicit no-op switch case in the scoring loop (contributes ZERO to any accumulator)
- `apps/cli/src/handlers/collect.ts:180-184`: emits the new types

## Change 3 — Impl signals reset the consensus streak

Prior streak loop excluded impl signals via `type === 'consensus'` filter, so `impl_test_pass` couldn't interrupt a stale consensus streak. Fix extends the streak to accept both types with a symmetric `NEGATIVE_IMPL_SIGNALS` set.

### Refactor details

- `readSignals()` return type: `ConsensusSignal[]` → `PerformanceSignal[]`. Retraction stays consensus-only (impl signals aren't retractable).
- `computeScores()` splits the union into `consensusSignals` / `implSignals` at function start. **All scoring math uses `consensusSignals` only** — accuracy, uniqueness, reliability, peerDiversity, categoryStrengths, retraction index. TypeScript enforces the split.
- Streak loop accepts both streams, sorted by taskCounter, per-type negative-set lookups.
- `NEGATIVE_IMPL_SIGNALS = {impl_test_fail, impl_peer_rejected}` — Bayesian-symmetric with consensus negatives.
- **New fallback** (spec gap caught during implementation): agents present only in impl signals (no consensus history) emit a neutral `AgentScore` so `circuitOpen` state is visible to downstream consumers.
- `getRecentCrossReviewCount()` gained a type narrow since `readSignals()` now returns a union.

## Tests

9 new unit cases in `tests/orchestrator/performance-reader.test.ts`:

- `task_timeout` doesn't bench (5 consecutive)
- `task_empty` doesn't bench (5 consecutive)
- `impl_test_pass` resets consensus streak
- `impl_test_fail` extends streak (3 → circuit open)
- `impl_peer_rejected` extends streak
- Mixed recovery — consensus agreement in middle resets, trailing impl fails counted
- Pure impl streak benches (3 consecutive `impl_test_fail`)
- Regression guard — `unique_unconfirmed` still doesn't bench

**1511 tests pass, `tsc --noEmit` clean across orchestrator + cli.**

## Validation-ready

Once both PRs (#71 + this) merge, replay `.gossip/agent-performance.jsonl` via `PerformanceReader` and confirm the three currently-benched agents (haiku-researcher, sonnet-implementer, openclaw-agent) exit the bench cleanly — or identify genuine issues if they don't.

## Consensus context

Root causes validated in consensus round `4d6406d5-b0e147a5` (sonnet-reviewer + gemini-reviewer, 2026-04-14).

## Backward compatibility

No migration needed. Existing signal records in `.gossip/agent-performance.jsonl` work unchanged. Old `unique_unconfirmed` signals stop being circuit-breaker negatives (per PR #71); new `task_timeout` / `task_empty` only appear going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)