### PR TITLE
fix(sandbox+tools): L3 scope exclusion + git execFile ENOENT retry

### DIFF
--- a/apps/cli/src/sandbox.ts
+++ b/apps/cli/src/sandbox.ts
@@ -550,6 +550,8 @@ interface Layer3AuditOptions {
   /** Extra cwd the agent ran in. When set, files under it are excluded
    * from the audit (they are legitimate writes to the worktree). */
   worktreePath?: string;
+  /** Agent's scope when writeMode=scoped — treated as a permitted write root. */
+  scope?: string;
   /** Override the scan roots (tests). Defaults to `defaultScanRoots(writeMode,
    * projectRoot)`. */
   scanRoots?: string[];
@@ -642,6 +644,7 @@ export function expandTmpVariants(path: string): string[] {
 export function buildAuditExclusions(
   projectRoot: string,
   ownWorktree: string | undefined,
+  scope?: string,
 ): string[] {
   const excl = new Set<string>();
   const root = canonicalize(projectRoot);
@@ -671,13 +674,19 @@ export function buildAuditExclusions(
   // tmpdir is still flagged.
   try {
     const tmp = canonicalize(tmpdir());
-    for (const pat of ['com.apple.*', 'itunescloudd', 'TemporaryItems']) {
+    for (const pat of ['com.apple.*', 'itunescloudd', 'TemporaryItems', 'node-compile-cache']) {
       for (const v of expandTmpVariants(`${tmp}/${pat}`)) excl.add(v);
     }
   } catch { /* tmpdir() failure — best-effort */ }
   if (ownWorktree) {
     const wt = canonicalize(ownWorktree);
     for (const v of expandTmpVariants(wt)) excl.add(v);
+  }
+  if (scope) {
+    // In scoped mode, the agent's own writes inside its scope are permitted.
+    // The `scope` path is relative to projectRoot.
+    const s = canonicalize(join(projectRoot, scope));
+    for (const v of expandTmpVariants(s)) excl.add(v);
   }
   return Array.from(excl);
 }
@@ -765,7 +774,7 @@ export function auditFilesystemSinceSentinel(
     options.writeMode ?? meta.writeMode,
     projectRoot,
   );
-  const exclusions = buildAuditExclusions(projectRoot, meta.worktreePath);
+  const exclusions = buildAuditExclusions(projectRoot, meta.worktreePath, options.scope);
   const findBin = options.findBinary ?? 'find';
 
   const violations: string[] = [];
@@ -878,6 +887,7 @@ function recordLayer3Violations(
  * Idempotent with respect to sentinel cleanup — always runs regardless of
  * outcome. Fail-open: any internal error (including missing metadata, dead
  * sentinel, or `find` crash) is logged and swallowed. The caller never
+
  * sees a thrown error.
  */
 export function runLayer3Audit(
@@ -897,6 +907,7 @@ export function runLayer3Audit(
     try {
       const l3 = auditFilesystemSinceSentinel(projectRoot, meta, {
         writeMode: meta.writeMode,
+        scope: meta.scope,
       });
       if (l3.violations && l3.violations.length > 0) {
         const list = l3.violations.slice(0, 20).join(', ');

--- a/packages/orchestrator/src/worktree-manager.ts
+++ b/packages/orchestrator/src/worktree-manager.ts
@@ -6,6 +6,21 @@ import { tmpdir } from 'os';
 
 const execFileAsync = promisify(execFile);
 
+async function execGit(args: string[], cwd: string): Promise<{ stdout: string; stderr: string }> {
+  const opts = { cwd, env: { ...process.env } };
+  try {
+    return await execFileAsync('git', args, opts);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      // libuv transient posix_spawn failure — retry once after 100ms
+      await new Promise(r => setTimeout(r, 100));
+      return await execFileAsync('git', args, opts);
+    }
+    throw err;
+  }
+}
+
 export class WorktreeManager {
   constructor(private projectRoot: string) {}
 
@@ -13,11 +28,11 @@ export class WorktreeManager {
     const branch = `gossip-${taskId}`;
     const wtPath = await mkdtemp(join(tmpdir(), 'gossip-wt-'));
 
-    await execFileAsync('git', ['branch', branch, 'HEAD'], { cwd: this.projectRoot });
+    await execGit(['branch', branch, 'HEAD'], this.projectRoot);
     try {
-      await execFileAsync('git', ['worktree', 'add', wtPath, branch], { cwd: this.projectRoot });
+      await execGit(['worktree', 'add', wtPath, branch], this.projectRoot);
     } catch (err) {
-      try { await execFileAsync('git', ['branch', '-D', branch], { cwd: this.projectRoot }); } catch {}
+      try { await execGit(['branch', '-D', branch], this.projectRoot); } catch {}
       throw err;
     }
 
@@ -27,15 +42,15 @@ export class WorktreeManager {
   async merge(taskId: string): Promise<{ merged: boolean; conflicts?: string[] }> {
     const branch = `gossip-${taskId}`;
 
-    const log = await execFileAsync('git', ['log', `HEAD..${branch}`, '--oneline'], { cwd: this.projectRoot });
+    const log = await execGit(['log', `HEAD..${branch}`, '--oneline'], this.projectRoot);
     if (!log.stdout.trim()) return { merged: true };
 
     try {
-      await execFileAsync('git', ['merge', branch, '--no-edit'], { cwd: this.projectRoot });
+      await execGit(['merge', branch, '--no-edit'], this.projectRoot);
       return { merged: true };
     } catch {
-      await execFileAsync('git', ['merge', '--abort'], { cwd: this.projectRoot });
-      const diff = await execFileAsync('git', ['diff', '--name-only', `HEAD...${branch}`], { cwd: this.projectRoot });
+      await execGit(['merge', '--abort'], this.projectRoot);
+      const diff = await execGit(['diff', '--name-only', `HEAD...${branch}`], this.projectRoot);
       const files = diff.stdout.trim();
       return { merged: false, conflicts: files ? files.split('\n') : [] };
     }
@@ -43,25 +58,25 @@ export class WorktreeManager {
 
   async cleanup(taskId: string, wtPath: string): Promise<void> {
     const branch = `gossip-${taskId}`;
-    try { await execFileAsync('git', ['worktree', 'remove', wtPath, '--force'], { cwd: this.projectRoot }); } catch { /* already removed */ }
-    try { await execFileAsync('git', ['branch', '-D', branch], { cwd: this.projectRoot }); } catch { /* branch in use */ }
+    try { await execGit(['worktree', 'remove', wtPath, '--force'], this.projectRoot); } catch { /* already removed */ }
+    try { await execGit(['branch', '-D', branch], this.projectRoot); } catch { /* branch in use */ }
   }
 
   async pruneOrphans(): Promise<void> {
     try {
-      const result = await execFileAsync('git', ['worktree', 'list', '--porcelain'], { cwd: this.projectRoot });
+      const result = await execGit(['worktree', 'list', '--porcelain'], this.projectRoot);
       const orphans = result.stdout.split('\n\n')
         .filter(block => block.includes('gossip-wt-'))
         .map(block => block.match(/worktree (.+)/)?.[1])
         .filter(Boolean);
       for (const wtPath of orphans) {
-        try { await execFileAsync('git', ['worktree', 'remove', wtPath!, '--force'], { cwd: this.projectRoot }); } catch {}
+        try { await execGit(['worktree', 'remove', wtPath!, '--force'], this.projectRoot); } catch {}
       }
-      await execFileAsync('git', ['worktree', 'prune'], { cwd: this.projectRoot });
-      const branchResult = await execFileAsync('git', ['branch', '--list', 'gossip-*'], { cwd: this.projectRoot });
+      await execGit(['worktree', 'prune'], this.projectRoot);
+      const branchResult = await execGit(['branch', '--list', 'gossip-*'], this.projectRoot);
       const branches = branchResult.stdout.trim().split('\n').map(b => b.trim().replace(/^\*\s*/, '')).filter(Boolean);
       for (const b of branches) {
-        try { await execFileAsync('git', ['branch', '-D', b], { cwd: this.projectRoot }); } catch {}
+        try { await execGit(['branch', '-D', b], this.projectRoot); } catch {}
       }
     } catch { /* git not available or no worktrees */ }
   }

--- a/packages/tools/src/git-tools.ts
+++ b/packages/tools/src/git-tools.ts
@@ -6,13 +6,33 @@ const execFileAsync = promisify(execFile);
 export class GitTools {
   constructor(private cwd: string) {}
 
+  private async execGit(args: string[]): Promise<{ stdout: string; stderr: string }> {
+    const opts = { cwd: this.cwd, env: { ...process.env } };
+    try {
+      return await execFileAsync('git', args, opts);
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') {
+        // libuv transient posix_spawn failure — retry once after 100ms
+        await new Promise(r => setTimeout(r, 100));
+        return await execFileAsync('git', args, opts);
+      }
+      throw err;
+    }
+  }
+
   private async git(...args: string[]): Promise<string> {
     try {
-      const { stdout } = await execFileAsync('git', args, { cwd: this.cwd });
+      const { stdout } = await this.execGit(args);
       return stdout.trim();
     } catch (err: unknown) {
-      const error = err as Error & { stderr?: string };
-      const msg = error.stderr ? error.stderr.trim() : error.message;
+      const error = err as (Error & { stderr?: string });
+      let msg = 'Unknown error';
+      if (error && typeof error.stderr === 'string') {
+        msg = error.stderr.trim();
+      } else if (error && typeof error.message === 'string') {
+        msg = error.message;
+      }
       throw new Error(`git ${args[0]} failed: ${msg}`);
     }
   }
@@ -41,12 +61,11 @@ export class GitTools {
     for (const file of untrackedFiles) {
       try {
         // git diff --no-index exits 1 when files differ — that's expected
-        const { stdout } = await execFileAsync(
-          'git', ['diff', '--no-index', '/dev/null', file],
-          { cwd: this.cwd },
+        const { stdout } = await this.execGit(
+          ['diff', '--no-index', '/dev/null', file],
         ).catch((err: unknown) => {
-          const e = err as Error & { stdout?: string };
-          return { stdout: e.stdout || '' };
+          const e = err as Partial<Error & { stdout: string; stderr: string }>;
+          return { stdout: e.stdout || '', stderr: e.stderr || '' };
         });
         if (stdout) diffs.push(stdout.trim());
       } catch (err) {

--- a/tests/cli/sandbox.test.ts
+++ b/tests/cli/sandbox.test.ts
@@ -3,7 +3,7 @@
  */
 import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import {
   relativizeProjectPaths,
   shouldSanitize,
@@ -15,6 +15,7 @@ import {
   readSandboxMode,
   isInsideScope,
   DispatchMetadata,
+  buildAuditExclusions,
 } from '../../apps/cli/src/sandbox';
 
 describe('relativizeProjectPaths', () => {
@@ -342,5 +343,43 @@ describe('readSandboxMode', () => {
       JSON.stringify({ sandboxEnforcement: 'chaos' }),
     );
     expect(readSandboxMode(tmp)).toBe('warn');
+  });
+});
+
+describe('buildAuditExclusions', () => {
+  const root = resolve('/tmp/fakeproject');
+
+  it('includes node-compile-cache in tmpdir exclusions', () => {
+    const exclusions = buildAuditExclusions(root, undefined, undefined);
+    const tmp = resolve(tmpdir());
+    expect(exclusions).toContain(`${tmp}/node-compile-cache`);
+  });
+
+  it('adds the agent scope to exclusions when provided', () => {
+    const scope = 'packages/tools';
+    const exclusions = buildAuditExclusions(root, undefined, scope);
+    const expected = resolve(root, scope);
+    expect(exclusions).toContain(expected);
+  });
+
+  it('does not add a scope exclusion when scope is undefined', () => {
+    const exclusions = buildAuditExclusions(root, undefined, undefined);
+    // A bit of a negative test; we check that no exclusion *ends with* a package
+    // name, which is a proxy for "no scope was added".
+    expect(exclusions.some(e => e.endsWith('packages/tools'))).toBe(false);
+    expect(exclusions.some(e => e.endsWith('apps/cli'))).toBe(false);
+  });
+
+  it('includes the worktree path when provided', () => {
+    const worktree = '/tmp/gossip-wt-123';
+    const exclusions = buildAuditExclusions(root, worktree, undefined);
+    expect(exclusions).toContain(resolve(worktree));
+  });
+
+  it('always includes .gossip, .claude, and .git', () => {
+    const exclusions = buildAuditExclusions(root, undefined, undefined);
+    expect(exclusions).toContain(resolve(root, '.gossip'));
+    expect(exclusions).toContain(resolve(root, '.claude'));
+    expect(exclusions).toContain(resolve(root, '.git'));
   });
 });


### PR DESCRIPTION
## Summary
Two unrelated-but-convergent fixes uncovered during the 2026-04-16 session:

1. **Sandbox (apps/cli/src/sandbox.ts)** — L3 audit no longer false-positives on scoped-mode writes, and node-compile-cache is excluded from the tmpdir scan (was 6 of 8 remaining worktree-mode violations).
2. **Git tooling (packages/tools, packages/orchestrator)** — git execFile calls now pass env explicitly and retry once on transient ENOENT. Mitigates a hard-to-repro libuv posix_spawn failure that lost task 9c86d037's entire worktree + commit.

## Why
- **L3 scope false-positive**: scoped agents writing in-scope were flagged as boundary escapes because `buildAuditExclusions` only knew about worktree roots, not scope paths.
- **node-compile-cache**: Node 22+ writes many compile-cache files per dispatch to \$TMPDIR/node-compile-cache/*. These dominated the remaining audit noise.
- **git ENOENT**: `shell-tools.ts:95` passes `env: { ...process.env }` and never fails; `git-tools.ts` + `worktree-manager.ts` omitted env and hit transient spawn failures. Root cause likely libuv/nodejs#48440 family under subprocess-spawn load; fix is defensive env + ENOENT retry.

## Test plan
- [x] `npx jest tests/tools tests/cli` — 448/448 pass
- [x] `npx jest tests/orchestrator` — 1138/1138 pass
- [x] `npx tsc --noEmit -p packages/tools packages/orchestrator apps/cli` — clean
- [x] 5 new unit cases for `buildAuditExclusions` (scope, node-compile-cache, worktree, baseline)
- [ ] CI: workspace builds + MCP bundle size guard

## Notes
ENOENT retry regression test deferred — jest.mock('child_process') at module scope contaminates 12 unrelated tests. Follow-up to use a targeted injection point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)