### PR TITLE
feat(dashboard): PR-H — home rebalance (fleet trend + verdicts + signals peek + drift)

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -11,6 +11,10 @@ import { NeuralAvatar } from '@/components/NeuralAvatar';
 import { TaskDetailModal } from '@/components/TaskDetailModal';
 import { TasksSection } from '@/components/TasksSection';
 import { MemoryFolders } from '@/components/MemoryFolders';
+import { FleetHealthTrend } from '@/components/FleetHealthTrend';
+import { SkillVerdictsSnapshot } from '@/components/SkillVerdictsSnapshot';
+import { RecentSignalsPeek } from '@/components/RecentSignalsPeek';
+import { DroppedFindingDrift } from '@/components/DroppedFindingDrift';
 import { AgentPage } from '@/components/AgentPage';
 import { LogsPage } from '@/components/LogsPage';
 import { TaskRow } from '@/components/TaskRow';
@@ -496,6 +500,14 @@ function Dashboard() {
           <ActiveTasksBanner onCountChange={setActiveTaskCount} />
           {tasks && <TasksSection tasks={tasks} limit={5} />}
           {agents && <TeamHero agents={agents} />}
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <FleetHealthTrend />
+            <SkillVerdictsSnapshot overview={overview} />
+          </div>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <RecentSignalsPeek />
+            <DroppedFindingDrift overview={overview} />
+          </div>
           <FindingsMetrics consensus={consensus} reports={consensusReports} />
           {(gossipMemories || nativeMemories) && (
             <MemoryFolders

--- a/packages/dashboard-v2/src/components/DroppedFindingDrift.tsx
+++ b/packages/dashboard-v2/src/components/DroppedFindingDrift.tsx
@@ -1,0 +1,61 @@
+import type { OverviewData } from '@/lib/types';
+
+// Deterministic color picker from a palette — no hash randomness to keep
+// the same type the same color across renders.
+const PALETTE = [
+  'bg-disputed',
+  'bg-unverified',
+  'bg-unique',
+  'bg-muted-foreground/60',
+  'bg-primary/70',
+  'bg-confirmed/70',
+];
+
+function colorFor(type: string): string {
+  let h = 0;
+  for (let i = 0; i < type.length; i++) h = (h * 31 + type.charCodeAt(i)) >>> 0;
+  return PALETTE[h % PALETTE.length];
+}
+
+export function DroppedFindingDrift({ overview }: { overview: OverviewData | null }) {
+  const counts = overview?.droppedFindingTypeCounts;
+  const entries = counts ? Object.entries(counts).sort((a, b) => b[1] - a[1]) : [];
+  const total = entries.reduce((acc, [, n]) => acc + n, 0);
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <header className="mb-3 flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Dropped Finding Types</h3>
+        <span className="text-xs text-muted-foreground">last 20 rounds</span>
+      </header>
+      {total === 0 ? (
+        <p className="text-xs text-muted-foreground">all clean — no invalid types</p>
+      ) : (
+        <>
+          <div className="mb-3 flex h-3 w-full overflow-hidden rounded">
+            {entries.map(([type, n]) => {
+              const pct = (n / total) * 100;
+              return (
+                <div
+                  key={type}
+                  className={colorFor(type)}
+                  style={{ width: `${pct}%` }}
+                  title={`invalid type "${type}" emitted ${n} times in last 20 consensus rounds`}
+                />
+              );
+            })}
+          </div>
+          <ul className="space-y-1 text-xs">
+            {entries.map(([type, n]) => (
+              <li key={type} className="flex items-center gap-2">
+                <span className={`h-2 w-2 rounded-sm ${colorFor(type)}`} />
+                <span className="truncate font-mono text-foreground">{type}</span>
+                <span className="ml-auto tabular-nums text-muted-foreground">{n}</span>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </section>
+  );
+}

--- a/packages/dashboard-v2/src/components/FleetHealthTrend.tsx
+++ b/packages/dashboard-v2/src/components/FleetHealthTrend.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useMemo, useState } from 'react';
+import { api } from '@/lib/api';
+import type { FleetTrendPoint, FleetTrendResponse } from '@/lib/types';
+
+interface AgentSeries {
+  agentId: string;
+  points: FleetTrendPoint[];
+  latest: number;
+}
+
+function groupByAgent(points: FleetTrendPoint[]): AgentSeries[] {
+  const map = new Map<string, FleetTrendPoint[]>();
+  for (const p of points) {
+    const arr = map.get(p.agentId) ?? [];
+    arr.push(p);
+    map.set(p.agentId, arr);
+  }
+  const series: AgentSeries[] = [];
+  for (const [agentId, arr] of map) {
+    arr.sort((a, b) => a.day.localeCompare(b.day));
+    const latest = arr.length > 0 ? arr[arr.length - 1].accuracy : 0;
+    series.push({ agentId, points: arr, latest });
+  }
+  series.sort((a, b) => b.latest - a.latest);
+  return series;
+}
+
+function Sparkline({ values }: { values: number[] }) {
+  const W = 120;
+  const H = 20;
+  if (values.length === 0) return <svg width={W} height={H} />;
+  if (values.length === 1) {
+    const y = H - values[0] * H;
+    return (
+      <svg width={W} height={H}>
+        <circle cx={W / 2} cy={y} r={2} fill="currentColor" />
+      </svg>
+    );
+  }
+  const step = W / (values.length - 1);
+  const pts = values.map((v, i) => `${(i * step).toFixed(1)},${(H - v * H).toFixed(1)}`).join(' ');
+  return (
+    <svg width={W} height={H} className="text-primary">
+      <polyline points={pts} fill="none" stroke="currentColor" strokeWidth={1.5} />
+    </svg>
+  );
+}
+
+export function FleetHealthTrend() {
+  const [data, setData] = useState<FleetTrendResponse | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    api<FleetTrendResponse>('fleet-trend?days=30')
+      .then(setData)
+      .catch((e) => setErr(String(e?.message ?? e)));
+  }, []);
+
+  const series = useMemo(() => (data ? groupByAgent(data.points) : []), [data]);
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <header className="mb-3 flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Fleet Health Trend</h3>
+        <span className="text-xs text-muted-foreground">last 30d</span>
+      </header>
+      {err && <p className="text-xs text-muted-foreground">unavailable</p>}
+      {!err && data && series.length === 0 && (
+        <p className="text-xs text-muted-foreground">no recent consensus signals</p>
+      )}
+      {!err && series.length > 0 && (
+        <ul className="space-y-1.5">
+          {series.map((s) => (
+            <li key={s.agentId} className="flex items-center justify-between gap-3 text-xs">
+              <span className="truncate font-mono text-foreground">{s.agentId}</span>
+              <div className="flex items-center gap-2">
+                <Sparkline values={s.points.map((p) => p.accuracy)} />
+                <span className="w-10 text-right tabular-nums text-muted-foreground">
+                  {Math.round(s.latest * 100)}%
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/packages/dashboard-v2/src/components/RecentSignalsPeek.tsx
+++ b/packages/dashboard-v2/src/components/RecentSignalsPeek.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { api } from '@/lib/api';
+import { timeAgo } from '@/lib/utils';
+import { navigate } from '@/lib/router';
+import type { SignalEntry } from '@/lib/types';
+
+interface SignalsResponse {
+  items: SignalEntry[];
+  total: number;
+}
+
+const LABELS: Record<string, string> = {
+  agreement: 'confirmed',
+  consensus_verified: 'confirmed',
+  unique_confirmed: 'unique',
+  unique_unconfirmed: 'unique?',
+  disagreement: 'disputed',
+  hallucination_caught: 'hallucination',
+  new_finding: 'new',
+  unverified: 'unverified',
+};
+
+function truncate(s: string, n: number): string {
+  if (!s) return '';
+  return s.length > n ? s.slice(0, n - 1) + '…' : s;
+}
+
+export function RecentSignalsPeek() {
+  const [items, setItems] = useState<SignalEntry[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    api<SignalsResponse>('signals?limit=5')
+      .then((r) => setItems(r.items ?? []))
+      .catch((e) => setErr(String(e?.message ?? e)));
+  }, []);
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <header className="mb-3 flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Recent Signals</h3>
+        <button
+          type="button"
+          onClick={() => navigate('/signals')}
+          className="text-xs text-primary hover:underline"
+        >
+          all signals →
+        </button>
+      </header>
+      {err && <p className="text-xs text-muted-foreground">unavailable</p>}
+      {!err && items && items.length === 0 && (
+        <p className="text-xs text-muted-foreground">no signals recorded</p>
+      )}
+      {!err && items && items.length > 0 && (
+        <ul className="space-y-1.5">
+          {items.map((s, i) => (
+            <li key={`${s.timestamp}-${i}`} className="flex items-center gap-2 text-xs">
+              <span className="w-14 shrink-0 text-muted-foreground tabular-nums">{timeAgo(s.timestamp)}</span>
+              <span className="w-20 shrink-0 font-mono uppercase tracking-wide text-foreground">
+                {LABELS[s.signal] ?? s.signal}
+              </span>
+              <span className="w-24 shrink-0 truncate font-mono text-muted-foreground">{s.agentId}</span>
+              <span className="flex-1 truncate text-muted-foreground">{truncate(s.evidence ?? '', 80)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/packages/dashboard-v2/src/components/SkillVerdictsSnapshot.tsx
+++ b/packages/dashboard-v2/src/components/SkillVerdictsSnapshot.tsx
@@ -1,0 +1,57 @@
+import type { OverviewData } from '@/lib/types';
+
+const SEGMENTS: { key: keyof NonNullable<OverviewData['skillVerdictSummary']>; label: string; cls: string }[] = [
+  { key: 'passed', label: 'passed', cls: 'bg-confirmed' },
+  { key: 'pending', label: 'pending', cls: 'bg-unique/60' },
+  { key: 'silent_skill', label: 'silent', cls: 'bg-unverified' },
+  { key: 'insufficient_evidence', label: 'insufficient', cls: 'bg-muted' },
+  { key: 'inconclusive', label: 'inconclusive', cls: 'bg-muted-foreground/40' },
+  { key: 'failed', label: 'failed', cls: 'bg-disputed' },
+];
+
+export function SkillVerdictsSnapshot({ overview }: { overview: OverviewData | null }) {
+  const s = overview?.skillVerdictSummary;
+  const total = s ? SEGMENTS.reduce((acc, seg) => acc + (s[seg.key] ?? 0), 0) : 0;
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <header className="mb-3 flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Skill Verdicts</h3>
+        <span className="text-xs text-muted-foreground">{total} total</span>
+      </header>
+      {!s || total === 0 ? (
+        <p className="text-xs text-muted-foreground">no skill verdicts yet</p>
+      ) : (
+        <>
+          <div className="mb-3 flex h-3 w-full overflow-hidden rounded">
+            {SEGMENTS.map((seg) => {
+              const n = s[seg.key] ?? 0;
+              if (n === 0) return null;
+              const pct = (n / total) * 100;
+              return (
+                <div
+                  key={seg.key}
+                  className={seg.cls}
+                  style={{ width: `${pct}%` }}
+                  title={`${seg.label}: ${n}`}
+                />
+              );
+            })}
+          </div>
+          <ul className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
+            {SEGMENTS.map((seg) => {
+              const n = s[seg.key] ?? 0;
+              return (
+                <li key={seg.key} className="flex items-center gap-2">
+                  <span className={`h-2 w-2 rounded-sm ${seg.cls}`} />
+                  <span className="text-muted-foreground">{seg.label}</span>
+                  <span className="ml-auto tabular-nums text-foreground">{n}</span>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </section>
+  );
+}

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -13,6 +13,27 @@ export interface OverviewData {
   lastConsensusTimestamp: string;
   actionableFindings: number;
   hourlyActivity: number[];
+  skillVerdictSummary?: {
+    pending: number;
+    passed: number;
+    failed: number;
+    silent_skill: number;
+    insufficient_evidence: number;
+    inconclusive: number;
+  };
+  droppedFindingTypeCounts?: Record<string, number>;
+}
+
+export interface FleetTrendPoint {
+  day: string;
+  agentId: string;
+  accuracy: number;
+  signals: number;
+}
+
+export interface FleetTrendResponse {
+  days: number;
+  points: FleetTrendPoint[];
 }
 
 export interface AgentData {

--- a/packages/relay/src/dashboard/api-fleet-trend.ts
+++ b/packages/relay/src/dashboard/api-fleet-trend.ts
@@ -18,7 +18,25 @@ const MAX_DAYS = 90;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 interface CacheEntry { mtime: number; payload: FleetTrendResponse; }
+// LRU-bounded: distinct (projectRoot, days) keys from unknown callers would otherwise
+// grow the Map unbounded with each entry holding a full FleetTrendResponse.
+const CACHE_MAX = 64;
 const cache = new Map<string, CacheEntry>();
+
+function cacheGet(key: string): CacheEntry | undefined {
+  const v = cache.get(key);
+  if (v !== undefined) { cache.delete(key); cache.set(key, v); }
+  return v;
+}
+function cacheSet(key: string, value: CacheEntry): void {
+  if (cache.has(key)) cache.delete(key);
+  cache.set(key, value);
+  while (cache.size > CACHE_MAX) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+}
 
 export async function fleetTrendHandler(projectRoot: string, query?: URLSearchParams): Promise<FleetTrendResponse> {
   const rawDays = parseInt(query?.get('days') ?? '', 10);
@@ -28,7 +46,7 @@ export async function fleetTrendHandler(projectRoot: string, query?: URLSearchPa
   if (!existsSync(perfPath)) return { days, points: [] };
   const mtime = statSync(perfPath).mtimeMs;
   const cacheKey = `${projectRoot}::${days}`;
-  const cached = cache.get(cacheKey);
+  const cached = cacheGet(cacheKey);
   if (cached && cached.mtime === mtime) return cached.payload;
 
   const cutoff = Date.now() - days * DAY_MS;
@@ -64,6 +82,11 @@ export async function fleetTrendHandler(projectRoot: string, query?: URLSearchPa
   points.sort((a, b) => a.day.localeCompare(b.day) || a.agentId.localeCompare(b.agentId));
 
   const payload: FleetTrendResponse = { days, points };
-  cache.set(cacheKey, { mtime, payload });
+  // Re-stat after read closes the TOCTOU gap: if the file was appended between the
+  // initial stat and readFileSync, the new mtime differs and we skip the cache write
+  // rather than cache a payload computed from a stale snapshot.
+  let postMtime: number | null = null;
+  try { postMtime = statSync(perfPath).mtimeMs; } catch { /* file gone */ }
+  if (postMtime === mtime) cacheSet(cacheKey, { mtime, payload });
   return payload;
 }

--- a/packages/relay/src/dashboard/api-fleet-trend.ts
+++ b/packages/relay/src/dashboard/api-fleet-trend.ts
@@ -1,0 +1,69 @@
+import { readFileSync, existsSync, statSync } from 'fs';
+import { join } from 'path';
+
+export interface FleetTrendPoint {
+  day: string; // ISO date YYYY-MM-DD
+  agentId: string;
+  accuracy: number;
+  signals: number;
+}
+
+export interface FleetTrendResponse {
+  days: number;
+  points: FleetTrendPoint[];
+}
+
+const DEFAULT_DAYS = 30;
+const MAX_DAYS = 90;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+interface CacheEntry { mtime: number; payload: FleetTrendResponse; }
+const cache = new Map<string, CacheEntry>();
+
+export async function fleetTrendHandler(projectRoot: string, query?: URLSearchParams): Promise<FleetTrendResponse> {
+  const rawDays = parseInt(query?.get('days') ?? '', 10);
+  const days = isNaN(rawDays) || rawDays < 1 ? DEFAULT_DAYS : Math.min(rawDays, MAX_DAYS);
+
+  const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+  if (!existsSync(perfPath)) return { days, points: [] };
+  const mtime = statSync(perfPath).mtimeMs;
+  const cacheKey = `${projectRoot}::${days}`;
+  const cached = cache.get(cacheKey);
+  if (cached && cached.mtime === mtime) return cached.payload;
+
+  const cutoff = Date.now() - days * DAY_MS;
+  // per-agent per-day: {good, total} → accuracy = good/total
+  const buckets = new Map<string, Map<string, { good: number; total: number }>>();
+
+  try {
+    const lines = readFileSync(perfPath, 'utf-8').trim().split('\n').filter(Boolean);
+    for (const line of lines) {
+      try {
+        const rec = JSON.parse(line);
+        if (rec.type !== 'consensus' || !rec.agentId || rec.agentId === '_system' || !rec.timestamp) continue;
+        const t = Date.parse(rec.timestamp);
+        if (!Number.isFinite(t) || t < cutoff) continue;
+        const day = new Date(t).toISOString().slice(0, 10);
+        let byDay = buckets.get(rec.agentId);
+        if (!byDay) { byDay = new Map(); buckets.set(rec.agentId, byDay); }
+        let counts = byDay.get(day);
+        if (!counts) { counts = { good: 0, total: 0 }; byDay.set(day, counts); }
+        counts.total++;
+        if (rec.signal === 'agreement' || rec.signal === 'unique_confirmed' || rec.signal === 'consensus_verified') counts.good++;
+      } catch { /* skip */ }
+    }
+  } catch { return { days, points: [] }; }
+
+  const points: FleetTrendPoint[] = [];
+  for (const [agentId, byDay] of buckets) {
+    for (const [day, c] of byDay) {
+      if (c.total === 0) continue;
+      points.push({ day, agentId, accuracy: c.good / c.total, signals: c.total });
+    }
+  }
+  points.sort((a, b) => a.day.localeCompare(b.day) || a.agentId.localeCompare(b.agentId));
+
+  const payload: FleetTrendResponse = { days, points };
+  cache.set(cacheKey, { mtime, payload });
+  return payload;
+}

--- a/packages/relay/src/dashboard/api-overview.ts
+++ b/packages/relay/src/dashboard/api-overview.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 
 interface AgentConfigLike {
@@ -28,6 +28,95 @@ export interface OverviewResponse {
   actionableFindings: number;
   /** Task counts for each of the last 12 hours (index 0 = 12h ago, index 11 = current hour). */
   hourlyActivity: number[];
+  /** Fleet-wide skill verdict counts bucketed by YAML frontmatter `status:` field. */
+  skillVerdictSummary?: {
+    pending: number;
+    passed: number;
+    failed: number;
+    silent_skill: number;
+    insufficient_evidence: number;
+    inconclusive: number;
+  };
+  /** Aggregate count of invalid finding type tokens from the last 20 consensus reports. */
+  droppedFindingTypeCounts?: Record<string, number>;
+}
+
+/**
+ * Hand-rolled frontmatter status parser. Returns the value of `status:` in
+ * the YAML frontmatter block, or null if none. Tolerant of quoted values.
+ */
+function readSkillStatus(path: string): string | null {
+  try {
+    const content = readFileSync(path, 'utf-8');
+    const m = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!m) return null;
+    const block = m[1];
+    for (const line of block.split('\n')) {
+      const sm = line.match(/^status\s*:\s*["']?([A-Za-z_][A-Za-z0-9_-]*)["']?\s*$/);
+      if (sm) return sm[1].toLowerCase();
+    }
+    return null;
+  } catch { return null; }
+}
+
+function computeSkillVerdictSummary(projectRoot: string): OverviewResponse['skillVerdictSummary'] {
+  const agentsDir = join(projectRoot, '.gossip', 'agents');
+  if (!existsSync(agentsDir)) return undefined;
+  const summary = { pending: 0, passed: 0, failed: 0, silent_skill: 0, insufficient_evidence: 0, inconclusive: 0 };
+  let seen = false;
+  try {
+    const agentIds = readdirSync(agentsDir);
+    for (const agentId of agentIds) {
+      const skillsDir = join(agentsDir, agentId, 'skills');
+      if (!existsSync(skillsDir)) continue;
+      let entries: string[];
+      try { entries = readdirSync(skillsDir); } catch { continue; }
+      for (const entry of entries) {
+        if (!entry.endsWith('.md')) continue;
+        const status = readSkillStatus(join(skillsDir, entry));
+        if (!status) continue;
+        seen = true;
+        if (status === 'pending') summary.pending++;
+        else if (status === 'passed') summary.passed++;
+        else if (status === 'failed') summary.failed++;
+        else if (status === 'silent_skill') summary.silent_skill++;
+        else if (status === 'insufficient_evidence') summary.insufficient_evidence++;
+        else if (status === 'inconclusive') summary.inconclusive++;
+      }
+    }
+  } catch { return undefined; }
+  return seen ? summary : summary;
+}
+
+function computeDroppedFindingTypeCounts(projectRoot: string): Record<string, number> | undefined {
+  const dir = join(projectRoot, '.gossip', 'consensus-reports');
+  if (!existsSync(dir)) return undefined;
+  try {
+    const files = readdirSync(dir)
+      .filter(f => f.endsWith('.json'))
+      .map(f => {
+        const full = join(dir, f);
+        try { return { full, mtime: statSync(full).mtimeMs }; } catch { return null; }
+      })
+      .filter((x): x is { full: string; mtime: number } => x !== null)
+      .sort((a, b) => b.mtime - a.mtime)
+      .slice(0, 20);
+    const counts: Record<string, number> = {};
+    let seen = false;
+    for (const { full } of files) {
+      try {
+        const report = JSON.parse(readFileSync(full, 'utf-8'));
+        const dropped = report?.droppedFindingsByType;
+        if (!dropped || typeof dropped !== 'object') continue;
+        for (const [type, count] of Object.entries(dropped)) {
+          if (typeof count !== 'number' || count <= 0) continue;
+          counts[type] = (counts[type] ?? 0) + count;
+          seen = true;
+        }
+      } catch { /* skip */ }
+    }
+    return seen ? counts : counts;
+  } catch { return undefined; }
 }
 
 export async function overviewHandler(projectRoot: string, ctx: OverviewContext): Promise<OverviewResponse> {
@@ -179,5 +268,8 @@ export async function overviewHandler(projectRoot: string, ctx: OverviewContext)
 
   const avgDurationMs = durationCount > 0 ? Math.round(totalDuration / durationCount) : 0;
 
-  return { agentsOnline, relayCount, relayConnected, nativeCount, consensusRuns, totalFindings, confirmedFindings, totalSignals, tasksCompleted, tasksFailed, avgDurationMs, lastConsensusTimestamp, actionableFindings, hourlyActivity };
+  const skillVerdictSummary = computeSkillVerdictSummary(projectRoot);
+  const droppedFindingTypeCounts = computeDroppedFindingTypeCounts(projectRoot);
+
+  return { agentsOnline, relayCount, relayConnected, nativeCount, consensusRuns, totalFindings, confirmedFindings, totalSignals, tasksCompleted, tasksFailed, avgDurationMs, lastConsensusTimestamp, actionableFindings, hourlyActivity, skillVerdictSummary, droppedFindingTypeCounts };
 }

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -1,6 +1,7 @@
 import { IncomingMessage, ServerResponse } from 'http';
 import { DashboardAuth } from './auth';
 import { overviewHandler } from './api-overview';
+import { fleetTrendHandler } from './api-fleet-trend';
 import { agentsHandler } from './api-agents';
 import { skillsGetHandler, skillsBindHandler } from './api-skills';
 import { memoryHandler } from './api-memory';
@@ -236,6 +237,12 @@ export class DashboardRouter {
     try {
       if (url === '/dashboard/api/overview' && req.method === 'GET') {
         const data = await overviewHandler(this.projectRoot, this.ctx);
+        this.json(res, 200, data);
+        return true;
+      }
+
+      if (url === '/dashboard/api/fleet-trend' && req.method === 'GET') {
+        const data = await fleetTrendHandler(this.projectRoot, query ?? undefined);
         this.json(res, 200, data);
         return true;
       }

--- a/tests/relay/api-fleet-trend.test.ts
+++ b/tests/relay/api-fleet-trend.test.ts
@@ -1,0 +1,58 @@
+import { fleetTrendHandler } from '../../packages/relay/src/dashboard/api-fleet-trend';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('fleetTrendHandler', () => {
+  function makeRoot(records: Record<string, unknown>[]): string {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-test-fleet-'));
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+    writeFileSync(
+      join(root, '.gossip', 'agent-performance.jsonl'),
+      records.map(r => JSON.stringify(r)).join('\n') + '\n',
+    );
+    return root;
+  }
+
+  it('returns per-day per-agent accuracy buckets from agent-performance.jsonl', async () => {
+    const now = new Date().toISOString();
+    const root = makeRoot([
+      { type: 'consensus', signal: 'agreement', agentId: 'alice', timestamp: now },
+      { type: 'consensus', signal: 'hallucination_caught', agentId: 'alice', timestamp: now },
+      { type: 'consensus', signal: 'unique_confirmed', agentId: 'bob', timestamp: now },
+    ]);
+    const res = await fleetTrendHandler(root);
+    expect(res.days).toBe(30);
+    const alice = res.points.find(p => p.agentId === 'alice');
+    const bob = res.points.find(p => p.agentId === 'bob');
+    expect(alice).toBeDefined();
+    expect(alice!.signals).toBe(2);
+    expect(alice!.accuracy).toBe(0.5);
+    expect(bob!.accuracy).toBe(1);
+    expect(bob!.signals).toBe(1);
+  });
+
+  it('filters out entries older than the days window', async () => {
+    const recent = new Date().toISOString();
+    const old = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+    const root = makeRoot([
+      { type: 'consensus', signal: 'agreement', agentId: 'alice', timestamp: recent },
+      { type: 'consensus', signal: 'agreement', agentId: 'alice', timestamp: old },
+    ]);
+    const res = await fleetTrendHandler(root, new URLSearchParams({ days: '30' }));
+    const alice = res.points.find(p => p.agentId === 'alice');
+    expect(alice).toBeDefined();
+    expect(alice!.signals).toBe(1);
+  });
+
+  it('excludes _system sentinel agent', async () => {
+    const now = new Date().toISOString();
+    const root = makeRoot([
+      { type: 'consensus', signal: 'consensus_round_retracted', agentId: '_system', timestamp: now },
+      { type: 'consensus', signal: 'agreement', agentId: 'alice', timestamp: now },
+    ]);
+    const res = await fleetTrendHandler(root);
+    expect(res.points.some(p => p.agentId === '_system')).toBe(false);
+    expect(res.points.some(p => p.agentId === 'alice')).toBe(true);
+  });
+});

--- a/tests/relay/api-overview-extras.test.ts
+++ b/tests/relay/api-overview-extras.test.ts
@@ -1,0 +1,59 @@
+import { overviewHandler } from '../../packages/relay/src/dashboard/api-overview';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+function setupRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'gossip-test-overview-'));
+  mkdirSync(join(root, '.gossip'), { recursive: true });
+  return root;
+}
+
+describe('overviewHandler extras', () => {
+  it('skillVerdictSummary counts bucketed statuses across skill files', async () => {
+    const root = setupRoot();
+    const agentsDir = join(root, '.gossip', 'agents');
+    const aliceSkills = join(agentsDir, 'alice', 'skills');
+    const bobSkills = join(agentsDir, 'bob', 'skills');
+    mkdirSync(aliceSkills, { recursive: true });
+    mkdirSync(bobSkills, { recursive: true });
+
+    writeFileSync(join(aliceSkills, 's1.md'), '---\nname: "s1"\nstatus: passed\n---\nbody\n');
+    writeFileSync(join(aliceSkills, 's2.md'), '---\nname: "s2"\nstatus: "failed"\n---\nbody\n');
+    writeFileSync(join(bobSkills, 's3.md'), '---\nname: "s3"\nstatus: pending\n---\nbody\n');
+    writeFileSync(join(bobSkills, 's4.md'), '---\nname: "s4"\nstatus: silent_skill\n---\nbody\n');
+    // No-status file should be skipped
+    writeFileSync(join(bobSkills, 's5.md'), '---\nname: "s5"\n---\nbody\n');
+
+    const data = await overviewHandler(root, { agentConfigs: [], relayConnections: 0, connectedAgentIds: [] });
+    expect(data.skillVerdictSummary).toBeDefined();
+    expect(data.skillVerdictSummary!.passed).toBe(1);
+    expect(data.skillVerdictSummary!.failed).toBe(1);
+    expect(data.skillVerdictSummary!.pending).toBe(1);
+    expect(data.skillVerdictSummary!.silent_skill).toBe(1);
+    expect(data.skillVerdictSummary!.insufficient_evidence).toBe(0);
+  });
+
+  it('droppedFindingTypeCounts aggregates from recent consensus reports', async () => {
+    const root = setupRoot();
+    const dir = join(root, '.gossip', 'consensus-reports');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'r1.json'),
+      JSON.stringify({ id: 'r1', droppedFindingsByType: { approval: 2, concern: 1 } }),
+    );
+    writeFileSync(
+      join(dir, 'r2.json'),
+      JSON.stringify({ id: 'r2', droppedFindingsByType: { approval: 3 } }),
+    );
+    writeFileSync(
+      join(dir, 'r3.json'),
+      JSON.stringify({ id: 'r3' }), // no droppedFindingsByType
+    );
+
+    const data = await overviewHandler(root, { agentConfigs: [], relayConnections: 0, connectedAgentIds: [] });
+    expect(data.droppedFindingTypeCounts).toBeDefined();
+    expect(data.droppedFindingTypeCounts!.approval).toBe(5);
+    expect(data.droppedFindingTypeCounts!.concern).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Final PR of dashboard-v2 modernization. Stacks on #138 (PR-F). Adds four home-page widgets: Fleet Health Trend sparklines, Skill Verdicts snapshot, Recent Signals peek, and Dropped-Finding-Type Drift.

## What changed

**Server:**
- `packages/relay/src/dashboard/api-fleet-trend.ts` (new) — `/dashboard/api/fleet-trend?days=30` returns per-agent per-day accuracy buckets from `agent-performance.jsonl`. mtime-cached (`projectRoot::days` key), excludes `_system` sentinel, max 90 days.
- `packages/relay/src/dashboard/api-overview.ts` — `OverviewResponse` extended with `skillVerdictSummary` (pending/passed/failed/silent_skill/insufficient_evidence/inconclusive counts by globbing `.gossip/agents/*/skills/*.md` frontmatter) and `droppedFindingTypeCounts` (aggregated from 20 most-recent consensus reports).
- `packages/relay/src/dashboard/routes.ts` — wires the new fleet-trend route.

**Client — 4 new components (all < 120 LOC):**
- `FleetHealthTrend.tsx` (88 LOC) — per-agent SVG sparkline + latest accuracy
- `SkillVerdictsSnapshot.tsx` (57 LOC) — stacked bar + legend
- `RecentSignalsPeek.tsx` (70 LOC) — last 5 signals + link to `/signals`
- `DroppedFindingDrift.tsx` (61 LOC) — horizontal stacked bar of invalid finding-type counts

Wired into `App.tsx` Dashboard home between `TeamHero` and `FindingsMetrics` as two 2-column grid rows.

## Tests

- `tests/relay/api-fleet-trend.test.ts` — 3 tests (per-day buckets, days filter, _system exclusion)
- `tests/relay/api-overview-extras.test.ts` — 2 tests (verdict summary bucketing, dropped-type aggregation)
- 5/5 new pass, 127/127 regression, build clean (332 kB / 94 kB gzip)

## Caveats

- `RecentSignalsPeek` links to `/signals` — that route is in PR-S ([#140](https://github.com/gossipcat-ai/gossipcat-ai/pull/140)). Until PR-S lands, the link falls through to home silently.
- `skillVerdictSummary` always returns a zero-initialized object when no skills have `status:` — gives the client stable fields to render. Flip to `undefined` if preferred.

## Test plan

- [ ] Home loads with existing widgets plus 4 new ones
- [ ] Fleet Health Trend shows per-agent sparklines (or empty state)
- [ ] Skill Verdicts Snapshot shows bar + legend
- [ ] Recent Signals Peek shows 5 most recent signals
- [ ] Dropped Finding Drift shows type counts or hides when empty
- [ ] No console errors on fresh install with no `.gossip/` data

🤖 Generated with [Claude Code](https://claude.com/claude-code)