### PR TITLE
feat(dashboard): expose unverified signal counts per agent

### DIFF
--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -91,11 +91,26 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
     { label: 'impact', value: s.impactScore, fill: 'bg-[var(--color-impact)]' },
   ];
 
+  // Unverified signals carry two meanings depending on whose column they land in:
+  // - emitted: this agent was the reviewer saying "I can't verify this"
+  // - received: this agent's findings were un-verifiable by peers (often bad/missing citations)
+  // Both are signals of friction, not fault, so we render them muted-amber — neither
+  // green like agreements nor red like hallucinations.
+  const unvEmitted = s.unverifiedsEmitted ?? 0;
+  const unvReceived = s.unverifiedsReceived ?? 0;
+  const unvTotal = unvEmitted + unvReceived;
+
   const compactStats = [
     { label: 'Signals', value: String(s.signals), color: 'text-foreground' },
     { label: 'Agreements', value: String(s.agreements), color: 'text-confirmed' },
     { label: 'Disagreements', value: String(s.disagreements), color: 'text-disputed' },
     { label: 'Hallucinations', value: String(s.hallucinations), color: s.hallucinations > 0 ? 'text-disputed' : 'text-muted-foreground' },
+    {
+      label: 'Unverified',
+      value: unvTotal > 0 ? `${unvEmitted}↑ ${unvReceived}↓` : '0',
+      color: unvTotal > 0 ? 'text-unverified' : 'text-muted-foreground',
+      title: unvTotal > 0 ? `${unvEmitted} emitted (as reviewer) · ${unvReceived} received (as author)` : undefined,
+    },
     { label: 'Tokens', value: agent.totalTokens.toLocaleString(), color: 'text-foreground' },
   ];
 
@@ -283,9 +298,13 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
                 </div>
               ))}
             </div>
