### PR TITLE
fix(consensus): allow NEW cross-review entries to survive self-review filter (#131)

### DIFF
--- a/apps/cli/src/handlers/relay-cross-review.ts
+++ b/apps/cli/src/handlers/relay-cross-review.ts
@@ -148,6 +148,11 @@ export async function handleRelayCrossReview(
     // Filter to round members only — prevents fabricated peerAgentId targeting agents outside the round
     const validPeerIds = new Set(round.allResults.map((r: any) => r.agentId));
     const filtered = entries.filter(e => {
+      // NEW findings have no peer — they are discoveries the submitter surfaces
+      // after reading peer work. Skip the self-review/peer-validity check for
+      // them (see GH #131: otherwise every NEW entry is rejected because agents
+      // naturally emit findingId "<self>:n<N>", which flags as self-review).
+      if (e.action === 'new') return true;
       const selfReview = e.peerAgentId === agent_id;
       const unknownPeer = !validPeerIds.has(e.peerAgentId);
       if (selfReview || unknownPeer) {
@@ -156,6 +161,18 @@ export async function handleRelayCrossReview(
       }
       return true;
     });
+    // Rewrite NEW findingIds to the consensus-wide form
+    // `<consensusId>:new:<agentId>:<counter>`. Counter is scoped to this
+    // submission (restarts at 1 per handler call).
+    let newCounter = 0;
+    for (const e of filtered) {
+      if (e.action === 'new') {
+        e.findingId = `${round.consensusId}:new:${agent_id}:${++newCounter}`;
+        // peerAgentId is meaningless for NEW — clear it so downstream code
+        // doesn't accidentally resolve it as a peer reference.
+        e.peerAgentId = '';
+      }
+    }
     acceptedCount = filtered.length;
     round.nativeCrossReviewEntries.push(...filtered);
     if (parsedCount > 0 && acceptedCount === 0) {

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -543,9 +543,11 @@ Respond with one of:
 
 IMPORTANT: Use DISAGREE only when you have evidence the finding is WRONG. Use UNVERIFIED when you simply cannot check it.
 
-Return ONLY a JSON array. Use findingId to reference findings:
+Return ONLY a JSON array. findingId format:
+- For agree/disagree/unverified: "<peer_agent_id>:f<N>" referencing a peer's phase-1 finding (e.g., "gemini-reviewer:f1").
+- For new: "self:n<N>" — the server rewrites this to a consensus-wide ID. Do NOT reference a peer.
 [
-  { "action": "agree"|"disagree"|"unverified"|"new", "findingId": "agent:f1", "finding": "brief summary", "evidence": "your reasoning", "confidence": 1-5 }
+  { "action": "agree"|"disagree"|"unverified"|"new", "findingId": "...", "finding": "brief summary", "evidence": "your reasoning", "confidence": 1-5 }
 ]`;
 
     // Inject the reviewer's skills (if any) so their Phase-2 methodology
@@ -650,8 +652,14 @@ Return only valid JSON.${skillsBlock}`;
       if (entries.length === 0) {
         _log('consensus', `${agent.agentId} cross-review parsed to 0 entries (response length: ${response.text.length})`);
       }
-      // Filter: no self-references, peerAgentId must be a real agent in this batch
-      return entries.filter(e => e.peerAgentId !== agent.agentId && validPeerIds.has(e.peerAgentId));
+      // Filter: no self-references, peerAgentId must be a real agent in this batch.
+      // Exception: NEW findings have no peer — the submitter is raising a fresh
+      // issue all agents missed. Rejecting them on self-review (GH #131) drops
+      // ConsensusReport.newFindings[] to empty in every round.
+      return entries.filter(e => {
+        if (e.action === 'new') return true;
+        return e.peerAgentId !== agent.agentId && validPeerIds.has(e.peerAgentId);
+      });
     } catch (err) {
       _log('consensus', `${agent.agentId} cross-review LLM call failed: ${(err as Error).message}`);
       return [];
@@ -966,7 +974,14 @@ Return only valid JSON.${skillsBlock}`;
         // Sanitize before storage — strip XML-like tags that could be re-injected as instructions
         // in future sessions via gossip_remember() or session context loading.
         const sanitize = (t: string) => t.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 2000);
-        const newFindingId = `${consensusId}:${entry.agentId}:n${++newFindingIdx}`;
+        // Prefer the pre-rewritten findingId from relay-cross-review
+        // (format: `<consensusId>:new:<agentId>:<counter>`). Falls back to
+        // generating our own when the entry arrived via the in-process
+        // Phase-2 path (runSelectedCrossReview / dispatchCrossReview) which
+        // does not rewrite findingIds.
+        const newFindingId = entry.findingId && entry.findingId.includes(':new:')
+          ? entry.findingId
+          : `${consensusId}:new:${entry.agentId}:${++newFindingIdx}`;
         newFindings.push({
           agentId: entry.agentId,
           finding: sanitize(entry.finding),

--- a/tests/cli/relay-cross-review-new-findings.test.ts
+++ b/tests/cli/relay-cross-review-new-findings.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression tests for GH #131 — the self-review filter in
+ * handleRelayCrossReview dropped every NEW entry because agents naturally
+ * emit findingId "<self>:n<N>" (no peer to reference), which matched the
+ * `peerAgentId === agent_id` guard.
+ *
+ * Fix invariants:
+ *   1. NEW entries survive the filter regardless of peerAgentId.
+ *   2. NEW findingIds are rewritten to `<consensusId>:new:<agentId>:<counter>`.
+ *   3. Self-AGREE still rejected (no regression on the peer-ID guard).
+ */
+import { handleRelayCrossReview } from '../../apps/cli/src/handlers/relay-cross-review';
+import { ctx } from '../../apps/cli/src/mcp-context';
+import { MainAgent } from '@gossip/orchestrator';
+
+// Avoid disk writes from persistPendingConsensus during the test.
+jest.mock('fs', () => ({
+  writeFileSync: jest.fn(),
+  readFileSync: jest.fn(),
+  existsSync: jest.fn(() => false),
+  unlinkSync: jest.fn(),
+  mkdirSync: jest.fn(),
+}));
+
+const CONSENSUS_ID = 'cafecafe-beefbeef';
+const AGENT_ID = 'my-agent-id';
+const PEER_ID = 'peer-agent';
+
+function seedRound(pendingSet: Set<string>) {
+  ctx.pendingConsensusRounds.set(CONSENSUS_ID, {
+    consensusId: CONSENSUS_ID,
+    allResults: [
+      { agentId: AGENT_ID, status: 'completed', result: '- Phase-1 finding', task: 't' },
+      { agentId: PEER_ID, status: 'completed', result: '- Peer finding', task: 't' },
+    ],
+    relayCrossReviewEntries: [],
+    relayCrossReviewSkipped: undefined,
+    pendingNativeAgents: pendingSet,
+    nativeCrossReviewEntries: [],
+    deadline: Date.now() + 60_000,
+    createdAt: Date.now(),
+    nativePrompts: [],
+  });
+}
+
+describe('relay-cross-review NEW-finding handling (GH #131)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    ctx.pendingConsensusRounds.clear();
+
+    // ConsensusEngine needs a MainAgent-like stub for parseCrossReviewResponse.
+    // parseCrossReviewResponse does not call the LLM, but the engine ctor
+    // still requires one — handler supplies a no-op when getLlm() returns
+    // undefined, so we mirror that here.
+    ctx.mainAgent = {
+      projectRoot: '/tmp/relay-cross-review-test',
+      getLlm: () => undefined,
+      getAgentConfig: () => undefined,
+    } as unknown as MainAgent;
+  });
+
+  it('accepts a NEW entry with self-prefixed findingId and rewrites it to the consensus-wide form', async () => {
+    // Two pending agents so this submission does NOT trigger synthesis (which
+    // would require a real LLM). We only assert the filter+rewrite step.
+    seedRound(new Set([AGENT_ID, PEER_ID]));
+
+    const payload = JSON.stringify([
+      {
+        action: 'new',
+        findingId: `${AGENT_ID}:n1`, // self-prefixed — this is what agents emit
+        finding: 'A totally new issue all agents missed',
+        evidence: 'Surfaced after reading peer work at foo.ts:42',
+        confidence: 4,
+      },
+    ]);
+
+    const res = await handleRelayCrossReview(CONSENSUS_ID, AGENT_ID, payload);
+
+    const round = ctx.pendingConsensusRounds.get(CONSENSUS_ID)!;
+    expect(round.nativeCrossReviewEntries).toHaveLength(1);
+    const entry = round.nativeCrossReviewEntries[0];
+    expect(entry.action).toBe('new');
+    expect(entry.agentId).toBe(AGENT_ID);
+    expect(entry.finding).toContain('A totally new issue');
+    // findingId rewritten to `<consensusId>:new:<agentId>:<counter>`
+    expect(entry.findingId).toBe(`${CONSENSUS_ID}:new:${AGENT_ID}:1`);
+    // peerAgentId cleared — NEW has no peer
+    expect(entry.peerAgentId).toBe('');
+
+    const txt = (res.content[0] as { text: string }).text;
+    expect(txt).toContain('accepted');
+  });
+
+  it('rejects a self-prefixed AGREE entry (no regression on the peer-ID filter)', async () => {
+    seedRound(new Set([AGENT_ID, PEER_ID]));
+
+    const payload = JSON.stringify([
+      {
+        action: 'agree',
+        findingId: `${AGENT_ID}:f1`, // self-review, not allowed
+        finding: 'I confirm my own Phase-1 finding',
+        evidence: 'self-verification is not valid cross-review',
+        confidence: 5,
+      },
+    ]);
+
+    await handleRelayCrossReview(CONSENSUS_ID, AGENT_ID, payload);
+
+    const round = ctx.pendingConsensusRounds.get(CONSENSUS_ID)!;
+    // Self-AGREE must be dropped by the filter.
+    expect(round.nativeCrossReviewEntries).toHaveLength(0);
+  });
+
+  it('assigns independent counters to multiple NEW findings in one submission', async () => {
+    seedRound(new Set([AGENT_ID, PEER_ID]));
+
+    const payload = JSON.stringify([
+      { action: 'new', findingId: 'self:n1', finding: 'NEW one at a.ts:1', evidence: 'e1', confidence: 3 },
+      { action: 'new', findingId: 'self:n2', finding: 'NEW two at b.ts:2', evidence: 'e2', confidence: 3 },
+    ]);
+
+    await handleRelayCrossReview(CONSENSUS_ID, AGENT_ID, payload);
+
+    const round = ctx.pendingConsensusRounds.get(CONSENSUS_ID)!;
+    expect(round.nativeCrossReviewEntries).toHaveLength(2);
+    expect(round.nativeCrossReviewEntries[0].findingId).toBe(`${CONSENSUS_ID}:new:${AGENT_ID}:1`);
+    expect(round.nativeCrossReviewEntries[1].findingId).toBe(`${CONSENSUS_ID}:new:${AGENT_ID}:2`);
+  });
+});

--- a/tests/orchestrator/consensus-engine.test.ts
+++ b/tests/orchestrator/consensus-engine.test.ts
@@ -433,6 +433,29 @@ Summary: 1 agree, 1 disagree.`;
         expect(report.newFindings[0].agentId).toBe('agent-2');
       });
 
+      it('preserves a pre-rewritten NEW findingId from relay-cross-review (GH #131)', async () => {
+        // When a NEW entry has been rewritten by handleRelayCrossReview to
+        // `<consensusId>:new:<agentId>:<counter>`, synthesize MUST use that
+        // exact ID for the new_finding signal (instead of re-generating).
+        const rewritten = 'deadbeef-1234abcd:new:agent-2:7';
+        const crossReview: CrossReviewEntry[] = [
+          {
+            action: 'new',
+            agentId: 'agent-2',
+            peerAgentId: '',
+            findingId: rewritten,
+            finding: 'NEW with pre-rewritten id',
+            evidence: 'rewritten by relay handler',
+            confidence: 4,
+          },
+        ];
+        const report = await engine.synthesize(results, crossReview);
+        expect(report.newFindings.length).toBe(1);
+        const newSignal = report.signals.find(s => s.signal === 'new_finding');
+        expect(newSignal).toBeDefined();
+        expect(newSignal!.findingId).toBe(rewritten);
+      });
+
       it('populates authorDiagnostics when agent output contains entity-encoded tags', async () => {
         // agent-html is emitting `&lt;agent_finding&gt;` instead of `<agent_finding>`.
         // parseAgentFindingsStrict produces 0 findings (tags invisible), but the


### PR DESCRIPTION
## Summary

Fixes #131. The phase-2 cross-review filter at `apps/cli/src/handlers/relay-cross-review.ts:150-158` and the mirror site in `packages/orchestrator/src/consensus-engine.ts:657-660` reject every entry where `peerAgentId === agent_id` (self-review). Agents emit `action: "new"` entries with their own `agent_id` as the findingId prefix (no peer to reference), so every NEW entry was silently dropped. `ConsensusReport.newFindings[]` was always empty.

## Fix (Option C from the issue)

- Both filter sites now skip the self-review / unknown-peer check when `action === "new"`.
- The relay handler rewrites NEW `findingId` to `<consensusId>:new:<agentId>:<counter>` and clears `peerAgentId` so downstream resolution doesn't treat it as a peer reference.
- `synthesize()` preserves the pre-rewritten findingId on the emitted `new_finding` signal; it falls back to the same format for in-process cross-review.
- Phase-2 prompt at `consensus-engine.ts:546-550` now documents the NEW convention: `self:n<N>` — server rewrites.

## Testing

- `tests/cli/relay-cross-review-new-findings.test.ts` (new file, 3 cases):
  - Accepts NEW with self-prefixed findingId and rewrites to consensus-wide form
  - Still rejects self-prefixed AGREE (no regression on peer-ID filter)
  - Multiple NEW entries in one submission get independent counters
- `tests/orchestrator/consensus-engine.test.ts` — 1 added case for pre-rewritten findingId preservation in synthesize
- Full suite: 1910 passed / 1911 (1 pre-existing skip), 148 suites.
- `tsc --noEmit` clean on touched files.
- `npm run build:mcp` succeeds.

## Test plan

- [ ] CI green
- [ ] Run a real 3-agent consensus round with phase-2 NEW emission; confirm `newFindings[]` contains entries with `<consensusId>:new:<agent>:<n>` ids
- [ ] Verify dashboard consensus view still renders NEW findings after the ID format change

🤖 Generated with [Claude Code](https://claude.com/claude-code)