### PR TITLE
fix(sandbox): exclude test-fixture temp dirs from Layer-3 audit (NODE_ENV/jest-gated)

### DIFF
--- a/apps/cli/src/sandbox.ts
+++ b/apps/cli/src/sandbox.ts
@@ -788,6 +788,116 @@ export function buildAuditExclusions(
       for (const v of expandTmpVariants(`${tmp}/${pat}`)) excl.add(v);
     }
   } catch { /* tmpdir() failure — best-effort */ }
+  // Test-fixture exclusion — only active under a real test runner.
+  // JEST_WORKER_ID is set by jest (including --runInBand). NODE_ENV=test is
+  // the universal fallback. Neither is settable by a dispatched agent —
+  // agents run in child processes launched via execFileSync / native bridge,
+  // never inside a jest runner. That makes this gate structurally unforgeable.
+  //
+  // Noise accounting (pre-fix): 6,128 / 8,590 = 71% of entries in
+  // .gossip/boundary-escapes.jsonl came from mkdtempSync(join(tmpdir(),
+  // 'gossip-*')) fixtures during `npm test`. Prefix list enumerated by
+  // grepping `mkdtemp.*'gossip-|join\(tmpdir.*'gossip-` — do NOT collapse
+  // to a bare `gossip-*` glob (too broad even when gated).
+  if (process.env.JEST_WORKER_ID !== undefined || process.env.NODE_ENV === 'test') {
+    try {
+      const tmp = canonicalize(tmpdir());
+      const TEST_FIXTURE_PREFIXES = [
+        // Spec'd core set.
+        'gossip-test-',
+        'gossip-wt-',
+        'gossip-verify-',
+        'gossip-native-prompt-',
+        'gossip-mcp-test-',
+        'gossip-signals-val-',
+        'gossip-pipeline-test-',
+        'gossip-relay-duration-test-',
+        'gossip-hook-ns-',
+        'gossip-memory-test-',
+        'sandbox-test-',
+        'perf-writer-',
+        // Observed via grep (mkdtemp*/join(tmpdir()*) — all test-fixture-only.
+        'gossip-empty-',
+        'gossip-no-mem-',
+        'gossip-symlink-',
+        'gossip-outside-',
+        'gossip-bridge-',
+        'gossip-native-consensus-',
+        'gossip-dash-',
+        'gossip-dash-edge-',
+        'gossip-home-',
+        'gossip-consensus-',
+        'gossip-real-',
+        'gossip-skillgen-',
+        'gossip-signal-types-',
+        'gossip-profile-dispatch-',
+        'gossip-ati-integration-',
+        'gossip-skilldev-integ-',
+        'gossip-migration-',
+        'gossip-cat-hook-',
+        'gossip-hook-install-',
+        'gossip-hook-sentinel-',
+        'gossip-wt-test-',
+        'gossip-skill-tools-test-',
+        'gossip-hygiene-seed-test-',
+        'gossip-searcher-test-',
+        'gossip-registry-test-',
+        'gossip-catalog-test-',
+        'gossip-taskgraph-test-',
+        'gossip-memwriter-test-',
+        'gossip-memwriter-edge-test-',
+        'gossip-memreader-edge-test-',
+        'gossip-prefetch-test-',
+        'gossip-bootstrap-test-',
+        'gossip-bootstrap-spec-test-',
+        'gossip-skill-index-test-',
+        'gossip-gap-tracker-test-',
+        'gossip-gap-tracker-fresh-test-',
+        'gossip-gap-tracker-malformed-',
+        'gossip-gap-test-',
+        'gossip-ctx-',
+        'gossip-lru-',
+        'gossip-task-type-',
+        'gossip-cat-boost-',
+        'gossip-status-filter-',
+        'gossip-discovery-e2e-',
+        'gossip-compactor-test-',
+        'gossip-rules-test-',
+        'gossip-audit-roundtrip-',
+        'gossip-remember-validation-',
+        'gossip-skills-test-',
+        'gossip-verify-mem-',
+        'gossip-fullstack-',
+        'gossip-sim-',
+        'gossip-round-retract-',
+        // NOTE: `gossip-l3-`, `gossip-l3-scan-`, `gossip-l3-bin-` are used by
+        // the Layer-3 audit tests THEMSELVES as scan roots — excluding them
+        // would make those tests silently pass without verifying behavior.
+        // They don't appear in real-world boundary-escapes.jsonl noise; they
+        // exist only as in-test isolation directories and are rmSync'd at
+        // teardown. Intentionally omitted.
+        // Non-gossip test prefixes (scoped fixtures).
+        'scope-tracker-',
+        'scope-outside-',
+        'tg-sync-',
+        'findings-cat-',
+        'signals-dedup-',
+        'cer-',
+        'pcr-',
+        'vrr-',
+        'dgw-',
+        'skill-gen-test-',
+        'skill-eff-test-',
+        'skill-migration-test-',
+        'skill-nan-test-',
+        'skill-safename-test-',
+        'collect-eff-test-',
+      ];
+      for (const prefix of TEST_FIXTURE_PREFIXES) {
+        for (const v of expandTmpVariants(`${tmp}/${prefix}`)) excl.add(v + '*');
+      }
+    } catch { /* tmpdir() failure — best-effort */ }
+  }
   if (ownWorktree) {
     const wt = canonicalize(ownWorktree);
     for (const v of expandTmpVariants(wt)) excl.add(v);

--- a/tests/cli/sandbox.test.ts
+++ b/tests/cli/sandbox.test.ts
@@ -383,3 +383,115 @@ describe('buildAuditExclusions', () => {
     expect(exclusions).toContain(resolve(root, '.git'));
   });
 });
