### PR TITLE
fix(signals): populate category on bulk_from_consensus + new_finding paths

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2382,8 +2382,18 @@ server.tool(
           }
         } catch { /* file may not exist yet */ }
 
-        const { PerformanceWriter, PerformanceReader } = await import('@gossip/orchestrator');
+        const { PerformanceWriter, PerformanceReader, DEFAULT_KEYWORDS: BULK_DK } = await import('@gossip/orchestrator');
         const writer = new PerformanceWriter(process.cwd());
+        const bulkInferCategory = (text: string): string | undefined => {
+          if (!text.trim()) return undefined;
+          let bestCategory = '';
+          let bestHits = 0;
+          for (const [category, keywords] of Object.entries(BULK_DK)) {
+            const hits = (keywords as string[]).filter(kw => text.includes(kw)).length;
+            if (hits > bestHits) { bestHits = hits; bestCategory = category; }
+          }
+          return bestHits >= 1 ? bestCategory : undefined;
+        };
         // Warn if the target round was retracted — signals will be recorded but
         // filtered out at read time by the round tombstone.
         try {
@@ -2400,10 +2410,14 @@ server.tool(
         const toRecord: PS[] = [];
         const dupes: string[] = [];
         let agreementCount = 0, disagreementCount = 0, uniqueCount = 0;
+        let categorizedCount = 0;
 
         const addSignal = (signalType: string, f: any) => {
           const fid = f.id as string | undefined;
           if (fid && existingFindingIds.has(fid)) { dupes.push(fid); return; }
+          const findingText = (f.finding || '').toLowerCase();
+          const category = bulkInferCategory(findingText);
+          if (category) categorizedCount++;
           toRecord.push({
             type: 'consensus',
             signal: signalType as any,
@@ -2411,6 +2425,7 @@ server.tool(
             taskId: batchTaskId,
             findingId: fid,
             severity: f.severity,
+            category,
             source: 'manual',
             evidence: (f.finding || '').slice(0, 2000),
             timestamp: batchTs,
@@ -2424,8 +2439,11 @@ server.tool(
         if (toRecord.length > 0) writer.appendSignals(toRecord);
 
         const skipped = dupes.length;
-        let receipt = `Recorded ${agreementCount} agreement, ${disagreementCount} disagreement, ${uniqueCount} unique signals from ${consensus_id}. ${skipped} duplicate(s) skipped.`;
+        const totalRecorded = toRecord.length;
+        let receipt = `Recorded ${agreementCount} agreement, ${disagreementCount} disagreement, ${uniqueCount} unique signals from ${consensus_id}. ${skipped} duplicate(s) skipped. Categorized ${categorizedCount}/${totalRecorded}.`;
         if (dupes.length > 0) receipt += `\nSkipped finding_ids: ${dupes.join(', ')}`;
+        const uncategorized = toRecord.filter(s => !(s as any).category).map(s => (s as any).findingId).filter(Boolean);
+        if (uncategorized.length > 0) receipt += `\nUncategorized finding_ids: ${uncategorized.join(', ')}`;
         return { content: [{ type: 'text' as const, text: receipt }] };
       } catch (err) {
         return { content: [{ type: 'text' as const, text: `bulk_from_consensus failed: ${(err as Error).message}` }] };

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -1045,6 +1045,7 @@ Return only valid JSON.${skillsBlock}`;
           evidence: capEvidence(entry.evidence),
           timestamp: now,
           findingId: newFindingId,
+          category: resolveSignalCategory(undefined, entry.evidence, entry.finding) ?? undefined,
         });
         continue;
       }

--- a/tests/cli/mcp-signals-validation.test.ts
+++ b/tests/cli/mcp-signals-validation.test.ts
@@ -520,6 +520,93 @@ describe('gossip_signals formatting — taskId synthesis, evidence truncation, t
   });
 });
 
+// ── 5b. bulk_from_consensus category assignment ───────────────────────────────
+
+/**
+ * The bulk_from_consensus addSignal helper must call bulkInferCategory on the
+ * finding text so signals get a category field. Signals without category are
+ * invisible to getCountersSince() — they count toward signal volume but not
+ * toward skill accuracy. We test the inferCategory logic directly (same
+ * DEFAULT_KEYWORDS table) and assert structural presence in the source.
+ */
+
+function bulkInferCategory(text: string): string | undefined {
+  if (!text.trim()) return undefined;
+  let bestCategory = '';
+  let bestHits = 0;
+  for (const [category, keywords] of Object.entries(DEFAULT_KEYWORDS)) {
+    const hits = (keywords as string[]).filter(kw => text.includes(kw)).length;
+    if (hits > bestHits) { bestHits = hits; bestCategory = category; }
+  }
+  return bestHits >= 1 ? bestCategory : undefined;
+}
+
+describe('bulk_from_consensus — category assignment via bulkInferCategory', () => {
+  it('returns a category when finding text contains a keyword match', () => {
+    // "race condition" is a concurrency keyword
+    const category = bulkInferCategory('race condition in the dispatch loop at dispatcher.ts:42');
+    expect(category).toBeDefined();
+    expect(category).toBe('concurrency');
+  });
+
+  it('returns undefined when finding text has no keyword matches', () => {
+    const category = bulkInferCategory('this finding has no recognizable category keywords xyz');
+    expect(category).toBeUndefined();
+  });
+
+  it('returns undefined for empty finding text', () => {
+    expect(bulkInferCategory('')).toBeUndefined();
+    expect(bulkInferCategory('   ')).toBeUndefined();
+  });
+
+  it('signal with undefined category is still persisted to PerformanceWriter (no drop gate)', () => {
+    const testDir = makeTmpDir('bulk-no-category');
+    try {
+      const writer = new PerformanceWriter(testDir);
+      // Simulate what addSignal does when category is undefined
+      writer.appendSignals([{
+        type: 'consensus' as const,
+        signal: 'agreement',
+        agentId: 'agent-a',
+        taskId: 'bulk-test-001',
+        findingId: 'cid-1234:agent-a:f1',
+        source: 'manual',
+        evidence: 'this finding has no category keywords xyz',
+        timestamp: new Date().toISOString(),
+        // category intentionally omitted — mirrors undefined path
+      }]);
+      const path = join(testDir, '.gossip', 'agent-performance.jsonl');
+      const line = JSON.parse(readFileSync(path, 'utf-8').trim());
+      // Signal must be persisted regardless of missing category
+      expect(line.signal).toBe('agreement');
+      expect(line.agentId).toBe('agent-a');
+      expect(line.category).toBeUndefined();
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('receipt includes "Categorized M/N" substring in the bulk_from_consensus handler', () => {
+    const src = readFileSync(
+      join(__dirname, '..', '..', 'apps', 'cli', 'src', 'mcp-server-sdk.ts'),
+      'utf-8',
+    );
+    expect(src).toContain('Categorized ${categorizedCount}/${totalRecorded}');
+  });
+
+  it('handler assigns category field in the toRecord.push call', () => {
+    const src = readFileSync(
+      join(__dirname, '..', '..', 'apps', 'cli', 'src', 'mcp-server-sdk.ts'),
+      'utf-8',
+    );
+    const bulkPush = src.match(
+      /toRecord\.push\(\{[\s\S]{0,800}?timestamp: batchTs,\s*\}/,
+    );
+    expect(bulkPush).not.toBeNull();
+    expect(bulkPush![0]).toContain('category');
+  });
+});
+
 // ── 6. Retraction validation ──────────────────────────────────────────────────
 
 describe('gossip_signals retraction validation', () => {

--- a/tests/orchestrator/consensus-engine.test.ts
+++ b/tests/orchestrator/consensus-engine.test.ts
@@ -463,6 +463,47 @@ Summary: 1 agree, 1 disagree.`;
         expect(newSignal!.findingId).toBe(rewritten);
       });
 
+      it('new_finding signal has category resolved from finding text when evidence has keyword', async () => {
+        // resolveSignalCategory must be called for new_finding — the field was
+        // previously omitted, making these signals invisible to getCountersSince.
+        const crossReview: CrossReviewEntry[] = [
+          {
+            action: 'new',
+            agentId: 'agent-2',
+            peerAgentId: '',
+            finding: 'Race condition in the shared dispatch map — concurrent writes can corrupt state',
+            evidence: 'Found a race condition in the concurrent map at dispatcher.ts:55',
+            confidence: 4,
+          },
+        ];
+        const report = await engine.synthesize(results, crossReview);
+        const newSignal = report.signals.find(s => s.signal === 'new_finding');
+        expect(newSignal).toBeDefined();
+        // category must be resolved — 'race condition' / 'concurrent' are concurrency keywords
+        expect((newSignal as any).category).toBeDefined();
+        expect((newSignal as any).category).toBe('concurrency');
+      });
+
+      it('new_finding signal persists with undefined category when no keyword matches', async () => {
+        // No drop gate for new_finding — even without a category the signal
+        // contributes to uniqueFindings scoring in performance-reader.
+        const crossReview: CrossReviewEntry[] = [
+          {
+            action: 'new',
+            agentId: 'agent-2',
+            peerAgentId: '',
+            finding: 'Unusual architectural pattern with no keyword match xyz',
+            evidence: 'No recognizable category signals here',
+            confidence: 3,
+          },
+        ];
+        const report = await engine.synthesize(results, crossReview);
+        const newSignal = report.signals.find(s => s.signal === 'new_finding');
+        expect(newSignal).toBeDefined();
+        // Signal must be present even when category resolves to undefined
+        expect(newSignal!.agentId).toBe('agent-2');
+      });
+
       it('populates authorDiagnostics when agent output contains entity-encoded tags', async () => {
         // agent-html is emitting `&lt;agent_finding&gt;` instead of `<agent_finding>`.
         // parseAgentFindingsStrict produces 0 findings (tags invisible), but the


### PR DESCRIPTION
## Summary

Two consensus-signal write paths were shipping records without a `category` field, making them invisible to `CategoryCompetency` dashboard buckets and skill-gap analysis.

- **`apps/cli/src/mcp-server-sdk.ts` `bulk_from_consensus` `addSignal`** — add `bulkInferCategory` helper (mirrors the record-path bestHits algorithm) and attach the resolved category to each written signal. Receipt now includes `Categorized M/N` + optional `Uncategorized finding_ids:` line (mirroring existing `Skipped finding_ids:` pattern).
- **`packages/orchestrator/src/consensus-engine.ts` `new_finding` push at line 1048** — add `category: resolveSignalCategory(undefined, entry.evidence, entry.finding) ?? undefined` to match the pattern every other consensus signal push uses.

## Context

Consensus round `4e6f7258-d76842ec` identified both gaps. A follow-up debate round (same agents, adversarial positions) agreed on **"record with undefined on classifier miss"** as the policy:

- Non-hallucination signals still contribute to aggregate accuracy (`performance-reader.ts:581-585` increments `weightedImpact`/`weightedConfirmedCount` **before** the `if (signal.category)` guard at 586).
- Write-time dropping would silently regress `dispatchWeight` routing for agents whose findings don't hit the 8-category security-flavored classifier.
- Reader already handles `undefined` correctly (guards per-category queries, preserves aggregate).

## Test plan

- [x] `npm test` — 155 suites, 1959 tests passed, 1 skipped
- [x] New tests cover: bulk inferCategory keyword-match, no-match, empty text, persist-without-drop, `Categorized M/N` receipt format, new_finding category resolution, new_finding persists with undefined
- [ ] Manually verify dashboard `CategoryCompetency` counts increment after a bulk-recorded round post-merge

## Follow-ups (separate PRs)

- Unify the 6 drop gates in `consensus-engine.ts` (lines 985, 1061, 1111, 1139, 1243, 1271) to match the record-undefined policy — they currently drop category-less signals to stderr.
- Dedupe `bulkInferCategory` and `inferCategory` (both use the same bestHits algorithm; lift to a shared helper).
- Add dashboard metric: uncategorized-signal-rate per agent, surfaces classifier gaps empirically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)