### PR TITLE
fix(sandbox): orchestrator env exemption + quoted-arg extraction (#162)

### DIFF
--- a/assets/hooks/worktree-sandbox.sh
+++ b/assets/hooks/worktree-sandbox.sh
@@ -180,6 +180,21 @@ if [ -z "$cwd" ]; then
   exit 0
 fi
 
+# Env-based orchestrator exemption (issue #162 problem 1).
+#
+# When the orchestrator shell cd's into a worktree to inspect/commit a
+# subagent's work (which is a legitimate operation), the cwd-glob logic
+# below pins it as if it were the subagent. Set
+# GOSSIPCAT_ORCHESTRATOR_ROLE=1 on the top-level orchestrator session to
+# short-circuit the gate.
+#
+# The harness does not yet set this env automatically — users must opt in.
+# Setup docs should describe the flag. Subagent harnesses must NOT inherit
+# this env; if that ever breaks, the cwd-glob fallback still applies.
+case "$GOSSIPCAT_ORCHESTRATOR_ROLE" in
+  1|true|TRUE|yes|YES) exit 0 ;;
+esac
+
 # Distinguish orchestrator from subagent using $CLAUDE_PROJECT_DIR as anchor.
 # The orchestrator runs with its project dir as cwd; subagents run inside a
 # gossipcat worktree. We only gate subagents.
@@ -268,7 +283,41 @@ ${edit_paths}"
     # absolute-path token `/etc/passwd` would be missed.
     cmd="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null)"
     if [ -n "$cmd" ]; then
-      candidates="$(printf '%s\n' "$cmd" \
+      # Quoted-string false-positive mitigation (issue #162 problem 2).
+      #
+      # The raw grep matches any /path token preceded by a shell metachar,
+      # including tokens inside single-quoted arg bodies like `git commit -m
+      # 'fixes /etc/config'` or `gh pr create --body '... see /etc/passwd
+      # ...'`. These never write to those paths, but they falsely trip the
+      # boundary check.
+      #
+      # Mitigation: if argv[0] (the first whitespace-separated token with
+      # any leading path stripped) is NOT a shell wrapper, strip single-
+      # quoted content before extraction. Shell wrappers (`bash -c`,
+      # `sh -c`, `eval`, `zsh -c`, `ksh -c`) may carry the REAL command
+      # inside single quotes, so we leave their bodies untouched.
+      #
+      # Known bypass: `env bash -c 'cp /wt /etc/x'` — argv[0] is `env`, so
+      # we strip the single-quoted body. The subagent prompt (Layer 1) and
+      # the git porcelain audit (Layer 3) still apply. Documented in
+      # docs/specs/2026-04-18-sandbox-hook-quoted-args.md (if/when we ship it).
+      argv0_raw="$(printf '%s' "$cmd" | awk '{print $1}')"
+      argv0_basename="${argv0_raw##*/}"
+      cmd_for_extraction="$cmd"
+      case "$argv0_basename" in
+        bash|sh|zsh|ksh|dash|eval|exec)
+          # Shell wrapper — keep quoted content for extraction.
+          ;;
+        *)
+          # Non-shell — strip balanced single-quoted spans. POSIX sed, no
+          # state. Caveats: ANSI-C `$'...'` quoting and `'\''` escaped
+          # apostrophe edges leak partial content; these are narrow cases
+          # and the downstream grep still catches any absolute-path token
+          # that survives the strip.
+          cmd_for_extraction="$(printf '%s' "$cmd" | sed "s/'[^']*'//g")"
+          ;;
+      esac
+      candidates="$(printf '%s\n' "$cmd_for_extraction" \
         | grep -oE '(^|[[:space:]=><;\|(){},&`])/[^[:space:]"'"'"'`;\|><(){},&]+' 2>/dev/null \
         | sed -E -e 's/^[[:space:]=><;\|(){},&`]//')"
     fi

--- a/tests/cli/worktree-sandbox-hook.test.ts
+++ b/tests/cli/worktree-sandbox-hook.test.ts
@@ -615,6 +615,87 @@ runIfJq('worktree-sandbox.sh', () => {
     expect(parsed.hookSpecificOutput.permissionDecision).toBe('deny');
     expect(parsed.hookSpecificOutput.permissionDecisionReason).toContain('/fake/project/src/foo.ts');
   });
