### PR TITLE
feat(dashboard): PR-F — Finding-Detail drawer + findingId on signals

### DIFF
--- a/packages/dashboard-v2/src/components/CitationSnippet.tsx
+++ b/packages/dashboard-v2/src/components/CitationSnippet.tsx
@@ -1,0 +1,19 @@
+import type { CitationSnippet as CS } from '@/lib/types';
+
+export function CitationSnippet({ citation }: { citation: CS }) {
+  const lines = citation.snippet.split('\n');
+  return (
+    <div className="rounded-md border border-border/40 bg-card/60 overflow-hidden">
+      <div className="flex items-center justify-between px-3 py-1 border-b border-border/40 bg-muted/40">
+        <span className="font-mono text-[10px] text-muted-foreground">
+          {citation.file}:{citation.line}
+        </span>
+      </div>
+      <pre className="px-3 py-2 font-mono text-[11px] leading-relaxed overflow-x-auto">
+        {lines.map((l, i) => (
+          <div key={i} className="whitespace-pre">{l || '\u00A0'}</div>
+        ))}
+      </pre>
+    </div>
+  );
+}

--- a/packages/dashboard-v2/src/components/FindingDetailDrawer.tsx
+++ b/packages/dashboard-v2/src/components/FindingDetailDrawer.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from 'react';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { api } from '@/lib/api';
+import { timeAgo } from '@/lib/utils';
+import { CitationSnippet } from './CitationSnippet';
+import type { FindingDetail } from '@/lib/types';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  consensusId: string | null;
+  findingId: string | null;
+}
+
+const SEVERITY_COLORS: Record<string, string> = {
+  critical: 'bg-disputed text-disputed-foreground',
+  high: 'bg-disputed/70 text-disputed-foreground',
+  medium: 'bg-unique text-unique-foreground',
+  low: 'bg-muted text-muted-foreground',
+};
+
+const TAG_COLORS: Record<string, string> = {
+  confirmed: 'bg-confirmed',
+  disputed: 'bg-disputed',
+  unverified: 'bg-unverified',
+  unique: 'bg-unique',
+  insight: 'bg-muted',
+  newFinding: 'bg-unique',
+};
+
+export function FindingDetailDrawer({ open, onOpenChange, consensusId, findingId }: Props) {
+  const [detail, setDetail] = useState<FindingDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !consensusId || !findingId) { setDetail(null); setError(null); return; }
+    setDetail(null);
+    setError(null);
+    api<FindingDetail>(`finding/${encodeURIComponent(consensusId)}/${encodeURIComponent(findingId)}`)
+      .then(setDetail)
+      .catch((e) => setError(e.message || 'failed to load finding'));
+  }, [open, consensusId, findingId]);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-[480px] sm:w-[480px] sm:max-w-[480px] overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle className="font-mono text-sm">Finding detail</SheetTitle>
+        </SheetHeader>
+
+        {error && <div className="mt-4 text-[11px] text-disputed">{error}</div>}
+        {!error && !detail && <div className="mt-4 text-[11px] text-muted-foreground">Loading…</div>}
+
+        {detail && (
+          <div className="mt-4 space-y-4">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className={`font-mono text-[9px] uppercase tracking-widest px-2 py-0.5 rounded ${TAG_COLORS[detail.finding.tag] || 'bg-muted'}`}>
+                {detail.finding.tag}
+              </span>
+              {detail.finding.severity && (
+                <span className={`font-mono text-[9px] uppercase tracking-widest px-2 py-0.5 rounded ${SEVERITY_COLORS[detail.finding.severity] || 'bg-muted'}`}>
+                  {detail.finding.severity}
+                </span>
+              )}
+              <span className="font-mono text-[9px] text-muted-foreground">
+                by {detail.finding.originalAgentId}
+              </span>
+              {detail.retracted && (
+                <span className="font-mono text-[9px] uppercase tracking-widest px-2 py-0.5 rounded bg-disputed/50">
+                  retracted
+                </span>
+              )}
+            </div>
+
+            <div className="text-[12px] leading-relaxed whitespace-pre-wrap">
+              {detail.finding.finding.replace(/<cite tag="file">[^<]+<\/cite>/g, '').trim()}
+            </div>
+
+            {detail.citations.length > 0 && (
+              <div className="space-y-2">
+                <div className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+                  Citations
+                </div>
+                {detail.citations.map((c, i) => <CitationSnippet key={i} citation={c} />)}
+              </div>
+            )}
+
+            <div className="space-y-1">
+              <div className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+                Coverage
+              </div>
+              {detail.finding.confirmedBy.length > 0 && (
+                <div className="text-[11px]">
+                  <span className="text-confirmed">✓</span> confirmed by {detail.finding.confirmedBy.join(', ')}
+                </div>
+              )}
+              {detail.finding.disputedBy.map((d, i) => (
+                <div key={i} className="text-[11px]">
+                  <span className="text-disputed">✗</span> disputed by {d.agentId}: <span className="text-muted-foreground">{d.reason}</span>
+                </div>
+              ))}
+              {detail.finding.confirmedBy.length === 0 && detail.finding.disputedBy.length === 0 && (
+                <div className="text-[11px] text-muted-foreground">No peer review</div>
+              )}
+            </div>
+
+            {detail.signals.length > 0 && (
+              <div className="space-y-2">
+                <div className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+                  Signals ({detail.signals.length})
+                </div>
+                <div className="space-y-1">
+                  {detail.signals.map((s, i) => (
+                    <div key={i} className="text-[11px] border-l-2 border-border/40 pl-2">
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono font-semibold">{s.signal}</span>
+                        <span className="text-muted-foreground">·</span>
+                        <span>{s.agentId}</span>
+                        {s.counterpartId && <>
+                          <span className="text-muted-foreground">→</span>
+                          <span>{s.counterpartId}</span>
+                        </>}
+                        <span className="text-muted-foreground ml-auto">{timeAgo(s.timestamp)}</span>
+                      </div>
+                      {s.evidence && <div className="text-muted-foreground mt-0.5">{s.evidence.slice(0, 200)}</div>}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="pt-2 border-t border-border/40">
+              <a href={`#/consensus/${detail.consensusId}`} className="font-mono text-[10px] text-primary hover:underline">
+                → consensus round {detail.consensusId}
+              </a>
+            </div>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/packages/dashboard-v2/src/components/SignalTimeline.tsx
+++ b/packages/dashboard-v2/src/components/SignalTimeline.tsx
@@ -2,13 +2,8 @@ import { useState, useEffect } from 'react';
 import { api } from '@/lib/api';
 import { timeAgo } from '@/lib/utils';
 import { EmptyState } from './EmptyState';
-
-interface SignalEntry {
-  signal: string;
-  agentId: string;
-  timestamp: string;
-  evidence?: string;
-}
+import { FindingDetailDrawer } from './FindingDetailDrawer';
+import type { SignalEntry } from '@/lib/types';
 
 interface SignalsResponse {
   items: SignalEntry[];
@@ -40,6 +35,8 @@ const SIGNAL_LABELS: Record<string, string> = {
 export function SignalTimeline({ agentId }: { agentId: string }) {
   const [signals, setSignals] = useState<SignalEntry[]>([]);
   const [total, setTotal] = useState(0);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [selected, setSelected] = useState<{ consensusId: string; findingId: string } | null>(null);
 
   useEffect(() => {
     api<SignalsResponse>(`signals?agent=${encodeURIComponent(agentId)}&limit=100`)
@@ -107,15 +104,26 @@ export function SignalTimeline({ agentId }: { agentId: string }) {
         </div>
       </div>
       <div className="flex items-center gap-0.5">
-        {ordered.map((s, i) => (
-          <div
-            key={i}
-            className={`h-4 w-1.5 rounded-sm transition-opacity hover:opacity-80 ${
-              SIGNAL_COLORS[s.signal] || 'bg-muted'
-            }`}
-            title={`${SIGNAL_LABELS[s.signal] || s.signal} — ${timeAgo(s.timestamp)}`}
-          />
-        ))}
+        {ordered.map((s, i) => {
+          const clickable = !!(s.consensusId && s.findingId);
+          return (
+            <button
+              key={i}
+              type="button"
+              disabled={!clickable}
+              onClick={() => {
+                if (s.consensusId && s.findingId) {
+                  setSelected({ consensusId: s.consensusId, findingId: s.findingId });
+                  setDrawerOpen(true);
+                }
+              }}
+              className={`h-4 w-1.5 rounded-sm transition-opacity hover:opacity-80 ${
+                SIGNAL_COLORS[s.signal] || 'bg-muted'
+              } ${clickable ? 'cursor-pointer' : 'cursor-default'}`}
+              title={`${SIGNAL_LABELS[s.signal] || s.signal} — ${timeAgo(s.timestamp)}${clickable ? ' (click for detail)' : ''}`}
+            />
+          );
+        })}
       </div>
       {/* Legend — "Disputed" covers disagreement + hallucination_caught; the
           counts row above uses the same name so a red bar has exactly one
@@ -133,6 +141,12 @@ export function SignalTimeline({ agentId }: { agentId: string }) {
           </div>
         ))}
       </div>
+      <FindingDetailDrawer
+        open={drawerOpen}
+        onOpenChange={setDrawerOpen}
+        consensusId={selected?.consensusId ?? null}
+        findingId={selected?.findingId ?? null}
+      />
     </div>
   );
 }

--- a/packages/dashboard-v2/src/components/ui/sheet.tsx
+++ b/packages/dashboard-v2/src/components/ui/sheet.tsx
@@ -1,0 +1,80 @@
+import { useEffect, type ReactNode, type HTMLAttributes } from 'react';
+
+/**
+ * Hand-rolled minimal Sheet primitive. Exposes the shadcn-style surface
+ * (Sheet, SheetContent, SheetHeader, SheetTitle) used by
+ * FindingDetailDrawer. Built directly rather than via `npx shadcn add sheet`
+ * because this project does not depend on @radix-ui/react-dialog; pulling it
+ * in just for one side panel is heavier than a ~60-line bespoke primitive.
+ *
+ * Behaviour:
+ * - Click the backdrop to close.
+ * - Escape closes.
+ * - Body scroll is locked while open.
+ * - `side="right"` renders the panel flush to the right edge (other sides
+ *   are accepted for API parity but collapse to right since the drawer only
+ *   ever uses right).
+ */
+
+interface SheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+}
+
+export function Sheet({ open, onOpenChange, children }: SheetProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onOpenChange(false);
+    };
+    document.addEventListener('keydown', onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div
+        className="absolute inset-0 bg-background/70 backdrop-blur-sm"
+        onClick={() => onOpenChange(false)}
+      />
+      <div className="absolute inset-y-0 right-0 flex">
+        {/* stopPropagation keeps clicks inside the panel from closing it */}
+        <div onClick={(e) => e.stopPropagation()} className="contents">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface SheetContentProps extends HTMLAttributes<HTMLDivElement> {
+  side?: 'right' | 'left' | 'top' | 'bottom';
+  children: ReactNode;
+}
+
+export function SheetContent({ side: _side = 'right', className = '', children, ...rest }: SheetContentProps) {
+  return (
+    <div
+      className={`h-full border-l border-border/60 bg-card shadow-xl p-6 ${className}`}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function SheetHeader({ className = '', ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={`mb-2 ${className}`} {...rest} />;
+}
+
+export function SheetTitle({ className = '', ...rest }: HTMLAttributes<HTMLHeadingElement>) {
+  return <h2 className={`font-semibold ${className}`} {...rest} />;
+}

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -178,6 +178,51 @@ export interface MemoryData {
   cognitiveCount: number;
 }
 
+export interface SignalEntry {
+  signal: string;
+  agentId: string;
+  counterpartId?: string;
+  taskId?: string;
+  consensusId?: string;
+  findingId?: string;
+  severity?: 'critical' | 'high' | 'medium' | 'low';
+  evidence?: string;
+  timestamp: string;
+}
+
+export interface CitationSnippet {
+  file: string;
+  line: number;
+  snippet: string;
+}
+
+export interface FindingDetailSignal {
+  signal: string;
+  agentId: string;
+  counterpartId?: string;
+  evidence?: string;
+  timestamp: string;
+}
+
+export interface FindingDetail {
+  consensusId: string;
+  finding: {
+    id: string;
+    authorFindingId?: string;
+    originalAgentId: string;
+    finding: string;
+    findingType: 'finding' | 'suggestion' | 'insight';
+    severity?: 'critical' | 'high' | 'medium' | 'low';
+    tag: 'confirmed' | 'disputed' | 'unverified' | 'unique' | 'insight' | 'newFinding';
+    confirmedBy: string[];
+    disputedBy: { agentId: string; reason: string }[];
+    confidence: number;
+  };
+  signals: FindingDetailSignal[];
+  citations: CitationSnippet[];
+  retracted?: { reason: string; at: string };
+}
+
 export type DashboardEvent =
   | { type: 'task_dispatched'; taskId: string; agentId: string }
   | { type: 'task_completed'; taskId: string; agentId: string }

--- a/packages/relay/src/dashboard/api-finding.ts
+++ b/packages/relay/src/dashboard/api-finding.ts
@@ -1,0 +1,124 @@
+import { readFileSync, existsSync } from 'fs';
+import { join, resolve, relative } from 'path';
+
+export interface CitationSnippet {
+  file: string;
+  line: number;
+  snippet: string;
+}
+
+export interface FindingDetailSignal {
+  signal: string;
+  agentId: string;
+  counterpartId?: string;
+  evidence?: string;
+  timestamp: string;
+}
+
+export interface FindingDetail {
+  consensusId: string;
+  finding: {
+    id: string;
+    authorFindingId?: string;
+    originalAgentId: string;
+    finding: string;
+    findingType: 'finding' | 'suggestion' | 'insight';
+    severity?: 'critical' | 'high' | 'medium' | 'low';
+    tag: 'confirmed' | 'disputed' | 'unverified' | 'unique' | 'insight' | 'newFinding';
+    confirmedBy: string[];
+    disputedBy: { agentId: string; reason: string }[];
+    confidence: number;
+  };
+  signals: FindingDetailSignal[];
+  citations: CitationSnippet[];
+  retracted?: { reason: string; at: string };
+}
+
+const SNIPPET_CONTEXT = 2;
+const CITE_RE = /<cite tag="file">([^<:]+):(\d+)<\/cite>/g;
+
+function extractCitations(findingText: string, projectRoot: string): CitationSnippet[] {
+  const out: CitationSnippet[] = [];
+  const resolvedRoot = resolve(projectRoot);
+  let m: RegExpExecArray | null;
+  CITE_RE.lastIndex = 0;
+  while ((m = CITE_RE.exec(findingText)) !== null) {
+    const filePath = m[1];
+    const line = parseInt(m[2], 10);
+    if (!Number.isFinite(line) || line < 1) continue;
+    const abs = resolve(projectRoot, filePath);
+    const rel = relative(resolvedRoot, abs);
+    if (rel.startsWith('..') || rel === '') continue;
+    if (!existsSync(abs)) { out.push({ file: filePath, line, snippet: '// file not found' }); continue; }
+    try {
+      const lines = readFileSync(abs, 'utf-8').split('\n');
+      const start = Math.max(0, line - 1 - SNIPPET_CONTEXT);
+      const end = Math.min(lines.length, line + SNIPPET_CONTEXT);
+      out.push({ file: filePath, line, snippet: lines.slice(start, end).join('\n') });
+    } catch { out.push({ file: filePath, line, snippet: '// read error' }); }
+  }
+  return out;
+}
+
+export async function findingHandler(
+  projectRoot: string,
+  consensusId: string,
+  findingId: string,
+): Promise<FindingDetail> {
+  const reportPath = join(projectRoot, '.gossip', 'consensus-reports', `${consensusId}.json`);
+  if (!existsSync(reportPath)) throw new Error(`consensus ${consensusId} not found`);
+  const report = JSON.parse(readFileSync(reportPath, 'utf-8'));
+
+  const buckets: [string, FindingDetail['finding']['tag']][] = [
+    ['confirmed', 'confirmed'], ['disputed', 'disputed'],
+    ['unverified', 'unverified'], ['unique', 'unique'],
+    ['insights', 'insight'], ['newFindings', 'newFinding'],
+  ];
+  let found: any = null;
+  let tag: FindingDetail['finding']['tag'] = 'unverified';
+  for (const [bucket, tagName] of buckets) {
+    const hit = (report[bucket] || []).find((f: any) => f.id === findingId);
+    if (hit) { found = hit; tag = tagName; break; }
+  }
+  if (!found) throw new Error(`finding ${findingId} not found in ${consensusId}`);
+
+  const signals: FindingDetailSignal[] = [];
+  const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+  if (existsSync(perfPath)) {
+    const lines = readFileSync(perfPath, 'utf-8').trim().split('\n').filter(Boolean);
+    for (const line of lines) {
+      try {
+        const rec = JSON.parse(line);
+        if (rec.findingId === findingId) {
+          signals.push({
+            signal: rec.signal,
+            agentId: rec.agentId,
+            counterpartId: rec.counterpartId,
+            evidence: rec.evidence,
+            timestamp: rec.timestamp,
+          });
+        }
+      } catch { /* skip */ }
+    }
+  }
+
+  const citations = extractCitations(found.finding || '', projectRoot);
+
+  return {
+    consensusId,
+    finding: {
+      id: found.id,
+      authorFindingId: found.authorFindingId,
+      originalAgentId: found.originalAgentId,
+      finding: found.finding,
+      findingType: found.findingType,
+      severity: found.severity,
+      tag,
+      confirmedBy: found.confirmedBy || [],
+      disputedBy: found.disputedBy || [],
+      confidence: found.confidence ?? 0,
+    },
+    signals,
+    citations,
+  };
+}

--- a/packages/relay/src/dashboard/api-signals.ts
+++ b/packages/relay/src/dashboard/api-signals.ts
@@ -7,6 +7,9 @@ interface SignalEntry {
   agentId: string;
   counterpartId?: string;
   taskId?: string;
+  consensusId?: string;
+  findingId?: string;
+  severity?: 'critical' | 'high' | 'medium' | 'low';
   evidence?: string;
   finding?: string;
   timestamp: string;

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -8,6 +8,7 @@ import { autoMemoryHandler } from './api-native-memory';
 import { gossipMemoryHandler } from './api-gossip-memory';
 import { consensusHandler } from './api-consensus';
 import { signalsHandler } from './api-signals';
+import { findingHandler } from './api-finding';
 import { learningsHandler } from './api-learnings';
 import { tasksHandler } from './api-tasks';
 import { activeTasksHandler } from './api-active-tasks';
@@ -275,6 +276,19 @@ export class DashboardRouter {
         const result = this.archiveFindings();
         this.json(res, 200, result);
         return true;
+      }
+
+      {
+        const m = url.match(/^\/dashboard\/api\/finding\/([^/]+)\/(.+)$/);
+        if (m && req.method === 'GET') {
+          try {
+            const data = await findingHandler(this.projectRoot, decodeURIComponent(m[1]), decodeURIComponent(m[2]));
+            this.json(res, 200, data);
+          } catch (e: any) {
+            this.json(res, 404, { error: e.message });
+          }
+          return true;
+        }
       }
 
       if (url === '/dashboard/api/signals' && req.method === 'GET') {

--- a/tests/relay/api-finding.test.ts
+++ b/tests/relay/api-finding.test.ts
@@ -1,0 +1,77 @@
+import { findingHandler } from '../../packages/relay/src/dashboard/api-finding';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('findingHandler', () => {
+  it('returns finding + signals + citation snippets', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-test-finding-'));
+    mkdirSync(join(root, '.gossip', 'consensus-reports'), { recursive: true });
+    mkdirSync(join(root, 'src'), { recursive: true });
+    writeFileSync(join(root, 'src', 'foo.ts'), 'line1\nline2\nline3\nline4\nline5\n');
+
+    writeFileSync(join(root, '.gossip', 'consensus-reports', 'abc-def.json'), JSON.stringify({
+      id: 'abc-def',
+      timestamp: '2026-04-17T10:00:00Z',
+      confirmed: [{
+        id: 'abc-def:f1',
+        authorFindingId: 'sonnet-reviewer:f1',
+        originalAgentId: 'sonnet-reviewer',
+        finding: 'Bug in <cite tag="file">src/foo.ts:3</cite>',
+        findingType: 'finding',
+        severity: 'high',
+        tag: 'confirmed',
+        confirmedBy: ['gemini-reviewer'],
+        disputedBy: [],
+        confidence: 5,
+      }],
+      disputed: [], unverified: [], unique: [], insights: [], newFindings: [],
+    }));
+
+    writeFileSync(join(root, '.gossip', 'agent-performance.jsonl'),
+      JSON.stringify({ type: 'consensus', signal: 'agreement', agentId: 'gemini-reviewer',
+        findingId: 'abc-def:f1', timestamp: '2026-04-17T10:01:00Z' }) + '\n');
+
+    const res = await findingHandler(root, 'abc-def', 'abc-def:f1');
+    expect(res.finding.id).toBe('abc-def:f1');
+    expect(res.finding.severity).toBe('high');
+    expect(res.finding.tag).toBe('confirmed');
+    expect(res.signals).toHaveLength(1);
+    expect(res.signals[0].agentId).toBe('gemini-reviewer');
+    expect(res.citations).toHaveLength(1);
+    expect(res.citations[0].file).toBe('src/foo.ts');
+    expect(res.citations[0].line).toBe(3);
+    expect(res.citations[0].snippet).toContain('line3');
+  });
+
+  it('404s on unknown consensusId', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-test-finding-'));
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+    await expect(findingHandler(root, 'missing', 'missing:f1')).rejects.toThrow(/not found/i);
+  });
+
+  it('404s on unknown findingId within a valid consensus', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-test-finding-'));
+    mkdirSync(join(root, '.gossip', 'consensus-reports'), { recursive: true });
+    writeFileSync(join(root, '.gossip', 'consensus-reports', 'abc-def.json'), JSON.stringify({
+      id: 'abc-def', confirmed: [], disputed: [], unverified: [], unique: [], insights: [], newFindings: [],
+    }));
+    await expect(findingHandler(root, 'abc-def', 'abc-def:f99')).rejects.toThrow(/not found/i);
+  });
+
+  it('rejects path-traversal citations', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-test-finding-'));
+    mkdirSync(join(root, '.gossip', 'consensus-reports'), { recursive: true });
+    writeFileSync(join(root, '.gossip', 'consensus-reports', 'c1-c2.json'), JSON.stringify({
+      id: 'c1-c2',
+      confirmed: [{
+        id: 'c1-c2:f1', originalAgentId: 'x', findingType: 'finding', tag: 'confirmed',
+        finding: 'evil <cite tag="file">../../etc/passwd:1</cite>',
+        confirmedBy: [], disputedBy: [], confidence: 1,
+      }],
+      disputed: [], unverified: [], unique: [], insights: [], newFindings: [],
+    }));
+    const res = await findingHandler(root, 'c1-c2', 'c1-c2:f1');
+    expect(res.citations).toHaveLength(0);
+  });
+});

--- a/tests/relay/api-signals-findingid.test.ts
+++ b/tests/relay/api-signals-findingid.test.ts
@@ -1,0 +1,29 @@
+import { signalsHandler } from '../../packages/relay/src/dashboard/api-signals';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('signalsHandler findingId/consensusId pass-through', () => {
+  it('surfaces findingId, consensusId, severity on returned items', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-test-signals-'));
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+    const rec = {
+      type: 'consensus',
+      signal: 'agreement',
+      agentId: 'sonnet-reviewer',
+      counterpartId: 'gemini-reviewer',
+      taskId: '81e580b2',
+      consensusId: 'd07eac46-5f464e89',
+      findingId: 'd07eac46-5f464e89:sonnet-reviewer:f1',
+      severity: 'high',
+      evidence: 'race condition confirmed',
+      timestamp: '2026-04-17T10:00:00.000Z',
+    };
+    writeFileSync(join(root, '.gossip', 'agent-performance.jsonl'), JSON.stringify(rec) + '\n');
+    const res = await signalsHandler(root);
+    expect(res.items).toHaveLength(1);
+    expect(res.items[0].findingId).toBe('d07eac46-5f464e89:sonnet-reviewer:f1');
+    expect(res.items[0].consensusId).toBe('d07eac46-5f464e89');
+    expect(res.items[0].severity).toBe('high');
+  });
+});


### PR DESCRIPTION
## Summary

Foundational PR-F of the dashboard-v2 modernization plan (`docs/specs/2026-04-17-dashboard-v2-modernization.md`). Ships a reusable Finding-Detail drawer + exposes `findingId`/`consensusId`/`severity` on `/api/signals` so downstream PRs (PR-S `/signals`, PR-A agent modernization) can reuse the drawer from any row.

Plan: `docs/specs/2026-04-17-dashboard-v2-pr-f.md`.

## What changed

**Server (pure pass-through + new endpoint):**
- `packages/relay/src/dashboard/api-signals.ts` — `SignalEntry` interface now includes optional `consensusId`, `findingId`, `severity`. The fields already existed in `agent-performance.jsonl` (1393 rows); only the TS interface was filtering them out.
- `packages/relay/src/dashboard/api-finding.ts` — new endpoint `/dashboard/api/finding/:consensusId/:findingId` returning consolidated `FindingDetail` (finding + attached signals + citation snippets with ±2 lines context). Path-traversal guard via `resolve`+`relative` skips any `<cite>` pointing outside projectRoot.
- `packages/relay/src/dashboard/routes.ts` — wires the new route before the existing signals route.

**Client (drawer + types):**
- `packages/dashboard-v2/src/lib/types.ts` — hoisted `SignalEntry`, added `CitationSnippet`, `FindingDetailSignal`, `FindingDetail`.
- `packages/dashboard-v2/src/components/CitationSnippet.tsx` — file:line header + monospace snippet block.
- `packages/dashboard-v2/src/components/FindingDetailDrawer.tsx` — sidebar-right drawer (480px) with 6 zones: tag/severity chips · finding text · citations · cross-review coverage · attached signals · consensus-round link.
- `packages/dashboard-v2/src/components/SignalTimeline.tsx` — bars are now clickable `<button>`s when `consensusId` + `findingId` are present; opens the drawer. Non-findingId signals remain display-only.
- `packages/dashboard-v2/src/components/ui/sheet.tsx` — minimal hand-rolled Sheet primitive (backdrop-click + Esc close, body-scroll lock, right-edge panel). Did **not** add `@radix-ui/react-dialog` dep just for one side panel; the dashboard-v2 workspace has no Radix elsewhere.

## Design decision: sidebar-right

Plan resolved between sidebar-right / modal / inline-expansion.

Chose **sidebar-right**: preserves list context while drilling into a finding, matches what PR-A wants for AgentPage modernization, and avoids layout-shift issues of inline expansion on a 6-zone detail view.

## Tests

- `tests/relay/api-signals-findingid.test.ts` — pass-through surfaces all 3 new fields (1 test)
- `tests/relay/api-finding.test.ts` — happy path, unknown consensusId, unknown findingId, path-traversal rejection (4 tests)
- 5/5 new tests pass, 121/121 regression in `tests/relay/`, `tsc -b` clean, `npm run build` clean (325 kB / 93 kB gzip)

## Deferred (not in this PR)

- Retraction badge — `detail.retracted` is typed and rendered if present, but server doesn't populate it yet. PR-R will wire `getRetractedConsensusIds()` into `findingHandler` — additive, no client changes needed.
- URL-state persistence, shared poller — PR-S.
- Accordion removal on AgentPage — PR-A.

## Test plan

- [ ] Open `/agent/sonnet-reviewer`, hover a bar in Signal Timeline — tooltip says "(click for detail)" for bars with findingId
- [ ] Click a clickable bar — drawer slides in from right with 6 zones populated
- [ ] Verify citation snippets render with ±2 lines of context
- [ ] Press `Esc` → drawer closes
- [ ] Click backdrop → drawer closes
- [ ] Click a pre-findingId signal bar (legacy) — nothing happens, cursor stays default

🤖 Generated with [Claude Code](https://claude.com/claude-code)