### PR TITLE
chore(release): v0.4.6 — L3 user-dir excludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ## [Unreleased]
 
+## [0.4.6] — 2026-04-16
+
+### Fixed
+
+- **Layer 3 audit now excludes user-level app directories** (#105). Live-fire verification against v0.4.5 produced 44 "boundary escape" violations that were 100% OS-level churn — Chrome cookies, Spotify cache, NordVPN data, Claude Code's own `~/.claude/projects/*.jsonl` session logs — not a single agent action. These app directories are unreachable through the Tool Server sandbox or the Layer 2 PreToolUse hook, so false positives from them were pure noise drowning out any real signal. `buildAuditExclusions` now adds `$HOME/Library`, `$HOME/.cache`, `$HOME/.npm`, `$HOME/.claude/projects` to the `find -not -path` list. Broad `$HOME` scan is preserved for defense-in-depth against `shell_exec` bypass; real agent violations anywhere else in `$HOME` are still caught. (`apps/cli/src/sandbox.ts`)
+
 ## [0.4.5] — 2026-04-16
 
 Tool Server union-of-roots — worktree-mode relay agents can now actually write inside their own worktrees.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossipcat",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
   "mcpName": "io.github.ataberk-xyz/gossipcat",
   "repository": {


### PR DESCRIPTION
## Summary

Bundles #105 into a point release. Live-fire verification of v0.4.5 showed 44 false-positive "boundary escape" entries per dispatch, all from OS/app churn under `$HOME/Library` and `$HOME/.claude/projects`. v0.4.6 eliminates them.

## Changes

- `package.json`: 0.4.5 → 0.4.6
- `CHANGELOG.md`: [0.4.6] entry

## Test plan

- [ ] CI green
- [ ] Tag + npm publish on merge
- [ ] Live-fire: dispatch `gemini-implementer` with `write_mode: worktree` — boundary-escapes.jsonl entries from the task should drop from ~44 to near-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)