### PR TITLE
feat(orchestrator): Layer 1 signal-pipeline parity test

### DIFF
--- a/packages/orchestrator/src/completion-signals.allowlist.ts
+++ b/packages/orchestrator/src/completion-signals.allowlist.ts
@@ -1,0 +1,23 @@
+/**
+ * COMPLETION_SIGNAL_ALLOWLIST — the committed set of signal types that
+ * emitCompletionSignals (./completion-signals.ts) is permitted to emit.
+ *
+ * This file is a Layer 1 drift guard. The parity test at
+ * tests/orchestrator/completion-signals-parity.test.ts parses the helper
+ * source and fails when the two sets diverge.
+ *
+ * ── Adding a new signal ──────────────────────────────────────────────────
+ *  (a) Add the emission to packages/orchestrator/src/completion-signals.ts.
+ *  (b) Add the signal name below.
+ *  (c) Run `npm test` (or `npx jest tests/orchestrator/completion-signals-parity`)
+ *      to confirm the parity test passes.
+ *
+ * ── Removing a signal ────────────────────────────────────────────────────
+ * Mirror image: remove from helper, prune here, re-run test.
+ */
+export const COMPLETION_SIGNAL_ALLOWLIST: readonly string[] = [
+  'task_completed',
+  'task_tool_turns',
+  'format_compliance',
+  'finding_dropped_format',
+] as const;

--- a/tests/orchestrator/completion-signals-parity.test.ts
+++ b/tests/orchestrator/completion-signals-parity.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Layer 1 signal-pipeline drift guard.
+ *
+ * Parses packages/orchestrator/src/completion-signals.ts with the TypeScript
+ * Compiler API (already a devDep; ts-morph is not installed and was flagged
+ * rather than added unilaterally). Extracts every string literal assigned
+ * to a property named `signal` inside the helper's exported function bodies,
+ * then compares the set against the committed allowlist.
+ *
+ * A mismatch in EITHER direction fails — new signals must be allowlisted,
+ * and removed signals must be pruned from the allowlist.
+ */
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import * as ts from 'typescript';
+import { COMPLETION_SIGNAL_ALLOWLIST } from '../../packages/orchestrator/src/completion-signals.allowlist';
+
+const HELPER_PATH = join(
+  __dirname,
+  '../../packages/orchestrator/src/completion-signals.ts',
+);
+
+interface ExtractedSignal {
+  name: string;
+  line: number;
+  column: number;
+}
+
+function extractSignalsFromHelper(filePath: string): ExtractedSignal[] {
+  const source = readFileSync(filePath, 'utf8');
+  const sf = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true);
+  const found: ExtractedSignal[] = [];
+
+  // Walk only named function declarations at module top-level. This scopes
+  // extraction to the helper's own function bodies and ignores anything
+  // imported or referenced from elsewhere.
+  for (const stmt of sf.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.body) {
+      visit(stmt.body);
+    }
+  }
+
+  function visit(node: ts.Node): void {
+    // Match: { signal: 'literal', ... }
+    if (ts.isPropertyAssignment(node)) {
+      const nameNode = node.name;
+      const keyName = ts.isIdentifier(nameNode)
+        ? nameNode.text
+        : ts.isStringLiteral(nameNode)
+          ? nameNode.text
+          : undefined;
+      if (keyName === 'signal' && ts.isStringLiteral(node.initializer)) {
+        const pos = sf.getLineAndCharacterOfPosition(node.initializer.getStart(sf));
+        found.push({
+          name: node.initializer.text,
+          line: pos.line + 1,
+          column: pos.character + 1,
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  return found;
+}
+
+describe('completion-signals parity (Layer 1 drift guard)', () => {
+  it('helper emissions exactly match COMPLETION_SIGNAL_ALLOWLIST', () => {
+    const extracted = extractSignalsFromHelper(HELPER_PATH);
+    const codeSet = new Set(extracted.map(s => s.name));
+    const allowSet = new Set(COMPLETION_SIGNAL_ALLOWLIST);
+
+    const addedInCode = [...codeSet].filter(s => !allowSet.has(s));
+    const orphanedInAllowlist = [...allowSet].filter(s => !codeSet.has(s));
+
+    if (addedInCode.length > 0 || orphanedInAllowlist.length > 0) {
+      const lines: string[] = ['Signal allowlist drift detected:'];
+      if (addedInCode.length > 0) {
+        lines.push('  new signal added — update allowlist:');
+        for (const name of addedInCode) {
+          const locs = extracted
+            .filter(s => s.name === name)
+            .map(s => `completion-signals.ts:${s.line}:${s.column}`)
+            .join(', ');
+          lines.push(`    - ${name} (at ${locs})`);
+        }
+      }
+      if (orphanedInAllowlist.length > 0) {
+        lines.push('  signal removed — prune allowlist:');
+        for (const name of orphanedInAllowlist) {
+          lines.push(`    - ${name}`);
+        }
+      }
+      throw new Error(lines.join('\n'));
+    }
+
+    expect(codeSet).toEqual(allowSet);
+  });
+});


### PR DESCRIPTION
## Summary

Layer 1 of signal-pipeline drift detection per `project_signal_pipeline_drift_detection.md`. AST parity test for `emitCompletionSignals` — the single convergence point for native + relay completion signals (PR #169).

- **`completion-signals.allowlist.ts`** — committed readonly array of signal names the helper is permitted to emit, with top-of-file 3-step extension doc (helper + allowlist + re-run).
- **`completion-signals-parity.test.ts`** — TypeScript Compiler API walks top-level named function bodies in the helper, extracts string literals keyed `signal`, compares to the allowlist. Mismatch in either direction fails with a descriptive diff including file:line.
- Used the TypeScript Compiler API directly rather than adding `ts-morph` as a devDep (typescript is already transitively available).
- Initial allowlist: `task_completed`, `task_tool_turns`, `format_compliance`, `finding_dropped_format`.

## Test plan

- [x] Parity test passes on HEAD
- [x] Sanity-check injection: added `{ signal: 'test_bogus', ... }` to the helper → test failed with `"Signal allowlist drift detected: new signal added — update allowlist: test_bogus (at completion-signals.ts:159:51)"` → reverted
- [x] `npx tsc --noEmit -p packages/orchestrator/tsconfig.json` clean
- [x] Full orchestrator suite: 1285/1285 pass

## Follow-ups (per memory execution order L1 → L3 → L2)

- **L3** — standalone runtime drift detector (~150-200 LOC, tags every emission with `emission_path: native|relay`, fires `pipeline_drift_detected` on rolling-window divergence). No dependency on L1/L2.
- **L2** — visibility restriction on `PerformanceWriter.appendSignals` (2-3 days, requires a helper-taxonomy consensus round first; 14 direct callers need typed wrappers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)