### PR TITLE
docs(readme): add Socket badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <a href="https://github.com/gossipcat-ai/gossipcat-ai/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT License" /></a>
   <a href="#quickstart"><img src="https://img.shields.io/badge/node-22%2B-green" alt="Node 22+" /></a>
   <a href="https://github.com/gossipcat-ai/gossipcat-ai/stargazers"><img src="https://img.shields.io/github/stars/gossipcat-ai/gossipcat-ai?style=social" alt="GitHub stars" /></a>
+  <a href="https://socket.dev/npm/package/gossipcat"><img src="https://badge.socket.dev/npm/package/gossipcat/0.4.2" alt="Socket Score" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Adds a Socket supply-chain badge from [socket.dev](https://socket.dev/npm/package/gossipcat) next to the existing npm/license/node/stars badges. Pinned to the current published version (0.4.2).

## Test plan

- [ ] README renders the badge correctly on GitHub
- [ ] Socket link resolves to the gossipcat package page

🤖 Generated with [Claude Code](https://claude.com/claude-code)