### PR TITLE
fix(dashboard): dim CategoryCompetency rows with n<10 to avoid false authority

### DIFF
--- a/packages/dashboard-v2/src/components/CategoryCompetency.tsx
+++ b/packages/dashboard-v2/src/components/CategoryCompetency.tsx
@@ -52,8 +52,8 @@ export function CategoryCompetency({ categoryAccuracy, categoryCorrect, category
         return (
           <div
             key={row.key}
-            className="grid grid-cols-[128px_1fr_auto_44px] items-center gap-3"
-            title={title}
+            className={`grid grid-cols-[128px_1fr_auto_44px] items-center gap-3 ${row.n > 0 && row.n < 10 ? 'opacity-50' : ''}`}
+            title={row.n > 0 && row.n < 10 ? `${title} — low sample (n<10)` : title}
           >
             <span className="truncate font-mono text-[11px] text-muted-foreground">
               {row.key.replace(/_/g, ' ')}


### PR DESCRIPTION
## Summary

Rows in `CategoryCompetency` with fewer than 10 signals rendered at full opacity, visually equal to rows with 50+ signals — misleading because percentages at small N are noise-dominated. A `verification` bucket at 4/5 (80%) looked authoritative despite being 1-hallucination-away from 60%.

## Change

Two lines in `packages/dashboard-v2/src/components/CategoryCompetency.tsx:55-56`:
- Apply `opacity-50` to rows where `0 < n < 10`
- Append `— low sample (n<10)` to the tooltip so hover reveals the reason

## Why

Caught during session 2026-04-17 while inspecting agent competency data — the `verification` row at 4/5 looked as authoritative as `injection_vectors` at 28/28 (100%). Dim treatment signals "preliminary" without dropping the row.

## Test plan

- [x] Change is CSS-only; no logic changes
- [ ] Visual verification post-merge: row with n<10 dims, tooltip shows "low sample"

## Notes

Small standalone — separate from the category-classifier / drop-gate work that shipped in this session (PRs #154, #156, #158).

Generated with Claude Code