### PR TITLE
fix(tool-server): union-of-roots for worktree writes

### DIFF
--- a/packages/tools/src/file-tools.ts
+++ b/packages/tools/src/file-tools.ts
@@ -5,8 +5,12 @@ import { Sandbox } from './sandbox';
 export class FileTools {
   constructor(private sandbox: Sandbox) {}
 
-  async fileRead(args: { path: string; startLine?: number; endLine?: number }): Promise<string> {
-    const absPath = this.sandbox.validatePath(args.path);
+  async fileRead(
+    args: { path: string; startLine?: number; endLine?: number },
+    agentRoot?: string,
+  ): Promise<string> {
+    const allowed = agentRoot ? [agentRoot] : [];
+    const absPath = this.sandbox.validatePath(args.path, allowed);
     try {
       const content = await readFile(absPath, 'utf-8');
       const lines = content.split('\n');
@@ -24,30 +28,40 @@ export class FileTools {
     }
   }
 
-  async fileWrite(args: { path: string; content: string }): Promise<string> {
-    const absPath = this.sandbox.validatePath(args.path);
+  async fileWrite(
+    args: { path: string; content: string },
+    agentRoot?: string,
+  ): Promise<string> {
+    const allowed = agentRoot ? [agentRoot] : [];
+    const absPath = this.sandbox.validatePath(args.path, allowed);
     const dir = resolve(absPath, '..');
     await mkdir(dir, { recursive: true });
     await writeFile(absPath, args.content, 'utf-8');
     return `Written ${args.content.length} bytes to ${args.path}`;
   }
 
-  async fileDelete(args: { path: string }): Promise<string> {
-    const absPath = this.sandbox.validatePath(args.path);
+  async fileDelete(args: { path: string }, agentRoot?: string): Promise<string> {
+    const allowed = agentRoot ? [agentRoot] : [];
+    const absPath = this.sandbox.validatePath(args.path, allowed);
     await unlink(absPath);
     return `Deleted ${args.path}`;
   }
 
-  async fileSearch(args: { pattern: string }): Promise<string> {
+  async fileSearch(args: { pattern: string }, agentRoot?: string): Promise<string> {
     const results: string[] = [];
-    await this.walkDir(this.sandbox.projectRoot, args.pattern, results, 0, 10);
+    const root = agentRoot || this.sandbox.projectRoot;
+    await this.walkDir(root, args.pattern, results, 0, 10);
     return results.join('\n') || 'No files found';
   }
 
-  async fileGrep(args: { pattern: string; path?: string }): Promise<string> {
+  async fileGrep(
+    args: { pattern: string; path?: string },
+    agentRoot?: string,
+  ): Promise<string> {
+    const allowed = agentRoot ? [agentRoot] : [];
     const searchRoot = args.path
-      ? this.sandbox.validatePath(args.path)
-      : this.sandbox.projectRoot;
+      ? this.sandbox.validatePath(args.path, allowed)
+      : (agentRoot || this.sandbox.projectRoot);
     let regex: RegExp;
     try {
       regex = new RegExp(args.pattern);
@@ -59,10 +73,14 @@ export class FileTools {
     return results.join('\n') || 'No matches found';
   }
 
-  async fileTree(args: { path?: string; depth?: number }): Promise<string> {
+  async fileTree(
+    args: { path?: string; depth?: number },
+    agentRoot?: string,
+  ): Promise<string> {
+    const allowed = agentRoot ? [agentRoot] : [];
     const root = args.path
-      ? this.sandbox.validatePath(args.path)
-      : this.sandbox.projectRoot;
+      ? this.sandbox.validatePath(args.path, allowed)
+      : (agentRoot || this.sandbox.projectRoot);
     const maxDepth = args.depth || 3;
     const lines: string[] = [];
     await this.buildTree(root, '', lines, 0, maxDepth);

--- a/packages/tools/src/sandbox.ts
+++ b/packages/tools/src/sandbox.ts
@@ -1,6 +1,29 @@
 import { resolve, dirname } from 'path';
 import { existsSync, realpathSync } from 'fs';
 
+/**
+ * Case-insensitive filesystems (darwin/win32) require case-folded path
+ * compares — otherwise a worktree root of `/tmp/gossip-wt-AB/` could be
+ * matched by `/TMP/gossip-wt-AB/…` on the same disk. Mirrors the behavior
+ * of scope.ts so Sandbox and scope enforcement agree.
+ */
+const CASE_INSENSITIVE_FS =
+  process.platform === 'darwin' || process.platform === 'win32';
+
+function fold(p: string): string {
+  return CASE_INSENSITIVE_FS ? p.toLowerCase() : p;
+}
+
+/**
+ * Canonical trailing-slash form for the root side of a prefix comparison.
+ * Blocks sibling-prefix bypass: e.g. a root of `/tmp/gossip-wt-AB` must not
+ * accept `/tmp/gossip-wt-ABXYZ/file.txt`. A filesystem root (`/`) is left
+ * as-is since it already ends in `/`.
+ */
+function rootWithSlash(p: string): string {
+  return p.endsWith('/') ? p : p + '/';
+}
+
 export class Sandbox {
   private root: string;
 
@@ -11,12 +34,26 @@ export class Sandbox {
   get projectRoot(): string { return this.root; }
 
   /**
-   * Validate that a path resolves within the project root.
-   * Handles non-existent files (for file_write) by walking up to the
-   * deepest existing ancestor and resolving from there.
-   * Resolves symlinks to prevent symlink escape attacks.
+   * Validate that a path resolves within the project root OR inside any
+   * entry in `allowedRoots` (union-of-roots). Handles non-existent files
+   * (for file_write) by walking up to the deepest existing ancestor and
+   * resolving from there. Resolves symlinks BEFORE the membership check
+   * to prevent symlink escape attacks.
+   *
+   * Preserves these security properties:
+   *   - path.resolve() on candidate AND every allowed root before compare
+   *   - realpathSync on deepest existing ancestor of candidate
+   *   - trailing-slash canonical form on root side (blocks sibling-prefix
+   *     bypass like `/tmp/gossip-wt-AB` vs `/tmp/gossip-wt-ABXYZ`)
+   *   - case-fold on darwin/win32
+   *
+   * @param filePath  Path to validate. May be relative (resolved against
+   *                  projectRoot) or absolute.
+   * @param allowedRoots Optional absolute paths that should also be
+   *                  accepted as roots. Defaults to `[]` so existing
+   *                  callers are unchanged.
    */
-  validatePath(filePath: string): string {
+  validatePath(filePath: string, allowedRoots: string[] = []): string {
     // Resolve relative to project root
     const resolved = resolve(this.root, filePath);
 
@@ -32,9 +69,31 @@ export class Sandbox {
     const remainder = resolved.slice(checkPath.length);
     const fullReal = real + remainder;
 
-    if (!fullReal.startsWith(this.root + '/') && fullReal !== this.root) {
-      throw new Error(`Path "${filePath}" resolves outside project root`);
+    // Build the set of candidate roots. this.root already went through
+    // realpathSync in the constructor. allowedRoots are caller-supplied
+    // absolute paths (e.g. agent worktree root); run realpathSync on each
+    // when the path exists so a worktree under /var/folders (darwin) is
+    // compared in its /private/var form.
+    const candidateRoots: string[] = [this.root];
+    for (const r of allowedRoots) {
+      if (!r) continue;
+      const absR = resolve(r);
+      const realR = existsSync(absR) ? (() => {
+        try { return realpathSync(absR); } catch { return absR; }
+      })() : absR;
+      candidateRoots.push(realR);
     }
-    return fullReal; // Return post-symlink-resolved path to close TOCTOU gap
+
+    const foldedFull = fold(fullReal);
+    for (const r of candidateRoots) {
+      const foldedRoot = fold(r);
+      if (foldedFull === foldedRoot) return fullReal;
+      if (foldedFull.startsWith(rootWithSlash(foldedRoot))) return fullReal;
+    }
+
+    const msg = allowedRoots.length > 0
+      ? `Path "${filePath}" resolves outside project root or agent root`
+      : `Path "${filePath}" resolves outside project root`;
+    throw new Error(msg);
   }
 }

--- a/packages/tools/src/tool-server.ts
+++ b/packages/tools/src/tool-server.ts
@@ -322,7 +322,7 @@ export class ToolServer {
             throw new Error(`Read blocked: "${args.path}" is outside scope "${readScope}"`);
           }
         }
-        return this.fileTools.fileRead(args as { path: string; startLine?: number; endLine?: number });
+        return this.fileTools.fileRead(args as { path: string; startLine?: number; endLine?: number }, agentRoot);
       }
       case 'file_write': {
         // Check cap BEFORE write to avoid write-success-with-false-error
@@ -333,20 +333,20 @@ export class ToolServer {
             throw new Error(`Agent ${callerId} exceeded max tracked file writes (${ToolServer.MAX_WRITTEN_FILES_PER_AGENT})`);
           }
         }
-        const result = await this.fileTools.fileWrite(args as { path: string; content: string });
+        const result = await this.fileTools.fileWrite(args as { path: string; content: string }, agentRoot);
         if (callerId) {
           this.agentWrittenFiles.get(callerId)!.add(args.path as string);
         }
         return result;
       }
       case 'file_delete':
-        return this.fileTools.fileDelete(args as { path: string });
+        return this.fileTools.fileDelete(args as { path: string }, agentRoot);
       case 'file_search':
-        return this.fileTools.fileSearch(args as { pattern: string });
+        return this.fileTools.fileSearch(args as { pattern: string }, agentRoot);
       case 'file_grep':
-        return this.fileTools.fileGrep(args as { pattern: string; path?: string });
+        return this.fileTools.fileGrep(args as { pattern: string; path?: string }, agentRoot);
       case 'file_tree':
-        return this.fileTools.fileTree(args as { path?: string; depth?: number });
+        return this.fileTools.fileTree(args as { path?: string; depth?: number }, agentRoot);
       case 'shell_exec':
         return this.shellTools.shellExec({
           ...(args as { command: string; timeout?: number }),

--- a/tests/tools/tool-server-scope.test.ts
+++ b/tests/tools/tool-server-scope.test.ts
@@ -250,4 +250,126 @@ describe('ToolServer scope enforcement', () => {
       }
     });
   });
+
+  describe('union-of-roots (agent worktree)', () => {
+    // Previously, worktree-mode agents were gated correctly at enforceWriteScope
+    // (against agentRoots) but then FileTools → Sandbox.validatePath re-checked
+    // against projectRoot only, rejecting every absolute worktree path because
+    // worktrees live under os.tmpdir() by construction. These tests verify the
+    // fix: validatePath accepts path if it resolves inside projectRoot OR any
+    // entry in allowedRoots, while preserving all existing security properties
+    // (symlink resolve, trailing-slash root compare, case-fold on darwin/win32).
+    let wtRoot: string;
+    let agentId: string;
+
+    beforeEach(() => {
+      // Use a real directory under os.tmpdir() so we exercise the same
+      // "root lives outside projectRoot" geometry production has.
+      wtRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gossip-wt-'));
+      agentId = 'agent-wt-union';
+      server.assignRoot(agentId, wtRoot);
+    });
+
+    afterEach(() => {
+      try { fs.rmSync(wtRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+    });
+
+    it('a) allows absolute path inside agent worktree root', async () => {
+      // Pre-create the intermediate `sub/` dir so canonicalizeForBoundary in
+      // enforceWriteScope can resolve symlinks on an existing ancestor; this
+      // keeps the test focused on the Sandbox-layer union-of-roots fix rather
+      // than tangling with the scope-layer walk-to-ancestor behavior.
+      fs.mkdirSync(path.join(wtRoot, 'sub'), { recursive: true });
+      const target = path.join(wtRoot, 'sub', 'file.txt');
+      const result = await server.executeTool(
+        'file_write',
+        { path: target, content: 'hello' },
+        agentId,
+      );
+      expect(result).toContain('Written');
+      expect(fs.existsSync(target)).toBe(true);
+      expect(fs.readFileSync(target, 'utf-8')).toBe('hello');
+    });
+
+    it('b) rejects absolute path outside both roots', async () => {
+      await expect(
+        server.executeTool(
+          'file_write',
+          { path: '/etc/passwd', content: 'evil' },
+          agentId,
+        ),
+      ).rejects.toThrow(/outside worktree root|outside project root/);
+    });
+
+    it('c) relative path still resolves against projectRoot (unchanged)', async () => {
+      // Register a scope-less agent so the write only exercises the Sandbox
+      // gate, not enforceWriteScope's worktree guard (which would reject
+      // writes outside the worktree root even if projectRoot contains them).
+      // Instead, we read an existing projectRoot file — this path exercises
+      // Sandbox.validatePath with agentRoot populated but a relative path
+      // inside projectRoot, and must succeed (union semantics).
+      const innerFile = path.join(projectRoot, 'inside.txt');
+      fs.writeFileSync(innerFile, 'ok');
+      const content = await server.executeTool(
+        'file_read',
+        { path: 'inside.txt' },
+        agentId,
+      );
+      expect(content).toContain('ok');
+    });
+
+    it('d) blocks sibling-prefix bypass against worktree root', async () => {
+      // Root is `<tmp>/gossip-wt-XXXX`; create a sibling under the same
+      // parent named `<same>XYZ` and verify a write into it is rejected
+      // even though the name shares a prefix with the assigned root.
+      const siblingRoot = wtRoot + 'XYZ';
+      fs.mkdirSync(siblingRoot, { recursive: true });
+      const victim = path.join(siblingRoot, 'file.txt');
+      try {
+        await expect(
+          server.executeTool(
+            'file_write',
+            { path: victim, content: 'x' },
+            agentId,
+          ),
+        ).rejects.toThrow(/outside worktree root|outside project root/);
+      } finally {
+        fs.rmSync(siblingRoot, { recursive: true, force: true });
+      }
+    });
+
+    it('e) blocks symlink escape planted inside worktree', async () => {
+      // Create a symlink inside the worktree pointing at an out-of-root
+      // directory (here: /etc). A write through the symlink must be
+      // rejected because validatePath follows the symlink before the
+      // membership check.
+      const link = path.join(wtRoot, 'bounce');
+      try {
+        fs.symlinkSync('/etc', link);
+      } catch {
+        // On some CI filesystems symlink creation may fail; skip gracefully.
+        return;
+      }
+      await expect(
+        server.executeTool(
+          'file_write',
+          { path: path.join(link, 'evil.txt'), content: 'x' },
+          agentId,
+        ),
+      ).rejects.toThrow(/outside worktree root|outside project root/);
+    });
+
+    it('f) agent without assigned root falls back to projectRoot-only check', async () => {
+      // A non-write agent with no scope/root should behave exactly as
+      // before — absolute paths outside projectRoot get rejected by the
+      // Sandbox, even though allowedRoots defaults to [].
+      await expect(
+        server.executeTool(
+          'file_read',
+          { path: '/etc/hosts' },
+          'agent-no-root',
+        ),
+      ).rejects.toThrow(/outside project root/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Tool Server's file_* tools were worktree-blind: `Sandbox.validatePath` re-resolved the caller path against `projectRoot` even when the agent had an assigned worktree root via `assignRoot`. Worktrees are created under `os.tmpdir()/gossip-wt-*` — always outside projectRoot — so every worktree-mode relay agent's absolute write was rejected with the misleading `"resolves outside project root"` error, and every relative write silently landed at repo root (diverging from `shell_exec`'s cwd).

Design consensus: tasks `21e974c8` (haiku-researcher archaeology) + `9e737678` (sonnet-reviewer design review), 2026-04-16.

## Fix: union-of-roots

Thread `agentRoot` through `FileTools` + add optional `allowedRoots` param to `Sandbox.validatePath`. Sandbox accepts paths inside `projectRoot` OR any allowed root. 6 worktree-blind tools now honor the agent's assigned worktree: `file_read`, `file_write`, `file_delete`, `file_search`, `file_grep`, `file_tree`.

## Security properties preserved

- Normalize before check (`path.resolve()` on candidate + roots)
- `realpathSync` symlink resolution before membership check
- Trailing-slash canonical form (blocks sibling-prefix bypass, e.g. `/tmp/gossip-wt-AB` vs `/tmp/gossip-wt-ABXYZ`)
- Case-fold on darwin/win32
- Per-agent keyed `agentRoots` Map (never path-derived)

## Changes

- `packages/tools/src/sandbox.ts` (+71/-10)
- `packages/tools/src/file-tools.ts` (+26/-15)
- `packages/tools/src/tool-server.ts` (+6/-6)
- `tests/tools/tool-server-scope.test.ts` (+124/-0) — 6 new cases

## Out of scope (intentional)

- `run_tests` / `run_typecheck` / `verify_write` still use projectRoot-only scope (separate concern)
- `shell_exec` / `git_*` unchanged (already use `agentRoot` as cwd)
- Relative-path resolution base unchanged (Tool-vs-shell_exec cwd divergence captured separately)

## Follow-up found

`scope.ts::canonicalizeForBoundary` only walks up ONE directory to find an existing ancestor, unlike `sandbox.ts::validatePath` which walks up N levels. Deep non-existent subtrees under a worktree (`<wtRoot>/sub/file.txt` where `sub/` is new) fail silently in boundary canonicalization. Test case (a) pre-creates `sub/` to sidestep. Latent bug in enforceWriteScope's worktree guard — not blocking this PR, filing separately.

## Test plan

- [x] `tests/tools/` 83 → 89 (+6 union-of-roots cases: inside/outside both roots, sibling-prefix bypass, symlink escape, no-root fallback, relative-path sanity)
- [x] Full jest suite 1739 passed / 1 skipped / 0 failed
- [x] Typecheck clean for touched files
- [ ] CI green (GitHub Actions)
- [ ] Post-release: re-dispatch `gemini-implementer` with `write_mode: worktree`, confirm file_write inside worktree succeeds and relative paths no longer land at repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)