-            <div className="mt-4 grid grid-cols-5 gap-px overflow-hidden rounded-md border border-border/30 bg-border/30">
+            <div className="mt-4 grid grid-cols-6 gap-px overflow-hidden rounded-md border border-border/30 bg-border/30">
               {compactStats.map(st => (
-                <div key={st.label} className="bg-background/60 px-2 py-2 text-center">
+                <div
+                  key={st.label}
+                  className="bg-background/60 px-2 py-2 text-center"
+                  title={(st as { title?: string }).title}
+                >
                   <div className={`font-mono text-sm font-bold tabular-nums ${st.color}`}>{st.value}</div>
                   <div className="mt-0.5 font-mono text-[9px] uppercase tracking-wider text-muted-foreground/70">{st.label}</div>
                 </div>

--- a/packages/dashboard-v2/src/components/CategoryCompetency.tsx
+++ b/packages/dashboard-v2/src/components/CategoryCompetency.tsx
@@ -6,22 +6,21 @@ interface Props {
   categoryHallucinated?: Record<string, number>;
 }
 
-// Matches the overall-accuracy hallucinationMultiplier at
-// `performance-reader.ts:705` — `1 / (1 + h * 0.3)`. Applying it per-category
-// keeps this widget consistent with the scorecard: a category with zero
-// hallucinations keeps its raw accuracy; hallucinations drag the bar the
-// same way they drag the overall score. Previously the widget showed raw
-// `c/(c+h)` which read 95% on a category with 3 hallucinations, even when
-// the agent's overall accuracy was 0.37 — confusing UX.
-function penalize(rawAcc: number, h: number): number {
-  const multiplier = 1 / (1 + h * 0.3);
-  return Math.max(0, Math.min(1, rawAcc * multiplier));
-}
-
-/** Horizontal bars per category. Each bar shows the WEIGHTED accuracy
- * (raw ratio × hallucination-penalty, mirroring the global accuracy
- * formula). Raw c/n + hallucination count shown in the tuple so the
- * composition is visible. */
+/** Horizontal bars per category. Shows raw `c/(c+h)` accuracy — the
+ * honest per-category success rate — with hallucination count visible
+ * as a `·N✗` badge in the tuple so the composition isn't hidden.
+ *
+ * Previous revisions tried to apply the global `1/(1+h*0.3)` penalty
+ * per-category to match the scorecard's 0.37-style overall accuracy,
+ * but that formula is calibrated for overall signal counts (10–50
+ * lifetime), not category slices with 100+ signals. On a 145/147
+ * category, 2 hallucinations = 1.4% error rate — genuinely near-perfect.
+ * Applying the multiplier dragged it to 62%, which was misleading in
+ * the opposite direction. Honest raw display with halluc count wins.
+ *
+ * The scorecard's overall weighted accuracy is shown elsewhere; this
+ * widget answers "where does this agent do well?" not "how much do I
+ * trust this agent overall?" — two different questions. */
 export function CategoryCompetency({ categoryAccuracy, categoryCorrect, categoryHallucinated }: Props) {
   const keys = Object.keys(categoryAccuracy ?? {});
   if (keys.length === 0) {
@@ -36,24 +35,20 @@ export function CategoryCompetency({ categoryAccuracy, categoryCorrect, category
 
   const rows = keys
     .map((k) => {
-      const rawAcc = Math.max(0, Math.min(1, categoryAccuracy![k] ?? 0));
+      const acc = Math.max(0, Math.min(1, categoryAccuracy![k] ?? 0));
       const c = categoryCorrect?.[k] ?? 0;
       const h = categoryHallucinated?.[k] ?? 0;
-      const acc = penalize(rawAcc, h);
-      return { key: k, rawAcc, acc, c, h, n: c + h };
+      return { key: k, acc, c, h, n: c + h };
     })
     .sort((a, b) => b.acc - a.acc);
 
   return (
     <div className="space-y-2">
       {rows.map((row) => {
-        const fill = row.acc >= 0.7 ? 'bg-confirmed' : row.acc >= 0.4 ? 'bg-unverified' : 'bg-disputed';
-        const rawDelta = Math.round((row.rawAcc - row.acc) * 100);
-        const rawPct = Math.round(row.rawAcc * 100);
-        const title =
-          row.n > 0
-            ? `${row.c} correct / ${row.h} hallucinated / ${row.n} total — raw ${rawPct}%${rawDelta > 0 ? `, penalized −${rawDelta}pp for ${row.h} hallucination${row.h === 1 ? '' : 's'}` : ''}`
-            : undefined;
+        const fill = row.acc >= 0.9 ? 'bg-confirmed' : row.acc >= 0.7 ? 'bg-unverified' : 'bg-disputed';
+        const title = row.n > 0
+          ? `${row.c} correct / ${row.h} hallucinated / ${row.n} total`
+          : undefined;
         return (
           <div
             key={row.key}
@@ -63,18 +58,9 @@ export function CategoryCompetency({ categoryAccuracy, categoryCorrect, category
             <span className="truncate font-mono text-[11px] text-muted-foreground">
               {row.key.replace(/_/g, ' ')}
             </span>
-            <div className="relative h-2 overflow-hidden rounded-sm bg-muted/30">
-              {/* Ghost bar at raw accuracy shows the unweighted position,
-                  so a category with penalty has a visible gap between
-                  the ghost (muted/light) and the weighted fill. */}
-              {row.h > 0 && row.rawAcc > row.acc && (
-                <div
-                  className="absolute inset-y-0 left-0 rounded-sm bg-muted/50"
-                  style={{ width: `${row.rawAcc * 100}%` }}
-                />
-              )}
+            <div className="h-2 overflow-hidden rounded-sm bg-muted/30">
               <div
-                className={`absolute inset-y-0 left-0 h-full rounded-sm transition-all ${fill}`}
+                className={`h-full rounded-sm transition-all ${fill}`}
                 style={{ width: `${row.acc * 100}%` }}
               />
             </div>

--- a/packages/dashboard-v2/src/components/CategoryCompetency.tsx
+++ b/packages/dashboard-v2/src/components/CategoryCompetency.tsx
@@ -6,9 +6,22 @@ interface Props {
   categoryHallucinated?: Record<string, number>;
 }
 
-/** Horizontal bars per category with accuracy %. Reads categoryAccuracy
- * (server-gated ratio in [0,1]) and renders one row per category with
- * optional "(c/n)" tuple when raw counts are available. */
+// Matches the overall-accuracy hallucinationMultiplier at
+// `performance-reader.ts:705` — `1 / (1 + h * 0.3)`. Applying it per-category
+// keeps this widget consistent with the scorecard: a category with zero
+// hallucinations keeps its raw accuracy; hallucinations drag the bar the
+// same way they drag the overall score. Previously the widget showed raw
+// `c/(c+h)` which read 95% on a category with 3 hallucinations, even when
+// the agent's overall accuracy was 0.37 — confusing UX.
+function penalize(rawAcc: number, h: number): number {
+  const multiplier = 1 / (1 + h * 0.3);
+  return Math.max(0, Math.min(1, rawAcc * multiplier));
+}
+
+/** Horizontal bars per category. Each bar shows the WEIGHTED accuracy
+ * (raw ratio × hallucination-penalty, mirroring the global accuracy
+ * formula). Raw c/n + hallucination count shown in the tuple so the
+ * composition is visible. */
 export function CategoryCompetency({ categoryAccuracy, categoryCorrect, categoryHallucinated }: Props) {
   const keys = Object.keys(categoryAccuracy ?? {});
   if (keys.length === 0) {
@@ -23,10 +36,11 @@ export function CategoryCompetency({ categoryAccuracy, categoryCorrect, category
 
   const rows = keys
     .map((k) => {
-      const acc = Math.max(0, Math.min(1, categoryAccuracy![k] ?? 0));
+      const rawAcc = Math.max(0, Math.min(1, categoryAccuracy![k] ?? 0));
       const c = categoryCorrect?.[k] ?? 0;
       const h = categoryHallucinated?.[k] ?? 0;
-      return { key: k, acc, c, n: c + h };
+      const acc = penalize(rawAcc, h);
+      return { key: k, rawAcc, acc, c, h, n: c + h };
     })
     .sort((a, b) => b.acc - a.acc);
 
@@ -34,23 +48,45 @@ export function CategoryCompetency({ categoryAccuracy, categoryCorrect, category
     <div className="space-y-2">
       {rows.map((row) => {
         const fill = row.acc >= 0.7 ? 'bg-confirmed' : row.acc >= 0.4 ? 'bg-unverified' : 'bg-disputed';
+        const rawDelta = Math.round((row.rawAcc - row.acc) * 100);
+        const rawPct = Math.round(row.rawAcc * 100);
+        const title =
+          row.n > 0
+            ? `${row.c} correct / ${row.h} hallucinated / ${row.n} total — raw ${rawPct}%${rawDelta > 0 ? `, penalized −${rawDelta}pp for ${row.h} hallucination${row.h === 1 ? '' : 's'}` : ''}`
+            : undefined;
         return (
           <div
             key={row.key}
             className="grid grid-cols-[128px_1fr_auto_44px] items-center gap-3"
-            title={row.n > 0 ? `${row.c} correct / ${row.n} total` : undefined}
+            title={title}
           >
             <span className="truncate font-mono text-[11px] text-muted-foreground">
               {row.key.replace(/_/g, ' ')}
             </span>
-            <div className="h-2 overflow-hidden rounded-sm bg-muted/30">
+            <div className="relative h-2 overflow-hidden rounded-sm bg-muted/30">
+              {/* Ghost bar at raw accuracy shows the unweighted position,
+                  so a category with penalty has a visible gap between
+                  the ghost (muted/light) and the weighted fill. */}
+              {row.h > 0 && row.rawAcc > row.acc && (
+                <div
+                  className="absolute inset-y-0 left-0 rounded-sm bg-muted/50"
+                  style={{ width: `${row.rawAcc * 100}%` }}
+                />
+              )}
               <div
-                className={`h-full rounded-sm transition-all ${fill}`}
+                className={`absolute inset-y-0 left-0 h-full rounded-sm transition-all ${fill}`}
                 style={{ width: `${row.acc * 100}%` }}
               />
             </div>
-            <span className="shrink-0 text-right font-mono text-[10px] tabular-nums text-muted-foreground/60 w-12">
-              {row.n > 0 ? `${row.c}/${row.n}` : '—'}
+            <span className="shrink-0 text-right font-mono text-[10px] tabular-nums text-muted-foreground/60 w-16">
+              {row.n > 0 ? (
+                <>
+                  {row.c}/{row.n}
+                  {row.h > 0 && <span className="ml-1 text-disputed/70">·{row.h}✗</span>}
+                </>
+              ) : (
+                '—'
+              )}
             </span>
             <span className="text-right font-mono text-[11px] font-bold tabular-nums text-foreground">
               {Math.round(row.acc * 100)}%

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -78,6 +78,7 @@ export interface AgentData {
     accuracy: number; uniqueness: number; reliability: number;
     impactScore: number; dispatchWeight: number; signals: number;
     agreements: number; disagreements: number; hallucinations: number;
+    unverifiedsEmitted?: number; unverifiedsReceived?: number;
     consecutiveFailures: number; circuitOpen: boolean;
     bench: {
       state: 'benched' | 'kept-for-coverage' | 'none';

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -21,6 +21,10 @@ export interface AgentScore {
   disagreements: number;
   uniqueFindings: number;
   hallucinations: number;
+  /** Unverified signals emitted by this agent as a reviewer — "I can't verify peer's finding". */
+  unverifiedsEmitted: number;
+  /** Unverified signals received by this agent as a finding author — a peer couldn't verify the citation. */
+  unverifiedsReceived: number;
   weightedHallucinations: number; // decay-weighted hallucination count (used by auto-bench)
   consecutiveFailures: number; // circuit breaker: consecutive negative signals at tail
   circuitOpen: boolean;        // true when consecutiveFailures >= CIRCUIT_BREAKER_THRESHOLD
@@ -467,6 +471,8 @@ export class PerformanceReader {
       disagreements: number;
       uniqueFindings: number;
       hallucinations: number;
+      unverifiedsEmitted: number;
+      unverifiedsReceived: number;
       totalSignals: number;
       lastSignalMs: number;
       categoryStrengths: Record<string, number>;
@@ -481,6 +487,7 @@ export class PerformanceReader {
         weightedImpact: 0, weightedConfirmedCount: 0,
         tasksSeen: new Map(), taskCounter: 0,
         agreements: 0, disagreements: 0, uniqueFindings: 0, hallucinations: 0,
+        unverifiedsEmitted: 0, unverifiedsReceived: 0,
         totalSignals: 0, lastSignalMs: 0, categoryStrengths: {},
         categoryCorrect: {}, categoryHallucinated: {},
       });
@@ -598,8 +605,16 @@ export class PerformanceReader {
           break;
         }
         case 'unverified': {
-          // Near-neutral cost — "I don't know" is not evidence of incorrectness
+          // Near-neutral cost — "I don't know" is not evidence of incorrectness.
+          // Tracked in both directions for dashboard visibility:
+          // - emitted: this agent couldn't verify a peer's finding (reviewer role)
+          // - received: a peer couldn't verify THIS agent's finding (author role)
           a.weightedTotal += decay * 0.02;
+          a.unverifiedsEmitted++;
+          if (signal.counterpartId && signal.counterpartId.length > 0) {
+            const author = ensure(signal.counterpartId);
+            author.unverifiedsReceived++;
+          }
           break;
         }
         case 'unique_confirmed': {
@@ -770,6 +785,8 @@ export class PerformanceReader {
         disagreements: a.disagreements,
         uniqueFindings: a.uniqueFindings,
         hallucinations: a.hallucinations,
+        unverifiedsEmitted: a.unverifiedsEmitted,
+        unverifiedsReceived: a.unverifiedsReceived,
         weightedHallucinations: a.weightedHallucinations,
         consecutiveFailures: consec,
         circuitOpen: consec >= CIRCUIT_BREAKER_THRESHOLD,
@@ -788,6 +805,7 @@ export class PerformanceReader {
         scores.set(agentId, {
           agentId, accuracy: 0.5, uniqueness: 0.5, reliability: 0.5, impactScore: 0.5,
           totalSignals: 0, agreements: 0, disagreements: 0, uniqueFindings: 0, hallucinations: 0,
+          unverifiedsEmitted: 0, unverifiedsReceived: 0,
           weightedHallucinations: 0,
           consecutiveFailures: consec,
           circuitOpen: consec >= CIRCUIT_BREAKER_THRESHOLD,

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -21,10 +21,12 @@ export interface AgentScore {
   disagreements: number;
   uniqueFindings: number;
   hallucinations: number;
-  /** Unverified signals emitted by this agent as a reviewer — "I can't verify peer's finding". */
-  unverifiedsEmitted: number;
-  /** Unverified signals received by this agent as a finding author — a peer couldn't verify the citation. */
-  unverifiedsReceived: number;
+  /** Unverified signals emitted by this agent as a reviewer — "I can't verify peer's finding".
+   *  Optional for back-compat with historical AgentScore fixtures in tests. */
+  unverifiedsEmitted?: number;
+  /** Unverified signals received by this agent as a finding author — a peer couldn't verify the citation.
+   *  Optional for back-compat with historical AgentScore fixtures in tests. */
+  unverifiedsReceived?: number;
   weightedHallucinations: number; // decay-weighted hallucination count (used by auto-bench)
   consecutiveFailures: number; // circuit breaker: consecutive negative signals at tail
   circuitOpen: boolean;        // true when consecutiveFailures >= CIRCUIT_BREAKER_THRESHOLD

--- a/packages/relay/src/dashboard/api-agents.ts
+++ b/packages/relay/src/dashboard/api-agents.ts
@@ -155,6 +155,8 @@ export interface AgentResponse {
     agreements: number;
     disagreements: number;
     hallucinations: number;
+    unverifiedsEmitted: number;
+    unverifiedsReceived: number;
     bench: {
       state: 'benched' | 'kept-for-coverage' | 'none';
       reason?: 'chronic-low-accuracy' | 'burst-hallucination';
@@ -165,6 +167,7 @@ export interface AgentResponse {
 const DEFAULT_SCORE: AgentScore = {
   agentId: '', accuracy: 0.5, uniqueness: 0.5, reliability: 0.5, impactScore: 0.5,
   totalSignals: 0, agreements: 0, disagreements: 0, uniqueFindings: 0, hallucinations: 0,
+  unverifiedsEmitted: 0, unverifiedsReceived: 0,
   weightedHallucinations: 0,
   consecutiveFailures: 0, circuitOpen: false, categoryStrengths: {},
   categoryCorrect: {}, categoryHallucinated: {}, categoryAccuracy: {},
@@ -317,6 +320,8 @@ export async function agentsHandler(
         agreements: score.agreements,
         disagreements: score.disagreements,
         hallucinations: score.hallucinations,
+        unverifiedsEmitted: score.unverifiedsEmitted ?? 0,
+        unverifiedsReceived: score.unverifiedsReceived ?? 0,
         consecutiveFailures: score.consecutiveFailures ?? 0,
         circuitOpen: score.circuitOpen ?? false,
         bench,


### PR DESCRIPTION
Surfaces two new counters in AgentScore + AgentResponse and renders them on /agent/:id:
- **unverifiedsEmitted** — as reviewer, N signals said "I can't verify this"
- **unverifiedsReceived** — as author, N findings were un-verifiable by peers

Shown as a single Unverified stat with `N↑ M↓` format (emitted up-arrow, received down-arrow) + hover title. Color = muted amber (unverified palette). Compact stats grid goes from 5 to 6 columns.

Why both directions: emitted is a reviewer-caution signal (how often this agent punts on verification), received is an author-quality signal (how often this agent's citations confuse peers). Dashboard previously exposed neither, even though the counter's been in the raw jsonl the whole time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)