### PR TITLE
feat(consensus): round-level retraction via gossip_signals consensus_id

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2284,10 +2284,10 @@ server.tool(
   'gossip_signals',
   'Record or retract consensus performance signals. Use action "record" (default) to record signals after cross-referencing agent findings — call IMMEDIATELY when you verify. Use action "retract" to undo a previously recorded signal.',
   {
-    action: z.enum(['record', 'retract', 'bulk_from_consensus']).default('record').describe('Action: "record" to add signals, "retract" to undo a previous signal, "bulk_from_consensus" to auto-record signals for all findings in a consensus report'),
-    consensus_id: z.string().optional().describe('Consensus report ID (8-8 hex format, e.g. "5e8a7194-73e240da"). Required for action: "bulk_from_consensus".'),
+    action: z.enum(['record', 'retract', 'bulk_from_consensus']).default('record').describe('Action: "record" to add signals, "retract" to undo a previous signal or an entire consensus round, "bulk_from_consensus" to auto-record signals for all findings in a consensus report'),
+    consensus_id: z.string().regex(/^[0-9a-f]{8}-[0-9a-f]{8}$/, 'consensus_id must be 8-8 hex format (e.g. "5e8a7194-73e240da")').optional().describe('Consensus report ID (8-8 hex format, e.g. "5e8a7194-73e240da"). Required for action: "bulk_from_consensus". For action: "retract" — supplying this (with `reason`) retracts ALL signals in that consensus round; mutually exclusive with agent_id+task_id per-signal retraction.'),
     // record params
-    task_id: z.string().optional().describe('Task ID to link signals to. For record: optional (synthetic ID if omitted). For retract: required.'),
+    task_id: z.string().optional().describe('Task ID to link signals to. For record: optional (synthetic ID if omitted). For per-signal retract: required.'),
     task_start_time: z.string().optional().describe('ISO-8601 timestamp of the underlying task/consensus round. Used as the per-batch fallback timestamp so bulk-recording from a backlog preserves true chronology. Falls back to wall-clock if omitted.'),
     signals: z.array(z.object({
       signal: z.enum(['agreement', 'disagreement', 'unique_confirmed', 'unique_unconfirmed', 'new_finding', 'hallucination_caught', 'impl_test_pass', 'impl_test_fail', 'impl_peer_approved', 'impl_peer_rejected'])
@@ -2302,22 +2302,43 @@ server.tool(
       timestamp: z.string().optional().describe('ISO-8601 timestamp of when this specific finding occurred. Highest precedence; overrides task_start_time. Use for per-finding chronology when known.'),
     })).optional().describe('Array of consensus signals (required for action: "record")'),
     // retract params
-    agent_id: z.string().optional().describe('Agent whose signal to retract (required for action: "retract")'),
-    reason: z.string().optional().describe('Why this signal is being retracted (required for action: "retract")'),
+    agent_id: z.string().optional().describe('Agent whose signal to retract (required for per-signal action: "retract"; mutually exclusive with consensus_id round-scope form)'),
+    reason: z.string().min(1).max(1024).optional().describe('Why this signal/round is being retracted (required for action: "retract"; 1-1024 chars)'),
   },
   async ({ action, task_id, task_start_time, signals, agent_id, reason, consensus_id }) => {
     await boot();
 
     if (action === 'retract') {
-      // Validate retract params
-      if (!agent_id || agent_id.trim().length === 0) {
-        return { content: [{ type: 'text' as const, text: 'Error: agent_id is required for retraction.' }] };
+      // Branch: round-scope retraction vs per-signal retraction. Mutually exclusive.
+      const hasRound = !!(consensus_id && consensus_id.trim().length > 0);
+      const hasPerSignal = !!((agent_id && agent_id.trim().length > 0) || (task_id && task_id.trim().length > 0));
+      if (hasRound && hasPerSignal) {
+        return { content: [{ type: 'text' as const, text: 'Error: consensus_id and agent_id+task_id are mutually exclusive. Supply either a round-scope retraction (consensus_id + reason) or a per-signal retraction (agent_id + task_id + reason).' }] };
       }
-      if (!task_id || task_id.trim().length === 0) {
-        return { content: [{ type: 'text' as const, text: 'Error: task_id is required for retraction. Use the task ID from the original signal.' }] };
+      if (!hasRound && !hasPerSignal) {
+        return { content: [{ type: 'text' as const, text: 'Error: supply either consensus_id (round-scope) or agent_id+task_id (per-signal) to retract.' }] };
       }
       if (!reason || reason.trim().length === 0) {
         return { content: [{ type: 'text' as const, text: 'Error: reason is required for retraction.' }] };
+      }
+
+      if (hasRound) {
+        try {
+          const { PerformanceWriter } = await import('@gossip/orchestrator');
+          const writer = new PerformanceWriter(process.cwd());
+          writer.recordConsensusRoundRetraction(consensus_id!, reason);
+          return { content: [{ type: 'text' as const, text: `Retracted consensus round ${consensus_id}.\nReason: ${reason}\n\nAll signals whose finding_id starts with "${consensus_id}:" will be excluded from scoring. The tombstone row and original signals remain in the audit log.` }] };
+        } catch (err) {
+          return { content: [{ type: 'text' as const, text: `Failed to retract round: ${(err as Error).message}` }] };
+        }
+      }
+
+      // Per-signal retraction
+      if (!agent_id || agent_id.trim().length === 0) {
+        return { content: [{ type: 'text' as const, text: 'Error: agent_id is required for per-signal retraction.' }] };
+      }
+      if (!task_id || task_id.trim().length === 0) {
+        return { content: [{ type: 'text' as const, text: 'Error: task_id is required for per-signal retraction. Use the task ID from the original signal.' }] };
       }
       try {
         const { PerformanceWriter } = await import('@gossip/orchestrator');
@@ -2361,8 +2382,17 @@ server.tool(
           }
         } catch { /* file may not exist yet */ }
 
-        const { PerformanceWriter } = await import('@gossip/orchestrator');
+        const { PerformanceWriter, PerformanceReader } = await import('@gossip/orchestrator');
         const writer = new PerformanceWriter(process.cwd());
+        // Warn if the target round was retracted — signals will be recorded but
+        // filtered out at read time by the round tombstone.
+        try {
+          const reader = new PerformanceReader(process.cwd());
+          if (reader.getRetractedConsensusIds().has(consensus_id)) {
+            // eslint-disable-next-line no-console
+            console.warn(`[signals] bulk_from_consensus targeted retracted round ${consensus_id}; signals will be filtered out`);
+          }
+        } catch { /* reader unavailable — skip warn */ }
         const batchTs = report.timestamp || new Date().toISOString();
         const batchTaskId = task_id || `bulk-${consensus_id}`;
 

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -231,6 +231,11 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
   const [loadedReports, setLoadedReports] = useState<ConsensusReport[]>([]);
   const [totalReports, setTotalReports] = useState(0);
   const [loadingMore, setLoadingMore] = useState(false);
+  // consensus_id → most recent retraction reason. Populated from the
+  // `roundRetractions` field on the consensus-reports API response. Used to
+  // render a banner on retracted rounds and strike through their findings.
+  const [retractionsByConsensusId, setRetractionsByConsensusId] =
+    useState<Record<string, { reason: string; retracted_at: string }>>({});
 
   // When the initial reports prop arrives (page 1 data), seed loadedReports
   useEffect(() => {
@@ -238,6 +243,14 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
       setLoadedReports(reports.reports);
       setTotalReports(reports.totalReports ?? reports.reports.length);
       setReportPage(1);
+    }
+    if (reports?.roundRetractions) {
+      const map: Record<string, { reason: string; retracted_at: string }> = {};
+      // Later entries overwrite earlier ones → latest-wins for the banner.
+      for (const r of reports.roundRetractions) {
+        map[r.consensus_id] = { reason: r.reason, retracted_at: r.retracted_at };
+      }
+      setRetractionsByConsensusId(map);
     }
   }, [reports]);
 
@@ -252,6 +265,13 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
         setLoadedReports(data.reports || []);
         setTotalReports(data.totalReports ?? (data.reports?.length || 0));
         setReportPage(1);
+        if (data.roundRetractions) {
+          const map: Record<string, { reason: string; retracted_at: string }> = {};
+          for (const r of data.roundRetractions) {
+            map[r.consensus_id] = { reason: r.reason, retracted_at: r.retracted_at };
+          }
+          setRetractionsByConsensusId(map);
+        }
       } catch {
         // keep the seeded page-1 data
       }
@@ -415,6 +435,8 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
             )];
             const agentIds = allAgentIds.slice(0, 5);
 
+            const retraction = retractionsByConsensusId[report.id];
+            const isRetracted = !!retraction;
             return (
               <div key={report.id}>
                 {showBucketHeader && (
@@ -428,11 +450,31 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
               <div
                 className={`group rounded-md border-l-2 border border-border/40 transition-all duration-150
                   ${dominantBorderCls}
+                  ${isRetracted ? 'opacity-60 line-through decoration-disputed/40' : ''}
                   ${isExpanded
                     ? 'bg-card border-r-border/60 border-t-border/60 border-b-border/60'
                     : 'bg-card/50 hover:bg-card/70 hover:border-r-border/60 hover:border-t-border/60 hover:border-b-border/60 hover:shadow-sm hover:shadow-black/20 hover:-translate-y-px'
                   }`}
+                data-retracted={isRetracted ? 'true' : undefined}
               >
+                {/* Retraction banner — inline per-card (not shared AlertBanner
+                    refactor per spec non-goals). Rendered above the clickable
+                    header so the status is visible in collapsed + expanded
+                    views. Strike-through on the card container handles the
+                    struck-through findings requirement. */}
+                {isRetracted && (
+                  <div className="no-underline rounded-t-md border-b border-disputed/30 bg-disputed/10 px-3 py-2 font-mono text-[11px] text-disputed" style={{ textDecoration: 'none' }}>
+                    <span className="font-bold">⚠ RETRACTED</span>
+                    {retraction!.retracted_at && (
+                      <span className="ml-2 text-disputed/70">
+                        on {retraction!.retracted_at.slice(0, 10)}
+                      </span>
+                    )}
+                    {retraction!.reason && (
+                      <span className="ml-2 text-muted-foreground/80">— {retraction!.reason}</span>
+                    )}
+                  </div>
+                )}
                 <button
                   className="flex w-full items-start gap-3 px-3 py-2.5 text-left"
                   aria-expanded={isExpanded}

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -131,11 +131,29 @@ export type ParseDiagnostic =
   | { code: 'SCHEMA_DRIFT_INVENTED_TYPE_TOKENS'; message: string; matchedTokens: string[] }
   | { code: 'SCHEMA_DRIFT_NESTED_SUBTAGS'; message: string; subtagTypes: string[] };
 
+export interface RoundRetraction {
+  consensus_id: string;
+  reason: string;
+  retracted_at: string;
+}
+
 export interface ConsensusReportsData {
   reports: ConsensusReport[];
   totalReports?: number;
   page?: number;
   pageSize?: number;
+  /**
+   * Consensus round IDs that have been retracted via
+   * `gossip_signals({action:'retract', consensus_id, reason})`. The report
+   * page renders a banner + strike-through findings when a report's id
+   * is in this set.
+   */
+  retractedConsensusIds?: string[];
+  /**
+   * Full tombstone rows, preserving duplicates so an admin "retracted
+   * rounds" view can show each retraction reason.
+   */
+  roundRetractions?: RoundRetraction[];
 }
 
 export interface MemoryFile {

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -121,6 +121,7 @@ export interface ConsensusSignal {
     | 'category_confirmed'
     | 'consensus_verified'
     | 'signal_retracted'
+    | 'consensus_round_retracted'
     | 'severity_miscalibrated'
     | 'task_timeout'
     | 'task_empty';

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -52,6 +52,7 @@ const KNOWN_SIGNALS: Record<ConsensusSignal['signal'], true> = {
   category_confirmed: true,
   consensus_verified: true,
   signal_retracted: true,
+  consensus_round_retracted: true,
   severity_miscalibrated: true,
   task_timeout: true,
   task_empty: true,
@@ -114,6 +115,57 @@ export class PerformanceReader {
     const impl = this.getImplScore(agentId);
     if (!impl) return 1.0; // no impl data, neutral
     return clamp(0.3 + impl.reliability * 1.7, 0.3, 2.0);
+  }
+
+  /**
+   * Return the set of consensus round IDs that have been retracted via
+   * `gossip_signals({action:'retract', consensus_id, reason})`. Dashboard
+   * uses this to render banners and strike-through on retracted rounds.
+   */
+  getRetractedConsensusIds(): Set<string> {
+    if (!existsSync(this.filePath)) return new Set();
+    try {
+      const lines = readFileSync(this.filePath, 'utf-8').trim().split('\n').filter(Boolean);
+      const ids = new Set<string>();
+      for (const line of lines) {
+        try {
+          const r = JSON.parse(line);
+          if (r && r.type === 'consensus' && r.signal === 'consensus_round_retracted' && typeof r.consensus_id === 'string') {
+            ids.add(r.consensus_id);
+          }
+        } catch { /* skip */ }
+      }
+      return ids;
+    } catch {
+      return new Set();
+    }
+  }
+
+  /**
+   * Return all round-retraction tombstone entries, preserving duplicates
+   * so an admin view can see multiple retraction reasons for the same round.
+   */
+  getRoundRetractions(): Array<{ consensus_id: string; reason: string; retracted_at: string }> {
+    if (!existsSync(this.filePath)) return [];
+    try {
+      const lines = readFileSync(this.filePath, 'utf-8').trim().split('\n').filter(Boolean);
+      const out: Array<{ consensus_id: string; reason: string; retracted_at: string }> = [];
+      for (const line of lines) {
+        try {
+          const r = JSON.parse(line);
+          if (r && r.type === 'consensus' && r.signal === 'consensus_round_retracted' && typeof r.consensus_id === 'string') {
+            out.push({
+              consensus_id: r.consensus_id,
+              reason: typeof r.reason === 'string' ? r.reason : '',
+              retracted_at: typeof r.retracted_at === 'string' ? r.retracted_at : (r.timestamp || ''),
+            });
+          }
+        } catch { /* skip */ }
+      }
+      return out;
+    } catch {
+      return [];
+    }
   }
 
   /** Check if an agent's circuit breaker is open (3+ consecutive failures) */
@@ -265,7 +317,14 @@ export class PerformanceReader {
 
       // Collect retraction keys: agentId + taskId + signalType combos that have been retracted
       const retracted = new Set<string>();
+      // Collect round-level retracted consensus IDs (tombstone rows).
+      const retractedConsensusIds = new Set<string>();
       for (const s of all) {
+        if (s.signal === 'consensus_round_retracted') {
+          const cid = (s as any).consensus_id;
+          if (typeof cid === 'string' && cid.length > 0) retractedConsensusIds.add(cid);
+          continue;
+        }
         if (s.signal === 'signal_retracted') {
           const taskKey = s.taskId || s.timestamp;
           if (s.retractedSignal) {
@@ -278,9 +337,19 @@ export class PerformanceReader {
         }
       }
 
-      // Filter: exclude retracted signals and the retraction signals themselves
+      // Filter: exclude retracted signals, tombstones, and the retraction signals themselves
       return all.filter(s => {
         if (s.signal === 'signal_retracted') return false;
+        if (s.signal === 'consensus_round_retracted') return false;
+        // Exclude sentinel rows from per-agent aggregation defence-in-depth
+        if (s.agentId === '_system') return false;
+        // Round-level: drop any consensus signal whose findingId sits inside a retracted round
+        if (s.type === 'consensus' && (s as any).findingId) {
+          const fid = (s as any).findingId as string;
+          for (const retractedId of retractedConsensusIds) {
+            if (fid.startsWith(retractedId + ':')) return false;
+          }
+        }
         // Skip retracted signals (check both scoped and wildcard keys)
         const taskKey = s.taskId || s.timestamp;
         if (retracted.has(s.agentId + ':' + taskKey + ':' + s.signal)) return false;
@@ -310,8 +379,15 @@ export class PerformanceReader {
       // Collect retraction keys: agentId + taskId + signalType combos that have been retracted
       // Only consensus signals can carry retractions.
       const retracted = new Set<string>();
+      // Round-level retracted consensus IDs (tombstone rows).
+      const retractedConsensusIds = new Set<string>();
       for (const s of all) {
         if (s.type !== 'consensus') continue;
+        if (s.signal === 'consensus_round_retracted') {
+          const cid = (s as any).consensus_id;
+          if (typeof cid === 'string' && cid.length > 0) retractedConsensusIds.add(cid);
+          continue;
+        }
         if (s.signal === 'signal_retracted') {
           const taskKey = s.taskId || s.timestamp;
           if (s.retractedSignal) {
@@ -324,9 +400,12 @@ export class PerformanceReader {
         }
       }
 
-      // Filter: exclude expired, retracted, and retraction signals themselves
+      // Filter: exclude expired, retracted, tombstones, and retraction signals themselves
       return all.filter(s => {
         if (s.type === 'consensus' && s.signal === 'signal_retracted') return false;
+        if (s.type === 'consensus' && s.signal === 'consensus_round_retracted') return false;
+        // Drop sentinel rows from per-agent aggregation defence-in-depth
+        if (s.agentId === '_system') return false;
         // Expire old signals — missing/bad timestamps are treated as expired
         const ts = s.timestamp ? new Date(s.timestamp).getTime() : 0;
         if (!isFinite(ts) || ts === 0 || ts < expiryMs) return false;
@@ -335,6 +414,16 @@ export class PerformanceReader {
           const taskKey = s.taskId || s.timestamp;
           if (retracted.has(s.agentId + ':' + taskKey + ':' + s.signal)) return false;
           if (retracted.has(s.agentId + ':' + taskKey + ':*')) return false;
+          // Round-level: drop consensus signals whose findingId sits inside a retracted round.
+          // Use startsWith(cid + ':') — finding_id shapes: `<cid>:fN` (bulk) and
+          // `<cid>:<agent>:fN` (manual). ImplSignal has no findingId so impl signals
+          // are structurally unaffected.
+          const fid = (s as any).findingId;
+          if (typeof fid === 'string' && fid.length > 0) {
+            for (const retractedId of retractedConsensusIds) {
+              if (fid.startsWith(retractedId + ':')) return false;
+            }
+          }
         }
         return true;
       });
@@ -419,7 +508,13 @@ export class PerformanceReader {
     // Build per-agent retraction index so computeScores skips retracted signals
     // even when called with a raw (unfiltered) signal array (e.g. directly from tests).
     const retractedKeys = new Set<string>();
+    const retractedConsensusIds = new Set<string>();
     for (const signal of consensusSignals) {
+      if (signal.signal === 'consensus_round_retracted') {
+        const cid = (signal as any).consensus_id;
+        if (typeof cid === 'string' && cid.length > 0) retractedConsensusIds.add(cid);
+        continue;
+      }
       if (signal.signal === 'signal_retracted') {
         const taskKey = signal.taskId || signal.timestamp;
         if (signal.retractedSignal) {
@@ -434,6 +529,19 @@ export class PerformanceReader {
       const isKnown = KNOWN_SIGNALS[signal.signal];
       if (!isKnown) continue;
       if (signal.signal === 'signal_retracted') continue;
+      if (signal.signal === 'consensus_round_retracted') continue;
+      // Tombstone sentinel rows have no real agent — ignore.
+      if (signal.agentId === '_system') continue;
+
+      // Round-level retraction — drop any signal whose findingId sits inside a retracted round.
+      const fidAny = (signal as any).findingId;
+      if (typeof fidAny === 'string' && fidAny.length > 0) {
+        let dropped = false;
+        for (const retractedId of retractedConsensusIds) {
+          if (fidAny.startsWith(retractedId + ':')) { dropped = true; break; }
+        }
+        if (dropped) continue;
+      }
 
       // Skip signals retracted by a signal_retracted entry
       const taskKey2 = signal.taskId || signal.timestamp;

--- a/packages/orchestrator/src/performance-writer.ts
+++ b/packages/orchestrator/src/performance-writer.ts
@@ -7,6 +7,7 @@ const VALID_CONSENSUS_SIGNALS = new Set([
   'agreement', 'disagreement', 'unverified', 'unique_confirmed',
   'unique_unconfirmed', 'new_finding', 'hallucination_caught',
   'category_confirmed', 'consensus_verified', 'signal_retracted',
+  'consensus_round_retracted',
   'task_timeout', 'task_empty',
 ]);
 
@@ -17,6 +18,13 @@ const VALID_IMPL_SIGNALS = new Set([
 const VALID_META_SIGNALS = new Set([
   'task_completed', 'task_tool_turns', 'format_compliance',
 ]);
+
+/**
+ * Sentinel agentId used on round-level tombstone rows. Not a real agent —
+ * readers must skip `agentId === '_system'` rows from any per-agent
+ * aggregation. See docs/specs/2026-04-17-consensus-round-retraction.md.
+ */
+const SYSTEM_SENTINEL_AGENT_ID = '_system';
 
 function validateSignal(signal: PerformanceSignal): void {
   if (!signal || typeof signal !== 'object') {
@@ -72,5 +80,36 @@ export class PerformanceWriter {
     for (const s of signals) validateSignal(s);
     const data = signals.map(s => JSON.stringify(s)).join('\n') + '\n';
     appendFileSync(this.filePath, data);
+  }
+
+  /**
+   * Append a round-level retraction tombstone.
+   *
+   * Tombstone row uses the `_system` sentinel as `agentId`. Readers must
+   * filter `agentId === '_system'` out of per-agent aggregation; signal
+   * scoring uses `consensus_id` to drop every signal whose `findingId`
+   * starts with `<consensus_id>:`. Idempotence is a reader concern — extra
+   * rows from duplicate retractions are harmless audit data that the
+   * reader's `retractedConsensusIds: Set<string>` dedupes.
+   *
+   * See docs/specs/2026-04-17-consensus-round-retraction.md.
+   */
+  recordConsensusRoundRetraction(consensusId: string, reason: string): void {
+    const row: any = {
+      type: 'consensus',
+      signal: 'consensus_round_retracted',
+      agentId: SYSTEM_SENTINEL_AGENT_ID,
+      // taskId is required by validateSignal. Mirror consensus_id so
+      // the tombstone is structurally addressable without inventing a
+      // second identifier.
+      taskId: consensusId,
+      consensus_id: consensusId,
+      reason,
+      retracted_at: new Date().toISOString(),
+      timestamp: new Date().toISOString(),
+      evidence: `Consensus round ${consensusId} retracted: ${reason}`,
+    };
+    validateSignal(row as PerformanceSignal);
+    appendFileSync(this.filePath, JSON.stringify(row) + '\n');
   }
 }

--- a/packages/relay/src/dashboard/api-overview.ts
+++ b/packages/relay/src/dashboard/api-overview.ts
@@ -126,9 +126,21 @@ export async function overviewHandler(projectRoot: string, ctx: OverviewContext)
         try {
           const entry = JSON.parse(line);
           // totalSignals counts only real consensus signals — impl_*, signal_retracted,
-          // and future metadata rows are not "signals" for this counter.
-          if (entry.type === 'consensus' && typeof entry.signal === 'string') {
+          // consensus_round_retracted tombstones, and future metadata rows are not
+          // "signals" for this counter. Also drop `_system` sentinel rows at the
+          // data layer (round tombstones use agentId='_system').
+          if (
+            entry.type === 'consensus'
+            && typeof entry.signal === 'string'
+            && entry.signal !== 'signal_retracted'
+            && entry.signal !== 'consensus_round_retracted'
+            && entry.agentId !== '_system'
+          ) {
             totalSignals++;
+          }
+          // Skip round-retraction tombstones from per-run aggregation.
+          if (entry.signal === 'consensus_round_retracted' || entry.agentId === '_system') {
+            continue;
           }
           if (entry.type === 'consensus' && (entry.consensusId || entry.taskId)) {
             const runId = entry.consensusId ?? entry.taskId;

--- a/packages/relay/src/dashboard/api-signals.ts
+++ b/packages/relay/src/dashboard/api-signals.ts
@@ -12,11 +12,25 @@ interface SignalEntry {
   timestamp: string;
 }
 
+export interface RoundRetractionEntry {
+  consensus_id: string;
+  reason: string;
+  retracted_at: string;
+}
+
 export interface SignalsResponse {
   items: SignalEntry[];
   total: number;
   offset: number;
   limit: number;
+  /**
+   * Round-level retraction tombstones, returned in their own channel so
+   * they don't corrupt per-agent SignalEntry rendering (tombstones have
+   * agentId='_system' sentinel, not a real agent). Every row with the
+   * same consensus_id is preserved so admin views can see duplicate
+   * retractions with different reasons.
+   */
+  roundRetractions?: RoundRetractionEntry[];
 }
 
 const MAX_LIMIT = 200;
@@ -31,12 +45,25 @@ export async function signalsHandler(projectRoot: string, query?: URLSearchParam
   if (!existsSync(perfPath)) return { items: [], total: 0, offset, limit };
 
   const all: SignalEntry[] = [];
+  const roundRetractions: RoundRetractionEntry[] = [];
   try {
     const lines = readFileSync(perfPath, 'utf-8').trim().split('\n').filter(Boolean);
     for (const line of lines) {
       try {
         const entry = JSON.parse(line);
         if (entry.type !== 'consensus') continue;
+        // Route round-retraction tombstones into their own channel and drop
+        // `_system` sentinel rows from per-agent signal rendering.
+        if (entry.signal === 'consensus_round_retracted' || entry.agentId === '_system') {
+          if (entry.signal === 'consensus_round_retracted' && typeof entry.consensus_id === 'string') {
+            roundRetractions.push({
+              consensus_id: entry.consensus_id,
+              reason: typeof entry.reason === 'string' ? entry.reason : '',
+              retracted_at: typeof entry.retracted_at === 'string' ? entry.retracted_at : (entry.timestamp || ''),
+            });
+          }
+          continue;
+        }
         if (agentFilter && entry.agentId !== agentFilter) continue;
         all.push(entry);
       } catch { /* skip malformed */ }
@@ -44,5 +71,5 @@ export async function signalsHandler(projectRoot: string, query?: URLSearchParam
   } catch { return { items: [], total: 0, offset, limit }; }
 
   all.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
-  return { items: all.slice(offset, offset + limit), total: all.length, offset, limit };
+  return { items: all.slice(offset, offset + limit), total: all.length, offset, limit, roundRetractions };
 }

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -412,10 +412,19 @@ export class DashboardRouter {
     return match ? match[1] : null;
   }
 
-  private getConsensusReports(page = 1, pageSize = 5): { reports: any[]; totalReports: number; page: number; pageSize: number } {
+  private getConsensusReports(page = 1, pageSize = 5): { reports: any[]; totalReports: number; page: number; pageSize: number; retractedConsensusIds: string[]; roundRetractions: Array<{ consensus_id: string; reason: string; retracted_at: string }> } {
     const { readdirSync, readFileSync, existsSync } = require('fs');
     const reportsDir = join(this.projectRoot, '.gossip', 'consensus-reports');
-    if (!existsSync(reportsDir)) return { reports: [], totalReports: 0, page, pageSize };
+    // Load retraction tombstones once so the dashboard can render banners + strike-through.
+    let retractedConsensusIds: string[] = [];
+    let roundRetractions: Array<{ consensus_id: string; reason: string; retracted_at: string }> = [];
+    try {
+      const { PerformanceReader } = require('@gossip/orchestrator');
+      const reader = new PerformanceReader(this.projectRoot);
+      retractedConsensusIds = Array.from(reader.getRetractedConsensusIds()) as string[];
+      roundRetractions = reader.getRoundRetractions();
+    } catch { /* reader unavailable — leave empty */ }
+    if (!existsSync(reportsDir)) return { reports: [], totalReports: 0, page, pageSize, retractedConsensusIds, roundRetractions };
 
     try {
       const { statSync } = require('fs');
@@ -446,8 +455,8 @@ export class DashboardRouter {
         } catch { return null; }
       }).filter(Boolean);
 
-      return { reports, totalReports, page: clampedPage, pageSize: clampedPageSize };
-    } catch { return { reports: [], totalReports: 0, page, pageSize }; }
+      return { reports, totalReports, page: clampedPage, pageSize: clampedPageSize, retractedConsensusIds, roundRetractions };
+    } catch { return { reports: [], totalReports: 0, page, pageSize, retractedConsensusIds, roundRetractions }; }
   }
 
   private archiveFindings(): { archived: number; remaining: number; findingsCleared: number } {

--- a/tests/orchestrator/consensus-round-retraction.test.ts
+++ b/tests/orchestrator/consensus-round-retraction.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Consensus-round retraction tests.
+ *
+ * Covers the 14 spec scenarios in
+ * docs/specs/2026-04-17-consensus-round-retraction.md.
+ */
+
+import { mkdtempSync, rmSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { PerformanceWriter, PerformanceReader } from '@gossip/orchestrator';
+import type { PerformanceSignal, ConsensusSignal } from '@gossip/orchestrator/consensus-types';
+import { z } from 'zod';
+
+// Mirrors the mcp-server-sdk.ts zod constraints on the retract payload. If
+// the handler constraint drifts, these tests catch it — keep in sync.
+const consensusIdSchema = z.string().regex(/^[0-9a-f]{8}-[0-9a-f]{8}$/);
+const reasonSchema = z.string().min(1).max(1024);
+
+function makeTmpDir(label: string): string {
+  return mkdtempSync(join(tmpdir(), `gossip-round-retract-${label}-`));
+}
+
+function readJsonl(dir: string): any[] {
+  const path = join(dir, '.gossip', 'agent-performance.jsonl');
+  return readFileSync(path, 'utf-8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line));
+}
+
+const VALID_CID = '1537efbb-2b44492d';
+const VALID_CID_2 = 'abcd0123-deadbeef';
+
+describe('consensus-round retraction', () => {
+  let dir: string;
+  beforeEach(() => { dir = makeTmpDir('basic'); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  // 1. retract appends tombstone and succeeds
+  it('appends a tombstone row with agentId="_system"', () => {
+    const writer = new PerformanceWriter(dir);
+    writer.recordConsensusRoundRetraction(VALID_CID, 'wrong branch reviewed');
+
+    const rows = readJsonl(dir);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      type: 'consensus',
+      signal: 'consensus_round_retracted',
+      agentId: '_system',
+      consensus_id: VALID_CID,
+      reason: 'wrong branch reviewed',
+    });
+    expect(typeof rows[0].retracted_at).toBe('string');
+    expect(typeof rows[0].timestamp).toBe('string');
+  });
+
+  // 14. performance-writer accepts the sentinel without throwing
+  it('writer accepts agentId="_system" without validation failure', () => {
+    const writer = new PerformanceWriter(dir);
+    expect(() => writer.recordConsensusRoundRetraction(VALID_CID, 'r')).not.toThrow();
+  });
+
+  // 2/3/4/5. zod validation at the MCP boundary
+  describe('zod validation', () => {
+    it('rejects consensus_id that fails the 8-8 hex regex', () => {
+      expect(() => consensusIdSchema.parse('notahex')).toThrow();
+      expect(() => consensusIdSchema.parse('1537efbb2b44492d')).toThrow(); // no dash
+      expect(() => consensusIdSchema.parse('1537efbb-2b44492')).toThrow(); // short
+      expect(() => consensusIdSchema.parse('1537EFBB-2B44492D')).toThrow(); // uppercase
+      expect(() => consensusIdSchema.parse(`${VALID_CID} extra`)).toThrow(); // trailing
+      expect(consensusIdSchema.parse(VALID_CID)).toBe(VALID_CID);
+    });
+
+    it('rejects empty reason', () => {
+      expect(() => reasonSchema.parse('')).toThrow();
+    });
+
+    it('rejects reason longer than 1024 chars', () => {
+      expect(() => reasonSchema.parse('x'.repeat(1025))).toThrow();
+      expect(reasonSchema.parse('x'.repeat(1024))).toHaveLength(1024);
+    });
+
+    it('accepts valid 8-8 hex consensus_id', () => {
+      expect(consensusIdSchema.parse('abcdef01-deadbeef')).toBe('abcdef01-deadbeef');
+    });
+  });
+
+  // 6. signals whose findingId starts with retracted cid + ':' are dropped at read
+  it('filters signals whose findingId starts with retracted cid + ":"', () => {
+    const writer = new PerformanceWriter(dir);
+    const now = new Date().toISOString();
+    writer.appendSignals([
+      // In-scope signal (bulk_from_consensus shape: <cid>:fN)
+      {
+        type: 'consensus', taskId: 't1', signal: 'agreement',
+        agentId: 'a1', counterpartId: 'a2',
+        findingId: `${VALID_CID}:f1`,
+        evidence: 'e', timestamp: now,
+      } as ConsensusSignal,
+      // In-scope signal (manual shape: <cid>:<agent>:fN)
+      {
+        type: 'consensus', taskId: 't2', signal: 'unique_confirmed',
+        agentId: 'a1', findingId: `${VALID_CID}:a1:f7`,
+        evidence: 'e', timestamp: now,
+      } as ConsensusSignal,
+      // Different round — should NOT be filtered
+      {
+        type: 'consensus', taskId: 't3', signal: 'agreement',
+        agentId: 'a1', counterpartId: 'a2',
+        findingId: `${VALID_CID_2}:f1`,
+        evidence: 'e', timestamp: now,
+      } as ConsensusSignal,
+    ]);
+    writer.recordConsensusRoundRetraction(VALID_CID, 'r');
+
+    const reader = new PerformanceReader(dir);
+    const score = reader.getAgentScore('a1');
+    // Only the VALID_CID_2 agreement should have contributed.
+    expect(score?.agreements).toBe(1);
+  });
+
+  // 7. impl_* signals (no findingId) unaffected
+  it('impl signals without findingId are unaffected by round retraction', () => {
+    const writer = new PerformanceWriter(dir);
+    const now = new Date().toISOString();
+    writer.appendSignals([
+      {
+        type: 'impl', signal: 'impl_test_pass',
+        agentId: 'a1', taskId: 't1', timestamp: now,
+      } as PerformanceSignal,
+      {
+        type: 'impl', signal: 'impl_test_pass',
+        agentId: 'a1', taskId: 't2', timestamp: now,
+      } as PerformanceSignal,
+    ]);
+    writer.recordConsensusRoundRetraction(VALID_CID, 'r');
+
+    const reader = new PerformanceReader(dir);
+    const impl = reader.getImplScore('a1');
+    expect(impl).not.toBeNull();
+    expect(impl!.passRate).toBe(1);
+  });
+
+  // 8. Non-consensus signals with a synthetic findingId are NOT filtered
+  it('does not filter non-consensus signals (type !== "consensus") by findingId', () => {
+    // Meta signals carry no findingId structurally but test the type gate:
+    // write a row that looks impl-typed yet somehow has a findingId-shaped
+    // prefix — reader must not drop it because the filter is scoped to
+    // type === 'consensus'. Constructed via JSON append so we sidestep
+    // validation (simulates a future signal variant).
+    const writer = new PerformanceWriter(dir);
+    writer.recordConsensusRoundRetraction(VALID_CID, 'r');
+    // Append a raw impl-typed row with an odd findingId to prove the scope guard:
+    const path = join(dir, '.gossip', 'agent-performance.jsonl');
+    const now = new Date().toISOString();
+    const row = {
+      type: 'impl',
+      signal: 'impl_test_pass',
+      agentId: 'a1',
+      taskId: 't1',
+      findingId: `${VALID_CID}:synthetic`,
+      timestamp: now,
+    };
+    require('fs').appendFileSync(path, JSON.stringify(row) + '\n');
+
+    const reader = new PerformanceReader(dir);
+    const impl = reader.getImplScore('a1');
+    // The impl signal must survive the consensus-scoped filter.
+    expect(impl).not.toBeNull();
+    expect(impl!.passRate).toBe(1);
+  });
+
+  // 9/10. Duplicate retractions → reader dedupes via Set; audit preserves both
+  it('duplicate retractions append extra rows; reader dedupes via Set', () => {
+    const writer = new PerformanceWriter(dir);
+    writer.recordConsensusRoundRetraction(VALID_CID, 'first reason');
+    writer.recordConsensusRoundRetraction(VALID_CID, 'second reason');
+
+    const rows = readJsonl(dir);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].reason).toBe('first reason');
+    expect(rows[1].reason).toBe('second reason');
+
+    const reader = new PerformanceReader(dir);
+    const ids = reader.getRetractedConsensusIds();
+    expect(ids.size).toBe(1);
+    expect(ids.has(VALID_CID)).toBe(true);
+
+    const all = reader.getRoundRetractions();
+    expect(all).toHaveLength(2);
+    const reasons = all.map(r => r.reason).sort();
+    expect(reasons).toEqual(['first reason', 'second reason']);
+  });
+
+  // 11. Dashboard overview excludes tombstones from totalSignals. (asserted via data-layer filter — exercise api-overview.ts directly.)
+  it('api-overview totalSignals excludes consensus_round_retracted rows and _system sentinel', async () => {
+    const { overviewHandler } = await import('@gossip/relay/dashboard/api-overview');
+    const writer = new PerformanceWriter(dir);
+    const now = new Date().toISOString();
+    writer.appendSignals([
+      {
+        type: 'consensus', taskId: 't1', signal: 'agreement',
+        agentId: 'a1', counterpartId: 'a2',
+        evidence: 'e', timestamp: now,
+      } as ConsensusSignal,
+    ]);
+    writer.recordConsensusRoundRetraction(VALID_CID, 'r');
+
+    const overview = await overviewHandler(dir, { agentConfigs: [], relayConnections: 0, connectedAgentIds: [] });
+    expect(overview.totalSignals).toBe(1); // tombstone not counted
+  });
+
+  // Reader exposes retractedConsensusIds for dashboard banner
+  it('getRetractedConsensusIds returns the set of retracted round IDs', () => {
+    const writer = new PerformanceWriter(dir);
+    writer.recordConsensusRoundRetraction(VALID_CID, 'r1');
+    writer.recordConsensusRoundRetraction(VALID_CID_2, 'r2');
+
+    const reader = new PerformanceReader(dir);
+    const ids = reader.getRetractedConsensusIds();
+    expect(ids.has(VALID_CID)).toBe(true);
+    expect(ids.has(VALID_CID_2)).toBe(true);
+    expect(ids.size).toBe(2);
+  });
+
+  // 13. bulk_from_consensus on a retracted round: signals recorded but dropped at read
+  it('signals recorded for a retracted round are filtered out at read time', () => {
+    const writer = new PerformanceWriter(dir);
+    writer.recordConsensusRoundRetraction(VALID_CID, 'premise invalid');
+    const now = new Date().toISOString();
+    // Simulate bulk_from_consensus recording signals for the retracted round.
+    writer.appendSignals([
+      {
+        type: 'consensus', taskId: 'bulk-t', signal: 'agreement',
+        agentId: 'a1', counterpartId: 'a2',
+        findingId: `${VALID_CID}:f1`,
+        evidence: 'e', timestamp: now,
+      } as ConsensusSignal,
+      {
+        type: 'consensus', taskId: 'bulk-t', signal: 'unique_confirmed',
+        agentId: 'a1', findingId: `${VALID_CID}:f2`,
+        evidence: 'e', timestamp: now,
+      } as ConsensusSignal,
+    ]);
+
+    const reader = new PerformanceReader(dir);
+    const score = reader.getAgentScore('a1');
+    // Both signals dropped → agent has no record.
+    expect(score?.agreements ?? 0).toBe(0);
+    expect(score?.uniqueFindings ?? 0).toBe(0);
+  });
+
+  // Mutual-exclusivity guard (handler-level XOR)
+  describe('mutual-exclusivity guard', () => {
+    // Mirrors the handler logic at apps/cli/src/mcp-server-sdk.ts in the
+    // retract branch. Kept inline because the handler is registerTool-
+    // coupled and not directly unit-testable.
+    function handlerGuard(p: {
+      consensus_id?: string;
+      agent_id?: string;
+      task_id?: string;
+      reason?: string;
+    }): string | null {
+      const hasRound = !!(p.consensus_id && p.consensus_id.trim().length > 0);
+      const hasPerSignal = !!((p.agent_id && p.agent_id.trim().length > 0) || (p.task_id && p.task_id.trim().length > 0));
+      if (hasRound && hasPerSignal) return 'Error: mutually exclusive';
+      if (!hasRound && !hasPerSignal) return 'Error: supply either';
+      if (!p.reason || p.reason.trim().length === 0) return 'Error: reason';
+      return null;
+    }
+
+    it('rejects round + per-signal combination', () => {
+      const err = handlerGuard({
+        consensus_id: VALID_CID, agent_id: 'a1', task_id: 't1', reason: 'r',
+      });
+      expect(err).toMatch(/mutually exclusive/);
+    });
+
+    it('rejects neither form supplied', () => {
+      const err = handlerGuard({ reason: 'r' });
+      expect(err).toMatch(/supply either/);
+    });
+
+    it('accepts round form', () => {
+      const err = handlerGuard({ consensus_id: VALID_CID, reason: 'r' });
+      expect(err).toBeNull();
+    });
+
+    it('accepts per-signal form', () => {
+      const err = handlerGuard({ agent_id: 'a1', task_id: 't1', reason: 'r' });
+      expect(err).toBeNull();
+    });
+
+    it('rejects empty reason on round form', () => {
+      const err = handlerGuard({ consensus_id: VALID_CID, reason: '' });
+      expect(err).toMatch(/reason/);
+    });
+  });
+
+  // Source-level guard: zod regex + reason cap still present in the handler
+  it('mcp-server-sdk.ts retains the strict consensus_id regex + reason cap', () => {
+    const src = readFileSync(
+      join(__dirname, '..', '..', 'apps', 'cli', 'src', 'mcp-server-sdk.ts'),
+      'utf-8',
+    );
+    expect(src).toMatch(/\/\^\[0-9a-f\]\{8\}-\[0-9a-f\]\{8\}\$\//);
+    expect(src).toMatch(/reason:.*z\.string\(\)\.min\(1\)\.max\(1024\)/);
+    // Handler XOR guard present
+    expect(src).toMatch(/consensus_id and agent_id\+task_id are mutually exclusive/);
+  });
+});


### PR DESCRIPTION
## Summary

Extends `gossip_signals` `action:"retract"` to accept `{consensus_id, reason}` alongside the existing per-signal `{agent_id, task_id, signal_type?}` payload. Mirrors the forward direction of `bulk_from_consensus`.

## Context

Today a consensus round with bad premise (wrong branch, stale state, misconfigured team) leaves a trail of signals that can only be retracted one-by-one by `agentId + taskKey + signalType`. This PR adds round-scope retraction: one call cascades to all signals whose `finding_id` starts with `consensus_id + ':'`.

Pattern: **tombstone layer, append-only**. Matches existing signal retraction and cross-round dedupe (`docs/specs/2026-04-17-cross-round-dedupe-key.md`). No mutation of prior data.

Spec: `docs/specs/2026-04-17-consensus-round-retraction.md` (v2, ratified by consensus round `3e0bb470-47a448c0`).

## Design highlights

- **zod**: `consensus_id` `^[0-9a-f]{8}-[0-9a-f]{8}$`, `reason` `min(1).max(1024)`. Strict regex is the typo guard.
- **Sentinel `agentId: "_system"`** on the tombstone row — `validateSignal` requires `agentId` today; sentinel is least-invasive.
- **Reader filter scoped to `type === 'consensus'`** — impl/meta signals structurally unaffected.
- **Dashboard filters at data-fetch layer** (`api-overview`, `api-signals`, `routes`). `_system` rows and `consensus_round_retracted` signals excluded from `totalSignals` and per-agent aggregation; tombstones routed to a new `roundRetractions` channel.
- **Idempotence via reader `Set.add`** — no writer check-then-write. Duplicate retractions append audit rows; reader dedupes.
- **Un-retraction not supported** — append-only model; re-run a new round if retracted in error. The regex above catches 1-char typos.

## Symmetric scoring impact

Retracting a round removes all signals (positive and negative) for that round. If the premise was invalid, no performance signal within it is trustworthy. Asymmetric schemes would require encoding why the round was invalid — out of scope for retraction.

## Test plan
- [x] 19 new tests in `tests/orchestrator/consensus-round-retraction.test.ts` covering all 14 spec scenarios
- [x] `npm test --ci`: 147 suites, 1906 passed, 1 skipped, 0 failed
- [x] `npx tsc --noEmit`: clean for orchestrator / relay / dashboard-v2
- [ ] Manual: retract a real consensus round on the dashboard and verify banner + struck-through findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)