### PR TITLE
feat(dashboard): PR-A — /agent/:id zones (competency + skills + activity + drawer)

### DIFF
--- a/packages/dashboard-v2/src/components/AgentActivityTimeline.tsx
+++ b/packages/dashboard-v2/src/components/AgentActivityTimeline.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react';
+import { api } from '@/lib/api';
+import { timeAgo } from '@/lib/utils';
+import { EmptyState } from './EmptyState';
+import { FindingDetailDrawer } from './FindingDetailDrawer';
+import type { SignalEntry } from '@/lib/types';
+
+interface Props {
+  agentId: string;
+}
+
+interface SignalsResponse {
+  items: SignalEntry[];
+  total: number;
+}
+
+type FilterKey = 'all' | 'signals' | 'tasks' | 'skills';
+
+const SIGNAL_TAG_CLS: Record<string, string> = {
+  agreement: 'text-confirmed bg-confirmed/10',
+  consensus_verified: 'text-confirmed bg-confirmed/10',
+  unique_confirmed: 'text-unique bg-unique/10',
+  unique_unconfirmed: 'text-unique bg-unique/10',
+  new_finding: 'text-unique bg-unique/10',
+  disagreement: 'text-disputed bg-disputed/10',
+  hallucination_caught: 'text-disputed bg-disputed/10',
+  unverified: 'text-unverified bg-unverified/10',
+};
+
+export function AgentActivityTimeline({ agentId }: Props) {
+  const [signals, setSignals] = useState<SignalEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<FilterKey>('all');
+  const [drawer, setDrawer] = useState<{ consensusId: string; findingId: string } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    api<SignalsResponse>(`signals?agent=${encodeURIComponent(agentId)}&limit=100`)
+      .then((data) => { if (!cancelled) { setSignals(data.items || []); setLoading(false); } })
+      .catch(() => { if (!cancelled) { setSignals([]); setLoading(false); } });
+    return () => { cancelled = true; };
+  }, [agentId]);
+
+  // Reverse-chronological: server returns newest-first for SignalTimeline
+  // via the same endpoint, but we sort defensively in case of ordering drift.
+  const ordered = [...signals].sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''));
+  const visible = filter === 'all' || filter === 'signals' ? ordered : [];
+
+  const FilterButton = ({ k, label, enabled }: { k: FilterKey; label: string; enabled: boolean }) => (
+    <button
+      type="button"
+      onClick={() => enabled && setFilter(k)}
+      disabled={!enabled}
+      className={`rounded-sm px-2 py-0.5 font-mono text-[10px] font-semibold transition ${
+        filter === k ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'
+      } ${enabled ? '' : 'opacity-40 cursor-not-allowed'}`}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="rounded-md border border-border/40 bg-card/80 px-4 py-3">
+      <div className="mb-3 flex items-center justify-between">
+        <span className="font-mono text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
+          Activity
+        </span>
+        <div className="flex gap-1">
+          <FilterButton k="all" label="All" enabled />
+          <FilterButton k="signals" label="Signals" enabled />
+          <FilterButton k="tasks" label="Tasks (none yet)" enabled={false} />
+          <FilterButton k="skills" label="Skills (none yet)" enabled={false} />
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="py-6 text-center text-xs text-muted-foreground">Loading…</div>
+      ) : visible.length === 0 ? (
+        <EmptyState
+          title="No activity yet"
+          hint="Signals, task completions, and skill binds will appear here."
+          compact
+        />
+      ) : (
+        <div className="space-y-1">
+          {visible.map((s, i) => {
+            const tagCls = SIGNAL_TAG_CLS[s.signal] || 'text-muted-foreground bg-muted';
+            const clickable = !!(s.consensusId && s.findingId);
+            const row = (
+              <div className="flex items-start gap-2 py-1.5">
+                <span className="shrink-0 font-mono text-[9px] text-muted-foreground/60 tabular-nums w-16">
+                  {timeAgo(s.timestamp)}
+                </span>
+                <span className={`shrink-0 rounded-sm px-1.5 py-0.5 font-mono text-[9px] font-bold ${tagCls}`}>
+                  {s.signal}
+                </span>
+                <div className="min-w-0 flex-1 text-[11px] text-muted-foreground">
+                  {s.counterpartId && (
+                    <span className="font-mono text-[10px] text-muted-foreground/70">→ {s.counterpartId} · </span>
+                  )}
+                  {s.evidence && <span>{s.evidence.length > 160 ? s.evidence.slice(0, 160) + '…' : s.evidence}</span>}
+                </div>
+              </div>
+            );
+            if (clickable) {
+              return (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => setDrawer({ consensusId: s.consensusId!, findingId: s.findingId! })}
+                  className="w-full rounded-sm text-left transition hover:bg-accent/40"
+                >
+                  {row}
+                </button>
+              );
+            }
+            return <div key={i}>{row}</div>;
+          })}
+        </div>
+      )}
+
+      <FindingDetailDrawer
+        open={!!drawer}
+        onOpenChange={(open) => { if (!open) setDrawer(null); }}
+        consensusId={drawer?.consensusId ?? null}
+        findingId={drawer?.findingId ?? null}
+      />
+    </div>
+  );
+}

