### PR TITLE
fix(consensus-engine): refuse to write category-less signals

### DIFF
--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -64,6 +64,28 @@ const VERIFIER_TOOLS: ToolDefinition[] = [
   { name: 'git_log', description: 'Show git log for a file or path', parameters: { type: 'object', properties: { path: { type: 'string', description: 'File or directory to show history for' }, maxCount: { type: 'number', description: 'Maximum number of commits to return' } }, required: [] } },
 ];
 
+/**
+ * Resolve the category for a signal write, preferring the explicit field and
+ * falling back to regex extraction over any nearby text. Returns null when
+ * all sources fail — the caller MUST then either drop the signal or log the
+ * miss. See #148: category-less signals are silently dropped by
+ * `performance-reader.getCountersSince` (which skips `!s.category`), so a
+ * write with `category: ''` is effectively lost and makes MIN_EVIDENCE=120
+ * measure the wrong denominator.
+ */
+function resolveSignalCategory(
+  explicit: string | undefined,
+  ...texts: (string | undefined | null)[]
+): string | null {
+  if (explicit && explicit.trim()) return explicit;
+  for (const t of texts) {
+    if (!t) continue;
+    const hit = extractCategories(t)[0];
+    if (hit) return hit;
+  }
+  return null;
+}
+
 export interface ConsensusEngineConfig {
   llm: ILLMProvider;
   registryGet: (agentId: string) => AgentConfig | undefined;
@@ -1033,18 +1055,27 @@ Return only valid JSON.${skillsBlock}`;
         if (matchKey && f) {
           f.confirmedBy.push(entry.agentId);
           f.confidences.push(entry.confidence);
-          signals.push({
-            type: 'consensus',
-            taskId: getTaskId(entry.agentId),
-            consensusId,
-            signal: 'agreement',
-            agentId: entry.agentId,
-            counterpartId: entry.peerAgentId,
-            evidence: capEvidence(entry.evidence),
-            timestamp: now,
-            severity: f.severity,
-            category: f.category,
-          });
+          // #148 — require non-empty category or skip the write. Signals
+          // without category are silently dropped by getCountersSince.
+          const agreeCat = resolveSignalCategory(f.category, entry.evidence, f.finding);
+          if (!agreeCat) {
+            process.stderr.write(
+              `[consensus-engine] dropped agreement for ${entry.agentId}: no category. evidence="${(entry.evidence || '').slice(0, 80)}"\n`,
+            );
+          } else {
+            signals.push({
+              type: 'consensus',
+              taskId: getTaskId(entry.agentId),
+              consensusId,
+              signal: 'agreement',
+              agentId: entry.agentId,
+              counterpartId: entry.peerAgentId,
+              evidence: capEvidence(entry.evidence),
+              timestamp: now,
+              severity: f.severity,
+              category: agreeCat,
+            });
+          }
         }
         continue;
       }
@@ -1103,18 +1134,26 @@ Return only valid JSON.${skillsBlock}`;
               reason: sanitizeEvidence(entry.evidence),
               evidence: sanitizeEvidence(entry.evidence),
             });
-            signals.push({
-              type: 'consensus',
-              taskId: getTaskId(entry.agentId),
-              consensusId,
-              signal: 'disagreement',
-              agentId: entry.agentId,
-              counterpartId: entry.peerAgentId,
-              evidence: capEvidence(entry.evidence),
-              timestamp: now,
-              severity: f.severity,
-              category: f.category,
-            });
+            // #148 — require non-empty category or skip the write.
+            const disagreeCat = resolveSignalCategory(f.category, entry.evidence, f.finding);
+            if (!disagreeCat) {
+              process.stderr.write(
+                `[consensus-engine] dropped disagreement for ${entry.agentId}: no category. evidence="${(entry.evidence || '').slice(0, 80)}"\n`,
+              );
+            } else {
+              signals.push({
+                type: 'consensus',
+                taskId: getTaskId(entry.agentId),
+                consensusId,
+                signal: 'disagreement',
+                agentId: entry.agentId,
+                counterpartId: entry.peerAgentId,
+                evidence: capEvidence(entry.evidence),
+                timestamp: now,
+                severity: f.severity,
+                category: disagreeCat,
+              });
+            }
           }
         }
       }
