### PR TITLE
fix(signal-pipeline): shared emitCompletionSignals helper + error-path + memoryQueryCalled threading

### DIFF
--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -326,6 +326,14 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
   // Release scope if this native task held one
   try { ctx.mainAgent.scopeTracker.release(task_id); } catch { /* best-effort — no scope registered is fine */ }
 
+  // Bug f13: cleanup worktree on native error — mirrors dispatch-pipeline.ts:473-475.
+  // Native worktrees use Claude Code's Agent(isolation:"worktree") so there's no
+  // worktreePath in NativeTaskInfo, but WorktreeManager.cleanup(taskId) is safe to call
+  // with an undefined path — it will prune by taskId from the orphan list.
+  if (error && taskInfo.writeMode === 'worktree') {
+    try { ctx.mainAgent.getWorktreeManager()?.cleanup(task_id, undefined as any).catch(() => {}); } catch { /* best-effort */ }
+  }
+
   // Run the same post-collect pipeline as custom agents:
   // 1. Memory write  2. Knowledge extraction  3. Gossip  4. Compaction
   const agentId = taskInfo.agentId;
@@ -338,7 +346,8 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
 
   // 0. Record in TaskGraph (makes native tasks visible to CLI + Supabase sync)
   // Pass null duration through — recordNativeTaskCompleted handles undefined/null via ?? -1
-  try { ctx.mainAgent.recordNativeTaskCompleted(task_id, result, error || undefined, elapsed ?? undefined); } catch { /* best-effort */ }
+  // Bug f8: thread memoryQueryCalled so TaskGraph records compliance auditing data.
+  try { ctx.mainAgent.recordNativeTaskCompleted(task_id, result, error || undefined, elapsed ?? undefined, taskInfo.memoryQueryCalled); } catch { /* best-effort */ }
 
   // 0a. Auto-record impl signal for write-mode tasks (gate on error param only — string heuristics are unreliable)
   if (taskInfo.writeMode && !taskInfo.utilityType && agentId !== '_utility') {
@@ -357,49 +366,22 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
     } catch { /* best-effort */ }
   }
 
-  // 0c. Emit task_completed + task_tool_turns + format_compliance meta signals.
-  // Closes the metrics-asymmetry gap haiku flagged on PR #61: relay dispatches
-  // emit all three at dispatch-pipeline.ts:395-399 but the native completion
-  // path only had format_compliance. Without task_completed (durationMs) and
-  // task_tool_turns (toolCalls), native agents are invisible in dispatcher
-  // performance analytics. Native tool-call count isn't observable from
-  // gossipcat (the Agent() tool runs out-of-process), so we emit 0 — the
-  // signal still slots into the time series even if its value is unknown.
+  // 0c. Emit task_completed + format_compliance + (optional) finding_dropped_format signals.
+  // Uses shared emitCompletionSignals helper — closes the native/relay signal-pipeline
+  // drift (consensus 23687227-1462428b). Bugs addressed: f1 (finding_dropped_format),
+  // f4 (diagnostic_codes in format_compliance), f11 (task_completed always emitted).
+  // F16 preserved: toolCalls left undefined so task_tool_turns is never emitted for
+  // native agents (tool-use is inside Claude Code's subagent framework, unobservable).
   if (!error && !taskInfo.utilityType && agentId !== '_utility') {
-    try {
-      const { PerformanceWriter, detectFormatCompliance } = await import('@gossip/orchestrator');
-      const compliance = detectFormatCompliance(result ?? '');
-      const metaWriter = new PerformanceWriter(process.cwd());
-      const now = new Date().toISOString();
-      // F16: skip task_tool_turns for native agents — tool-use happens inside
-      // Claude Code's subagent framework and isn't observable from the relay.
-      // Emitting value: 0 would make downstream scorers treat native agents
-      // as never-using-tools and fire spurious skill-gap alerts. task_completed
-      // and format_compliance stay (both ARE observable from our side).
-      metaWriter.appendSignals([
-        // Skip task_completed signal when duration is null — emitting value: null
-        // would produce misleading analytics (treated as 0ms by downstream scorers).
-        ...(elapsed !== null ? [{ type: 'meta' as const, signal: 'task_completed', agentId, taskId: task_id, value: elapsed, timestamp: now } as any] : []),
-        {
-          type: 'meta' as const,
-          signal: 'format_compliance',
-          agentId,
-          taskId: task_id,
-          value: compliance.formatCompliant ? 1 : 0,
-          metadata: {
-            findingCount: compliance.findingCount,
-            citationCount: compliance.citationCount,
-            tags_total: compliance.tags_total,
-            tags_accepted: compliance.tags_accepted,
-            tags_dropped_unknown_type: compliance.tags_dropped_unknown_type,
-            tags_dropped_short_content: compliance.tags_dropped_short_content,
-          },
-          timestamp: now,
-        } as any,
-      ]);
-    } catch (err) {
-      process.stderr.write(`[gossipcat] native meta signals: ${(err as Error).message}\n`);
-    }
+    const { emitCompletionSignals } = await import('@gossip/orchestrator');
+    emitCompletionSignals(process.cwd(), {
+      agentId,
+      taskId: task_id,
+      result: result ?? '',
+      elapsedMs: elapsed,
+      // toolCalls intentionally omitted — F16: native tool-call count is unobservable
+      memoryQueryCalled: taskInfo.memoryQueryCalled,
+    });
   }
 
   // 0b. Record plan step result so subsequent steps get chain context
@@ -414,7 +396,14 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
       const memWriter = new MemoryWriter(process.cwd());
       // Wire LLM for cognitive summaries — same as relay agents get
       try { if (ctx.mainAgent.getLLM()) memWriter.setSummaryLlm(ctx.mainAgent.getLLM()); } catch {}