--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -1,7 +1,10 @@
 import { useState, useEffect, useMemo } from 'react';
 import { api } from '@/lib/api';
 import { NeuralAvatar } from './NeuralAvatar';
-import { CategoryStrengths } from './CategoryStrengths';
+import { CategoryCompetency } from './CategoryCompetency';
+import { SkillCard } from './SkillCard';
+import { AgentActivityTimeline } from './AgentActivityTimeline';
+import { FindingDetailDrawer } from './FindingDetailDrawer';
 import { SignalTimeline } from './SignalTimeline';
 import { TaskRow } from './TaskRow';
 import { timeAgo, cleanFindingTags } from '@/lib/utils';
@@ -27,8 +30,7 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
   const [memories, setMemories] = useState<MemoryFile[]>([]);
   const [reports, setReports] = useState<ConsensusReport[]>([]);
   const [expandedMem, setExpandedMem] = useState<string | null>(null);
-  const [expandedRun, setExpandedRun] = useState<number | null>(null);
-  const [runFilter, setRunFilter] = useState<'all' | 'confirmed' | 'disputed' | 'unverified' | 'unique'>('all');
+  const [drawerFinding, setDrawerFinding] = useState<{ consensusId: string; findingId: string } | null>(null);
   const [taskPage, setTaskPage] = useState(0);
   const [memDayIdx, setMemDayIdx] = useState(0);
 
@@ -291,51 +293,49 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
           </div>
         </div>
 
-        {/* Right: Category Strengths */}
+        {/* Right: Category Competency — accuracy-first horizontal bars. The
+            legacy CategoryStrengths (severity-weighted sort + sparse rows) is
+            retained for reference but we lead with the ratio view here. */}
         <div>
           <h2 className="mb-3 font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
-            Category Strengths
+            Category Competency
           </h2>
-          <CategoryStrengths
-            strengths={s.categoryStrengths}
-            accuracy={s.categoryAccuracy}
-            correctCounts={s.categoryCorrect}
-            hallucinatedCounts={s.categoryHallucinated}
+          <CategoryCompetency
+            categoryAccuracy={s.categoryAccuracy}
+            categoryCorrect={s.categoryCorrect}
+            categoryHallucinated={s.categoryHallucinated}
           />
         </div>
       </section>
 
-      {/* Skills */}
+      {/* Skills — rich card view with effectiveness, status, strikes, forced-develop history. */}
       {(agent.skillSlots.length > 0 || agent.skills.length > 0) && (
         <section className="mb-8">
           <h2 className="mb-3 font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
             Skills <span className="text-primary">{agent.skillSlots.length || agent.skills.length}</span>
           </h2>
-          <div className="flex flex-wrap gap-1.5">
-            {agent.skillSlots.length > 0 ? agent.skillSlots.map(slot => (
-              <span
-                key={slot.name}
-                className={`rounded-sm border px-2.5 py-1 font-mono text-xs ${
-                  !slot.enabled
-                    ? 'border-border/50 text-muted-foreground/50 line-through'
-                    : slot.mode === 'contextual'
-                    ? 'border-amber-500/30 bg-amber-500/10 text-amber-400'
-                    : 'border-border bg-card text-muted-foreground'
-                }`}
-                title={`${slot.mode} · ${slot.source} · ${slot.enabled ? 'enabled' : 'disabled'}`}
-              >
-                {slot.mode === 'contextual' && '\u26A1 '}{slot.name}
-              </span>
-            )) : agent.skills.map(skill => (
-              <span key={skill} className="rounded-sm border border-border bg-card px-2.5 py-1 font-mono text-xs text-muted-foreground">
-                {skill}
-              </span>
-            ))}
-          </div>
+          {agent.skillSlots.length > 0 ? (
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+              {agent.skillSlots.map(slot => (
+                <SkillCard key={slot.name} slot={slot} />
+              ))}
+            </div>
+          ) : (
+            <div className="flex flex-wrap gap-1.5">
+              {agent.skills.map(skill => (
+                <span key={skill} className="rounded-sm border border-border bg-card px-2.5 py-1 font-mono text-xs text-muted-foreground">
+                  {skill}
+                </span>
+              ))}
+            </div>
+          )}
         </section>
       )}
 
-      {/* Consensus Participation */}
+      {/* Consensus Participation — per-finding rows open the shared
+          FindingDetailDrawer (PR-F). The legacy inline accordion made users
+          scroll several screens to see one finding's citation + signals; the
+          drawer surfaces both in one click. */}
       <section className="mb-8">
         <h2 className="mb-3 font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
           Consensus Runs <span className="text-primary">{agentRuns.length}</span>
@@ -346,36 +346,26 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
               const c = run.counts;
               const total = (c.agreement || 0) + (c.disagreement || 0) + (c.hallucination || 0) + (c.unverified || 0) + (c.unique || 0) + (c.new || 0);
               const barTotal = total || 1;
