### PR TITLE
feat(sandbox): L3 sensitive-targets pass restores exfiltration coverage with signal emission (#113)

### DIFF
--- a/apps/cli/src/sandbox.ts
+++ b/apps/cli/src/sandbox.ts
@@ -155,7 +155,9 @@ const SCOPE_NOTE =
   'SCOPE NOTE: SANDBOXED WRITE BOUNDARY.\n' +
   'This task runs in an isolated worktree. You MUST use only relative paths (./package/file.ts).\n' +
   'Any write outside the worktree — absolute paths (/Users/...), parent-escape (../), or cd-into-parent\n' +
-  '— is a BOUNDARY ESCAPE. Detected post-task and logged to .gossip/boundary-escapes.jsonl.\n' +
+  '— is a BOUNDARY ESCAPE. Writes to sensitive paths (SSH keys, cloud credentials, system config)\n' +
+  'are recorded as a `disagreement` signal under `trust_boundaries` and PENALIZE YOUR ACCURACY SCORE.\n' +
+  'Writes to other non-scoped paths are logged to .gossip/boundary-escapes.jsonl for orchestrator review.\n' +
   'In block mode the task fails; in warn mode it may be reviewed by the orchestrator.\n' +
   '\n' +
   'Rules:\n' +
@@ -629,20 +631,119 @@ export function defaultScanRoots(
 }
 
 /**
- * Emit both /tmp and /private/tmp variants of a path so `find -not -path`
- * matches whichever form `find` surfaces on macOS (where /tmp is a symlink
- * to /private/tmp and the kernel reports the resolved form for files opened
- * via either). Lexical-only — never touches the filesystem.
+ * Emit both short and /private/-prefixed variants of a path so `find -path`
+ * matches whichever form `find` surfaces on macOS. On darwin, /tmp, /etc,
+ * and /var are all symlinks to /private/{tmp,etc,var}; the kernel reports
+ * the resolved form for files opened via either. Lexical-only — never
+ * touches the filesystem.
  */
 export function expandTmpVariants(path: string): string[] {
   const p = path.replace(/\/+$/, '') || '/';
-  if (p === '/tmp' || p.startsWith('/tmp/')) {
-    return [p, '/private' + p];
-  }
-  if (p === '/private/tmp' || p.startsWith('/private/tmp/')) {
-    return [p, p.replace(/^\/private/, '')];
+  for (const root of ['/tmp', '/etc', '/var']) {
+    if (p === root || p.startsWith(root + '/')) {
+      return [p, '/private' + p];
+    }
+    const privateRoot = '/private' + root;
+    if (p === privateRoot || p.startsWith(privateRoot + '/')) {
+      return [p, p.replace(/^\/private/, '')];
+    }
   }
   return [p];
+}
+
+/**
+ * Vetted watchlist of sensitive exfiltration/persistence targets scanned in
+ * a SECOND pass with ZERO noise-exclusions. Each entry is either a single
+ * file to stat-check, or a directory with an optional include-list of
+ * basename globs. The pass runs AFTER the main Layer 3 pass so the main
+ * pass can shed $HOME noise (see PR1 #115) while these high-value paths
+ * stay covered.
+ *
+ * Scoping rules (vetted 2026-04-17):
+ *   - ~/.claude: file-level ONLY (settings.json, credentials.json). The
+ *     directory as a whole is harness churn (plugins, caches, projects
+ *     rotate per release). Same reason as main-pass exclusion at
+ *     buildAuditExclusions.
+ *   - ~/.ssh: include-list (id_*, *.key, *.pem, authorized_keys, config).
+ *     known_hosts{,.old} churn on every `git pull` — excluded.
+ *   - ~/.gnupg: full subtree. Keyring access is rare during dispatch.
+ *   - /etc/{passwd,shadow}: system-config persistence vectors. On macOS
+ *     /etc is a symlink to /private/etc; expandTmpVariants handles both.
+ *   - macOS only: ~/Library/LaunchAgents/*.plist — agentic persistence.
+ *
+ * Hits in this pass emit a `disagreement` signal under `trust_boundaries`
+ * via PerformanceWriter.appendSignals, which IS retractable via
+ * gossip_signals action:"retract" if we learn of a false-positive source.
+ * Browser cookies and 1Password are intentionally SKIPPED — denylist-grows
+ * pattern, and Chrome FP during user browsing would kill the signal.
+ */
+export interface SensitiveTarget {
+  /** Absolute path. Either a file (stat-check) or a directory (recurse). */
+  path: string;
+  /** When set and path is a directory, only filenames matching ANY of
+   * these globs (basename) are flagged. Passed to `find -name`. */
+  nameIncludes?: string[];
+  /** Optional OS guard. Only included when process.platform matches. */
+  platform?: NodeJS.Platform;
+}
+
+/**
+ * Build the vetted sensitive-targets watchlist, resolving $HOME and
+ * applying per-OS guards. Null-safe: returns [] if homedir() throws.
+ * Tests can override platform; exported via buildSensitiveTargets().
+ */
+export function buildSensitiveTargets(
+  platform: NodeJS.Platform = process.platform,
+): SensitiveTarget[] {
+  let home: string;
+  try {
+    home = homedir();
+  } catch {
+    return [];
+  }
+  if (!home) return [];
+
+  const out: SensitiveTarget[] = [
+    // Claude Code credentials — file-level (dir as a whole is harness churn).
+    { path: `${home}/.claude/settings.json` },
+    { path: `${home}/.claude/credentials.json` },
+    // SSH: private keys + auth + config only. known_hosts excluded (churn).
+    {
+      path: `${home}/.ssh`,
+      nameIncludes: ['id_*', '*.key', '*.pem', 'authorized_keys', 'config'],
+    },
+    // Cloud credentials.
+    { path: `${home}/.aws/credentials` },
+    { path: `${home}/.aws/config` },
+    // GPG keyring (full dir — low churn, legitimate access rare during dispatch).
+    { path: `${home}/.gnupg` },
+    // Shell/git credential stores.
+    { path: `${home}/.git-credentials` },
+    { path: `${home}/.netrc` },
+    // GitHub CLI auth.
+    { path: `${home}/.config/gh/hosts.yml` },
+    // Docker + Kubernetes.
+    { path: `${home}/.docker/config.json` },
+    { path: `${home}/.kube/config` },
+    // DB credentials.
+    { path: `${home}/.pgpass` },
+    { path: `${home}/.my.cnf` },
+    // System config (passwd/shadow). On macOS /etc → /private/etc; both forms
+    // canonicalized at audit time via expandTmpVariants.
+    { path: '/etc/passwd' },
+    { path: '/etc/shadow' },
+  ];
+
+  // macOS-only: LaunchAgents persistence vector.
+  if (platform === 'darwin') {
+    out.push({
+      path: `${home}/Library/LaunchAgents`,
+      nameIncludes: ['*.plist'],
+      platform: 'darwin',
+    });
+  }
+
+  return out;
 }
 
 /** Build the exclusion list for the Layer 3 audit. The current task's own
@@ -738,16 +839,77 @@ export function buildFindPruneArgs(
 }
 
 /**
- * Post-dispatch `find -newer <sentinel>` audit. Walks scan roots and records
- * any file modified after the sentinel's mtime that is NOT inside the
- * current task's worktree or a gossipcat infrastructure directory.
+ * Build `find` argv for the sensitive-targets pass: ZERO noise-exclusions
+ * (the watchlist is pre-vetted sparse; nothing to prune) but KEEPING an
+ * optional sentinel-dir carve-out and an optional `-name` include-list.
+ *
+ * Shape when nameIncludes is empty:
+ *   <target> [ -path <sentinel-dir> -prune -o ] -type f -newer <sentinel> -print
+ *
+ * Shape when nameIncludes is non-empty (basename whitelist):
+ *   <target> [ -path <sentinel-dir> -prune -o ] -type f
+ *     ( -name <n1> -o -name <n2> ... ) -newer <sentinel> -print
+ *
+ * Exported for arg-shape tests. The sentinelDir carve-out exists because
+ * when the sentinel is itself under $HOME (e.g. a tests writing projectRoot
+ * into a $HOME-adjacent tmp dir), the watchlist scan must not self-match on
+ * the sentinel's own mtime.
+ */
+export function buildSensitiveFindArgs(
+  target: string,
+  sentinel: string,
+  nameIncludes?: string[],
+  sentinelDir?: string,
+): string[] {
+  const args: string[] = [target];
+  // Optional sentinel-dir carve-out — one -path entry with its twin
+  // (via expandTmpVariants) so macOS /private/... resolution is covered.
+  if (sentinelDir) {
+    const twins = expandTmpVariants(sentinelDir);
+    args.push('(');
+    for (let i = 0; i < twins.length; i++) {
+      if (i > 0) args.push('-o');
+      args.push('-path', twins[i]);
+    }
+    args.push(')', '-prune', '-o');
+  }
+  args.push('-type', 'f');
+  if (nameIncludes && nameIncludes.length > 0) {
+    args.push('(');
+    for (let i = 0; i < nameIncludes.length; i++) {
+      if (i > 0) args.push('-o');
+      args.push('-name', nameIncludes[i]);
+    }
+    args.push(')');
+  }
+  args.push('-newer', sentinel, '-print');
+  return args;
+}
+
+/**
+ * Post-dispatch `find -newer <sentinel>` audit. Runs TWO passes:
+ *   Pass 1 (main): walks default scan roots (projectRoot + tmpdir + /tmp
+ *     variants; $HOME excluded post-PR1) and records any file modified
+ *     after the sentinel's mtime that is NOT inside the current task's
+ *     worktree, gossipcat infra, or the user-level churn dirs. Violations
+ *     recorded with source='layer3-main' — JSONL-only (no score penalty).
+ *   Pass 2 (sensitive, PR2): iterates buildSensitiveTargets() and runs
+ *     find with ZERO noise-exclusions per target (watchlist is pre-vetted
+ *     sparse). Violations recorded with source='layer3-sensitive' AND
+ *     emit a retractable `disagreement` signal under `trust_boundaries`.
+ *
+ * Dedup: a path seen in both passes is reported ONLY as sensitive. The
+ * main pass JSONL entry is suppressed for that path.
  *
  * Contract:
  *   - Windows: skipped (POSIX-only primitive). Logged, not failed.
  *   - `find` error: logged, empty result returned. MUST NOT propagate.
  *   - Sentinel missing: skipped with reason. Audit fail-opens.
- *   - Any violations: appended to .gossip/boundary-escapes.jsonl with
- *     source='layer3-audit', one line per violating path.
+ *   - Sensitive-pass permission errors: stderr warning SUPPRESSED (would
+ *     fire every dispatch on macOS /etc and train users to ignore Layer 3);
+ *     partial-stdout recovery still runs.
+ *   - Any violations: appended to .gossip/boundary-escapes.jsonl, one line
+ *     per violating path, with source ∈ {'layer3-main', 'layer3-sensitive'}.
  */
 export function auditFilesystemSinceSentinel(
   projectRoot: string,
@@ -785,18 +947,21 @@ export function auditFilesystemSinceSentinel(
   );
   const exclusions = buildAuditExclusions(projectRoot, meta.worktreePath, options.scope);
   const findBin = options.findBinary ?? 'find';
+  const sentinelDir = canonicalize(join(projectRoot, '.gossip', SENTINEL_DIR));
 
-  const violations: string[] = [];
+  // Canonicalized violation sets — kept separate by source so we can record
+  // each pass independently, but a path that appears in BOTH passes is
+  // deduped to avoid dashboard double-counting.
+  const mainSet = new Set<string>();
+  const sensitiveSet = new Set<string>();
 
+  // ── Pass 1: main scan (post-PR1: narrow roots, $HOME excluded) ──
   for (const root of scanRoots) {
     if (!existsSync(root)) continue;
     const canonRoot = canonicalize(root);
 
-    // Always exclude the sentinel dir itself (stamping it bumps its own
-    // mtime and would otherwise self-match if tmpdir == .gossip path).
     // buildAuditExclusions already emits /tmp + /private/tmp twins for its
     // inputs; do the same for the sentinel dir so both forms are covered.
-    const sentinelDir = canonicalize(join(projectRoot, '.gossip', SENTINEL_DIR));
     const allExcl = [...exclusions, ...expandTmpVariants(sentinelDir)];
     const args = buildFindPruneArgs(canonRoot, allExcl, sentinel);
 
@@ -812,7 +977,7 @@ export function auditFilesystemSinceSentinel(
       for (const line of out.split('\n')) {
         const p = line.trim();
         if (!p) continue;
-        violations.push(p);
+        mainSet.add(canonicalize(p));
       }
     } catch (err) {
       // find exits non-zero on ANY permission error (macOS TCC is the common
@@ -825,7 +990,7 @@ export function auditFilesystemSinceSentinel(
         : (e.stdout?.toString?.('utf-8') ?? '');
       for (const line of partial.split('\n')) {
         const p = line.trim();
-        if (p) violations.push(p);
+        if (p) mainSet.add(canonicalize(p));
       }
       if (logFailures) {
         const msg = e.message || String(err);
@@ -838,29 +1003,111 @@ export function auditFilesystemSinceSentinel(
     }
   }
 
-  if (violations.length > 0) {
-    recordLayer3Violations(projectRoot, meta, violations);
+  // ── Pass 2: sensitive-targets scan (PR2) ──
+  // Zero noise-exclusions on this pass (watchlist is pre-vetted sparse),
+  // but KEEP the sentinelDir carve-out so a sentinel under $HOME doesn't
+  // self-match. Permission errors on sensitive paths (e.g. /etc on macOS
+  // SIP) are suppressed from stderr to avoid training users to ignore the
+  // warning; the partial-stdout recovery still runs.
+  const sensitiveTargets = buildSensitiveTargets(platform);
+  for (const target of sensitiveTargets) {
+    if (!existsSync(target.path)) continue;
+    const canonTarget = canonicalize(target.path);
+    const args = buildSensitiveFindArgs(
+      canonTarget,
+      sentinel,
+      target.nameIncludes,
+      sentinelDir,
+    );
+
+    try {
+      const out = execFileSync(findBin, args, {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 30_000,
+        maxBuffer: 8 * 1024 * 1024,
+      });
+      for (const line of out.split('\n')) {
+        const p = line.trim();
+        if (!p) continue;
+        sensitiveSet.add(canonicalize(p));
+      }
+    } catch (err) {
+      // TCC / SIP: /etc reads can trigger "Operation not permitted" on macOS
+      // even though /etc/passwd is world-readable. Salvage stdout; suppress
+      // the per-dispatch stderr warning for this pass (would otherwise fire
+      // every dispatch and train users to ignore Layer 3 warnings).
+      const e = err as { stdout?: Buffer | string };
+      const partial = typeof e.stdout === 'string'
+        ? e.stdout
+        : (e.stdout?.toString?.('utf-8') ?? '');
+      for (const line of partial.split('\n')) {
+        const p = line.trim();
+        if (p) sensitiveSet.add(canonicalize(p));
+      }
+      // Intentionally NO logFailures warning here — see comment above.
+      continue;
+    }
+  }
+
+  // Dedup: a path in both passes goes to sensitive only (stronger signal).
+  for (const p of sensitiveSet) mainSet.delete(p);
+
+  const mainViolations = Array.from(mainSet);
+  const sensitiveViolations = Array.from(sensitiveSet);
+  const combined = [...mainViolations, ...sensitiveViolations];
+
+  if (mainViolations.length > 0) {
+    recordLayer3Violations(projectRoot, meta, mainViolations, 'layer3-main');
     if (logFailures) {
       process.stderr.write(
-        `[gossipcat] ⚠ Layer 3 BOUNDARY ESCAPE: ${meta.agentId} task ${meta.taskId} touched ${violations.length} path(s) outside worktree:\n` +
-          violations.slice(0, 20).map(v => `    ${v}`).join('\n') +
+        `[gossipcat] ⚠ Layer 3 BOUNDARY ESCAPE: ${meta.agentId} task ${meta.taskId} touched ${mainViolations.length} path(s) outside worktree:\n` +
+          mainViolations.slice(0, 20).map(v => `    ${v}`).join('\n') +
+          '\n',
+      );
+    }
+  }
+  if (sensitiveViolations.length > 0) {
+    recordLayer3Violations(projectRoot, meta, sensitiveViolations, 'layer3-sensitive');
+    if (logFailures) {
+      process.stderr.write(
+        `[gossipcat] ⚠ Layer 3 SENSITIVE-TARGET EXFILTRATION: ${meta.agentId} task ${meta.taskId} touched ${sensitiveViolations.length} sensitive path(s):\n` +
+          sensitiveViolations.slice(0, 20).map(v => `    ${v}`).join('\n') +
           '\n',
       );
     }
   }
 
-  return { violations };
+  return { violations: combined };
 }
+
+/** Source discriminator for Layer 3 JSONL entries. `layer3-main` is the
+ * narrow post-PR1 scan (warn-only — JSONL only). `layer3-sensitive` is the
+ * PR2 vetted watchlist pass (emits a retractable `disagreement` signal
+ * under `trust_boundaries` on top of the JSONL). */
+export type Layer3Source = 'layer3-main' | 'layer3-sensitive';
 
 /** Append one entry per violating path to boundary-escapes.jsonl. Shape
  * mirrors Layer 2's `recordBoundaryEscape`: `violatingPaths` is a
  * 1-element array per line (Layer 3 does NOT aggregate across paths so the
  * audit trail stays path-granular, but the field type matches Layer 2 so
- * downstream readers can parse either source with one shape). */
+ * downstream readers can parse either source with one shape).
+ *
+ * When source === 'layer3-sensitive', emits a `disagreement` signal under
+ * `trust_boundaries` via PerformanceWriter.appendSignals ONCE per dispatch
+ * (not per violation — one dispatch = one sensitive event regardless of
+ * how many files it touched; signal evidence lists up to 10 paths). The
+ * signal is RETRACTABLE via gossip_signals action:"retract" if a false-
+ * positive source is identified later.
+ *
+ * The `layer3-main` source stays JSONL-only (PR1 behavior) — the narrow
+ * main pass is too noise-prone for scoring penalties.
+ */
 function recordLayer3Violations(
   projectRoot: string,
   meta: DispatchMetadata,
   violations: string[],
+  source: Layer3Source,
 ): void {
   try {
     const dir = join(projectRoot, '.gossip');
@@ -872,12 +1119,37 @@ function recordLayer3Violations(
         taskId: meta.taskId,
         agentId: meta.agentId,
         violatingPaths: [path],
-        source: 'layer3-audit',
+        source,
       }),
     );
     appendFileSync(join(dir, BOUNDARY_ESCAPE_FILE), lines.join('\n') + '\n');
   } catch {
     /* best-effort */
+  }
+
+  // Signal emission — sensitive pass only. Main pass stays JSONL-only to
+  // match PR1 scoring discipline. Mirrors Layer 2's recordBoundaryEscape
+  // shape: try/catch, best-effort, never blocks audit completion.
+  if (source === 'layer3-sensitive' && violations.length > 0) {
+    try {
+      const { PerformanceWriter } = require('@gossip/orchestrator');
+      const writer = new PerformanceWriter(projectRoot);
+      writer.appendSignals([
+        {
+          type: 'consensus' as const,
+          taskId: meta.taskId,
+          signal: 'disagreement' as const,
+          agentId: meta.agentId,
+          category: 'trust_boundaries',
+          evidence:
+            `Sensitive-target exfiltration attempt: ${meta.writeMode ?? 'unknown'} task wrote to ${violations.length} sensitive path(s). ` +
+            `Paths: ${violations.slice(0, 10).join(', ')}`,
+          timestamp: new Date().toISOString(),
+        },
+      ]);
+    } catch {
+      /* best-effort */
+    }
   }
 }
 

--- a/tests/cli/worktree-audit-layer3-sensitive.test.ts
+++ b/tests/cli/worktree-audit-layer3-sensitive.test.ts
@@ -1,0 +1,618 @@
+/**
+ * Tests for Layer 3 sensitive-targets pass (issue #113 PR2).
+ *
+ * PR1 (#115) dropped $HOME from the main L3 scan to eliminate sibling-process
+ * noise. That regressed coverage of exfiltration/persistence vectors under
+ * $HOME (SSH keys, cloud credentials, LaunchAgents, etc.).
+ *
+ * PR2 restores coverage via a SECOND pass over a sparse, vetted watchlist
+ * with ZERO noise-exclusions and a retractable `disagreement` signal under
+ * `trust_boundaries`. See buildSensitiveTargets for the locked scope.
+ *
+ * These tests shim the $HOME lookup to a test tmpdir via mock of os.homedir
+ * — DO NOT write to the real ~/.ssh etc. from CI.
+ */
+// Hoist the mutable fakeHome holder so jest.mock (which is hoisted above
+// imports) can close over it. Tests set holder.value in beforeEach.
+const fakeHomeHolder: { value: string | null } = { value: null };
+
+// Mock `os.homedir` at the module boundary so buildSensitiveTargets resolves
+// its watchlist entries against our test tmp dir, not the real $HOME. All
+// other os exports pass through.
+jest.mock('os', () => {
+  const actual = jest.requireActual<typeof import('os')>('os');
+  return {
+    ...actual,
+    homedir: () => fakeHomeHolder.value ?? actual.homedir(),
+  };
+});
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'fs';
+import * as os from 'os';
+import { join } from 'path';
+import {
+  auditFilesystemSinceSentinel,
+  buildSensitiveFindArgs,
+  buildSensitiveTargets,
+  DispatchMetadata,
+  expandTmpVariants,
+  stampTaskSentinel,
+} from '../../apps/cli/src/sandbox';
+
+const itOnPosix = process.platform === 'win32' ? it.skip : it;
+const describeOnPosix = process.platform === 'win32' ? describe.skip : describe;
+
+function mkTmp(prefix = 'gossip-l3-sens-'): string {
+  return mkdtempSync(join(os.tmpdir(), prefix));
+}
+
+function backdateSentinel(path: string, pastMs: number): void {
+  const when = new Date(Date.now() - pastMs);
+  utimesSync(path, when, when);
+}
+
+describeOnPosix('buildSensitiveTargets — watchlist shape', () => {
+  const REAL_HOME = os.homedir();
+
+  it('includes universal watchlist entries on both OS branches', () => {
+    // Assert UNIVERSAL entries (both darwin and linux): credential stores,
+    // cloud configs, system /etc files. These are identical cross-OS per
+    // decision 3.
+    for (const platform of ['darwin', 'linux'] as NodeJS.Platform[]) {
+      const targets = buildSensitiveTargets(platform);
+      const paths = targets.map(t => t.path);
+      // Cloud credentials.
+      expect(paths).toContain(`${REAL_HOME}/.aws/credentials`);
+      expect(paths).toContain(`${REAL_HOME}/.aws/config`);
+      // Claude Code (file-level, NOT the whole dir).
+      expect(paths).toContain(`${REAL_HOME}/.claude/settings.json`);
+      expect(paths).toContain(`${REAL_HOME}/.claude/credentials.json`);
+      expect(paths).not.toContain(`${REAL_HOME}/.claude`);
+      expect(paths).not.toContain(`${REAL_HOME}/.claude/plugins`);
+      expect(paths).not.toContain(`${REAL_HOME}/.claude/caches`);
+      expect(paths).not.toContain(`${REAL_HOME}/.claude/projects`);
+      // SSH include-list (dir-level with -name filter).
+      const ssh = targets.find(t => t.path === `${REAL_HOME}/.ssh`);
+      expect(ssh).toBeDefined();
+      expect(ssh!.nameIncludes).toContain('id_*');
+      expect(ssh!.nameIncludes).toContain('*.key');
+      expect(ssh!.nameIncludes).toContain('*.pem');
+      expect(ssh!.nameIncludes).toContain('authorized_keys');
+      expect(ssh!.nameIncludes).toContain('config');
+      // known_hosts MUST NOT be in the include-list (churn).
+      expect(ssh!.nameIncludes).not.toContain('known_hosts');
+      expect(ssh!.nameIncludes).not.toContain('known_hosts.old');
+      // GPG keyring (full subtree).
+      expect(paths).toContain(`${REAL_HOME}/.gnupg`);
+      // Git + netrc + GitHub CLI.
+      expect(paths).toContain(`${REAL_HOME}/.git-credentials`);
+      expect(paths).toContain(`${REAL_HOME}/.netrc`);
+      expect(paths).toContain(`${REAL_HOME}/.config/gh/hosts.yml`);
+      // Docker + Kubernetes.
+      expect(paths).toContain(`${REAL_HOME}/.docker/config.json`);
+      expect(paths).toContain(`${REAL_HOME}/.kube/config`);
+      // DB credentials.
+      expect(paths).toContain(`${REAL_HOME}/.pgpass`);
+      expect(paths).toContain(`${REAL_HOME}/.my.cnf`);
+      // System config.
+      expect(paths).toContain('/etc/passwd');
+      expect(paths).toContain('/etc/shadow');
+    }
+  });
+
+  it('adds ~/Library/LaunchAgents ONLY on macOS', () => {
+    const darwin = buildSensitiveTargets('darwin');
+    const linux = buildSensitiveTargets('linux');
+    const launchAgents = `${REAL_HOME}/Library/LaunchAgents`;
+
+    expect(darwin.map(t => t.path)).toContain(launchAgents);
+    const darwinEntry = darwin.find(t => t.path === launchAgents);
+    expect(darwinEntry!.nameIncludes).toEqual(['*.plist']);
+    expect(darwinEntry!.platform).toBe('darwin');
+
+    // Linux: LaunchAgents MUST NOT be present.
+    expect(linux.map(t => t.path)).not.toContain(launchAgents);
+  });
+
+  it('skips browser cookies and 1Password (denylist-grows pattern SKIPPED per decision 6)', () => {
+    // Decision 6: Chrome FP during user browsing kills accuracy signal.
+    // Browser cookies and 1Password vaults are INTENTIONALLY not in the
+    // watchlist. Guard against accidental addition.
+    for (const platform of ['darwin', 'linux'] as NodeJS.Platform[]) {
+      const paths = buildSensitiveTargets(platform).map(t => t.path);
+      expect(paths.some(p => /Chrome|Chromium|Firefox|Safari|1Password/i.test(p))).toBe(false);
+      expect(paths.some(p => /[Cc]ookies/.test(p))).toBe(false);
+    }
+  });
+
+  it('default platform argument is process.platform', () => {
+    // Smoke test: calling with no args must not throw.
+    expect(() => buildSensitiveTargets()).not.toThrow();
+    const defaultList = buildSensitiveTargets();
+    const explicit = buildSensitiveTargets(process.platform);
+    expect(defaultList.map(t => t.path)).toEqual(explicit.map(t => t.path));
+  });
+});
+
+describeOnPosix('buildSensitiveFindArgs — arg shape', () => {
+  const SENT = '/tmp/fake-sentinel';
+
+  it('emits plain find args when nameIncludes is empty', () => {
+    const args = buildSensitiveFindArgs('/home/u/.aws/credentials', SENT);
+    expect(args).toEqual([
+      '/home/u/.aws/credentials',
+      '-type', 'f',
+      '-newer', SENT,
+      '-print',
+    ]);
+  });
+
+  it('emits a ( -name X -o -name Y ) group when nameIncludes is set', () => {
+    const args = buildSensitiveFindArgs(
+      '/home/u/.ssh',
+      SENT,
+      ['id_*', '*.key', '*.pem', 'authorized_keys', 'config'],
+    );
+    expect(args).toEqual([
+      '/home/u/.ssh',
+      '-type', 'f',
+      '(',
+      '-name', 'id_*',
+      '-o',
+      '-name', '*.key',
+      '-o',
+      '-name', '*.pem',
+      '-o',
+      '-name', 'authorized_keys',
+      '-o',
+      '-name', 'config',
+      ')',
+      '-newer', SENT,
+      '-print',
+    ]);
+  });
+
+  it('prepends a sentinel-dir carve-out with /private twin when sentinelDir is set', () => {
+    const args = buildSensitiveFindArgs(
+      '/etc/passwd',
+      SENT,
+      undefined,
+      '/tmp/proj/.gossip/sentinels',
+    );
+    // Carve-out group must come BEFORE -type f.
+    const openIdx = args.indexOf('(');
+    const closeIdx = args.indexOf(')');
+    const pruneIdx = args.indexOf('-prune');
+    expect(openIdx).toBeGreaterThan(0);
+    expect(closeIdx).toBeGreaterThan(openIdx);
+    expect(pruneIdx).toBe(closeIdx + 1);
+    // Twins: both /tmp/proj/.gossip/sentinels and /private/tmp/proj/.gossip/sentinels.
+    expect(args).toContain('/tmp/proj/.gossip/sentinels');
+    expect(args).toContain('/private/tmp/proj/.gossip/sentinels');
+  });
+});
+
+describeOnPosix('expandTmpVariants — /etc and /var handling (PR2 addition)', () => {
+  it('emits /etc and /private/etc twins', () => {
+    expect(expandTmpVariants('/etc')).toEqual(['/etc', '/private/etc']);
+    expect(expandTmpVariants('/etc/passwd')).toEqual(['/etc/passwd', '/private/etc/passwd']);
+  });
+
+  it('emits /private/etc and /etc twins (reverse direction)', () => {
+    expect(expandTmpVariants('/private/etc/passwd')).toEqual(['/private/etc/passwd', '/etc/passwd']);
+  });
+
+  it('emits /var and /private/var twins', () => {
+    expect(expandTmpVariants('/var/log')).toEqual(['/var/log', '/private/var/log']);
+  });
+
+  it('preserves legacy /tmp behavior', () => {
+    expect(expandTmpVariants('/tmp')).toEqual(['/tmp', '/private/tmp']);
+    expect(expandTmpVariants('/tmp/proj')).toEqual(['/tmp/proj', '/private/tmp/proj']);
+  });
+
+  it('does not twin unrelated paths', () => {
+    expect(expandTmpVariants('/Users/u/code')).toEqual(['/Users/u/code']);
+    expect(expandTmpVariants('/opt/foo')).toEqual(['/opt/foo']);
+  });
+});
+
+/**
+ * Shim-based tests for the two-pass audit. We spy on homedir() via a jest
+ * module mock so buildSensitiveTargets resolves to our tmp dir rather than
+ * the real $HOME. This lets us assert sensitive-pass detection without
+ * touching the real host.
+ */
+describeOnPosix('auditFilesystemSinceSentinel — two-pass detection + dedup', () => {
+  let fakeHome: string;
+  let projectRoot: string;
+  let scanRoot: string;
+
+  beforeEach(() => {
+    fakeHome = mkTmp('gossip-l3-home-');
+    projectRoot = mkTmp();
+    scanRoot = mkTmp('gossip-l3-scan-');
+    fakeHomeHolder.value = fakeHome;
+  });
+
+  afterEach(() => {
+    fakeHomeHolder.value = null;
+    rmSync(fakeHome, { recursive: true, force: true });
+    rmSync(projectRoot, { recursive: true, force: true });
+    rmSync(scanRoot, { recursive: true, force: true });
+  });
+
+  function runAudit(scanRoots: string[] = [scanRoot]) {
+    const sentinel = stampTaskSentinel(projectRoot, 'sens-test')!;
+    backdateSentinel(sentinel, 5000);
+    const meta: DispatchMetadata = {
+      taskId: 'sens-test',
+      agentId: 'opus-implementer',
+      writeMode: 'worktree',
+      timestamp: Date.now(),
+      sentinelPath: sentinel,
+    };
+    return auditFilesystemSinceSentinel(projectRoot, meta, {
+      scanRoots,
+      logFailures: false,
+    });
+  }
+
+  itOnPosix('DETECTS writes to ~/.ssh/id_rsa', () => {
+    mkdirSync(join(fakeHome, '.ssh'), { recursive: true });
+    writeFileSync(join(fakeHome, '.ssh', 'id_rsa'), 'FAKE KEY');
+
+    const res = runAudit();
+    expect(res.violations.some(v => v.endsWith('/.ssh/id_rsa'))).toBe(true);
+  });
+
+  itOnPosix('DETECTS writes to ~/.aws/credentials', () => {
+    mkdirSync(join(fakeHome, '.aws'), { recursive: true });
+    writeFileSync(join(fakeHome, '.aws', 'credentials'), '[default]\naws_access_key_id=AKIA...');
+
+    const res = runAudit();
+    expect(res.violations.some(v => v.endsWith('/.aws/credentials'))).toBe(true);
+  });
+
+  itOnPosix('DETECTS writes to ~/.docker/config.json', () => {
+    mkdirSync(join(fakeHome, '.docker'), { recursive: true });
+    writeFileSync(join(fakeHome, '.docker', 'config.json'), '{"auths":{}}');
+
+    const res = runAudit();
+    expect(res.violations.some(v => v.endsWith('/.docker/config.json'))).toBe(true);
+  });
+
+  itOnPosix('DETECTS writes to ~/.claude/settings.json (file-level scope)', () => {
+    mkdirSync(join(fakeHome, '.claude'), { recursive: true });
+    writeFileSync(join(fakeHome, '.claude', 'settings.json'), '{}');
+
+    const res = runAudit();
+    expect(res.violations.some(v => v.endsWith('/.claude/settings.json'))).toBe(true);
+  });
+
+  itOnPosix('IGNORES ~/.ssh/known_hosts (excluded from SSH include-list)', () => {
+    mkdirSync(join(fakeHome, '.ssh'), { recursive: true });
+    writeFileSync(join(fakeHome, '.ssh', 'known_hosts'), 'github.com ssh-rsa ...');
+
+    const res = runAudit();
+    expect(res.violations.some(v => v.endsWith('/known_hosts'))).toBe(false);
+  });
+
+  itOnPosix('IGNORES ~/.claude/plugins/* (harness churn, NOT in file-level watchlist)', () => {
+    mkdirSync(join(fakeHome, '.claude', 'plugins', 'foo'), { recursive: true });
+    writeFileSync(join(fakeHome, '.claude', 'plugins', 'foo', 'manifest.json'), '{}');
+
+    const res = runAudit();
+    // .claude/plugins/foo/manifest.json MUST NOT appear — only settings.json
+    // and credentials.json are in the sensitive watchlist.
+    expect(res.violations.some(v => v.includes('/.claude/plugins/'))).toBe(false);
+  });
+
+  itOnPosix('IGNORES ~/.claude/caches/* (harness churn)', () => {
+    mkdirSync(join(fakeHome, '.claude', 'caches'), { recursive: true });
+    writeFileSync(join(fakeHome, '.claude', 'caches', 'ast.cache'), 'binary');
+
+    const res = runAudit();
+    expect(res.violations.some(v => v.includes('/.claude/caches/'))).toBe(false);
+  });
+
+  itOnPosix('sentinel-dir stamping does NOT self-match in sensitive pass when sentinel is under $HOME', () => {
+    // Simulate scenario where projectRoot is under $HOME (so the sentinel
+    // dir might overlap with a sensitive watchlist entry). Stamp a sentinel,
+    // write an unrelated sensitive file, audit — the sentinel itself must
+    // NOT show up as a violation.
+    const hostedProject = join(fakeHome, 'project');
+    mkdirSync(hostedProject, { recursive: true });
+    const sentinel = stampTaskSentinel(hostedProject, 'self-match')!;
+    backdateSentinel(sentinel, 5000);
+
+    // Touch NO sensitive files — so if the sentinel itself matched, we'd
+    // see it in violations. It must not.
+    const meta: DispatchMetadata = {
+      taskId: 'self-match',
+      agentId: 'opus-implementer',
+      writeMode: 'worktree',
+      timestamp: Date.now(),
+      sentinelPath: sentinel,
+    };
+    const res = auditFilesystemSinceSentinel(hostedProject, meta, {
+      scanRoots: [scanRoot],
+      logFailures: false,
+    });
+    // The sentinel path must never appear as a violation.
+    expect(res.violations.every(v => !v.includes('sentinels'))).toBe(true);
+  });
+
+  itOnPosix('dedups a path that appears in both passes (one JSONL entry, sensitive-only)', () => {
+    // Contrive a case: write an SSH key path and also put scanRoot at
+    // $HOME so the MAIN pass would normally flag the same file. We use a
+    // scanRoot that IS fakeHome so both passes can see the SSH file.
+    mkdirSync(join(fakeHome, '.ssh'), { recursive: true });
+    const keyPath = join(fakeHome, '.ssh', 'id_ed25519');
+    writeFileSync(keyPath, 'FAKE KEY');
+
+    const sentinel = stampTaskSentinel(projectRoot, 'dedup-test')!;
+    backdateSentinel(sentinel, 5000);
+    const meta: DispatchMetadata = {
+      taskId: 'dedup-test',
+      agentId: 'opus-implementer',
+      writeMode: 'worktree',
+      timestamp: Date.now(),
+      sentinelPath: sentinel,
+    };
+    // Force main pass to scan fakeHome so it ALSO finds the key (normally
+    // $HOME is dropped from defaultScanRoots; this test's scanRoots override
+    // simulates "what if both passes saw it").
+    auditFilesystemSinceSentinel(projectRoot, meta, {
+      scanRoots: [fakeHome],
+      logFailures: false,
+    });
+
+    const logPath = join(projectRoot, '.gossip', 'boundary-escapes.jsonl');
+    expect(existsSync(logPath)).toBe(true);
+    const entries = readFileSync(logPath, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .map(l => JSON.parse(l));
+
+    // Count entries mentioning the id_ed25519 path. After dedup we expect
+    // exactly ONE (the sensitive entry) — the main-pass duplicate is
+    // removed in the Set dedup.
+    const hits = entries.filter(e =>
+      (e.violatingPaths as string[]).some(p => p.endsWith('/id_ed25519')),
+    );
+    expect(hits.length).toBe(1);
+    expect(hits[0].source).toBe('layer3-sensitive');
+  });
+});
+
+describeOnPosix('recordLayer3Violations — source discriminator + signal emission', () => {
+  let fakeHome: string;
+  let projectRoot: string;
+  let scanRoot: string;
+
+  beforeEach(() => {
+    fakeHome = mkTmp('gossip-l3-home-');
+    projectRoot = mkTmp();
+    scanRoot = mkTmp('gossip-l3-scan-');
+    fakeHomeHolder.value = fakeHome;
+  });
+
+  afterEach(() => {
+    fakeHomeHolder.value = null;
+    rmSync(fakeHome, { recursive: true, force: true });
+    rmSync(projectRoot, { recursive: true, force: true });
+    rmSync(scanRoot, { recursive: true, force: true });
+  });
+
+  itOnPosix('sensitive-pass hit: JSONL entry has source=layer3-sensitive AND appendSignals fires', () => {
+    // Arrange: sensitive file under fake $HOME.
+    mkdirSync(join(fakeHome, '.aws'), { recursive: true });
+    writeFileSync(join(fakeHome, '.aws', 'credentials'), 'secret');
+
+    const sentinel = stampTaskSentinel(projectRoot, 'sig-test')!;
+    backdateSentinel(sentinel, 5000);
+    const meta: DispatchMetadata = {
+      taskId: 'sig-test',
+      agentId: 'opus-implementer',
+      writeMode: 'worktree',
+      timestamp: Date.now(),
+      sentinelPath: sentinel,
+    };
+    auditFilesystemSinceSentinel(projectRoot, meta, {
+      scanRoots: [scanRoot], // main pass finds nothing — only sensitive pass hits
+      logFailures: false,
+    });
+
+    // JSONL assertion.
+    const logPath = join(projectRoot, '.gossip', 'boundary-escapes.jsonl');
+    expect(existsSync(logPath)).toBe(true);
+    const entries = readFileSync(logPath, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .map(l => JSON.parse(l));
+    const sensitiveEntries = entries.filter(e => e.source === 'layer3-sensitive');
+    expect(sensitiveEntries.length).toBeGreaterThanOrEqual(1);
+    expect(sensitiveEntries.some(e =>
+      (e.violatingPaths as string[]).some(p => p.endsWith('/credentials')),
+    )).toBe(true);
+
+    // Signal assertion: PerformanceWriter writes to .gossip/performance.jsonl.
+    // We decide ONCE-PER-DISPATCH (not per-violation) — evidence string
+    // lists up to 10 paths; one dispatch = one signal line regardless of
+    // how many sensitive files the agent touched.
+    const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+    expect(existsSync(perfPath)).toBe(true);
+    const perfEntries = readFileSync(perfPath, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .map(l => JSON.parse(l));
+    const disagreement = perfEntries.find(e =>
+      e.type === 'consensus' &&
+      e.signal === 'disagreement' &&
+      e.category === 'trust_boundaries' &&
+      e.taskId === 'sig-test',
+    );
+    expect(disagreement).toBeDefined();
+    expect(disagreement.agentId).toBe('opus-implementer');
+    expect(disagreement.evidence).toContain('Sensitive-target exfiltration');
+    expect(disagreement.evidence).toContain('credentials');
+  });
+
+  itOnPosix('main-pass hit: JSONL entry has source=layer3-main AND appendSignals does NOT fire', () => {
+    // Arrange: file only in scanRoot (main pass hit), NO sensitive target touched.
+    writeFileSync(join(scanRoot, 'bypass.txt'), 'leaked');
+
+    const sentinel = stampTaskSentinel(projectRoot, 'main-only')!;
+    backdateSentinel(sentinel, 5000);
+    const meta: DispatchMetadata = {
+      taskId: 'main-only',
+      agentId: 'opus-implementer',
+      writeMode: 'worktree',
+      timestamp: Date.now(),
+      sentinelPath: sentinel,
+    };
+    auditFilesystemSinceSentinel(projectRoot, meta, {
+      scanRoots: [scanRoot],
+      logFailures: false,
+    });
+
+    // JSONL must have a layer3-main entry.
+    const logPath = join(projectRoot, '.gossip', 'boundary-escapes.jsonl');
+    const entries = readFileSync(logPath, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .map(l => JSON.parse(l));
+    const mainEntries = entries.filter(e => e.source === 'layer3-main');
+    expect(mainEntries.some(e =>
+      (e.violatingPaths as string[]).some(p => p.endsWith('/bypass.txt')),
+    )).toBe(true);
+    // No sensitive entries — nothing in the watchlist was touched.
+    expect(entries.some(e => e.source === 'layer3-sensitive')).toBe(false);
+
+    // Signal: PerformanceWriter MUST NOT have fired for main-pass hits
+    // (PR1 behavior preserved). performance.jsonl must either not exist OR
+    // contain no disagreement for this taskId.
+    const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+    if (existsSync(perfPath)) {
+      const perfEntries = readFileSync(perfPath, 'utf-8')
+        .split('\n')
+        .filter(Boolean)
+        .map(l => JSON.parse(l));
+      const fromThisTask = perfEntries.filter(e =>
+        e.taskId === 'main-only' && e.signal === 'disagreement',
+      );
+      expect(fromThisTask.length).toBe(0);
+    }
+  });
+});
+
+describeOnPosix('auditFilesystemSinceSentinel — /etc/passwd detection (canonicalize assertion)', () => {
+  itOnPosix('/etc/passwd write is reported in SOME stable form (handles macOS /private/etc)', () => {
+    // We can't actually write to /etc/passwd in a test — it's system-owned.
+    // Instead, shim `find` so it reports /etc/passwd as a hit when the
+    // sensitive pass queries it.
+    const projectRoot = mkTmp();
+    const binDir = mkTmp('gossip-l3-bin-');
+    const shim = join(binDir, 'etc-shim-find');
+    try {
+      // Shim: if first arg is /etc/passwd, emit /etc/passwd and exit 0.
+      // For every other invocation (including main pass and other
+      // sensitive targets), exit 0 silently.
+      writeFileSync(
+        shim,
+        `#!/bin/sh\n` +
+          `if [ "$1" = "/etc/passwd" ] || [ "$1" = "/private/etc/passwd" ]; then\n` +
+          `  echo "$1"\n` +
+          `fi\n` +
+          `exit 0\n`,
+      );
+      chmodSync(shim, 0o755);
+
+      const sentinel = stampTaskSentinel(projectRoot, 'etc-test')!;
+      backdateSentinel(sentinel, 5000);
+      const meta: DispatchMetadata = {
+        taskId: 'etc-test',
+        agentId: 'opus-implementer',
+        writeMode: 'worktree',
+        timestamp: Date.now(),
+        sentinelPath: sentinel,
+      };
+
+      // Also point scanRoots to a tmp dir so main pass has nothing to find.
+      const emptyScan = mkTmp('gossip-l3-empty-');
+      const res = auditFilesystemSinceSentinel(projectRoot, meta, {
+        scanRoots: [emptyScan],
+        findBinary: shim,
+        logFailures: false,
+      });
+
+      // /etc/passwd must be in violations in SOME form — either /etc/passwd
+      // or /private/etc/passwd (macOS realpath). Canonicalize for assertion.
+      const hasEtcPasswd = res.violations.some(v =>
+        v === '/etc/passwd' || v === '/private/etc/passwd',
+      );
+      expect(hasEtcPasswd).toBe(true);
+
+      rmSync(emptyScan, { recursive: true, force: true });
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describeOnPosix('buildSensitiveTargets — macOS LaunchAgents detection', () => {
+  let fakeHome: string;
+  let projectRoot: string;
+  let scanRoot: string;
+
+  beforeEach(() => {
+    fakeHome = mkTmp('gossip-l3-home-');
+    projectRoot = mkTmp();
+    scanRoot = mkTmp('gossip-l3-scan-');
+    fakeHomeHolder.value = fakeHome;
+  });
+
+  afterEach(() => {
+    fakeHomeHolder.value = null;
+    rmSync(fakeHome, { recursive: true, force: true });
+    rmSync(projectRoot, { recursive: true, force: true });
+    rmSync(scanRoot, { recursive: true, force: true });
+  });
+
+  itOnPosix('on macOS: detects ~/Library/LaunchAgents/evil.plist write', () => {
+    if (process.platform !== 'darwin') {
+      // Skip on non-darwin; watchlist doesn't include LaunchAgents there.
+      return;
+    }
+    const laDir = join(fakeHome, 'Library', 'LaunchAgents');
+    mkdirSync(laDir, { recursive: true });
+    writeFileSync(join(laDir, 'evil.plist'), '<plist/>');
+
+    const sentinel = stampTaskSentinel(projectRoot, 'la-test')!;
+    backdateSentinel(sentinel, 5000);
+    const meta: DispatchMetadata = {
+      taskId: 'la-test',
+      agentId: 'opus-implementer',
+      writeMode: 'worktree',
+      timestamp: Date.now(),
+      sentinelPath: sentinel,
+    };
+    const res = auditFilesystemSinceSentinel(projectRoot, meta, {
+      scanRoots: [scanRoot],
+      logFailures: false,
+    });
+
+    expect(res.violations.some(v => v.endsWith('/evil.plist'))).toBe(true);
+  });
+});

--- a/tests/cli/worktree-audit-layer3.test.ts
+++ b/tests/cli/worktree-audit-layer3.test.ts
@@ -730,9 +730,15 @@ describeOnPosix('auditFilesystemSinceSentinel — user-level OS/app dir exclusio
     }
   });
 
-  itOnPosix('end-to-end arg shape has exactly one ( ) -prune -o group', () => {
+  itOnPosix('end-to-end arg shape has exactly one ( ) -prune -o group (main pass)', () => {
     // Guards against duplicate grouping (e.g. one -prune group per scan root
     // inside a loop). The per-root build emits exactly ONE group.
+    //
+    // NOTE PR2: the shim is also invoked by the sensitive-targets pass for
+    // any watchlist path that exists on the host. Their args get appended
+    // to the same log. We slice to the FIRST invocation (main pass) by
+    // locating the scanRoot marker — subsequent invocations start with a
+    // different first-arg (the sensitive target path).
     const projectRoot = mkTmp();
     const scanRoot = mkTmp('gossip-l3-scan-');
     const binDir = mkTmp('gossip-l3-bin-');
@@ -760,12 +766,19 @@ describeOnPosix('auditFilesystemSinceSentinel — user-level OS/app dir exclusio
         logFailures: false,
       });
 
-      const args = readFileSync(argLog, 'utf-8').split('\n').filter(Boolean);
+      const allArgs = readFileSync(argLog, 'utf-8').split('\n').filter(Boolean);
 
-      // Only ONE '(' and ONE ')' — no nested grouping.
+      // Isolate the first invocation (main pass). Each invocation's argv
+      // ends with '-print'; subsequent invocations start with a different
+      // first token. Slice up through the first '-print'.
+      const firstPrintIdx = allArgs.indexOf('-print');
+      expect(firstPrintIdx).toBeGreaterThan(-1);
+      const args = allArgs.slice(0, firstPrintIdx + 1);
+
+      // Only ONE '(' and ONE ')' in the main-pass invocation.
       expect(args.filter(a => a === '(').length).toBe(1);
       expect(args.filter(a => a === ')').length).toBe(1);
-      // Only ONE -prune, one -print.
+      // Only ONE -prune, one -print in the main-pass invocation.
       expect(args.filter(a => a === '-prune').length).toBe(1);
       expect(args.filter(a => a === '-print').length).toBe(1);
       // -type f -newer <sentinel> comes AFTER the `-prune -o` pair, never
@@ -919,7 +932,9 @@ describeOnPosix('auditFilesystemSinceSentinel — boundary-escapes.jsonl logging
       for (const entry of parsed) {
         expect(entry.taskId).toBe('logged');
         expect(entry.agentId).toBe('opus-implementer');
-        expect(entry.source).toBe('layer3-audit');
+        // PR2 renamed source: 'layer3-audit' → 'layer3-main' to distinguish
+        // from the new 'layer3-sensitive' pass.
+        expect(entry.source).toBe('layer3-main');
         // F6: shape matches Layer 2's violatingPaths array — 1 element per line.
         expect(Array.isArray(entry.violatingPaths)).toBe(true);
         expect(entry.violatingPaths.length).toBe(1);


### PR DESCRIPTION
## Summary
- Stacked on #115 (PR1). Adds a **zero-noise-exclusion second pass** over a sparse, vetted watchlist to restore coverage of exfiltration/persistence vectors PR1 temporarily regressed.
- Sensitive-pass hits emit a `disagreement` signal under `trust_boundaries` (retractable via `gossip_signals action:"retract"`). Main pass stays JSONL-only.
- SCOPE_NOTE text restored to accurately describe sensitive-path signal emission.

## Locked design (consensus round `2a95bc50-ad534229` + user Q&A)

| # | Decision |
|---|----------|
| 1 | `~/.claude` scoped to `settings.json` + `credentials.json` only — `plugins/caches/projects` are harness churn |
| 2 | `~/.ssh` include-list via `-name`: `id_*`, `*.key`, `*.pem`, `authorized_keys`, `config` — skips `known_hosts` |
| 3 | Universal watchlist: `~/.aws/{credentials,config}`, `~/.gnupg/**`, `~/.git-credentials`, `~/.netrc`, `~/.config/gh/hosts.yml`, `~/.docker/config.json`, `~/.kube/config`, `~/.pgpass`, `~/.my.cnf`, `/etc/{passwd,shadow}` |
| 4 | macOS-only: `~/Library/LaunchAgents/*.plist` (guarded by `process.platform === 'darwin'`) |
| 5 | Signal emission: `PerformanceWriter.appendSignals` once per dispatch, up to 10 paths in evidence |
| 6 | Browser cookies + 1Password **skipped** (Chrome FP during user browsing; denylist-grows pattern) |

## Implementation notes
- `buildSensitiveTargets(platform)` — resolves `homedir()`, applies OS branch, null-safe
- `buildSensitiveFindArgs()` — `find` argv with optional `-name` include-list + sentinel-dir carve-out (zero-exclusion ≠ zero carve-outs)
- `auditFilesystemSinceSentinel` — two-pass; violations collected into `Set<string>` of canonicalized paths (sensitive wins on collision)
- `recordLayer3Violations(..., source: Layer3Source)` — `'layer3-main' | 'layer3-sensitive'`; `appendSignals` fires only on `'layer3-sensitive'`
- `expandTmpVariants` extended for `/etc ↔ /private/etc` and `/var ↔ /private/var` (macOS SIP symlinks)
- Sensitive-pass `find` permission-error stderr warning suppressed to avoid training users to ignore it

## Breaking-ish change
**JSONL `source` field rename** in `.gossip/boundary-escapes.jsonl`: `'layer3-audit'` → `'layer3-main'`. Grep confirmed no production consumers of the old string; if any external tooling parses the file, they need to update.

## Test plan
- [x] `npx tsc --noEmit -p apps/cli && npx tsc --noEmit -p packages/orchestrator` — clean
- [x] `npx jest tests/cli/worktree-audit-layer3` — **47/47 pass** (PR1 suite preserved)
- [x] `npx jest tests/cli/worktree-audit-layer3-sensitive` — **25/25 pass** (new)
- [x] `npx jest tests/cli/` — **379/379 pass**
- [x] Full suite — **1800 pass / 1 skip** (unchanged from PR1 baseline)
- [ ] Manual smoke: dispatch a worktree-isolated agent, write to `~/.ssh/id_rsa` (test account), confirm `disagreement` signal appears in `.gossip/agent-performance.jsonl` with `source: 'layer3-sensitive'`

## Stacked PR notes
- Base: `fix/issue-113-pr1-drop-home-scan` (#115). Merges **after** PR1 lands.
- Once #115 merges to master, GitHub will auto-rebase this PR's base to master.