### PR TITLE
feat(memory): propagate status frontmatter convention — per-session + setup-time

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1925,6 +1925,21 @@ server.tool(
       process.stderr.write(`[gossipcat] gossip_setup: sandbox hook install failed: ${e}\n`);
     }
 
+    // Memory hygiene CLAUDE.md seeding — spec 2026-04-17-memory-hygiene-propagation.
+    // Idempotent: appends convention block if CLAUDE.md exists but lacks the heading;
+    // no-ops if heading present; skips silently if CLAUDE.md missing.
+    try {
+      const { seedMemoryHygiene } = require('@gossip/orchestrator') as typeof import('@gossip/orchestrator');
+      const seedResult = seedMemoryHygiene(root);
+      const msg = seedResult.action === 'appended' ? 'appended'
+        : seedResult.action === 'already-present' ? 'already present'
+        : seedResult.action === 'skipped-no-claude-md' ? 'skipped (no CLAUDE.md)'
+        : `error (${(seedResult as { error: string }).error})`;
+      process.stderr.write(`[gossipcat] gossip_setup: memory hygiene — ${msg}\n`);
+    } catch (e) {
+      process.stderr.write(`[gossipcat] gossip_setup: memory hygiene seed failed: ${(e as Error).message}\n`);
+    }
+
     // Refresh all runtime caches of .gossip/config.json state — dashboard,
     // ctx.nativeAgentConfigs, ctx.workers, and ctx.mainAgent registry — so
     // the new team is fully dispatchable without /mcp reconnect. PR #59

--- a/packages/orchestrator/src/bootstrap.ts
+++ b/packages/orchestrator/src/bootstrap.ts
@@ -213,6 +213,19 @@ To auto-allow writes, add to \`.claude/settings.local.json\`:
       ? `\n## Operating Rules\n\n${demote(rulesContent.trim())}\n`
       : '';
 
