### PR TITLE
fix(dashboard): CategoryCompetency — raw accuracy + hallucination badge

### DIFF
--- a/packages/dashboard-v2/src/components/CategoryCompetency.tsx
+++ b/packages/dashboard-v2/src/components/CategoryCompetency.tsx
@@ -6,22 +6,21 @@ interface Props {
   categoryHallucinated?: Record<string, number>;
 }
 
-// Matches the overall-accuracy hallucinationMultiplier at
-// `performance-reader.ts:705` — `1 / (1 + h * 0.3)`. Applying it per-category
-// keeps this widget consistent with the scorecard: a category with zero
-// hallucinations keeps its raw accuracy; hallucinations drag the bar the
-// same way they drag the overall score. Previously the widget showed raw
-// `c/(c+h)` which read 95% on a category with 3 hallucinations, even when
-// the agent's overall accuracy was 0.37 — confusing UX.
-function penalize(rawAcc: number, h: number): number {
-  const multiplier = 1 / (1 + h * 0.3);
-  return Math.max(0, Math.min(1, rawAcc * multiplier));
-}
-
-/** Horizontal bars per category. Each bar shows the WEIGHTED accuracy
- * (raw ratio × hallucination-penalty, mirroring the global accuracy
- * formula). Raw c/n + hallucination count shown in the tuple so the
- * composition is visible. */
+/** Horizontal bars per category. Shows raw `c/(c+h)` accuracy — the
+ * honest per-category success rate — with hallucination count visible
+ * as a `·N✗` badge in the tuple so the composition isn't hidden.
+ *
+ * Previous revisions tried to apply the global `1/(1+h*0.3)` penalty
+ * per-category to match the scorecard's 0.37-style overall accuracy,
+ * but that formula is calibrated for overall signal counts (10–50
+ * lifetime), not category slices with 100+ signals. On a 145/147
+ * category, 2 hallucinations = 1.4% error rate — genuinely near-perfect.
+ * Applying the multiplier dragged it to 62%, which was misleading in
+ * the opposite direction. Honest raw display with halluc count wins.
+ *
+ * The scorecard's overall weighted accuracy is shown elsewhere; this
+ * widget answers "where does this agent do well?" not "how much do I
+ * trust this agent overall?" — two different questions. */
 export function CategoryCompetency({ categoryAccuracy, categoryCorrect, categoryHallucinated }: Props) {
   const keys = Object.keys(categoryAccuracy ?? {});
   if (keys.length === 0) {
@@ -36,24 +35,20 @@ export function CategoryCompetency({ categoryAccuracy, categoryCorrect, category
 
   const rows = keys
     .map((k) => {
-      const rawAcc = Math.max(0, Math.min(1, categoryAccuracy![k] ?? 0));
+      const acc = Math.max(0, Math.min(1, categoryAccuracy![k] ?? 0));
       const c = categoryCorrect?.[k] ?? 0;
       const h = categoryHallucinated?.[k] ?? 0;
-      const acc = penalize(rawAcc, h);
-      return { key: k, rawAcc, acc, c, h, n: c + h };
+      return { key: k, acc, c, h, n: c + h };
     })
     .sort((a, b) => b.acc - a.acc);
 
   return (
     <div className="space-y-2">
       {rows.map((row) => {
-        const fill = row.acc >= 0.7 ? 'bg-confirmed' : row.acc >= 0.4 ? 'bg-unverified' : 'bg-disputed';
-        const rawDelta = Math.round((row.rawAcc - row.acc) * 100);
-        const rawPct = Math.round(row.rawAcc * 100);
-        const title =
-          row.n > 0
-            ? `${row.c} correct / ${row.h} hallucinated / ${row.n} total — raw ${rawPct}%${rawDelta > 0 ? `, penalized −${rawDelta}pp for ${row.h} hallucination${row.h === 1 ? '' : 's'}` : ''}`
-            : undefined;
+        const fill = row.acc >= 0.9 ? 'bg-confirmed' : row.acc >= 0.7 ? 'bg-unverified' : 'bg-disputed';
+        const title = row.n > 0
+          ? `${row.c} correct / ${row.h} hallucinated / ${row.n} total`
+          : undefined;
         return (
           <div
             key={row.key}
@@ -63,18 +58,9 @@ export function CategoryCompetency({ categoryAccuracy, categoryCorrect, category
             <span className="truncate font-mono text-[11px] text-muted-foreground">
               {row.key.replace(/_/g, ' ')}
             </span>
-            <div className="relative h-2 overflow-hidden rounded-sm bg-muted/30">
-              {/* Ghost bar at raw accuracy shows the unweighted position,
-                  so a category with penalty has a visible gap between
-                  the ghost (muted/light) and the weighted fill. */}
-              {row.h > 0 && row.rawAcc > row.acc && (
-                <div
-                  className="absolute inset-y-0 left-0 rounded-sm bg-muted/50"
-                  style={{ width: `${row.rawAcc * 100}%` }}
-                />
-              )}
+            <div className="h-2 overflow-hidden rounded-sm bg-muted/30">
               <div
-                className={`absolute inset-y-0 left-0 h-full rounded-sm transition-all ${fill}`}
+                className={`h-full rounded-sm transition-all ${fill}`}
                 style={{ width: `${row.acc * 100}%` }}
               />
             </div>

--- a/packages/dashboard-v2/src/components/CategoryCompetency.tsx
+++ b/packages/dashboard-v2/src/components/CategoryCompetency.tsx
@@ -6,9 +6,22 @@ interface Props {
   categoryHallucinated?: Record<string, number>;
 }
 
-/** Horizontal bars per category with accuracy %. Reads categoryAccuracy
- * (server-gated ratio in [0,1]) and renders one row per category with
- * optional "(c/n)" tuple when raw counts are available. */
+// Matches the overall-accuracy hallucinationMultiplier at
+// `performance-reader.ts:705` — `1 / (1 + h * 0.3)`. Applying it per-category
+// keeps this widget consistent with the scorecard: a category with zero
+// hallucinations keeps its raw accuracy; hallucinations drag the bar the
+// same way they drag the overall score. Previously the widget showed raw
+// `c/(c+h)` which read 95% on a category with 3 hallucinations, even when
+// the agent's overall accuracy was 0.37 — confusing UX.
+function penalize(rawAcc: number, h: number): number {
+  const multiplier = 1 / (1 + h * 0.3);
+  return Math.max(0, Math.min(1, rawAcc * multiplier));
+}
+
+/** Horizontal bars per category. Each bar shows the WEIGHTED accuracy
+ * (raw ratio × hallucination-penalty, mirroring the global accuracy
+ * formula). Raw c/n + hallucination count shown in the tuple so the
+ * composition is visible. */
 export function CategoryCompetency({ categoryAccuracy, categoryCorrect, categoryHallucinated }: Props) {
   const keys = Object.keys(categoryAccuracy ?? {});
   if (keys.length === 0) {
@@ -23,10 +36,11 @@ export function CategoryCompetency({ categoryAccuracy, categoryCorrect, category
 
   const rows = keys
     .map((k) => {
-      const acc = Math.max(0, Math.min(1, categoryAccuracy![k] ?? 0));
+      const rawAcc = Math.max(0, Math.min(1, categoryAccuracy![k] ?? 0));
       const c = categoryCorrect?.[k] ?? 0;
       const h = categoryHallucinated?.[k] ?? 0;
-      return { key: k, acc, c, n: c + h };
+      const acc = penalize(rawAcc, h);
+      return { key: k, rawAcc, acc, c, h, n: c + h };
     })
     .sort((a, b) => b.acc - a.acc);
 
@@ -34,23 +48,45 @@ export function CategoryCompetency({ categoryAccuracy, categoryCorrect, category
     <div className="space-y-2">
       {rows.map((row) => {
         const fill = row.acc >= 0.7 ? 'bg-confirmed' : row.acc >= 0.4 ? 'bg-unverified' : 'bg-disputed';
+        const rawDelta = Math.round((row.rawAcc - row.acc) * 100);
+        const rawPct = Math.round(row.rawAcc * 100);
+        const title =
+          row.n > 0
+            ? `${row.c} correct / ${row.h} hallucinated / ${row.n} total — raw ${rawPct}%${rawDelta > 0 ? `, penalized −${rawDelta}pp for ${row.h} hallucination${row.h === 1 ? '' : 's'}` : ''}`
+            : undefined;
         return (
           <div
             key={row.key}
             className="grid grid-cols-[128px_1fr_auto_44px] items-center gap-3"
-            title={row.n > 0 ? `${row.c} correct / ${row.n} total` : undefined}
+            title={title}
           >
             <span className="truncate font-mono text-[11px] text-muted-foreground">
               {row.key.replace(/_/g, ' ')}
             </span>
-            <div className="h-2 overflow-hidden rounded-sm bg-muted/30">
+            <div className="relative h-2 overflow-hidden rounded-sm bg-muted/30">
+              {/* Ghost bar at raw accuracy shows the unweighted position,
+                  so a category with penalty has a visible gap between
+                  the ghost (muted/light) and the weighted fill. */}
+              {row.h > 0 && row.rawAcc > row.acc && (
+                <div
+                  className="absolute inset-y-0 left-0 rounded-sm bg-muted/50"
+                  style={{ width: `${row.rawAcc * 100}%` }}
+                />
+              )}
               <div
-                className={`h-full rounded-sm transition-all ${fill}`}
+                className={`absolute inset-y-0 left-0 h-full rounded-sm transition-all ${fill}`}
                 style={{ width: `${row.acc * 100}%` }}
               />
             </div>
-            <span className="shrink-0 text-right font-mono text-[10px] tabular-nums text-muted-foreground/60 w-12">
-              {row.n > 0 ? `${row.c}/${row.n}` : '—'}
+            <span className="shrink-0 text-right font-mono text-[10px] tabular-nums text-muted-foreground/60 w-16">
+              {row.n > 0 ? (
+                <>
+                  {row.c}/{row.n}
+                  {row.h > 0 && <span className="ml-1 text-disputed/70">·{row.h}✗</span>}
+                </>
+              ) : (
+                '—'
+              )}
             </span>
             <span className="text-right font-mono text-[11px] font-bold tabular-nums text-foreground">
               {Math.round(row.acc * 100)}%


### PR DESCRIPTION
## Summary

The CategoryCompetency widget displayed `c/(c+h)` per-category accuracy, which reads 80–100% across most categories for any agent that has consensus history. A user viewing gemini-reviewer's page saw 100% bars alongside an overall scorecard accuracy of 0.37 — the two views contradicted each other.

## Fix

Keep the **honest raw accuracy** (`c/(c+h)`) since it's genuinely what this widget should answer — _where does this agent do well?_ — but make the composition visible so the number can't be misread as an overall quality claim:

- Tuple now shows `c/n` plus a small disputed-colored **`·N✗`** badge when hallucinations exist (e.g. `145/147 · 2✗`)
- Hover title gives the full breakdown: `145 correct / 2 hallucinated / 147 total`
- Color thresholds tightened: ≥90% green · ≥70% amber · <70% red. Bars no longer paint _everything_ green; a category with 30% hallucination rate is clearly red.

## What this widget is (and isn't)

**Is:** per-category success rate — useful for spotting which categories an agent is strong in.

**Isn't:** a global trust score. That's what `scorecard.accuracy` is for, and it applies a hallucination penalty tuned for overall signal volume, not per-category slices.

Answering both questions in one widget required either (a) mangling the per-category number with a penalty curve designed for a different domain, or (b) surfacing both views honestly. This PR goes with (b).

## History

An earlier commit on this branch tried to apply the scorecard's `1 / (1 + h * 0.3)` hallucination multiplier per-category — on 145/147 with h=2 that dragged the bar to 62%, which was _more_ misleading than showing 99%. That formula is calibrated for agents with 10–50 lifetime signals, not category slices with 100+. Reverted to the honest raw display with the `·N✗` badge surfaced.

## Diff

Single file: `packages/dashboard-v2/src/components/CategoryCompetency.tsx` (23 insertions, 37 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)