### PR TITLE
feat(memory-config): kill-switch for bundled institutional-knowledge skills (ikp §4)

### DIFF
--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -95,3 +95,5 @@ export { COMPLETION_SIGNAL_ALLOWLIST, EMISSION_PATHS } from './completion-signal
 export type { EmissionPath } from './completion-signals.allowlist';
 export { PipelineDriftDetector } from './pipeline-drift-detector';
 export type { DriftDetectionResult, DriftOffender, PipelineDriftDetectorOptions } from './pipeline-drift-detector';
+export { loadMemoryConfig } from './memory-config';
+export type { MemoryConfig } from './memory-config';

--- a/packages/orchestrator/src/memory-config.ts
+++ b/packages/orchestrator/src/memory-config.ts
@@ -1,0 +1,72 @@
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { log } from './log';
+
+export interface MemoryConfig {
+  bundledMemories: {
+    enabled: boolean;
+    exclude: string[];
+  };
+}
+
+const DEFAULTS: MemoryConfig = {
+  bundledMemories: {
+    enabled: true,
+    exclude: [],
+  },
+};
+
+/**
+ * Load memory-config.json from <projectRoot>/.gossip/memory-config.json.
+ *
+ * - Missing file  → returns defaults silently.
+ * - Malformed JSON → logs warning to stderr, returns defaults (never throws).
+ * - Valid file     → merges with defaults so partial configs are safe.
+ *
+ * This config is the kill-switch for institutional-knowledge propagation (ikp §4):
+ * `bundledMemories.enabled: false` suppresses all skills flagged `propagated: true`.
+ * `bundledMemories.exclude: ["skill-name"]` suppresses listed propagated skills.
+ */
+export function loadMemoryConfig(projectRoot: string): MemoryConfig {
+  const configPath = resolve(projectRoot, '.gossip', 'memory-config.json');
+  if (!existsSync(configPath)) {
+    return { ...DEFAULTS, bundledMemories: { ...DEFAULTS.bundledMemories } };
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, 'utf-8');
+  } catch (err: any) {
+    log('memory-config', `WARNING: failed to read ${configPath}: ${err?.message ?? err} — using defaults`);
+    return { ...DEFAULTS, bundledMemories: { ...DEFAULTS.bundledMemories } };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err: any) {
+    log('memory-config', `WARNING: malformed JSON in ${configPath}: ${err?.message ?? err} — using defaults`);
+    return { ...DEFAULTS, bundledMemories: { ...DEFAULTS.bundledMemories } };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    log('memory-config', `WARNING: ${configPath} must be a JSON object — using defaults`);
+    return { ...DEFAULTS, bundledMemories: { ...DEFAULTS.bundledMemories } };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const bm = obj.bundledMemories;
+
+  if (typeof bm !== 'object' || bm === null || Array.isArray(bm)) {
+    return { ...DEFAULTS, bundledMemories: { ...DEFAULTS.bundledMemories } };
+  }
+
+  const bmObj = bm as Record<string, unknown>;
+
+  const enabled = typeof bmObj.enabled === 'boolean' ? bmObj.enabled : DEFAULTS.bundledMemories.enabled;
+  const exclude = Array.isArray(bmObj.exclude)
+    ? bmObj.exclude.filter((x): x is string => typeof x === 'string')
+    : DEFAULTS.bundledMemories.exclude;
+
+  return { bundledMemories: { enabled, exclude } };
+}

--- a/packages/orchestrator/src/skill-loader.ts
+++ b/packages/orchestrator/src/skill-loader.ts
@@ -4,6 +4,8 @@ import type { SkillIndex } from './skill-index';
 import { parseSkillFrontmatter } from './skill-parser';
 import { normalizeSkillName } from './skill-name';
 import { gossipLog, log as _log } from './log';
+import { loadMemoryConfig } from './memory-config';
+import { PerformanceWriter } from './performance-writer';
 
 const SAFE_AGENT_ID = /^[a-z0-9][a-z0-9_-]{0,62}$/;
 
