### PR TITLE
fix(sandbox): self-documenting deny + gossip_setup env-var tip

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2076,7 +2076,13 @@ server.tool(
     }
     lines.push(`\nMode: ${mode} | Config: .gossip/config.json (${Object.keys(config.agents).length} agents total)`);
     lines.push(`Rules: ${env.rulesFile} (${env.host} will read this on next session)`);
-    if (hookSummary) lines.push(hookSummary);
+    if (hookSummary) {
+      lines.push(hookSummary);
+      lines.push('  ⚠ If the orchestrator cd\'s into a worktree to inspect/commit subagent work,');
+      lines.push('    the hook will gate it as a subagent. Exempt the orchestrator shell with:');
+      lines.push('      export GOSSIPCAT_ORCHESTRATOR_ROLE=1   # add to ~/.zshrc or ~/.bashrc');
+      lines.push('    Then relaunch Claude Code. See issue #162 for rationale.');
+    }
     lines.push('Agents will connect to relay on first gossip_dispatch() call.');
     if (nativeCreated.length > 0) {
       lines.push(`\nTip: Native agents may prompt for file write permissions. To auto-allow, add to .claude/settings.local.json:`);

--- a/assets/hooks/worktree-sandbox.sh
+++ b/assets/hooks/worktree-sandbox.sh
@@ -373,7 +373,7 @@ while IFS= read -r path_arg; do
   fi
 
   if ! path_is_inside "$cwd_norm" "$path_norm"; then
-    emit_deny "BOUNDARY ESCAPE: ${tool_name} targets '${path_arg}' (normalized: '${path_norm}') outside worktree cwd '${cwd_norm}'. Use a relative path (./...) inside the worktree."
+    emit_deny "BOUNDARY ESCAPE: ${tool_name} targets '${path_arg}' (normalized: '${path_norm}') outside worktree cwd '${cwd_norm}'. Use a relative path (./...) inside the worktree. If you are the orchestrator (not a subagent) and cd'd into a worktree, exempt this shell with: export GOSSIPCAT_ORCHESTRATOR_ROLE=1 and relaunch Claude Code (issue #162)."
   fi
 done <<EOF
 $candidates

--- a/tests/cli/worktree-sandbox-hook.test.ts
+++ b/tests/cli/worktree-sandbox-hook.test.ts
@@ -686,6 +686,19 @@ runIfJq('worktree-sandbox.sh', () => {
     expect(parsed.hookSpecificOutput.permissionDecision).toBe('deny');
   });
 
+  it('[hints] BOUNDARY ESCAPE deny reason mentions GOSSIPCAT_ORCHESTRATOR_ROLE remediation', () => {
+    const { stdout } = runHook({
+      tool_name: 'Write',
+      tool_input: { file_path: '/Users/someone/secrets.txt' },
+      cwd: '/private/tmp/gossip-wt-abc123',
+    });
+    const parsed = JSON.parse(stdout);
+    const reason = parsed.hookSpecificOutput.permissionDecisionReason;
+    expect(reason).toContain('BOUNDARY ESCAPE');
+    expect(reason).toContain('GOSSIPCAT_ORCHESTRATOR_ROLE=1');
+    expect(reason).toContain('issue #162');
+  });
+
   it('[quotes] sh -c absolute path also keeps quoted body — deny unchanged', () => {
     const { stdout, status } = runHook({
       tool_name: 'Bash',


### PR DESCRIPTION
## Summary

Discoverability follow-up to #164. Gating logic unchanged; users now learn the \`GOSSIPCAT_ORCHESTRATOR_ROLE=1\` remediation from either the deny itself or the gossip_setup receipt instead of reading issue #162.

- **\`assets/hooks/worktree-sandbox.sh\`** — BOUNDARY ESCAPE deny reason appends: *\"If you are the orchestrator (not a subagent) and cd'd into a worktree, exempt this shell with: export GOSSIPCAT_ORCHESTRATOR_ROLE=1 and relaunch Claude Code (issue #162).\"*
- **\`apps/cli/src/mcp-server-sdk.ts\`** — gossip_setup receipt prints the env-var tip right after the hook-install summary.
- +1 test locks in the remediation hint so future edits don't silently drop it.

## Test plan

- [x] 44/44 hook tests pass (+1 new)
- [x] Full suite 2014/2015 pass (1 pre-existing skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)