-              const isOpen = expandedRun === i;
               const segments = [
                 { key: 'confirmed' as const, count: c.agreement || 0, color: 'bg-confirmed', text: 'text-confirmed' },
                 { key: 'disputed' as const, count: (c.disagreement || 0) + (c.hallucination || 0), color: 'bg-disputed', text: 'text-disputed' },
                 { key: 'unverified' as const, count: c.unverified || 0, color: 'bg-unverified', text: 'text-unverified' },
                 { key: 'unique' as const, count: (c.unique || 0) + (c.new || 0), color: 'bg-unique', text: 'text-unique' },
               ];
-              const tagMap: Record<string, { label: string; filter: string; cls: string }> = {
-                agreement: { label: 'CONFIRMED', filter: 'confirmed', cls: 'text-confirmed bg-confirmed/10' },
-                consensus_verified: { label: 'CONFIRMED', filter: 'confirmed', cls: 'text-confirmed bg-confirmed/10' },
-                disagreement: { label: 'DISPUTED', filter: 'disputed', cls: 'text-disputed bg-disputed/10' },
-                hallucination_caught: { label: 'DISPUTED', filter: 'disputed', cls: 'text-disputed bg-disputed/10' },
-                unverified: { label: 'UNVERIFIED', filter: 'unverified', cls: 'text-unverified bg-unverified/10' },
-                unique_confirmed: { label: 'UNIQUE', filter: 'unique', cls: 'text-unique bg-unique/10' },
-                unique_unconfirmed: { label: 'UNIQUE', filter: 'unique', cls: 'text-unique bg-unique/10' },
-                new_finding: { label: 'NEW', filter: 'unique', cls: 'text-unique bg-unique/10' },
+              const tagMap: Record<string, { label: string; cls: string }> = {
+                agreement: { label: 'CONFIRMED', cls: 'text-confirmed bg-confirmed/10' },
+                consensus_verified: { label: 'CONFIRMED', cls: 'text-confirmed bg-confirmed/10' },
+                disagreement: { label: 'DISPUTED', cls: 'text-disputed bg-disputed/10' },
+                hallucination_caught: { label: 'DISPUTED', cls: 'text-disputed bg-disputed/10' },
+                unverified: { label: 'UNVERIFIED', cls: 'text-unverified bg-unverified/10' },
+                unique_confirmed: { label: 'UNIQUE', cls: 'text-unique bg-unique/10' },
+                unique_unconfirmed: { label: 'UNIQUE', cls: 'text-unique bg-unique/10' },
+                new_finding: { label: 'NEW', cls: 'text-unique bg-unique/10' },
               };
-              const filteredSignals = run.signals.filter(sig => {
-                if (sig.signal === 'signal_retracted') return false;
-                const tag = tagMap[sig.signal];
-                if (!tag) return false;
-                return runFilter === 'all' || tag.filter === runFilter;
-              });
+              const runSignals = run.signals.filter(sig => sig.signal !== 'signal_retracted' && tagMap[sig.signal]);
               return (
-                <div key={run.taskId + i} className={`rounded-md border bg-card transition ${isOpen ? 'border-primary/25' : 'border-border/40'}`}>
-                  <button
-                    onClick={() => { setExpandedRun(isOpen ? null : i); setRunFilter('all'); }}
-                    className="flex w-full items-center p-3 text-left transition hover:bg-accent/50"
-                  >
-                    <span className={`mr-3 font-mono text-xs ${isOpen ? 'text-primary' : 'text-muted-foreground'}`}>{isOpen ? '\u25BE' : '\u25B8'}</span>
+                <div key={run.taskId + i} className="rounded-md border border-border/40 bg-card">
+                  <div className="flex items-center p-3">
                     <div className="flex-1">
                       <div className="flex items-center justify-between">
                         <span className="font-mono text-sm font-semibold text-foreground">{total} findings</span>
@@ -392,51 +382,38 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
                         ))}
                       </div>
                     </div>
