### PR TITLE
fix(sandbox): L3 audit drops $HOME scan to kill sibling-process false positives (#113)

### DIFF
--- a/apps/cli/src/sandbox.ts
+++ b/apps/cli/src/sandbox.ts
@@ -155,8 +155,8 @@ const SCOPE_NOTE =
   'SCOPE NOTE: SANDBOXED WRITE BOUNDARY.\n' +
   'This task runs in an isolated worktree. You MUST use only relative paths (./package/file.ts).\n' +
   'Any write outside the worktree — absolute paths (/Users/...), parent-escape (../), or cd-into-parent\n' +
-  '— is a BOUNDARY ESCAPE. Detected post-task, recorded as a `disagreement` signal under\n' +
-  '`trust_boundaries`, logged to .gossip/boundary-escapes.jsonl, and PENALIZES YOUR ACCURACY SCORE.\n' +
+  '— is a BOUNDARY ESCAPE. Detected post-task and logged to .gossip/boundary-escapes.jsonl.\n' +
+  'In block mode the task fails; in warn mode it may be reviewed by the orchestrator.\n' +
   '\n' +
   'Rules:\n' +
   '- Tools: use Edit/Write/Read/Glob/Grep with relative paths only.\n' +
@@ -592,9 +592,16 @@ function canonicalize(p: string): string {
  *                primitive. Scanning $HOME has zero true-positive capacity
  *                (live-fire 2026-04-16: 1064 violations per dispatch were
  *                100% orchestrator/OS noise).
- *   - worktree / sequential / undefined: broad scan ($HOME + tmpdir + /tmp
- *                + /private/tmp). Relay shell_exec can escape $HOME and
- *                tmpdir, so bypasses under these roots ARE reachable.
+ *   - worktree / sequential / undefined: narrow scan (projectRoot + tmpdir
+ *                + /tmp + /private/tmp). Worktree/sequential historically
+ *                scanned $HOME to catch relay shell_exec bypasses to
+ *                ~/.zshrc, ~/.gitconfig, ~/Library/LaunchAgents, etc. That
+ *                scan produced unbounded false positives from unrelated
+ *                process churn (sibling gossipcat projects, Docker buildx,
+ *                vitest caches). PR1 accepts a temporary regression in
+ *                coverage of those persistence vectors; PR2 will restore
+ *                via a sensitive-targets pass with vetted watchlist +
+ *                disagreement signal.
  */
 export function defaultScanRoots(
   writeMode: DispatchWriteMode,
@@ -608,8 +615,10 @@ export function defaultScanRoots(
     try { out.add(canonicalize(projectRoot)); } catch { /* ignore */ }
     return Array.from(out);
   }
-  // Worktree / sequential: broad scan — relay shell_exec can escape $HOME/tmpdir.
-  try { out.add(canonicalize(homedir())); } catch { /* ignore */ }
+  // Worktree / sequential: narrow scan — projectRoot catches peer-worktree
+  // leaks; tmpdir + /tmp + /private/tmp catch the classic bypass drops.
+  // $HOME is intentionally excluded — see docstring for the trade-off.
+  try { out.add(canonicalize(projectRoot)); } catch { /* ignore */ }
   try { out.add(canonicalize(tmpdir())); } catch { /* ignore */ }
   // macOS's shell-level TMPDIR often points into /var/folders/..., but
   // `/tmp` and `/private/tmp` are the classic bypass drops. Include both

--- a/tests/cli/worktree-audit-layer3.test.ts
+++ b/tests/cli/worktree-audit-layer3.test.ts
@@ -211,17 +211,18 @@ describeOnPosix('buildAuditExclusions', () => {
 });
 
 describeOnPosix('defaultScanRoots', () => {
-  it('worktree mode includes $HOME, tmpdir, /tmp, /private/tmp (dedup)', () => {
+  it('worktree mode includes projectRoot + tmpdir + /tmp + /private/tmp and EXCLUDES $HOME (PR1 issue #113)', () => {
     const roots = defaultScanRoots('worktree', '/some/project');
     // Should contain at least one of these.
     expect(roots.length).toBeGreaterThan(0);
     // Unique values only (Set semantics)
     expect(new Set(roots).size).toBe(roots.length);
-    // projectRoot MUST NOT be in worktree scan-roots — it's covered via
-    // $HOME traversal AND worktrees legitimately write inside projectRoot/
-    // .claude/worktrees, which is already excluded separately.
+    expect(roots).toContain('/some/project');
     expect(roots).toContain('/tmp');
     expect(roots).toContain('/private/tmp');
+    // $HOME dropped in PR1 — sibling-process churn produced unbounded false
+    // positives. PR2 will restore coverage via sensitive-targets pass.
+    expect(roots).not.toContain(homedir());
   });
 
   it('scoped mode returns ONLY canonicalized projectRoot (no $HOME scan)', () => {
@@ -238,19 +239,31 @@ describeOnPosix('defaultScanRoots', () => {
     expect(roots).not.toContain('/private/tmp');
   });
 
-  it('undefined writeMode behaves as worktree (broad scan)', () => {
+  it('undefined writeMode behaves as worktree (narrow scan, no $HOME)', () => {
     const roots = defaultScanRoots(undefined, '/some/project');
-    // Must include the broad-scan entries.
+    expect(roots).toContain('/some/project');
     expect(roots).toContain('/tmp');
     expect(roots).toContain('/private/tmp');
-    // Must include $HOME and tmpdir (canonicalized).
-    expect(roots.length).toBeGreaterThanOrEqual(3);
+    expect(roots).not.toContain(homedir());
   });
 
-  it('sequential writeMode behaves as worktree (broad scan)', () => {
+  it('sequential writeMode behaves as worktree (narrow scan, no $HOME)', () => {
     const roots = defaultScanRoots('sequential', '/some/project');
+    expect(roots).toContain('/some/project');
     expect(roots).toContain('/tmp');
     expect(roots).toContain('/private/tmp');
+    expect(roots).not.toContain(homedir());
+  });
+
+  it('regression #113: sibling .gossip dir in $HOME is not a scan root for worktree/sequential', () => {
+    // Live-fire 2026-04-16: sibling gossipcat projects under $HOME attributed
+    // 830 writes per dispatch via mtime (no per-process attribution in find).
+    // Verify homedir() never appears as a scan root for any mode that might
+    // catch a sibling project.
+    for (const mode of ['worktree', 'sequential', undefined] as const) {
+      const roots = defaultScanRoots(mode, '/some/project');
+      expect(roots).not.toContain(homedir());
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Drops `$HOME` from `defaultScanRoots` for worktree/sequential modes. L3 scan narrows to `[projectRoot, tmpdir, /tmp, /private/tmp]`.
- Fixes misleading `SCOPE_NOTE` text that falsely claimed L3 warn-mode emits a `disagreement` signal under `trust_boundaries` (only L2 does).
- Bundled: drops the declared-but-unused `HTML_ENTITY_CLOSE_PATTERN` regex from `parse-findings.ts` (follow-up from #112).

## Why
L3 used `find -newer <sentinel>` over `$HOME + tmpdirs`. `mtime` has no per-process attribution, so sibling gossipcat projects, Docker buildx, and vitest caches attributed **830 writes per dispatch** to the tracked agent. The exclusion list is an allowlist-against-known-noise — every new noise source defaulted to attribution.

See #113 for the full evidence + 5-approach evaluation (A through E) reviewed by sonnet-reviewer + gemini-reviewer in consensus round `2a95bc50-ad534229`.

## Trade-off (documented in docstring)
This PR accepts a **temporary regression** in coverage of `shell_exec` persistence vectors under `$HOME`:
- `~/.zshrc` / `~/.bashrc` / `~/.zshenv` (shell-startup persistence)
- `~/.gitconfig` (core.fsmonitor / core.hooksPath / insteadOf RCE)
- `~/Library/LaunchAgents/*.plist` (macOS persistence)
- `~/bin/*` / `~/.local/bin/*` (PATH hijacking)

L2 hook still catches `file_write` via the Tool Server. These paths are only reachable via relay `shell_exec` bash-level writes, which L2 does not intercept.

## Follow-up (PR2)
Restores the coverage via a **sensitive-targets pass** with a vetted watchlist, zero-exclusion scan, dedup via `Set<string>`, `/etc ↔ /private/etc` symlink handling, sentinel-dir carve-out, source discriminator in `recordLayer3Violations`, and `disagreement` signal emission. Consensus round flagged several design issues with the original Approach E watchlist (`~/.claude` collision, missing `.git-credentials`/`.netrc`/`.docker/config.json`/`.kube/config`, `~/.ssh/known_hosts` churn) that need resolution before PR2 ships.

## Test plan
- [x] `npx tsc --noEmit -p apps/cli` — clean
- [x] `npx tsc --noEmit -p packages/orchestrator` — clean
- [x] `npx jest tests/cli/worktree-audit-layer3.test.ts` — **47/47 passed** (includes new `#113 regression` case asserting `homedir()` never appears in worktree/sequential roots)
- [x] `npx jest tests/cli/` — **354/354 passed across 23 suites** (no #90 regressions)
- [x] `npx jest tests/orchestrator/parse-findings` — **39/39 passed**
- [ ] Manual smoke: dispatch a worktree-isolated agent, confirm mcp.log no longer lists sibling `.gossip/` paths in L3 violations