### PR TITLE
chore(sandbox): single-slot 5MB rotation for boundary-escapes.jsonl

### DIFF
--- a/apps/cli/src/sandbox.ts
+++ b/apps/cli/src/sandbox.ts
@@ -29,6 +29,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  renameSync,
   statSync,
   unlinkSync,
   utimesSync,
@@ -59,6 +60,35 @@ export interface DispatchMetadata {
 const METADATA_FILE = 'dispatch-metadata.jsonl';
 const BOUNDARY_ESCAPE_FILE = 'boundary-escapes.jsonl';
 const SENTINEL_DIR = 'sentinels';
+
+/** Max bytes for `.gossip/boundary-escapes.jsonl` before single-slot rotation. */
+export const MAX_BOUNDARY_ESCAPE_BYTES = 5 * 1024 * 1024; // 5MB
+
+/**
+ * Best-effort single-slot size rotation.
+ *
+ * If `filePath` exists and is at least `maxBytes`, rename it to `filePath + '.1'`,
+ * overwriting any pre-existing `.1` slot. No `.2`/`.3`, no compression. Silent
+ * on any error (missing file, EPERM, etc.) — matches the surrounding try/catch
+ * best-effort style for boundary-escape logging.
+ */
+export function rotateIfNeeded(filePath: string, maxBytes: number): void {
+  try {
+    const st = statSync(filePath);
+    if (st.size < maxBytes) return;
+    const rotated = filePath + '.1';
+    // fs.renameSync overwrites an existing destination on POSIX. Wrap in an
+    // unlink+rename for belt-and-suspenders safety across platforms.
+    try {
+      if (existsSync(rotated)) unlinkSync(rotated);
+    } catch {
+      /* best-effort */
+    }
+    renameSync(filePath, rotated);
+  } catch {
+    /* best-effort */
+  }
+}
 
 // Paths that agents legitimately write outside their declared boundary.
 // These are infrastructure artifacts, not application code — false-positive
@@ -508,7 +538,9 @@ function recordBoundaryEscape(
       violatingPaths: violations,
       action: mode, // "warn" or "block"
     };
-    appendFileSync(join(dir, BOUNDARY_ESCAPE_FILE), JSON.stringify(line) + '\n');
+    const escapeFile = join(dir, BOUNDARY_ESCAPE_FILE);
+    rotateIfNeeded(escapeFile, MAX_BOUNDARY_ESCAPE_BYTES);
+    appendFileSync(escapeFile, JSON.stringify(line) + '\n');
   } catch {
     /* best-effort */
   }
@@ -1232,7 +1264,9 @@ function recordLayer3Violations(
         source,
       }),
     );
-    appendFileSync(join(dir, BOUNDARY_ESCAPE_FILE), lines.join('\n') + '\n');
+    const escapeFile = join(dir, BOUNDARY_ESCAPE_FILE);
+    rotateIfNeeded(escapeFile, MAX_BOUNDARY_ESCAPE_BYTES);
+    appendFileSync(escapeFile, lines.join('\n') + '\n');
   } catch {
     /* best-effort */
   }

--- a/tests/cli/sandbox.test.ts
+++ b/tests/cli/sandbox.test.ts
@@ -1,7 +1,16 @@
 /**
  * Tests for sandbox enforcement — prompt sanitization + boundary audit.
  */
