### PR TITLE
fix(consensus): surface UNVERIFIED peers on CONFIRMED findings

### DIFF
--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -121,6 +121,15 @@ function ReportFinding({ f, reviewInfo }: { f: ConsensusReportFinding; reviewInf
             {f.disputedBy.length} ⚡
           </span>
         )}
+        {f.unverifiedBy && f.unverifiedBy.length > 0 && (
+          <span
+            className="cursor-help rounded px-1 py-0.5 font-mono text-[10px] text-unverified/50 transition hover:bg-unverified/10"
+            data-tooltip={`Unverified by:\n${f.unverifiedBy.map(u => u.agentId).join(', ')}`}
+            data-tooltip-pos="left"
+          >
+            {f.unverifiedBy.length} ◇
+          </span>
+        )}
       </div>
       {/* Row 2: Disputed by details (if disputed) */}
       {f.disputedBy && f.disputedBy.length > 0 && (

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -85,6 +85,7 @@ export interface ConsensusReportFinding {
   tag: string;
   confirmedBy: string[];
   disputedBy?: Array<{ agentId: string; reason: string; evidence: string }>;
+  unverifiedBy?: Array<{ agentId: string; reason: string }>;
   confidence: number;
 }
 

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -1825,7 +1825,10 @@ Return only valid JSON.${skillsBlock}`;
         const origPreset = this.config.registryGet(f.originalAgentId)?.preset || f.originalAgentId;
         const confirmerPresets = f.confirmedBy.map(id => this.config.registryGet(id)?.preset || id).join(', ');
         const sev = f.severity ? ` [${f.severity.toUpperCase()}]` : '';
-        lines.push(`  ✓ [${origPreset} + ${confirmerPresets}]${sev} ${f.finding}`);
+        const unvPresets = f.unverifiedBy && f.unverifiedBy.length > 0
+          ? `, unverified by ${f.unverifiedBy.map(u => this.config.registryGet(u.agentId)?.preset || u.agentId).join(', ')}`
+          : '';
+        lines.push(`  ✓ [${origPreset} + ${confirmerPresets}${unvPresets}]${sev} ${f.finding}`);
       }
       lines.push('');
     }


### PR DESCRIPTION
## Summary

Both the text-mode consensus report and the dashboard finding card were only showing AGREE confirmers after the `+` on CONFIRMED findings. Peers who voted UNVERIFIED on the same finding were invisible in the summary, masking the peer-pool-saturation signal — when a finding is confirmed by M peers but another N peers couldn't verify it because of pool shortage, that N is diagnostic information the user needs.

Addresses `project_consensus_verdict_coverage_display` (backlog memory) and `docs/specs/2026-04-06-dashboard-v3.md` finding-card parity gap.

## Changes

- **`packages/orchestrator/src/consensus-engine.ts`** — CONFIRMED line in `formatReport` now appends `, unverified by <preset(s)>` when the finding has any `unverifiedBy` entries. One line; empty array stays silent.
- **`packages/dashboard-v2/src/lib/types.ts`** — `ConsensusReportFinding` gains optional `unverifiedBy?: Array<{ agentId; reason }>`. The server already serializes this at `consensus-engine.ts:1014`; the dashboard type was just missing the declaration.
- **`packages/dashboard-v2/src/components/FindingsMetrics.tsx`** — finding card adds a third pill after the disputed ⚡ pill: `{count} ◇` in unverified-amber with tooltip listing the unverified peers. Consistent with existing confirmed ✓ / disputed ⚡ pattern.

## Test plan

- [ ] `tsc -b` clean in packages/orchestrator + packages/dashboard-v2
- [ ] 119 consensus-engine tests still pass
- [ ] Run a consensus round with a mix of CONFIRMED and UNVERIFIED findings; verify text report shows `, unverified by …` inline on CONFIRMED rows
- [ ] Open the dashboard; find a CONFIRMED finding that also has UNVERIFIED peers; confirm the ◇ pill appears with the correct tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)