### PR TITLE
fix(security): harden api-finding.ts against path traversal

### DIFF
--- a/packages/relay/src/dashboard/api-finding.ts
+++ b/packages/relay/src/dashboard/api-finding.ts
@@ -1,5 +1,11 @@
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, realpathSync } from 'fs';
 import { join, resolve, relative } from 'path';
+
+// Consensus/finding IDs come from URL segments after decodeURIComponent.
+// Reject anything that could escape the consensus-reports directory via
+// path separators, `..`, or NUL bytes. Alphanumerics, `-`, `_`, `:` only —
+// covers the 8-8 hex format and the `<consensusId>:<agentId>:fN` shape.
+const SAFE_ID = /^[\w:.\-]+$/;
 
 export interface CitationSnippet {
   file: string;
@@ -35,23 +41,39 @@ export interface FindingDetail {
 }
 
 const SNIPPET_CONTEXT = 2;
-const CITE_RE = /<cite tag="file">([^<:]+):(\d+)<\/cite>/g;
+// Stateful `g` regex is safe because extractCitations is synchronous, but use a
+// local instance anyway so a future `await` inside the loop cannot break
+// concurrent callers via shared `lastIndex`.
+const CITE_PATTERN = /<cite tag="file">([^<:]+):(\d+)<\/cite>/g;
 
 function extractCitations(findingText: string, projectRoot: string): CitationSnippet[] {
   const out: CitationSnippet[] = [];
-  const resolvedRoot = resolve(projectRoot);
+  // Resolve the root through any symlinks (e.g. macOS `/tmp` → `/private/tmp`)
+  // so subsequent realpath comparisons are apples-to-apples.
+  let realRoot: string;
+  try { realRoot = realpathSync(resolve(projectRoot)); } catch { return out; }
+  const re = new RegExp(CITE_PATTERN.source, 'g');
   let m: RegExpExecArray | null;
-  CITE_RE.lastIndex = 0;
-  while ((m = CITE_RE.exec(findingText)) !== null) {
+  while ((m = re.exec(findingText)) !== null) {
     const filePath = m[1];
     const line = parseInt(m[2], 10);
     if (!Number.isFinite(line) || line < 1) continue;
-    const abs = resolve(projectRoot, filePath);
-    const rel = relative(resolvedRoot, abs);
-    if (rel.startsWith('..') || rel === '') continue;
+    // Reject NUL bytes outright — they can split paths on some filesystems.
+    if (filePath.includes('\0')) continue;
+    const abs = resolve(realRoot, filePath);
+    // Pre-check on the resolved-but-not-real path — catches `../../etc/passwd`
+    // before we touch the filesystem at all.
+    const preRel = relative(realRoot, abs);
+    if (preRel === '' || preRel.startsWith('..')) continue;
     if (!existsSync(abs)) { out.push({ file: filePath, line, snippet: '// file not found' }); continue; }
+    // Resolve symlinks and confirm the REAL path still lives under the REAL
+    // project root. A bare `relative().startsWith('..')` is symlink-blind.
+    let realAbs: string;
+    try { realAbs = realpathSync(abs); } catch { continue; }
+    const rel = relative(realRoot, realAbs);
+    if (rel === '' || rel.startsWith('..')) continue;
     try {
-      const lines = readFileSync(abs, 'utf-8').split('\n');
+      const lines = readFileSync(realAbs, 'utf-8').split('\n');
       const start = Math.max(0, line - 1 - SNIPPET_CONTEXT);
       const end = Math.min(lines.length, line + SNIPPET_CONTEXT);
       out.push({ file: filePath, line, snippet: lines.slice(start, end).join('\n') });
@@ -65,6 +87,11 @@ export async function findingHandler(
   consensusId: string,
   findingId: string,
 ): Promise<FindingDetail> {
+  // URL segments reach this handler already decodeURIComponent'd, so `%2e%2e%2f`
+  // will have expanded to `../` — allowlist the decoded form before it touches
+  // the filesystem.
+  if (!SAFE_ID.test(consensusId)) throw new Error(`consensus ${consensusId} not found`);
+  if (!SAFE_ID.test(findingId)) throw new Error(`finding ${findingId} not found in ${consensusId}`);
   const reportPath = join(projectRoot, '.gossip', 'consensus-reports', `${consensusId}.json`);
   if (!existsSync(reportPath)) throw new Error(`consensus ${consensusId} not found`);
   const report = JSON.parse(readFileSync(reportPath, 'utf-8'));

--- a/tests/relay/api-finding.test.ts
+++ b/tests/relay/api-finding.test.ts
@@ -1,5 +1,5 @@
 import { findingHandler } from '../../packages/relay/src/dashboard/api-finding';
-import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { mkdtempSync, writeFileSync, mkdirSync, symlinkSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -57,6 +57,40 @@ describe('findingHandler', () => {
       id: 'abc-def', confirmed: [], disputed: [], unverified: [], unique: [], insights: [], newFindings: [],
     }));
     await expect(findingHandler(root, 'abc-def', 'abc-def:f99')).rejects.toThrow(/not found/i);
+  });
+
+  it('rejects path-traversal consensusId (percent-decoded `..`)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-test-finding-'));
+    mkdirSync(join(root, '.gossip', 'consensus-reports'), { recursive: true });
+    // A file outside the reports dir that the attacker would reach via traversal
+    writeFileSync(join(root, '.gossip', 'secret.json'), JSON.stringify({
+      id: 'secret', confirmed: [{ id: 'secret:f1', originalAgentId: 'x', findingType: 'finding', tag: 'confirmed', finding: 'leak', confirmedBy: [], disputedBy: [], confidence: 1 }],
+      disputed: [], unverified: [], unique: [], insights: [], newFindings: [],
+    }));
+    await expect(findingHandler(root, '../secret', 'secret:f1')).rejects.toThrow(/not found/i);
+    await expect(findingHandler(root, '..%2Fsecret', 'secret:f1')).rejects.toThrow(/not found/i);
+  });
+
+  it('rejects symlink-based citation escape', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-test-finding-sym-'));
+    const outside = mkdtempSync(join(tmpdir(), 'gossip-test-outside-'));
+    mkdirSync(join(root, '.gossip', 'consensus-reports'), { recursive: true });
+    writeFileSync(join(outside, 'secret.txt'), 'OUTSIDE-SECRET\n');
+    try { symlinkSync(join(outside, 'secret.txt'), join(root, 'link.txt')); } catch { return; /* no symlink support */ }
+    if (!existsSync(join(root, 'link.txt'))) return;
+
+    writeFileSync(join(root, '.gossip', 'consensus-reports', 'c1-c2.json'), JSON.stringify({
+      id: 'c1-c2',
+      confirmed: [{
+        id: 'c1-c2:f1', originalAgentId: 'x', findingType: 'finding', tag: 'confirmed',
+        finding: 'read via symlink <cite tag="file">link.txt:1</cite>',
+        confirmedBy: [], disputedBy: [], confidence: 1,
+      }],
+      disputed: [], unverified: [], unique: [], insights: [], newFindings: [],
+    }));
+    const res = await findingHandler(root, 'c1-c2', 'c1-c2:f1');
+    // Symlink target is outside the project root — must be rejected by realpath check.
+    expect(res.citations).toHaveLength(0);
   });
 
   it('rejects path-traversal citations', async () => {


### PR DESCRIPTION
## Summary

Security hotfix for 2 HIGH findings caught by consensus review (`f502359c-37c14877`) on the endpoint shipped in #138.

## Vulnerabilities

**HIGH — Percent-encoded path traversal via `consensusId` / `findingId`**
The route regex `^/dashboard/api/finding/([^/]+)/(.+)$` blocks literal slashes, but `decodeURIComponent` expanded `%2e%2e%2f` to `../` **after** the regex match. A request to `/dashboard/api/finding/%2E%2E%2fsecret/anyId` would decode `consensusId` to `../secret` and then hit `join(root, '.gossip', 'consensus-reports', '../secret.json')` — escaping the target directory to read other `.json` files anywhere under `projectRoot`.

Fix: validate decoded IDs against `/^[\w:.\-]+$/` before use.

**HIGH — Symlink-blind path check in `extractCitations`**
Previous guard `relative(root, abs).startsWith('..')` did not dereference symlinks. An attacker-writable symlink inside the project (e.g. `project/link.txt → /etc/passwd`) would pass the relative check and then `readFileSync` would follow the link.

Fix: `realpathSync` both the project root and the resolved absolute path before comparing. Matches the pattern used in the static-asset handler at `routes.ts:413-416`.

## Also fixed (lower severity)

- `CITE_RE` is now a local regex instance per call — no module-level shared `lastIndex`, removes the future-await trap
- NUL-byte paths rejected outright
- `projectRoot` normalized through `realpath` so `/tmp` → `/private/tmp` (macOS) comparisons are apples-to-apples

## Tests

- New: `rejects path-traversal consensusId (percent-decoded ..)` — verifies `../secret` and `..%2Fsecret` both throw `not found`
- New: `rejects symlink-based citation escape` — creates a symlink to an outside file and verifies it's not read
- Existing: `rejects path-traversal citations` still passes (pre-existsSync check order preserved)
- 6/6 api-finding tests pass, 126/127 full relay regression (1 pre-existing skip)

## Credit

Findings from consensus round `f502359c-37c14877` (sonnet-reviewer + gemini-reviewer, cross-validated). Both reviewers independently caught the core path-traversal vector; sonnet additionally flagged the symlink and regex-state issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)