### PR TITLE
fix(scoring): hallucination decay tune + category enforcement

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2350,6 +2350,29 @@ server.tool(
         };
       });
 
+      // Category enforcement for hallucination_caught: if inferCategory failed
+      // above AND we can't derive from the finding text via extractCategories,
+      // drop the signal rather than persist it without a category. Category-less
+      // hallucinations are invisible to getCountersSince / skill-gap analysis
+      // and have grown into a 47% data gap — stop writing new ones at the source.
+      // Write-time only; legacy signals are not backfilled.
+      const { extractCategories } = await import('@gossip/orchestrator');
+      const categoryEnforced = formatted.filter((s, i) => {
+        if (s.type !== 'consensus' || s.signal !== 'hallucination_caught') return true;
+        if (s.category) return true;
+        const srcFinding = signals[i]?.finding ?? '';
+        const srcEvidence = signals[i]?.evidence ?? '';
+        const extracted = extractCategories(`${srcFinding} ${srcEvidence}`)[0];
+        if (extracted) {
+          (s as { category?: string }).category = extracted;
+          return true;
+        }
+        process.stderr.write(
+          `[gossip_signals] dropped hallucination_caught for ${s.agentId}: no category could be derived. finding="${srcFinding.slice(0, 80)}"\n`,
+        );
+        return false;
+      });
+
       // Dedup gate: reject signals whose finding_id already exists in the performance file.
       // Prevents duplicate scoring when a future session re-verifies stale UNVERIFIED findings.
       const existingFindingIds = new Set<string>();
@@ -2366,7 +2389,7 @@ server.tool(
       } catch { /* file may not exist yet */ }
 
       const dupes: string[] = [];