@@ -60,7 +62,17 @@ export interface DroppedSkill {
      * BEFORE keyword-hit threshold and category boost so mismatched skills
      * never consume the contextual budget.
      */
-    | 'task-type-mismatch';
+    | 'task-type-mismatch'
+    /**
+     * Skill is flagged `propagated: true` and the project's memory-config.json
+     * has `bundledMemories.enabled: false`. All propagated skills are suppressed.
+     */
+    | 'kill-switch'
+    /**
+     * Skill is flagged `propagated: true` and its name appears in
+     * `bundledMemories.exclude`. Only this skill is suppressed.
+     */
+    | 'excluded';
   hits: number;
 }
 
@@ -131,6 +143,10 @@ export function loadSkills(
 
   const categories = taskCategories ?? [];
 
+  // Load kill-switch config once per invocation (not inside the loop).
+  const memConfig = loadMemoryConfig(projectRoot);
+  const perfWriter = new PerformanceWriter(projectRoot);
+
   const permanent: Array<{ name: string; content: string }> = [];
   const contextualCandidates: Array<{ name: string; content: string; hits: number; rawHits: number; boost: number }> = [];
   const loaded: string[] = [];
@@ -156,6 +172,41 @@ export function loadSkills(
     }
     if (frontmatterStatus === 'flagged_for_manual_review') {
       gossipLog(`Injecting flagged_for_manual_review skill ${agentId}/${skill} — manual review recommended`);
+    }
+
+    // Kill-switch filter: propagated skills (ikp §4).
+    // Read propagated from raw frontmatter — SkillFrontmatter interface does not
+    // expose it yet (intentional: this field is for bundled skills only).
+    const isPropagated = /^propagated:\s*true\s*$/m.test(content.split('\n---')[0]);
+    if (isPropagated) {
+      if (!memConfig.bundledMemories.enabled) {
+        const reason = 'kill-switch' as const;
+        _log('skill-loader', `Skipping propagated skill ${agentId}/${skill}: bundledMemories.enabled=false`);
+        perfWriter.appendSignal({
+          type: 'pipeline',
+          signal: 'skill_injection_skipped',
+          agentId,
+          taskId: `skill-loader:${agentId}:${skill}`,
+          metadata: { skillName: skill, reason },
+          timestamp: new Date().toISOString(),
+        }, 'dispatch-pipeline');
+        dropped.push({ skill, reason, hits: 0 });
+        continue;
+      }
+      if (memConfig.bundledMemories.exclude.includes(skill)) {
+        const reason = 'excluded' as const;
+        _log('skill-loader', `Skipping propagated skill ${agentId}/${skill}: listed in bundledMemories.exclude`);
+        perfWriter.appendSignal({
+          type: 'pipeline',
+          signal: 'skill_injection_skipped',
+          agentId,
+          taskId: `skill-loader:${agentId}:${skill}`,
+          metadata: { skillName: skill, reason },
+          timestamp: new Date().toISOString(),
+        }, 'dispatch-pipeline');
+        dropped.push({ skill, reason, hits: 0 });
+        continue;
+      }
     }
 
     // Task-type axis filter. Evaluated BEFORE keyword-hit counting and the

--- a/tests/fixtures/propagated-skill.md
+++ b/tests/fixtures/propagated-skill.md
@@ -1,0 +1,14 @@
+---
+name: propagated-skill
+description: Test fixture for propagated institutional-knowledge skill (ikp §4 kill-switch)
+keywords: [test]
+category: testing
+mode: permanent
+propagated: true
+status: active
+---
+
+# Propagated Skill (Test Fixture)
+
+This skill is flagged `propagated: true` for use by memory-config kill-switch tests.
+Do NOT add this file to packages/orchestrator/src/default-skills.

--- a/tests/orchestrator/memory-config.test.ts
+++ b/tests/orchestrator/memory-config.test.ts
@@ -1,0 +1,193 @@
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadMemoryConfig } from '../../packages/orchestrator/src/memory-config';
+import { loadSkills } from '../../packages/orchestrator/src/skill-loader';
+import { SkillIndex } from '../../packages/orchestrator/src/skill-index';
+
+const PROPAGATED_SKILL_CONTENT = `---
+name: propagated-skill
+description: Test fixture for ikp §4 kill-switch
+keywords: [test]
+category: testing
+mode: permanent
+propagated: true
+status: active
+---
+
+# Propagated Skill (Test Fixture)
+`;
+
+const REGULAR_SKILL_CONTENT = `---
+name: regular-skill
+description: Non-propagated skill — should always pass kill-switch
+keywords: [test]
+category: testing
+mode: permanent
+status: active
+---
+
+# Regular Skill (not propagated)
+`;
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `gossip-memcfg-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(join(dir, '.gossip'), { recursive: true });
+  return dir;
+}
+
+function writeConfig(dir: string, config: object): void {
+  writeFileSync(join(dir, '.gossip', 'memory-config.json'), JSON.stringify(config));
+}
+
+function writeSkill(dir: string, agentId: string, skillName: string, content: string): void {
+  const skillDir = join(dir, '.gossip', 'agents', agentId, 'skills');
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, `${skillName}.md`), content);
+}
+
+describe('loadMemoryConfig', () => {
+  it('returns defaults when file is absent', () => {
+    const dir = makeTmpDir();
+    try {
+      const config = loadMemoryConfig(dir);
+      expect(config.bundledMemories.enabled).toBe(true);
+      expect(config.bundledMemories.exclude).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns defaults and logs warning on malformed JSON (does not throw)', () => {
+    const dir = makeTmpDir();
+    try {
+      writeFileSync(join(dir, '.gossip', 'memory-config.json'), 'not-valid-json{{{');
+      const config = loadMemoryConfig(dir);
+      expect(config.bundledMemories.enabled).toBe(true);
+      expect(config.bundledMemories.exclude).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('honors enabled:false', () => {
+    const dir = makeTmpDir();
+    try {
+      writeConfig(dir, { bundledMemories: { enabled: false, exclude: [] } });
+      const config = loadMemoryConfig(dir);
+      expect(config.bundledMemories.enabled).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('honors exclude list', () => {
+    const dir = makeTmpDir();
+    try {
+      writeConfig(dir, { bundledMemories: { enabled: true, exclude: ['skill-a', 'skill-b'] } });
+      const config = loadMemoryConfig(dir);
+      expect(config.bundledMemories.exclude).toEqual(['skill-a', 'skill-b']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to defaults for partial config (missing bundledMemories)', () => {
+    const dir = makeTmpDir();
+    try {
+      writeConfig(dir, {});
+      const config = loadMemoryConfig(dir);
+      expect(config.bundledMemories.enabled).toBe(true);
+      expect(config.bundledMemories.exclude).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('loadSkills — kill-switch integration', () => {
+  it('skips propagated skill when enabled:false', () => {
+    const dir = makeTmpDir();
+    try {
+      writeConfig(dir, { bundledMemories: { enabled: false, exclude: [] } });
+      writeSkill(dir, 'test-agent', 'propagated-skill', PROPAGATED_SKILL_CONTENT);
+
+      const index = new SkillIndex(dir);
+      index.bind('test-agent', 'propagated-skill', { mode: 'permanent' });
+
+      const result = loadSkills('test-agent', ['propagated-skill'], dir, index);
+      expect(result.loaded).not.toContain('propagated-skill');
+      expect(result.dropped.map(d => d.skill)).toContain('propagated-skill');
+      const drop = result.dropped.find(d => d.skill === 'propagated-skill');
+      expect(drop?.reason).toBe('kill-switch');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips propagated skill when listed in exclude', () => {
+    const dir = makeTmpDir();
+    try {
+      writeConfig(dir, { bundledMemories: { enabled: true, exclude: ['propagated-skill'] } });
+      writeSkill(dir, 'test-agent', 'propagated-skill', PROPAGATED_SKILL_CONTENT);
+
+      const index = new SkillIndex(dir);
+      index.bind('test-agent', 'propagated-skill', { mode: 'permanent' });
+
+      const result = loadSkills('test-agent', ['propagated-skill'], dir, index);
+      expect(result.loaded).not.toContain('propagated-skill');
+      const drop = result.dropped.find(d => d.skill === 'propagated-skill');
+      expect(drop?.reason).toBe('excluded');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('non-propagated skill passes regardless of enabled:false', () => {
+    const dir = makeTmpDir();
+    try {
+      writeConfig(dir, { bundledMemories: { enabled: false, exclude: [] } });
+      writeSkill(dir, 'test-agent', 'regular-skill', REGULAR_SKILL_CONTENT);
+
+      const index = new SkillIndex(dir);
+      index.bind('test-agent', 'regular-skill', { mode: 'permanent' });
+
+      const result = loadSkills('test-agent', ['regular-skill'], dir, index);
+      expect(result.loaded).toContain('regular-skill');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('non-propagated skill passes even when listed in exclude', () => {
+    const dir = makeTmpDir();
+    try {
+      writeConfig(dir, { bundledMemories: { enabled: true, exclude: ['regular-skill'] } });
+      writeSkill(dir, 'test-agent', 'regular-skill', REGULAR_SKILL_CONTENT);
+
+      const index = new SkillIndex(dir);
+      index.bind('test-agent', 'regular-skill', { mode: 'permanent' });
+
+      const result = loadSkills('test-agent', ['regular-skill'], dir, index);
+      expect(result.loaded).toContain('regular-skill');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('propagated skill loads normally when config is absent (defaults)', () => {
+    const dir = makeTmpDir();
+    try {
+      // No config file — defaults apply (enabled:true, exclude:[])
+      writeSkill(dir, 'test-agent', 'propagated-skill', PROPAGATED_SKILL_CONTENT);
+
+      const index = new SkillIndex(dir);
+      index.bind('test-agent', 'propagated-skill', { mode: 'permanent' });
+
+      const result = loadSkills('test-agent', ['propagated-skill'], dir, index);
+      expect(result.loaded).toContain('propagated-skill');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/orchestrator/signal-type-snapshot.test.ts
+++ b/tests/orchestrator/signal-type-snapshot.test.ts
@@ -48,7 +48,7 @@ const DOCUMENTED_PATH_SPECIFIC = new Map<string, string>([
   ['relay_received',            'dispatch-pipeline.ts (relay receive)'],
   ['synthesis_completed',       'consensus-coordinator.ts'],
   ['circuit_open_fired',        'performance-reader.ts / dispatch-pipeline.ts'],
-  ['skill_injection_skipped',   'prompt-assembler.ts'],
+  ['skill_injection_skipped',   'prompt-assembler.ts / skill-loader.ts (ikp §4 kill-switch)'],
 ]);
 
 // ── Exhaustive union of all known signal names ─────────────────────────────


### PR DESCRIPTION
## Summary

- Ships `packages/orchestrator/src/memory-config.ts` — reads `.gossip/memory-config.json` and exposes a `MemoryConfig` interface with `bundledMemories.{enabled, exclude}` fields. Missing/malformed file → safe defaults, never throws.
- Modifies `packages/orchestrator/src/skill-loader.ts` — before injecting a skill, checks for `propagated: true` in its frontmatter. If found, suppresses it when `bundledMemories.enabled === false` (kill-switch) or when its name is in `bundledMemories.exclude`. Emits a `skill_injection_skipped` pipeline signal in both cases. Non-propagated skills are unaffected.
- 10 new tests in `tests/orchestrator/memory-config.test.ts` covering all four contract cases (absent file, malformed JSON, enabled:false, exclude list, non-propagated pass-through).
- Test fixture `tests/fixtures/propagated-skill.md` for the new tests.

## Config example

```json
// .gossip/memory-config.json
{
  "bundledMemories": {
    "enabled": false,
    "exclude": ["specific-skill-name"]
  }
}
```

## ikp §4 convention

Skills marked `propagated: true` in frontmatter are bundled institutional-knowledge skills that gossipcat injects from the memory propagation pipeline. This PR ships the suppression infrastructure only — **no existing default-skill is flagged `propagated: true` yet**. That flagging happens in the follow-up PR that actually ships the first ikp bundle.

The `enabled: false` switch is a global circuit-breaker for all propagated skills. The `exclude` list is a fine-grained per-skill override (e.g. suppress a specific topic area without disabling the whole pipeline). Both can coexist: a skill must pass both gates.

## Test plan

- [x] `npx jest tests/orchestrator/memory-config` — 10/10 green
- [x] `npx jest tests/orchestrator/skill-loader` — 44/44 green (no regression)
- [x] `npx jest tests/orchestrator/completion-signals-parity` — 2/2 green (L1 drift guard clean)
- [x] `npx jest tests/orchestrator/signal-type-snapshot` — 5/5 green
- [x] `npx tsc -p packages/orchestrator/tsconfig.json --noEmit` — clean (CLI TS errors pre-exist on master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)