### PR TITLE
feat(audit-memories): triage tool for institutional-knowledge-propagation §6

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "build:dashboard": "cd packages/dashboard-v2 && npx vite build --outDir ../../dist-dashboard --emptyOutDir",
     "prepublishOnly": "npm run build:mcp && npm run build:dashboard",
     "gossipcat": "npx ts-node -r tsconfig-paths/register -P tsconfig.json apps/cli/src/index.ts",
-    "start": "npx ts-node -r tsconfig-paths/register -P tsconfig.json apps/cli/src/index.ts"
+    "start": "npx ts-node -r tsconfig-paths/register -P tsconfig.json apps/cli/src/index.ts",
+    "audit:memories": "node scripts/audit-memories.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/audit-memories.lib.cjs
+++ b/scripts/audit-memories.lib.cjs
@@ -1,0 +1,217 @@
+// CommonJS library for scripts/audit-memories.mjs.
+// Pure functions only — no I/O at import time. Kept as .cjs so both the ESM
+// CLI wrapper and ts-jest tests can load it without needing Jest's
+// experimental ESM mode.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_CODENAMES = ['crab-language', 'gossip-v2'];
+
+const HELP = `audit-memories — triage Claude Code auto-memory files.
+
+Usage:
+  node scripts/audit-memories.mjs [options]
+
+Options:
+  --dir <path>          Override the default memory dir.
+  --json                Emit JSON array instead of an ASCII table.
+  --candidates-only     Hide rows whose proposed_target is DROP.
+  --codenames a,b,c     Extra codename strings to count as provenance.
+  --help                Show this message and exit.
+
+Default dir is derived from process.cwd():
+  ~/.claude/projects/<cwd-with-slashes-as-dashes>/memory/
+The leading dash from an absolute path is dropped.
+
+This tool is read-only — it never writes to memory files.`;
+
+function parseArgs(argv) {
+  const out = {
+    dir: null,
+    json: false,
+    candidatesOnly: false,
+    codenames: [],
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') out.help = true;
+    else if (a === '--json') out.json = true;
+    else if (a === '--candidates-only') out.candidatesOnly = true;
+    else if (a === '--dir') out.dir = argv[++i];
+    else if (a.startsWith('--dir=')) out.dir = a.slice('--dir='.length);
+    else if (a === '--codenames') out.codenames = (argv[++i] || '').split(',').filter(Boolean);
+    else if (a.startsWith('--codenames=')) out.codenames = a.slice('--codenames='.length).split(',').filter(Boolean);
+  }
+  return out;
+}
+
+function defaultMemoryDir(cwd, home) {
+  let encoded = cwd.replace(/\//g, '-');
+  if (encoded.startsWith('-')) encoded = encoded.slice(1);
+  return path.join(home, '.claude', 'projects', encoded, 'memory');
+}
+
+function scoreRubric(body) {
+  let score = 0;
+  const dates = body.match(/\b20\d{2}-\d{2}-\d{2}\b/g) || [];
+  const distinctDates = new Set(dates);
+  if (distinctDates.size >= 2 || body.includes('originSessionId')) score += 1;
+  if (/\b(STOP|MUST|ALWAYS|NEVER)\b/.test(body)) score += 1;
+  if (/lost|silently|wrong|bypass|security/i.test(body)) score += 1;
+  return score;
+}
+
+function classify(body) {
+  const modelHit = /(gemini|sonnet|haiku|opus|claude)/i.test(body);
+  const failHit = /(hallucinat|fabricat|consistent|always)/i.test(body);
+  if (modelHit && failHit) return 'MODEL_INTRINSIC';
+
+  const protoToolMatch = /(gossip_\w+|mcp__gossipcat__\w+)/.test(body);
+  const projectPathMatch = /(packages|apps|\.gossip)\//.test(body);
+
+  let identifierNearKeyword = false;
+  const identRegex = /`[^`\n]+`/g;
+  let m;
+  while ((m = identRegex.exec(body)) !== null) {
+    const start = Math.max(0, m.index - 80);
+    const end = Math.min(body.length, m.index + m[0].length + 80);
+    const window = body.slice(start, end);
+    if (/\b(must|required|cannot)\b/i.test(window)) {
+      identifierNearKeyword = true;
+      break;
+    }
+  }
+
+  if (protoToolMatch || projectPathMatch || identifierNearKeyword) return 'PROTOCOL_BOUND';
+  return 'USER_SPECIFIC';
+}
+
+function provenanceHits(body, extraCodenames) {
+  const codenames = DEFAULT_CODENAMES.concat(extraCodenames || []);
+
+  const prMatches = body.match(/(?:PR\s*#?\d+|#\d+)/gi) || [];
+  const prCount = prMatches.length;
+
+  const prDigitRuns = new Set();
+  for (const pr of prMatches) {
+    const digits = pr.match(/\d+/);
+    if (digits) prDigitRuns.add(digits[0]);
+  }
+
+  const commitMatches = body.match(/\b[0-9a-f]{7,}\b/g) || [];
+  const commitCount = commitMatches.filter((h) => !prDigitRuns.has(h)).length;
+
+  const dateMatches = body.match(/\b20\d{2}-\d{2}-\d{2}\b/g) || [];
+  const distinctDates = new Set(dateMatches).size;
+
+  let codenameCount = 0;
+  for (const cn of codenames) {
+    if (!cn) continue;
+    const re = new RegExp(cn.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
+    const hits = body.match(re);
+    if (hits) codenameCount += hits.length;
+  }
+
+  return prCount + commitCount + distinctDates + codenameCount;
+}
+
+function proposeTarget(rubric, bucket) {
+  if (rubric === 3 && bucket === 'MODEL_INTRINSIC') return 'model-skill';
+  if (rubric === 3 && bucket === 'PROTOCOL_BOUND') return 'HANDBOOK';
+  return 'DROP';
+}
+
+function auditBody(file, body, extraCodenames) {
+  const rubric = scoreRubric(body);
+  const bucket = classify(body);
+  const hits = provenanceHits(body, extraCodenames);
+  const target = proposeTarget(rubric, bucket);
+  return {
+    file,
+    bucket,
+    rubric_score: rubric,
+    provenance_hits: hits,
+    strip_needed: hits > 0,
+    proposed_target: target,
+  };
+}
+
+const TARGET_ORDER = { HANDBOOK: 0, 'model-skill': 1, DROP: 2 };
+
+function sortRows(rows) {
+  return rows.slice().sort((a, b) => {
+    const t = TARGET_ORDER[a.proposed_target] - TARGET_ORDER[b.proposed_target];
+    if (t !== 0) return t;
+    if (b.rubric_score !== a.rubric_score) return b.rubric_score - a.rubric_score;
+    return a.file.localeCompare(b.file);
+  });
+}
+
+function renderTable(rows) {
+  const header = ['file', 'bucket', 'rubric_score', 'provenance_hits', 'strip_needed', 'proposed_target'];
+  const data = rows.map((r) => [
+    r.file,
+    r.bucket,
+    String(r.rubric_score),
+    String(r.provenance_hits),
+    String(r.strip_needed),
+    r.proposed_target,
+  ]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...data.map((row) => row[i].length))
+  );
+  const fmt = (cells) => cells.map((c, i) => c.padEnd(widths[i])).join('  ');
+  const sep = widths.map((w) => '-'.repeat(w)).join('  ');
+  return [fmt(header), sep].concat(data.map(fmt)).join('\n');
+}
+
+function auditDir(dir, opts) {
+  opts = opts || {};
+  const codenames = opts.codenames || [];
+  const warnings = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(dir);
+  } catch (err) {
+    const e = new Error(`memory dir not readable: ${dir}`);
+    e.cause = err;
+    e.resolvedDir = dir;
+    throw e;
+  }
+  const rows = [];
+  for (const name of entries.sort()) {
+    if (!name.endsWith('.md')) continue;
+    if (name === 'MEMORY.md') continue;
+    const full = path.join(dir, name);
+    let body;
+    try {
+      const stat = fs.statSync(full);
+      if (!stat.isFile()) continue;
+      body = fs.readFileSync(full, 'utf8');
+    } catch (err) {
+      warnings.push(`warn: skipping unreadable file ${name}: ${err.message}`);
+      continue;
+    }
+    rows.push(auditBody(name, body, codenames));
+  }
+  return { rows: sortRows(rows), warnings, dir };
+}
+
+module.exports = {
+  HELP,
+  DEFAULT_CODENAMES,
+  parseArgs,
+  defaultMemoryDir,
+  scoreRubric,
+  classify,
+  provenanceHits,
+  proposeTarget,
+  auditBody,
+  sortRows,
+  renderTable,
+  auditDir,
+};

--- a/scripts/audit-memories.mjs
+++ b/scripts/audit-memories.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Triage tool for institutional-knowledge-propagation §6.
+// READ-ONLY. Scores memory files on a 0-3 rubric, classifies them into
+// MODEL_INTRINSIC / PROTOCOL_BOUND / USER_SPECIFIC, counts provenance hits,
+// and proposes a target destination (HANDBOOK | model-skill | DROP).
+//
+// Spec: docs/specs/2026-04-19-institutional-knowledge-propagation.md §6
+//
+// Usage:
+//   node scripts/audit-memories.mjs [--dir <path>] [--json] [--candidates-only]
+//                                   [--codenames a,b,c] [--help]
+//
+// Pure logic lives in ./audit-memories.lib.cjs so ts-jest can require it
+// without flipping on Jest's experimental ESM mode.
+
+import os from 'node:os';
+import process from 'node:process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const lib = require('./audit-memories.lib.cjs');
+
+async function main() {
+  const args = lib.parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(lib.HELP + '\n');
+    return 0;
+  }
+  const dir = args.dir ?? lib.defaultMemoryDir(process.cwd(), os.homedir());
+  let result;
+  try {
+    result = lib.auditDir(dir, { codenames: args.codenames });
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n`);
+    return 1;
+  }
+  for (const w of result.warnings) process.stderr.write(w + '\n');
+  let rows = result.rows;
+  if (args.candidatesOnly) rows = rows.filter((r) => r.proposed_target !== 'DROP');
+  if (args.json) {
+    process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+  } else {
+    process.stdout.write(`# audit-memories — ${dir}\n`);
+    process.stdout.write(`# rows: ${rows.length}\n`);
+    process.stdout.write(lib.renderTable(rows) + '\n');
+  }
+  return 0;
+}
+
+main().then((code) => process.exit(code));

