### PR TITLE
fix(orchestrator): self-heal lastKeyByAgent snapshot on first syncWorkers

### DIFF
--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -349,9 +349,13 @@ export class MainAgent {
       const hadKeySnapshot = this.lastKeyByAgent.has(ac.id);
       const prevKey = this.lastKeyByAgent.get(ac.id) ?? null;
 
-      if (existing && hadKeySnapshot && prevKey === key) {
-        // No-op: worker is live and the keychain value matches what we built
-        // it with. Do NOT teardown, do NOT increment added.
+      if (existing && (!hadKeySnapshot || prevKey === key)) {
+        // No-op: worker is live, and either (a) the keychain value matches
+        // what we built it with, or (b) we have no prior snapshot because
+        // the worker was created outside syncWorkers (e.g. at MCP boot in
+        // mcp-server-sdk.ts:488). In case (b), record the current key as
+        // the snapshot so subsequent calls can compare. Do NOT teardown.
+        if (!hadKeySnapshot) this.lastKeyByAgent.set(ac.id, key);
         continue;
       }
 


### PR DESCRIPTION
## Summary

PR #75's key-change gate skipped teardown only when `existing && hadKeySnapshot && prevKey === key`. But on fresh MCP boot, workers get created by `apps/cli/src/mcp-server-sdk.ts:488-500` and stored in `ctx.workers` (which shares a Map reference with `mainAgent.workers` via `setWorkers()` at line 627), while `mainAgent.lastKeyByAgent` stays empty. The first dispatch after reboot then tears down and rebuilds all workers, producing the `RELAY DISCONNECTED` burst.

Evidence from `.gossip/mcp.log`:
```
[relay] shutdown reason=SIGTERM pid=72004
[relay] PID=90543
08:13:03.955 ... RELAY DISCONNECTED (4 workers, all rebuilt)
```

## Fix

In `syncWorkers`: when an existing worker is present but no prior snapshot exists, record the current key as the snapshot and skip teardown. 7-line change. The worker was built by the boot path with the same keychain we're reading now; near-zero risk of mismatch in the boot→first-dispatch window.

## Test plan

- [ ] Existing `tests/orchestrator/sync-workers.test.ts` still 4/4 (the pre-populated-snapshot path)
- [ ] Manual: restart MCP, run a dispatch, grep `mcp.log` for `RELAY DISCONNECTED` — should be zero new lines

Companion to PR #75 (`df43ede`). Without this, the disconnect-burst fix doesn't actually hold across MCP restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)