### PR TITLE
feat(relay): Option 1 memoryQueryCalled attribution for native agents

### DIFF
--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -3,6 +3,7 @@
  * All state accessed via the shared context object.
  */
 import { randomUUID } from 'crypto';
+import { hasMemoryQuery } from '@gossip/relay';
 import { ctx, NATIVE_TASK_TTL_MS, defaultImportanceScores } from '../mcp-context';
 
 /** Active timeout watchers — keyed by task ID */
@@ -347,6 +348,21 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
   // 0. Record in TaskGraph (makes native tasks visible to CLI + Supabase sync)
   // Pass null duration through — recordNativeTaskCompleted handles undefined/null via ?? -1
   // Bug f8: thread memoryQueryCalled so TaskGraph records compliance auditing data.
+  //
+  // Option 1 attribution (project_memory_query_observability.md): when the
+  // native agent invoked memory_query / gossip_remember during this task,
+  // the relay router buffered (agent_id, ts) entries. Query the window
+  // [taskInfo.startedAt, now+2s] (small forward slack absorbs clock skew
+  // between MCP call decode time and the relay record time). Only set
+  // memoryQueryCalled when the lookup says true — preserve undefined
+  // semantics so absence is distinguishable from "checked, did not call".
+  if (taskInfo.memoryQueryCalled === undefined && !taskInfo.utilityType && agentId !== '_utility') {
+    try {
+      if (hasMemoryQuery(agentId, taskInfo.startedAt, Date.now() + 2000)) {
+        taskInfo.memoryQueryCalled = true;
+      }
+    } catch { /* best-effort — attribution never blocks completion */ }
+  }
   try { ctx.mainAgent.recordNativeTaskCompleted(task_id, result, error || undefined, elapsed ?? undefined, taskInfo.memoryQueryCalled); } catch { /* best-effort */ }
 
   // 0a. Auto-record impl signal for write-mode tasks (gate on error param only — string heuristics are unreliable)

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -3687,6 +3687,8 @@ server.tool(
     // (agent_id, ts) record into the buffer here so native-tasks.handleRelay
     // can attribute the call back to the parent dispatch task.
     try {
+      // `@gossip/relay` was already loaded by boot() → getModules() above,
+      // so this resolves from the module cache with no first-call latency.
       const { recordMemoryQueryAttribution } = await import('@gossip/relay');
       recordMemoryQueryAttribution(agent_id, 'gossip_remember');
     } catch { /* best-effort — attribution never blocks the tool */ }

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -3681,6 +3681,15 @@ server.tool(
     if (isReservedAgentId(agent_id)) {
       return { content: [{ type: 'text' as const, text: `Error: agent_id "${agent_id}" is reserved (underscore-prefixed ids other than "_project" are not allowed)` }] };
     }
+    // Option 1 attribution (project_memory_query_observability.md): native
+    // subagents reach gossip_remember through the MCP server, not the relay
+    // router, so the router-level hook can't see them. Mirror the same
+    // (agent_id, ts) record into the buffer here so native-tasks.handleRelay
+    // can attribute the call back to the parent dispatch task.
+    try {
+      const { recordMemoryQueryAttribution } = await import('@gossip/relay');
+      recordMemoryQueryAttribution(agent_id, 'gossip_remember');
+    } catch { /* best-effort — attribution never blocks the tool */ }
     const { MemorySearcher } = await import('@gossip/orchestrator');
     const { wrapMemoryEnvelope, recordMemoryQuery } = await import('@gossip/tools');
     const projectRoot = process.cwd();

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -8,4 +8,4 @@ export { SubscriptionManager } from './subscription-manager';
 export { PresenceTracker } from './presence';
 export { DashboardAuth, DashboardRouter, DashboardWs } from './dashboard';
 export type { DashboardEvent } from './dashboard';
-export { recordMemoryQueryAttribution, hasMemoryQuery, MEMORY_QUERY_TOOLS } from './memory-query-buffer';
+export { recordMemoryQueryAttribution, hasMemoryQuery, MEMORY_QUERY_TOOLS, sweepExpiredAgents } from './memory-query-buffer';

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -8,3 +8,4 @@ export { SubscriptionManager } from './subscription-manager';
 export { PresenceTracker } from './presence';
 export { DashboardAuth, DashboardRouter, DashboardWs } from './dashboard';
 export type { DashboardEvent } from './dashboard';
+export { recordMemoryQueryAttribution, hasMemoryQuery, MEMORY_QUERY_TOOLS } from './memory-query-buffer';

--- a/packages/relay/src/memory-query-buffer.ts
+++ b/packages/relay/src/memory-query-buffer.ts
@@ -74,6 +74,22 @@ export function recordMemoryQueryAttribution(agent_id: string, tool_name: string
 }
 
 /**
+ * Drop agent keys whose entries have all expired. Callers don't need this
+ * during normal operation (prune-on-insert keeps active agents tidy) but
+ * it prevents the outer Map from accumulating dead keys for agents that
+ * disconnect and never return. Call from a periodic sweep if desired.
+ */
+export function sweepExpiredAgents(nowMs: number = Date.now()): void {
+  const cutoff = nowMs - RETENTION_MS;
+  for (const [agent_id, entries] of buffer) {
+    while (entries.length > 0 && entries[0].ts < cutoff) {
+      entries.shift();
+    }
+    if (entries.length === 0) buffer.delete(agent_id);
+  }
+}
+
+/**
  * Did `agent_id` invoke any memory-query tool in the half-open window
  * [sinceMs, untilMs)? Returns false for unknown agents.
  */

--- a/packages/relay/src/memory-query-buffer.ts
+++ b/packages/relay/src/memory-query-buffer.ts
@@ -1,0 +1,95 @@
+/**
+ * Memory-query attribution buffer.
+ *
+ * When a native agent calls memory_query / gossip_remember during a dispatched
+ * task, the relay router sees the RPC_REQUEST and records (agent_id, ts) here.
+ * On task completion (gossip_relay), the native-tasks handler queries this
+ * buffer with the dispatch window [startedAt, now] to populate
+ * `memoryQueryCalled` on the TaskGraph entry.
+ *
+ * This is Option 1 from project_memory_query_observability.md — relay-side
+ * attribution. Avoids modifying the gossip_relay MCP schema or injecting
+ * markers into agent prompts.
+ *
+ * Bookkeeping:
+ *   - Per-agent ring of recent calls (cap 256 entries each).
+ *   - Anything older than 5 minutes is pruned on every insert (cheap O(n)
+ *     because arrays stay small under the 256-cap).
+ *
+ * The buffer is in-memory only. Across /mcp reconnects the relay process
+ * survives (it's the parent), so entries persist; if the relay itself
+ * restarts, in-flight tasks lose attribution — acceptable since the task
+ * itself would also be in flux.
+ */
+
+/** Tools whose invocation should be attributed as a memory query. */
+export const MEMORY_QUERY_TOOLS: ReadonlySet<string> = new Set([
+  'gossip_remember',
+  'memory_query',
+]);
+
+/** Cap per agent. Memory queries are infrequent (skill says one per task is the floor). */
+const PER_AGENT_CAP = 256;
+
+/** Anything older than this is discarded on insert. 5 minutes covers any realistic native task. */
+const RETENTION_MS = 5 * 60 * 1000;
+
+interface Entry {
+  tool: string;
+  ts: number;
+}
+
+const buffer: Map<string, Entry[]> = new Map();
+
+/**
+ * Record that `agent_id` invoked `tool_name` at `ts` (default: now).
+ * Caller is responsible for filtering by MEMORY_QUERY_TOOLS — recording a
+ * non-memory-query tool is a no-op (we still filter here defensively).
+ */
+export function recordMemoryQueryAttribution(agent_id: string, tool_name: string, ts?: number): void {
+  if (!MEMORY_QUERY_TOOLS.has(tool_name)) return;
+  if (!agent_id) return;
+
+  const now = ts ?? Date.now();
+  const cutoff = now - RETENTION_MS;
+
+  let entries = buffer.get(agent_id);
+  if (!entries) {
+    entries = [];
+    buffer.set(agent_id, entries);
+  }
+
+  // Prune anything older than the retention window. Arrays stay small (cap 256)
+  // so this O(n) pass is cheap and keeps memory bounded for long-lived agents.
+  while (entries.length > 0 && entries[0].ts < cutoff) {
+    entries.shift();
+  }
+
+  entries.push({ tool: tool_name, ts: now });
+
+  // Drop oldest if over per-agent cap.
+  while (entries.length > PER_AGENT_CAP) {
+    entries.shift();
+  }
+}
+
+/**
+ * Did `agent_id` invoke any memory-query tool in the half-open window
+ * [sinceMs, untilMs)? Returns false for unknown agents.
+ */
+export function hasMemoryQuery(agent_id: string, sinceMs: number, untilMs: number): boolean {
+  const entries = buffer.get(agent_id);
+  if (!entries || entries.length === 0) return false;
+  for (const entry of entries) {
+    if (entry.ts >= sinceMs && entry.ts < untilMs) return true;
+  }
+  return false;
+}
+
+/**
+ * Test-only reset. Not exported via index.ts; tests import from the module
+ * directly. Production code never calls this.
+ */
+export function _resetMemoryQueryBuffer(): void {
+  buffer.clear();
+}

--- a/packages/relay/src/router.ts
+++ b/packages/relay/src/router.ts
@@ -6,12 +6,14 @@
  */
 
 import { randomUUID } from 'crypto';
+import { decode as msgpackDecode } from '@msgpack/msgpack';
 import { MessageEnvelope, MessageType } from '@gossip/types';
 import { ConnectionManager } from './connection-manager';
 import { AgentConnection } from './agent-connection';
 import { ChannelManager } from './channels';
 import { SubscriptionManager } from './subscription-manager';
 import { PresenceTracker } from './presence';
+import { recordMemoryQueryAttribution, MEMORY_QUERY_TOOLS } from './memory-query-buffer';
 
 export interface RouterMetrics {
   messagesRouted: number;
@@ -53,6 +55,7 @@ export class MessageRouter {
           this.routeChannel(envelope);
           break;
         case MessageType.RPC_REQUEST:
+          this.attributeMemoryQuery(envelope);
           this.routeToAgent(envelope);
           break;
         case MessageType.RPC_RESPONSE:
@@ -93,6 +96,28 @@ export class MessageRouter {
         );
       } catch { /* ignore */ }
     }
+  }
+
+  /**
+   * Inspect an RPC_REQUEST body for a memory-query tool call and record
+   * (agent_id, ts) into the memory-query buffer. Best-effort: any decode
+   * failure is swallowed — message routing must not be blocked by
+   * attribution bookkeeping.
+   *
+   * RPC body wire format (worker-agent.ts:439): msgpack({ tool, args }).
+   * Only memory_query / gossip_remember are recorded; everything else
+   * short-circuits cheaply via MEMORY_QUERY_TOOLS lookup.
+   */
+  private attributeMemoryQuery(envelope: MessageEnvelope): void {
+    try {
+      if (!envelope.sid || !envelope.body || envelope.body.length === 0) return;
+      const decoded = msgpackDecode(envelope.body) as { tool?: unknown } | null;
+      if (!decoded || typeof decoded !== 'object') return;
+      const tool = decoded.tool;
+      if (typeof tool !== 'string') return;
+      if (!MEMORY_QUERY_TOOLS.has(tool)) return;
+      recordMemoryQueryAttribution(envelope.sid, tool, envelope.ts);
+    } catch { /* best-effort — never block routing */ }
   }
 
   private routeDirect(envelope: MessageEnvelope): void {

--- a/packages/relay/src/router.ts
+++ b/packages/relay/src/router.ts
@@ -116,7 +116,11 @@ export class MessageRouter {
       const tool = decoded.tool;
       if (typeof tool !== 'string') return;
       if (!MEMORY_QUERY_TOOLS.has(tool)) return;
-      recordMemoryQueryAttribution(envelope.sid, tool, envelope.ts);
+      // Server-authoritative timestamp. envelope.ts is client-stamped and
+      // trusted only for ordering; for attribution windows we use receive
+      // time so a stale/drifting client clock can't push entries outside
+      // the [taskStartedAt, now+slack) query window.
+      recordMemoryQueryAttribution(envelope.sid, tool);
     } catch { /* best-effort — never block routing */ }
   }
 

--- a/tests/relay/memory-query-buffer.test.ts
+++ b/tests/relay/memory-query-buffer.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Memory-query buffer — Option 1 attribution for native-agent memory_query
+ * observability. See project_memory_query_observability.md.
+ */
+import {
+  recordMemoryQueryAttribution,
+  hasMemoryQuery,
+  MEMORY_QUERY_TOOLS,
+  _resetMemoryQueryBuffer,
+} from '@gossip/relay/memory-query-buffer';
+
+describe('memory-query-buffer', () => {
+  beforeEach(() => {
+    _resetMemoryQueryBuffer();
+  });
+
+  it('records a memory_query call and returns true within the window', () => {
+    const start = Date.now();
+    recordMemoryQueryAttribution('opus-implementer', 'memory_query', start + 100);
+    expect(hasMemoryQuery('opus-implementer', start, start + 1000)).toBe(true);
+  });
+
+  it('returns false when the call is outside the requested window', () => {
+    const start = Date.now();
+    recordMemoryQueryAttribution('opus-implementer', 'gossip_remember', start - 5000);
+    expect(hasMemoryQuery('opus-implementer', start, start + 1000)).toBe(false);
+  });
+
+  it('returns false for a different agent', () => {
+    const start = Date.now();
+    recordMemoryQueryAttribution('agent-a', 'memory_query', start + 50);
+    expect(hasMemoryQuery('agent-b', start, start + 1000)).toBe(false);
+  });
+
+  it('ignores tools that are not memory queries', () => {
+    const start = Date.now();
+    recordMemoryQueryAttribution('agent-x', 'file_read', start + 10);
+    recordMemoryQueryAttribution('agent-x', 'self_identity', start + 20);
+    expect(hasMemoryQuery('agent-x', start, start + 1000)).toBe(false);
+  });
+
+  it('drops oldest entries when per-agent cap is exceeded', () => {
+    const base = Date.now() - 1000;
+    // Insert 300 entries — cap is 256.
+    for (let i = 0; i < 300; i++) {
+      recordMemoryQueryAttribution('agent-cap', 'memory_query', base + i);
+    }
+    // Earliest entries should be evicted: anything before base+44 is gone
+    // (300 - 256 = 44 dropped from the head).
+    expect(hasMemoryQuery('agent-cap', base, base + 44)).toBe(false);
+    // Most recent retained entries should still be visible.
+    expect(hasMemoryQuery('agent-cap', base + 44, base + 300)).toBe(true);
+  });
+
+  it('prunes entries older than the 5-minute retention window on insert', () => {
+    const now = Date.now();
+    // Stale entry from 6 minutes ago — should be pruned by the next insert.
+    recordMemoryQueryAttribution('agent-prune', 'memory_query', now - 6 * 60 * 1000);
+    // Fresh entry triggers the prune pass.
+    recordMemoryQueryAttribution('agent-prune', 'memory_query', now);
+    // The stale entry's window is no longer queryable.
+    expect(hasMemoryQuery('agent-prune', now - 7 * 60 * 1000, now - 5 * 60 * 1000 - 1)).toBe(false);
+    // The fresh entry is still there.
+    expect(hasMemoryQuery('agent-prune', now - 100, now + 1000)).toBe(true);
+  });
+
+  it('exposes both memory_query and gossip_remember as recognised tools', () => {
+    expect(MEMORY_QUERY_TOOLS.has('memory_query')).toBe(true);
+    expect(MEMORY_QUERY_TOOLS.has('gossip_remember')).toBe(true);
+    expect(MEMORY_QUERY_TOOLS.has('file_read')).toBe(false);
+  });
+});

--- a/tests/relay/memory-query-buffer.test.ts
+++ b/tests/relay/memory-query-buffer.test.ts
@@ -6,6 +6,7 @@ import {
   recordMemoryQueryAttribution,
   hasMemoryQuery,
   MEMORY_QUERY_TOOLS,
+  sweepExpiredAgents,
   _resetMemoryQueryBuffer,
 } from '@gossip/relay/memory-query-buffer';
 
@@ -68,5 +69,57 @@ describe('memory-query-buffer', () => {
     expect(MEMORY_QUERY_TOOLS.has('memory_query')).toBe(true);
     expect(MEMORY_QUERY_TOOLS.has('gossip_remember')).toBe(true);
     expect(MEMORY_QUERY_TOOLS.has('file_read')).toBe(false);
+  });
+
+  it('isolates agents under interleaved inserts', () => {
+    const t0 = Date.now();
+    for (let i = 0; i < 10; i++) {
+      recordMemoryQueryAttribution('agent-a', 'memory_query', t0 + i * 2);
+      recordMemoryQueryAttribution('agent-b', 'gossip_remember', t0 + i * 2 + 1);
+    }
+    // Both agents see their own hits.
+    expect(hasMemoryQuery('agent-a', t0, t0 + 1000)).toBe(true);
+    expect(hasMemoryQuery('agent-b', t0, t0 + 1000)).toBe(true);
+    // Narrow window to a slot only agent-a wrote (even offsets): hits agent-a, not agent-b.
+    expect(hasMemoryQuery('agent-a', t0, t0 + 1)).toBe(true);
+    expect(hasMemoryQuery('agent-b', t0, t0 + 1)).toBe(false);
+  });
+
+  it('hasMemoryQuery exclusive upper bound — entry at untilMs is excluded', () => {
+    const at = Date.now();
+    recordMemoryQueryAttribution('agent-edge', 'memory_query', at);
+    // Query with untilMs === at: half-open [at, at) excludes the exact point.
+    expect(hasMemoryQuery('agent-edge', at - 1, at)).toBe(false);
+    // Query with untilMs === at+1 includes it.
+    expect(hasMemoryQuery('agent-edge', at - 1, at + 1)).toBe(true);
+  });
+
+  it('native-tasks integration pattern: record during task window, observe on completion', () => {
+    // Simulates the shape of apps/cli/src/handlers/native-tasks.ts:handleNativeRelay.
+    // Agent dispatch starts at startedAt; mid-task the agent calls gossip_remember
+    // which fires recordMemoryQueryAttribution; on completion the handler checks the buffer
+    // using the same [startedAt, now+2000) window.
+    const startedAt = Date.now();
+    recordMemoryQueryAttribution('opus-implementer', 'gossip_remember', startedAt + 50);
+    const observed = hasMemoryQuery('opus-implementer', startedAt, Date.now() + 2000);
+    expect(observed).toBe(true);
+
+    // Sibling agent never invoked the tool — window returns false cleanly.
+    expect(hasMemoryQuery('sonnet-reviewer', startedAt, Date.now() + 2000)).toBe(false);
+
+    // An earlier task's memoryQueryCalled does not bleed into a fresh task's window.
+    const laterTaskStart = Date.now() + 3000;
+    expect(hasMemoryQuery('opus-implementer', laterTaskStart, laterTaskStart + 2000)).toBe(false);
+  });
+
+  it('sweepExpiredAgents drops dead keys from the outer Map', () => {
+    const longAgo = Date.now() - 10 * 60 * 1000; // older than 5-min retention
+    recordMemoryQueryAttribution('agent-gone', 'memory_query', longAgo);
+    // Before sweep: even though the single entry is older than retention, the
+    // agent key exists in the Map (prune-on-insert only fires on subsequent writes).
+    expect(hasMemoryQuery('agent-gone', longAgo - 1, longAgo + 1)).toBe(true);
+    sweepExpiredAgents(Date.now());
+    // After sweep the key is gone — query returns false because entries is undefined.
+    expect(hasMemoryQuery('agent-gone', longAgo - 1, longAgo + 1)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes the f8/f10 backlog item: `memoryQueryCalled` was always `undefined` for native agents because Claude Code subagents run out-of-process and their MCP tool calls were invisible to the parent relay.
- Adds a small per-agent ring buffer in `packages/relay/src/memory-query-buffer.ts` (Map<agent_id, Entry[]>, 256-entry cap, 5-min retention pruned on insert).
- Dual capture: router RPC_REQUEST hook (for relay-routed calls) + `gossip_remember` MCP handler mirror (for native-subagent direct calls — the primary path today).
- `handleNativeRelay` queries `hasMemoryQuery(agentId, startedAt, now+2s)` before `recordNativeTaskCompleted`; sets `memoryQueryCalled=true` only on observation, preserving the `undefined` vs `false` distinction.
- `TaskGraph` and `gossip_relay` MCP schemas unchanged (Option 1 is fully relay-side per `project_memory_query_observability.md`).

## Test plan

- [x] 7 new unit tests in `tests/relay/memory-query-buffer.test.ts` (window, agent isolation, non-memory-query filter, cap eviction, retention prune, exposed constants)
- [x] `npx jest tests/relay/` — 147/147 pass
- [x] `npx tsc --noEmit` — relay + CLI clean (after standard rebuilds)
- [x] MCP bundle rebuilt (`npm run build:mcp`) — 1.8mb, under 5mb guard
- [ ] Post-merge: smoke-test with a native agent calling `gossip_remember` mid-task; verify dashboard signal shows `memoryQueryCalled=true`
- [ ] Post-merge: verify quiet native task (no memory call) still shows field as undefined/false, not spuriously true

🤖 Generated with [Claude Code](https://claude.com/claude-code)