+    // Memory Hygiene Convention: injected every session so fresh users pick up the
+    // `status:` frontmatter convention without depending on a pre-seeded CLAUDE.md.
+    // See docs/specs/2026-04-17-memory-hygiene-propagation.md.
+    const memoryHygieneSection = `\n## Memory Hygiene Convention
+
+When saving a \`project_*\` memory, include a \`status\` frontmatter field:
+- \`status: open\` — active backlog, in-progress, or decision pending revisit
+- \`status: shipped\` — work has landed; reference only
+- \`status: closed\` — decided not to pursue; archive semantics
+
+Without it, the dashboard defaults to "backlog" and applies staleness verification conservatively.
+`;
+
     return `# Gossipcat — Multi-Agent Orchestration
 
 ## Your Role
@@ -227,7 +240,7 @@ You are the **orchestrator**, not an implementer. Your job is to dispatch tasks 
 - Change is under 10 lines with no side effects on shared state
 
 When in doubt, dispatch. The cost of a unnecessary dispatch is minutes; the cost of unreviewed code in shared state is bugs that pass all tests.
-${rulesSection}
+${rulesSection}${memoryHygieneSection}
 ## Your Team
 
 ${teamSection}

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -1,4 +1,6 @@
 export { MainAgent } from './main-agent';
+export { seedMemoryHygiene } from './memory-hygiene-seed';
+export type { MemoryHygieneSeedResult } from './memory-hygiene-seed';
 export { detectFormatCompliance } from './dispatch-pipeline';
 export { loadSkills, DEFAULT_KEYWORDS, resolveSkillExists } from './skill-loader';
 export type { LoadSkillsResult, DroppedSkill } from './skill-loader';

--- a/packages/orchestrator/src/memory-hygiene-seed.ts
+++ b/packages/orchestrator/src/memory-hygiene-seed.ts
@@ -1,0 +1,43 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+export type MemoryHygieneSeedResult =
+  | { action: 'appended' }
+  | { action: 'already-present' }
+  | { action: 'skipped-no-claude-md' }
+  | { action: 'error'; error: string };
+
+/**
+ * Idempotently seed the project CLAUDE.md with the gossipcat memory hygiene
+ * convention block. See docs/specs/2026-04-17-memory-hygiene-propagation.md.
+ *
+ * Behavior:
+ * - If CLAUDE.md does not exist: skip silently (do NOT create one).
+ * - If "## Memory hygiene" heading is already present (case-insensitive, line-start):
+ *   no-op.
+ * - Otherwise: append the canonical block.
+ */
+export function seedMemoryHygiene(projectRoot: string): MemoryHygieneSeedResult {
+  const claudeMdPath = join(projectRoot, 'CLAUDE.md');
+  try {
+    if (!existsSync(claudeMdPath)) {
+      return { action: 'skipped-no-claude-md' };
+    }
+    const existing = readFileSync(claudeMdPath, 'utf-8');
+    if (/^## memory hygiene/im.test(existing)) {
+      return { action: 'already-present' };
+    }
+    const block =
+      '\n## Memory hygiene (gossipcat convention)\n\n' +
+      'When saving a `project_*` memory, include a `status` field in the frontmatter:\n\n' +
+      '- `status: open` — active backlog item, work in progress, or decision pending revisit\n' +
+      '- `status: shipped` — the work it describes has landed; reference only\n' +
+      '- `status: closed` — decision was made not to pursue; archive semantics\n\n' +
+      'Without it, the dashboard defaults to "backlog" and applies staleness verification conservatively. See docs/specs/2026-04-17-memory-hygiene-propagation.md.\n';
+    const sep = existing.endsWith('\n') ? '' : '\n';
+    writeFileSync(claudeMdPath, existing + sep + block, 'utf-8');
+    return { action: 'appended' };
+  } catch (e) {
+    return { action: 'error', error: (e as Error).message };
+  }
+}

--- a/tests/orchestrator/bootstrap.test.ts
+++ b/tests/orchestrator/bootstrap.test.ts
@@ -57,6 +57,23 @@ describe('BootstrapGenerator', () => {
     });
   });
 
+  describe('memory hygiene convention', () => {
+    it('bootstrap output includes Memory Hygiene Convention heading in full tier', () => {
+      const dir = join(testDir, 'hygiene-full');
+      mkdirSync(join(dir, '.gossip'), { recursive: true });
+      writeFileSync(join(dir, '.gossip', 'config.json'), JSON.stringify({
+        main_agent: { provider: 'local', model: 'q' },
+        agents: { 'a1': { provider: 'local', model: 'q', skills: ['t'] } }
+      }));
+      const gen = new BootstrapGenerator(dir);
+      const result = gen.generate();
+      expect(result.prompt).toContain('## Memory Hygiene Convention');
+      expect(result.prompt).toContain('status: open');
+      expect(result.prompt).toContain('status: shipped');
+      expect(result.prompt).toContain('status: closed');
+    });
+  });
+
   describe('error handling', () => {
     it('falls back to no-config on malformed config JSON', () => {
       const dir = join(testDir, 'bad-json');

--- a/tests/orchestrator/memory-hygiene-seed.test.ts
+++ b/tests/orchestrator/memory-hygiene-seed.test.ts
@@ -1,0 +1,72 @@
+import { seedMemoryHygiene } from '@gossip/orchestrator';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('seedMemoryHygiene', () => {
+  const testDir = join(tmpdir(), `gossip-hygiene-seed-test-${Date.now()}`);
+  afterAll(() => { rmSync(testDir, { recursive: true, force: true }); });
+
+  it('skips silently when CLAUDE.md does not exist (does not create one)', () => {
+    const dir = join(testDir, 'no-claude-md');
+    mkdirSync(dir, { recursive: true });
+    const result = seedMemoryHygiene(dir);
+    expect(result.action).toBe('skipped-no-claude-md');
+    expect(existsSync(join(dir, 'CLAUDE.md'))).toBe(false);
+  });
+
+  it('appends hygiene block when heading is absent', () => {
+    const dir = join(testDir, 'append');
+    mkdirSync(dir, { recursive: true });
+    const original = '# My Project\n\nSome existing content.\n';
+    writeFileSync(join(dir, 'CLAUDE.md'), original, 'utf-8');
+
+    const result = seedMemoryHygiene(dir);
+    expect(result.action).toBe('appended');
+
+    const updated = readFileSync(join(dir, 'CLAUDE.md'), 'utf-8');
+    // Original content preserved
+    expect(updated.startsWith(original)).toBe(true);
+    // Canonical block appended
+    expect(updated).toContain('## Memory hygiene (gossipcat convention)');
+    expect(updated).toContain('status: open');
+    expect(updated).toContain('status: shipped');
+    expect(updated).toContain('status: closed');
+    expect(updated).toContain('docs/specs/2026-04-17-memory-hygiene-propagation.md');
+  });
+
+  it('is idempotent — re-running on seeded CLAUDE.md is a no-op', () => {
+    const dir = join(testDir, 'idempotent');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'CLAUDE.md'), '# Project\n', 'utf-8');
+
+    const first = seedMemoryHygiene(dir);
+    expect(first.action).toBe('appended');
+    const afterFirst = readFileSync(join(dir, 'CLAUDE.md'), 'utf-8');
+
+    const second = seedMemoryHygiene(dir);
+    expect(second.action).toBe('already-present');
+    const afterSecond = readFileSync(join(dir, 'CLAUDE.md'), 'utf-8');
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  it('detects existing heading case-insensitively', () => {
+    const dir = join(testDir, 'case-insensitive');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'CLAUDE.md'),
+      '# Project\n\n## MEMORY HYGIENE (custom form)\n\nUser wrote their own block.\n', 'utf-8');
+    const result = seedMemoryHygiene(dir);
+    expect(result.action).toBe('already-present');
+  });
+
+  it('handles CLAUDE.md without trailing newline (adds one before block)', () => {
+    const dir = join(testDir, 'no-trailing-newline');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'CLAUDE.md'), '# Project\n\nLast line, no newline', 'utf-8');
+    const result = seedMemoryHygiene(dir);
+    expect(result.action).toBe('appended');
+    const updated = readFileSync(join(dir, 'CLAUDE.md'), 'utf-8');
+    // Should insert a newline before the block so heading starts at column 0
+    expect(updated).toContain('no newline\n\n## Memory hygiene');
+  });
+});


### PR DESCRIPTION
## Summary
- Inject `## Memory Hygiene Convention` into `gossip_status()` bootstrap output every session — fresh users pick up the `status:` frontmatter convention without depending on a pre-seeded CLAUDE.md.
- Idempotent `seedMemoryHygiene()` helper appended to project CLAUDE.md on `gossip_setup` if heading absent; never creates a new CLAUDE.md.

