### PR TITLE
fix(completion-signals): _system guard + parity length assert + redundant nullish

### DIFF
--- a/packages/orchestrator/src/completion-signals.ts
+++ b/packages/orchestrator/src/completion-signals.ts
@@ -68,8 +68,12 @@ export interface CompletionSignalInput {
 export function emitCompletionSignals(projectRoot: string, input: CompletionSignalInput): void {
   try {
     const { agentId, taskId, result, elapsedMs, toolCalls, memoryQueryCalled, error } = input;
+    if (agentId === '_system') {
+      process.stderr.write(`[gossipcat] emitCompletionSignals refused reserved agentId '_system' (taskId=${taskId})\n`);
+      return;
+    }
     const now = new Date().toISOString();
-    const compliance = detectFormatCompliance(result ?? '');
+    const compliance = detectFormatCompliance(result);
 
     const signals: (MetaSignal | PipelineSignal)[] = [];
 

--- a/tests/orchestrator/completion-signals-parity.test.ts
+++ b/tests/orchestrator/completion-signals-parity.test.ts
@@ -97,6 +97,7 @@ describe('completion-signals parity (Layer 1 drift guard)', () => {
       throw new Error(lines.join('\n'));
     }
 
+    expect(extracted.length).toBeGreaterThan(0);
     expect(codeSet).toEqual(allowSet);
   });
 


### PR DESCRIPTION
## Summary

Ships 3 peer-confirmed fixes from consensus round **34e0a534-fb994382**.

| Finding(s) | Severity | Change |
|---|---|---|
| f6 + f2 | MEDIUM | Add `_system` sentinel guard at top of `emitCompletionSignals` — prevents the tombstone sentinel (`SYSTEM_SENTINEL_AGENT_ID` from `performance-writer.ts:54`) from corrupting per-agent aggregation if passed through this entry point |
| f7 + f1 | HIGH | Add `expect(extracted.length).toBeGreaterThan(0)` before the set-equality assertion in the parity test — turns a silent pass (zero coverage after a refactor from `function emitCompletionSignals` to arrow-function form) into a loud failure |
| f3 + f11 | cleanup | Remove redundant `?? ''` on `detectFormatCompliance(result ?? '')` — `CompletionSignalInput.result` is typed as non-optional `string`; both callers already guard before invoking the helper |

## Test plan

- [x] `npx jest tests/orchestrator/completion-signals-parity` — 2/2 pass (both `✓` green)
- [x] `npm run build:mcp` — clean build, no type errors surfaced

Consensus round: `34e0a534-fb994382`
Findings: f2/f6 (MEDIUM), f1/f7 (HIGH), f3/f11 (cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)