### PR TITLE
fix(dashboard): pagination + agent list + collapsed runs (UX review)

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -308,7 +308,7 @@ function TasksPage({ tasks }: { tasks: import('@/lib/types').TasksData }) {
   const [query, setQuery] = useState('');
   const [page, setPage] = useState(0);
   const [selected, setSelected] = useState<import('@/lib/types').TaskItem | null>(null);
-  const PAGE_SIZE = 50;
+  const PAGE_SIZE = 100;
 
   const completed = tasks.items.filter((t) => t.status === 'completed').length;
   const failed = tasks.items.filter((t) => t.status === 'failed').length;

--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -30,6 +30,7 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
   const [memories, setMemories] = useState<MemoryFile[]>([]);
   const [reports, setReports] = useState<ConsensusReport[]>([]);
   const [expandedMem, setExpandedMem] = useState<string | null>(null);
+  const [expandedRun, setExpandedRun] = useState<string | null>(null);
   const [drawerFinding, setDrawerFinding] = useState<{ consensusId: string; findingId: string } | null>(null);
   const [taskPage, setTaskPage] = useState(0);
   const [memDayIdx, setMemDayIdx] = useState(0);
@@ -363,12 +364,24 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
                 new_finding: { label: 'NEW', cls: 'text-unique bg-unique/10' },
               };
               const runSignals = run.signals.filter(sig => sig.signal !== 'signal_retracted' && tagMap[sig.signal]);
+              const runKey = run.taskId + ':' + i;
+              const isOpen = expandedRun === runKey;
               return (
-                <div key={run.taskId + i} className="rounded-md border border-border/40 bg-card">
-                  <div className="flex items-center p-3">
+                <div key={runKey} className="rounded-md border border-border/40 bg-card">
+                  <button
+                    type="button"
+                    onClick={() => setExpandedRun(isOpen ? null : runKey)}
+                    disabled={runSignals.length === 0}
+                    className={`flex w-full items-center p-3 text-left transition ${runSignals.length > 0 ? 'hover:bg-accent/20' : 'cursor-default'}`}
+                  >
                     <div className="flex-1">
                       <div className="flex items-center justify-between">
-                        <span className="font-mono text-sm font-semibold text-foreground">{total} findings</span>
+                        <span className="font-mono text-sm font-semibold text-foreground">
+                          {runSignals.length > 0 && (
+                            <span className="mr-1.5 inline-block text-muted-foreground">{isOpen ? '▾' : '▸'}</span>
+                          )}
+                          {total} findings
+                        </span>
                         <span className="font-mono text-xs text-muted-foreground">{timeAgo(run.timestamp)}</span>
                       </div>
                       <div className="mt-1.5 flex gap-2">
@@ -382,8 +395,8 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
                         ))}
                       </div>
                     </div>
