### PR TITLE
feat(parser): schema-drift diagnostic — Phase 2 of parse-diagnostic work

### DIFF
--- a/apps/cli/src/handlers/relay-cross-review.ts
+++ b/apps/cli/src/handlers/relay-cross-review.ts
@@ -86,13 +86,7 @@ export function startConsensusTimeout(consensusId: string): void {
           newFindings: report.newFindings || [],
           timedOut: missingAgents,
           ...(report.droppedFindingsByType ? { droppedFindingsByType: report.droppedFindingsByType } : {}),
-          // authorDiagnostics is a new ConsensusReport field; cast during the
-          // worktree/master split so this file builds while master's dist
-          // hasn't picked up the field yet. Once this branch merges and the
-          // next build runs in master, the cast can be removed.
-          ...((report as unknown as { authorDiagnostics?: Record<string, unknown[]> }).authorDiagnostics
-            ? { authorDiagnostics: (report as unknown as { authorDiagnostics?: Record<string, unknown[]> }).authorDiagnostics }
-            : {}),
+          ...(report.authorDiagnostics ? { authorDiagnostics: report.authorDiagnostics } : {}),
         }, null, 2));
       } catch { /* best-effort */ }
 
@@ -278,10 +272,7 @@ export async function handleRelayCrossReview(
         insights: report.insights || [],
         newFindings: report.newFindings || [],
         ...(report.droppedFindingsByType ? { droppedFindingsByType: report.droppedFindingsByType } : {}),
-        // See note above about worktree/master split.
-        ...((report as unknown as { authorDiagnostics?: Record<string, unknown[]> }).authorDiagnostics
-          ? { authorDiagnostics: (report as unknown as { authorDiagnostics?: Record<string, unknown[]> }).authorDiagnostics }
-          : {}),
+        ...(report.authorDiagnostics ? { authorDiagnostics: report.authorDiagnostics } : {}),
       }, null, 2));
     } catch { /* best-effort */ }
 

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -69,9 +69,9 @@ interface FindingReviewInfo {
 const DIAGNOSTIC_LABELS: Record<ParseDiagnostic['code'], string> = {
   HTML_ENTITY_ENCODED_TAGS: 'HTML-entity-encoded <agent_finding> tags — parser saw 0 tags',
   HTML_ENTITY_MIXED_PAYLOAD: 'Mixed raw + HTML-entity-encoded tags — some findings dropped',
-  SCHEMA_DRIFT_UNKNOWN_TYPE: 'Unknown type attribute on <agent_finding>',
-  SCHEMA_DRIFT_MISSING_TYPE: 'Missing type attribute on <agent_finding>',
-  SCHEMA_DRIFT_SHORT_CONTENT: 'Content below MIN_FINDING_CONTENT',
+  SCHEMA_DRIFT_PHASE2_VERDICT_TOKENS: 'Schema drift — Phase-2 consensus verdict types emitted (confirmed/disputed/unique/verdict)',
+  SCHEMA_DRIFT_INVENTED_TYPE_TOKENS: 'Schema drift — invented <agent_finding> type names (valid: finding | suggestion | insight)',
+  SCHEMA_DRIFT_NESTED_SUBTAGS: 'Schema drift — nested <type>...</type> subtags instead of type="..." attribute',
 };
 
 function ReportFinding({ f, reviewInfo, diagnostics }: {

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -123,9 +123,9 @@ export interface ConsensusReport {
 export type ParseDiagnostic =
   | { code: 'HTML_ENTITY_ENCODED_TAGS'; message: string; entityTagCount: number }
   | { code: 'HTML_ENTITY_MIXED_PAYLOAD'; message: string; rawTagCount: number; entityTagCount: number }
-  | { code: 'SCHEMA_DRIFT_UNKNOWN_TYPE'; message: string; offendingTypes: Record<string, number> }
-  | { code: 'SCHEMA_DRIFT_MISSING_TYPE'; message: string; count: number }
-  | { code: 'SCHEMA_DRIFT_SHORT_CONTENT'; message: string; count: number };
+  | { code: 'SCHEMA_DRIFT_PHASE2_VERDICT_TOKENS'; message: string; matchedTokens: string[] }
+  | { code: 'SCHEMA_DRIFT_INVENTED_TYPE_TOKENS'; message: string; matchedTokens: string[] }
+  | { code: 'SCHEMA_DRIFT_NESTED_SUBTAGS'; message: string; subtagTypes: string[] };
 
 export interface ConsensusReportsData {
   reports: ConsensusReport[];

--- a/packages/orchestrator/src/parse-findings.ts
+++ b/packages/orchestrator/src/parse-findings.ts
@@ -43,6 +43,67 @@ const CANONICAL_TYPES: ReadonlySet<string> = new Set(['finding', 'suggestion', '
 const HTML_ENTITY_OPEN_PATTERN = /&lt;agent_finding\b/gi;
 const HTML_ENTITY_CLOSE_PATTERN = /&lt;\/agent_finding&gt;/gi;
 
+/**
+ * Schema-drift token buckets — see `docs/specs/2026-04-16-schema-drift-diagnostic.md`.
+ *
+ * Two non-overlapping sets so the diagnostic can distinguish legacy Phase-2
+ * consensus verdict drift (high-signal: reviewer prompt teaches the wrong
+ * format) from generic type invention (lower-signal: reviewer made up a type
+ * name that doesn't match the schema).
+ *
+ * Membership is exhaustive by intent, not by enumeration: token lists are
+ * curated from observed drift patterns. See consensus round `2c0c1e0b-66cf4919:f16`
+ * for the split rationale.
+ */
+const PHASE2_VERDICT_TOKENS: ReadonlySet<string> = new Set([
+  'confirmed',
+  'disputed',
+  'unique',
+  'verdict',
+]);
+
+const INVENTED_TYPE_TOKENS: ReadonlySet<string> = new Set([
+  'approval',
+  'rejection',
+  'concern',
+  'risk',
+  'recommendation',
+  'observation',
+  'critique',
+  'bug',
+  'issue',
+  'warning',
+]);
+
+// Matches a `<type>value</type>` nested subtag. Used ONLY when
+// `droppedMissingType > 0` — the nested-subtag drift mode hits the missing-
+// type bucket because the parser looks for a `type="..."` attribute on the
+// outer `<agent_finding>`, not a child tag. See consensus round
+// `2c0c1e0b-66cf4919:f9`.
+const NESTED_SUBTAG_PATTERN = /<type>\s*([a-z_]+)\s*<\/type>/gi;
+
+/**
+ * Escape HTML-significant characters in strings that are interpolated into
+ * diagnostic messages. The parser runs orchestrator-side and must not import
+ * from the dashboard package (backward dependency), so the helper is mirrored
+ * here. Keep in sync with `packages/dashboard-v2/src/lib/sanitize.ts`.
+ *
+ * Design note: we considered promoting `escapeHtml` to a shared package
+ * (`packages/common/` or similar) but the orchestrator has no other need for
+ * HTML escaping and creating a new package for a 5-line helper is more churn
+ * than it's worth. A second-order mirror is the right call until a third
+ * consumer appears — at which point `packages/common/src/html.ts` becomes
+ * the obvious home.
+ */
+function escapeHtml(raw: string): string {
+  return raw
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export type FindingType = 'finding' | 'suggestion' | 'insight';
 export type Severity = 'critical' | 'high' | 'medium' | 'low';
 
@@ -52,10 +113,23 @@ export type Severity = 'critical' | 'high' | 'medium' | 'low';
  * so the dashboard can render a banner explaining why a round has 0 findings
  * despite agents producing content.
  *
- * Discriminated union on `code`. HTML_ENTITY_* producers ship in Phase 1;
- * SCHEMA_DRIFT_* codes are reserved here as type definitions so downstream
- * consumers can exhaustively switch without a follow-up type change when
- * Phase 2 adds the producers.
+ * Discriminated union on `code`.
+ *
+ * **HTML_ENTITY_* (Phase 1)** — upstream layer HTML-escaped the agent output
+ * before it reached the parser.
+ *
+ * **SCHEMA_DRIFT_* (Phase 2)** — reviewer instructions conflict with the
+ * schema. Three failure modes:
+ *   - `PHASE2_VERDICT_TOKENS`: reviewer emitted types matching legacy Phase-2
+ *     consensus verdict format (`confirmed`, `disputed`, `unique`, `verdict`).
+ *   - `INVENTED_TYPE_TOKENS`: reviewer emitted types not in the schema (e.g.
+ *     `approval`, `risk`, `bug`) but not a Phase-2 verdict either. Fires only
+ *     when PHASE2_VERDICT_TOKENS did NOT fire (Phase 2 takes precedence).
+ *   - `NESTED_SUBTAGS`: reviewer emitted `<agent_finding><type>foo</type>...</agent_finding>`
+ *     (child subtag) instead of the attribute form `<agent_finding type="foo">`.
+ *
+ * See `docs/specs/2026-04-16-schema-drift-diagnostic.md` for detection logic
+ * and consensus rounds behind the split.
  */
 export type ParseDiagnostic =
   | {
@@ -74,25 +148,36 @@ export type ParseDiagnostic =
       entityTagCount: number;
     }
   | {
-      /** Reserved for Phase 2 — producer not implemented yet. */
-      code: 'SCHEMA_DRIFT_UNKNOWN_TYPE';
+      code: 'SCHEMA_DRIFT_PHASE2_VERDICT_TOKENS';
       message: string;
-      /** Offending type values (lowercased) with their counts. */
-      offendingTypes: Record<string, number>;
+      /**
+       * Subset of `droppedUnknownType` keys that matched the
+       * Phase-2 verdict token list (`confirmed`, `disputed`, `unique`, `verdict`).
+       * Lowercased.
+       */
+      matchedTokens: string[];
     }
   | {
-      /** Reserved for Phase 2 — producer not implemented yet. */
-      code: 'SCHEMA_DRIFT_MISSING_TYPE';
+      code: 'SCHEMA_DRIFT_INVENTED_TYPE_TOKENS';
       message: string;
-      /** Count of tags missing a `type=` attribute. */
-      count: number;
+      /**
+       * Subset of `droppedUnknownType` keys that matched the invented-type
+       * token list (`approval`, `risk`, `bug`, etc.). Lowercased. Fires ONLY
+       * when no PHASE2_VERDICT_TOKENS overlap exists — Phase-2 drift takes
+       * precedence because it points to a specific upstream cause (legacy
+       * reviewer prompt).
+       */
+      matchedTokens: string[];
     }
   | {
-      /** Reserved for Phase 2 — producer not implemented yet. */
-      code: 'SCHEMA_DRIFT_SHORT_CONTENT';
+      code: 'SCHEMA_DRIFT_NESTED_SUBTAGS';
       message: string;
-      /** Count of tags dropped for sub-minimum content length. */
-      count: number;
+      /**
+       * Nested `<type>value</type>` subtag values detected in the raw text
+       * when `droppedMissingType > 0`. Lowercased. May contain duplicates if
+       * the same subtag type appears multiple times.
+       */
+      subtagTypes: string[];
     };
 
 export interface ParsedFinding {
@@ -123,10 +208,9 @@ export interface ParseFindingsResult {
   rawTagCount: number;
   /**
    * Structured diagnostics describing recognizable parse failure modes in the
-   * raw input. Empty when the parse is clean. HTML_ENTITY_* diagnostics are
-   * emitted by this parser directly; SCHEMA_DRIFT_* codes are reserved for a
-   * later phase (producers not implemented yet — the type exists so
-   * downstream consumers can exhaustively switch without a follow-up change).
+   * raw input. Empty when the parse is clean. Both HTML_ENTITY_* and
+   * SCHEMA_DRIFT_* codes are emitted by this parser directly — see the
+   * `ParseDiagnostic` union doc for failure mode descriptions.
    */
   diagnostics: ParseDiagnostic[];
 }
@@ -265,8 +349,93 @@ export function parseAgentFindingsStrict(
       });
     }
   }
-  // Suppress unused-variable in the close-pattern until Phase 2 needs it.
+  // Suppress unused-variable in the close-pattern. Kept in source because it
+  // documents the intended boundary for future diagnostics that want to count
+  // entity-encoded closers independently of openers.
   void HTML_ENTITY_CLOSE_PATTERN;
+
+  // --- Schema-drift diagnostics (Phase 2) -----------------------------------
+  //
+  // All three fire regardless of `rawTagCount` / accepted-findings count —
+  // partial-drift (some valid, some drifted) is in scope per consensus round
+  // `2c0c1e0b-66cf4919:f10`. The dashboard banners are dedup'd at render time,
+  // not by the parser.
+  //
+  // Token interpolations into `message` strings are routed through `escapeHtml`
+  // because the message is rendered via `dangerouslySetInnerHTML` downstream
+  // (gemini-reviewer `2c0c1e0b-66cf4919:f1`). Even though `droppedUnknownType`
+  // keys are already constrained by TYPE_ATTR_PATTERN (`[a-zA-Z]+`), and the
+  // nested-subtag regex is `[a-z_]+`, escaping is applied defensively so a
+  // future regex relaxation does not silently introduce an XSS sink.
+
+  const unknownTypeKeys = Object.keys(droppedUnknownType);
+
+  // Order matters: Phase-2 verdict precedence. When a single round has BOTH
+  // verdict-token drops AND invented-token drops, we surface only the Phase-2
+  // diagnostic — it points to a specific, well-known prompt regression
+  // (legacy Phase-2 consensus verdict format) and is higher-signal than the
+  // generic invented-type hint.
+  const phase2Matches = unknownTypeKeys.filter(k => PHASE2_VERDICT_TOKENS.has(k));
+  let phase2Fired = false;
+  if (phase2Matches.length > 0) {
+    phase2Fired = true;
+    const tokenList = phase2Matches.map(escapeHtml).join(', ');
+    diagnostics.push({
+      code: 'SCHEMA_DRIFT_PHASE2_VERDICT_TOKENS',
+      message:
+        `Reviewer emitted <agent_finding> tag type(s) [${tokenList}] that were ` +
+        `dropped as unknown. These look like Phase-2 consensus verdicts, not ` +
+        `Phase-1 finding types. The reviewer's instructions likely teach the ` +
+        `legacy CONFIRMED/DISPUTED/UNIQUE format. Valid Phase-1 types are ` +
+        `finding | suggestion | insight (handbook invariant #8).`,
+      matchedTokens: phase2Matches,
+    });
+  }
+
+  if (!phase2Fired) {
+    const inventedMatches = unknownTypeKeys.filter(k => INVENTED_TYPE_TOKENS.has(k));
+    if (inventedMatches.length > 0) {
+      const tokenList = inventedMatches.map(escapeHtml).join(', ');
+      diagnostics.push({
+        code: 'SCHEMA_DRIFT_INVENTED_TYPE_TOKENS',
+        message:
+          `Reviewer emitted invented <agent_finding> tag type(s) [${tokenList}] ` +
+          `that were dropped as unknown. Valid types are ` +
+          `finding | suggestion | insight (handbook invariant #8). Check the ` +
+          `reviewer's instructions for schema drift.`,
+        matchedTokens: inventedMatches,
+      });
+    }
+  }
+
+  // Nested-subtag drift: the reviewer emitted `<agent_finding><type>finding</type>`
+  // form instead of attribute form. These tags fail the TYPE_ATTR_PATTERN
+  // check on the outer tag and land in `droppedMissingType`. We only scan
+  // when `droppedMissingType > 0` because the regex scan is O(text length)
+  // and most rounds have no missing-type drops.
+  if (droppedMissingType > 0) {
+    // Fresh regex per call — NESTED_SUBTAG_PATTERN is shared module-scope so
+    // we must reset .lastIndex via a new instance.
+    const subtagRe = new RegExp(NESTED_SUBTAG_PATTERN.source, NESTED_SUBTAG_PATTERN.flags);
+    const subtagTypes: string[] = [];
+    let subMatch: RegExpExecArray | null;
+    while ((subMatch = subtagRe.exec(raw)) !== null) {
+      subtagTypes.push(subMatch[1].toLowerCase());
+    }
+    if (subtagTypes.length > 0) {
+      const escapedList = subtagTypes.map(escapeHtml).join(', ');
+      diagnostics.push({
+        code: 'SCHEMA_DRIFT_NESTED_SUBTAGS',
+        message:
+          `Reviewer emitted nested <type>...</type> subtag(s) [${escapedList}] ` +
+          `inside <agent_finding> instead of using the attribute form ` +
+          `<agent_finding type="...">. ${droppedMissingType} tag(s) were dropped ` +
+          `for missing the type attribute. Handbook invariant #8 requires the ` +
+          `attribute form.`,
+        subtagTypes,
+      });
+    }
+  }
 
   return {
     findings,

--- a/tests/orchestrator/parse-findings.test.ts
+++ b/tests/orchestrator/parse-findings.test.ts
@@ -348,4 +348,131 @@ and a second paragraph.
       expect(res.droppedMissingType).toBe(1);
     });
   });
+
+  // Schema-drift diagnostics — see docs/specs/2026-04-16-schema-drift-diagnostic.md
+  // Six cases mandated by the spec's "Validation" section.
+  describe('schema drift diagnostics', () => {
+    it('emits no drift diagnostic when all types are valid', () => {
+      // Spec validation case #1.
+      const raw = `
+<agent_finding type="finding" severity="high">Anchored at foo.ts:12 valid content</agent_finding>
+<agent_finding type="suggestion">Consider refactoring this logic</agent_finding>
+<agent_finding type="insight">Observation about the codebase shape</agent_finding>
+`;
+      const res = parseAgentFindingsStrict(raw);
+      expect(res.findings).toHaveLength(3);
+      // No SCHEMA_DRIFT_* diagnostic should appear — a clean round stays silent.
+      const driftCodes = res.diagnostics
+        .map(d => d.code)
+        .filter(c => c.startsWith('SCHEMA_DRIFT_'));
+      expect(driftCodes).toEqual([]);
+    });
+
+    it('fires SCHEMA_DRIFT_PHASE2_VERDICT_TOKENS when `type="confirmed"` is dropped with zero accepted', () => {
+      // Spec validation case #2. Full-drift: reviewer emitted Phase-2 verdict
+      // format and nothing parsed.
+      const raw = `
+<agent_finding type="confirmed" severity="high">Legacy verdict format at foo.ts:10</agent_finding>
+<agent_finding type="disputed" severity="high">Another legacy verdict bar.ts:20</agent_finding>
+`;
+      const res = parseAgentFindingsStrict(raw);
+      expect(res.findings).toHaveLength(0);
+      const phase2 = res.diagnostics.find(d => d.code === 'SCHEMA_DRIFT_PHASE2_VERDICT_TOKENS');
+      expect(phase2).toBeDefined();
+      if (phase2 && phase2.code === 'SCHEMA_DRIFT_PHASE2_VERDICT_TOKENS') {
+        // matchedTokens contains both drifted tokens, lowercased.
+        expect(phase2.matchedTokens.sort()).toEqual(['confirmed', 'disputed']);
+        // The message must name the Phase-2 verdict framing for the operator.
+        expect(phase2.message).toMatch(/Phase-2/);
+        expect(phase2.message).toContain('confirmed');
+        expect(phase2.message).toContain('disputed');
+      }
+    });
+
+    it('fires SCHEMA_DRIFT_PHASE2_VERDICT_TOKENS on partial drift (some valid, some Phase-2 tokens)', () => {
+      // Spec validation case #3. Partial-drift: the diagnostic STILL fires
+      // even though some tags parsed successfully — per consensus round
+      // 2c0c1e0b-66cf4919:f10, partial-drift is in scope.
+      const raw = `
+<agent_finding type="finding" severity="high">Valid finding content at foo.ts:10</agent_finding>
+<agent_finding type="confirmed" severity="high">Drifted Phase-2 verdict format</agent_finding>
+`;
+      const res = parseAgentFindingsStrict(raw);
+      expect(res.findings).toHaveLength(1);
+      expect(res.rawTagCount).toBe(2);
+      const phase2 = res.diagnostics.find(d => d.code === 'SCHEMA_DRIFT_PHASE2_VERDICT_TOKENS');
+      expect(phase2).toBeDefined();
+      if (phase2 && phase2.code === 'SCHEMA_DRIFT_PHASE2_VERDICT_TOKENS') {
+        expect(phase2.matchedTokens).toEqual(['confirmed']);
+      }
+    });
+
+    it('fires SCHEMA_DRIFT_INVENTED_TYPE_TOKENS when only invented tokens are dropped', () => {
+      // Spec validation case #4. No Phase-2 overlap → invented fires.
+      const raw = `
+<agent_finding type="risk" severity="high">Security risk identified bar.ts:30</agent_finding>
+<agent_finding type="bug" severity="high">Bug at foo.ts:40 some content</agent_finding>
+`;
+      const res = parseAgentFindingsStrict(raw);
+      expect(res.findings).toHaveLength(0);
+      const invented = res.diagnostics.find(d => d.code === 'SCHEMA_DRIFT_INVENTED_TYPE_TOKENS');
+      expect(invented).toBeDefined();
+      if (invented && invented.code === 'SCHEMA_DRIFT_INVENTED_TYPE_TOKENS') {
+        expect(invented.matchedTokens.sort()).toEqual(['bug', 'risk']);
+        expect(invented.message).toContain('finding | suggestion | insight');
+      }
+      // Phase-2 diagnostic MUST NOT fire when no verdict tokens present.
+      expect(
+        res.diagnostics.find(d => d.code === 'SCHEMA_DRIFT_PHASE2_VERDICT_TOKENS'),
+      ).toBeUndefined();
+    });
+
+    it('only fires SCHEMA_DRIFT_PHASE2_VERDICT_TOKENS when both verdict AND invented tokens present (precedence)', () => {
+      // Spec validation case #5. Phase-2 takes precedence because it points
+      // to a specific known regression (legacy prompt).
+      const raw = `
+<agent_finding type="confirmed" severity="high">Phase-2 verdict format at foo.ts:10</agent_finding>
+<agent_finding type="risk" severity="high">Invented type at bar.ts:20</agent_finding>
+`;
+      const res = parseAgentFindingsStrict(raw);
+      expect(res.findings).toHaveLength(0);
+      const codes = res.diagnostics.map(d => d.code);
+      expect(codes).toContain('SCHEMA_DRIFT_PHASE2_VERDICT_TOKENS');
+      expect(codes).not.toContain('SCHEMA_DRIFT_INVENTED_TYPE_TOKENS');
+    });
+
+    it('fires SCHEMA_DRIFT_NESTED_SUBTAGS when droppedMissingType > 0 and <type> subtags present', () => {
+      // Spec validation case #6. Nested-subtag drift hits droppedMissingType
+      // (not droppedUnknownType) because the outer tag has no `type="..."`
+      // attribute.
+      const raw = `
+<agent_finding severity="high"><type>finding</type>Body with anchor foo.ts:50</agent_finding>
+`;
+      const res = parseAgentFindingsStrict(raw);
+      expect(res.findings).toHaveLength(0);
+      expect(res.droppedMissingType).toBe(1);
+      const nested = res.diagnostics.find(d => d.code === 'SCHEMA_DRIFT_NESTED_SUBTAGS');
+      expect(nested).toBeDefined();
+      if (nested && nested.code === 'SCHEMA_DRIFT_NESTED_SUBTAGS') {
+        expect(nested.subtagTypes).toEqual(['finding']);
+        // Message names the attribute-form fix.
+        expect(nested.message).toMatch(/attribute form/);
+      }
+    });
+
+    it('does NOT fire SCHEMA_DRIFT_NESTED_SUBTAGS when droppedMissingType is 0 (even if <type> prose appears)', () => {
+      // Guard: the nested-subtag regex only runs when there's actually a
+      // missing-type drop. A raw string containing `<type>foo</type>` prose
+      // outside any <agent_finding> tag must not trigger.
+      const raw = `
+<agent_finding type="finding" severity="high">Doc says <type>finding</type> is the canonical type at foo.ts:10</agent_finding>
+`;
+      const res = parseAgentFindingsStrict(raw);
+      expect(res.findings).toHaveLength(1);
+      expect(res.droppedMissingType).toBe(0);
+      expect(
+        res.diagnostics.find(d => d.code === 'SCHEMA_DRIFT_NESTED_SUBTAGS'),
+      ).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Phase 2 of two. Adds three `SCHEMA_DRIFT_*` diagnostic producers on top of the infrastructure shipped in #112. When a reviewer agent emits `<agent_finding>` tags that the strict parser drops (unknown type, missing type, or nested-subtag pattern), detect the drop pattern and emit a specific diagnostic that names the likely reviewer-instruction conflict.

Depends on #112 (Phase 1). Spec: `docs/specs/2026-04-16-schema-drift-diagnostic.md`. Consensus: `2c0c1e0b-66cf4919` (sonnet-reviewer + gemini-reviewer).

## Codes

Replaces the three reserved placeholder codes from Phase 1 (`UNKNOWN_TYPE`, `MISSING_TYPE`, `SHORT_CONTENT`) with the three spec-defined codes — grep-verified no code referenced the placeholders beyond the union + label map.

- `SCHEMA_DRIFT_PHASE2_VERDICT_TOKENS` — tokens like `confirmed`, `disputed`, `unique`, `verdict` appear in `droppedUnknownType`. Reviewer is emitting Phase-2 verdicts, not Phase-1 findings.
- `SCHEMA_DRIFT_INVENTED_TYPE_TOKENS` — tokens like `approval`, `risk`, `recommendation`, `bug` appear. Reviewer invented types; fires only when no Phase-2 overlap (Phase-2 takes precedence).
- `SCHEMA_DRIFT_NESTED_SUBTAGS` — `droppedMissingType > 0` AND body contains `<type>foo</type>`. Reviewer used nested subtags instead of attributes.

All three fire regardless of `tags_accepted` — partial-drift is explicitly in scope (consensus `2c0c1e0b-66cf4919:f10`). Token interpolation routes through a local `escapeHtml` mirror to prevent XSS (per gemini-reviewer `2c0c1e0b-66cf4919:f1`).

## Phase 1 cleanup

Removed the temporary `report as unknown as { authorDiagnostics?: ... }` cast at `apps/cli/src/handlers/relay-cross-review.ts:89,275`. Worktree now resolves the proper `ConsensusReport` type via master's rebuilt `@gossip/orchestrator` dist.

## Test plan

- [x] `tests/orchestrator/parse-findings.test.ts` — +7 cases (6 spec-mandated + 1 guard):
  1. all types valid → no drift diagnostic
  2. `type="confirmed"` dropped + zero accepted → `PHASE2_VERDICT_TOKENS` fires
  3. `type="confirmed"` dropped + `type="finding"` accepted → `PHASE2_VERDICT_TOKENS` still fires (partial-drift)
  4. `type="risk"` dropped only → `INVENTED_TYPE_TOKENS` fires
  5. `type="confirmed"` + `type="risk"` both dropped → only `PHASE2_VERDICT_TOKENS` (precedence)
  6. nested `<type>finding</type>` + `droppedMissingType > 0` → `NESTED_SUBTAGS` fires with `subtagTypes: ['finding']`
- [x] `npm run build` — all workspaces pass
- [x] `npm test` — 1781 pass across 135 suites
- [x] `npm run build:mcp` + `npm run build:dashboard` — bundles clean

## Notes for reviewers

- `HTML_ENTITY_CLOSE_PATTERN` remains declared-but-unused (carried over from Phase 1). Consider removing in a follow-up or wiring to a future diagnostic for partial-sanitize detection.
- Dashboard render path now double-escapes (parser + `FindingsMetrics.tsx:176`) — intentional defense-in-depth; parser escape is no-op for valid tokens since capture regexes exclude HTML-sig chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)