-                  </button>
-                  {isOpen && (
-                    <div className="border-t border-border px-4 pb-3 pt-3">
-                      {/* Filter chips are neutral. They used to echo the
-                          finding colors (confirmed/disputed/unverified/unique),
-                          which collided visually with the actual count chips
-                          above — users couldn't tell "filter for disputed"
-                          from "there were 3 disputed findings". Matching the
-                          LogsPage filter pattern for consistency. */}
-                      <div className="mb-3 flex gap-1.5">
-                        {(['all', 'confirmed', 'disputed', 'unverified', 'unique'] as const).map(f => (
-                          <button
-                            key={f}
-                            onClick={() => setRunFilter(f)}
-                            className={`rounded-sm px-2 py-0.5 font-mono text-[10px] font-semibold transition ${
-                              runFilter === f
-                                ? 'text-foreground bg-muted'
-                                : 'text-muted-foreground hover:text-foreground'
-                            }`}
-                          >
-                            {f.charAt(0).toUpperCase() + f.slice(1)}
-                          </button>
-                        ))}
-                      </div>
-                      {filteredSignals.length === 0 ? (
-                        <div className="py-3 text-center text-xs text-muted-foreground">No findings match this filter.</div>
-                      ) : (
-                        <div className="space-y-1.5">
-                          {filteredSignals.map((sig, j) => {
-                            const tag = tagMap[sig.signal];
-                            if (!tag) return null;
-                            return (
-                              <div key={j} className="flex items-start gap-2">
-                                <span className={`shrink-0 rounded-sm px-1.5 py-0.5 font-mono text-[9px] font-bold ${tag.cls}`}>{tag.label}</span>
-                                <div className="min-w-0 flex-1">
-                                  <span className="text-xs text-muted-foreground [&_.cite-file]:rounded [&_.cite-file]:bg-blue-500/10 [&_.cite-file]:px-1 [&_.cite-file]:font-mono [&_.cite-file]:text-blue-400 [&_.cite-fn]:rounded [&_.cite-fn]:bg-purple-500/10 [&_.cite-fn]:px-1 [&_.cite-fn]:font-mono [&_.cite-fn]:text-purple-400" dangerouslySetInnerHTML={{ __html: cleanFindingTags(sig.evidence || '') }} />
-                                  <span className="ml-2 font-mono text-[10px] text-muted-foreground/50">
-                                    {sig.agentId}{sig.counterpartId ? ` + ${sig.counterpartId}` : ''}
-                                  </span>
-                                </div>
+                  </div>
+                  {runSignals.length > 0 && (
+                    <div className="border-t border-border/30 px-3 pb-2 pt-2">
+                      <div className="space-y-1">
+                        {runSignals.map((sig, j) => {
+                          const tag = tagMap[sig.signal];
+                          const clickable = !!(sig.findingId && run.taskId);
+                          // run.taskId is the consensusId on the agent-page shape.
+                          const row = (
+                            <div className="flex items-start gap-2 py-1">
+                              <span className={`shrink-0 rounded-sm px-1.5 py-0.5 font-mono text-[9px] font-bold ${tag.cls}`}>{tag.label}</span>
+                              <div className="min-w-0 flex-1">
+                                <span className="text-xs text-muted-foreground [&_.cite-file]:rounded [&_.cite-file]:bg-blue-500/10 [&_.cite-file]:px-1 [&_.cite-file]:font-mono [&_.cite-file]:text-blue-400 [&_.cite-fn]:rounded [&_.cite-fn]:bg-purple-500/10 [&_.cite-fn]:px-1 [&_.cite-fn]:font-mono [&_.cite-fn]:text-purple-400" dangerouslySetInnerHTML={{ __html: cleanFindingTags(sig.evidence || '') }} />
+                                <span className="ml-2 font-mono text-[10px] text-muted-foreground/50">
+                                  {sig.agentId}{sig.counterpartId ? ` + ${sig.counterpartId}` : ''}
+                                </span>
                               </div>
+                            </div>
+                          );
+                          if (clickable) {
+                            return (
+                              <button
+                                key={j}
+                                type="button"
+                                onClick={() => setDrawerFinding({ consensusId: run.taskId, findingId: sig.findingId! })}
+                                className="block w-full rounded-sm text-left transition hover:bg-accent/40"
+                              >{row}</button>
                             );
-                          })}
-                        </div>
-                      )}
+                          }
+                          return <div key={j}>{row}</div>;
+                        })}
+                      </div>
                     </div>
                   )}
                 </div>
@@ -447,6 +424,18 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
           <div className="py-6 text-center text-sm text-muted-foreground">No consensus participation recorded.</div>
         )}
       </section>
+
+      {/* Activity feed — reverse-chronological signals (+ tasks/skills later) */}
+      <section className="mb-8">
+        <AgentActivityTimeline agentId={agentId} />
+      </section>
+
+      <FindingDetailDrawer
+        open={!!drawerFinding}
+        onOpenChange={(open) => { if (!open) setDrawerFinding(null); }}
+        consensusId={drawerFinding?.consensusId ?? null}
+        findingId={drawerFinding?.findingId ?? null}
+      />
 
       {/* Tasks */}
       <section className="mb-8">

--- a/packages/dashboard-v2/src/components/CategoryCompetency.tsx
+++ b/packages/dashboard-v2/src/components/CategoryCompetency.tsx
@@ -1,0 +1,63 @@
+import { EmptyState } from './EmptyState';
+
+interface Props {
+  categoryAccuracy?: Record<string, number>;
+  categoryCorrect?: Record<string, number>;
+  categoryHallucinated?: Record<string, number>;
+}
+
+/** Horizontal bars per category with accuracy %. Reads categoryAccuracy
+ * (server-gated ratio in [0,1]) and renders one row per category with
+ * optional "(c/n)" tuple when raw counts are available. */
+export function CategoryCompetency({ categoryAccuracy, categoryCorrect, categoryHallucinated }: Props) {
+  const keys = Object.keys(categoryAccuracy ?? {});
+  if (keys.length === 0) {
+    return (
+      <EmptyState
+        title="No category data yet"
+        hint="Accuracy accrues after ≥5 signals per category."
+        compact
+      />
+    );
+  }
+
+  const rows = keys
+    .map((k) => {
+      const acc = Math.max(0, Math.min(1, categoryAccuracy![k] ?? 0));
+      const c = categoryCorrect?.[k] ?? 0;
+      const h = categoryHallucinated?.[k] ?? 0;
+      return { key: k, acc, c, n: c + h };
+    })
+    .sort((a, b) => b.acc - a.acc);
+
+  return (
+    <div className="space-y-2">
+      {rows.map((row) => {
+        const fill = row.acc >= 0.7 ? 'bg-confirmed' : row.acc >= 0.4 ? 'bg-unverified' : 'bg-disputed';
+        return (
+          <div
+            key={row.key}
+            className="grid grid-cols-[128px_1fr_auto_44px] items-center gap-3"
+            title={row.n > 0 ? `${row.c} correct / ${row.n} total` : undefined}
+          >
+            <span className="truncate font-mono text-[11px] text-muted-foreground">
+              {row.key.replace(/_/g, ' ')}
+            </span>
+            <div className="h-2 overflow-hidden rounded-sm bg-muted/30">
+              <div
+                className={`h-full rounded-sm transition-all ${fill}`}
+                style={{ width: `${row.acc * 100}%` }}
+              />
+            </div>
+            <span className="shrink-0 text-right font-mono text-[10px] tabular-nums text-muted-foreground/60 w-12">
+              {row.n > 0 ? `${row.c}/${row.n}` : '—'}
+            </span>
+            <span className="text-right font-mono text-[11px] font-bold tabular-nums text-foreground">
+              {Math.round(row.acc * 100)}%
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/dashboard-v2/src/components/SkillCard.tsx
+++ b/packages/dashboard-v2/src/components/SkillCard.tsx
@@ -1,0 +1,89 @@
+import { timeAgo } from '@/lib/utils';
+import type { SkillSlot, SkillStatus } from '@/lib/types';
+
+interface Props {
+  slot: SkillSlot;
+}
+
+const STATUS_CLS: Record<SkillStatus, string> = {
+  pending: 'border-border/50 bg-muted/30 text-muted-foreground',
+  passed: 'border-confirmed/40 bg-confirmed/10 text-confirmed',
+  failed: 'border-disputed/40 bg-disputed/10 text-disputed',
+  silent_skill: 'border-unverified/40 bg-unverified/10 text-unverified',
+  insufficient_evidence: 'border-unverified/40 bg-unverified/10 text-unverified',
+  inconclusive: 'border-unique/40 bg-unique/10 text-unique',
+  flagged_for_manual_review: 'border-disputed/40 bg-disputed/10 text-disputed',
+};
+
+function formatEffectiveness(value: number): { text: string; cls: string } {
+  // value is in [-1, 1] as a delta (pre/post hallucination rate).
+  const pp = Math.round(value * 100);
+  const sign = pp > 0 ? '+' : '';
+  const cls = pp > 0 ? 'text-confirmed' : pp < 0 ? 'text-disputed' : 'text-muted-foreground';
+  return { text: `${sign}${pp}pp`, cls };
+}
+
+export function SkillCard({ slot }: Props) {
+  const status = slot.status;
+  const statusCls = status ? STATUS_CLS[status] : 'border-border/50 bg-muted/30 text-muted-foreground';
+  const showStrikes = status === 'inconclusive' && (slot.inconclusiveStrikes ?? 0) > 0;
+  const forced = slot.forcedDevelops ?? [];
+  const latestForced = forced.length > 0 ? forced[forced.length - 1] : null;
+  const effectiveness = typeof slot.effectiveness === 'number' ? formatEffectiveness(slot.effectiveness) : null;
+
+  return (
+    <div
+      className={`rounded-md border bg-card/80 p-3 ${slot.enabled ? 'border-border/50' : 'border-border/30 opacity-60'}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className={`font-mono text-xs font-semibold ${slot.enabled ? 'text-foreground' : 'text-muted-foreground line-through'}`}>
+              {slot.mode === 'contextual' && '\u26A1 '}
+              {slot.name}
+            </span>
+            <span className="rounded-sm bg-muted px-1.5 py-0.5 font-mono text-[9px] text-muted-foreground">
+              {slot.source}
+            </span>
+            {slot.mode === 'contextual' && (
+              <span className="rounded-sm border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 font-mono text-[9px] text-amber-400">
+                contextual
+              </span>
+            )}
+          </div>
+          <div className="mt-1 font-mono text-[10px] text-muted-foreground/60">
+            bound {timeAgo(slot.boundAt)}
+          </div>
+        </div>
+        {status && (
+          <span className={`shrink-0 rounded-sm border px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase ${statusCls}`}>
+            {status.replace(/_/g, ' ')}
+          </span>
+        )}
+      </div>
+
+      <div className="mt-2 flex items-center gap-3 font-mono text-[10px]">
+        {effectiveness && (
+          <span className={effectiveness.cls} title="Effectiveness: change in hallucination rate pre/post">
+            {effectiveness.text}
+          </span>
+        )}
+        {showStrikes && (
+          <span className="text-unique" title={slot.inconclusiveAt ? `last strike ${timeAgo(slot.inconclusiveAt)}` : undefined}>
+            {slot.inconclusiveStrikes} strike{slot.inconclusiveStrikes === 1 ? '' : 's'}
+          </span>
+        )}
+      </div>
+
+      {forced.length > 0 && (
+        <div
+          className="mt-2 border-t border-border/40 pt-2 font-mono text-[10px] text-muted-foreground"
+          title={latestForced?.reason ? `latest: ${latestForced.reason}` : undefined}
+        >
+          forced {forced.length} time{forced.length === 1 ? '' : 's'}
+          {latestForced && ` · last ${timeAgo(latestForced.timestamp)}`}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -15,6 +15,33 @@ export interface OverviewData {
   hourlyActivity: number[];
 }
 
+export interface ForcedDevelopEntry {
+  timestamp: string;
+  reason?: string;
+}
+
+export type SkillStatus =
+  | 'pending'
+  | 'passed'
+  | 'failed'
+  | 'silent_skill'
+  | 'insufficient_evidence'
+  | 'inconclusive'
+  | 'flagged_for_manual_review';
+
+export interface SkillSlot {
+  name: string;
+  enabled: boolean;
+  source: string;
+  mode: 'permanent' | 'contextual';
+  boundAt: string;
+  effectiveness?: number | null;
+  status?: SkillStatus;
+  inconclusiveStrikes?: number;
+  inconclusiveAt?: string;
+  forcedDevelops?: ForcedDevelopEntry[];
+}
+
 export interface AgentData {
   id: string;
   provider: string;
@@ -22,7 +49,7 @@ export interface AgentData {
   preset?: string;
   native: boolean;
   skills: string[];
-  skillSlots: { name: string; enabled: boolean; source: string; mode: 'permanent' | 'contextual'; boundAt: string }[];
+  skillSlots: SkillSlot[];
   online: boolean;
   totalTokens: number;
   lastTask: { task: string; timestamp: string } | null;

--- a/packages/relay/src/dashboard/api-agents.ts
+++ b/packages/relay/src/dashboard/api-agents.ts
@@ -17,12 +17,122 @@ interface LastTask {
   timestamp: string;
 }
 
+export interface ForcedDevelopEntry {
+  timestamp: string;
+  reason?: string;
+}
+
+export type SkillStatus =
+  | 'pending'
+  | 'passed'
+  | 'failed'
+  | 'silent_skill'
+  | 'insufficient_evidence'
+  | 'inconclusive'
+  | 'flagged_for_manual_review';
+
 export interface SkillSlotResponse {
   name: string;
   enabled: boolean;
   source: string;
   mode: 'permanent' | 'contextual';
   boundAt: string;
+  effectiveness?: number | null;
+  status?: SkillStatus;
+  inconclusiveStrikes?: number;
+  inconclusiveAt?: string;
+  forcedDevelops?: ForcedDevelopEntry[];
+}
+
+interface SkillFrontmatter {
+  effectiveness?: number;
+  status?: string;
+  inconclusive_strikes?: number;
+  inconclusive_at?: string;
+}
+
+/** Parse a YAML-like frontmatter block. We avoid pulling a YAML dep and only
+ * extract the 4 scalar keys we need. Returns null on any failure. */
+function readSkillFrontmatter(
+  projectRoot: string,
+  agentId: string,
+  skillName: string,
+): SkillFrontmatter | null {
+  try {
+    const path = join(projectRoot, '.gossip', 'agents', agentId, 'skills', `${skillName}.md`);
+    if (!existsSync(path)) return null;
+    const raw = readFileSync(path, 'utf-8');
+    // Frontmatter must start with --- on the first line.
+    if (!raw.startsWith('---')) return null;
+    const end = raw.indexOf('\n---', 3);
+    if (end === -1) return null;
+    const block = raw.slice(3, end);
+    const out: SkillFrontmatter = {};
+    for (const line of block.split('\n')) {
+      const m = line.match(/^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.+?)\s*$/);
+      if (!m) continue;
+      const key = m[1];
+      let value: string = m[2];
+      // Strip surrounding quotes if present.
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      if (key === 'effectiveness') {
+        const n = Number(value);
+        if (Number.isFinite(n)) out.effectiveness = n;
+      } else if (key === 'status') {
+        out.status = value;
+      } else if (key === 'inconclusive_strikes') {
+        const n = Number(value);
+        if (Number.isFinite(n)) out.inconclusive_strikes = n;
+      } else if (key === 'inconclusive_at') {
+        out.inconclusive_at = value;
+      }
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+interface ForcedDevelopRow {
+  agent_id?: string;
+  agentId?: string;
+  category?: string;
+  timestamp?: string;
+  reason?: string;
+}
+
+/** Normalize a category key so "input_validation" and "input-validation" match. */
+function normalizeCategory(s: string): string {
+  return s.replace(/[-_]/g, '').toLowerCase();
+}
+
+function readForcedDevelops(
+  projectRoot: string,
+  agentId: string,
+  category: string,
+): ForcedDevelopEntry[] {
+  try {
+    const path = join(projectRoot, '.gossip', 'forced-skill-develops.jsonl');
+    if (!existsSync(path)) return [];
+    const raw = readFileSync(path, 'utf-8');
+    const target = normalizeCategory(category);
+    const out: ForcedDevelopEntry[] = [];
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      let row: ForcedDevelopRow;
+      try { row = JSON.parse(line); } catch { continue; }
+      const rowAgent = row.agent_id ?? row.agentId;
+      if (rowAgent !== agentId) continue;
+      if (!row.category || normalizeCategory(row.category) !== target) continue;
+      if (!row.timestamp) continue;
+      out.push({ timestamp: row.timestamp, reason: row.reason });
+    }
+    return out;
+  } catch {
+    return [];
+  }
 }
 
 export interface AgentResponse {
@@ -164,13 +274,25 @@ export async function agentsHandler(
     let skillSlots: SkillSlotResponse[] = [];
     try {
       if (skillIndex) {
-        skillSlots = skillIndex.getAgentSlots(config.id).map((slot: SkillSlot) => ({
-          name: slot.skill,
-          enabled: slot.enabled,
-          source: slot.source,
-          mode: slot.mode ?? 'permanent',
-          boundAt: slot.boundAt,
-        }));
+        skillSlots = skillIndex.getAgentSlots(config.id).map((slot: SkillSlot) => {
+          const fm = readSkillFrontmatter(projectRoot, config.id, slot.skill);
+          const forced = readForcedDevelops(projectRoot, config.id, slot.skill);
+          const response: SkillSlotResponse = {
+            name: slot.skill,
+            enabled: slot.enabled,
+            source: slot.source,
+            mode: slot.mode ?? 'permanent',
+            boundAt: slot.boundAt,
+          };
+          if (fm) {
+            if (fm.effectiveness !== undefined) response.effectiveness = fm.effectiveness;
+            if (fm.status !== undefined) response.status = fm.status as SkillStatus;
+            if (fm.inconclusive_strikes !== undefined) response.inconclusiveStrikes = fm.inconclusive_strikes;
+            if (fm.inconclusive_at !== undefined) response.inconclusiveAt = fm.inconclusive_at;
+          }
+          if (forced.length > 0) response.forcedDevelops = forced;
+          return response;
+        });
       }
     } catch { /* return empty on error */ }
 

--- a/tests/relay/api-agents-skill-effectiveness.test.ts
+++ b/tests/relay/api-agents-skill-effectiveness.test.ts
@@ -1,0 +1,98 @@
+import { agentsHandler } from '../../packages/relay/src/dashboard/api-agents';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+function setupRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'gossip-test-agents-skill-'));
+  mkdirSync(join(root, '.gossip', 'agents', 'sonnet-reviewer', 'skills'), { recursive: true });
+  // Seed the skill-index.json so SkillIndex returns a slot for the agent.
+  writeFileSync(
+    join(root, '.gossip', 'skill-index.json'),
+    JSON.stringify({
+      'sonnet-reviewer': {
+        'data-integrity': {
+          skill: 'data-integrity',
+          enabled: true,
+          source: 'manual',
+          mode: 'permanent',
+          version: 1,
+          boundAt: '2026-04-10T00:00:00Z',
+        },
+      },
+    }),
+  );
+  return root;
+}
+
+const CONFIG = [{
+  id: 'sonnet-reviewer',
+  provider: 'anthropic',
+  model: 'claude-3-5-sonnet',
+  skills: ['data-integrity'],
+  native: false,
+}];
+
+describe('agentsHandler — skill effectiveness + forced develops', () => {
+  it('reads effectiveness and status from skill frontmatter', async () => {
+    const root = setupRoot();
+    writeFileSync(
+      join(root, '.gossip', 'agents', 'sonnet-reviewer', 'skills', 'data-integrity.md'),
+      [
+        '---',
+        'effectiveness: 0.72',
+        'status: passed',
+        'inconclusive_strikes: 0',
+        '---',
+        '# Data integrity skill',
+        '',
+        'Body text.',
+      ].join('\n'),
+    );
+
+    const res = await agentsHandler(root, CONFIG);
+    expect(res).toHaveLength(1);
+    const slot = res[0].skillSlots.find(s => s.name === 'data-integrity');
+    expect(slot).toBeDefined();
+    expect(slot!.effectiveness).toBeCloseTo(0.72);
+    expect(slot!.status).toBe('passed');
+    expect(slot!.inconclusiveStrikes).toBe(0);
+  });
+
+  it('reads forced_develops from audit jsonl, filtered by agent + category', async () => {
+    const root = setupRoot();
+    writeFileSync(
+      join(root, '.gossip', 'agents', 'sonnet-reviewer', 'skills', 'data-integrity.md'),
+      '---\nstatus: inconclusive\ninconclusive_strikes: 2\n---\nbody\n',
+    );
+    // Mix of matching + non-matching rows; normalize across dash/underscore.
+    writeFileSync(
+      join(root, '.gossip', 'forced-skill-develops.jsonl'),
+      [
+        JSON.stringify({ agent_id: 'sonnet-reviewer', category: 'data_integrity', timestamp: '2026-04-14T10:00:00Z', reason: 'strike threshold' }),
+        JSON.stringify({ agent_id: 'sonnet-reviewer', category: 'data-integrity', timestamp: '2026-04-15T10:00:00Z', reason: 'manual force' }),
+        JSON.stringify({ agent_id: 'other-agent', category: 'data-integrity', timestamp: '2026-04-16T10:00:00Z', reason: 'should not match' }),
+        JSON.stringify({ agent_id: 'sonnet-reviewer', category: 'input-validation', timestamp: '2026-04-16T10:00:00Z', reason: 'wrong category' }),
+      ].join('\n'),
+    );
+
+    const res = await agentsHandler(root, CONFIG);
+    const slot = res[0].skillSlots.find(s => s.name === 'data-integrity');
+    expect(slot!.forcedDevelops).toBeDefined();
+    expect(slot!.forcedDevelops).toHaveLength(2);
+    expect(slot!.forcedDevelops!.map(e => e.reason).sort()).toEqual(['manual force', 'strike threshold']);
+  });
+
+  it('returns undefined effectiveness fields when skill file is missing', async () => {
+    const root = setupRoot();
+    // No skill file, no forced-develops jsonl.
+    const res = await agentsHandler(root, CONFIG);
+    const slot = res[0].skillSlots.find(s => s.name === 'data-integrity');
+    expect(slot).toBeDefined();
+    expect(slot!.name).toBe('data-integrity');
+    expect(slot!.effectiveness).toBeUndefined();
+    expect(slot!.status).toBeUndefined();
+    expect(slot!.inconclusiveStrikes).toBeUndefined();
+    expect(slot!.forcedDevelops).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

PR-A of dashboard-v2 modernization. Stacks on #138 (PR-F). Rewrites `/agent/:id` into vertical zones: existing status header (kept) + new competency bars + skill cards with effectiveness + activity timeline. Replaces the inline consensus-run accordion with the Finding-Detail drawer from PR-F.

## What changed

**Server — `packages/relay/src/dashboard/api-agents.ts`:**
- `SkillSlotResponse` extended with `effectiveness`, `status`, `inconclusiveStrikes`, `inconclusiveAt`, `forcedDevelops`
- New `readSkillFrontmatter()` helper — hand-rolled YAML scalar parser (no dep), reads `.gossip/agents/<id>/skills/<name>.md` frontmatter
- New `readForcedDevelops()` helper — reads `.gossip/forced-skill-develops.jsonl`, filters by agent + category, handles dash/underscore category normalization

**Client:**
- `packages/dashboard-v2/src/lib/types.ts` — hoisted `SkillSlot`, added `SkillStatus` union + `ForcedDevelopEntry`
- `packages/dashboard-v2/src/components/CategoryCompetency.tsx` (63 LOC) — horizontal accuracy bars per category
- `packages/dashboard-v2/src/components/SkillCard.tsx` (89 LOC) — per-slot card: status chip + effectiveness delta + strike counter + forced-develop history
- `packages/dashboard-v2/src/components/AgentActivityTimeline.tsx` (131 LOC) — reverse-chron signal feed with Filter bar; row click → FindingDetailDrawer
- `packages/dashboard-v2/src/components/AgentPage.tsx` — `CategoryStrengths` → `CategoryCompetency`, skills flex → `SkillCard` grid, consensus-run accordion deleted (state `expandedRun`/`runFilter` removed), findings rows now open drawer; `AgentActivityTimeline` appended

## Tests

- `tests/relay/api-agents-skill-effectiveness.test.ts` — 3 new tests: frontmatter read, forced-develops read, graceful missing-file handling
- 3/3 new pass, 125/125 regression (0 failures), build clean (329 kB / 94 kB gzip)

## Scope reduced from spec

- Zone 1 status header kept as-is (not fully redesigned)
- Competency rendered as bars, not radar chart — readability over novelty
- Activity timeline fetches signals only; tasks + skill-bind interleaving deferred (filter bar shows "(none yet)")
- `CategoryStrengths.tsx` left on disk (unused on agent page) — cheap to keep; delete in a follow-up cleanup if wanted

## Caveats

- `effectiveness` rendered as `+Npp` assumes a delta in [-1, 1]. If producer writes an absolute rate the label will read oddly — revisit if numbers look wrong in live data.
- Root `tsconfig.json` has pre-existing dashboard-v2 DOM-lib errors unrelated to this PR.

## Test plan

- [ ] Open `/agent/sonnet-reviewer` — see status header + CategoryCompetency bars + SkillCard grid + AgentActivityTimeline
- [ ] SkillCard shows status chip + effectiveness delta where present
- [ ] Timeline bars clickable where findingId present → FindingDetailDrawer opens
- [ ] Consensus-run accordion is gone; findings rows click → drawer opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)