### PR TITLE
fix(audit-memories): derive default dir from git-common-dir so worktree runs resolve main project memory

### DIFF
--- a/scripts/audit-memories.lib.cjs
+++ b/scripts/audit-memories.lib.cjs
@@ -7,6 +7,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { execSync } = require('node:child_process');
 
 const DEFAULT_CODENAMES = ['crab-language', 'gossip-v2'];
 
@@ -22,9 +23,14 @@ Options:
   --codenames a,b,c     Extra codename strings to count as provenance.
   --help                Show this message and exit.
 
-Default dir is derived from process.cwd():
-  ~/.claude/projects/<cwd-with-slashes-as-dashes>/memory/
-The leading dash from an absolute path is dropped.
+Default dir is derived from the main project root (first success wins):
+  1. git rev-parse --show-superproject-working-tree
+  2. git rev-parse --git-common-dir  →  parent dir
+  3. git rev-parse --show-toplevel
+  4. process.cwd() fallback
+  Encoded as ~/.claude/projects/<path-with-slashes-as-dashes>/memory/
+  The leading dash from an absolute path is dropped.
+  Running from a worktree resolves to the main project root, not the worktree.
 
 This tool is read-only — it never writes to memory files.`;
 
@@ -49,8 +55,32 @@ function parseArgs(argv) {
   return out;
 }
 
-function defaultMemoryDir(cwd, home) {
-  let encoded = cwd.replace(/\//g, '-');
+function resolveProjectRoot(cwd, _execSync) {
+  const exec = _execSync || execSync;
+  const run = (cmd) => exec(cmd, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+  try {
+    const superproject = run('git rev-parse --show-superproject-working-tree');
+    if (superproject) return superproject;
+  } catch (_) {}
+  try {
+    const commonDir = run('git rev-parse --git-common-dir');
+    // commonDir is either an absolute path or relative (e.g. ".git" or
+    // "/path/to/.git/worktrees/agent-XXXX/../../.."); resolve then go up one.
+    const resolved = path.isAbsolute(commonDir)
+      ? path.dirname(commonDir)
+      : path.dirname(path.resolve(cwd, commonDir));
+    if (resolved) return resolved;
+  } catch (_) {}
+  try {
+    const toplevel = run('git rev-parse --show-toplevel');
+    if (toplevel) return toplevel;
+  } catch (_) {}
+  return cwd;
+}
+
+function defaultMemoryDir(cwd, home, _execSync) {
+  const root = resolveProjectRoot(cwd, _execSync);
+  let encoded = root.replace(/\//g, '-');
   if (encoded.startsWith('-')) encoded = encoded.slice(1);
   return path.join(home, '.claude', 'projects', encoded, 'memory');
 }
@@ -205,6 +235,7 @@ module.exports = {
   HELP,
   DEFAULT_CODENAMES,
   parseArgs,
+  resolveProjectRoot,
   defaultMemoryDir,
   scoreRubric,
   classify,

--- a/tests/scripts/audit-memories.test.ts
+++ b/tests/scripts/audit-memories.test.ts
@@ -125,6 +125,50 @@ describe('defaultMemoryDir', () => {
   });
 });
 
+describe('resolveProjectRoot', () => {
+  it('uses git-common-dir parent when superproject is empty', () => {
+    const fakeExec = (cmd: string) => {
+      if (cmd.includes('--show-superproject-working-tree')) return '';
+      if (cmd.includes('--git-common-dir')) return '/Users/alice/code/proj/.git';
+      throw new Error('unexpected');
+    };
+    const root = mod.resolveProjectRoot('/Users/alice/code/proj/.claude/worktrees/agent-XXXX', fakeExec);
+    // parent of /Users/alice/code/proj/.git is /Users/alice/code/proj
+    expect(root).toBe('/Users/alice/code/proj');
+  });
+
+  it('uses git-common-dir when superproject throws', () => {
+    const fakeExec = (cmd: string) => {
+      if (cmd.includes('--show-superproject-working-tree')) throw new Error('not a superproject');
+      if (cmd.includes('--git-common-dir')) return '/Users/alice/code/proj/.git';
+      throw new Error('unexpected');
+    };
+    const root = mod.resolveProjectRoot('/Users/alice/code/proj/.claude/worktrees/agent-XXXX', fakeExec);
+    expect(root).toBe('/Users/alice/code/proj');
+  });
+
+  it('defaultMemoryDir uses git-common-dir root, not cwd', () => {
+    const fakeExec = (cmd: string) => {
+      if (cmd.includes('--show-superproject-working-tree')) return '';
+      if (cmd.includes('--git-common-dir')) return '/Users/alice/code/proj/.git';
+      throw new Error('unexpected');
+    };
+    const dir = mod.defaultMemoryDir('/Users/alice/code/proj/.claude/worktrees/agent-XXXX', '/home/alice', fakeExec);
+    expect(dir).toBe('/home/alice/.claude/projects/Users-alice-code-proj/memory');
+  });
+
+  it('falls back to cwd when all git commands fail', () => {
+    const fakeExec = () => { throw new Error('not a git repo'); };
+    const root = mod.resolveProjectRoot('/some/non-git/dir', fakeExec);
+    expect(root).toBe('/some/non-git/dir');
+  });
+
+  it('--dir flag overrides derivation (parseArgs test)', () => {
+    const args = mod.parseArgs(['--dir', '/custom/memory/path']);
+    expect(args.dir).toBe('/custom/memory/path');
+  });
+});
+
 describe('parseArgs', () => {
   it('parses flags and values', () => {
     const a = mod.parseArgs(['--json', '--dir', '/tmp/x', '--candidates-only', '--codenames', 'a,b']);


### PR DESCRIPTION
## Summary

- **Bug:** `audit-memories.mjs` used `process.cwd()` to derive the default memory directory. When invoked from a gossipcat worktree (`.claude/worktrees/agent-XXXX`), the encoded path becomes `-Users-goku-Desktop-gossip-.claude-worktrees-agent-XXXX` which does not exist under `~/.claude/projects/`, causing the tool to exit 1 and prompt the user for `--dir`.
- **Fix:** Introduced `resolveProjectRoot()` in `scripts/audit-memories.lib.cjs` that tries four strategies in order (first non-empty success wins), all wrapped in try/catch:
  1. `git rev-parse --show-superproject-working-tree` — submodule root
  2. `git rev-parse --git-common-dir` → `path.dirname(commonDir)` — linked worktree resolves to main `.git` parent
  3. `git rev-parse --show-toplevel` — regular git root
  4. `process.cwd()` fallback — preserves original behavior outside git repos
- **`--dir` still overrides all derivation** — flag wins via `parseArgs`, unchanged.
- `resolveProjectRoot` accepts an optional `_execSync` parameter so it can be tested with a fake executor without needing to spy on non-configurable Node built-ins.

## Test plan

- [x] `npx jest tests/scripts/audit-memories` — 30/30 pass (4 new tests for the resolution chain)
  - Mock `git-common-dir` → derived dir uses main project root
  - All git calls fail → cwd fallback preserves original behavior
  - `--dir <path>` → wins over any derivation (parseArgs test)
  - Superproject throws, git-common-dir succeeds → correct root returned
- [x] `node scripts/audit-memories.mjs --help` — first line shows updated default-dir description
- [x] `npx tsc --noEmit -p apps/cli/tsconfig.json` — exit 2, identical errors on master (pre-existing, not caused by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)