### PR TITLE
fix(worktree): run git hooks on merge (remove -c core.hooksPath=/dev/null)

### DIFF
--- a/packages/orchestrator/src/worktree-manager.ts
+++ b/packages/orchestrator/src/worktree-manager.ts
@@ -31,7 +31,7 @@ export class WorktreeManager {
     if (!log.stdout.trim()) return { merged: true };
 
     try {
-      await execFileAsync('git', ['-c', 'core.hooksPath=/dev/null', 'merge', branch, '--no-edit'], { cwd: this.projectRoot });
+      await execFileAsync('git', ['merge', branch, '--no-edit'], { cwd: this.projectRoot });
       return { merged: true };
     } catch {
       await execFileAsync('git', ['merge', '--abort'], { cwd: this.projectRoot });

--- a/tests/orchestrator/worktree-manager.test.ts
+++ b/tests/orchestrator/worktree-manager.test.ts
@@ -1,6 +1,6 @@
 import { WorktreeManager } from '../../packages/orchestrator/src/worktree-manager';
 import { execFileSync } from 'child_process';
-import { existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { chmodSync, existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -53,6 +53,31 @@ describe('WorktreeManager', () => {
     // Verify branch is actually deleted
     const branches = execFileSync('git', ['branch', '--list', 'gossip-test-4'], { cwd: testDir }).toString().trim();
     expect(branches).toBe('');
+  });
+
+  it('runs pre-merge-commit hook on non-ff merge', async () => {
+    const hookDir = join(testDir, '.git', 'hooks');
+    const sentinel = join(tmpdir(), `gossip-hook-sentinel-${Date.now()}`);
+    const hookPath = join(hookDir, 'pre-merge-commit');
+    writeFileSync(hookPath, `#!/bin/sh\ntouch ${sentinel}\nexit 0\n`);
+    chmodSync(hookPath, 0o755);
+
+    const { path } = await manager.create('test-hook');
+    writeFileSync(join(path, 'wt-only.txt'), 'x');
+    execFileSync('git', ['add', '.'], { cwd: path });
+    execFileSync('git', ['commit', '-m', 'wt'], { cwd: path });
+
+    // Force non-ff by adding a commit on main after worktree branched
+    writeFileSync(join(testDir, 'main-only.txt'), 'y');
+    execFileSync('git', ['add', '.'], { cwd: testDir });
+    execFileSync('git', ['commit', '-m', 'main'], { cwd: testDir });
+
+    await manager.merge('test-hook');
+    expect(existsSync(sentinel)).toBe(true);
+
+    rmSync(hookPath, { force: true });
+    rmSync(sentinel, { force: true });
+    await manager.cleanup('test-hook', path);
   });
 
   it('detects merge conflicts', async () => {


### PR DESCRIPTION
Closes #91.

## Summary
- Removes the `-c core.hooksPath=/dev/null` override from `WorktreeManager.merge()`, restoring normal hook execution at merge time.
- Adds a regression test that writes a sentinel-creating `pre-merge-commit` hook, forces a non-ff merge, and asserts the hook fired.

## Why
Before this fix, any pre-commit / pre-merge-commit / pre-push hooks configured in the repo were silently bypassed whenever gossipcat merged a worktree branch back into `master`. That includes lint, secret scanning, coverage gates, and any custom file-path audit hooks — the last line of defense for catching drift in agent-generated code before it lands. The "worktree agents are trusted" framing from #90 does not justify hook bypass at merge time — trust is about *intent*, not *correctness*.

Surfaced by sonnet-reviewer during the consensus review of #90 (round \`da350e45-62b14579\`, finding f10, HIGH severity). Signal recorded.

## Files
\`\`\`
packages/orchestrator/src/worktree-manager.ts |  2 +-
tests/orchestrator/worktree-manager.test.ts   | 27 ++++++++++++++++++++++++++-
2 files, +27 −2
\`\`\`

## Tests
\`\`\`
Test Suites: 132 passed, 132 total
Tests:       1 skipped, 1661 passed, 1662 total
\`\`\`

New: \`tests/orchestrator/worktree-manager.test.ts\` — \"runs pre-merge-commit hook on non-ff merge\".

## Test plan
- [x] \`npm test --ci\` green (1661 pass, 0 fail)
- [x] Existing merge tests (merge-with-changes, conflict-detect, cleanup-unmerged) still pass
- [x] Manual: new regression test verifies hook *does* fire post-fix

## If a hook fails on a worktree merge in practice
The right response is to **fix that hook**, not re-disable them all. Possibilities if a hook fails:
- Machine-identity config mismatch → fix identity, not bypass hooks
- Redundant test gate → the hook is the right place; remove the redundant downstream check
- Hook confused by the worktree path → fix the hook to handle the path

🤖 Generated with [Claude Code](https://claude.com/claude-code)