### PR TITLE
fix(dispatch-pipeline): length cap on detectFormatCompliance input

### DIFF
--- a/packages/orchestrator/src/dispatch-pipeline.ts
+++ b/packages/orchestrator/src/dispatch-pipeline.ts
@@ -74,6 +74,9 @@ type TrackedTask = TaskEntry & {
  * "agent emitted tags but all had invalid type=" — the second case points at
  * a skill/prompt-format drift that instruction edits won't fix.
  */
+/** Maximum byte length of `result` fed into `detectFormatCompliance` regex passes. */
+export const MAX_COMPLIANCE_INPUT = 1_048_576;
+
 export interface FormatComplianceResult {
   findingCount: number;
   citationCount: number;
@@ -92,7 +95,11 @@ export interface FormatComplianceResult {
 }
 
 export function detectFormatCompliance(result: string): FormatComplianceResult {
-  const parseRes = parseAgentFindingsStrict(result);
+  // Guard against multi-megabyte inputs blocking the event loop.
+  const truncated = result.length > MAX_COMPLIANCE_INPUT;
+  const body = truncated ? result.slice(0, MAX_COMPLIANCE_INPUT) : result;
+
+  const parseRes = parseAgentFindingsStrict(body);
   const tags_total = parseRes.rawTagCount;
   const tags_accepted = parseRes.findings.length;
   const tags_dropped_unknown_type =
@@ -100,11 +107,20 @@ export function detectFormatCompliance(result: string): FormatComplianceResult {
     parseRes.droppedMissingType;
   const tags_dropped_short_content = parseRes.droppedShortContent;
   // Preserve legacy raw-tag count (includes dropped tags) for back-compat.
-  const findingCount = (result.match(/<agent_finding[\s>]/g) ?? []).length;
-  const citationCount = (result.match(/\b[\w./-]+\.\w+:\d+\b/g) ?? []).length;
+  const findingCount = (body.match(/<agent_finding[\s>]/g) ?? []).length;
+  const citationCount = (body.match(/\b[\w./-]+\.\w+:\d+\b/g) ?? []).length;
   // Compliance now requires ACCEPTED tags (previous behavior accepted
   // dropped-type tags too, which let format-invalid output pass as compliant).
   const formatCompliant = tags_accepted > 0 && citationCount >= tags_accepted;
+
+  const diagnostics = [...parseRes.diagnostics];
+  if (truncated) {
+    diagnostics.push({
+      code: 'input_truncated',
+      detail: `result length ${result.length} > cap ${MAX_COMPLIANCE_INPUT}`,
+    } as unknown as import('./parse-findings').ParseDiagnostic);
+  }
+
   return {
     findingCount,
     citationCount,
@@ -113,7 +129,7 @@ export function detectFormatCompliance(result: string): FormatComplianceResult {
     tags_accepted,
     tags_dropped_unknown_type,
     tags_dropped_short_content,
-    diagnostics: parseRes.diagnostics,
+    diagnostics,
   };
 }
 

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -1,7 +1,7 @@
 export { MainAgent } from './main-agent';
 export { seedMemoryHygiene } from './memory-hygiene-seed';
 export type { MemoryHygieneSeedResult } from './memory-hygiene-seed';
-export { detectFormatCompliance } from './dispatch-pipeline';
+export { detectFormatCompliance, MAX_COMPLIANCE_INPUT } from './dispatch-pipeline';
 export { loadSkills, DEFAULT_KEYWORDS, resolveSkillExists } from './skill-loader';
 export type { LoadSkillsResult, DroppedSkill } from './skill-loader';
 export { SkillCounterTracker } from './skill-counters';

--- a/tests/orchestrator/dispatch-pipeline.test.ts
+++ b/tests/orchestrator/dispatch-pipeline.test.ts
@@ -581,4 +581,51 @@ describe('DispatchPipeline', () => {
       expect(codes).toEqual(['HTML_ENTITY_MIXED_PAYLOAD']);
     });
   });
+
+  describe('detectFormatCompliance — MAX_COMPLIANCE_INPUT length cap', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { detectFormatCompliance, MAX_COMPLIANCE_INPUT } = require('@gossip/orchestrator');
+
+    it('MAX_COMPLIANCE_INPUT equals 1 MiB (1048576 bytes)', () => {
+      expect(MAX_COMPLIANCE_INPUT).toBe(1_048_576);
+    });
+
+    it('does not emit input_truncated for 100 KB input', () => {
+      const input = 'x'.repeat(100 * 1024);
+      const compliance = detectFormatCompliance(input);
+      const codes = compliance.diagnostics.map((d: { code: string }) => d.code);
+      expect(codes).not.toContain('input_truncated');
+    });
+
+    it('does not emit input_truncated for exactly 1 MiB input', () => {
+      const input = 'x'.repeat(MAX_COMPLIANCE_INPUT);
+      const compliance = detectFormatCompliance(input);
+      const codes = compliance.diagnostics.map((d: { code: string }) => d.code);
+      expect(codes).not.toContain('input_truncated');
+    });
+
+    it('emits input_truncated diagnostic for 1.5 MiB input and counts reflect first MiB only', () => {
+      // Build a 1.5 MiB string that contains an <agent_finding> tag AFTER the 1 MiB boundary.
+      const padding = 'x'.repeat(MAX_COMPLIANCE_INPUT);
+      const suffix = '<agent_finding type="finding" severity="high">Beyond cap foo.ts:99 content</agent_finding>';
+      const oversized = padding + suffix;
+      expect(oversized.length).toBeGreaterThan(MAX_COMPLIANCE_INPUT);
+
+      const compliance = detectFormatCompliance(oversized);
+
+      // The truncation diagnostic must be present.
+      const codes = compliance.diagnostics.map((d: { code: string }) => d.code);
+      expect(codes).toContain('input_truncated');
+
+      // The detail must reference the real input length and cap.
+      const truncDiag = compliance.diagnostics.find((d: { code: string }) => d.code === 'input_truncated') as { code: string; detail: string };
+      expect(truncDiag.detail).toContain(`result length ${oversized.length}`);
+      expect(truncDiag.detail).toContain(`cap ${MAX_COMPLIANCE_INPUT}`);
+
+      // Findings/citations from beyond the cap boundary must not be counted.
+      // The suffix tag is after the cut-off, so tags_accepted must be 0.
+      expect(compliance.tags_accepted).toBe(0);
+      expect(compliance.findingCount).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes finding **f3** from consensus `34e0a534-fb994382` (MEDIUM, peer-confirmed by sonnet-reviewer + haiku-researcher).

`detectFormatCompliance` in `packages/orchestrator/src/dispatch-pipeline.ts` ran two regex passes over the full agent \`result\` string with no length cap. A runaway agent emitting multi-megabyte output would block the MCP event loop synchronously.

## Change

- New exported constant \`MAX_COMPLIANCE_INPUT = 1_048_576\` (1 MiB).
- Internal truncation: \`const body = result.length > MAX_COMPLIANCE_INPUT ? result.slice(0, MAX_COMPLIANCE_INPUT) : result;\` — body used for all regex and parser calls inside the function.
- When truncation fires, appends a diagnostic \`{ code: 'input_truncated', detail: 'result length N > cap 1048576' }\` so downstream \`format_compliance\` signals remain observable.
- Parameter \`result\` is not renamed; truncation is internal only.

## Rationale

1 MiB is conservative headroom. Typical agent outputs (per session-gossip sampling) are under 100 KiB; 1 MiB accommodates the 99.9p without letting a rogue producer lock the event loop.

## Verification

- \`npx jest tests/orchestrator/dispatch-pipeline\`: 64/64 green (includes 4 new length-cap tests).
- \`npm run build --workspaces\`: clean.
- \`npx tsc --noEmit -p apps/cli/tsconfig.json\`: exit 0.

Base merged from master to pick up #179 kill-switch changes.