### PR TITLE
feat(memory): separate native and gossip memory stores with ordered writes

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -220,6 +220,52 @@ let bootPromise: Promise<void> | null = null;
 let planExecutionDepth = 0;
 // Stash gathered session data between utility dispatch and re-entry (keyed by task ID)
 const _pendingSessionData = new Map<string, { gossip: string; consensus: string; performance: string; gitLog: string; notes?: string }>();
+
+/**
+ * Write the three session-save artifacts in mandatory order per
+ * docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md:
+ *   1. next-session.md       → bootstrap continuity (throws on failure)
+ *   2. cognitive knowledge   → LRU store (logged & continues on failure)
+ *   3. .gossip/memory/       → dashboard visibility (logged & continues on failure)
+ *
+ * Each write lives in its own try/catch so a failure in (2) or (3) does NOT
+ * prevent (1) from having landed, and does not cause session_save to report
+ * a top-level failure. Returns the summary body (empty string if write-order
+ * invariant is violated and (1) fails hard — in that case caller surfaces error).
+ */
+async function writeArtifactsInOrder(
+  a: import('@gossip/orchestrator').SessionArtifacts,
+): Promise<string> {
+  const { writeFileSync: wf, mkdirSync: md } = await import('fs');
+  const { dirname } = await import('path');
+
+  // (1) next-session.md — highest priority; bootstrap continuity depends on it.
+  try {
+    md(dirname(a.nextSessionPath), { recursive: true });
+    wf(a.nextSessionPath, a.nextSessionContent);
+  } catch (err) {
+    process.stderr.write(`[gossipcat] next-session.md write FAILED: ${(err as Error).message}\n`);
+    throw err;
+  }
+
+  // (2) cognitive knowledge file — best-effort; cognitive store degraded is not fatal.
+  try {
+    md(dirname(a.knowledgePath), { recursive: true });
+    wf(a.knowledgePath, a.knowledgeContent);
+  } catch (err) {
+    process.stderr.write(`[gossipcat] cognitive knowledge write failed: ${(err as Error).message}\n`);
+  }
+
+  // (3) .gossip/memory/session_*.md — best-effort dashboard visibility.
+  try {
+    md(a.gossipMemoryDir, { recursive: true });
+    wf(a.gossipMemoryPath, a.gossipMemoryContent);
+  } catch (err) {
+    process.stderr.write(`[gossipcat] .gossip/memory write failed: ${(err as Error).message}\n`);
+  }
+
+  return a.summaryBody;
+}
 // Stash skill develop prompt metadata between native-utility dispatch and re-entry (keyed by task ID)
 const _pendingSkillData = new Map<string, { agentId: string; category: string; skillName: string; skillPath: string; baseline_accuracy_correct: number; baseline_accuracy_hallucinated: number; bound_at: string }>();
 
