### PR TITLE
fix(sandbox): F2 consume race + macOS TCC stdout parse

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2111,8 +2111,9 @@ server.tool(
       // needed by the Layer 3 audit to exclude the agent's own worktree.
       if (write_mode === 'worktree') {
         try {
-          const task = ctx.mainAgent.getTask(taskId);
-          const wtPath = (task as any)?.worktreeInfo?.path;
+          // collect() consumes the task entry, so ctx.mainAgent.getTask(taskId) would
+          // return undefined here. The result entry already carries worktreeInfo.
+          const wtPath = (entry as any)?.worktreeInfo?.path;
           if (wtPath) {
             const { updateDispatchMetadata } = require('./sandbox');
             updateDispatchMetadata(process.cwd(), taskId, { worktreePath: wtPath });

--- a/apps/cli/src/sandbox.ts
+++ b/apps/cli/src/sandbox.ts
@@ -709,12 +709,23 @@ export function auditFilesystemSinceSentinel(
         violations.push(p);
       }
     } catch (err) {
-      // Fail-open: log and continue. Audit failure must not block the
-      // dispatch result from returning to the orchestrator.
+      // find exits non-zero on ANY permission error (macOS TCC is the common
+      // case — Library/Group Containers etc). But stdout still contains the
+      // files it COULD see. Parse that before fail-opening, otherwise every
+      // real violation on macOS gets silently dropped.
+      const e = err as { stdout?: Buffer | string; message?: string };
+      const partial = typeof e.stdout === 'string'
+        ? e.stdout
+        : (e.stdout?.toString?.('utf-8') ?? '');
+      for (const line of partial.split('\n')) {
+        const p = line.trim();
+        if (p) violations.push(p);
+      }
       if (logFailures) {
-        const msg = (err as Error).message || String(err);
+        const msg = e.message || String(err);
+        const parsedCount = partial ? partial.split('\n').filter(Boolean).length : 0;
         process.stderr.write(
-          `[gossipcat] Layer 3 audit: find failed under '${canonRoot}': ${msg}\n`,
+          `[gossipcat] Layer 3 audit: find partial failure under '${canonRoot}' (stdout parsed, ${parsedCount} entries): ${msg}\n`,
         );
       }
       continue;

--- a/tests/cli/worktree-audit-layer3.test.ts
+++ b/tests/cli/worktree-audit-layer3.test.ts
@@ -11,6 +11,7 @@
  * own-worktree exclusion, peer-worktree inclusion, and Windows gating.
  */
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -431,6 +432,99 @@ describeOnPosix('auditFilesystemSinceSentinel — fail-open on find errors', () 
     } finally {
       rmSync(projectRoot, { recursive: true, force: true });
       rmSync(scanRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describeOnPosix('auditFilesystemSinceSentinel — macOS TCC partial stdout parse (Bug B)', () => {
+  /**
+   * macOS Transparency, Consent, and Control (TCC) denies `find` read access
+   * to sandboxed Library paths (Group Containers, Safari SandboxBroker, etc.)
+   * even when the parent scan root is readable. `find` prints a permission
+   * error to stderr, writes the files it COULD see to stdout, and exits
+   * non-zero. execFileSync throws on non-zero exit, but the error object
+   * still carries `.stdout` — we must parse it instead of dropping it.
+   */
+  itOnPosix('parses err.stdout when find exits non-zero with partial output', () => {
+    const projectRoot = mkTmp();
+    const scanRoot = mkTmp('gossip-l3-scan-');
+    // Synthetic find shim that emits two partial paths then exits 1.
+    // Mirrors macOS TCC behavior: some paths visible, process exits non-zero.
+    const binDir = mkTmp('gossip-l3-bin-');
+    const shim = join(binDir, 'fake-find');
+    const leakedA = join(scanRoot, 'leaked-a.txt');
+    const leakedB = join(scanRoot, 'leaked-b.txt');
+    try {
+      writeFileSync(
+        shim,
+        `#!/bin/sh\n` +
+          `echo '${leakedA}'\n` +
+          `echo '${leakedB}'\n` +
+          `echo "find: /Users/x/Library/Group Containers/com.apple.x: Operation not permitted" 1>&2\n` +
+          `exit 1\n`,
+      );
+      chmodSync(shim, 0o755);
+
+      const sentinel = stampTaskSentinel(projectRoot, 'tcc-partial')!;
+      const meta: DispatchMetadata = {
+        taskId: 'tcc-partial',
+        agentId: 'opus-implementer',
+        writeMode: 'worktree',
+        timestamp: Date.now(),
+        sentinelPath: sentinel,
+      };
+
+      const res = auditFilesystemSinceSentinel(projectRoot, meta, {
+        scanRoots: [scanRoot],
+        findBinary: shim,
+        logFailures: false,
+      });
+
+      // Both paths from stdout MUST end up in violations, even though find exited 1.
+      expect(res.violations).toContain(leakedA);
+      expect(res.violations).toContain(leakedB);
+      expect(res.violations.length).toBe(2);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(scanRoot, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  itOnPosix('returns empty violations when find exits non-zero with NO stdout', () => {
+    const projectRoot = mkTmp();
+    const scanRoot = mkTmp('gossip-l3-scan-');
+    const binDir = mkTmp('gossip-l3-bin-');
+    const shim = join(binDir, 'fake-find-empty');
+    try {
+      // Exit 1 with stderr only — nothing to parse. Audit must not throw and
+      // must not invent violations from nothing.
+      writeFileSync(
+        shim,
+        `#!/bin/sh\necho "find: permission denied" 1>&2\nexit 1\n`,
+      );
+      chmodSync(shim, 0o755);
+
+      const sentinel = stampTaskSentinel(projectRoot, 'tcc-empty')!;
+      const meta: DispatchMetadata = {
+        taskId: 'tcc-empty',
+        agentId: 'opus-implementer',
+        writeMode: 'worktree',
+        timestamp: Date.now(),
+        sentinelPath: sentinel,
+      };
+
+      const res = auditFilesystemSinceSentinel(projectRoot, meta, {
+        scanRoots: [scanRoot],
+        findBinary: shim,
+        logFailures: false,
+      });
+
+      expect(res.violations).toEqual([]);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(scanRoot, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary

Two related bugfixes uncovered by live-fire Layer 3 audit verification on v0.4.3 (task `56641e6e`, mcp.log 2026-04-16).

- **Bug A — F2 worktreePath patch was a no-op.** `DispatchPipeline.collect()` deletes the task entry from its `this.tasks` Map before returning (default `consume: true`), so the post-collect `ctx.mainAgent.getTask(taskId)` call at `mcp-server-sdk.ts:2114` always returned `undefined`. Every relay worktree dispatch since #99 recorded `worktreePath: undefined`, defeating the exclusion logic the fix was meant to enable. Fix reads `worktreeInfo.path` from the result entry (which already carries it from `dispatch-pipeline.ts:742`'s `results.map` builder) instead of re-querying the consumed map.

- **Bug B — macOS TCC silently swallowed the Layer 3 audit.** `execFileSync` in `auditFilesystemSinceSentinel` threw on any non-zero exit from `find`, and macOS TCC returns "Operation not permitted" whenever `find` crosses into sandboxed Library paths (Safari Group Containers, Photos, etc.). The entire scan root's violations were discarded even when `find` had successfully captured real files on stdout. Fix parses `err.stdout` on throw before logging — permission errors still log to stderr, but real violations survive. Verified live: `/Users/goku/Library/Group Containers/.../SandboxBroker: Operation not permitted` was the smoking gun.

## Changes

| File | LOC |
|------|-----|
| `apps/cli/src/mcp-server-sdk.ts` | +3 / -2 |
| `apps/cli/src/sandbox.ts` | +15 / -4 |
| `tests/cli/worktree-audit-layer3.test.ts` | +94 / -0 |

## Test plan

- [x] Layer 3 suite: 29 → 31 (2 new Bug B partial-stdout-parse tests, including a negative case that proves empty-stdout failures still fail-open without fabricating violations)
- [x] Full jest suite: 1733 passed / 1 skipped / 0 new failures
- [x] Typecheck clean
- [x] Scope respected: only `apps/cli/src/` and `tests/cli/`

## Post-merge

- [ ] Release v0.4.4 to pick up these fixes
- [ ] Re-run live-fire verification: dispatch `gemini-implementer` with `write_mode: worktree`, confirm `dispatch-metadata.jsonl` now contains `worktreePath`, and confirm real violations land in `boundary-escapes.jsonl` even when `find` hits TCC-protected paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)