### PR TITLE
docs(sandbox): harden SCOPE_NOTE + document skill-develop throttle

### DIFF
--- a/apps/cli/src/sandbox.ts
+++ b/apps/cli/src/sandbox.ts
@@ -130,7 +130,19 @@ export function shouldSanitize(
 }
 
 const SCOPE_NOTE =
-  'SCOPE NOTE: This task has been sanitized. All project paths are relative to the workspace root. Use relative paths (./x) — do NOT reconstruct absolute paths.\n\n';
+  'SCOPE NOTE: SANDBOXED WRITE BOUNDARY.\n' +
+  'This task runs in an isolated worktree. You MUST use only relative paths (./package/file.ts).\n' +
+  'Any write outside the worktree — absolute paths (/Users/...), parent-escape (../), or cd-into-parent\n' +
+  '— is a BOUNDARY ESCAPE. Detected post-task, recorded as a `disagreement` signal under\n' +
+  '`trust_boundaries`, logged to .gossip/boundary-escapes.jsonl, and PENALIZES YOUR ACCURACY SCORE.\n' +
+  '\n' +
+  'Rules:\n' +
+  '- Tools: use Edit/Write/Read/Glob/Grep with relative paths only.\n' +
+  '- Never run `cd`, `realpath`, `pwd -P`, or any shell command that emits an absolute path.\n' +
+  '- Never reconstruct a path you see in task context back to absolute form — treat such paths as\n' +
+  '  opaque relative references even if they look absolute.\n' +
+  '- Project root is `./`. Nothing else.\n' +
+  '\n';
 
 /** Prepend the SCOPE NOTE to a prompt. Idempotent — won't double-prepend. */
 export function prependScopeNote(prompt: string): string {

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -142,6 +142,18 @@ When you verify a finding as real (or catch a hallucination), **record the signa
 
 **Every signal must include `finding_id`** in the format `<consensusId>:<agentId>:fN`. Without it, the dashboard can't trace back from signal → finding → agent and scoring becomes opaque.
 
+### Skill-develop cooldown gate
+
+`gossip_skills(action: "develop")` is throttled to prevent churn. Redeveloping the same skill while its effectiveness window is still accumulating evidence resets the `MIN_EVIDENCE=120` counter and collapses the statistical signal. Cooldown is verdict-aware:
+
+- `pending` — no gate (skill may need 60-120d to reach MIN_EVIDENCE)
+- `silent_skill` / `insufficient_evidence` — 30d
+- `inconclusive` — 60d (preserves strike rotation)
+- `passed` / `failed` — hard-block (terminal)
+- missing `bound_at` — allow (pre-schema files)
+
+When blocked, the error message shows age + remaining cooldown + override instruction. Pass `force: true` to bypass; every override is appended to `.gossip/forced-skill-develops.jsonl` for auditability. Chronic override patterns on an agent+category pair are a signal that the skill prompt is ineffective or `MIN_EVIDENCE` is miscalibrated for that category — investigate before reflexively forcing.
+
 ### Verifying UNVERIFIED findings
 
 When a consensus report has `UNVERIFIED` findings (cross-reviewer couldn't check), **you must verify them yourself before presenting results**. UNVERIFIED means "the peer didn't have the tools or context to check" — you do. Read the cited files, grep for the identifiers, confirm or reject. Do not show raw consensus output with unexamined UNVERIFIED findings.


### PR DESCRIPTION
## Summary

Two orthogonal clarifications for fresh users, both triggered by real incidents today.

### 1. SCOPE_NOTE hardening (`apps/cli/src/sandbox.ts:132`)

Triggered by: sonnet-implementer escaping the worktree on PR #84 by writing absolute paths to the main repo, tripping the post-task boundary audit (per \`feedback_worktree_boundary_escape.md\`).

Old note was one soft sentence. New note:
- Explicit about consequences (`disagreement` signal under `trust_boundaries`, accuracy penalty)
- Names forbidden shell commands: `cd`, `realpath`, `pwd -P`
- States the project root is `./` and nothing else
- Warns against reconstructing opaque relative paths back to absolute form

Still prefixed `SCOPE NOTE:` so `prependScopeNote`'s idempotency check at `sandbox.ts:137` and the existing test at `tests/cli/sandbox.test.ts:103` still pass.

### 2. HANDBOOK: skill-develop throttle section

Adds a paragraph under "Operator playbook" documenting the cooldown gate shipped in PR #84. Covers:
- When the gate fires (any `gossip_skills(action: "develop")` call)
- Verdict-aware thresholds (`pending`=none, `silent_skill`/`insufficient_evidence`=30d, `inconclusive`=60d, terminal=hard-block)
- The `force: true` override + audit trail at `.gossip/forced-skill-develops.jsonl`
- Guidance on chronic override patterns as a signal of ineffective skills

## Test plan

- [x] `npm test --ci -- --testPathPattern="sandbox"` — 46/46 pass
- [x] No behavioral change — only prompt text + docs

## Trade-off noted

Prompt hardening is a soft mitigation. A determined agent can still escape (absolute paths bypass the harness). The real fix is process-level FS sandboxing (macOS `sandbox-exec` / Linux namespaces) — tracked as a separate eventual investment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)