### PR TITLE
fix(skill-engine): preserve bound_at when redeveloping pending skills

### DIFF
--- a/packages/orchestrator/src/skill-engine.ts
+++ b/packages/orchestrator/src/skill-engine.ts
@@ -15,6 +15,7 @@ import { PerformanceReader } from './performance-reader';
 import { LLMMessage } from '@gossip/types';
 import { ConsensusSignal } from './consensus-types';
 import { normalizeSkillName } from './skill-name';
+import { readSkillFreshness } from './skill-freshness';
 import {
   resolveVerdict,
   TIMEOUT_MS,
@@ -160,7 +161,17 @@ export class SkillEngine {
     const lifetime = this.perfReader.getCountersSince(agentId, category, 0);
     const baseline_accuracy_correct = lifetime.correct;
     const baseline_accuracy_hallucinated = lifetime.hallucinated;
-    const bound_at = new Date().toISOString();
+
+    // Invariant #6: bound_at is set at first-bind and is immutable thereafter.
+    // If the existing skill file is still `pending` (evidence accumulating),
+    // preserve its bound_at so redevelopment refines the prompt without
+    // restarting the MIN_EVIDENCE window. The cooldown gate hard-blocks
+    // redevelop for terminal verdicts (passed/failed/silent_skill/insufficient_evidence),
+    // so this branch is only reachable for pending or fresh skills. See #147.
+    const existing = readSkillFreshness(agentId, category, this.projectRoot);
+    const bound_at = (existing.status === 'pending' && existing.boundAt)
+      ? existing.boundAt
+      : new Date().toISOString();
 
     const skillName = normalizeSkillName(category);
     const skillPath = join(this.projectRoot, '.gossip', 'agents', agentId, 'skills', `${skillName}.md`);

--- a/tests/orchestrator/skill-engine-baseline-snapshot.test.ts
+++ b/tests/orchestrator/skill-engine-baseline-snapshot.test.ts
@@ -173,6 +173,40 @@ describe('SkillEngine — baseline snapshot in frontmatter', () => {
     expect(fm).toMatch(/status:\s*pending/);
   });
 
+  it('preserves bound_at when redeveloping a pending skill (regression: #147)', async () => {
+    const llm = makeStubLLM();
+    const perfReader = makeStubPerfReader(tmpDir, { trust_boundaries: 3 }, { trust_boundaries: 1 });
+    const gen = new SkillEngine(llm, perfReader, tmpDir);
+
+    // First bind — records initial bound_at
+    const first = await gen.generate('test-agent', 'trust_boundaries');
+    const firstFm = readFileSync(first.path, 'utf-8').match(/^---\n([\s\S]*?)\n---/)![1];
+    const firstBoundAt = firstFm.match(/bound_at:\s*(.+)/)![1].trim();
+
+    // Small delay so any new timestamp would differ from the first
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Re-develop — skill is still pending (status was written as pending)
+    const second = await gen.generate('test-agent', 'trust_boundaries');
+    const secondFm = readFileSync(second.path, 'utf-8').match(/^---\n([\s\S]*?)\n---/)![1];
+    const secondBoundAt = secondFm.match(/bound_at:\s*(.+)/)![1].trim();
+
+    expect(secondBoundAt).toBe(firstBoundAt); // bound_at MUST be preserved for pending redevelop
+  });
+
+  it('mints a fresh bound_at when there is no existing skill file (first bind)', async () => {
+    const llm = makeStubLLM();
+    const perfReader = makeStubPerfReader(tmpDir, {}, {});
+    const gen = new SkillEngine(llm, perfReader, tmpDir);
+
+    const before = Date.now();
+    const result = await gen.generate('test-agent', 'trust_boundaries');
+    const fm = readFileSync(result.path, 'utf-8').match(/^---\n([\s\S]*?)\n---/)![1];
+    const boundAtTs = new Date(fm.match(/bound_at:\s*(.+)/)![1].trim()).getTime();
+
+    expect(boundAtTs).toBeGreaterThanOrEqual(before);
+  });
+
   it('writes effectiveness: 0.0 (number, not string)', async () => {
     const llm = makeStubLLM();
     const perfReader = makeStubPerfReader(tmpDir, {}, {});


### PR DESCRIPTION
Closes #147.

## Summary

`gossip_skills develop` was resetting `bound_at` on every call, restarting the MIN_EVIDENCE=120 post-bind window and making accumulated signals invisible. This was confirmed by consensus round `cc56c92c-b38649d4` as the **primary reason** skills with sub-1.3 signals/day stay `pending` indefinitely.

## Fix

In `SkillEngine.buildPrompt()`, consult `readSkillFreshness(agentId, category, projectRoot)` before minting a new timestamp. If the existing skill file is `pending` and already has a `bound_at`, reuse it.

The cooldown gate already hard-blocks redevelop for terminal verdicts (passed/failed=∞, silent_skill/insufficient_evidence=30d, inconclusive=60d), so the preserve branch only triggers for pending or fresh skills — exactly the cases where restarting the clock is harmful.

Invariant #6 (handbook): _\"bound_at is set at buildPrompt time and is immutable thereafter\"_ — the implementation now matches the documented invariant.

## Diff

- `packages/orchestrator/src/skill-engine.ts` — import `readSkillFreshness`; in `buildPrompt` read existing skill state and preserve `bound_at` when status is `pending`
- `tests/orchestrator/skill-engine-baseline-snapshot.test.ts` — 2 new regression tests (preserve-on-pending-redevelop, mint-on-first-bind)

## Tests

- 9/9 baseline-snapshot tests pass (7 existing + 2 new)
- 52/52 skill-engine + skill-freshness suite pass
- No other tests touched; fix is additive

## Follow-up

- **#148 (category-less signals silently dropped)** — independent bug, same consensus round, separate PR
- Consider a follow-up that audits existing `.gossip/agents/*/skills/*.md` files against current `.gossip/agent-performance.jsonl` signal timestamps to identify skills whose accumulated evidence was wiped by previous reset events (may need manual \`bound_at\` restoration from the first signal after bind)

🤖 Generated with [Claude Code](https://claude.com/claude-code)