@@ -3011,20 +3057,24 @@ server.tool(
       const writer = new MemoryWriter(process.cwd());
       try { if (ctx.mainAgent.getLLM()) writer.setSummaryLlm(ctx.mainAgent.getLLM()); } catch {}
 
-      let summary: string;
+      // Prepare artifacts (no writes yet). Write order is enforced below per
+      // docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md.
+      let artifacts;
       if (utilityResult?.status === 'completed' && utilityResult.result) {
         try {
-          summary = await writer.writeSessionSummaryFromRaw({ ...summaryData, raw: utilityResult.result });
+          artifacts = await writer.prepareSessionArtifactsFromRaw({ ...summaryData, raw: utilityResult.result });
         } catch (err) {
           process.stderr.write(`[gossipcat] Native session summary post-processing failed: ${(err as Error).message}\n`);
-          summary = await writer.writeSessionSummary(summaryData);
+          artifacts = await writer.prepareSessionArtifacts(summaryData);
         }
       } else {
         process.stderr.write(`[gossipcat] Native session summary utility ${_utility_task_id} failed/timed out, falling back to LLM\n`);
-        summary = await writer.writeSessionSummary(summaryData);
+        artifacts = await writer.prepareSessionArtifacts(summaryData);
       }
       ctx.nativeResultMap.delete(_utility_task_id);
       ctx.nativeTaskMap.delete(_utility_task_id);
+
+      const summary = await writeArtifactsInOrder(artifacts);
 
       // Auto-resolve findings that appear in recent commits (same as normal path)
       if (summaryData.gitLog) {
@@ -3297,8 +3347,11 @@ server.tool(
       };
     }
 
-    // Normal path (no re-entry): call LLM directly
-    summary = await writer.writeSessionSummary(summaryData);
+    // Normal path (no re-entry): call LLM directly. Prepare artifacts without
+    // writing, then perform the three writes in mandatory order with per-artifact
+    // try/catch (docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md).
+    const artifacts = await writer.prepareSessionArtifacts(summaryData);
+    summary = await writeArtifactsInOrder(artifacts);
 
     // 5d. Append open findings to next-session.md as structured data (outside LLM prose)
     if (findingsTable) {

--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -10,7 +10,7 @@ import { TeamHero } from '@/components/TeamHero';
 import { NeuralAvatar } from '@/components/NeuralAvatar';
 import { TaskDetailModal } from '@/components/TaskDetailModal';
 import { TasksSection } from '@/components/TasksSection';
-import { MemoryFolders } from '@/components/MemoryFolders';
+import { NativeMemories, GossipMemories } from '@/components/MemoryFolders';
 import { AgentPage } from '@/components/AgentPage';
 import { LogsPage } from '@/components/LogsPage';
 import { TaskRow } from '@/components/TaskRow';
@@ -407,7 +407,7 @@ function FindingsPage({
 
 function Dashboard() {
   const route = useRoute();
-  const { overview, agents, tasks, consensus, consensusReports, memories, loading, refresh } = useDashboardData();
+  const { overview, agents, tasks, consensus, consensusReports, nativeMemories, gossipMemories, loading, refresh } = useDashboardData();
   const [activeTaskCount, setActiveTaskCount] = useState(0);
 
   const handleWsEvent = useCallback((event: DashboardEvent) => {
@@ -455,7 +455,8 @@ function Dashboard() {
           {tasks && <TasksSection tasks={tasks} limit={5} />}
           {agents && <TeamHero agents={agents} />}
           <FindingsMetrics consensus={consensus} reports={consensusReports} />
-          {memories && <MemoryFolders memories={memories} />}
+          {gossipMemories && <GossipMemories memories={gossipMemories} />}
+          {nativeMemories && <NativeMemories memories={nativeMemories} />}
         </main>
       </div>
     );

--- a/packages/dashboard-v2/src/components/MemoryFolders.tsx
+++ b/packages/dashboard-v2/src/components/MemoryFolders.tsx
@@ -7,7 +7,24 @@ import { MemoryDialog } from './MemoryDialog';
 
 interface MemoryFoldersProps {
   memories: MemoryFile[];
+  /**
+   * Section heading override. Defaults to "Memory" for backward-compat with
+   * the pre-split single-section layout; pass "Gossip Memory" when rendering
+   * the `.gossip/memory/` store alongside a sibling `<NativeMemories>` block.
+   */
+  heading?: string;
+  /**
+   * When true, show an additional status-based filter (open / shipped / all).
+   * Used by the gossip-memory view per the native-vs-gossip separation spec.
+   * Native memories don't carry a canonical `status` field, so the filter is
+   * off by default.
+   */
+  statusFilter?: boolean;
 }
+
+/** Status values that count as "shipped/closed" in the status filter. */
+const SHIPPED_STATUSES = new Set(['shipped', 'closed']);
+type StatusFilter = 'all' | 'open' | 'shipped';
 
 /**
  * Per-folder accent — text color class applied to count + icon stroke.
@@ -83,9 +100,10 @@ const DAY_MS = 24 * 60 * 60 * 1000;
  *
  * Spec: docs/specs/2026-04-15-memory-taxonomy-hybrid.md
  */
-export function MemoryFolders({ memories }: MemoryFoldersProps) {
+export function MemoryFolders({ memories, heading = 'Memory', statusFilter = false }: MemoryFoldersProps) {
   const [folder, setFolder] = useState<DisplayType | null>(null);
   const [open, setOpen] = useState<MemoryFile | null>(null);
+  const [statusView, setStatusView] = useState<StatusFilter>('all');
 
   // De-dupe by filename: the same file can be returned for both its agent and
   // _project when an agent shares it.
@@ -93,6 +111,19 @@ export function MemoryFolders({ memories }: MemoryFoldersProps) {
     () => memories.filter((m, i, arr) => arr.findIndex((x) => x.filename === m.filename) === i),
     [memories],
   );
+
+  // Apply status filter (gossip-memory only). Native store doesn't carry status
+  // consistently, so we only filter when the caller opts in.
+  const filtered = useMemo(() => {
+    if (!statusFilter || statusView === 'all') return unique;
+    return unique.filter((m) => {
+      const s = (m.frontmatter?.status || '').toLowerCase();
+      if (statusView === 'shipped') return SHIPPED_STATUSES.has(s);
+      // 'open' means explicitly open OR missing — missing status is treated as
+      // open backlog per the memory-taxonomy default-to-backlog rule.
+      return s === 'open' || !s;
+    });
+  }, [unique, statusFilter, statusView]);
 
   // Group memories by display folder, plus per-folder "active in last 24h" flag.
   const byFolder = useMemo(() => {
@@ -109,13 +140,13 @@ export function MemoryFolders({ memories }: MemoryFoldersProps) {
       rule: false,
     };
     const now = Date.now();
-    for (const m of unique) {
+    for (const m of filtered) {
       const t = toDisplayType(m);
       buckets[t].push(m);
       if (!recent[t] && isRecent(m, now)) recent[t] = true;
     }
     return { buckets, recent };
-  }, [unique]);
+  }, [filtered]);
 
   if (folder) {
     return (
@@ -133,9 +164,30 @@ export function MemoryFolders({ memories }: MemoryFoldersProps) {
 
   return (
     <section className="flex h-full flex-col">
-      <h2 className="mb-3 font-mono text-xs font-bold uppercase tracking-widest text-foreground">
-        Memory <span className="text-primary">{unique.length}</span>
-      </h2>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h2 className="font-mono text-xs font-bold uppercase tracking-widest text-foreground">
+          {heading} <span className="text-primary">{filtered.length}</span>
+        </h2>
+        {statusFilter && (
+          <div className="flex gap-1 font-mono text-[10px]" role="tablist" aria-label="Status filter">
+            {(['all', 'open', 'shipped'] as const).map((s) => (
+              <button
+                key={s}
+                role="tab"
+                aria-selected={statusView === s}
+                onClick={() => setStatusView(s)}
+                className={`rounded-sm border px-2 py-0.5 uppercase tracking-widest transition ${
+                  statusView === s
+                    ? 'border-primary/50 bg-primary/10 text-primary'
+                    : 'border-border/30 text-muted-foreground hover:border-primary/30 hover:text-foreground'
+                }`}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         {DISPLAY_TYPES.map(({ type, label, blurb }) => {
           const count = byFolder.buckets[type].length;
@@ -209,11 +261,81 @@ export function MemoryFolders({ memories }: MemoryFoldersProps) {
 function isRecent(mem: MemoryFile, now: number): boolean {
   const fm = mem.frontmatter;
   if (!fm) return false;
-  for (const key of ['timestamp', 'updated', 'updatedAt', 'modified', 'created', 'date']) {
+  // lastAccessed is the canonical gossip-memory freshness key (see
+  // memory-writer.ts frontmatter schema); updated is included as a duplicate
+  // for the native store's "updated" convention. The extra keys stay for
+  // defensive parsing across both stores.
+  for (const key of ['lastAccessed', 'updated', 'timestamp', 'updatedAt', 'modified', 'created', 'date']) {
     const v = fm[key];
     if (!v) continue;
     const t = new Date(v).getTime();
     if (!isNaN(t) && now - t <= DAY_MS) return true;
   }
   return false;
+}
+
+/**
+ * Gossip-memory wrapper — 4-folder taxonomy with status filter. Used to render
+ * `.gossip/memory/` entries alongside `<NativeMemories>` in the dashboard per
+ * docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md.
+ */
+export function GossipMemories({ memories }: { memories: MemoryFile[] }) {
+  return <MemoryFolders memories={memories} heading="Gossip Memory" statusFilter />;
+}
+
+/**
+ * Native-memory wrapper — flat list view of Claude Code's auto-memory. No
+ * taxonomy, no status filter (Claude Code doesn't write a canonical status).
+ * The separation invariant (spec risk matrix) forbids merging native + gossip
+ * arrays; render them as two distinct sections.
+ */
+export function NativeMemories({ memories }: { memories: MemoryFile[] }) {
+  const [open, setOpen] = useState<MemoryFile | null>(null);
+  const unique = useMemo(
+    () => memories.filter((m, i, arr) => arr.findIndex((x) => x.filename === m.filename) === i),
+    [memories],
+  );
+  const now = Date.now();
+
+  return (
+    <section className="flex h-full flex-col">
+      <h2 className="mb-3 font-mono text-xs font-bold uppercase tracking-widest text-foreground">
+        Native Memory <span className="text-primary">{unique.length}</span>
+      </h2>
+      {unique.length === 0 ? (
+        <p className="font-mono text-[11px] text-muted-foreground">No native memories yet.</p>
+      ) : (
+        <ul className="space-y-1 font-mono text-[11px]">
+          {unique.slice(0, 20).map((m) => {
+            const recent = isRecent(m, now);
+            const desc = m.frontmatter?.description || m.frontmatter?.name || '';
+            return (
+              <li key={m.filename}>
+                <button
+                  onClick={() => setOpen(m)}
+                  className="flex w-full items-center justify-between gap-3 rounded-sm border border-border/20 bg-muted/40 px-3 py-2 text-left transition hover:border-primary/30 hover:bg-accent/40"
+                >
+                  <span className="flex min-w-0 items-center gap-2">
+                    {recent && (
+                      <span
+                        className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
+                        style={{ boxShadow: '0 0 8px rgba(139, 92, 246, 0.6)' }}
+                        aria-label="Activity in the last 24h"
+                      />
+                    )}
+                    <span className="truncate text-foreground">{m.filename}</span>
+                  </span>
+                  {desc && <span className="shrink-0 truncate text-muted-foreground/80">{desc.slice(0, 60)}</span>}
+                </button>
+              </li>
+            );
+          })}
+          {unique.length > 20 && (
+            <li className="pl-3 text-[10px] text-muted-foreground">… and {unique.length - 20} more</li>
+          )}
+        </ul>
+      )}
+      <MemoryDialog memory={open} onClose={() => setOpen(null)} />
+    </section>
+  );
 }

--- a/packages/dashboard-v2/src/hooks/useDashboardData.ts
+++ b/packages/dashboard-v2/src/hooks/useDashboardData.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { api } from '@/lib/api';
 import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, MemoryFile } from '@/lib/types';
 
-interface AutoMemoryResponse { knowledge: MemoryFile[] }
+interface MemoryApiResponse { knowledge: MemoryFile[] }
 
 export interface DashboardState {
   overview: OverviewData | null;
@@ -10,6 +10,22 @@ export interface DashboardState {
   tasks: TasksData | null;
   consensus: ConsensusData | null;
   consensusReports: ConsensusReportsData | null;
+  /**
+   * Claude Code auto-memory (`~/.claude/projects/-<cwd>/memory/`). Flat list,
+   * no 4-folder taxonomy. Separate from gossipMemories — callers MUST NOT merge
+   * the two arrays (spec invariant: separation is the whole point).
+   */
+  nativeMemories: MemoryFile[] | null;
+  /**
+   * Gossipcat-owned memory store (`<projectRoot>/.gossip/memory/`). Renders
+   * with the 4-folder taxonomy + status filter.
+   */
+  gossipMemories: MemoryFile[] | null;
+  /**
+   * @deprecated Legacy unified field; still populated with nativeMemories for
+   * one release so callers that haven't migrated keep working. New code should
+   * read `nativeMemories` and `gossipMemories` directly.
+   */
   memories: MemoryFile[] | null;
   loading: boolean;
   error: string | null;
@@ -17,13 +33,14 @@ export interface DashboardState {
 
 export function useDashboardData() {
   const [state, setState] = useState<DashboardState>({
-    overview: null, agents: null, tasks: null, consensus: null, consensusReports: null, memories: null,
+    overview: null, agents: null, tasks: null, consensus: null, consensusReports: null,
+    nativeMemories: null, gossipMemories: null, memories: null,
     loading: true, error: null,
   });
 
   const refresh = useCallback(async () => {
     try {
-      const [overview, agents, tasks, consensus, consensusReports, autoMemory] = await Promise.all([
+      const [overview, agents, tasks, consensus, consensusReports, nativeResp, gossipResp] = await Promise.all([
         api<OverviewData>('overview'),
         api<AgentData[]>('agents'),
         api<TasksData>('tasks?limit=50'),
@@ -32,17 +49,27 @@ export function useDashboardData() {
         // the full round history instead of the first 10 runs.
         api<ConsensusData>('consensus?pageSize=50'),
         api<ConsensusReportsData>('consensus-reports?page=1&pageSize=5').catch(() => ({ reports: [] })),
-        api<AutoMemoryResponse>('auto-memory').catch(() => ({ knowledge: [] as MemoryFile[] })),
+        // Native + gossip stores are fetched in parallel and kept SEPARATE. The
+        // taxonomy/status split only applies to gossip memories. Native memories
+        // render flat. Spec: docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md
+        api<MemoryApiResponse>('native-memory').catch(() => ({ knowledge: [] as MemoryFile[] })),
+        api<MemoryApiResponse>('gossip-memory').catch(() => ({ knowledge: [] as MemoryFile[] })),
       ]);
 
-      // MemoryFolders consumes Claude Code's project-scoped auto-memory
-      // (~/.claude/projects/-<cwd>/memory/). No trim — the taxonomy mapper
-      // needs the full set to compute folder counts.
-      const memories = [...(autoMemory.knowledge || [])].sort(
+      const nativeMemories = [...(nativeResp.knowledge || [])].sort(
+        (a, b) => (b.filename > a.filename ? 1 : -1),
+      );
+      const gossipMemories = [...(gossipResp.knowledge || [])].sort(
         (a, b) => (b.filename > a.filename ? 1 : -1),
       );
 
-      setState({ overview, agents, tasks, consensus, consensusReports, memories, loading: false, error: null });
+      setState({
+        overview, agents, tasks, consensus, consensusReports,
+        nativeMemories,
+        gossipMemories,
+        memories: nativeMemories, // deprecated legacy alias — do NOT merge
+        loading: false, error: null,
+      });
     } catch (err) {
       setState((s) => ({ ...s, loading: false, error: (err as Error).message }));
     }

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -33,6 +33,7 @@ export { parseAgentFindingsStrict, PARSE_FINDINGS_LIMITS } from './parse-finding
 export type { ParsedFinding, ParseFindingsResult, ParseFindingsOptions, FindingType, Severity } from './parse-findings';
 export { AgentMemoryReader } from './agent-memory';
 export { MemoryWriter } from './memory-writer';
+export type { SessionArtifacts } from './memory-writer';
 export { MemoryCompactor } from './memory-compactor';
 export { TaskGraph } from './task-graph';
 export { TaskGraphSync } from './task-graph-sync';

--- a/packages/orchestrator/src/memory-writer.ts
+++ b/packages/orchestrator/src/memory-writer.ts
@@ -40,6 +40,50 @@ function sanitizeTaskId(taskId: string): string {
   return taskId.replace(/[/\\:*?"<>|\0]/g, '_');
 }
 
+/**
+ * The three artifacts produced by a session save, plus the metadata needed
+ * to write them. Returned by `prepareSessionArtifacts*` so the caller can
+ * control write order + per-artifact try/catch semantics.
+ *
+ * Write order (mandatory):
+ *   1. next-session.md       (bootstrap continuity)
+ *   2. cognitive knowledge   (LRU store)
+ *   3. .gossip/memory/*.md   (dashboard visibility)
+ *
+ * Spec: docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md
+ */
+export interface SessionArtifacts {
+  /** The processed summary body (post STALE/PINNED cleanup, pre-write). */
+  summaryBody: string;
+  /** One-line session summary extracted from SUMMARY: or fallback heuristic. */
+  summaryOneLiner: string;
+  /** ISO-ish timestamp used for cognitive-store filename (YYYY-MM-DDTHH-mm-ss). */
+  timestamp: string;
+  /** Calendar date (YYYY-MM-DD). */
+  today: string;
+  /** True if the LLM flagged the session as PINNED. */
+  pinned: boolean;
+
+  /** Absolute path of the cognitive knowledge file (.gossip/agents/_project/memory/knowledge/<ts>-session.md). */
+  knowledgePath: string;
+  /** Content to write to knowledgePath. */
+  knowledgeContent: string;
+
+  /** Absolute path of .gossip/next-session.md. */
+  nextSessionPath: string;
+  /** Content to write to nextSessionPath. */
+  nextSessionContent: string;
+
+  /** Directory containing the dashboard-visible gossip memory files (.gossip/memory/). */
+  gossipMemoryDir: string;
+  /** Absolute path of the gossip-memory session file. */
+  gossipMemoryPath: string;
+  /** Content to write to gossipMemoryPath. */
+  gossipMemoryContent: string;
+  /** Resolved status derived from the summary's "Open for next session" section ("open" | "shipped"). */
+  gossipStatus: 'open' | 'shipped';
+}
+
 export class MemoryWriter {
   private summaryLlm: ILLMProvider | null = null;
 
@@ -308,33 +352,41 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
   }
 
   /**
-   * Write session summary from raw LLM output (skips the LLM call).
-   * Used by the native utility path after Agent() completes.
+   * Prepare session artifacts from raw LLM output without writing the three
+   * main files. The caller is responsible for writing them in order:
+   *   1. next-session.md     (bootstrap continuity — highest priority)
+   *   2. cognitive knowledge (LRU store)
+   *   3. .gossip/memory/     (dashboard visibility — best-effort)
+   *
+   * Book-keeping side effects (STALE normalization, LRU pruning, tasks.jsonl
+   * entry, MEMORY.md rebuild, compaction) happen during preparation because
+   * they are internal to the cognitive store and orthogonal to the three
+   * artifact writes. Used by the native utility path after Agent() completes.
    */
-  async writeSessionSummaryFromRaw(data: {
+  async prepareSessionArtifactsFromRaw(data: {
     gossip: string;
     consensus: string;
     performance: string;
     gitLog: string;
     notes?: string;
     raw: string;
-  }): Promise<string> {
+  }): Promise<SessionArtifacts> {
     const { memDir, knowledgeDir, timestamp, today, rawInput, existingFiles } = this.sessionSummaryData(data);
     return this.processSessionResponse(data.raw, rawInput, knowledgeDir, memDir, today, timestamp, existingFiles);
   }
 
   /**
-   * Write a session summary to the _project virtual agent's memory.
-   * Dedicated method with higher output cap (4000 chars) and session-specific prompt.
-   * Falls back to raw data save if LLM fails.
+   * Prepare session artifacts using the configured summary LLM (with fallback).
+   * The caller (see apps/cli/src/mcp-server-sdk.ts session_save handler) is
+   * responsible for writing the three files in order.
    */
-  async writeSessionSummary(data: {
+  async prepareSessionArtifacts(data: {
     gossip: string;
     consensus: string;
     performance: string;
     gitLog: string;
     notes?: string;
-  }): Promise<string> {
+  }): Promise<SessionArtifacts> {
     const SESSION_SUMMARY_MAX_CHARS = 4000;
     const { memDir, knowledgeDir, timestamp, today, rawInput, existingFiles } = this.sessionSummaryData(data);
 
@@ -367,8 +419,87 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
   }
 
   /**
+   * Convenience wrapper: prepare artifacts AND write the three files in order.
+   * Preserved for backward-compat with existing callers/tests that rely on the
+   * single-call signature returning the summary body string.
+   *
+   * New callers should prefer `prepareSessionArtifactsFromRaw` + `writeSessionArtifacts`
+   * so each write can have its own try/catch with caller-owned semantics.
+   */
+  async writeSessionSummaryFromRaw(data: {
+    gossip: string;
+    consensus: string;
+    performance: string;
+    gitLog: string;
+    notes?: string;
+    raw: string;
+  }): Promise<string> {
+    const artifacts = await this.prepareSessionArtifactsFromRaw(data);
+    this.writeSessionArtifacts(artifacts);
+    return artifacts.summaryBody;
+  }
+
+  /** Convenience wrapper: prepare + write all three files. See prepareSessionArtifacts() for the separated API. */
+  async writeSessionSummary(data: {
+    gossip: string;
+    consensus: string;
+    performance: string;
+    gitLog: string;
+    notes?: string;
+  }): Promise<string> {
+    const artifacts = await this.prepareSessionArtifacts(data);
+    this.writeSessionArtifacts(artifacts);
+    return artifacts.summaryBody;
+  }
+
+  /**
+   * Write the three session artifacts in mandatory order:
+   *   1. next-session.md       — bootstrap continuity; throws on failure
+   *   2. cognitive knowledge   — LRU store; logged & continued on failure
+   *   3. .gossip/memory/       — dashboard visibility; logged & continued on failure
+   *
+   * Per-artifact failure isolation: a failure in (2) or (3) must not prevent
+   * (1) from being persisted, and must not cause the session save to report
+   * failure to the user. See docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md.
+   */
+  writeSessionArtifacts(a: SessionArtifacts): void {
+    // (1) next-session.md — must succeed; bootstrap continuity is the highest-priority artifact.
+    try {
+      writeFileSync(a.nextSessionPath, a.nextSessionContent);
+    } catch (err) {
+      gossipLog(`next-session.md write failed: ${(err as Error).message}`);
+      throw err;
+    }
+
+    // (2) cognitive knowledge file — best-effort but logged loudly; cognitive store degraded is not fatal.
+    try {
+      writeFileSync(a.knowledgePath, a.knowledgeContent);
+    } catch (err) {
+      gossipLog(`cognitive knowledge write failed: ${(err as Error).message}`);
+    }
+
+    // (3) .gossip/memory/session_*.md — best-effort dashboard visibility.
+    try {
+      mkdirSync(a.gossipMemoryDir, { recursive: true });
+      writeFileSync(a.gossipMemoryPath, a.gossipMemoryContent);
+    } catch (err) {
+      gossipLog(`.gossip/memory write failed: ${(err as Error).message}`);
+    }
+  }
+
+  /**
    * Shared post-processing for session summary responses.
-   * Validates, truncates, extracts metadata, handles STALE/PINNED, writes files.
+   * Validates, truncates, extracts metadata, handles STALE/PINNED.
+   *
+   * Prepares the three artifact contents (next-session.md, cognitive knowledge,
+   * gossip-memory session file) and returns them in a SessionArtifacts record.
+   * Internal book-keeping side effects (STALE normalization, LRU pruning,
+   * tasks.jsonl append, MEMORY.md rebuild, compaction) happen here because
+   * they are cognitive-store internals, not dashboard-visible artifacts.
+   *
+   * The three main writes are deliberately NOT performed here — the caller
+   * controls order, try/catch boundaries, and per-artifact failure semantics
+   * per docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md.
    */
   private async processSessionResponse(
     raw: string,
@@ -379,7 +510,7 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
     timestamp: string,
     existingFiles: string[],
     isFallback = false,
-  ): Promise<string> {
+  ): Promise<SessionArtifacts> {
     const SESSION_SUMMARY_MAX_CHARS = 4000;
     const filename = `${timestamp}-session.md`;
     let summaryBody: string;
@@ -474,7 +605,8 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
     // Prune AFTER staleness downgrades so demoted files are eviction candidates
     this.pruneProjectKnowledge(knowledgeDir);
 
-    const content = [
+    // (a) cognitive knowledge file content
+    const knowledgeContent = [
       '---',
       `name: Session ${today} — ${summaryOneLiner}`,
       `description: ${summaryOneLiner}`,
@@ -486,10 +618,9 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
       '',
       summaryBody,
     ].filter(l => l !== '').join('\n');
+    const knowledgePath = join(knowledgeDir, filename);
 
-    writeFileSync(join(knowledgeDir, filename), content);
-
-    // Write next-session.md with ONLY the priorities section (≤1500 chars).
+    // (b) next-session.md — ONLY the priorities section (≤1500 chars).
     // Full session detail stays in the knowledge file for on-demand retrieval.
     // This keeps bootstrap context lean — agents get priorities, not history.
     const nextSessionPath = join(this.projectRoot, '.gossip', 'next-session.md');
@@ -498,7 +629,33 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
     const nextSessionContent = openMatch
       ? `# Next Session\n\n${openMatch[0].trim()}\n`
       : `# Next Session\n\n${truncateAtWord(summaryBody, NEXT_SESSION_MAX_CHARS)}\n`;
-    writeFileSync(nextSessionPath, nextSessionContent);
+
+    // (c) .gossip/memory/session_YYYY_MM_DD.md — canonical dashboard-visible artifact.
+    // Separate store from cognitive knowledge: dashboard-facing, pruned on its own
+    // schedule, never a destination for cognitive-store importance values (always 0.4).
+    // Same-date collision: second save overwrites first (semantics pinned in spec
+    // invariant 4). Cognitive store retains per-timestamp versions for recall.
+    const gossipMemoryDir = join(this.projectRoot, '.gossip', 'memory');
+    const gossipMemoryFilename = `session_${today.replace(/-/g, '_')}.md`;
+    const gossipMemoryPath = join(gossipMemoryDir, gossipMemoryFilename);
+    const gossipStatus = openMatch && openMatch[0].trim().length > '## Open for next session'.length + 5
+      ? 'open'
+      : 'shipped';
+    const gossipName = sanitizeYamlValue(`Session ${today} — ${summaryOneLiner}`).slice(0, 120);
+    const gossipMemoryContent = [
+      '---',
+      `name: ${gossipName}`,
+      `description: ${summaryOneLiner}`,
+      `status: ${gossipStatus}`,
+      `type: session`,
+      `importance: 0.4`,
+      `lastAccessed: ${today}`,
+      `updated: ${today}`,
+      `accessCount: 0`,
+      '---',
+      '',
+      summaryBody,
+    ].join('\n');
 
     // One-time migration: normalize old importance=1.0 entries
     const migrationTasksPath = join(memDir, 'tasks.jsonl');
@@ -517,7 +674,7 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
       } catch { /* best-effort */ }
     }
 
-    // Write task entry for session tracking
+    // Write task entry for session tracking (internal cognitive-store bookkeeping)
     await this.writeTaskEntry('_project', {
       taskId: `session-${timestamp}`,
       task: `Session ${today}: ${summaryOneLiner}`,
@@ -533,7 +690,21 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
       compactor.compactIfNeeded('_project', 15);
     } catch { /* best-effort compaction */ }
 
-    return summaryBody;
+    return {
+      summaryBody,
+      summaryOneLiner,
+      timestamp,
+      today,
+      pinned,
+      knowledgePath,
+      knowledgeContent,
+      nextSessionPath,
+      nextSessionContent,
+      gossipMemoryDir,
+      gossipMemoryPath,
+      gossipMemoryContent,
+      gossipStatus,
+    };
   }
 
   /** Warmth-aware pruning for _project knowledge files */

--- a/packages/relay/src/dashboard/api-gossip-memory.ts
+++ b/packages/relay/src/dashboard/api-gossip-memory.ts
@@ -1,0 +1,76 @@
+import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { join } from 'path';
+import { parseFrontmatter } from './api-native-memory';
+
+/**
+ * Gossip-memory API — exposes gossipcat's canonical, dashboard-visible memory
+ * store at `.gossip/memory/` (inside the project). Gossipcat owns the write
+ * side (see memory-writer.ts `prepareSessionArtifacts*`); Claude Code never
+ * writes here. Separate from api-native-memory.ts (Claude Code's auto-memory)
+ * and api-memory.ts (per-agent cognitive memory under .gossip/agents/*).
+ *
+ * Contrast:
+ *   - Native memory  → `~/.claude/projects/-<cwd>/memory/` (CC-owned, flat list)
+ *   - Gossip memory  → `<projectRoot>/.gossip/memory/`    (gossipcat-owned, 4-folder taxonomy)
+ *
+ * The dashboard consumes this endpoint via `useDashboardData.gossipMemories`
+ * and renders it with the 4-folder taxonomy (backlog / record / session / rule)
+ * mapped by `memory-taxonomy.ts`. Dashboard must NEVER merge native + gossip
+ * arrays — separation is an invariant (see spec risk matrix).
+ *
+ * Route: GET /dashboard/api/gossip-memory
+ * Spec: docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md
+ */
+
+const FILENAME_RE = /^[A-Za-z0-9_.-]+\.md$/;
+
+interface KnowledgeFile {
+  filename: string;
+  frontmatter: Record<string, string>;
+  content: string;
+  agentId?: string;
+}
+
+export interface GossipMemoryResponse {
+  knowledge: KnowledgeFile[];
+}
+
+/** Resolve the `.gossip/memory/` directory for `projectRoot`. */
+export function gossipMemoryDir(projectRoot: string): string {
+  return join(projectRoot, '.gossip', 'memory');
+}
+
+/**
+ * Read every `.md` file under `.gossip/memory/` and return the parsed
+ * frontmatter + body. Unreadable or malformed files are skipped silently —
+ * one bad file must not take down the dashboard. Filename allowlist enforced
+ * to block traversal and non-markdown artifacts.
+ */
+export async function gossipMemoryHandler(projectRoot: string): Promise<GossipMemoryResponse> {
+  const dir = gossipMemoryDir(projectRoot);
+  if (!existsSync(dir)) return { knowledge: [] };
+
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return { knowledge: [] };
+  }
+
+  const knowledge: KnowledgeFile[] = [];
+  for (const filename of entries) {
+    if (!FILENAME_RE.test(filename)) continue;
+    const full = join(dir, filename);
+    try {
+      const st = statSync(full);
+      if (!st.isFile()) continue;
+      const raw = readFileSync(full, 'utf-8');
+      const { frontmatter, content } = parseFrontmatter(raw);
+      knowledge.push({ filename, frontmatter, content, agentId: '_gossip' });
+    } catch {
+      // Skip unreadable files silently — dashboard should not fail because of one bad entry.
+    }
+  }
+
+  return { knowledge };
+}

--- a/packages/relay/src/dashboard/api-native-memory.ts
+++ b/packages/relay/src/dashboard/api-native-memory.ts
@@ -3,15 +3,19 @@ import { join } from 'path';
 import { homedir } from 'os';
 
 /**
- * Auto-memory API — exposes Claude Code's project-scoped auto-memory directory
- * (`~/.claude/projects/-<encoded-cwd>/memory/`). Separate from api-memory.ts,
- * which serves gossipcat per-agent cognitive memory under .gossip/agents/*.
+ * Native memory API — exposes Claude Code's project-scoped auto-memory directory
+ * (`~/.claude/projects/-<encoded-cwd>/memory/`). "Native" because Claude Code
+ * owns the write side (append-only from gossipcat's view); gossipcat never
+ * writes here. Separate from api-memory.ts (per-agent cognitive memory under
+ * .gossip/agents/*) and api-gossip-memory.ts (the canonical .gossip/memory/
+ * store written by gossipcat's session-save pipeline).
  *
  * Claude Code encodes the absolute cwd by replacing every `/` with `-`. The
  * directory path is derived from `projectRoot` at request time so it follows
  * the user's project, not a hardcoded path.
  *
- * Spec: docs/specs/2026-04-15-memory-taxonomy-hybrid.md (Path B)
+ * Route: GET /dashboard/api/native-memory (canonical), /dashboard/api/auto-memory (legacy alias).
+ * Spec: docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md
  */
 
 const FILENAME_RE = /^[A-Za-z0-9_.-]+\.md$/;
@@ -26,6 +30,9 @@ interface KnowledgeFile {
 export interface AutoMemoryResponse {
   knowledge: KnowledgeFile[];
 }
+
+/** Canonical alias for AutoMemoryResponse (same shape, clearer name). */
+export type NativeMemoryResponse = AutoMemoryResponse;
 
 /** Resolve the Claude Code auto-memory directory for `projectRoot`.
  *  Claude Code replaces every `/` in the absolute cwd with `-`. Because
@@ -70,7 +77,7 @@ export async function autoMemoryHandler(projectRoot: string, home?: string): Pro
   return { knowledge };
 }
 
-function parseFrontmatter(raw: string): { frontmatter: Record<string, string>; content: string } {
+export function parseFrontmatter(raw: string): { frontmatter: Record<string, string>; content: string } {
   if (!raw.startsWith('---')) return { frontmatter: {}, content: raw };
   // Frontmatter delimiter is `---` on its own line. Search from position 3 for
   // the next `---` occurrence to locate the closing fence.
@@ -87,3 +94,8 @@ function parseFrontmatter(raw: string): { frontmatter: Record<string, string>; c
   if (rest.startsWith('\n')) rest = rest.slice(1);
   return { frontmatter: fm, content: rest.trim() };
 }
+
+/** Canonical alias: nativeMemoryHandler === autoMemoryHandler (legacy name). */
+export const nativeMemoryHandler = autoMemoryHandler;
+/** Canonical alias: nativeMemoryDir === autoMemoryDir (legacy name). */
+export const nativeMemoryDir = autoMemoryDir;

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -4,7 +4,8 @@ import { overviewHandler } from './api-overview';
 import { agentsHandler } from './api-agents';
 import { skillsGetHandler, skillsBindHandler } from './api-skills';
 import { memoryHandler } from './api-memory';
-import { autoMemoryHandler } from './api-auto-memory';
+import { autoMemoryHandler } from './api-native-memory';
+import { gossipMemoryHandler } from './api-gossip-memory';
 import { consensusHandler } from './api-consensus';
 import { signalsHandler } from './api-signals';
 import { learningsHandler } from './api-learnings';
@@ -235,9 +236,24 @@ export class DashboardRouter {
         return true;
       }
 
-      // Auto-memory: /dashboard/api/auto-memory (Claude Code project memory)
-      if (url === '/dashboard/api/auto-memory' && req.method === 'GET') {
+      // Native memory: /dashboard/api/native-memory (Claude Code auto-memory, flat).
+      // Legacy alias `/dashboard/api/auto-memory` is kept for one release — the
+      // dashboard now calls the canonical path; remove the alias after the next
+      // dashboard bundle ships to all users.
+      if (
+        (url === '/dashboard/api/native-memory' || url === '/dashboard/api/auto-memory')
+        && req.method === 'GET'
+      ) {
         const data = await autoMemoryHandler(this.projectRoot);
+        this.json(res, 200, data);
+        return true;
+      }
+
+      // Gossip memory: /dashboard/api/gossip-memory — gossipcat-owned `.gossip/memory/`
+      // store with 4-folder taxonomy. Parallel to native-memory but a different
+      // store; dashboard must render them as two separate sections (spec invariant).
+      if (url === '/dashboard/api/gossip-memory' && req.method === 'GET') {
+        const data = await gossipMemoryHandler(this.projectRoot);
         this.json(res, 200, data);
         return true;
       }

--- a/scripts/migrate-gossip-memory.ts
+++ b/scripts/migrate-gossip-memory.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env ts-node
+/**
+ * Idempotent migration: normalize `.gossip/memory/*.md` frontmatter to the
+ * canonical schema defined in docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md.
+ *
+ * Canonical fields:
+ *   name, description, status, type, importance, lastAccessed, updated, accessCount
+ *
+ * Transformation rules (spec §143-151):
+ *   1. name           → "Session <date> — <SUMMARY first 40 chars>"
+ *   2. description    → existing SUMMARY: line body
+ *   3. status         → `open` if "Open for next session" section is non-empty, else `shipped`
+ *   4. type           → always `session` for `session_*.md`
+ *   5. importance     → always 0.4 (canonical gossip default — never inherit cognitive-store values)
+ *   6. lastAccessed   → file mtime, formatted YYYY-MM-DD
+ *   7. updated        → mirror of lastAccessed
+ *   8. accessCount    → 0 (reset; the cognitive recall pipeline maintains its own counter)
+ *   9. Preserve any pre-existing fields not in the canonical set (harmless; mapper ignores them)
+ *
+ * Usage:
+ *   npx ts-node scripts/migrate-gossip-memory.ts [projectRoot]
+ *
+ * Idempotency: a second run on an already-canonical file is a no-op (skips
+ * when all canonical fields are present).
+ */
+import { readdirSync, readFileSync, writeFileSync, existsSync, statSync } from 'fs';
+import { join } from 'path';
+
+const CANONICAL_FIELDS = ['name', 'description', 'status', 'type', 'importance', 'lastAccessed', 'accessCount'] as const;
+
+export interface MigrationResult {
+  migrated: string[];
+  skipped: string[];
+  errors: Array<{ file: string; error: string }>;
+}
+
+/**
+ * Parse frontmatter leniently. Returns the raw frontmatter body (between the
+ * --- fences), an ordered list of keys, a kv map, and the post-frontmatter
+ * body. Files without frontmatter get empty fm / full raw body.
+ */
+export function parseFrontmatter(raw: string): {
+  fmRaw: string;
+  fm: Record<string, string>;
+  body: string;
+} {
+  if (!raw.startsWith('---')) return { fmRaw: '', fm: {}, body: raw };
+  const end = raw.indexOf('\n---', 3);
+  if (end === -1) return { fmRaw: '', fm: {}, body: raw };
+  const fmBlock = raw.slice(3, end).trim();
+  const fm: Record<string, string> = {};
+  for (const line of fmBlock.split('\n')) {
+    const colon = line.indexOf(':');
+    if (colon > 0) fm[line.slice(0, colon).trim()] = line.slice(colon + 1).trim();
+  }
+  let rest = raw.slice(end + 4);
+  if (rest.startsWith('\n')) rest = rest.slice(1);
+  return { fmRaw: fmBlock, fm, body: rest };
+}
+
+/** True when all canonical fields are present — migration is a no-op. */
+export function hasCanonicalSchema(fm: Record<string, string>): boolean {
+  return CANONICAL_FIELDS.every((k) => fm[k] !== undefined && fm[k] !== '');
+}
+
+/** Extract the SUMMARY: line from the body or a legacy "SUMMARY: ..." line anywhere. */
+function extractSummary(body: string): string {
+  const m = body.match(/^SUMMARY:\s*(.+)$/m);
+  return m ? m[1].trim() : '';
+}
+
+/** True when the body has an "## Open for next session" section with non-empty content. */
+function hasOpenSection(body: string): boolean {
+  const m = body.match(/##\s+Open[^\n]*\n([\s\S]*?)(?=\n##|\s*$)/i);
+  if (!m) return false;
+  const section = m[1].trim();
+  // Strip bullet markers and whitespace; non-empty means at least one meaningful bullet.
+  return section.replace(/[-*\s]/g, '').length > 0;
+}
+
+/** File mtime formatted as YYYY-MM-DD for lastAccessed / updated. */
+function formatMtime(filePath: string): string {
+  try {
+    const mt = statSync(filePath).mtime;
+    return mt.toISOString().slice(0, 10);
+  } catch {
+    return new Date().toISOString().slice(0, 10);
+  }
+}
+
+/**
+ * Build the canonical frontmatter block + body for one file. Pure function —
+ * takes raw file content, returns the rewritten content. Returns `null` when
+ * the file already has the canonical schema (idempotency guard).
+ */
+export function migrateOne(raw: string, filename: string, mtimeYmd: string): string | null {
+  const { fm: existing, body } = parseFrontmatter(raw);
+  if (hasCanonicalSchema(existing)) return null;
+
+  const summary = extractSummary(body);
+  const date = existing.date || existing.lastAccessed || mtimeYmd;
+
+  const nameBase = summary ? summary.slice(0, 40) : filename.replace(/\.md$/, '').replace(/_/g, ' ');
+  const name = existing.name || `Session ${date} — ${nameBase}`;
+  const description = existing.description || summary || nameBase;
+  const status = existing.status || (hasOpenSection(body) ? 'open' : 'shipped');
+  const type = existing.type || 'session';
+  const lastAccessed = existing.lastAccessed || mtimeYmd;
+  const updated = existing.updated || lastAccessed;
+
+  // Build canonical frontmatter. Canonical fields come first in a stable order;
+  // any pre-existing non-canonical fields are preserved at the end (harmless
+  // metadata survives — spec rule 8).
+  const canonicalKeys = new Set<string>([...CANONICAL_FIELDS, 'updated', 'pinned']);
+  const canonical: Array<[string, string]> = [
+    ['name', name],
+    ['description', description],
+    ['status', status],
+    ['type', type],
+    ['importance', '0.4'],
+    ['lastAccessed', lastAccessed],
+    ['updated', updated],
+    ['accessCount', existing.accessCount || '0'],
+  ];
+
+  const preserved: Array<[string, string]> = [];
+  for (const [k, v] of Object.entries(existing)) {
+    if (canonicalKeys.has(k)) continue;
+    preserved.push([k, v]);
+  }
+
+  const fmLines = [...canonical, ...preserved].map(([k, v]) => `${k}: ${v}`);
+  return `---\n${fmLines.join('\n')}\n---\n\n${body.replace(/^\n+/, '')}`;
+}
+
+/** Migrate every `session_*.md` file under `<projectRoot>/.gossip/memory/`. */
+export function migrateGossipMemory(projectRoot: string): MigrationResult {
+  const result: MigrationResult = { migrated: [], skipped: [], errors: [] };
+  const dir = join(projectRoot, '.gossip', 'memory');
+  if (!existsSync(dir)) return result;
+
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch (err) {
+    result.errors.push({ file: dir, error: (err as Error).message });
+    return result;
+  }
+
+  for (const filename of entries) {
+    if (!filename.endsWith('.md')) continue;
+    const full = join(dir, filename);
+    try {
+      const raw = readFileSync(full, 'utf-8');
+      const mtimeYmd = formatMtime(full);
+      const rewritten = migrateOne(raw, filename, mtimeYmd);
+      if (rewritten === null) {
+        result.skipped.push(filename);
+        continue;
+      }
+      writeFileSync(full, rewritten);
+      result.migrated.push(filename);
+    } catch (err) {
+      result.errors.push({ file: filename, error: (err as Error).message });
+    }
+  }
+
+  return result;
+}
+
+// CLI entry point: run the migration when invoked directly.
+if (require.main === module) {
+  const projectRoot = process.argv[2] || process.cwd();
+  const result = migrateGossipMemory(projectRoot);
+  process.stdout.write(`Migration complete — migrated: ${result.migrated.length}, skipped: ${result.skipped.length}, errors: ${result.errors.length}\n`);
+  if (result.migrated.length > 0) process.stdout.write(`  migrated: ${result.migrated.join(', ')}\n`);
+  if (result.skipped.length > 0) process.stdout.write(`  skipped:  ${result.skipped.join(', ')}\n`);
+  for (const e of result.errors) process.stderr.write(`  ERROR ${e.file}: ${e.error}\n`);
+  process.exit(result.errors.length > 0 ? 1 : 0);
+}

--- a/tests/dashboard/gossip-memory.test.ts
+++ b/tests/dashboard/gossip-memory.test.ts
@@ -1,0 +1,221 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { gossipMemoryHandler, gossipMemoryDir } from '@gossip/relay/dashboard/api-gossip-memory';
+import { migrateOne, hasCanonicalSchema, parseFrontmatter, migrateGossipMemory } from '../../scripts/migrate-gossip-memory';
+import { toDisplayType } from '../../packages/dashboard-v2/src/lib/memory-taxonomy';
+
+/**
+ * Spec: docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md
+ *
+ * Coverage:
+ *   - api-gossip-memory endpoint shape (taxonomy classification)
+ *   - missing frontmatter defaults to backlog without crash
+ *   - migration script idempotency + transformation rules
+ *   - separation invariant (no write to user auto-memory)
+ */
+
+function withProject(): { projectRoot: string; memoryPath: string } {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'gossip-memory-test-'));
+  const memoryPath = join(projectRoot, '.gossip', 'memory');
+  mkdirSync(memoryPath, { recursive: true });
+  return { projectRoot, memoryPath };
+}
+
+describe('api-gossip-memory handler', () => {
+  it('returns empty array when .gossip/memory/ does not exist', async () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'gossip-empty-'));
+    const result = await gossipMemoryHandler(projectRoot);
+    expect(result.knowledge).toEqual([]);
+  });
+
+  it('reads canonical session file and exposes parsed frontmatter', async () => {
+    const { projectRoot, memoryPath } = withProject();
+    writeFileSync(
+      join(memoryPath, 'session_2026_04_15.md'),
+      `---
+name: Session 2026-04-15 — shipped
+description: shipped
+status: open
+type: session
+importance: 0.4
+lastAccessed: 2026-04-15
+updated: 2026-04-15
+accessCount: 0
+---
+
+Session body here.
+`,
+    );
+
+    const result = await gossipMemoryHandler(projectRoot);
+    expect(result.knowledge).toHaveLength(1);
+    const file = result.knowledge[0];
+    expect(file.filename).toBe('session_2026_04_15.md');
+    expect(file.frontmatter.status).toBe('open');
+    expect(file.frontmatter.type).toBe('session');
+    expect(file.frontmatter.importance).toBe('0.4');
+    expect(file.content).toContain('Session body here.');
+  });
+
+  it('skips non-markdown files and traversal attempts (filename allowlist)', async () => {
+    const { projectRoot, memoryPath } = withProject();
+    writeFileSync(join(memoryPath, 'ok.md'), '# ok');
+    writeFileSync(join(memoryPath, 'README.txt'), 'nope');
+    // Filenames containing `/` are produced by readdirSync only on misuse, but
+    // we still verify the regex rejects suspicious shapes.
+
+    const result = await gossipMemoryHandler(projectRoot);
+    expect(result.knowledge.map((k) => k.filename)).toEqual(['ok.md']);
+  });
+
+  it('survives unreadable / malformed entries without crashing', async () => {
+    const { projectRoot, memoryPath } = withProject();
+    writeFileSync(join(memoryPath, 'broken.md'), '---\nname: incomplete'); // no closing ---
+    writeFileSync(join(memoryPath, 'good.md'), '---\nname: x\ndescription: y\n---\nbody');
+
+    const result = await gossipMemoryHandler(projectRoot);
+    // Both files load (parseFrontmatter returns empty fm for malformed input);
+    // critically, the handler does not throw.
+    expect(result.knowledge.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('default classification: missing frontmatter routes to backlog (mapper safe default)', () => {
+    // The taxonomy mapper, not the handler, classifies — but verify the contract
+    // here so a regression in either side breaks loudly.
+    expect(toDisplayType({ filename: 'project_x.md', content: '' })).toBe('backlog');
+  });
+
+  it('session_*.md routes to session via filename prefix even when frontmatter type drifts', () => {
+    expect(
+      toDisplayType({
+        filename: 'session_2026_04_15.md',
+        frontmatter: { type: 'project' },
+        content: '',
+      }),
+    ).toBe('session');
+  });
+
+  it('gossipMemoryDir resolves under project root (never under ~/.claude)', () => {
+    const dir = gossipMemoryDir('/some/project');
+    expect(dir).toBe('/some/project/.gossip/memory');
+    expect(dir).not.toContain('.claude/projects');
+  });
+});
+
+describe('migrate-gossip-memory script', () => {
+  it('parseFrontmatter returns kv map and body', () => {
+    const { fm, body } = parseFrontmatter('---\nfoo: bar\nbaz: qux\n---\nthe body\n');
+    expect(fm.foo).toBe('bar');
+    expect(fm.baz).toBe('qux');
+    expect(body.trim()).toBe('the body');
+  });
+
+  it('hasCanonicalSchema returns true only when ALL canonical fields are present', () => {
+    expect(hasCanonicalSchema({})).toBe(false);
+    expect(
+      hasCanonicalSchema({
+        name: 'x', description: 'y', status: 'open', type: 'session',
+        importance: '0.4', lastAccessed: '2026-04-15', accessCount: '0',
+      }),
+    ).toBe(true);
+  });
+
+  it('migrateOne transforms legacy frontmatter to canonical schema', () => {
+    const legacy = `---
+date: 2026-04-14/15
+prs: 4
+consensus_rounds: 5
+---
+
+SUMMARY: 4 PRs shipped, taxonomy validated
+
+## Open for next session
+- Address consensus regressions
+`;
+    const out = migrateOne(legacy, 'session_2026_04_14_15.md', '2026-04-15');
+    expect(out).not.toBeNull();
+    const { fm, body } = parseFrontmatter(out!);
+    expect(fm.status).toBe('open'); // open section is non-empty
+    expect(fm.type).toBe('session');
+    expect(fm.importance).toBe('0.4');
+    expect(fm.lastAccessed).toBe('2026-04-15');
+    expect(fm.updated).toBe('2026-04-15');
+    expect(fm.accessCount).toBe('0');
+    expect(fm.description).toContain('4 PRs shipped');
+    expect(fm.name).toContain('Session');
+    // Pre-existing non-canonical fields must be preserved (rule 8).
+    expect(fm.prs).toBe('4');
+    expect(fm.consensus_rounds).toBe('5');
+    expect(body).toContain('SUMMARY: 4 PRs shipped');
+  });
+
+  it('migrateOne assigns status:shipped when no Open section is present', () => {
+    const noOpen = `---
+date: 2026-04-15
+---
+
+SUMMARY: shipped sprint
+
+## What shipped
+- everything
+`;
+    const out = migrateOne(noOpen, 'session_2026_04_15.md', '2026-04-15');
+    const { fm } = parseFrontmatter(out!);
+    expect(fm.status).toBe('shipped');
+  });
+
+  it('idempotency: running migration on a canonical file is a no-op (returns null)', () => {
+    const canonical = `---
+name: Session 2026-04-15 — shipped
+description: shipped
+status: open
+type: session
+importance: 0.4
+lastAccessed: 2026-04-15
+updated: 2026-04-15
+accessCount: 0
+---
+
+body
+`;
+    expect(migrateOne(canonical, 'session_2026_04_15.md', '2026-04-15')).toBeNull();
+  });
+
+  it('migrateGossipMemory walks .gossip/memory and migrates only non-canonical files', () => {
+    const { projectRoot, memoryPath } = withProject();
+    writeFileSync(join(memoryPath, 'session_legacy.md'), `---\ndate: 2026-04-14\n---\n\nSUMMARY: legacy file\n`);
+    writeFileSync(
+      join(memoryPath, 'session_canonical.md'),
+      `---\nname: Session canonical\ndescription: x\nstatus: shipped\ntype: session\nimportance: 0.4\nlastAccessed: 2026-04-15\nupdated: 2026-04-15\naccessCount: 0\n---\nbody\n`,
+    );
+
+    const result = migrateGossipMemory(projectRoot);
+    expect(result.migrated).toContain('session_legacy.md');
+    expect(result.skipped).toContain('session_canonical.md');
+    expect(result.errors).toHaveLength(0);
+
+    // Re-running is a no-op for the just-migrated file.
+    const second = migrateGossipMemory(projectRoot);
+    expect(second.migrated).toEqual([]);
+    expect(second.skipped.sort()).toEqual(['session_canonical.md', 'session_legacy.md']);
+  });
+
+  it('migrateGossipMemory tolerates a missing .gossip/memory directory', () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'gossip-no-mem-'));
+    const result = migrateGossipMemory(projectRoot);
+    expect(result.migrated).toEqual([]);
+    expect(result.skipped).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+});
+
+describe('separation invariant', () => {
+  it('gossipMemoryDir always resolves to the project root, never the user home', () => {
+    expect(gossipMemoryDir('/projects/foo')).toBe('/projects/foo/.gossip/memory');
+    expect(gossipMemoryDir('/Users/x/projects/y')).toBe('/Users/x/projects/y/.gossip/memory');
+    // The native (Claude Code) auto-memory path lives under ~/.claude/projects;
+    // gossipMemoryDir must never produce something under that tree.
+    expect(gossipMemoryDir('/p').includes('.claude/projects')).toBe(false);
+  });
+});

--- a/tests/orchestrator/memory-writer.test.ts
+++ b/tests/orchestrator/memory-writer.test.ts
@@ -550,4 +550,125 @@ describe('MemoryWriter', () => {
       expect(content).toContain('Fix the auth bug');
     });
   });
+
+  // ─── Native vs Gossip memory separation
+  // Spec: docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md
+  describe('prepareSessionArtifactsFromRaw() — native/gossip separation', () => {
+    const RAW_OPEN = 'SUMMARY: Open work pending\n\n## Open for next session\n- Investigate flake in server.ts\n\n## What shipped\n- Wired oauth\n';
+    const RAW_SHIPPED = 'SUMMARY: Closed sprint\n\n## What shipped\n- Replaced parser\n- Added 12 tests\n';
+
+    it('returns SessionArtifacts containing all three artifact paths + contents', async () => {
+      const writer = new MemoryWriter(testDir);
+      const artifacts = await writer.prepareSessionArtifactsFromRaw({
+        gossip: 'g', consensus: 'c', performance: 'p', gitLog: 'gl', raw: RAW_OPEN,
+      });
+
+      expect(artifacts.knowledgePath).toContain('.gossip/agents/_project/memory/knowledge');
+      expect(artifacts.knowledgeContent).toContain('importance: 0.4');
+      expect(artifacts.nextSessionPath).toContain('.gossip/next-session.md');
+      expect(artifacts.nextSessionContent).toContain('Next Session');
+      expect(artifacts.gossipMemoryDir).toContain('.gossip/memory');
+      expect(artifacts.gossipMemoryPath).toContain('.gossip/memory/session_');
+      expect(artifacts.gossipMemoryPath.endsWith('.md')).toBe(true);
+    });
+
+    it('gossip memory frontmatter follows the canonical schema (importance always 0.4, status from open section)', async () => {
+      const writer = new MemoryWriter(testDir);
+      const open = await writer.prepareSessionArtifactsFromRaw({
+        gossip: 'g', consensus: 'c', performance: 'p', gitLog: 'gl', raw: RAW_OPEN,
+      });
+      const shipped = await writer.prepareSessionArtifactsFromRaw({
+        gossip: 'g', consensus: 'c', performance: 'p', gitLog: 'gl', raw: RAW_SHIPPED,
+      });
+
+      expect(open.gossipMemoryContent).toMatch(/^---\n/);
+      expect(open.gossipMemoryContent).toContain('status: open');
+      expect(open.gossipMemoryContent).toContain('type: session');
+      expect(open.gossipMemoryContent).toContain('importance: 0.4');
+      expect(open.gossipMemoryContent).toContain('lastAccessed:');
+      expect(open.gossipMemoryContent).toContain('updated:');
+      expect(open.gossipMemoryContent).toContain('accessCount: 0');
+      // No cognitive-store importance value should leak across — never 1, never 0.5+
+      expect(open.gossipMemoryContent).not.toMatch(/importance:\s*1\b/);
+      expect(open.gossipStatus).toBe('open');
+
+      expect(shipped.gossipMemoryContent).toContain('status: shipped');
+      expect(shipped.gossipStatus).toBe('shipped');
+    });
+
+    it('gossip memory filename uses session_YYYY_MM_DD.md (no timestamp suffix)', async () => {
+      const writer = new MemoryWriter(testDir);
+      const a = await writer.prepareSessionArtifactsFromRaw({
+        gossip: 'g', consensus: '', performance: '', gitLog: '', raw: RAW_SHIPPED,
+      });
+      const today = new Date().toISOString().slice(0, 10).replace(/-/g, '_');
+      expect(a.gossipMemoryPath).toContain(`session_${today}.md`);
+    });
+
+    it('writeSessionArtifacts writes all three files in mandatory order', async () => {
+      const writer = new MemoryWriter(testDir);
+      const a = await writer.prepareSessionArtifactsFromRaw({
+        gossip: 'g', consensus: 'c', performance: 'p', gitLog: 'gl', raw: RAW_OPEN,
+      });
+      writer.writeSessionArtifacts(a);
+
+      expect(existsSync(a.nextSessionPath)).toBe(true);
+      expect(existsSync(a.knowledgePath)).toBe(true);
+      expect(existsSync(a.gossipMemoryPath)).toBe(true);
+
+      // Critical separation invariant: gossipcat MUST NOT write to user
+      // auto-memory (`~/.claude/projects/`). We only check that the gossip
+      // memory file landed inside the project's .gossip/memory tree.
+      expect(a.gossipMemoryPath.startsWith(testDir)).toBe(true);
+      expect(a.gossipMemoryPath).not.toContain('.claude/projects');
+    });
+
+    it('per-artifact failure isolation: gossip-memory write failure does not erase next-session.md', async () => {
+      const writer = new MemoryWriter(testDir);
+      const a = await writer.prepareSessionArtifactsFromRaw({
+        gossip: 'g', consensus: '', performance: '', gitLog: '', raw: RAW_SHIPPED,
+      });
+
+      // Force the gossip-memory write to fail by pointing it at a path whose
+      // parent is a regular file (not a directory). mkdirSync will throw;
+      // writeSessionArtifacts catches and continues.
+      const { writeFileSync: wfs, mkdirSync: mds } = require('fs');
+      const badParent = join(testDir, 'not-a-dir');
+      wfs(badParent, 'this is a file, not a directory');
+      const broken = { ...a, gossipMemoryDir: join(badParent, 'sub'), gossipMemoryPath: join(badParent, 'sub', 'x.md') };
+
+      expect(() => writer.writeSessionArtifacts(broken)).not.toThrow();
+      expect(existsSync(broken.nextSessionPath)).toBe(true);
+      expect(existsSync(broken.knowledgePath)).toBe(true);
+      expect(existsSync(broken.gossipMemoryPath)).toBe(false);
+      mds; // silence unused-import lint
+    });
+
+    it('writeSessionSummary wrapper still writes all three files (backward compat)', async () => {
+      const writer = new MemoryWriter(testDir);
+      const summary = await writer.writeSessionSummaryFromRaw({
+        gossip: 'g', consensus: 'c', performance: 'p', gitLog: 'gl', raw: RAW_OPEN,
+      });
+      expect(summary.length).toBeGreaterThan(0);
+
+      const today = new Date().toISOString().slice(0, 10).replace(/-/g, '_');
+      const gossipPath = join(testDir, '.gossip', 'memory', `session_${today}.md`);
+      expect(existsSync(gossipPath)).toBe(true);
+      expect(existsSync(join(testDir, '.gossip', 'next-session.md'))).toBe(true);
+    });
+
+    it('does NOT write to user auto-memory (~/.claude/projects)', async () => {
+      const writer = new MemoryWriter(testDir);
+      const a = await writer.prepareSessionArtifactsFromRaw({
+        gossip: 'g', consensus: '', performance: '', gitLog: '', raw: RAW_SHIPPED,
+      });
+      // Defense in depth: assert artifact paths never reference the native
+      // auto-memory directory. The separation invariant is enforced by
+      // construction (we never compute that path), but a regression here would
+      // be a user-data corruption issue, so we belt-and-suspenders test it.
+      for (const p of [a.knowledgePath, a.nextSessionPath, a.gossipMemoryPath, a.gossipMemoryDir]) {
+        expect(p).not.toContain('.claude/projects');
+      }
+    });
+  });
 });

--- a/tests/relay/dashboard-api.test.ts
+++ b/tests/relay/dashboard-api.test.ts
@@ -2,7 +2,7 @@ import { overviewHandler } from '@gossip/relay/dashboard/api-overview';
 import { agentsHandler } from '@gossip/relay/dashboard/api-agents';
 import { skillsGetHandler, skillsBindHandler } from '@gossip/relay/dashboard/api-skills';
 import { memoryHandler } from '@gossip/relay/dashboard/api-memory';
-import { autoMemoryHandler } from '@gossip/relay/dashboard/api-auto-memory';
+import { autoMemoryHandler } from '@gossip/relay/dashboard/api-native-memory';
 import { tasksHandler } from '@gossip/relay/dashboard/api-tasks';
 import { signalsHandler } from '@gossip/relay/dashboard/api-signals';
 import { consensusHandler } from '@gossip/relay/dashboard/api-consensus';

--- a/tests/relay/dashboard-routes.test.ts
+++ b/tests/relay/dashboard-routes.test.ts
@@ -191,6 +191,54 @@ describe('URL query string handling', () => {
     await router.handle(req, res);
     expect(res._status).toBe(200);
   });
+
+  // ─── Native vs Gossip memory routing
+  // Spec: docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md
+  it('routes /dashboard/api/native-memory to native handler (canonical name)', async () => {
+    const req = mockReq('GET', '/dashboard/api/native-memory', validCookie);
+    const res = mockRes();
+    await router.handle(req, res);
+    expect(res._status).toBe(200);
+    const body = JSON.parse(res._body);
+    expect(body).toHaveProperty('knowledge');
+    expect(Array.isArray(body.knowledge)).toBe(true);
+  });
+
+  it('routes /dashboard/api/auto-memory to native handler (legacy alias kept for one release)', async () => {
+    const req = mockReq('GET', '/dashboard/api/auto-memory', validCookie);
+    const res = mockRes();
+    await router.handle(req, res);
+    expect(res._status).toBe(200);
+    const body = JSON.parse(res._body);
+    expect(body).toHaveProperty('knowledge');
+  });
+
+  it('routes /dashboard/api/gossip-memory to gossip handler (returns empty knowledge when dir missing)', async () => {
+    const req = mockReq('GET', '/dashboard/api/gossip-memory', validCookie);
+    const res = mockRes();
+    await router.handle(req, res);
+    expect(res._status).toBe(200);
+    const body = JSON.parse(res._body);
+    expect(body).toEqual({ knowledge: [] });
+  });
+
+  it('routes /dashboard/api/gossip-memory and surfaces a real session_*.md file', async () => {
+    const memDir = join(projectRoot, '.gossip', 'memory');
+    mkdirSync(memDir, { recursive: true });
+    const fs = require('fs');
+    fs.writeFileSync(
+      join(memDir, 'session_2026_04_15.md'),
+      `---\nname: x\ndescription: y\nstatus: open\ntype: session\nimportance: 0.4\nlastAccessed: 2026-04-15\nupdated: 2026-04-15\naccessCount: 0\n---\nbody`,
+    );
+    const req = mockReq('GET', '/dashboard/api/gossip-memory', validCookie);
+    const res = mockRes();
+    await router.handle(req, res);
+    expect(res._status).toBe(200);
+    const body = JSON.parse(res._body);
+    expect(body.knowledge).toHaveLength(1);
+    expect(body.knowledge[0].filename).toBe('session_2026_04_15.md');
+    expect(body.knowledge[0].frontmatter.status).toBe('open');
+  });
 });
 
 describe('SPA catch-all routing', () => {


### PR DESCRIPTION
## Summary

Implements `docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md` (consensus `8fecc61a-c26b46f0`, 11 confirmed findings).

- `gossip_session_save` now writes three artifacts in strict order — (1) `next-session.md` (throws on fail, bootstrap continuity), (2) cognitive knowledge (log+continue, LRU store), (3) `.gossip/memory/session_YYYY_MM_DD.md` (log+continue, dashboard visibility).
- Dashboard exposes two separate sections — **Native Memories** (Claude Code auto-memory, flat list, CC-managed) + **Gossip Memories** (gossipcat-owned, 4-folder taxonomy + status filter). No merge — separation invariant.
- `.gossip/memory/` frontmatter canonicalized: `importance: 0.4` always, `accessCount: 0`, both `lastAccessed` and `updated` (belt-and-suspenders for `isRecent`).
- Includes idempotent migration script for existing `.gossip/memory/` files.

## Design invariants

- User auto-memory (`~/.claude/projects/`) is never written to by gossipcat
- Per-artifact try/catch — one failure doesn't abort the others
- Same-date overwrite semantics pinned (`session_YYYY_MM_DD.md` filename)
- Backward-compat preserved — `writeSessionSummary*` wrappers unchanged, `/dashboard/api/auto-memory` kept as legacy alias for one release
- Cognitive store `importance: 1` convention stays local — never copied to gossip store

## Files changed

14 files, 1101 insertions, 52 deletions:
- `packages/orchestrator/src/memory-writer.ts` — `processSessionResponse` refactored to return `SessionArtifacts` + new `prepareSessionArtifacts*` / `writeSessionArtifacts` with per-artifact try/catch
- `apps/cli/src/mcp-server-sdk.ts` — both session_save paths route through `writeArtifactsInOrder` helper enforcing mandatory order
- `packages/relay/src/dashboard/api-native-memory.ts` — renamed from `api-auto-memory.ts`
- `packages/relay/src/dashboard/api-gossip-memory.ts` (NEW) — reads `.gossip/memory/*.md`
- `packages/relay/src/dashboard/routes.ts` — `/dashboard/api/gossip-memory` route + legacy alias
- `packages/dashboard-v2/src/hooks/useDashboardData.ts` — separate `nativeMemories` + `gossipMemories` state, parallel fetch, no merge
- `packages/dashboard-v2/src/components/MemoryFolders.tsx` — parameterized; `<NativeMemories>` flat + `<GossipMemories>` 4-folder + status filter
- `scripts/migrate-gossip-memory.ts` (NEW) — idempotent migration, all 8 transformation rules from spec

## Test plan

- [x] `npm run build:mcp` clean
- [x] `npm test --ci` — 1609 passed, 1 skipped, 128 suites
- [x] New test coverage: write-order, per-artifact failure isolation, route dispatch, taxonomy classification, migration idempotency, separation invariant (no write to `.claude/projects`)
- [ ] Manual: verify dashboard renders both sections with sample session file in `.gossip/memory/`
- [ ] Manual: verify migration script idempotent on a canonical-schema file

## Notes

Spec mentioned migrating 2 known files but only `session_2026_04_14_15.md` exists in `.gossip/memory/`. Migration is a no-op for the missing file — idempotency guard handles naturally. Minor doc update for the spec may follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)