### PR TITLE
fix(dashboard): surface agent-sync result in gossip_setup, reduce poll to 5s (#96)

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -50,7 +50,7 @@ export function loadConfig(configPath: string): GossipConfig {
   try {
     parsed = JSON.parse(raw);
   } catch {
-    throw new Error(`Failed to parse config at ${configPath}. Use JSON format for gossip.agents.json.`);
+    throw new Error(`Failed to parse config at ${configPath}. The gossipcat config file must be valid JSON (tried .gossip/config.json and gossip.agents.json legacy path).`);
   }
 
   return validateConfig(parsed);

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -89,6 +89,22 @@ export interface McpContext {
   /** Source of the HTTP MCP port. */
   httpMcpPortSource: 'env' | 'sticky' | 'auto' | null;
   booted: boolean;
+  /**
+   * True when `doBoot()` ran without a config file and synthesized an empty
+   * one (fresh-install / degraded-mode). The dashboard boots with 0 agents
+   * in this case — subsequent gossip_setup calls refresh it via
+   * ctx.relay.setAgentConfigs, but the dashboard poll interval (5s) still
+   * imposes a small latency. Used to surface a user-visible advisory in
+   * the gossip_setup response (issue #96).
+   */
+  bootedInDegradedMode: boolean;
+  /**
+   * Result of the last syncWorkersViaKeychain() call. Lets callers (e.g.
+   * gossip_setup) surface agent-count / error info to the user without
+   * having to reach into syncWorkers internals. Issue #96 — dashboard
+   * empty-agent-list on fresh install.
+   */
+  lastSyncResult: { ok: boolean; mergedAgentCount: number; error?: string } | null;
   boot: () => Promise<void>;
   syncWorkersViaKeychain: () => Promise<void>;
   getModules: () => Promise<any>;
@@ -115,6 +131,8 @@ export const ctx: McpContext = {
   relayPortSource: null,
   httpMcpPortSource: null,
   booted: false,
+  bootedInDegradedMode: false,
+  lastSyncResult: null,
   boot: async () => { throw new Error('boot not initialized'); },
   syncWorkersViaKeychain: async () => {},
   getModules: async () => { throw new Error('getModules not initialized'); },

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -34,6 +34,7 @@ import { handleCollect } from './handlers/collect';
 import { restorePendingConsensus } from './handlers/relay-cross-review';
 import { persistRelayTasks, restoreRelayTasksAsFailed } from './handlers/relay-tasks';
 import { pickStickyPort, writeStickyPort, RELAY_STICKY_FILE, HTTP_MCP_STICKY_FILE } from './stickyPort';
+import { buildDashboardAdvisory } from './setup-response';
 
 // ── Environment detection ────────────────────────────────────────────────
 
@@ -374,6 +375,7 @@ async function doBoot() {
     // primary path so "No config found" error messages match what users see
     // when they inspect the project directory.
     process.stderr.write('[gossipcat] ⚠️  No .gossip/config.json found — booting in degraded mode (dashboard + relay only). Run gossip_setup inside Claude Code to create your agent team.\n');
+    ctx.bootedInDegradedMode = true;
     config = {
       main_agent: { provider: 'none', model: 'none' },
       utility_model: { provider: 'none', model: 'none' },
@@ -997,9 +999,17 @@ async function doSyncWorkers() {
     try {
       const merged = [...agentConfigs, ...claudeSubagentsToConfigs(claudeSubagents)];
       ctx.relay?.setAgentConfigs(merged);
-    } catch { /* dashboard refresh is best-effort */ }
+      ctx.lastSyncResult = { ok: true, mergedAgentCount: merged.length };
+    } catch (e) {
+      // Dashboard refresh is best-effort, but record the failure so
+      // gossip_setup can surface it instead of the user seeing an empty
+      // dashboard with no explanation. Issue #96.
+      ctx.lastSyncResult = { ok: false, mergedAgentCount: 0, error: (e as Error).message };
+    }
   } catch (err) {
-    process.stderr.write(`[gossipcat] ❌ syncWorkers failed: ${(err as Error).message}\n`);
+    const msg = (err as Error).message;
+    process.stderr.write(`[gossipcat] ❌ syncWorkers failed: ${msg}\n`);
+    ctx.lastSyncResult = { ok: false, mergedAgentCount: 0, error: msg };
   }
 }
 
@@ -1949,10 +1959,19 @@ server.tool(
     // pushes to the dashboard at its tail, so one call refreshes everything.
     // Only fires on create modes (merge/replace); update_instructions
     // returns earlier at :1504.
+    // Reset the sync-result marker so stale data from a prior setup call
+    // can't leak into this response's advisory (issue #96).
+    ctx.lastSyncResult = null;
     try {
       await syncWorkersViaKeychain();
     } catch (e) {
-      process.stderr.write(`[gossipcat] gossip_setup: failed to refresh agent state: ${e}\n`);
+      const msg = (e as Error).message ?? String(e);
+      process.stderr.write(`[gossipcat] gossip_setup: failed to refresh agent state: ${msg}\n`);
+      // Record the failure for the advisory below, in case syncWorkers itself
+      // didn't reach its own result-write (e.g. the call threw synchronously).
+      if (!ctx.lastSyncResult) {
+        ctx.lastSyncResult = { ok: false, mergedAgentCount: 0, error: msg };
+      }
     }
 
     // Generate host-appropriate rules file so the IDE knows about the team
@@ -1990,6 +2009,16 @@ server.tool(
     if (nativeCreated.length > 0) {
       lines.push(`\nTip: Native agents may prompt for file write permissions. To auto-allow, add to .claude/settings.local.json:`);
       lines.push(`  { "permissions": { "allow": ["Edit", "Write"] } }`);
+    }
+
+    // Dashboard refresh advisory — see setup-response.ts for rationale (issue #96).
+    const advisory = buildDashboardAdvisory({
+      syncResult: ctx.lastSyncResult,
+      bootedInDegradedMode: ctx.bootedInDegradedMode,
+    });
+    if (advisory.length > 0) {
+      lines.push('');
+      lines.push(...advisory);
     }
 
     return { content: [{ type: 'text' as const, text: lines.join('\n') }] };

--- a/apps/cli/src/setup-response.ts
+++ b/apps/cli/src/setup-response.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure helpers for building the user-facing gossip_setup response. Extracted
+ * so the dashboard-refresh advisory (issue #96) can be unit-tested without
+ * booting the entire MCP server.
+ *
+ * The advisory covers three observable failure modes from issue #96:
+ *  1. setAgentConfigs throwing (syncResult.ok === false) → user sees empty
+ *     dashboard but gets no feedback in the gossip_setup response.
+ *  2. Degraded-mode boot (no config at boot time) → dashboard was initialized
+ *     with 0 agents and needs the next poll tick to pick up new ones.
+ *  3. Success case → show the agent count so the user has a confirmation
+ *     anchor when cross-referencing with the Team page.
+ */
+
+export interface SyncResultSummary {
+  ok: boolean;
+  mergedAgentCount: number;
+  error?: string;
+}
+
+export interface DashboardAdvisoryInput {
+  syncResult: SyncResultSummary | null;
+  bootedInDegradedMode: boolean;
+}
+
+/**
+ * Build the dashboard-refresh advisory lines appended to the gossip_setup
+ * response. Returns an array of lines (possibly empty). Callers prepend a
+ * blank line themselves — keeps this helper free of formatting coupling.
+ */
+export function buildDashboardAdvisory(input: DashboardAdvisoryInput): string[] {
+  const { syncResult, bootedInDegradedMode } = input;
+  const out: string[] = [];
+
+  if (!syncResult) {
+    // syncWorkersViaKeychain never populated lastSyncResult — either it threw
+    // before reaching the result-write, or the caller skipped the sync path.
+    out.push('⚠ Dashboard refresh status unknown. Run `/mcp` reconnect to see agents.');
+    return out;
+  }
+
+  if (syncResult.ok) {
+    out.push(`Dashboard: refreshed with ${syncResult.mergedAgentCount} agent${syncResult.mergedAgentCount === 1 ? '' : 's'}.`);
+  } else {
+    const reason = syncResult.error ? `: ${syncResult.error}` : '';
+    out.push(`⚠ Dashboard refresh failed${reason}. Run \`/mcp\` reconnect to see agents.`);
+  }
+
+  if (bootedInDegradedMode) {
+    out.push('Note: dashboard may take up to 10s to reflect new agents (relay booted before config existed). If it stays empty, `/mcp` reconnect populates it.');
+  }
+
+  return out;
+}

--- a/packages/dashboard-v2/src/hooks/useDashboardData.ts
+++ b/packages/dashboard-v2/src/hooks/useDashboardData.ts
@@ -6,9 +6,11 @@ import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReport
  * Polling interval for /api/agents and friends. Backs the "Team page updates
  * after gossip_setup without a full page reload" contract:
  * setAgentConfigs (server.ts:455) pushes new configs into ctx, but the SPA
- * needs to actually fetch them. 10s balances freshness vs request volume.
+ * needs to actually fetch them. 5s balances freshness vs request volume —
+ * dropped from 10s as part of issue #96 so fresh-install users don't stare
+ * at an empty Team page for up to 10 seconds after running gossip_setup.
  */
-const REFRESH_INTERVAL_MS = 10_000;
+const REFRESH_INTERVAL_MS = 5_000;
 
 interface MemoryApiResponse { knowledge: MemoryFile[] }
 

--- a/tests/cli/setup-response.test.ts
+++ b/tests/cli/setup-response.test.ts
@@ -1,0 +1,67 @@
+import { buildDashboardAdvisory } from '../../apps/cli/src/setup-response';
+
+describe('buildDashboardAdvisory (issue #96)', () => {
+  it('reports refreshed agent count on success', () => {
+    const out = buildDashboardAdvisory({
+      syncResult: { ok: true, mergedAgentCount: 4 },
+      bootedInDegradedMode: false,
+    });
+    expect(out).toEqual(['Dashboard: refreshed with 4 agents.']);
+  });
+
+  it('uses singular "agent" when count is exactly 1', () => {
+    const out = buildDashboardAdvisory({
+      syncResult: { ok: true, mergedAgentCount: 1 },
+      bootedInDegradedMode: false,
+    });
+    expect(out[0]).toBe('Dashboard: refreshed with 1 agent.');
+  });
+
+  it('surfaces the sync error message when refresh fails', () => {
+    const out = buildDashboardAdvisory({
+      syncResult: { ok: false, mergedAgentCount: 0, error: 'setAgentConfigs is not a function' },
+      bootedInDegradedMode: false,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain('Dashboard refresh failed');
+    expect(out[0]).toContain('setAgentConfigs is not a function');
+    expect(out[0]).toContain('/mcp');
+  });
+
+  it('falls back to a generic failure message when no error text is provided', () => {
+    const out = buildDashboardAdvisory({
+      syncResult: { ok: false, mergedAgentCount: 0 },
+      bootedInDegradedMode: false,
+    });
+    expect(out[0]).toBe('⚠ Dashboard refresh failed. Run `/mcp` reconnect to see agents.');
+  });
+
+  it('appends a degraded-mode note when ctx.bootedInDegradedMode is true', () => {
+    const out = buildDashboardAdvisory({
+      syncResult: { ok: true, mergedAgentCount: 3 },
+      bootedInDegradedMode: true,
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0]).toContain('refreshed with 3 agents');
+    expect(out[1]).toContain('relay booted before config existed');
+    expect(out[1]).toContain('/mcp');
+  });
+
+  it('combines failure + degraded-mode note when both apply', () => {
+    const out = buildDashboardAdvisory({
+      syncResult: { ok: false, mergedAgentCount: 0, error: 'boom' },
+      bootedInDegradedMode: true,
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0]).toContain('Dashboard refresh failed: boom');
+    expect(out[1]).toContain('relay booted before config existed');
+  });
+
+  it('emits an unknown-status advisory when syncResult is null', () => {
+    const out = buildDashboardAdvisory({
+      syncResult: null,
+      bootedInDegradedMode: false,
+    });
+    expect(out).toEqual(['⚠ Dashboard refresh status unknown. Run `/mcp` reconnect to see agents.']);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the user-reported case where the dashboard stayed empty after `gossip_setup` ran on a relay that had booted without `.gossip/config.json`.
- Root cause: a silent `try {} catch {}` at the tail of `doSyncWorkers` wrapping `ctx.relay.setAgentConfigs(...)` — any failure vanished, leaving `DashboardRouter.ctx.agentConfigs` empty and the user with no signal.
- Fix: thread the sync result back into `ctx.lastSyncResult`, surface it in the `gossip_setup` response via a new `buildDashboardAdvisory()` helper (success/failure/degraded-mode hint), and halve the dashboard poll interval.

Closes #96.

## Changes
| File | Purpose |
|---|---|
| `apps/cli/src/mcp-server-sdk.ts:997-1013,377,1961-1977,2013-2021` | Record `{ok, mergedAgentCount, error}` at `doSyncWorkers` tail; set `bootedInDegradedMode=true` on no-config boot; append advisory to `gossip_setup` response |
| `apps/cli/src/mcp-context.ts:91-123` | Add `bootedInDegradedMode`, `lastSyncResult` fields with defaults |
| `apps/cli/src/setup-response.ts` (new, 55 LOC) | Pure `buildDashboardAdvisory({ syncResult, bootedInDegradedMode })` helper |
| `apps/cli/src/config.ts:53` | Error message now names both `.gossip/config.json` (primary) and `gossip.agents.json` (legacy) |
| `packages/dashboard-v2/src/hooks/useDashboardData.ts:11` | Poll interval 10s → 5s |
| `tests/cli/setup-response.test.ts` (new, 7 cases) | Coverage: success singular/plural, failure with/without error text, null fallback, degraded+success, degraded+failure |

## Untouched (per scope)
- Relay boot flow
- DashboardRouter internals
- `syncWorkersViaKeychain` core logic (only tail writeback added)
- No WebSocket delta-push layer (kept polling)

## Test plan
- [x] `npm test` — 142 suites / 1847 passed (+7 new), 0 failed
- [x] `tsc -b packages/orchestrator apps/cli` clean
- [ ] Manual: delete `.gossip/config.json`, `/mcp` reconnect to trigger degraded boot, run `gossip_setup` with 3 native agents. Verify response includes "Dashboard: refreshed with 3 agents" and the degraded-boot note. Then open the dashboard — agents appear within 5s.
- [ ] Manual: simulate sync failure — verify response surfaces the error and suggests `/mcp` reconnect

## Research trail
- Research dispatch `ad69ed30` (haiku) — mapped the propagation chain and identified the three observable gaps
- Issue: https://github.com/gossipcat-ai/gossipcat-ai/issues/96

🤖 Generated with [Claude Code](https://claude.com/claude-code)