+
+  // Issue #162 problem 1: GOSSIPCAT_ORCHESTRATOR_ROLE env exemption.
+  it('[orch-env] GOSSIPCAT_ORCHESTRATOR_ROLE=1 allows Write to any path from worktree cwd', () => {
+    const { stdout, status } = runHook(
+      {
+        tool_name: 'Write',
+        tool_input: { file_path: '/Users/someone/outside.txt' },
+        cwd: '/fake/project/.claude/worktrees/agent-abc',
+      },
+      { GOSSIPCAT_ORCHESTRATOR_ROLE: '1', CLAUDE_PROJECT_DIR: '/fake/project' },
+    );
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('');
+  });
+
+  it('[orch-env] GOSSIPCAT_ORCHESTRATOR_ROLE=true allows Bash with external path from worktree cwd', () => {
+    const { stdout, status } = runHook(
+      {
+        tool_name: 'Bash',
+        tool_input: { command: 'cp /fake/project/src/foo.ts /tmp/somewhere-else' },
+        cwd: '/fake/project/.claude/worktrees/agent-abc',
+      },
+      { GOSSIPCAT_ORCHESTRATOR_ROLE: 'true' },
+    );
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('');
+  });
+
+  // Issue #162 problem 2 / #161: quoted-string false-positive mitigation.
+  it('[quotes] allows git commit -m with quoted body containing absolute path', () => {
+    const { stdout, status } = runHook({
+      tool_name: 'Bash',
+      tool_input: { command: "git commit -m 'fixes /etc/config reference'" },
+      cwd: '/fake/project/.claude/worktrees/agent-abc',
+    }, { CLAUDE_PROJECT_DIR: '/fake/project' });
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('');
+  });
+
+  it('[quotes] allows gh pr edit --body with quoted body containing absolute path', () => {
+    const { stdout, status } = runHook({
+      tool_name: 'Bash',
+      tool_input: { command: "gh pr edit --body 'see /etc/passwd in the discussion'" },
+      cwd: '/fake/project/.claude/worktrees/agent-abc',
+    }, { CLAUDE_PROJECT_DIR: '/fake/project' });
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('');
+  });
+
+  it('[quotes] still denies unquoted cp to external absolute path', () => {
+    const { stdout, status } = runHook({
+      tool_name: 'Bash',
+      tool_input: { command: 'cp /fake/project/.claude/worktrees/agent-abc/src/foo.ts /etc/passwd' },
+      cwd: '/fake/project/.claude/worktrees/agent-abc',
+    }, { CLAUDE_PROJECT_DIR: '/fake/project' });
+    expect(status).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.hookSpecificOutput.permissionDecision).toBe('deny');
+  });
+
+  it('[quotes] bash -c keeps quoted body for extraction — deny unchanged', () => {
+    const { stdout, status } = runHook({
+      tool_name: 'Bash',
+      tool_input: { command: "bash -c 'cp /fake/project/.claude/worktrees/agent-abc/src/foo.ts /etc/passwd'" },
+      cwd: '/fake/project/.claude/worktrees/agent-abc',
+    }, { CLAUDE_PROJECT_DIR: '/fake/project' });
+    expect(status).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.hookSpecificOutput.permissionDecision).toBe('deny');
+  });
+
+  it('[quotes] sh -c absolute path also keeps quoted body — deny unchanged', () => {
+    const { stdout, status } = runHook({
+      tool_name: 'Bash',
+      tool_input: { command: "/bin/sh -c 'cp /fake/project/.claude/worktrees/agent-abc/x /etc/shadow'" },
+      cwd: '/fake/project/.claude/worktrees/agent-abc',
+    }, { CLAUDE_PROJECT_DIR: '/fake/project' });
+    expect(status).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.hookSpecificOutput.permissionDecision).toBe('deny');
+  });
 });
 
 // Keep unused-import lint happy — writeFileSync, mkdirSync imported for


### PR DESCRIPTION
## Summary

Two fixes for the worktree sandbox hook, both surfaced by #162.

**Problem 1 — orchestrator pinning:** when the orchestrator shell cd's into a worktree, the cwd-glob gates it as a subagent. Adds \`GOSSIPCAT_ORCHESTRATOR_ROLE=1\` env exemption: set on the top-level session to short-circuit. Subagent harnesses don't inherit it, so the cwd-glob fallback still gates them.

**Problem 2 — quoted-arg extraction (dup #161):** the path grep was matching /path tokens inside single-quoted argument bodies like \`git commit -m 'fixes /etc/config'\`, blocking legitimate PR bodies, commit messages, and even filing the #162 issue itself. Mitigation: when argv[0] basename is NOT a shell wrapper (bash/sh/zsh/ksh/dash/eval/exec), strip single-quoted content via \`sed \"s/'[^']*'//g\"\` before the existing grep. Shell wrappers keep the body so \`bash -c 'cp /wt /etc/x'\` is still caught.

## Known bypass (accepted)

\`env bash -c 'cp /wt /etc/x'\` — argv[0] is \`env\`, so we strip the quoted body. Layer 1 (prompt injection) and Layer 3 (git porcelain audit) still apply. This is a pragmatic trade-off over the prior status quo which had worse false-positive friction (blocked filing the issue that describes the bug).

## Test plan

- [x] 43/43 hook tests pass (7 new)
- [x] Full suite 1984/1985 pass (1 pre-existing skip)
- [x] No regressions on the 36 existing hook cases

Closes #162. Closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)