### PR TITLE
docs(gossip_watch): surface in CLAUDE.md + gossip_status banner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,13 @@ what's running. Use a code block with this format:
 This is important — relay agents run invisibly without terminal indicators. The user needs
 to see what was dispatched and track task IDs for progress checks.
 
+**Watching signals land live:** Between a `gossip_dispatch` and its matching
+`gossip_collect`, you can call `gossip_watch(cursor)` to see signals as agents record
+them instead of waiting for synthesis. Useful for catching `finding_dropped_format`
+pipeline events mid-round. It's a deferred MCP tool — first use needs
+`ToolSearch(query: "select:mcp__gossipcat__gossip_watch")`, then it's callable freely.
+Pass the returned `next_cursor` on subsequent calls.
+
 **After consensus:** Verify ALL UNVERIFIED findings against the code before presenting
 results. UNVERIFIED means the cross-reviewer couldn't check — you can and must. Do not
 show raw consensus results with unexamined UNVERIFIED findings.

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1600,6 +1600,7 @@ server.tool(
         '  "Security audit the payment handler"',
         '  "Research how X works before I touch it"',
         '  "Show me agent scores"',
+        '  "Watch signals live" — gossip_watch(cursor) between dispatches',
         '─────────────────────────────────',
       ].join('\n'));
     } else {


### PR DESCRIPTION
## Summary

Two small discoverability nudges for \`gossip_watch\` (added in #163). Deferred MCP tools aren't in the default tool list, so fresh sessions don't reach for them without prompting.

- **CLAUDE.md**: one-paragraph \"Watching signals land live\" block with the exact ToolSearch query and the between-dispatch usage pattern.
- **mcp-server-sdk.ts**: adds a \`Try saying: \"Watch signals live\"\` hint to the \`gossip_status\` banner so it shows up every session.

No logic change, no tests needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)