-                  </div>
-                  {runSignals.length > 0 && (
+                  </button>
+                  {isOpen && runSignals.length > 0 && (
                     <div className="border-t border-border/30 px-3 pb-2 pt-2">
                       <div className="space-y-1">
                         {runSignals.map((sig, j) => {

--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -8,8 +8,9 @@ import type { SignalEntry } from '@/lib/types';
 interface SignalsResponse {
   items: SignalEntry[];
   total: number;
-  nextCursor?: string;
 }
+
+interface AgentsListItem { id: string }
 
 const EMPTY_FILTERS: SignalFilters = {
   agents: [],
@@ -41,9 +42,12 @@ const SEVERITY_BADGE: Record<string, string> = {
   low: 'bg-muted text-muted-foreground',
 };
 
-function buildQuery(filters: SignalFilters, cursor?: string, limit = 100): URLSearchParams {
+const PAGE_SIZE = 100;
+
+function buildQuery(filters: SignalFilters, offset: number, limit = PAGE_SIZE): URLSearchParams {
   const q = new URLSearchParams();
   q.set('limit', String(limit));
+  q.set('offset', String(offset));
   if (filters.agents.length === 1) q.set('agent', filters.agents[0]);
   if (filters.counterpart) q.set('counterpart', filters.counterpart);
   for (const s of filters.signals) q.append('signal', s);
@@ -54,7 +58,6 @@ function buildQuery(filters: SignalFilters, cursor?: string, limit = 100): URLSe
   if (filters.consensusId) q.set('consensus_id', filters.consensusId);
   if (filters.findingId) q.set('finding_id', filters.findingId);
   if (filters.source) q.set('source', filters.source);
-  if (cursor) q.set('cursor', cursor);
   return q;
 }
 
@@ -66,7 +69,7 @@ function truncate(s: string | undefined, n: number): string {
 export function SignalsPage() {
   const [filters, setFilters] = useState<SignalFilters>(EMPTY_FILTERS);
   const [rows, setRows] = useState<SignalEntry[]>([]);
-  const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
+  const [page, setPage] = useState(0);
   const [total, setTotal] = useState<number>(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -82,17 +85,16 @@ export function SignalsPage() {
   const latestReqId = useRef(0);
 
   const doFetch = useCallback(
-    async (f: SignalFilters, cursor?: string, append = false) => {
+    async (f: SignalFilters, pageIdx: number) => {
       const reqId = ++latestReqId.current;
       setLoading(true);
       setError(null);
       try {
-        const q = buildQuery(f, cursor);
+        const q = buildQuery(f, pageIdx * PAGE_SIZE);
         const res = await api<SignalsResponse>(`signals?${q.toString()}`);
         // Guard against racing older requests writing over newer results.
         if (reqId !== latestReqId.current) return;
-        setRows((prev) => (append ? [...prev, ...(res.items ?? [])] : res.items ?? []));
-        setNextCursor(res.nextCursor);
+        setRows(res.items ?? []);
         setTotal(res.total ?? 0);
       } catch (e) {
         if (reqId !== latestReqId.current) return;
@@ -104,38 +106,39 @@ export function SignalsPage() {
     []
   );
 
-  // Debounced reset-fetch on filter change
+  // Load the full agent list once on mount so the filter rail shows every agent,
+  // not just those that appear in the current signal window.
+  useEffect(() => {
+    api<AgentsListItem[]>('agents')
+      .then((list) => {
+        const ids = (list ?? []).map((a) => a.id).filter(Boolean).sort();
+        if (ids.length > 0) setAgents(ids);
+      })
+      .catch(() => { /* leave empty; page still works */ });
+  }, []);
+
+  // Reset to page 0 whenever filters change
+  useEffect(() => {
+    setPage(0);
+  }, [filters]);
+
+  // Debounced fetch on filter / page change
   useEffect(() => {
     if (debounceTimer.current) clearTimeout(debounceTimer.current);
     debounceTimer.current = setTimeout(() => {
-      doFetch(filters, undefined, false);
+      doFetch(filters, page);
     }, 250);
     return () => {
       if (debounceTimer.current) clearTimeout(debounceTimer.current);
     };
-  }, [filters, doFetch]);
-
-  // Derive agent list from returned rows so the filter rail self-populates as
-  // the user browses. (A dedicated /agents call would be nicer, but this
-  // keeps the page self-contained per the spec.)
-  useEffect(() => {
-    const seen = new Set<string>(agents);
-    for (const r of rows) {
-      if (r.agentId) seen.add(r.agentId);
-      if (r.counterpartId) seen.add(r.counterpartId);
-    }
-    const next = Array.from(seen).sort();
-    if (next.length !== agents.length) setAgents(next);
-  }, [rows, agents]);
+  }, [filters, page, doFetch]);
 
   const onFilterChange = useCallback((patch: Partial<SignalFilters>) => {
     setFilters((prev) => ({ ...prev, ...patch }));
   }, []);
 
-  const onLoadMore = useCallback(() => {
-    if (!nextCursor || loading) return;
-    doFetch(filters, nextCursor, true);
-  }, [nextCursor, loading, filters, doFetch]);
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const clampedPage = Math.min(page, totalPages - 1);
 
   const openDrawer = (consensusId?: string, findingId?: string) => {
     if (!consensusId || !findingId) return;
@@ -240,16 +243,27 @@ export function SignalsPage() {
 
           <div className="flex items-center justify-between border-t border-border/60 px-3 py-2">
             <span className="font-mono text-[10px] text-muted-foreground/60">
-              {loading ? 'loading…' : `${rows.length} rows`}
+              {loading
+                ? 'loading…'
+                : `${clampedPage * PAGE_SIZE + 1}–${clampedPage * PAGE_SIZE + rows.length} of ${total}`}
             </span>
-            <button
-              type="button"
-              className="rounded border border-border bg-background px-2 py-1 font-mono text-[10px] text-foreground hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-40"
-              disabled={!nextCursor || loading}
-              onClick={onLoadMore}
-            >
-              {nextCursor ? 'Load more' : 'End of results'}
-            </button>
+            <div className="flex items-center gap-2 font-mono text-[10px] text-muted-foreground">
+              <button
+                type="button"
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                disabled={clampedPage === 0 || loading}
+                className="rounded-sm border border-border/40 bg-card px-2 py-0.5 transition hover:bg-accent/50 disabled:opacity-30"
+              >◂ Prev</button>
+              <span className="tabular-nums">
+                {clampedPage + 1} / {totalPages}
+              </span>
+              <button
+                type="button"
+                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                disabled={clampedPage >= totalPages - 1 || loading}
+                className="rounded-sm border border-border/40 bg-card px-2 py-0.5 transition hover:bg-accent/50 disabled:opacity-30"
+              >Next ▸</button>
+            </div>
           </div>
         </section>
       </div>

--- a/packages/dashboard-v2/src/hooks/useDashboardData.ts
+++ b/packages/dashboard-v2/src/hooks/useDashboardData.ts
@@ -60,7 +60,7 @@ export function useDashboardData() {
       const [overview, agents, tasks, consensus, consensusReports, nativeResp, gossipResp] = await Promise.all([
         api<OverviewData>('overview'),
         api<AgentData[]>('agents'),
-        api<TasksData>('tasks?limit=50'),
+        api<TasksData>('tasks?limit=2000'),
         // pageSize=50 matches api-consensus MAX_PAGE_SIZE so header aggregates
         // (confirmedTotal/disputedTotal/unverifiedTotal in App.tsx:383-385) cover
         // the full round history instead of the first 10 runs.

--- a/packages/relay/src/dashboard/api-tasks.ts
+++ b/packages/relay/src/dashboard/api-tasks.ts
@@ -23,7 +23,7 @@ export interface TasksResponse {
 export async function tasksHandler(projectRoot: string, query?: URLSearchParams): Promise<TasksResponse> {
   const rawLimit = parseInt(query?.get('limit') ?? '50', 10);
   const rawOffset = parseInt(query?.get('offset') ?? '0', 10);
-  const limit = isNaN(rawLimit) || rawLimit < 1 ? 50 : Math.min(rawLimit, 200);
+  const limit = isNaN(rawLimit) || rawLimit < 1 ? 50 : Math.min(rawLimit, 2000);
   const offset = isNaN(rawOffset) || rawOffset < 0 ? 0 : rawOffset;
 
   const graphPath = join(projectRoot, '.gossip', 'task-graph.jsonl');


### PR DESCRIPTION
## Summary

Four UX fixes from visual review of the just-merged PR-S / PR-A.

## Fixes

**1. `/signals` — agent filter list incomplete**
The rail was self-populating from returned rows, so the user only saw 3 of 8 agents. Now fetches `/api/agents` on mount so all configured agents appear regardless of the current filter window.

**2. `/signals` — load-more → pagination**
User asked for 100-per-page navigation instead of infinite scroll. Replaced the `Load more` button with `◂ Prev · page X / Y · Next ▸` using offset-based pagination. Footer shows `N–M of TOTAL`. Switched from `cursor` param to `offset`/`limit` for predictable page semantics.

**3. `/tasks` — capped at 50 items**
`useDashboardData` fetched `tasks?limit=50`, so even with client-side pagination there were only 50 rows. Raised the fetch to `limit=2000`, bumped `api-tasks.ts` `MAX_LIMIT` cap to 2000, and set `TasksPage PAGE_SIZE=100`. All 1431+ tasks are now accessible via Prev/Next pagination.

**4. `/agent/:id` — consensus runs auto-expanded**
Findings for every run rendered inline at page load, creating wall-of-text. Runs are now collapsed by default; click the run header (shows `▸` when closed, `▾` when open) to expand one at a time.

## Verification

- `tests/relay/api-signals-filters.test.ts` + `api-signals-findingid.test.ts` — 7/7 pass
- Dashboard build clean (349 kB / 98 kB gzip)
- No schema changes; purely filter/pagination/state tweaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)