-      const deduped = formatted.filter(s => {
+      const deduped = categoryEnforced.filter(s => {
         if (s.type === 'consensus' && s.findingId && existingFindingIds.has(s.findingId)) {
           dupes.push(`${s.findingId} (${s.agentId}/${s.signal})`);
           return false;

--- a/docs/specs/2026-04-16-hallucination-decay-tune.md
+++ b/docs/specs/2026-04-16-hallucination-decay-tune.md
@@ -1,0 +1,85 @@
+# Hallucination decay tune + category consistency
+
+**Status:** proposal
+**Date:** 2026-04-16
+**Consensus:** `cc27bc83-a4254482` (3 agents, 17 confirmed, 2 unique-cross-confirmed, 0 disputed)
+
+## Problem
+
+Gemini-reviewer's dashboard accuracy is **0.28** while recent raw accuracy is **0.915** (7d, post-skill-binding). Simulated accuracy over its 831-signal history matches the dashboard within 0.03:
+
+- `rawAccuracy` (post-task-decay) = 0.895
+- `weightedHallucinations` = 8.20
+- `hallucinationMultiplier = 1 / (1 + 8.20 * 0.3)` = 0.289
+- Composed accuracy = 0.259 ≈ dashboard 0.28
+
+The drag is the **hallucination penalty** with `DECAY_HALF_LIFE = 50 tasks` applied uniformly to all signal types. Old hallucinations age out at the same rate as agreements, so an agent that has demonstrably improved (4 halluc / last 142 signals vs 46 / lifetime) still carries old-mistake weight.
+
+A separate, orthogonal bug was surfaced during consensus review: empty-string `signal.category` is silently ignored in two places (`computeScores`) but accepted in a third (`getCountersSince`).
+
+## Not the problem
+
+- **Diversity-drag fix already shipped** in PR #70 (50fe41e, 2026-04-15). All three `diversityMul` application sites are symmetric at `performance-reader.ts:387-408`.
+- **Skill-gated hallucination recovery** (per `project_skill_gated_recovery.md`) was reviewed and **deferred**. It would duplicate the existing `check-effectiveness.ts` verdict system (MIN_EVIDENCE=120 statistical gate vs a new 3-signal gate), and the pending-verdict interaction is unspecified. Revisit only if decay-tune proves insufficient over 30 days.
+
+## Scope of this change
+
+Three small, independently-verifiable changes:
+
+### 1. Separate decay half-life for hallucinations
+
+`packages/orchestrator/src/performance-reader.ts`
+
+- Add `HALLUCINATION_DECAY_HALF_LIFE = 20` next to the existing `DECAY_HALF_LIFE = 50` at `:279-281`.
+- In the `hallucination_caught` switch case at `:442-453`, compute a separate `hallucDecay = Math.pow(0.5, tasksSince / HALLUCINATION_DECAY_HALF_LIFE)` and use it for `a.weightedHallucinations += severity * hallucDecay`. The `a.weightedTotal += decay` on line 448 keeps the original decay so the raw accuracy ratio stays calibrated against all signal types equally.
+
+Expected impact (simulated):
+- gemini-reviewer: 0.28 → ~0.52
+- sonnet-reviewer: marginal (12 lifetime halluc, mostly recent)
+- haiku-researcher: marginal (18 lifetime halluc, mixed age)
+
+### 2. Empty-string category consistency
+
+`packages/orchestrator/src/performance-reader.ts:161`
+
+Currently `normalizeSkillName(s.category ?? '')` accepts empty strings as a valid category for comparison. The other two category sites (`:392`, `:450`) use `if (signal.category)` which rejects empty strings. Align to the rejection behavior:
+
+```ts
+// :161 — before
+if (normalizeSkillName(s.category ?? '') !== normalizedTarget) continue;
+
+// :161 — after
+if (!s.category) continue;
+if (normalizeSkillName(s.category) !== normalizedTarget) continue;
+```
+
+This prevents an empty-string category in `normalizedTarget` from matching empty-string signals (a cross-contamination edge case).
+
+### 3. Category enforcement on `hallucination_caught` emit sites
+
+`packages/orchestrator/src/consensus-engine.ts` and `packages/orchestrator/src/mcp-server-sdk.ts`
+
+Audit every path that writes `signal: 'hallucination_caught'` to `.gossip/agent-performance.jsonl`. If `category` is not derivable from the finding content (via `extractCategories`), log a warning and drop the signal rather than write it with missing category. This closes the 47% category-less-halluc data gap going forward. **Legacy signals are not backfilled** (per consensus f8 — `PerformanceReader` has no access to consensus reports).
+
+## Tests
+
+`tests/orchestrator/performance-reader.test.ts` and `tests/orchestrator/performance-reader-category-accuracy.test.ts`:
+
+- **halluc-decay-20**: agent with hallucination 20 tasks ago has half the `weightedHallucinations` of the same signal at `DECAY_HALF_LIFE=50`. Accuracy recovers proportionally.
+- **empty-category-rejected**: signal with `category: ''` is not counted by `getCountersSince` (aligns with `computeScores` behavior).
+- **category-undefined-legacy**: signal with `category: undefined` still increments `weightedHallucinations` (legacy-accept per f8).
+
+## Non-goals
+
+- Skill-gated hallucination recovery (deferred — see `cc27bc83-a4254482:f12`, `f16`)
+- Backfilling legacy hallucination signals with category (deferred — see `cc27bc83-a4254482:f8`)
+- Tuning the `0.3` penalty coefficient (`hallucinationMultiplier`) — the decay tune alone covers the observed case
+
+## Validation plan
+
+After merge, watch gemini-reviewer's dashboard accuracy for 7 days. Expected trajectory:
+- T+0: 0.28 (pre-merge baseline)
+- T+0 post-merge: ~0.52 (decay tune takes effect immediately — all existing halluc signals reweight)
+- T+7d: 0.55-0.65 if no new halluc, or drops if new halluc accumulate
+
+If gemini stays below 0.50 after 7 days, reopen the skill-gated recovery discussion with a fresh spec resolving pending-vs-passed + backfill policy.

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -15,6 +15,7 @@ import { AgentConfig, TaskEntry } from './types';
 import { ConsensusReport, ConsensusFinding, ConsensusNewFinding, ConsensusSignal, CrossReviewEntry } from './consensus-types';
 import { selectCrossReviewers, FindingForSelection, AgentCandidate } from './cross-reviewer-selection';
 import { parseAgentFindingsStrict, PARSE_FINDINGS_LIMITS } from './parse-findings';
+import { extractCategories } from './category-extractor';
 
 export type {
   ConsensusReport,
@@ -827,6 +828,19 @@ Return only valid JSON.${skillsBlock}`;
       if (!hasFabricatedCitation) return false;
       const hasHallucinationKeywords = this.detectHallucination(entry.finding);
       if (!hasHallucinationKeywords) return false;
+      // Category enforcement: prefer explicit, fall back to extractCategories over
+      // the finding text. If neither path yields a category, drop the signal
+      // rather than persist a category-less hallucination_caught — those entries
+      // are invisible to skill-gap analysis and bloat the "category-less halluc"
+      // data gap. Do NOT backfill legacy signals; write-time only.
+      const extracted = extractCategories(entry.finding);
+      const category = entry.category || extracted[0];
+      if (!category) {
+        process.stderr.write(
+          `[consensus-engine] dropped hallucination_caught for ${entry.originalAgentId}: no category (pre-filter). finding="${entry.finding.slice(0, 80)}"\n`,
+        );
+        return true; // still "detected" for control-flow purposes; just not persisted as a signal
+      }
       signals.push({
         type: 'consensus',
         taskId: getTaskId(entry.originalAgentId),
@@ -837,7 +851,7 @@ Return only valid JSON.${skillsBlock}`;
         evidence: capEvidence(`Finding cites non-existent code: "${entry.finding.slice(0, 200)}"`),
         timestamp: new Date().toISOString(),
         severity: capAutoSeverity(entry.severity),
-        category: entry.category,
+        category,
       });
       return true;
     };
@@ -924,19 +938,32 @@ Return only valid JSON.${skillsBlock}`;
             // && isCitationFabricated, so the second half is guaranteed true by construction.
             // The previous ternary `isCitationFabricated ? 'fabricated_citation' : 'incorrect'`
             // had an unreachable 'incorrect' branch. See consensus 82a3c123-19db41e7 Tier 1A Fix #2.
-            signals.push({
-              type: 'consensus',
-              taskId: getTaskId(entry.agentId),
-              consensusId,
-              signal: 'hallucination_caught',
-              agentId: entry.agentId,
-              counterpartId: entry.peerAgentId,
-              outcome: 'fabricated_citation',
-              evidence: capEvidence(entry.evidence),
-              timestamp: now,
-              severity: capAutoSeverity(f.severity),
-              category: f.category,
-            });
+            // Category enforcement: prefer the original finding's category, else
+            // try to derive from the reviewer's disagreement evidence, else
+            // fall back to the finding text. Drop (with warning) if all three
+            // fail — a category-less hallucination_caught is invisible to
+            // skill-gap analysis.
+            const extractedCat = extractCategories(entry.evidence || '')[0] || extractCategories(f.finding || '')[0];
+            const halluCategory = f.category || extractedCat;
+            if (!halluCategory) {
+              process.stderr.write(
+                `[consensus-engine] dropped hallucination_caught for ${entry.agentId}: no category (dispute path). evidence="${(entry.evidence || '').slice(0, 80)}"\n`,
+              );
+            } else {
+              signals.push({
+                type: 'consensus',
+                taskId: getTaskId(entry.agentId),
+                consensusId,
+                signal: 'hallucination_caught',
+                agentId: entry.agentId,
+                counterpartId: entry.peerAgentId,
+                outcome: 'fabricated_citation',
+                evidence: capEvidence(entry.evidence),
+                timestamp: now,
+                severity: capAutoSeverity(f.severity),
+                category: halluCategory,
+              });
+            }
           } else {
             const sanitizeEvidence = (t: string) => t.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 2000);
             f.disputedBy.push({

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -158,7 +158,12 @@ export class PerformanceReader {
 
     for (const s of allSignals) {
       if (s.agentId !== agentId) continue;
-      if (normalizeSkillName(s.category ?? '') !== normalizedTarget) continue;
+      // Empty/missing category is not a match. Aligns with `computeScores` at
+      // :392, :450 (both guard with `if (signal.category)` before populating
+      // categoryStrengths/categoryHallucinated) — an empty-string category
+      // should never satisfy a category-specific counter query.
+      if (!s.category) continue;
+      if (normalizeSkillName(s.category) !== normalizedTarget) continue;
       const ts = s.timestamp ? new Date(s.timestamp).getTime() : 0;
       if (!isFinite(ts) || ts === 0 || ts < sinceMs) continue;
 
@@ -277,6 +282,15 @@ export class PerformanceReader {
 
   private computeScores(signals: PerformanceSignal[]): Map<string, AgentScore> {
     const DECAY_HALF_LIFE = 50; // tasks
+    // Shorter half-life for hallucination penalties so agents can recover from old
+    // mistakes faster once they stop repeating them. Empirical calibration: 20 gives
+    // gemini-reviewer (17 historical hallucinations) an accuracy of ~0.52 vs the
+    // 0.28 the 50-task half-life produced — enough headroom to come off the
+    // "avoid as sole reviewer" list after a clean run, without erasing the
+    // penalty entirely. Decay tune alone is sufficient; do NOT also adjust the
+    // 0.3 coefficient on hallucinationMultiplier below. See spec
+    // docs/specs/2026-04-16-hallucination-decay-tune.md.
+    const HALLUCINATION_DECAY_HALF_LIFE = 20; // tasks
 
     const TIME_DECAY_HALF_LIFE_DAYS = 7; // scores drift toward neutral after a week of inactivity
     const now = Date.now();
@@ -444,7 +458,13 @@ export class PerformanceReader {
             signal.outcome === 'fabricated_citation' ||
             signal.outcome === 'confirmed_hallucination'
           ) ? 3.0 : 1.0;
-          a.weightedHallucinations += severity * decay;
+          // Use a dedicated (shorter) half-life for the hallucination counter so
+          // past mistakes can be outrun by recent good behavior. `weightedTotal`
+          // keeps the original DECAY_HALF_LIFE so the denominator that defines
+          // "overall cross-review activity" stays stable — only the numerator on
+          // the penalty side fades faster.
+          const hallucDecay = Math.pow(0.5, tasksSince / HALLUCINATION_DECAY_HALF_LIFE);
+          a.weightedHallucinations += severity * hallucDecay;
           a.weightedTotal += decay;
           a.hallucinations++;
           if (signal.category) {

--- a/tests/orchestrator/citation-verification.test.ts
+++ b/tests/orchestrator/citation-verification.test.ts
@@ -165,8 +165,13 @@ describe('ConsensusEngine.synthesize — citation verification integration', () 
   });
 
   test('fabricated dispute citing non-existent file does not suppress valid finding', async () => {
+    // Finding text includes "authentication" so extractCategories yields
+    // trust_boundaries — the category-enforcement check added in
+    // docs/specs/2026-04-16-hallucination-decay-tune.md drops hallucination_caught
+    // signals that cannot be attributed to any category, so the test fixture now
+    // must carry a categorizable keyword.
     const results = [
-      { id: 'task-1', agentId: 'agent-a', task: 'review', status: 'completed' as const, result: '## Consensus Summary\n- Empty agentId allows invalid dispatch', startedAt: Date.now() },
+      { id: 'task-1', agentId: 'agent-a', task: 'review', status: 'completed' as const, result: '## Consensus Summary\n- Empty agentId allows invalid dispatch (authentication bypass)', startedAt: Date.now() },
       { id: 'task-2', agentId: 'agent-b', task: 'review', status: 'completed' as const, result: '## Consensus Summary\n- Some other finding', startedAt: Date.now() },
     ];
 
@@ -175,7 +180,7 @@ describe('ConsensusEngine.synthesize — citation verification integration', () 
         action: 'disagree' as const,
         agentId: 'agent-b',
         peerAgentId: 'agent-a',
-        finding: 'Empty agentId allows invalid dispatch',
+        finding: 'Empty agentId allows invalid dispatch (authentication bypass)',
         evidence: 'The code at nonexistent-module.ts:3 explicitly throws an error.',
         confidence: 4,
       },
@@ -195,6 +200,9 @@ describe('ConsensusEngine.synthesize — citation verification integration', () 
       s => s.signal === 'hallucination_caught',
     );
     expect(hallucinationSignal).toBeDefined();
+    // Category enforcement: the emitted signal must have a category (trust_boundaries)
+    // derived either from the confirmed finding or the reviewer's evidence.
+    expect(hallucinationSignal!.category).toBeTruthy();
   });
 });
 

--- a/tests/orchestrator/performance-reader.test.ts
+++ b/tests/orchestrator/performance-reader.test.ts
@@ -682,3 +682,84 @@ describe('PerformanceReader — circuit breaker Changes 2 & 3 (2026-04-14-circui
     expect(score.circuitOpen).toBe(false);
   });
 });
+
+describe('PerformanceReader — hallucination decay tune (HALLUCINATION_DECAY_HALF_LIFE = 20)', () => {
+  // Shorter half-life for hallucination penalties so historical mistakes fade
+  // ~2.5x faster than the generic DECAY_HALF_LIFE=50. See spec
+  // docs/specs/2026-04-16-hallucination-decay-tune.md.
+
+  function tsRecent(secondsAgo: number): string {
+    return new Date(Date.now() - secondsAgo * 1000).toISOString();
+  }
+
+  it('halluc-decay-20: hallucination 20 tasks ago decays ~34% more than the old 50-task curve', () => {
+    // Construct 21 distinct tasks for one agent: the oldest is a hallucination,
+    // followed by 20 agreements. Task-order-based decay makes tasksSince for the
+    // hallucination = 21 - 0 - 1 = 20, so hallucDecay = 0.5^(20/20) = 0.5 under
+    // the new constant (vs 0.5^(20/50) ≈ 0.7579 under the old DECAY_HALF_LIFE=50).
+    //
+    // Observable effect via accuracy: with weightedHallucinations = 0.5, the
+    // hallucinationMultiplier is 1/(1+0.5*0.3) ≈ 0.8696. With the old decay
+    // (weightedHallucinations ≈ 0.7579) it would be ≈ 0.8147 — a ~6.7% shift
+    // downstream on accuracy. Assertion band is tight enough that only the
+    // new constant produces a passing result.
+    const sigs: any[] = [];
+    // Oldest signal: hallucination_caught at task index 0.
+    sigs.push({
+      type: 'consensus', signal: 'hallucination_caught', agentId: 'ag',
+      taskId: 'halluc-old', evidence: 'bad', timestamp: tsRecent(210),
+    });
+    // 20 agreements at task indices 1..20 (newer).
+    for (let i = 1; i <= 20; i++) {
+      sigs.push({
+        type: 'consensus', signal: 'agreement', agentId: 'ag', counterpartId: 'peer',
+        taskId: `agree-${i}`, evidence: 'ok', timestamp: tsRecent(210 - i * 10),
+      });
+    }
+    writeSignals(sigs);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('ag')!;
+
+    // Under the new constant: accuracy ≈ 0.958 * 0.8696 ≈ 0.833.
+    // Under the old constant: accuracy ≈ 0.958 * 0.8147 ≈ 0.780.
+    // Band [0.82, 0.87] excludes the old-constant result and permits the new one.
+    expect(score.accuracy).toBeGreaterThan(0.82);
+    expect(score.accuracy).toBeLessThan(0.87);
+    expect(score.hallucinations).toBe(1);
+  });
+
+  it('empty-category-rejected: getCountersSince skips signals with empty-string category', () => {
+    // Align with computeScores behavior at :392, :450 (both use `if (signal.category)`
+    // to gate category-specific accumulators). A signal with category: '' should
+    // never satisfy a category-specific counter query.
+    writeSignals([
+      { type: 'consensus', signal: 'agreement', agentId: 'ag', category: '', taskId: 't1', timestamp: new Date().toISOString() },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'ag', category: '', taskId: 't2', timestamp: new Date().toISOString() },
+      { type: 'consensus', signal: 'agreement', agentId: 'ag', category: 'cat-a', taskId: 't3', timestamp: new Date().toISOString() },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    // Query for cat-a: only the one cat-a signal counts; the empty-category ones are skipped.
+    const counters = reader.getCountersSince('ag', 'cat-a', 0);
+    expect(counters).toEqual({ correct: 1, hallucinated: 0 });
+  });
+
+  it('category-undefined-legacy: hallucination_caught with category=undefined still penalizes weightedHallucinations', () => {
+    // Legacy-accept path at computeScores :442-453 has no category guard —
+    // a hallucination without category still decrements accuracy via the
+    // hallucinationMultiplier. This preserves backwards compatibility with
+    // legacy signals written before category enforcement was added.
+    // Observable: agent accuracy drops below neutral (0.5) when dominated by
+    // category-less hallucinations.
+    writeSignals([
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'legacy', taskId: 't1', evidence: 'bad', timestamp: new Date().toISOString() },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'legacy', taskId: 't2', evidence: 'bad', timestamp: new Date().toISOString() },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'legacy', taskId: 't3', evidence: 'bad', timestamp: new Date().toISOString() },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getAgentScore('legacy')!;
+    // All three hallucinations count — weightedHallucinations > 0, so accuracy
+    // is pulled toward 0 by the multiplier even with no category attached.
+    expect(score.hallucinations).toBe(3);
+    expect(score.accuracy).toBeLessThan(0.5);
+  });
+});


### PR DESCRIPTION
## Summary

Separate half-life for hallucination penalty (20 tasks vs 50 for other signals). Gemini-reviewer's dashboard accuracy drops from a raw 0.915 → weighted 0.28 today because 46 lifetime hallucinations still carry weight equal to agreements. Math simulation on 831 real signals reproduces the 0.28 within 0.03; tuning the hallucination half-life alone recovers to ~0.52.

- `HALLUCINATION_DECAY_HALF_LIFE = 20` applied at `hallucination_caught` switch case in `performance-reader.ts`. `weightedTotal` still uses the original 50-task decay so the denominator stays calibrated.
- The `hallucinationMultiplier` coefficient (0.3) is unchanged. Decay tune alone is sufficient.

Plus two orthogonal fixes surfaced during consensus review:

- **Empty-string category consistency** at `performance-reader.ts:161`. `getCountersSince` previously matched empty-string categories while `computeScores` at `:392, :450` skips them. Aligned to skip behavior.
- **Category enforcement on hallucination_caught** emit sites in `consensus-engine.ts` and `mcp-server-sdk.ts`. Falls back to `extractCategories()` on finding/evidence text; drops the signal with a stderr warning if still no category. Closes the 47% category-less-halluc data gap for future writes. Legacy signals are NOT backfilled.

## What's deferred

Skill-gated hallucination recovery (per `project_skill_gated_recovery.md`) was reviewed and deferred — it would duplicate the `check-effectiveness.ts` verdict system (MIN_EVIDENCE=120 statistical gate vs a new 3-signal gate), and the pending-verdict interaction is underspecified. Revisit only if decay-tune proves insufficient over 30 days.

## Consensus backing

Round `cc27bc83-a4254482` — 3 agents (sonnet-reviewer, gemini-reviewer, haiku-researcher), 17 confirmed findings, 2 unique-cross-confirmed, 0 disputed, 0 unverified. All three convergent on "tune decay first, skill-gated later (if at all)."

## Test plan

- [x] 3 new golden cases in `tests/orchestrator/performance-reader.test.ts` (halluc-decay-20, empty-category-rejected, category-undefined-legacy)
- [x] Updated `tests/orchestrator/citation-verification.test.ts` fixture so `extractCategories` derives `trust_boundaries` and the emission survives the new category gate
- [x] Full test suite passes: 134 suites, 1702 tests
- [x] TypeScript clean on orchestrator package
- [ ] After merge, watch gemini-reviewer dashboard accuracy for 7 days — expected trajectory 0.28 → ~0.52 immediately, 0.55-0.65 at T+7d if no new halluc

## Spec

`docs/specs/2026-04-16-hallucination-decay-tune.md` — design + validation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)