Stacked on #119. Review after that merges.

## Why
Fresh gossipcat users on a new project never got the memory hygiene convention because it lived only in this repo's CLAUDE.md. Result: every `project_*.md` landed in Backlog with nothing flowing to Record. Haiku research (`bdc99a16`) empirically proved CC's auto-memory writer honors per-repo CLAUDE.md conventions (100% `status:` adoption post-convention, 0% pre), so injecting the convention at both in-session and setup-time layers makes it stick.

## Changes
| File | Lines | Purpose |
|---|---|---|
| `packages/orchestrator/src/bootstrap.ts` | +12 | New `## Memory Hygiene Convention` section injected after Operating Rules |
| `packages/orchestrator/src/memory-hygiene-seed.ts` | +44 new | Idempotent CLAUDE.md seeder, tagged-union result |
| `packages/orchestrator/src/index.ts` | +1 | Export |
| `apps/cli/src/mcp-server-sdk.ts` | +13 | `gossip_setup` invokes seeder, stderr log |
| `tests/orchestrator/memory-hygiene-seed.test.ts` | +73 new | 5 cases: skipped / append / idempotent / case-insensitive / no-trailing-newline |
| `tests/orchestrator/bootstrap.test.ts` | +16 | Bootstrap output contains heading + all three status values |

## What stays untouched (per spec non-goals)
- Writer pipeline — no new writes to `.gossip/memory/` or `~/.claude/projects/`
- Taxonomy mapper
- Native store
- No automated `status: shipped` transitions (deferred — would need spec invariant #5 retraction or `.gossip/backlog-status.jsonl` overlay)

## Test plan
- [x] `npm test` — 138 suites / 1820 passed (+6 new)
- [x] `tsc -b` clean
- [ ] Manual: fresh `gossip_setup` on a project with existing CLAUDE.md without hygiene heading — verify block appended with one stderr line
- [ ] Manual: re-run `gossip_setup` on same project — verify `already present` log, no duplicate block

## Research trail
- Spec: `docs/specs/2026-04-17-memory-hygiene-propagation.md` (in #119)
- Haiku: dispatch `bdc99a16` — CC honors CLAUDE.md conventions
- Sonnet: dispatch `63a2a6ec` — native-store write ruled out by spec invariant #5
- Gemini: dispatch `5574b79f` — fresh-user dashboard shows 3/4 folders populated day 1 without this change; Record stays empty until hygiene ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)