-import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  statSync,
+  rmSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
 import {
@@ -16,6 +25,8 @@ import {
   isInsideScope,
   DispatchMetadata,
   buildAuditExclusions,
+  rotateIfNeeded,
+  MAX_BOUNDARY_ESCAPE_BYTES,
 } from '../../apps/cli/src/sandbox';
 
 describe('relativizeProjectPaths', () => {
@@ -493,5 +504,94 @@ describe('buildAuditExclusions — test-fixture gate (NODE_ENV / JEST_WORKER_ID)
     // No test-fixture prefix should be in the argv.
     expect(args.some((a: string) => a.includes('gossip-test-'))).toBe(false);
     expect(args.some((a: string) => a.includes('sandbox-test-'))).toBe(false);
+  });
+});
+
+describe('rotateIfNeeded (boundary-escapes.jsonl size rotation)', () => {
+  let tmpDir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'gossip-test-rotation-'));
+    filePath = join(tmpDir, 'boundary-escapes.jsonl');
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  it('does not rotate when file is under the size limit', () => {
+    const line = JSON.stringify({ hello: 'world' }) + '\n';
+    writeFileSync(filePath, line);
+    rotateIfNeeded(filePath, 1024);
+    expect(existsSync(filePath)).toBe(true);
+    expect(existsSync(filePath + '.1')).toBe(false);
+    expect(readFileSync(filePath, 'utf8')).toBe(line);
+  });
+
+  it('does not rotate when the file does not exist', () => {
+    // Missing file → no-op, no throw.
+    rotateIfNeeded(filePath, 1024);
+    expect(existsSync(filePath)).toBe(false);
+    expect(existsSync(filePath + '.1')).toBe(false);
+  });
+
+  it('rotates to .1 when the file is at or over the size limit', () => {
+    const payload = 'x'.repeat(200);
+    writeFileSync(filePath, payload);
+    rotateIfNeeded(filePath, 100);
+    expect(existsSync(filePath)).toBe(false);
+    expect(existsSync(filePath + '.1')).toBe(true);
+    expect(readFileSync(filePath + '.1', 'utf8')).toBe(payload);
+  });
+
+  it('overwrites an existing .1 slot on a second rotation (single slot only)', () => {
+    // First rotation.
+    writeFileSync(filePath, 'first-generation');
+    rotateIfNeeded(filePath, 1);
+    expect(readFileSync(filePath + '.1', 'utf8')).toBe('first-generation');
+    expect(existsSync(filePath)).toBe(false);
+
+    // Second rotation — .1 must be overwritten, never promoted to .2.
+    writeFileSync(filePath, 'second-generation');
+    rotateIfNeeded(filePath, 1);
+    expect(readFileSync(filePath + '.1', 'utf8')).toBe('second-generation');
+    expect(existsSync(filePath + '.2')).toBe(false);
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  it('allows appends to continue after rotation (new file created fresh)', () => {
+    writeFileSync(filePath, 'old-content-that-is-rotated');
+    rotateIfNeeded(filePath, 1);
+    expect(existsSync(filePath)).toBe(false);
+
+    // Mimic the production call shape: rotateIfNeeded → appendFileSync.
+    const nextLine = JSON.stringify({ taskId: 't1', violatingPaths: ['foo'] }) + '\n';
+    appendFileSync(filePath, nextLine);
+
+    expect(readFileSync(filePath, 'utf8')).toBe(nextLine);
+    expect(readFileSync(filePath + '.1', 'utf8')).toBe('old-content-that-is-rotated');
+
+    // Another append accumulates into the same fresh file.
+    const line2 = JSON.stringify({ taskId: 't2' }) + '\n';
+    appendFileSync(filePath, line2);
+    expect(readFileSync(filePath, 'utf8')).toBe(nextLine + line2);
+  });
+
+  it('exposes a 5MB default limit constant', () => {
+    expect(MAX_BOUNDARY_ESCAPE_BYTES).toBe(5 * 1024 * 1024);
+  });
+
+  it('rotates exactly at the threshold (>= maxBytes)', () => {
+    const payload = 'a'.repeat(100);
+    writeFileSync(filePath, payload);
+    expect(statSync(filePath).size).toBe(100);
+    rotateIfNeeded(filePath, 100); // equal → rotate
+    expect(existsSync(filePath)).toBe(false);
+    expect(readFileSync(filePath + '.1', 'utf8')).toBe(payload);
   });
 });


### PR DESCRIPTION
## Summary
- `.gossip/boundary-escapes.jsonl` grew unbounded (~2.7MB / 9.9K lines today). Adds size-based rotation.
- New `rotateIfNeeded(filePath, maxBytes)` helper near `BOUNDARY_ESCAPE_FILE`. At `MAX_BOUNDARY_ESCAPE_BYTES = 5MB`, active file → `.1`, overwriting any prior `.1`. Single slot, no `.2`/`.3`, no compression.
- Called before both append sites: Layer 2 `recordBoundaryEscape` and Layer 3 `recordLayer3Violations`. All best-effort try/catch matching surrounding style — rotation never blocks audit completion.

## Test plan
- [x] 7 new jest cases in `tests/cli/sandbox.test.ts`: under-limit no-op, missing-file no-op, rotation trigger, second-rotation overwrites `.1`, post-rotation append, 5MB constant sanity, exact-threshold (`>=`) rotation
- [x] 90/90 sandbox suites pass (~3.3s)
- [x] Pre-unlink stale `.1` then `renameSync` for POSIX atomicity + Windows safety

Backlog: closes the `boundary-escapes.jsonl rotation` item from `next-session.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)