### PR TITLE
feat(dashboard): PR-R — retracted-round treatment on /debates

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -400,15 +400,24 @@ function FindingsPage({
   consensus: import('@/lib/types').ConsensusData;
   consensusReports: import('@/lib/types').ConsensusReportsData | null;
 }) {
-  const confirmedTotal = consensus.runs.reduce((acc, r) => acc + (r.counts.agreement || 0), 0);
-  const disputedTotal = consensus.runs.reduce((acc, r) => acc + ((r.counts.disagreement || 0) + (r.counts.hallucination || 0)), 0);
-  const unverifiedTotal = consensus.runs.reduce((acc, r) => acc + (r.counts.unverified || 0), 0);
+  const [showRetracted, setShowRetracted] = useState(false);
+  const visibleRuns = showRetracted ? consensus.runs : consensus.runs.filter(r => !r.retracted);
+  const retractedCount = consensus.runs.filter(r => r.retracted).length;
+
+  const confirmedTotal = visibleRuns.reduce((acc, r) => acc + (r.counts.agreement || 0), 0);
+  const disputedTotal = visibleRuns.reduce((acc, r) => acc + ((r.counts.disagreement || 0) + (r.counts.hallucination || 0)), 0);
+  const unverifiedTotal = visibleRuns.reduce((acc, r) => acc + (r.counts.unverified || 0), 0);
 
   return (
     <>
       <div className="mb-6">
         <h1 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
-          Debates <span className="ml-2 text-foreground">{consensus.totalRuns ?? consensus.runs.length}</span>
+          Debates <span className="ml-2 text-foreground">{visibleRuns.length}</span>
+          {!showRetracted && retractedCount > 0 && (
+            <span className="ml-2 font-normal normal-case tracking-normal text-muted-foreground/60">
+              / {consensus.totalRuns ?? consensus.runs.length} total
+            </span>
+          )}
         </h1>
         <div className="mt-2 flex gap-4 font-mono text-[11px] text-muted-foreground">
           <span><span className="text-confirmed">{confirmedTotal}</span> confirmed</span>
@@ -416,8 +425,24 @@ function FindingsPage({
           {unverifiedTotal > 0 && <span><span className="text-unverified">{unverifiedTotal}</span> unverified</span>}
           <span>{consensus.totalSignals} total signals</span>
         </div>
+        {retractedCount > 0 && (
+          <div className="mt-2 flex items-center gap-2 font-mono text-[11px] text-muted-foreground/70">
+            <span>
+              {showRetracted
+                ? `${retractedCount} retracted run${retractedCount === 1 ? '' : 's'} shown`
+                : `${retractedCount} retracted run${retractedCount === 1 ? '' : 's'} hidden`}
+            </span>
+            <button
+              type="button"
+              onClick={() => setShowRetracted(v => !v)}
+              className="rounded-sm border border-border/40 bg-card px-2 py-0.5 text-[10px] transition hover:bg-accent/50 hover:text-foreground"
+            >
+              {showRetracted ? 'hide' : 'show'}
+            </button>
+          </div>
+        )}
       </div>
-      <FindingsMetrics consensus={consensus} reports={consensusReports} showAll hideHeader />
+      <FindingsMetrics consensus={consensus} filteredRuns={visibleRuns} reports={consensusReports} showAll hideHeader />
     </>
   );
 }

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -12,6 +12,12 @@ interface FindingsMetricsProps {
   showAll?: boolean;
   /** If true, hides the section header. Useful when the parent page provides its own header. */
   hideHeader?: boolean;
+  /**
+   * Optional pre-filtered run list. When provided (e.g. by FindingsPage with
+   * its show/hide retracted toggle), used in place of `consensus.runs` in the
+   * fallback runs view. Does not affect the primary `reports` rendering path.
+   */
+  filteredRuns?: ConsensusData['runs'];
 }
 
 const MAX_RUNS = 5;
@@ -220,9 +226,10 @@ function ReportFinding({ f, reviewInfo, diagnostics }: {
   );
 }
 
-export function FindingsMetrics({ consensus, reports, showAll = false, hideHeader = false }: FindingsMetricsProps) {
-  const runs = showAll ? consensus.runs : consensus.runs.slice(0, MAX_RUNS);
-  const hasMore = !showAll && consensus.runs.length > MAX_RUNS;
+export function FindingsMetrics({ consensus, reports, showAll = false, hideHeader = false, filteredRuns }: FindingsMetricsProps) {
+  const sourceRuns = filteredRuns ?? consensus.runs;
+  const runs = showAll ? sourceRuns : sourceRuns.slice(0, MAX_RUNS);
+  const hasMore = !showAll && sourceRuns.length > MAX_RUNS;
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [filter, setFilter] = useState<FilterType>('all');
   const [sevFilter, setSevFilter] = useState<'all' | 'critical' | 'high' | 'medium' | 'low'>('all');
@@ -695,8 +702,27 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
               return tag && tag.filter === filter;
             });
 
+            const isRunRetracted = !!run.retracted;
             return (
-              <div key={run.taskId + i} className={`rounded-md border bg-card transition ${isOpen ? 'border-primary/25' : 'border-border'}`}>
+              <div
+                key={run.taskId + i}
+                className={`rounded-md border bg-card transition ${isOpen ? 'border-primary/25' : 'border-border'} ${isRunRetracted ? 'opacity-60' : ''}`}
+                data-retracted={isRunRetracted ? 'true' : undefined}
+                title={isRunRetracted && run.retractionReason ? `Retracted: ${run.retractionReason}` : undefined}
+              >
+                {isRunRetracted && (
+                  <div className="rounded-t-md border-b border-disputed/30 bg-disputed/50 px-3 py-1.5 font-mono text-[10px] text-disputed-foreground" style={{ textDecoration: 'none' }}>
+                    <span className="font-bold uppercase tracking-wider">⚠ Retracted</span>
+                    {run.retractedAt && (
+                      <span className="ml-2 text-disputed-foreground/80">
+                        on {run.retractedAt.slice(0, 10)}
+                      </span>
+                    )}
+                    {run.retractionReason && (
+                      <span className="ml-2 text-muted-foreground/90">— {run.retractionReason}</span>
+                    )}
+                  </div>
+                )}
                 {/* Header — clickable */}
                 <button
                   aria-expanded={isOpen}
@@ -710,7 +736,7 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-3">
                         <span className="font-mono text-[10px] text-primary/50">{run.taskId}</span>
-                        <span className="font-mono text-sm font-semibold text-foreground">{runTotal} findings</span>
+                        <span className={`font-mono text-sm font-semibold text-foreground ${isRunRetracted ? 'line-through decoration-disputed/40' : ''}`}>{runTotal} findings</span>
                         <div className="flex gap-1.5">
                           {run.agents.slice(0, 4).map((a) => (
                             <span key={a} className="rounded-sm bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
@@ -727,7 +753,7 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
 
                     <div className="mt-2 flex gap-2">
                       {segments.map((s) => s.count > 0 && (
-                        <span key={s.key} className={`font-mono text-[10px] font-semibold ${s.text}`}>
+                        <span key={s.key} className={`font-mono text-[10px] font-semibold ${s.text} ${isRunRetracted ? 'line-through decoration-disputed/40' : ''}`}>
                           {s.count} {s.label}
                         </span>
                       ))}

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -69,6 +69,9 @@ export interface ConsensusRun {
   agents: string[];
   signals: { signal: string; agentId: string; counterpartId?: string; findingId?: string; evidence?: string }[];
   counts: { agreement: number; disagreement: number; unverified: number; unique: number; hallucination: number; new: number; insights: number };
+  retracted?: boolean;
+  retractedAt?: string;
+  retractionReason?: string;
 }
 
 export interface ConsensusData {
@@ -78,6 +81,10 @@ export interface ConsensusData {
   totalSignals: number;
   page: number;
   pageSize: number;
+  /** Consensus round IDs that have been retracted via gossip_signals action:"retract". */
+  retractedConsensusIds?: string[];
+  /** Full tombstone rows preserving duplicates for admin "retracted rounds" views. */
+  roundRetractions?: Array<{ consensus_id: string; reason: string; retracted_at: string }>;
 }
 
 export interface ConsensusReportFinding {

--- a/packages/relay/src/dashboard/api-consensus.ts
+++ b/packages/relay/src/dashboard/api-consensus.ts
@@ -19,6 +19,9 @@ interface ConsensusRun {
   agents: string[];
   signals: { signal: string; agentId: string; counterpartId?: string; findingId?: string; evidence?: string }[];
   counts: { agreement: number; disagreement: number; unverified: number; unique: number; hallucination: number; new: number; insights: number };
+  retracted?: boolean;
+  retractedAt?: string;
+  retractionReason?: string;
 }
 
 export interface ConsensusResponse {
@@ -27,6 +30,8 @@ export interface ConsensusResponse {
   totalSignals: number;
   page: number;
   pageSize: number;
+  retractedConsensusIds?: string[];
+  roundRetractions?: Array<{ consensus_id: string; reason: string; retracted_at: string }>;
 }
 
 // Signals that resolve an UNVERIFIED finding
@@ -40,7 +45,25 @@ export async function consensusHandler(projectRoot: string, query?: URLSearchPar
   const page = isNaN(rawPage) || rawPage < 1 ? 1 : rawPage;
   const pageSize = isNaN(rawPageSize) || rawPageSize < 1 ? DEFAULT_PAGE_SIZE : Math.min(rawPageSize, MAX_PAGE_SIZE);
   const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
-  if (!existsSync(perfPath)) return { runs: [], totalRuns: 0, totalSignals: 0, page, pageSize };
+
+  // Load retraction tombstones so retracted rounds can be annotated (not filtered)
+  // in the response. Mirrors routes.ts:422 pattern.
+  let retractedIds = new Set<string>();
+  let roundRetractions: Array<{ consensus_id: string; reason: string; retracted_at: string }> = [];
+  try {
+    const { PerformanceReader } = require('@gossip/orchestrator');
+    const reader = new PerformanceReader(projectRoot);
+    retractedIds = reader.getRetractedConsensusIds();
+    roundRetractions = reader.getRoundRetractions();
+  } catch { /* reader unavailable — leave empty */ }
+  const retractionByConsensusId = new Map<string, { reason: string; retracted_at: string }>();
+  for (const r of roundRetractions) {
+    // latest-wins for banner reason
+    retractionByConsensusId.set(r.consensus_id, { reason: r.reason, retracted_at: r.retracted_at });
+  }
+  const retractedConsensusIds = Array.from(retractedIds);
+
+  if (!existsSync(perfPath)) return { runs: [], totalRuns: 0, totalSignals: 0, page, pageSize, retractedConsensusIds, roundRetractions };
 
   const signals: ConsensusSignal[] = [];
   try {
@@ -53,7 +76,7 @@ export async function consensusHandler(projectRoot: string, query?: URLSearchPar
         }
       } catch { /* skip malformed */ }
     }
-  } catch { return { runs: [], totalRuns: 0, totalSignals: 0, page, pageSize }; }
+  } catch { return { runs: [], totalRuns: 0, totalSignals: 0, page, pageSize, retractedConsensusIds, roundRetractions }; }
 
   // Group by consensusId (falls back to taskId for old signals)
   const byRun = new Map<string, ConsensusSignal[]>();
@@ -96,6 +119,7 @@ export async function consensusHandler(projectRoot: string, query?: URLSearchPar
 
     // Only show real consensus runs (multiple signals from cross-review), not manual recordings
     if (agents.size >= 2 && taskSignals.length >= 3) {
+      const tombstone = retractionByConsensusId.get(taskId);
       runs.push({
         taskId,
         timestamp: taskSignals[0].timestamp,
@@ -112,6 +136,11 @@ export async function consensusHandler(projectRoot: string, query?: URLSearchPar
           };
         }),
         counts,
+        ...(retractedIds.has(taskId) ? {
+          retracted: true,
+          retractedAt: tombstone?.retracted_at,
+          retractionReason: tombstone?.reason,
+        } : {}),
       });
     }
   }
@@ -124,5 +153,5 @@ export async function consensusHandler(projectRoot: string, query?: URLSearchPar
   const offset = (page - 1) * pageSize;
   const paginatedRuns = runs.slice(offset, offset + pageSize);
 
-  return { runs: paginatedRuns, totalRuns, totalSignals: signals.length, page, pageSize };
+  return { runs: paginatedRuns, totalRuns, totalSignals: signals.length, page, pageSize, retractedConsensusIds, roundRetractions };
 }

--- a/tests/relay/api-consensus-retracted.test.ts
+++ b/tests/relay/api-consensus-retracted.test.ts
@@ -1,0 +1,56 @@
+import { consensusHandler } from '@gossip/relay/dashboard/api-consensus';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('consensusHandler retraction annotation', () => {
+  it('marks retracted runs and exposes retractedConsensusIds', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-test-cret-'));
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+
+    const run1Sigs = Array.from({ length: 3 }, (_, i) => ({
+      type: 'consensus', taskId: 't1', consensusId: 'aaa-bbb',
+      signal: 'agreement', agentId: `agent-${i % 2 ? 'a' : 'b'}`,
+      counterpartId: `agent-${i % 2 ? 'b' : 'a'}`,
+      findingId: `aaa-bbb:f${i}`,
+      timestamp: `2026-04-17T10:0${i}:00Z`,
+    }));
+    const run2Sigs = Array.from({ length: 3 }, (_, i) => ({
+      type: 'consensus', taskId: 't2', consensusId: 'ccc-ddd',
+      signal: 'agreement', agentId: `agent-${i % 2 ? 'a' : 'b'}`,
+      counterpartId: `agent-${i % 2 ? 'b' : 'a'}`,
+      findingId: `ccc-ddd:f${i}`,
+      timestamp: `2026-04-17T11:0${i}:00Z`,
+    }));
+    const retract = {
+      type: 'consensus', signal: 'consensus_round_retracted',
+      agentId: '_system', consensus_id: 'aaa-bbb',
+      reason: 'reviewed wrong branch',
+      retracted_at: '2026-04-17T12:00:00Z',
+      timestamp: '2026-04-17T12:00:00Z',
+    };
+
+    writeFileSync(
+      join(root, '.gossip', 'agent-performance.jsonl'),
+      [...run1Sigs, ...run2Sigs, retract].map(r => JSON.stringify(r)).join('\n') + '\n',
+    );
+
+    const res = await consensusHandler(root);
+    expect(res.retractedConsensusIds).toContain('aaa-bbb');
+    expect(res.retractedConsensusIds).not.toContain('ccc-ddd');
+    const retracted = res.runs.find(r => r.taskId === 'aaa-bbb');
+    const live = res.runs.find(r => r.taskId === 'ccc-ddd');
+    expect(retracted?.retracted).toBe(true);
+    expect(retracted?.retractionReason).toBe('reviewed wrong branch');
+    expect(live?.retracted).toBeFalsy();
+  });
+
+  it('returns empty retractedConsensusIds when no retractions exist', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-test-cret-'));
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+    writeFileSync(join(root, '.gossip', 'agent-performance.jsonl'), '');
+    const res = await consensusHandler(root);
+    expect(res.retractedConsensusIds ?? []).toEqual([]);
+    expect(res.runs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

PR-R of dashboard-v2 modernization (spec: \`docs/specs/2026-04-17-dashboard-v2-modernization.md\`). Ships retracted-round treatment: \`api-consensus.ts\` now annotates retracted runs, and \`/debates\` lets you hide/show them with a toggle.

Independent of PR-F (#138) — can merge in either order.

## What changed

**Server:**
- \`packages/relay/src/dashboard/api-consensus.ts\` — uses \`PerformanceReader.getRetractedConsensusIds()\` and \`.getRoundRetractions()\` (already-shipped APIs). Each run now carries \`retracted\` / \`retractedAt\` / \`retractionReason\`. Response also exposes \`retractedConsensusIds\` + \`roundRetractions\` at the top level.
- Retracted runs are **annotated, not filtered** — frontend decides visibility.

**Client:**
- \`packages/dashboard-v2/src/lib/types.ts\` — \`ConsensusRun\` and \`ConsensusData\` extended to match server shape.
- \`packages/dashboard-v2/src/App.tsx\` \`FindingsPage\` — adds \`showRetracted\` state, filtered stat totals (so counts reflect visible runs), and a toggle row: "N retracted runs hidden [show]".
- \`packages/dashboard-v2/src/components/FindingsMetrics.tsx\` — accepts optional \`filteredRuns\` prop (back-compat default to \`consensus.runs\`). Retracted runs render with \`bg-disputed/50\` banner, opacity dim, and strikethrough count chips — matches the existing retraction style already used for reports.

## Tests

- \`tests/relay/api-consensus-retracted.test.ts\` — 2 new tests (retraction annotation + empty-state), 2/2 PASS
- Regression \`tests/relay/\` — 119 passed + 1 skipped across 10 suites
- \`tsc -b\` clean, dashboard-v2 \`npm run build\` clean (320 kB / 92 kB gzip)

## Test plan

- [ ] Open \`/debates\` with at least one retracted consensus round in \`agent-performance.jsonl\`
- [ ] Confirm the retracted run has a muted banner + strikethrough counts
- [ ] Confirm \"N retracted runs hidden [show]\" toggle row appears under the stats
- [ ] Click [show] — retracted run becomes visible inline with banner
- [ ] Click [hide] — back to filtered view
- [ ] Confirm stat totals (confirmed/disputed/unverified) recompute based on visible runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)