### PR TITLE
feat(dashboard): auto-benching v2 badges

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -18,6 +18,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import { useDashboardData } from '@/hooks/useDashboardData';
 import { timeAgo, cleanFindingTags } from '@/lib/utils';
+import { getBenchBadgeKind, needsAttention } from '@/lib/bench';
 import type { DashboardEvent, AgentData } from '@/lib/types';
 
 type SortKey = 'weight' | 'accuracy' | 'uniqueness' | 'impact' | 'signals' | 'agreements' | 'hallucinations' | 'lastTask';
@@ -39,7 +40,7 @@ function TeamPage({ agents, tasks }: { agents: AgentData[]; tasks: import('@/lib
     return m;
   }, [tasks]);
 
-  const circuitOpen = agents.filter((a) => a.scores.circuitOpen).length;
+  const circuitOpen = agents.filter(needsAttention).length;
   const healthy = agents.filter((a) => a.scores.accuracy >= 0.5).length;
   const totalSignals = agents.reduce((acc, a) => acc + a.scores.signals, 0);
   const totalTokens = agents.reduce((acc, a) => acc + a.totalTokens, 0);
@@ -199,12 +200,28 @@ function TeamPage({ agents, tasks }: { agents: AgentData[]; tasks: import('@/lib
                       <div className="min-w-0">
                         <div className="flex items-center gap-1.5">
                           <span className="truncate font-mono text-xs font-semibold text-foreground group-hover:text-primary">{agent.id}</span>
-                          {s.circuitOpen && (
-                            <span
-                              className="shrink-0 rounded bg-destructive/15 px-1 font-mono text-[8px] font-bold uppercase tracking-wider text-destructive"
-                              data-tooltip="Benched: too many consecutive failures. Deprioritized until new clean signals recover the score."
-                            >benched</span>
-                          )}
+                          {(() => {
+                            const kind = getBenchBadgeKind(s);
+                            if (kind === 'benched') return (
+                              <span
+                                className="shrink-0 rounded bg-destructive/15 px-1 font-mono text-[8px] font-bold uppercase tracking-wider text-destructive"
+                                data-tooltip={`Benched (${s.bench.reason ?? 'auto'}). Excluded from dispatch until recovery.`}
+                              >benched</span>
+                            );
+                            if (kind === 'struggling') return (
+                              <span
+                                className="shrink-0 rounded bg-unverified/15 px-1 font-mono text-[8px] font-bold uppercase tracking-wider text-unverified"
+                                data-tooltip="Struggling: consecutive failures tripped the circuit breaker. Deprioritized until new clean signals recover the score."
+                              >struggling</span>
+                            );
+                            if (kind === 'kept-for-coverage') return (
+                              <span
+                                className="shrink-0 rounded border border-unverified/40 px-1 font-mono text-[8px] font-bold uppercase tracking-wider text-unverified"
+                                data-tooltip={`Would bench (${s.bench.reason ?? 'rule'}), but kept as sole provider of a category.`}
+                              >kept for coverage</span>
+                            );
+                            return null;
+                          })()}
                         </div>
                         <div className="truncate font-mono text-[10px] text-muted-foreground/50">
                           {agent.provider}/{agent.model}

--- a/packages/dashboard-v2/src/components/AgentCardBig.tsx
+++ b/packages/dashboard-v2/src/components/AgentCardBig.tsx
@@ -1,6 +1,7 @@
 import type { AgentData } from '@/lib/types';
 import { NeuralAvatar } from './NeuralAvatar';
 import { timeAgo } from '@/lib/utils';
+import { getBenchBadgeKind } from '@/lib/bench';
 
 interface AgentCardBigProps {
   agent: AgentData;
@@ -62,14 +63,34 @@ export function AgentCardBig({ agent }: AgentCardBigProps) {
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5">
             <span className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">{agent.id}</span>
-            {s.circuitOpen && (
-              <span
-                className="shrink-0 rounded-sm bg-destructive/10 px-1 py-0.5 font-mono text-[8px] font-bold text-destructive"
-                data-tooltip="Benched: too many consecutive failures. Deprioritized until new clean signals recover the score."
-              >
-                BENCHED
-              </span>
-            )}
+            {(() => {
+              const kind = getBenchBadgeKind(s);
+              if (kind === 'benched') return (
+                <span
+                  className="shrink-0 rounded-sm bg-destructive/10 px-1 py-0.5 font-mono text-[8px] font-bold text-destructive"
+                  data-tooltip={`Benched (${s.bench.reason ?? 'auto'}). Excluded from dispatch until recovery.`}
+                >
+                  BENCHED
+                </span>
+              );
+              if (kind === 'struggling') return (
+                <span
+                  className="shrink-0 rounded-sm bg-unverified/10 px-1 py-0.5 font-mono text-[8px] font-bold text-unverified"
+                  data-tooltip="Struggling: consecutive failures tripped the circuit breaker."
+                >
+                  STRUGGLING
+                </span>
+              );
+              if (kind === 'kept-for-coverage') return (
+                <span
+                  className="shrink-0 rounded-sm border border-unverified/40 px-1 py-0.5 font-mono text-[8px] font-bold text-unverified"
+                  data-tooltip={`Would bench (${s.bench.reason ?? 'rule'}), but kept as sole provider of a category.`}
+                >
+                  KEPT FOR COVERAGE
+                </span>
+              );
+              return null;
+            })()}
           </div>
           <div className="mt-1 flex items-center gap-2 font-inter text-[10px] text-muted-foreground/60">
             <span

--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -5,6 +5,7 @@ import { CategoryStrengths } from './CategoryStrengths';
 import { SignalTimeline } from './SignalTimeline';
 import { TaskRow } from './TaskRow';
 import { timeAgo, cleanFindingTags } from '@/lib/utils';
+import { getBenchBadgeKind } from '@/lib/bench';
 import { escapeHtml } from '@/lib/sanitize';
 import type { AgentData, TasksData, ConsensusData, ConsensusReport, ConsensusReportsData, MemoryData, MemoryFile, ParseDiagnostic } from '@/lib/types';
 
@@ -120,17 +121,41 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
 
   return (
     <>
-      {/* Circuit breaker warning */}
-      {s.circuitOpen && (
-        <div className="mb-6 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
-          <div className="flex items-center gap-2">
-            <span className="font-mono text-xs font-bold text-destructive">CIRCUIT OPEN</span>
-            <span className="text-xs text-destructive/70">
-              {s.consecutiveFailures}+ consecutive failures. Agent will be deprioritized until clean signals recorded.
-            </span>
+      {/* Bench / circuit breaker warning — three-state panel */}
+      {(() => {
+        const kind = getBenchBadgeKind(s);
+        if (kind === 'benched') return (
+          <div className="mb-6 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-xs font-bold text-destructive">BENCHED</span>
+              <span className="text-xs text-destructive/70">
+                Auto-bench rule fired ({s.bench.reason ?? 'unknown'}). Agent excluded from dispatch until scores recover.
+              </span>
+            </div>
           </div>
-        </div>
-      )}
+        );
+        if (kind === 'struggling') return (
+          <div className="mb-6 rounded-lg border border-unverified/30 bg-unverified/5 px-4 py-3">
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-xs font-bold text-unverified">STRUGGLING</span>
+              <span className="text-xs text-unverified/70">
+                {s.consecutiveFailures}+ consecutive failures. Deprioritized until clean signals recorded.
+              </span>
+            </div>
+          </div>
+        );
+        if (kind === 'kept-for-coverage') return (
+          <div className="mb-6 rounded-lg border border-unverified/30 bg-unverified/5 px-4 py-3">
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-xs font-bold text-unverified">KEPT FOR COVERAGE</span>
+              <span className="text-xs text-unverified/70">
+                Would be benched ({s.bench.reason ?? 'rule'}), but is the sole provider of a category — kept to preserve coverage.
+              </span>
+            </div>
+          </div>
+        );
+        return null;
+      })()}
 
       {/* Persistent parse-diagnostic banner — fires when the same diagnostic
           code has tripped at least DIAGNOSTIC_BANNER_THRESHOLD times in the
@@ -191,11 +216,30 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
               {agent.preset && (
                 <span className="rounded-sm bg-muted px-2 py-0.5 font-mono text-[10px] text-muted-foreground">{agent.preset}</span>
               )}
-              {s.consecutiveFailures > 0 && !s.circuitOpen && (
-                <span className="rounded-sm bg-unverified/10 px-2 py-0.5 font-mono text-[10px] font-bold text-unverified">
-                  {s.consecutiveFailures} CONSECUTIVE FAILS
-                </span>
-              )}
+              {(() => {
+                const kind = getBenchBadgeKind(s);
+                if (kind === 'benched') return (
+                  <span className="rounded-sm bg-destructive/10 px-2 py-0.5 font-mono text-[10px] font-bold text-destructive">
+                    BENCHED
+                  </span>
+                );
+                if (kind === 'struggling') return (
+                  <span className="rounded-sm bg-unverified/10 px-2 py-0.5 font-mono text-[10px] font-bold text-unverified">
+                    STRUGGLING ({s.consecutiveFailures} FAILS)
+                  </span>
+                );
+                if (kind === 'kept-for-coverage') return (
+                  <span className="rounded-sm border border-unverified/40 px-2 py-0.5 font-mono text-[10px] font-bold text-unverified">
+                    KEPT FOR COVERAGE
+                  </span>
+                );
+                if (s.consecutiveFailures > 0) return (
+                  <span className="rounded-sm bg-unverified/10 px-2 py-0.5 font-mono text-[10px] font-bold text-unverified">
+                    {s.consecutiveFailures} CONSECUTIVE FAILS
+                  </span>
+                );
+                return null;
+              })()}
               <span className="font-mono text-[10px] text-muted-foreground/60">
                 {s.signals} signals{agent.lastTask ? ` · ${timeAgo(agent.lastTask.timestamp)}` : ''}
               </span>

--- a/packages/dashboard-v2/src/components/CircuitAlerts.tsx
+++ b/packages/dashboard-v2/src/components/CircuitAlerts.tsx
@@ -1,13 +1,39 @@
 import type { AgentData } from '@/lib/types';
 import { timeAgo } from '@/lib/utils';
+import { needsAttention } from '@/lib/bench';
 
 interface CircuitAlertsProps {
   agents: AgentData[];
 }
 
+type Reason =
+  | { label: 'benched (chronic)'; cls: string }
+  | { label: 'benched (burst)'; cls: string }
+  | { label: string; cls: string };
+
+function describe(agent: AgentData): Reason {
+  const s = agent.scores;
+  if (s.bench?.state === 'benched') {
+    if (s.bench.reason === 'chronic-low-accuracy') {
+      return { label: 'benched (chronic)', cls: 'bg-destructive/15 text-destructive' };
+    }
+    if (s.bench.reason === 'burst-hallucination') {
+      return { label: 'benched (burst)', cls: 'bg-destructive/15 text-destructive' };
+    }
+    return { label: 'benched', cls: 'bg-destructive/15 text-destructive' };
+  }
+  if (s.bench?.state === 'kept-for-coverage') {
+    return { label: 'kept for coverage', cls: 'border border-unverified/40 text-unverified' };
+  }
+  if (s.circuitOpen) {
+    return { label: `struggling (${s.consecutiveFailures} fails)`, cls: 'bg-unverified/15 text-unverified' };
+  }
+  return { label: '', cls: '' };
+}
+
 export function CircuitAlerts({ agents }: CircuitAlertsProps) {
-  const openCircuits = agents.filter((a) => a.scores.circuitOpen);
-  if (openCircuits.length === 0) return null;
+  const attention = agents.filter(needsAttention);
+  if (attention.length === 0) return null;
 
   return (
     <div className="rounded-lg border border-border bg-card">
@@ -17,16 +43,18 @@ export function CircuitAlerts({ agents }: CircuitAlertsProps) {
             !
           </span>
           <span className="font-mono text-[11px] font-bold uppercase tracking-widest text-destructive">
-            Benched Agents
+            Agents Needing Attention
           </span>
         </div>
         <span className="rounded-full border border-destructive/20 bg-destructive/10 px-2 py-0.5 font-mono text-xs font-bold text-destructive">
-          {openCircuits.length}
+          {attention.length}
         </span>
       </div>
       <div>
-        {openCircuits.map((agent, i) => {
+        {attention.map((agent, i) => {
           const lastTime = agent.lastTask?.timestamp ? timeAgo(agent.lastTask.timestamp) : '';
+          const r = describe(agent);
+          const isBenched = agent.scores.bench?.state === 'benched';
           return (
             <a
               key={agent.id}
@@ -36,8 +64,13 @@ export function CircuitAlerts({ agents }: CircuitAlertsProps) {
               }`}
             >
               <div className="mb-1 flex items-center gap-2.5">
-                <span className="h-1.5 w-1.5 rounded-full bg-destructive shadow-[0_0_6px_rgba(248,113,113,0.6)]" />
+                <span className={`h-1.5 w-1.5 rounded-full ${isBenched ? 'bg-destructive shadow-[0_0_6px_rgba(248,113,113,0.6)]' : 'bg-unverified'}`} />
                 <span className="text-sm font-semibold text-foreground">{agent.id}</span>
+                {r.label && (
+                  <span className={`shrink-0 rounded-sm px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase ${r.cls}`}>
+                    {r.label}
+                  </span>
+                )}
               </div>
               <div className="flex items-center justify-between pl-4 font-mono text-[10px] text-muted-foreground">
                 <span>{agent.scores.consecutiveFailures} consecutive fails</span>

--- a/packages/dashboard-v2/src/components/TeamRoster.tsx
+++ b/packages/dashboard-v2/src/components/TeamRoster.tsx
@@ -1,5 +1,6 @@
 import type { AgentData } from '@/lib/types';
 import { agentColor, timeAgo } from '@/lib/utils';
+import { getBenchBadgeKind } from '@/lib/bench';
 
 interface TeamRosterProps {
   agents: AgentData[];
@@ -46,11 +47,25 @@ export function TeamRoster({ agents }: TeamRosterProps) {
                 <div className="flex items-center justify-between gap-2">
                   <div className="flex min-w-0 items-center gap-1.5">
                     <span className="truncate font-mono text-xs font-semibold text-foreground">{agent.id}</span>
-                    {s.circuitOpen && (
-                      <span className="shrink-0 rounded-sm bg-destructive/10 px-1 py-0.5 font-mono text-[8px] font-bold text-destructive">
-                        CIRCUIT OPEN
-                      </span>
-                    )}
+                    {(() => {
+                      const kind = getBenchBadgeKind(s);
+                      if (kind === 'benched') return (
+                        <span className="shrink-0 rounded-sm bg-destructive/10 px-1 py-0.5 font-mono text-[8px] font-bold text-destructive">
+                          BENCHED
+                        </span>
+                      );
+                      if (kind === 'struggling') return (
+                        <span className="shrink-0 rounded-sm bg-unverified/10 px-1 py-0.5 font-mono text-[8px] font-bold text-unverified">
+                          STRUGGLING
+                        </span>
+                      );
+                      if (kind === 'kept-for-coverage') return (
+                        <span className="shrink-0 rounded-sm border border-unverified/40 px-1 py-0.5 font-mono text-[8px] font-bold text-unverified">
+                          KEPT
+                        </span>
+                      );
+                      return null;
+                    })()}
                   </div>
                   <div className="flex shrink-0 items-baseline gap-1.5">
                     <span className={`font-mono text-sm font-bold tabular-nums leading-none ${weightColor}`}>

--- a/packages/dashboard-v2/src/lib/bench.ts
+++ b/packages/dashboard-v2/src/lib/bench.ts
@@ -1,0 +1,30 @@
+import type { AgentData } from './types';
+
+export type BenchBadgeKind = 'benched' | 'struggling' | 'kept-for-coverage' | null;
+
+/**
+ * Three-state badge derivation for auto-bench v2:
+ * - `benched`           — isBenched rule fired AND safeguard passed
+ * - `struggling`        — legacy circuitOpen trips (consecutive failures), but
+ *                          the agent is NOT bench-rule benched. Keeps the old
+ *                          "too many fails in a row" signal visible without
+ *                          conflating it with chronic/burst bench.
+ * - `kept-for-coverage` — bench rule fired, but the agent is the sole provider
+ *                          of a category, so the safeguard blocked benching.
+ *                          Rendered as an amber-outline informational tag.
+ */
+export function getBenchBadgeKind(scores: AgentData['scores']): BenchBadgeKind {
+  if (scores.bench?.state === 'benched') return 'benched';
+  if (scores.circuitOpen) return 'struggling';
+  if (scores.bench?.state === 'kept-for-coverage') return 'kept-for-coverage';
+  return null;
+}
+
+/**
+ * Dashboard-wide filter: who needs operator attention?
+ * Any agent that is actively benched or tripped the legacy circuit breaker.
+ * kept-for-coverage agents are informational, not alerts.
+ */
+export function needsAttention(agent: AgentData): boolean {
+  return agent.scores.bench?.state === 'benched' || agent.scores.circuitOpen;
+}

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -31,6 +31,10 @@ export interface AgentData {
     impactScore: number; dispatchWeight: number; signals: number;
     agreements: number; disagreements: number; hallucinations: number;
     consecutiveFailures: number; circuitOpen: boolean;
+    bench: {
+      state: 'benched' | 'kept-for-coverage' | 'none';
+      reason?: 'chronic-low-accuracy' | 'burst-hallucination';
+    };
     // categoryStrengths is an unbounded dispatch-routing accumulator — do not
     // render as a percentage. categoryAccuracy = c / (c + h) is the real ratio.
     categoryStrengths: Record<string, number>;

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -137,8 +137,6 @@ export class PerformanceReader {
    * is the conventional window) acts as implicit hysteresis via the score
    * window itself. TODO(v2): explicit post-bench clean-streak counter if the
    * implicit window proves too flappy in production.
-   * TODO: surface bench state as a dashboard badge once the dashboard grows
-   * an agent-health view.
    */
   isBenched(
     agentId: string,

--- a/packages/relay/src/dashboard/api-agents.ts
+++ b/packages/relay/src/dashboard/api-agents.ts
@@ -45,6 +45,10 @@ export interface AgentResponse {
     agreements: number;
     disagreements: number;
     hallucinations: number;
+    bench: {
+      state: 'benched' | 'kept-for-coverage' | 'none';
+      reason?: 'chronic-low-accuracy' | 'burst-hallucination';
+    };
   };
 }
 
@@ -140,9 +144,22 @@ export async function agentsHandler(
   let skillIndex: SkillIndex | null = null;
   try { skillIndex = new SkillIndex(projectRoot); } catch { /* skill index unavailable */ }
 
+  const allIds = configs.map(c => c.id);
+
   return configs.map(config => {
     const score = scores.get(config.id) ?? { ...DEFAULT_SCORE, agentId: config.id };
     const agentTask = taskDataByAgent.get(config.id) ?? { totalTokens: 0, lastTask: null };
+
+    const categories = Object.keys({ ...score.categoryCorrect, ...score.categoryHallucinated });
+    const benchResult = reader.isBenched(config.id, categories, allIds);
+    const benchState: 'benched' | 'kept-for-coverage' | 'none' =
+      benchResult.benched ? 'benched'
+      : benchResult.safeguardBlocked ? 'kept-for-coverage'
+      : 'none';
+    const bench = {
+      state: benchState,
+      reason: benchResult.reason as 'chronic-low-accuracy' | 'burst-hallucination' | undefined,
+    };
 
     let skillSlots: SkillSlotResponse[] = [];
     try {
@@ -180,6 +197,7 @@ export async function agentsHandler(
         hallucinations: score.hallucinations,
         consecutiveFailures: score.consecutiveFailures ?? 0,
         circuitOpen: score.circuitOpen ?? false,
+        bench,
         // categoryStrengths is an UNBOUNDED severity-weighted accumulator used
         // for dispatch routing (severity × decay × 0.15 per confirmed signal),
         // not a [0,1] ratio. The dashboard must NOT render it as a percentage —


### PR DESCRIPTION
## Summary

- Expose Rule A/B auto-bench state on dashboard scores payload alongside legacy `circuitOpen`
- Three-state UI: red "benched" (chronic/burst), amber "struggling" (circuitOpen), amber-outline "kept for coverage" (safeguard-blocked)
- Retitle `CircuitAlerts` → "Agents Needing Attention" with per-reason chips

## Context

Resolves the `performance-reader.ts:140` TODO to surface auto-bench on the dashboard. v1 shipped Rule A (chronic low accuracy) + Rule B (burst hallucinations) in #93 but the dashboard only showed the legacy `circuitOpen` signal. This PR surfaces both signals independently — consensus round d9e9b53f-2e694c19 confirmed keeping both (they measure distinct failure modes; dispatch already filters both independently at cross-reviewer-selection.ts:93).

## Design notes

- `api-agents.ts` passes `Object.keys({...categoryCorrect, ...categoryHallucinated})` (not `categoryAccuracy` which drops sparse categories under `MIN_CATEGORY_N=5`) so the sole-provider safeguard fires correctly.
- New `packages/dashboard-v2/src/lib/bench.ts` helper de-dupes the three-state logic across 5 callers.
- Per-category benching deferred to a follow-up PR.

## Test plan
- [x] `tsc --noEmit` clean (orchestrator, relay, dashboard-v2)
- [x] `npm test --ci` — 1859 passed, 0 failed
- [ ] Dashboard smoke test: verify a benched agent renders red badge, a circuit-open agent renders amber "struggling"
- [ ] Verify "Agents Needing Attention" panel shows correct per-reason chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)