-      const scores = defaultImportanceScores();
+      // Bug f9: mirror dispatch-pipeline.ts:1065-1079 — use perfReader accuracy
+      // for importance scores so high-accuracy agents get higher-relevance memory.
+      const agentScore = ctx.mainAgent.getPerfReader()?.getAgentScore(agentId);
+      const scores = agentScore ? {
+        relevance: (result && result.length > 200) ? 4 : 3,
+        accuracy: Math.max(1, Math.round(agentScore.accuracy * 5)),
+        uniqueness: Math.max(1, Math.round(agentScore.uniqueness * 5)),
+      } : defaultImportanceScores();
       await memWriter.writeTaskEntry(agentId, {
         taskId: task_id,
         task: taskInfo.task,
@@ -424,8 +413,12 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
 
       // 2. Extract knowledge from result (files, tech, decisions)
       if (result) {
+        // Bug f9: pass agentAccuracy (reliability) so writeKnowledgeFromResult
+        // can weight knowledge extraction — mirrors dispatch-pipeline.ts:1076-1079.
+        const agentAccuracy = agentScore?.reliability;
         await memWriter.writeKnowledgeFromResult(agentId, {
           taskId: task_id, task: taskInfo.task, result,
+          ...(agentAccuracy !== undefined ? { agentAccuracy } : {}),
         });
       }
 

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -326,12 +326,14 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
   // Release scope if this native task held one
   try { ctx.mainAgent.scopeTracker.release(task_id); } catch { /* best-effort — no scope registered is fine */ }
 
-  // Bug f13: cleanup worktree on native error — mirrors dispatch-pipeline.ts:473-475.
+  // Bug f13: prune orphaned worktrees on native error — mirrors dispatch-pipeline.ts:473-475.
   // Native worktrees use Claude Code's Agent(isolation:"worktree") so there's no
-  // worktreePath in NativeTaskInfo, but WorktreeManager.cleanup(taskId) is safe to call
-  // with an undefined path — it will prune by taskId from the orphan list.
+  // worktreePath in NativeTaskInfo. pruneOrphans() iterates all gossip-wt-* worktrees
+  // and removes any whose task IDs no longer have active entries — broader than a
+  // single-task cleanup but actually works (cleanup(taskId, undefined) would run
+  // `git worktree remove undefined --force` and silently fail).
   if (error && taskInfo.writeMode === 'worktree') {
-    try { ctx.mainAgent.getWorktreeManager()?.cleanup(task_id, undefined as any).catch(() => {}); } catch { /* best-effort */ }
+    try { ctx.mainAgent.getWorktreeManager()?.pruneOrphans().catch(() => {}); } catch { /* best-effort */ }
   }
 
   // Run the same post-collect pipeline as custom agents:
@@ -372,7 +374,9 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
   // f4 (diagnostic_codes in format_compliance), f11 (task_completed always emitted).
   // F16 preserved: toolCalls left undefined so task_tool_turns is never emitted for
   // native agents (tool-use is inside Claude Code's subagent framework, unobservable).
-  if (!error && !taskInfo.utilityType && agentId !== '_utility') {
+  // Error path now included (skip only utility tasks) so downstream scorers get
+  // task_completed with error:true for failed tasks (consensus bac850a6-eeb048e3, f2).
+  if (!taskInfo.utilityType && agentId !== '_utility') {
     const { emitCompletionSignals } = await import('@gossip/orchestrator');
     emitCompletionSignals(process.cwd(), {
       agentId,
@@ -381,6 +385,7 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
       elapsedMs: elapsed,
       // toolCalls intentionally omitted — F16: native tool-call count is unobservable
       memoryQueryCalled: taskInfo.memoryQueryCalled,
+      error: error ? true : undefined,
     });
   }
 

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -45,6 +45,12 @@ export interface NativeTaskInfo {
   writeMode?: 'sequential' | 'scoped' | 'worktree';
   /** One-time token that must accompany gossip_relay — prevents task-ID spoofing */
   relayToken?: string;
+  /**
+   * Whether the native agent called memory_query during this task.
+   * Set by gossip_relay when the agent includes memoryQueryCalled in its result metadata.
+   * Threaded to TaskGraph.recordCompleted/recordFailed for compliance auditing.
+   */
+  memoryQueryCalled?: boolean;
 }
 
 export interface NativeResultInfo {

--- a/packages/orchestrator/src/completion-signals.ts
+++ b/packages/orchestrator/src/completion-signals.ts
@@ -45,6 +45,12 @@ export interface CompletionSignalInput {
    * NativeTaskInfo.memoryQueryCalled (native, after f8 thread).
    */
   memoryQueryCalled?: boolean;
+  /**
+   * Whether this signal is emitted on the error path (task failed).
+   * When true, adds error:true to task_completed metadata so downstream
+   * scorers can compute per-agent failure rate and latency separately.
+   */
+  error?: boolean;
 }
 
 /**
@@ -61,7 +67,7 @@ export interface CompletionSignalInput {
  */
 export function emitCompletionSignals(projectRoot: string, input: CompletionSignalInput): void {
   try {
-    const { agentId, taskId, result, elapsedMs, toolCalls, memoryQueryCalled } = input;
+    const { agentId, taskId, result, elapsedMs, toolCalls, memoryQueryCalled, error } = input;
     const now = new Date().toISOString();
     const compliance = detectFormatCompliance(result ?? '');
 
@@ -71,15 +77,20 @@ export function emitCompletionSignals(projectRoot: string, input: CompletionSign
     // Bug f11: previous native path skipped emission when elapsed === null.
     // Fix: always emit — use value 0 + estimated:true when null so the
     // event lands in the time-series even if its duration isn't meaningful.
+    // error:true is added when the task failed so downstream scorers can
+    // compute per-agent failure rate and latency from the time-series.
     {
       const durationValue = elapsedMs !== null ? elapsedMs : 0;
+      const metadataEntries: Record<string, unknown> = {};
+      if (elapsedMs === null) metadataEntries.estimated = true;
+      if (error) metadataEntries.error = true;
       const meta: MetaSignal = {
         type: 'meta',
         signal: 'task_completed',
         agentId,
         taskId,
         value: durationValue,
-        ...(elapsedMs === null ? { metadata: { estimated: true } } : {}),
+        ...(Object.keys(metadataEntries).length > 0 ? { metadata: metadataEntries } : {}),
         timestamp: now,
       };
       signals.push(meta);

--- a/packages/orchestrator/src/completion-signals.ts
+++ b/packages/orchestrator/src/completion-signals.ts
@@ -1,0 +1,151 @@
+/**
+ * emitCompletionSignals — shared helper for native and relay task completion.
+ *
+ * Fixes the signal-pipeline drift that caused native agents to be invisible
+ * in performance analytics (consensus 23687227-1462428b, bugs f1/f4/f8/f10/f11/f15).
+ *
+ * Both paths (apps/cli/src/handlers/native-tasks.ts and
+ * packages/orchestrator/src/dispatch-pipeline.ts) previously duplicated
+ * signal emission prose with divergent behaviour:
+ *   - Native: missing finding_dropped_format, missing diagnostic_codes, no
+ *     memoryQueryCalled threading, no effectiveStart fallback (f11), no
+ *     perfReader-weighted memory (f9), no worktree cleanup on error (f13).
+ *   - Relay: complete, but duplicated.
+ *
+ * This module is the single source of truth for task-completion signals.
+ * Call it from BOTH paths after the result is obtained.
+ */
+
+import { PerformanceWriter } from './performance-writer';
+import { detectFormatCompliance } from './dispatch-pipeline';
+import type { MetaSignal, PipelineSignal } from './consensus-types';
+
+export interface CompletionSignalInput {
+  agentId: string;
+  taskId: string;
+  result: string;
+  /**
+   * Measured wall-clock duration in milliseconds.
+   * Pass null when timing is genuinely unknown (then we emit 0 with
+   * metadata.estimated:true so downstream scorers can filter it).
+   */
+  elapsedMs: number | null;
+  /**
+   * Number of tool calls the agent made.
+   * Omit (leave undefined) for native agents where tool-call count is
+   * unobservable from gossipcat — this preserves the F16 skip contract:
+   * we NEVER emit task_tool_turns with value:null or value:0 for native
+   * agents because that would make downstream scorers treat them as
+   * never-using-tools and fire spurious skill-gap alerts.
+   */
+  toolCalls?: number;
+  /**
+   * Whether the agent called memory_query during this task.
+   * Threaded from TaskEntry.memoryQueryCalled (relay) or
+   * NativeTaskInfo.memoryQueryCalled (native, after f8 thread).
+   */
+  memoryQueryCalled?: boolean;
+}
+
+/**
+ * Emit task_completed, (conditionally) task_tool_turns, format_compliance,
+ * and (when drops > 0) finding_dropped_format signals.
+ *
+ * Contract:
+ * - Never throws — single try/catch writes to process.stderr on failure.
+ * - Never emits task_tool_turns when toolCalls is undefined (F16 preserve).
+ * - Always emits format_compliance with diagnostic_codes in metadata.
+ * - Emits task_completed with value:0 + metadata.estimated:true when
+ *   elapsedMs is null (bug f11: server-side startedAt is always present so
+ *   null should be rare, but we must not suppress the signal entirely).
+ */
+export function emitCompletionSignals(projectRoot: string, input: CompletionSignalInput): void {
+  try {
+    const { agentId, taskId, result, elapsedMs, toolCalls, memoryQueryCalled } = input;
+    const now = new Date().toISOString();
+    const compliance = detectFormatCompliance(result ?? '');
+
+    const signals: (MetaSignal | PipelineSignal)[] = [];
+
+    // ── task_completed ────────────────────────────────────────────────────
+    // Bug f11: previous native path skipped emission when elapsed === null.
+    // Fix: always emit — use value 0 + estimated:true when null so the
+    // event lands in the time-series even if its duration isn't meaningful.
+    {
+      const durationValue = elapsedMs !== null ? elapsedMs : 0;
+      const meta: MetaSignal = {
+        type: 'meta',
+        signal: 'task_completed',
+        agentId,
+        taskId,
+        value: durationValue,
+        ...(elapsedMs === null ? { metadata: { estimated: true } } : {}),
+        timestamp: now,
+      };
+      signals.push(meta);
+    }
+
+    // ── task_tool_turns ───────────────────────────────────────────────────
+    // F16: only emit when toolCalls is defined. Native agents don't pass it
+    // so this block is skipped — zero tool-call data is BETTER than false data.
+    if (toolCalls !== undefined) {
+      signals.push({
+        type: 'meta',
+        signal: 'task_tool_turns',
+        agentId,
+        taskId,
+        value: toolCalls,
+        ...(memoryQueryCalled !== undefined ? { metadata: { memoryQueryCalled } } : {}),
+        timestamp: now,
+      } as MetaSignal);
+    }
+
+    // ── format_compliance ─────────────────────────────────────────────────
+    // Bug f4: native path was missing diagnostic_codes in metadata.
+    signals.push({
+      type: 'meta',
+      signal: 'format_compliance',
+      agentId,
+      taskId,
+      value: compliance.formatCompliant ? 1 : 0,
+      metadata: {
+        findingCount: compliance.findingCount,
+        citationCount: compliance.citationCount,
+        tags_total: compliance.tags_total,
+        tags_accepted: compliance.tags_accepted,
+        tags_dropped_unknown_type: compliance.tags_dropped_unknown_type,
+        tags_dropped_short_content: compliance.tags_dropped_short_content,
+        diagnostic_codes: compliance.diagnostics.map(d => d.code),
+      },
+      timestamp: now,
+    } as MetaSignal);
+
+    // ── finding_dropped_format (pipeline) ─────────────────────────────────
+    // Bug f1: native path never emitted this — zero type:pipeline entries in
+    // agent-performance.jsonl for native agents. This is the event that would
+    // have caught the drop-gate bug in-session.
+    const droppedTotal = compliance.tags_dropped_unknown_type + compliance.tags_dropped_short_content;
+    if (droppedTotal > 0) {
+      signals.push({
+        type: 'pipeline',
+        signal: 'finding_dropped_format',
+        agentId,
+        taskId,
+        value: droppedTotal,
+        metadata: {
+          tags_total: compliance.tags_total,
+          tags_accepted: compliance.tags_accepted,
+          tags_dropped_unknown_type: compliance.tags_dropped_unknown_type,
+          tags_dropped_short_content: compliance.tags_dropped_short_content,
+          diagnostic_codes: compliance.diagnostics.map(d => d.code),
+        },
+        timestamp: now,
+      } as PipelineSignal);
+    }
+
+    const writer = new PerformanceWriter(projectRoot);
+    writer.appendSignals(signals);
+  } catch (err) {
+    process.stderr.write(`[gossipcat] emitCompletionSignals failed: ${(err as Error).message}\n`);
+  }
+}

--- a/packages/orchestrator/src/dispatch-pipeline.ts
+++ b/packages/orchestrator/src/dispatch-pipeline.ts
@@ -465,6 +465,15 @@ export class DispatchPipeline {
                 error: event.payload.error,
                 timestamp: new Date().toISOString(),
               }) + '\n');
+              // Emit task_completed with error:true so downstream scorers get failure-rate
+              // and latency data from relay tasks (consensus bac850a6-eeb048e3, f2).
+              emitCompletionSignals(this.projectRoot, {
+                agentId: entry.agentId,
+                taskId: entry.id,
+                result: '',
+                elapsedMs,
+                error: true,
+              });
             } catch { /* best-effort */ }
             throw new Error(event.payload.error);
           default:

--- a/packages/orchestrator/src/dispatch-pipeline.ts
+++ b/packages/orchestrator/src/dispatch-pipeline.ts
@@ -13,8 +13,7 @@ import { TaskGraph } from './task-graph';
 import { SkillCatalog } from './skill-catalog';
 import { SkillGapTracker } from './skill-gap-tracker';
 import { GossipPublisher } from './gossip-publisher';
-import { PerformanceWriter, rotateJsonlIfNeeded } from './performance-writer';
-import { MetaSignal, PipelineSignal } from './consensus-types';
+import { rotateJsonlIfNeeded } from './performance-writer';
 import { ScopeTracker } from './scope-tracker';
 import { WorktreeManager } from './worktree-manager';
 import { TaskGraphSync } from './task-graph-sync';
@@ -32,6 +31,7 @@ import { SessionContext } from './session-context';
 import { parseAgentFindingsStrict } from './parse-findings';
 import { extractCategories } from './category-extractor';
 import { inferTaskType } from './task-type-inference';
+import { emitCompletionSignals } from './completion-signals';
 
 import { gossipLog as log } from './log';
 
@@ -431,39 +431,16 @@ export class DispatchPipeline {
                 timestamp: new Date().toISOString(),
               }) + '\n');
             } catch { /* best-effort visibility — never crash dispatch on log/write failure */ }
-            // Emit meta signals for non-consensus dispatch telemetry
-            try {
-              const perfWriter = new PerformanceWriter(this.projectRoot);
-              const now = new Date().toISOString();
-              const durationMs = (entry.completedAt ?? Date.now()) - entry.startedAt;
-              const compliance = detectFormatCompliance(event.payload.result ?? '');
-              const metaSignals: MetaSignal[] = [
-                { type: 'meta', signal: 'task_completed', agentId: entry.agentId, taskId: entry.id, value: durationMs, timestamp: now },
-                { type: 'meta', signal: 'task_tool_turns', agentId: entry.agentId, taskId: entry.id, value: entry.toolCalls ?? 0, timestamp: now },
-                { type: 'meta', signal: 'format_compliance', agentId: entry.agentId, taskId: entry.id, value: compliance.formatCompliant ? 1 : 0, metadata: { findingCount: compliance.findingCount, citationCount: compliance.citationCount, tags_total: compliance.tags_total, tags_accepted: compliance.tags_accepted, tags_dropped_unknown_type: compliance.tags_dropped_unknown_type, tags_dropped_short_content: compliance.tags_dropped_short_content, diagnostic_codes: compliance.diagnostics.map(d => d.code) }, timestamp: now },
-              ];
-              // Priority pipeline emission: finding_dropped_format. Fires whenever
-              // parseAgentFindingsStrict drops tags by unknown type or short
-              // content. This is the event that would have caught the drop-gate
-              // bug in-session. Zero extra LLM cost; reuses detectFormatCompliance.
-              const droppedTotal = compliance.tags_dropped_unknown_type + compliance.tags_dropped_short_content;
-              const pipelineSignals: PipelineSignal[] = droppedTotal > 0 ? [{
-                type: 'pipeline',
-                signal: 'finding_dropped_format',
-                agentId: entry.agentId,
-                taskId: entry.id,
-                value: droppedTotal,
-                metadata: {
-                  tags_total: compliance.tags_total,
-                  tags_accepted: compliance.tags_accepted,
-                  tags_dropped_unknown_type: compliance.tags_dropped_unknown_type,
-                  tags_dropped_short_content: compliance.tags_dropped_short_content,
-                  diagnostic_codes: compliance.diagnostics.map(d => d.code),
-                },
-                timestamp: now,
-              }] : [];
-              perfWriter.appendSignals([...metaSignals, ...pipelineSignals]);
-            } catch { /* best-effort — never crash dispatch on signal write failure */ }
+            // Emit task_completed + task_tool_turns + format_compliance + finding_dropped_format
+            // via shared helper — eliminates native/relay signal-pipeline drift.
+            emitCompletionSignals(this.projectRoot, {
+              agentId: entry.agentId,
+              taskId: entry.id,
+              result: event.payload.result ?? '',
+              elapsedMs: (entry.completedAt ?? Date.now()) - entry.startedAt,
+              toolCalls: entry.toolCalls,
+              memoryQueryCalled: entry.memoryQueryCalled,
+            });
             return event.payload;
           case TaskStreamEventType.ERROR:
             entry.status = 'failed';
@@ -1163,12 +1140,12 @@ export class DispatchPipeline {
   }
 
   /** Record a native agent task completion in TaskGraph */
-  recordNativeTaskCompleted(taskId: string, result: string, error?: string, durationMs?: number): void {
+  recordNativeTaskCompleted(taskId: string, result: string, error?: string, durationMs?: number, memoryQueryCalled?: boolean): void {
     const duration = durationMs ?? -1;
     if (error) {
-      this.taskGraph.recordFailed(taskId, error, duration);
+      this.taskGraph.recordFailed(taskId, error, duration, undefined, undefined, memoryQueryCalled);
     } else {
-      this.taskGraph.recordCompleted(taskId, (result || '').slice(0, 4000), duration);
+      this.taskGraph.recordCompleted(taskId, (result || '').slice(0, 4000), duration, undefined, undefined, memoryQueryCalled);
     }
   }
 
@@ -1199,6 +1176,8 @@ export class DispatchPipeline {
   getSessionGossip() { return this.sessionContext.getSessionGossip(); }
   getLlm(): ILLMProvider | null { return this.llm; }
   getAgentConfig(agentId: string): AgentConfig | undefined { return this.registryGet(agentId); }
+  /** Expose perfReader for native path memory writes (bug f9: use accuracy-weighted writeKnowledgeFromResult). */
+  getPerfReader(): PerformanceReader | null { return this.perfReader; }
 
   // Track which (agentId, category) pairs have been suggested this session to avoid repeats
   private suggestedSkillGaps = new Set<string>();

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -89,3 +89,5 @@ export { MemorySearcher } from './memory-searcher';
 export type { SearchResult } from './memory-searcher';
 export { oneSidedZTest, resolveVerdict, MIN_EVIDENCE, ALPHA, Z_CRITICAL, TIMEOUT_DAYS, TIMEOUT_MS } from './check-effectiveness';
 export type { VerdictStatus, SkillSnapshot, CategoryCounters, VerdictResult } from './check-effectiveness';
+export { emitCompletionSignals } from './completion-signals';
+export type { CompletionSignalInput } from './completion-signals';

--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -259,6 +259,7 @@ export class MainAgent {
   getSkillIndex(): any { return this.pipeline.getSkillIndex(); }
   getLlm() { return this.pipeline.getLlm(); }
   getAgentConfig(agentId: string) { return this.pipeline.getAgentConfig(agentId); }
+  getPerfReader() { return this.pipeline.getPerfReader(); }
 
   /** Health check for active tasks — diagnostics for "is it working?" */
   getActiveTasksHealth() { return this.pipeline.getActiveTasksHealth(); }
@@ -302,10 +303,15 @@ export class MainAgent {
   }
 
   /** Record a native agent task completion in the TaskGraph */
-  recordNativeTaskCompleted(taskId: string, result: string, error?: string, durationMs?: number): void {
+  recordNativeTaskCompleted(taskId: string, result: string, error?: string, durationMs?: number, memoryQueryCalled?: boolean): void {
     try {
-      this.pipeline.recordNativeTaskCompleted(taskId, result, error, durationMs);
+      this.pipeline.recordNativeTaskCompleted(taskId, result, error, durationMs, memoryQueryCalled);
     } catch { /* best-effort */ }
+  }
+
+  /** Get the WorktreeManager from the dispatch pipeline (for native worktree cleanup). */
+  getWorktreeManager(): import('./worktree-manager').WorktreeManager {
+    return (this.pipeline as any).worktreeManager;
   }
 
   /** Get current orchestrator model info */

--- a/packages/orchestrator/src/parse-findings.ts
+++ b/packages/orchestrator/src/parse-findings.ts
@@ -253,11 +253,12 @@ export function parseAgentFindingsStrict(
     const attrs = match[1];
     let content = match[2].trim();
 
-    if (!content || content.length < MIN_FINDING_CONTENT) {
-      droppedShortContent++;
-      continue;
-    }
-
+    // Type-enum validation MUST precede short-content validation. An invalid
+    // type is a stricter contract violation than short content — if both apply,
+    // the drop must be attributed to `tags_dropped_unknown_type` (or
+    // `tags_dropped_missing_type`), not `tags_dropped_short_content`. Dashboard
+    // drift detection uses these buckets to distinguish agent-prompt schema
+    // regressions from mere verbosity issues; misattribution masks regressions.
     const typeMatch = attrs.match(TYPE_ATTR_PATTERN);
     if (!typeMatch) {
       droppedMissingType++;
@@ -275,6 +276,11 @@ export function parseAgentFindingsStrict(
           // Caller's logger should not break parsing.
         }
       }
+      continue;
+    }
+
+    if (!content || content.length < MIN_FINDING_CONTENT) {
+      droppedShortContent++;
       continue;
     }
 

--- a/packages/orchestrator/src/task-graph.ts
+++ b/packages/orchestrator/src/task-graph.ts
@@ -81,21 +81,23 @@ export class TaskGraph {
     this.appendEvent(event);
   }
 
-  recordCompleted(taskId: string, result: string, duration: number, inputTokens?: number, outputTokens?: number): void {
+  recordCompleted(taskId: string, result: string, duration: number, inputTokens?: number, outputTokens?: number, memoryQueryCalled?: boolean): void {
     const event: TaskCompletedEvent = {
       type: 'task.completed', taskId, result: this.redactSecrets(result.slice(0, 4000)), duration,
       ...(inputTokens !== undefined ? { inputTokens } : {}),
       ...(outputTokens !== undefined ? { outputTokens } : {}),
+      ...(memoryQueryCalled !== undefined ? { memoryQueryCalled } : {}),
       timestamp: new Date().toISOString(),
     };
     this.appendEvent(event);
   }
 
-  recordFailed(taskId: string, error: string, duration: number, inputTokens?: number, outputTokens?: number): void {
+  recordFailed(taskId: string, error: string, duration: number, inputTokens?: number, outputTokens?: number, memoryQueryCalled?: boolean): void {
     const event: TaskFailedEvent = {
       type: 'task.failed', taskId, error: this.redactSecrets(error), duration,
       ...(inputTokens !== undefined ? { inputTokens } : {}),
       ...(outputTokens !== undefined ? { outputTokens } : {}),
+      ...(memoryQueryCalled !== undefined ? { memoryQueryCalled } : {}),
       timestamp: new Date().toISOString(),
     };
     this.appendEvent(event);

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -272,6 +272,8 @@ export interface TaskCompletedEvent {
   duration: number;
   inputTokens?: number;
   outputTokens?: number;
+  /** Whether the agent called memory_query during this task (compliance auditing). */
+  memoryQueryCalled?: boolean;
   timestamp: string;
 }
 
@@ -282,6 +284,8 @@ export interface TaskFailedEvent {
   duration: number;
   inputTokens?: number;
   outputTokens?: number;
+  /** Whether the agent called memory_query before failing (compliance auditing). */
+  memoryQueryCalled?: boolean;
   timestamp: string;
 }
 

--- a/tests/orchestrator/completion-signals.test.ts
+++ b/tests/orchestrator/completion-signals.test.ts
@@ -153,4 +153,34 @@ More content here to ensure we exceed the minimum length threshold for rejection
       emitCompletionSignals('/nonexistent-path-that-cannot-exist/gossip', BASE_INPUT)
     ).not.toThrow();
   });
+
+  test('memoryQueryCalled:false explicitly serializes as false (not undefined) in task_tool_turns metadata', () => {
+    emitCompletionSignals(testDir, { ...BASE_INPUT, toolCalls: 2, memoryQueryCalled: false });
+    const sigs = readSignals();
+    const toolTurns = sigs.find(s => s.signal === 'task_tool_turns');
+    expect(toolTurns).toBeDefined();
+    expect(toolTurns.metadata).toBeDefined();
+    // Must be false, not undefined — explicit false means "agent had tools but did not query memory"
+    expect(toolTurns.metadata.memoryQueryCalled).toBe(false);
+  });
+
+  test('error:true path — task_completed has metadata.error:true', () => {
+    emitCompletionSignals(testDir, { ...BASE_INPUT, elapsedMs: 3000, error: true });
+    const sigs = readSignals();
+    const completed = sigs.find(s => s.signal === 'task_completed');
+    expect(completed).toBeDefined();
+    expect(completed.value).toBe(3000);
+    expect(completed.metadata?.error).toBe(true);
+    expect(completed.metadata?.estimated).toBeUndefined();
+  });
+
+  test('error:true + elapsedMs:null — task_completed has both estimated:true AND error:true', () => {
+    emitCompletionSignals(testDir, { ...BASE_INPUT, elapsedMs: null, error: true });
+    const sigs = readSignals();
+    const completed = sigs.find(s => s.signal === 'task_completed');
+    expect(completed).toBeDefined();
+    expect(completed.value).toBe(0);
+    expect(completed.metadata?.estimated).toBe(true);
+    expect(completed.metadata?.error).toBe(true);
+  });
 });

--- a/tests/orchestrator/completion-signals.test.ts
+++ b/tests/orchestrator/completion-signals.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for emitCompletionSignals (packages/orchestrator/src/completion-signals.ts).
+ *
+ * Covers:
+ * - task_completed always emitted (f11: was suppressed when elapsed null)
+ * - task_completed with estimated:true when elapsedMs null
+ * - task_tool_turns emitted when toolCalls defined
+ * - task_tool_turns NOT emitted when toolCalls undefined (F16 preserve)
+ * - format_compliance always emitted WITH diagnostic_codes (f4)
+ * - finding_dropped_format emitted when droppedTotal > 0 (f1)
+ * - finding_dropped_format NOT emitted when nothing dropped
+ * - never throws on write failure
+ */
+
+import { emitCompletionSignals } from '@gossip/orchestrator';
+import { readFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('emitCompletionSignals', () => {
+  const testDir = join(tmpdir(), 'gossip-completion-signals-' + Date.now());
+  const gossipDir = join(testDir, '.gossip');
+  const perfFile = join(gossipDir, 'agent-performance.jsonl');
+
+  beforeAll(() => mkdirSync(gossipDir, { recursive: true }));
+  afterAll(() => rmSync(testDir, { recursive: true, force: true }));
+
+  const readSignals = () =>
+    readFileSync(perfFile, 'utf-8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map(l => JSON.parse(l));
+
+  const BASE_INPUT = {
+    agentId: 'test-agent',
+    taskId: 'task-abc',
+    result: '',
+    elapsedMs: 1234,
+  };
+
+  beforeEach(() => {
+    // Reset file between tests
+    try { rmSync(perfFile); } catch { /* may not exist */ }
+  });
+
+  test('emits task_completed with measured duration', () => {
+    emitCompletionSignals(testDir, { ...BASE_INPUT, elapsedMs: 5000 });
+    const sigs = readSignals();
+    const completed = sigs.find(s => s.signal === 'task_completed');
+    expect(completed).toBeDefined();
+    expect(completed.type).toBe('meta');
+    expect(completed.value).toBe(5000);
+    expect(completed.agentId).toBe('test-agent');
+    expect(completed.taskId).toBe('task-abc');
+    expect(completed.metadata?.estimated).toBeUndefined();
+  });
+
+  test('emits task_completed with value 0 and estimated:true when elapsedMs is null (bug f11)', () => {
+    emitCompletionSignals(testDir, { ...BASE_INPUT, elapsedMs: null });
+    const sigs = readSignals();
+    const completed = sigs.find(s => s.signal === 'task_completed');
+    expect(completed).toBeDefined();
+    expect(completed.value).toBe(0);
+    expect(completed.metadata?.estimated).toBe(true);
+  });
+
+  test('emits task_tool_turns when toolCalls defined', () => {
+    emitCompletionSignals(testDir, { ...BASE_INPUT, toolCalls: 7 });
+    const sigs = readSignals();
+    const toolTurns = sigs.find(s => s.signal === 'task_tool_turns');
+    expect(toolTurns).toBeDefined();
+    expect(toolTurns.value).toBe(7);
+  });
+
+  test('does NOT emit task_tool_turns when toolCalls undefined (F16 preserve)', () => {
+    // toolCalls omitted — native agent path
+    emitCompletionSignals(testDir, { ...BASE_INPUT });
+    const sigs = readSignals();
+    const toolTurns = sigs.find(s => s.signal === 'task_tool_turns');
+    expect(toolTurns).toBeUndefined();
+  });
+
+  test('emits format_compliance always with diagnostic_codes in metadata (bug f4)', () => {
+    emitCompletionSignals(testDir, { ...BASE_INPUT, result: '<agent_finding type="finding">...</agent_finding>' });
+    const sigs = readSignals();
+    const fc = sigs.find(s => s.signal === 'format_compliance');
+    expect(fc).toBeDefined();
+    expect(fc.type).toBe('meta');
+    expect(fc.metadata).toBeDefined();
+    // diagnostic_codes must be present (even if empty array)
+    expect(Array.isArray(fc.metadata.diagnostic_codes)).toBe(true);
+  });
+
+  test('emits format_compliance even on empty result', () => {
+    emitCompletionSignals(testDir, { ...BASE_INPUT, result: '' });
+    const sigs = readSignals();
+    const fc = sigs.find(s => s.signal === 'format_compliance');
+    expect(fc).toBeDefined();
+    expect(fc.value).toBe(0); // not compliant with empty result
+  });
+
+  test('emits finding_dropped_format when tags are dropped (bug f1)', () => {
+    // An agent_finding with unknown type "approval" is dropped by strict parser
+    const resultWithDroppedTag = `<agent_finding type="approval" severity="high">
+This is definitely long enough content to not be dropped for short-content reasons.
+More content here to ensure we exceed the minimum length threshold for rejection.
+</agent_finding>`;
+    emitCompletionSignals(testDir, { ...BASE_INPUT, result: resultWithDroppedTag });
+    const sigs = readSignals();
+    const dropped = sigs.find(s => s.signal === 'finding_dropped_format');
+    expect(dropped).toBeDefined();
+    expect(dropped.type).toBe('pipeline');
+    expect(dropped.value).toBeGreaterThan(0);
+    expect(dropped.metadata?.diagnostic_codes).toBeDefined();
+  });
+
+  test('does NOT emit finding_dropped_format when nothing dropped', () => {
+    // No agent_finding tags → nothing to drop
+    emitCompletionSignals(testDir, { ...BASE_INPUT, result: 'Plain text result with no tags.' });
+    const sigs = readSignals();
+    const dropped = sigs.find(s => s.signal === 'finding_dropped_format');
+    expect(dropped).toBeUndefined();
+  });
+
+  test('emits all 3 meta signals in normal case (task_completed + format_compliance + task_tool_turns)', () => {
+    emitCompletionSignals(testDir, { ...BASE_INPUT, result: 'result', elapsedMs: 500, toolCalls: 3 });
+    const sigs = readSignals();
+    const types = sigs.map(s => s.signal);
+    expect(types).toContain('task_completed');
+    expect(types).toContain('format_compliance');
+    expect(types).toContain('task_tool_turns');
+  });
+
+  test('emits only 2 meta signals for native agents (no task_tool_turns)', () => {
+    emitCompletionSignals(testDir, { ...BASE_INPUT, result: 'result', elapsedMs: 500 });
+    const sigs = readSignals();
+    const types = sigs.map(s => s.signal);
+    expect(types).toContain('task_completed');
+    expect(types).toContain('format_compliance');
+    expect(types).not.toContain('task_tool_turns');
+  });
+
+  test('threads memoryQueryCalled into task_tool_turns metadata', () => {
+    emitCompletionSignals(testDir, { ...BASE_INPUT, toolCalls: 4, memoryQueryCalled: true });
+    const sigs = readSignals();
+    const toolTurns = sigs.find(s => s.signal === 'task_tool_turns');
+    expect(toolTurns?.metadata?.memoryQueryCalled).toBe(true);
+  });
+
+  test('never throws — invalid projectRoot path swallows error', () => {
+    expect(() =>
+      emitCompletionSignals('/nonexistent-path-that-cannot-exist/gossip', BASE_INPUT)
+    ).not.toThrow();
+  });
+});

--- a/tests/orchestrator/parse-findings.test.ts
+++ b/tests/orchestrator/parse-findings.test.ts
@@ -349,6 +349,48 @@ and a second paragraph.
     });
   });
 
+  // Drop attribution priority: type-enum check must precede short-content check.
+  // An invalid type is a stricter contract violation than short content; the
+  // attribution bucket must reflect the worst violation so dashboard drift
+  // detection is accurate.
+  describe('drop attribution priority (type-enum before short-content)', () => {
+    it('invalid type + short content → tags_dropped_unknown_type (not tags_dropped_short_content)', () => {
+      // Regression test: previously the short-content check ran first, so this
+      // tag was wrongly attributed to droppedShortContent instead of droppedUnknownType.
+      const raw = `<agent_finding type="approval">pipe test 1</agent_finding>`;
+      const res = parseAgentFindingsStrict(raw);
+      expect(res.findings).toHaveLength(0);
+      expect(res.rawTagCount).toBe(1);
+      // Must land in the unknown-type bucket, NOT in the short-content bucket.
+      expect(res.droppedUnknownType['approval']).toBe(1);
+      expect(res.droppedShortContent).toBe(0);
+    });
+
+    it('invalid type + valid content → tags_dropped_unknown_type', () => {
+      const raw = `<agent_finding type="approval">This is a long enough content string for the parser</agent_finding>`;
+      const res = parseAgentFindingsStrict(raw);
+      expect(res.findings).toHaveLength(0);
+      expect(res.droppedUnknownType['approval']).toBe(1);
+      expect(res.droppedShortContent).toBe(0);
+    });
+
+    it('valid type + short content → tags_dropped_short_content (unchanged)', () => {
+      const raw = `<agent_finding type="finding" severity="high">too short</agent_finding>`;
+      const res = parseAgentFindingsStrict(raw);
+      expect(res.findings).toHaveLength(0);
+      expect(res.droppedShortContent).toBe(1);
+      expect(Object.keys(res.droppedUnknownType)).toHaveLength(0);
+    });
+
+    it('valid type + valid content → tags_accepted (unchanged)', () => {
+      const raw = `<agent_finding type="finding" severity="high">This is a valid finding with enough content here</agent_finding>`;
+      const res = parseAgentFindingsStrict(raw);
+      expect(res.findings).toHaveLength(1);
+      expect(res.droppedShortContent).toBe(0);
+      expect(Object.keys(res.droppedUnknownType)).toHaveLength(0);
+    });
+  });
+
   // Schema-drift diagnostics — see docs/specs/2026-04-16-schema-drift-diagnostic.md
   // Six cases mandated by the spec's "Validation" section.
   describe('schema drift diagnostics', () => {

--- a/tests/orchestrator/signal-type-snapshot.test.ts
+++ b/tests/orchestrator/signal-type-snapshot.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Snapshot test: every SignalType in PerformanceSignal union must either:
+ * A) have an emission site in completion-signals.ts, OR
+ * B) be documented as path-specific in the DOCUMENTED_PATH_SPECIFIC set below.
+ *
+ * Purpose: when someone adds a new signal type, this test forces them to
+ * either wire it into emitCompletionSignals OR explicitly document why it
+ * lives somewhere else. Prevents silent signal-pipeline drift (the original
+ * bug that took consensus 23687227-1462428b to find).
+ */
+
+import type { PerformanceSignal } from '@gossip/orchestrator';
+
+// ── Signal types emitted by emitCompletionSignals ────────────────────────────
+const COMPLETION_SIGNALS_EMITTED = new Set<string>([
+  'task_completed',
+  'task_tool_turns',   // conditionally (when toolCalls defined)
+  'format_compliance',
+  'finding_dropped_format',
+]);
+
+// ── Path-specific signals: not emitted by emitCompletionSignals ──────────────
+// These are intentionally NOT in the shared helper because they have
+// specific dispatch contexts. Document the emission site here.
+const DOCUMENTED_PATH_SPECIFIC = new Map<string, string>([
+  // Consensus signals — emitted by ConsensusCoordinator / gossip_signals handler
+  ['agreement',                 'consensus-engine.ts / gossip_signals'],
+  ['disagreement',              'consensus-engine.ts / gossip_signals'],
+  ['unverified',                'consensus-engine.ts / gossip_signals'],
+  ['unique_confirmed',          'consensus-engine.ts / gossip_signals'],
+  ['unique_unconfirmed',        'consensus-engine.ts / gossip_signals'],
+  ['new_finding',               'consensus-engine.ts / gossip_signals'],
+  ['hallucination_caught',      'gossip_signals'],
+  ['category_confirmed',        'consensus-engine.ts'],
+  ['consensus_verified',        'consensus-engine.ts'],
+  ['signal_retracted',          'performance-writer.ts / gossip_signals'],
+  ['consensus_round_retracted', 'performance-writer.ts / gossip_signals'],
+  ['severity_miscalibrated',    'consensus-engine.ts'],
+  ['task_timeout',              'dispatch-pipeline.ts (timeout path)'],
+  ['task_empty',                'dispatch-pipeline.ts (empty result path)'],
+  // Impl signals — emitted by verify_write / auto-record in native-tasks.ts
+  ['impl_test_pass',            'native-tasks.ts / verify_write handler'],
+  ['impl_test_fail',            'native-tasks.ts / verify_write handler'],
+  ['impl_peer_approved',        'gossip_signals'],
+  ['impl_peer_rejected',        'gossip_signals'],
+  // Pipeline signals other than finding_dropped_format
+  ['dispatch_started',          'dispatch-pipeline.ts (dispatch entry)'],
+  ['relay_received',            'dispatch-pipeline.ts (relay receive)'],
+  ['synthesis_completed',       'consensus-coordinator.ts'],
+  ['circuit_open_fired',        'performance-reader.ts / dispatch-pipeline.ts'],
+  ['skill_injection_skipped',   'prompt-assembler.ts'],
+]);
+
+// ── Exhaustive union of all known signal names ─────────────────────────────
+// Derived from the consensus-types.ts union. Update this list when adding
+// new signal types — the test will fail if the list gets out of sync with
+// the DOCUMENTED_PATH_SPECIFIC map.
+const ALL_KNOWN_SIGNAL_NAMES: string[] = [
+  // ConsensusSignal
+  'agreement', 'disagreement', 'unverified', 'unique_confirmed', 'unique_unconfirmed',
+  'new_finding', 'hallucination_caught', 'category_confirmed', 'consensus_verified',
+  'signal_retracted', 'consensus_round_retracted', 'severity_miscalibrated',
+  'task_timeout', 'task_empty',
+  // ImplSignal
+  'impl_test_pass', 'impl_test_fail', 'impl_peer_approved', 'impl_peer_rejected',
+  // MetaSignal
+  'task_completed', 'task_tool_turns', 'format_compliance',
+  // PipelineSignal
+  'dispatch_started', 'relay_received', 'finding_dropped_format',
+  'synthesis_completed', 'circuit_open_fired', 'skill_injection_skipped',
+  // signal_retracted appears in both ConsensusSignal and PipelineSignal
+];
+
+describe('SignalType snapshot — every type has a documented emission site', () => {
+  test('every signal name is either in completion-signals.ts or documented as path-specific', () => {
+    const undocumented: string[] = [];
+    for (const name of ALL_KNOWN_SIGNAL_NAMES) {
+      if (!COMPLETION_SIGNALS_EMITTED.has(name) && !DOCUMENTED_PATH_SPECIFIC.has(name)) {
+        undocumented.push(name);
+      }
+    }
+    expect(undocumented).toEqual([]);
+  });
+
+  test('no signal_retracted-style duplicates — signal_retracted is documented', () => {
+    // signal_retracted is in both ConsensusSignal and PipelineSignal.
+    // It should be documented (either in COMPLETION_SIGNALS_EMITTED or
+    // DOCUMENTED_PATH_SPECIFIC) — not silently missing.
+    expect(
+      COMPLETION_SIGNALS_EMITTED.has('signal_retracted') ||
+      DOCUMENTED_PATH_SPECIFIC.has('signal_retracted')
+    ).toBe(true);
+  });
+
+  test('completion-signals emits task_completed, format_compliance, and finding_dropped_format', () => {
+    expect(COMPLETION_SIGNALS_EMITTED.has('task_completed')).toBe(true);
+    expect(COMPLETION_SIGNALS_EMITTED.has('format_compliance')).toBe(true);
+    expect(COMPLETION_SIGNALS_EMITTED.has('finding_dropped_format')).toBe(true);
+  });
+
+  test('task_tool_turns is in completion-signals (conditional F16 emit)', () => {
+    expect(COMPLETION_SIGNALS_EMITTED.has('task_tool_turns')).toBe(true);
+  });
+
+  // Type-level check: ensures PerformanceSignal union is importable and non-empty
+  test('PerformanceSignal type is importable', () => {
+    const sig: PerformanceSignal = {
+      type: 'meta',
+      signal: 'task_completed',
+      agentId: 'a',
+      taskId: 't',
+      value: 100,
+      timestamp: new Date().toISOString(),
+    };
+    expect(sig.type).toBe('meta');
+  });
+});


### PR DESCRIPTION
## Summary
- New `emitCompletionSignals` helper in `packages/orchestrator/src/completion-signals.ts` as single source of truth for completion-time signals from both native and relay paths
- Fixes 9 asymmetries identified in consensus `23687227-1462428b`: f1 (finding_dropped_format on native), f4 (diagnostic_codes), f8/f10 (memoryQueryCalled threading), f9 (perfReader.getAgentScore), f11 (task_completed fallback), f13 (worktree cleanup on error), error-path signal emission, memoryQueryCalled:false coverage
- Deferred to Layer 2 follow-up (backlog: `project_signal_pipeline_drift_detection.md`): snapshot test compile-time derivation, PerformanceWriter export restriction
- Reviewed via consensus `bac850a6-eeb048e3` — caught and fixed an f13 regression where `cleanup(taskId, undefined)` failed silently; now uses `pruneOrphans()`

## Commits
- `535ade3` shared emitCompletionSignals helper + 7 bug fixes (502/-86 LOC)
- `db1b1c4` f13 regression fix + error-path task_completed + memoryQueryCalled:false coverage (62/-7 LOC)

## Test plan
- [x] 2034 tests pass (2 new suites, 20 new tests)
- [x] Typecheck clean on all workspaces
- [ ] Post-merge smoke: dispatch a task with malformed tags, verify `grep '"type":"pipeline"' .gossip/agent-performance.jsonl` returns a `finding_dropped_format` entry for a native agent
- [ ] Post-merge smoke: dispatch a task that errors, verify `task_completed` emits with `metadata.error:true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)