@@ -1199,17 +1238,25 @@ Return only valid JSON.${skillsBlock}`;
           // Downgrade to unique with softer signal instead of hallucination penalty
           finding.tag = 'unique';
           unique.push(finding);
-          signals.push({
-            type: 'consensus',
-            taskId: getTaskId(entry.originalAgentId),
-            consensusId,
-            signal: 'unique_unconfirmed',
-            agentId: entry.originalAgentId,
-            evidence: capEvidence(`Confirmed finding has unresolvable citation (stale?): "${entry.finding.slice(0, 200)}"`),
-            timestamp: now,
-            severity: entry.severity,
-            category: entry.category,
-          });
+          // #148 — require non-empty category or skip the write.
+          const uniqueUnconfCat = resolveSignalCategory(entry.category, entry.finding);
+          if (!uniqueUnconfCat) {
+            process.stderr.write(
+              `[consensus-engine] dropped unique_unconfirmed for ${entry.originalAgentId}: no category.\n`,
+            );
+          } else {
+            signals.push({
+              type: 'consensus',
+              taskId: getTaskId(entry.originalAgentId),
+              consensusId,
+              signal: 'unique_unconfirmed',
+              agentId: entry.originalAgentId,
+              evidence: capEvidence(`Confirmed finding has unresolvable citation (stale?): "${entry.finding.slice(0, 200)}"`),
+              timestamp: now,
+              severity: entry.severity,
+              category: uniqueUnconfCat,
+            });
+          }
           continue;
         }
         finding.tag = 'confirmed';
@@ -1219,17 +1266,25 @@ Return only valid JSON.${skillsBlock}`;
           other => other !== entry && other.finding === entry.finding && other.originalAgentId !== entry.originalAgentId
         );
         if (isUniquelyDiscovered) {
-          signals.push({
-            type: 'consensus',
-            taskId: getTaskId(entry.originalAgentId),
-            consensusId,
-            signal: 'unique_confirmed',
-            agentId: entry.originalAgentId,
-            evidence: capEvidence(entry.finding),
-            timestamp: now,
-            severity: entry.severity,
-            category: entry.category,
-          });
+          // #148 — require non-empty category or skip the write.
+          const uniqueConfCat = resolveSignalCategory(entry.category, entry.finding);
+          if (!uniqueConfCat) {
+            process.stderr.write(
+              `[consensus-engine] dropped unique_confirmed for ${entry.originalAgentId}: no category.\n`,
+            );
+          } else {
+            signals.push({
+              type: 'consensus',
+              taskId: getTaskId(entry.originalAgentId),
+              consensusId,
+              signal: 'unique_confirmed',
+              agentId: entry.originalAgentId,
+              evidence: capEvidence(entry.finding),
+              timestamp: now,
+              severity: entry.severity,
+              category: uniqueConfCat,
+            });
+          }
         }
       } else if (entry.unverifiedBy.length > 0) {
         // Route suggestions/insights to insights array instead of unverified

--- a/packages/orchestrator/src/skill-engine.ts
+++ b/packages/orchestrator/src/skill-engine.ts
@@ -15,6 +15,7 @@ import { PerformanceReader } from './performance-reader';
 import { LLMMessage } from '@gossip/types';
 import { ConsensusSignal } from './consensus-types';
 import { normalizeSkillName } from './skill-name';
+import { readSkillFreshness } from './skill-freshness';
 import {
   resolveVerdict,
   TIMEOUT_MS,
@@ -160,7 +161,17 @@ export class SkillEngine {
     const lifetime = this.perfReader.getCountersSince(agentId, category, 0);
     const baseline_accuracy_correct = lifetime.correct;
     const baseline_accuracy_hallucinated = lifetime.hallucinated;
-    const bound_at = new Date().toISOString();
+
+    // Invariant #6: bound_at is set at first-bind and is immutable thereafter.
+    // If the existing skill file is still `pending` (evidence accumulating),
+    // preserve its bound_at so redevelopment refines the prompt without
+    // restarting the MIN_EVIDENCE window. The cooldown gate hard-blocks
+    // redevelop for terminal verdicts (passed/failed/silent_skill/insufficient_evidence),
+    // so this branch is only reachable for pending or fresh skills. See #147.
+    const existing = readSkillFreshness(agentId, category, this.projectRoot);
+    const bound_at = (existing.status === 'pending' && existing.boundAt)
+      ? existing.boundAt
+      : new Date().toISOString();
 
     const skillName = normalizeSkillName(category);
     const skillPath = join(this.projectRoot, '.gossip', 'agents', agentId, 'skills', `${skillName}.md`);

--- a/tests/orchestrator/consensus-engine.test.ts
+++ b/tests/orchestrator/consensus-engine.test.ts
@@ -340,10 +340,17 @@ Summary: 1 agree, 1 disagree.`;
     });
 
     it('should emit unique_confirmed signal for confirmed unique findings', async () => {
-      const crossReview: CrossReviewEntry[] = [
-        { action: 'agree', agentId: 'agent-2', peerAgentId: 'agent-1', finding: 'Finding A from agent 1', evidence: 'Confirmed', confidence: 5 },
+      // Finding + evidence carry a category keyword ("authentication") so
+      // resolveSignalCategory() can populate the signal's category field —
+      // required after #148 (category-less signals are skipped).
+      const fxResults: TaskEntry[] = [
+        createTaskEntry('agent-1', 'completed', '- Finding A from agent 1 — authentication missing\n- Finding B is also here'),
+        createTaskEntry('agent-2', 'completed', '- Finding C is by agent 2'),
       ];
-      const report = await engine.synthesize(results, crossReview);
+      const crossReview: CrossReviewEntry[] = [
+        { action: 'agree', agentId: 'agent-2', peerAgentId: 'agent-1', finding: 'Finding A from agent 1 — authentication missing', evidence: 'Confirmed', confidence: 5 },
+      ];
+      const report = await engine.synthesize(fxResults, crossReview);
       // Finding A was only found by agent-1 and confirmed by agent-2 → unique_confirmed
       const uniqueConfirmedSignals = report.signals.filter(s => s.signal === 'unique_confirmed');
       expect(uniqueConfirmedSignals.length).toBe(1);

--- a/tests/orchestrator/skill-engine-baseline-snapshot.test.ts
+++ b/tests/orchestrator/skill-engine-baseline-snapshot.test.ts
@@ -173,6 +173,40 @@ describe('SkillEngine — baseline snapshot in frontmatter', () => {
     expect(fm).toMatch(/status:\s*pending/);
   });
 
+  it('preserves bound_at when redeveloping a pending skill (regression: #147)', async () => {
+    const llm = makeStubLLM();
+    const perfReader = makeStubPerfReader(tmpDir, { trust_boundaries: 3 }, { trust_boundaries: 1 });
+    const gen = new SkillEngine(llm, perfReader, tmpDir);
+
+    // First bind — records initial bound_at
+    const first = await gen.generate('test-agent', 'trust_boundaries');
+    const firstFm = readFileSync(first.path, 'utf-8').match(/^---\n([\s\S]*?)\n---/)![1];
+    const firstBoundAt = firstFm.match(/bound_at:\s*(.+)/)![1].trim();
+
+    // Small delay so any new timestamp would differ from the first
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Re-develop — skill is still pending (status was written as pending)
+    const second = await gen.generate('test-agent', 'trust_boundaries');
+    const secondFm = readFileSync(second.path, 'utf-8').match(/^---\n([\s\S]*?)\n---/)![1];
+    const secondBoundAt = secondFm.match(/bound_at:\s*(.+)/)![1].trim();
+
+    expect(secondBoundAt).toBe(firstBoundAt); // bound_at MUST be preserved for pending redevelop
+  });
+
+  it('mints a fresh bound_at when there is no existing skill file (first bind)', async () => {
+    const llm = makeStubLLM();
+    const perfReader = makeStubPerfReader(tmpDir, {}, {});
+    const gen = new SkillEngine(llm, perfReader, tmpDir);
+
+    const before = Date.now();
+    const result = await gen.generate('test-agent', 'trust_boundaries');
+    const fm = readFileSync(result.path, 'utf-8').match(/^---\n([\s\S]*?)\n---/)![1];
+    const boundAtTs = new Date(fm.match(/bound_at:\s*(.+)/)![1].trim()).getTime();
+
+    expect(boundAtTs).toBeGreaterThanOrEqual(before);
+  });
+
   it('writes effectiveness: 0.0 (number, not string)', async () => {
     const llm = makeStubLLM();
     const perfReader = makeStubPerfReader(tmpDir, {}, {});


### PR DESCRIPTION
Closes #148.

## Summary

Four signal-write sites in `ConsensusEngine.synthesize()` were passing `category` through without validating non-empty — producing signals that `performance-reader.getCountersSince` then silently dropped. Dashboard counters over-reported progress toward MIN_EVIDENCE=120. Combined with #147 (bound_at reset), skills never crossed the gate.

Fixed sites:
- `agreement` at `consensus-engine.ts:1046`
- `disagreement` at `:1116`
- `unique_unconfirmed` fallback at `:1211`
- `unique_confirmed` at `:1231`

The `hallucination_caught` site already had the correct pattern — this PR extends it to the other four.

## Fix

Introduce a local `resolveSignalCategory(explicit, ...texts)` helper. Prefers the explicit category field; falls back to `extractCategories()` over supplied text sources (evidence, finding body); returns `null` only when all fail. Each write site now resolves via the helper and either writes with a non-empty category or drops the signal with a `stderr` audit line (mirroring the hallucination site's pattern).

## Statistical rationale

The MIN_EVIDENCE=120 gate calibrates for 80% power / +10pp at p=0.75 / Bonferroni α=0.025, measured over per-(agent, category) counters. Category-less signals are effectively phantom rows — they inflate gross signal counts in dashboards that don't filter by `category`, while the z-test's denominator never sees them. Loud-drop at the write boundary makes the counter truthful without changing the test's calibration.

## Tests

- `tests/orchestrator/consensus-engine.test.ts` — one existing test (\"emits unique_confirmed\") previously used a finding fixture with no category keywords. Updated the fixture to include an \`authentication\` keyword in the finding text so `resolveSignalCategory()` can populate the signal. This is closer to production reality — real findings from LLM agents always carry category-relevant text.
- Full orchestrator regression: **1234/1234 tests pass**.

## Follow-up

- **Audit existing jsonl** per haiku-researcher's suggestion (issue #148 body has the Python script) — quantify how many historical signals lack category so we know how much of the counter deficit on currently-pending skills comes from silent drops vs organic rate.
- After both #147 (this PR's predecessor, #149) and this one land, re-check `gossip_scores` + Skill Verdicts dashboard: the 7 slow skills should start accumulating post-bind signals monotonically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)