--- a/tests/scripts/audit-memories.test.ts
+++ b/tests/scripts/audit-memories.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for scripts/audit-memories.mjs.
+ *
+ * Pure logic lives in scripts/audit-memories.lib.cjs (a CommonJS module)
+ * so ts-jest can require it without flipping on Jest's experimental ESM
+ * mode. The .mjs is a thin CLI wrapper around this same library.
+ */
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { execFileSync } from 'node:child_process';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const mod = require(path.resolve(__dirname, '..', '..', 'scripts', 'audit-memories.lib.cjs'));
+const SCRIPT_MJS = path.resolve(__dirname, '..', '..', 'scripts', 'audit-memories.mjs');
+
+describe('scoreRubric', () => {
+  it('all-3-signals fixture scores 3', () => {
+    const body = [
+      'session 2026-04-01 and follow-up on 2026-04-15.',
+      'You MUST always record signals.',
+      'Without it, signals are silently lost.',
+    ].join('\n');
+    expect(mod.scoreRubric(body)).toBe(3);
+  });
+
+  it('empty body scores 0', () => {
+    expect(mod.scoreRubric('')).toBe(0);
+  });
+
+  it('originSessionId alone counts for criterion 1', () => {
+    const body = 'no dates here, but originSessionId is present.';
+    // No MUST/etc, no consequence keyword -> only criterion 1 fires
+    expect(mod.scoreRubric(body)).toBe(1);
+    const body2 = body + ' MUST proceed.';
+    expect(mod.scoreRubric(body2)).toBe(2);
+  });
+
+  it('case-sensitive on STOP/MUST/ALWAYS/NEVER', () => {
+    expect(mod.scoreRubric('must do it')).toBe(0);
+    expect(mod.scoreRubric('MUST do it')).toBe(1);
+  });
+});
+
+describe('classify', () => {
+  it('gemini-hallucinat fixture is MODEL_INTRINSIC', () => {
+    const body = 'gemini-reviewer hallucinates spec fields consistently.';
+    expect(mod.classify(body)).toBe('MODEL_INTRINSIC');
+  });
+
+  it('gossip_remember fixture is PROTOCOL_BOUND', () => {
+    const body = 'Always call gossip_remember before coding.';
+    expect(mod.classify(body)).toBe('PROTOCOL_BOUND');
+  });
+
+  it('UX-preference fixture is USER_SPECIFIC', () => {
+    const body = 'I prefer concise output and dark themes.';
+    expect(mod.classify(body)).toBe('USER_SPECIFIC');
+  });
+
+  it('packages/ project path triggers PROTOCOL_BOUND', () => {
+    const body = 'See packages/orchestrator/src/foo.ts for details.';
+    expect(mod.classify(body)).toBe('PROTOCOL_BOUND');
+  });
+
+  it('backticked identifier near "must" triggers PROTOCOL_BOUND', () => {
+    const body = 'The `finding_id` field must be present in every signal.';
+    expect(mod.classify(body)).toBe('PROTOCOL_BOUND');
+  });
+
+  it('MODEL_INTRINSIC wins over PROTOCOL_BOUND when both apply', () => {
+    const body = 'gemini-reviewer hallucinates findings in packages/foo/.';
+    expect(mod.classify(body)).toBe('MODEL_INTRINSIC');
+  });
+});
+
+describe('provenanceHits', () => {
+  it('PR #123 at commit abc1234 → hits ≥ 2 and strip_needed', () => {
+    const body = 'Shipped in PR #123 at commit abc1234.';
+    const hits = mod.provenanceHits(body);
+    expect(hits).toBeGreaterThanOrEqual(2);
+    const row = mod.auditBody('x.md', body);
+    expect(row.strip_needed).toBe(true);
+  });
+
+  it('does not double-count PR digits as commit hashes', () => {
+    // "#1234567" is a PR mention; the digit run is also 7 chars long
+    // so a naive commit-hash regex would re-match it. Make sure we don't.
+    const body = 'See PR #1234567 for context.';
+    const hits = mod.provenanceHits(body);
+    expect(hits).toBe(1);
+  });
+
+  it('counts codenames including extras passed via --codenames', () => {
+    const body = 'Initial work in crab-language; superseded by gossip-v2 and project-zeta.';
+    const hits = mod.provenanceHits(body, ['project-zeta']);
+    expect(hits).toBe(3);
+  });
+
+  it('zero provenance → strip_needed false', () => {
+    const row = mod.auditBody('x.md', 'plain text with no markers');
+    expect(row.strip_needed).toBe(false);
+  });
+});
+
+describe('proposeTarget', () => {
+  it('rubric=3 + PROTOCOL_BOUND → HANDBOOK', () => {
+    expect(mod.proposeTarget(3, 'PROTOCOL_BOUND')).toBe('HANDBOOK');
+  });
+  it('rubric=2 + PROTOCOL_BOUND → DROP', () => {
+    expect(mod.proposeTarget(2, 'PROTOCOL_BOUND')).toBe('DROP');
+  });
+  it('rubric=3 + MODEL_INTRINSIC → model-skill', () => {
+    expect(mod.proposeTarget(3, 'MODEL_INTRINSIC')).toBe('model-skill');
+  });
+  it('rubric=3 + USER_SPECIFIC → DROP', () => {
+    expect(mod.proposeTarget(3, 'USER_SPECIFIC')).toBe('DROP');
+  });
+});
+
+describe('defaultMemoryDir', () => {
+  it('encodes cwd by replacing slashes and dropping leading dash', () => {
+    const dir = mod.defaultMemoryDir('/Users/alice/code/proj', '/home/alice');
+    expect(dir).toBe('/home/alice/.claude/projects/Users-alice-code-proj/memory');
+  });
+});
+
+describe('parseArgs', () => {
+  it('parses flags and values', () => {
+    const a = mod.parseArgs(['--json', '--dir', '/tmp/x', '--candidates-only', '--codenames', 'a,b']);
+    expect(a.json).toBe(true);
+    expect(a.dir).toBe('/tmp/x');
+    expect(a.candidatesOnly).toBe(true);
+    expect(a.codenames).toEqual(['a', 'b']);
+  });
+  it('--help sets help flag', () => {
+    expect(mod.parseArgs(['--help']).help).toBe(true);
+  });
+});
+
+describe('auditDir end-to-end', () => {
+  let tmp: string;
+  beforeAll(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-mem-'));
+    fs.writeFileSync(
+      path.join(tmp, 'a.md'),
+      [
+        'gemini-reviewer hallucinates findings consistently.',
+        'You MUST verify and the consequence is silently dropped signals.',
+        '2026-04-01 and 2026-04-10 sessions confirm.',
+        'PR #42 at commit deadbee.',
+      ].join('\n'),
+    );
+    fs.writeFileSync(
+      path.join(tmp, 'b.md'),
+      'Just a UX note. Nothing remarkable.',
+    );
+    fs.writeFileSync(path.join(tmp, 'MEMORY.md'), '# index, should be skipped');
+    fs.writeFileSync(path.join(tmp, 'not-md.txt'), 'ignored');
+  });
+
+  it('returns sorted rows and skips MEMORY.md / non-md', () => {
+    const { rows } = mod.auditDir(tmp);
+    expect(rows.map((r: { file: string }) => r.file).sort()).toEqual(['a.md', 'b.md']);
+    const a = rows.find((r: { file: string }) => r.file === 'a.md');
+    expect(a.proposed_target).toBe('model-skill');
+    expect(a.bucket).toBe('MODEL_INTRINSIC');
+    expect(a.rubric_score).toBe(3);
+    expect(a.strip_needed).toBe(true);
+    const b = rows.find((r: { file: string }) => r.file === 'b.md');
+    expect(b.proposed_target).toBe('DROP');
+  });
+
+  it('sort order: HANDBOOK > model-skill > DROP', () => {
+    const { rows } = mod.auditDir(tmp);
+    const targets = rows.map((r: { proposed_target: string }) => r.proposed_target);
+    expect(targets).toEqual(['model-skill', 'DROP']);
+  });
+
+  it('missing dir throws with resolved path in message', () => {
+    expect(() => mod.auditDir('/no/such/dir/exists/here')).toThrow(/no\/such\/dir/);
+  });
+});
+
+describe('CLI smoke', () => {
+  it('--help prints usage and exits 0', () => {
+    const out = execFileSync('node', [SCRIPT_MJS, '--help'], { encoding: 'utf8' });
+    expect(out).toMatch(/audit-memories/);
+    expect(out).toMatch(/--candidates-only/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `scripts/audit-memories.mjs` — a read-only Node ES-module CLI that triages Claude Code auto-memory files for promotion into the gossipcat HANDBOOK or model-specific skills, per the spec at `docs/specs/2026-04-19-institutional-knowledge-propagation.md` §6.

For each `*.md` file in the memory directory it computes:

- **rubric_score (0-3)** — multi-session recurrence, behavioral-rule markers (STOP/MUST/ALWAYS/NEVER), and correctness-consequence markers (lost/silently/wrong/bypass/security).
- **bucket** — MODEL_INTRINSIC, PROTOCOL_BOUND, or USER_SPECIFIC (mutually exclusive, first match wins).
- **provenance_hits** — PR numbers, commit hashes (dedupe-aware vs PR digit runs), distinct session dates, and codenames (`crab-language`, `gossip-v2`, plus user-provided extras via `--codenames`).
- **proposed_target** — `HANDBOOK` (rubric=3 + PROTOCOL_BOUND), `model-skill` (rubric=3 + MODEL_INTRINSIC), else `DROP`.

Pure logic lives in `scripts/audit-memories.lib.cjs` so ts-jest can `require` it without enabling Jest's experimental ESM mode. The `.mjs` entry point is a thin CLI wrapper around the library.

### Sample run (this repo)

```
node scripts/audit-memories.mjs --dir ~/.claude/projects/-Users-goku-Desktop-gossip/memory
```

| target       | count |
|--------------|-------|
| HANDBOOK     | 2     |
| model-skill  | 5     |
| DROP         | 186   |
| **total**    | **193** |

168/193 (87%) require provenance stripping before promotion.

Bucket distribution: MODEL_INTRINSIC 69, PROTOCOL_BOUND 93, USER_SPECIFIC 31.

### Constraints honored

- Tool is **read-only**. Never writes to memory files.
- Missing dir → exit 1 with the resolved path in the error message.
- Unreadable files → warn on stderr, skip, continue.
- No YAML parsing — body is treated as plain text.
- Default dir resolves at runtime from `process.cwd()` and `os.homedir()`.

## Test plan

- [x] `npx jest tests/scripts/audit-memories` — 25 cases, all green.
- [x] `node scripts/audit-memories.mjs --help` prints usage.
- [x] `node scripts/audit-memories.mjs --dir /no/such/dir` exits 1 with resolved path.
- [x] `--json` produces a JSON array; default mode prints the ASCII table sorted HANDBOOK > model-skill > DROP, then rubric desc, then file asc.
- [x] `.gossip/boundary-escapes.jsonl` unchanged (file does not exist on this branch; sandboxed worktree confirmed clean).

Spec: `docs/specs/2026-04-19-institutional-knowledge-propagation.md` §6

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>