+
+/**
+ * Test-fixture noise gate for Layer 3 main pass.
+ *
+ * Context: 6,128 / 8,590 = 71% of .gossip/boundary-escapes.jsonl entries
+ * prior to this fix were mkdtempSync(join(tmpdir(), 'gossip-*-')) fixtures
+ * light-up during `npm test`. The gate only fires when JEST_WORKER_ID or
+ * NODE_ENV=test is set — neither is reachable from a dispatched agent
+ * (child processes launched via execFileSync / native bridge are never
+ * inside a jest runner), which makes the gate structurally unforgeable.
+ *
+ * Invariant: the gate MUST NOT affect the sensitive-targets pass
+ * (Layer 3 Pass 2). That pass takes ZERO exclusions from
+ * buildAuditExclusions and scans the vetted watchlist directly.
+ */
+describe('buildAuditExclusions — test-fixture gate (NODE_ENV / JEST_WORKER_ID)', () => {
+  const root = resolve('/tmp/fakeproject');
+  const tmp = resolve(tmpdir());
+
+  // Snapshot/restore env so one test does not leak into another.
+  const originalJestWorkerId = process.env.JEST_WORKER_ID;
+  const originalNodeEnv = process.env.NODE_ENV;
+  afterEach(() => {
+    if (originalJestWorkerId === undefined) delete process.env.JEST_WORKER_ID;
+    else process.env.JEST_WORKER_ID = originalJestWorkerId;
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('NODE_ENV=test: gossip-test- prefix IS excluded from the main-pass list', () => {
+    delete process.env.JEST_WORKER_ID;
+    process.env.NODE_ENV = 'test';
+    const excl = buildAuditExclusions(root, undefined, undefined);
+    expect(excl).toContain(`${tmp}/gossip-test-*`);
+  });
+
+  it('JEST_WORKER_ID set: gossip-test- prefix IS excluded from the main-pass list', () => {
+    delete process.env.NODE_ENV;
+    process.env.JEST_WORKER_ID = '1';
+    const excl = buildAuditExclusions(root, undefined, undefined);
+    expect(excl).toContain(`${tmp}/gossip-test-*`);
+  });
+
+  it('NODE_ENV and JEST_WORKER_ID both unset: test-fixture prefixes are NOT excluded', () => {
+    delete process.env.JEST_WORKER_ID;
+    delete process.env.NODE_ENV;
+    const excl = buildAuditExclusions(root, undefined, undefined);
+    expect(excl).not.toContain(`${tmp}/gossip-test-*`);
+    expect(excl).not.toContain(`${tmp}/sandbox-test-*`);
+    expect(excl).not.toContain(`${tmp}/gossip-wt-*`);
+    expect(excl).not.toContain(`${tmp}/perf-writer-*`);
+    // Non-test churn exclusions MUST still be present (baseline behavior).
+    expect(excl).toContain(`${tmp}/node-compile-cache`);
+  });
+
+  it('NODE_ENV=test: gossip-wt- prefix IS excluded (covers worktree-manager tmp dirs)', () => {
+    delete process.env.JEST_WORKER_ID;
+    process.env.NODE_ENV = 'test';
+    const excl = buildAuditExclusions(root, undefined, undefined);
+    expect(excl).toContain(`${tmp}/gossip-wt-*`);
+  });
+
+  it('NODE_ENV=test: sandbox-test- prefix IS excluded', () => {
+    delete process.env.JEST_WORKER_ID;
+    process.env.NODE_ENV = 'test';
+    const excl = buildAuditExclusions(root, undefined, undefined);
+    expect(excl).toContain(`${tmp}/sandbox-test-*`);
+  });
+
+  it('NODE_ENV=test: test-fixture exclusions emit /tmp ↔ /private/tmp twin variants', () => {
+    // If tmpdir() itself resolves to /tmp or /var/folders, expandTmpVariants
+    // may or may not emit a /private twin. But gossip-l3-* under an in-test
+    // /tmp path must be symmetric. Synthesize by asserting both forms
+    // coexist for the /tmp branch if tmpdir is /tmp-shaped. Otherwise skip
+    // the twin assertion — the expansion is already unit-tested upstream.
+    delete process.env.JEST_WORKER_ID;
+    process.env.NODE_ENV = 'test';
+    const excl = buildAuditExclusions(root, undefined, undefined);
+    // Every emitted test-fixture entry MUST end in '*' so `find -path`
+    // matches descendants. Guard against accidentally dropping the suffix.
+    const fixtureEntries = excl.filter(e => e.includes('gossip-test-'));
+    expect(fixtureEntries.length).toBeGreaterThan(0);
+    for (const e of fixtureEntries) {
+      expect(e.endsWith('*')).toBe(true);
+    }
+  });
+
+  it('gate MUST NOT alter buildSensitiveFindArgs (Layer 3 Pass 2 is independent of exclusions)', () => {
+    // Structural check: buildSensitiveFindArgs in sandbox.ts takes no
+    // exclusions parameter. We assert the function signature stays decoupled
+    // from the main-pass exclusions list — a regression here would mean the
+    // sensitive pass got gated off too.
+    //
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { buildSensitiveFindArgs } = require('../../apps/cli/src/sandbox');
+    // buildSensitiveFindArgs(target, sentinel, nameIncludes?, sentinelDir?)
+    // — exactly 4 declared parameters, no exclusion list. `.length` counts
+    // declared parameters (up to the first one with a default).
+    expect(typeof buildSensitiveFindArgs).toBe('function');
+    expect(buildSensitiveFindArgs.length).toBeLessThanOrEqual(4);
+    // Smoke: invoking with NODE_ENV=test must still produce a find argv that
+    // targets the given sensitive path without any test-fixture exclusion
+    // leaking in.
+    delete process.env.JEST_WORKER_ID;
+    process.env.NODE_ENV = 'test';
+    const args: string[] = buildSensitiveFindArgs('/Users/someuser/.ssh', '/tmp/fake-sentinel');
+    expect(args[0]).toBe('/Users/someuser/.ssh');
+    // No test-fixture prefix should be in the argv.
+    expect(args.some((a: string) => a.includes('gossip-test-'))).toBe(false);
+    expect(args.some((a: string) => a.includes('sandbox-test-'))).toBe(false);
+  });
+});

--- a/tests/cli/worktree-audit-layer3.test.ts
+++ b/tests/cli/worktree-audit-layer3.test.ts
@@ -161,7 +161,13 @@ describeOnPosix('buildAuditExclusions', () => {
 
   it('omits worktree exclusion when ownWorktree is undefined', () => {
     const excl = buildAuditExclusions('/tmp/proj', undefined);
-    expect(excl.some(e => e.includes('gossip-wt'))).toBe(false);
+    // When ownWorktree is undefined, no path ending in the worktree dir
+    // itself is added (there's nothing to exclude). Under NODE_ENV=test the
+    // env-gated list does include a `<tmp>/gossip-wt-*` glob as test-fixture
+    // noise exclusion — that is distinct from the ownWorktree entry, which
+    // is the unrooted canonicalized worktree path. Assert no entry exactly
+    // equals a canonicalized worktree-shaped path.
+    expect(excl.some(e => e === '/tmp/proj/gossip-wt' || /^\/private?\/tmp\/gossip-wt-[^*]+$/.test(e))).toBe(false);
   });
 
   it('excludes user-level OS/app churn dirs (~/Library, ~/.cache, ~/.npm, ~/.claude)', () => {
@@ -894,6 +900,127 @@ describeOnPosix('buildFindPruneArgs', () => {
       rmSync(scanRoot, { recursive: true, force: true });
       rmSync(binDir, { recursive: true, force: true });
     }
+  });
+});
+
+describeOnPosix('auditFilesystemSinceSentinel — test-fixture noise gate', () => {
+  /**
+   * Context: 6,128 / 8,590 = 71% of pre-fix boundary-escapes.jsonl entries
+   * came from `mkdtempSync(join(tmpdir(), 'gossip-*-'))` fixtures during
+   * `npm test`. The env-gated exclusion in buildAuditExclusions suppresses
+   * these ONLY when JEST_WORKER_ID or NODE_ENV=test is set — a dispatched
+   * agent running in a child process cannot reach either, so the gate is
+   * structurally unforgeable for production dispatch.
+   */
+  const originalJestWorkerId = process.env.JEST_WORKER_ID;
+  const originalNodeEnv = process.env.NODE_ENV;
+  afterEach(() => {
+    if (originalJestWorkerId === undefined) delete process.env.JEST_WORKER_ID;
+    else process.env.JEST_WORKER_ID = originalJestWorkerId;
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  itOnPosix('NODE_ENV=test: gossip-test-* path under tmpdir is EXCLUDED from mainSet', () => {
+    delete process.env.JEST_WORKER_ID;
+    process.env.NODE_ENV = 'test';
+
+    const projectRoot = mkTmp();
+    // Fixture dir sits directly under tmpdir() with the spec-named prefix.
+    const fixtureDir = mkdtempSync(join(tmpdir(), `gossip-test-synthetic-${Date.now()}-`));
+    try {
+      const sentinel = stampTaskSentinel(projectRoot, 'gate-test-1')!;
+      backdateSentinel(sentinel, 5000);
+
+      // Write a file inside the fixture AFTER the sentinel — without the gate,
+      // this would be flagged as a Layer 3 violation.
+      const innerDir = join(fixtureDir, '.gossip');
+      mkdirSync(innerDir, { recursive: true });
+      const fake = join(innerDir, 'fake.jsonl');
+      writeFileSync(fake, '{"x":1}\n');
+
+      const meta: DispatchMetadata = {
+        taskId: 'gate-test-1',
+        agentId: 'opus-implementer',
+        writeMode: 'worktree',
+        timestamp: Date.now(),
+        sentinelPath: sentinel,
+      };
+
+      const res = auditFilesystemSinceSentinel(projectRoot, meta, {
+        scanRoots: [tmpdir()],
+        logFailures: false,
+      });
+
+      // The synthetic fixture file MUST NOT appear — the env-gated prefix
+      // pruned it during the main pass.
+      expect(res.violations.some(v => v.includes('fake.jsonl'))).toBe(false);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  itOnPosix('NODE_ENV / JEST_WORKER_ID both unset: same path IS flagged (gate is closed)', () => {
+    delete process.env.JEST_WORKER_ID;
+    delete process.env.NODE_ENV;
+
+    const projectRoot = mkTmp();
+    const fixtureDir = mkdtempSync(join(tmpdir(), `gossip-test-synthetic-${Date.now()}-`));
+    try {
+      const sentinel = stampTaskSentinel(projectRoot, 'gate-test-2')!;
+      backdateSentinel(sentinel, 5000);
+
+      const innerDir = join(fixtureDir, '.gossip');
+      mkdirSync(innerDir, { recursive: true });
+      const fake = join(innerDir, 'fake.jsonl');
+      writeFileSync(fake, '{"x":1}\n');
+
+      const meta: DispatchMetadata = {
+        taskId: 'gate-test-2',
+        agentId: 'opus-implementer',
+        writeMode: 'worktree',
+        timestamp: Date.now(),
+        sentinelPath: sentinel,
+      };
+
+      const res = auditFilesystemSinceSentinel(projectRoot, meta, {
+        scanRoots: [tmpdir()],
+        logFailures: false,
+      });
+
+      // Gate closed → fixture path surfaces as a violation.
+      expect(res.violations.some(v => v.includes('fake.jsonl'))).toBe(true);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  itOnPosix('sensitive pass IS unaffected by the gate (Pass 2 takes no exclusions)', () => {
+    // We cannot safely write to a real sensitive target (~/.ssh), so this
+    // asserts the structural invariant: buildSensitiveFindArgs does not
+    // consult buildAuditExclusions, so the env gate cannot reach Pass 2.
+    // Regression here would mean the gate inadvertently suppressed a real
+    // sensitive-target hit under NODE_ENV=test.
+    //
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { buildSensitiveFindArgs } = require('../../apps/cli/src/sandbox');
+    delete process.env.JEST_WORKER_ID;
+    process.env.NODE_ENV = 'test';
+    const args: string[] = buildSensitiveFindArgs(
+      '/Users/someuser/.ssh',
+      '/tmp/fake-sentinel',
+      ['id_*', '*.key'],
+    );
+    // First positional arg is the sensitive target; no test-fixture prefix
+    // can leak in because Pass 2 does not consult the main-pass exclusions.
+    expect(args[0]).toBe('/Users/someuser/.ssh');
+    expect(args.some((a: string) => a.includes('gossip-test-synthetic-'))).toBe(false);
+    expect(args.some((a: string) => a.includes('sandbox-test-'))).toBe(false);
+    // And the -name include-list survived — watchlist semantics intact.
+    expect(args).toContain('-name');
+    expect(args).toContain('id_*');
   });
 });
 


### PR DESCRIPTION
## Summary

Layer-3 audit (`apps/cli/src/sandbox.ts`, `auditFilesystemSinceSentinel`) scans `tmpdir()` on every dispatch. During `npm test`, the per-test `mkdtempSync(join(tmpdir(), 'gossip-*-'))` fixtures lit up as Layer-3 violations.

**Noise accounting:** 6,128 / 8,590 = **71%** of entries in `.gossip/boundary-escapes.jsonl` before this fix came from test-fixture temp dirs during local `npm test` runs.

## Change

`buildAuditExclusions` now appends a test-fixture prefix list to the main-pass `-prune` exclusions — but **only when `JEST_WORKER_ID` or `NODE_ENV=test` is set**. The prefix list was enumerated via grep against `mkdtemp.*'gossip-|join\(tmpdir.*'gossip-` and the sandbox/perf-writer variants; a single bare `gossip-*` glob was intentionally avoided (too broad, even when gated).

### Security rationale — why the env gate is structurally unforgeable

Dispatched agents run in child processes launched via `execFileSync` (Tool Server) or the native-bridge spawn path. Neither code path is inside a jest runner, so **neither env var is reachable at dispatch time**. A hostile agent cannot set `JEST_WORKER_ID` or `NODE_ENV=test` to smuggle writes past Layer 3 — the gate only opens when the orchestrator itself is running under `jest`.

### Invariants preserved

- `buildSensitiveFindArgs` (Layer 3 Pass 2, watchlist pass) takes **no exclusions** and is untouched. A real sensitive-target hit under `NODE_ENV=test` still fires.
- The `ownWorktree` and `scope` additions to `buildAuditExclusions` still run after the gated block.
- `/tmp` <-> `/private/tmp` twin variants emitted via `expandTmpVariants` for each prefix so macOS symlink resolution doesn't produce false positives.

## Tests

New tests in `tests/cli/sandbox.test.ts` under `describe('buildAuditExclusions — test-fixture gate (NODE_ENV / JEST_WORKER_ID)')`:

- `NODE_ENV=test: gossip-test- prefix IS excluded from the main-pass list`
- `JEST_WORKER_ID set: gossip-test- prefix IS excluded from the main-pass list`
- `NODE_ENV and JEST_WORKER_ID both unset: test-fixture prefixes are NOT excluded`
- `NODE_ENV=test: gossip-wt- prefix IS excluded (covers worktree-manager tmp dirs)`
- `NODE_ENV=test: sandbox-test- prefix IS excluded`
- `NODE_ENV=test: test-fixture exclusions emit /tmp <-> /private/tmp twin variants` (asserts `*` suffix)
- `gate MUST NOT alter buildSensitiveFindArgs (Layer 3 Pass 2 is independent of exclusions)`

New tests in `tests/cli/worktree-audit-layer3.test.ts` under `describe('auditFilesystemSinceSentinel — test-fixture noise gate')`:

- `NODE_ENV=test: gossip-test-* path under tmpdir is EXCLUDED from mainSet` (end-to-end via `auditFilesystemSinceSentinel`)
- `NODE_ENV / JEST_WORKER_ID both unset: same path IS flagged (gate is closed)`
- `sensitive pass IS unaffected by the gate (Pass 2 takes no exclusions)`

## Test plan

- [x] `npm test` — all 1,916 tests pass (147 suites, 1 skipped pre-existing)
- [x] `npm run build:mcp` — succeeds, bundle at `dist-mcp/mcp-server.js` (1.7 MB)
- [x] Typecheck: pre-existing `dist/` staleness errors in `collect.ts`, `relay-cross-review.ts`, `mcp-server-sdk.ts` (all on master; none involve `sandbox.ts`; confirmed by stash+checkout against `origin/master`)

## Review provenance

sonnet-reviewer + gemini-reviewer agreed on this architecture (env-gated prefix list over an ungated `mkdtemp`-shape regex or a post-audit filter). Spec required start: verify prefix list is complete, avoid collapsing to a single `gossip-*` glob. Done: 60+ prefixes enumerated from actual code grep.

## Follow-up (not in scope)

`.gossip/boundary-escapes.jsonl` currently grows without bound (file already ~1.4 MB locally). Separate concern — rotation / age-out policy should land in its own PR.

Generated with Claude Code (https://claude.com/claude-code)
