### PR TITLE
fix(dashboard): signal timeline legend + full-width pill row

### DIFF
--- a/packages/dashboard-v2/src/components/SignalTimeline.tsx
+++ b/packages/dashboard-v2/src/components/SignalTimeline.tsx
@@ -117,7 +117,7 @@ export function SignalTimeline({ agentId }: { agentId: string }) {
                   setDrawerOpen(true);
                 }
               }}
-              className={`h-4 w-1.5 rounded-sm transition-opacity hover:opacity-80 ${
+              className={`h-4 min-w-[4px] max-w-[12px] flex-1 rounded-sm transition-opacity hover:opacity-80 ${
                 SIGNAL_COLORS[s.signal] || 'bg-muted'
               } ${clickable ? 'cursor-pointer' : 'cursor-default'}`}
               title={`${SIGNAL_LABELS[s.signal] || s.signal} — ${timeAgo(s.timestamp)}${clickable ? ' (click for detail)' : ''}`}
@@ -132,7 +132,8 @@ export function SignalTimeline({ agentId }: { agentId: string }) {
         {[
           { color: 'bg-confirmed', label: 'Confirmed' },
           { color: 'bg-disputed', label: 'Disputed' },
-          { color: 'bg-unique', label: 'Unique' },
+          { color: 'bg-unique', label: 'Unique (confirmed)' },
+          { color: 'bg-unique/50', label: 'Unique (unconfirmed)' },
           { color: 'bg-unverified', label: 'Unverified' },
         ].map((l) => (
           <div key={l.label} className="flex items-center gap-1">


### PR DESCRIPTION
## Summary

Fixes the two UX items in `project_agent_page_timeline_ux.md`:

- **Legend missing `unique_unconfirmed`** — timeline painted two purples (`bg-unique` and `bg-unique/50`) but the legend only listed "Unique". Users couldn't distinguish confirmed-unique from unconfirmed-unique, collapsing a scoring-relevant distinction into visual noise. Split into "Unique (confirmed)" and "Unique (unconfirmed)".
- **Right-side whitespace with 100 pills** — pills used fixed `w-1.5` (~8px incl. gap), so 100 pills capped at ~800px and left a gap on wider containers. Switched to `flex-1 min-w-[4px] max-w-[12px]` so the row stretches to fill the available width while staying clickable.

3 lines changed net. Dashboard-only, no backend touch.

## Test plan

- [x] `npx tsc --noEmit` clean in `packages/dashboard-v2`
- [ ] Visual check in running dashboard: agent page with ≥100 signals fills the full width of the card, legend shows 5 entries (Confirmed, Disputed, Unique (confirmed), Unique (unconfirmed), Unverified)
- [ ] Sanity check on narrow container: pills clamp to 4px min rather than disappearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)