### PR TITLE
feat(audit-memories): drop shipped/closed status from triage

### DIFF
--- a/scripts/audit-memories.lib.cjs
+++ b/scripts/audit-memories.lib.cjs
@@ -21,6 +21,8 @@ Options:
   --json                Emit JSON array instead of an ASCII table.
   --candidates-only     Hide rows whose proposed_target is DROP.
   --codenames a,b,c     Extra codename strings to count as provenance.
+  --include-shipped     Include files with status:shipped or status:closed
+                        (default: those files are forced to DROP).
   --help                Show this message and exit.
 
 Default dir is derived from the main project root (first success wins):
@@ -40,6 +42,7 @@ function parseArgs(argv) {
     json: false,
     candidatesOnly: false,
     codenames: [],
+    includeShipped: false,
     help: false,
   };
   for (let i = 0; i < argv.length; i++) {
@@ -47,6 +50,7 @@ function parseArgs(argv) {
     if (a === '--help' || a === '-h') out.help = true;
     else if (a === '--json') out.json = true;
     else if (a === '--candidates-only') out.candidatesOnly = true;
+    else if (a === '--include-shipped') out.includeShipped = true;
     else if (a === '--dir') out.dir = argv[++i];
     else if (a.startsWith('--dir=')) out.dir = a.slice('--dir='.length);
     else if (a === '--codenames') out.codenames = (argv[++i] || '').split(',').filter(Boolean);
@@ -83,6 +87,14 @@ function defaultMemoryDir(cwd, home, _execSync) {
   let encoded = root.replace(/\//g, '-');
   if (encoded.startsWith('-')) encoded = encoded.slice(1);
   return path.join(home, '.claude', 'projects', encoded, 'memory');
+}
+
+function parseFrontmatterStatus(body) {
+  const m = body.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  const fm = m[1];
+  const statusMatch = fm.match(/^status:\s*(\w+)\s*$/m);
+  return statusMatch ? statusMatch[1] : null;
 }
 
 function scoreRubric(body) {
@@ -155,18 +167,36 @@ function proposeTarget(rubric, bucket) {
   return 'DROP';
 }
 
-function auditBody(file, body, extraCodenames) {
+function auditBody(file, body, extraCodenames, opts) {
+  opts = opts || {};
+  const includeShipped = !!opts.includeShipped;
   const rubric = scoreRubric(body);
   const bucket = classify(body);
   const hits = provenanceHits(body, extraCodenames);
-  const target = proposeTarget(rubric, bucket);
+  const status = parseFrontmatterStatus(body);
+  const rubricTarget = proposeTarget(rubric, bucket);
+
+  let proposed_target = rubricTarget;
+  let drop_reason;
+
+  if (rubricTarget === 'DROP') {
+    drop_reason = 'low_rubric';
+  }
+
+  if (!includeShipped && (status === 'shipped' || status === 'closed')) {
+    proposed_target = 'DROP';
+    drop_reason = status === 'shipped' ? 'status_shipped' : 'status_closed';
+  }
+
   return {
     file,
     bucket,
+    status: status || null,
     rubric_score: rubric,
     provenance_hits: hits,
     strip_needed: hits > 0,
-    proposed_target: target,
+    proposed_target,
+    drop_reason,
   };
 }
 
@@ -182,10 +212,11 @@ function sortRows(rows) {
 }
 
 function renderTable(rows) {
-  const header = ['file', 'bucket', 'rubric_score', 'provenance_hits', 'strip_needed', 'proposed_target'];
+  const header = ['file', 'bucket', 'status', 'rubric_score', 'provenance_hits', 'strip_needed', 'proposed_target'];
   const data = rows.map((r) => [
     r.file,
     r.bucket,
+    r.status || '—',
     String(r.rubric_score),
     String(r.provenance_hits),
     String(r.strip_needed),
@@ -202,6 +233,7 @@ function renderTable(rows) {
 function auditDir(dir, opts) {
   opts = opts || {};
   const codenames = opts.codenames || [];
+  const includeShipped = opts.includeShipped || false;
   const warnings = [];
   let entries;
   try {
@@ -226,7 +258,7 @@ function auditDir(dir, opts) {
       warnings.push(`warn: skipping unreadable file ${name}: ${err.message}`);
       continue;
     }
-    rows.push(auditBody(name, body, codenames));
+    rows.push(auditBody(name, body, codenames, { includeShipped }));
   }
   return { rows: sortRows(rows), warnings, dir };
 }
@@ -237,6 +269,7 @@ module.exports = {
   parseArgs,
   resolveProjectRoot,
   defaultMemoryDir,
+  parseFrontmatterStatus,
   scoreRubric,
   classify,
   provenanceHits,

--- a/scripts/audit-memories.mjs
+++ b/scripts/audit-memories.mjs
@@ -29,7 +29,7 @@ async function main() {
   const dir = args.dir ?? lib.defaultMemoryDir(process.cwd(), os.homedir());
   let result;
   try {
-    result = lib.auditDir(dir, { codenames: args.codenames });
+    result = lib.auditDir(dir, { codenames: args.codenames, includeShipped: args.includeShipped });
   } catch (err) {
     process.stderr.write(`error: ${err.message}\n`);
     return 1;

--- a/tests/scripts/audit-memories.test.ts
+++ b/tests/scripts/audit-memories.test.ts
@@ -226,10 +226,100 @@ describe('auditDir end-to-end', () => {
   });
 });
 
+describe('parseFrontmatterStatus', () => {
+  it('returns status value from frontmatter', () => {
+    const body = '---\nstatus: shipped\ntitle: foo\n---\nsome body';
+    expect(mod.parseFrontmatterStatus(body)).toBe('shipped');
+  });
+
+  it('returns null when no frontmatter', () => {
+    expect(mod.parseFrontmatterStatus('just plain text')).toBeNull();
+  });
+
+  it('returns null when frontmatter has no status field', () => {
+    const body = '---\ntitle: foo\n---\nbody';
+    expect(mod.parseFrontmatterStatus(body)).toBeNull();
+  });
+
+  it('returns closed for status:closed', () => {
+    const body = '---\nstatus: closed\n---\nbody';
+    expect(mod.parseFrontmatterStatus(body)).toBe('closed');
+  });
+
+  it('returns open for status:open', () => {
+    const body = '---\nstatus: open\n---\nbody';
+    expect(mod.parseFrontmatterStatus(body)).toBe('open');
+  });
+});
+
+describe('auditBody — status filter', () => {
+  // A body that scores rubric 3 + PROTOCOL_BOUND → HANDBOOK (without status filter)
+  const handbookBody = [
+    '2026-04-01 and 2026-04-10 confirm.',
+    'You MUST always call gossip_remember.',
+    'Without it, signals are silently dropped.',
+  ].join('\n');
+
+  it('status:shipped + rubric 3 PROTOCOL_BOUND + includeShipped:false → DROP with drop_reason:status_shipped', () => {
+    const body = '---\nstatus: shipped\n---\n' + handbookBody;
+    const row = mod.auditBody('x.md', body, [], { includeShipped: false });
+    expect(row.proposed_target).toBe('DROP');
+    expect(row.drop_reason).toBe('status_shipped');
+    expect(row.status).toBe('shipped');
+  });
+
+  it('status:shipped + rubric 3 PROTOCOL_BOUND + includeShipped:true → HANDBOOK', () => {
+    const body = '---\nstatus: shipped\n---\n' + handbookBody;
+    const row = mod.auditBody('x.md', body, [], { includeShipped: true });
+    expect(row.proposed_target).toBe('HANDBOOK');
+    expect(row.status).toBe('shipped');
+  });
+
+  it('status:closed → DROP with drop_reason:status_closed (includeShipped:false)', () => {
+    const body = '---\nstatus: closed\n---\n' + handbookBody;
+    const row = mod.auditBody('x.md', body, [], { includeShipped: false });
+    expect(row.proposed_target).toBe('DROP');
+    expect(row.drop_reason).toBe('status_closed');
+    expect(row.status).toBe('closed');
+  });
+
+  it('status:open → normal rubric-based target', () => {
+    const body = '---\nstatus: open\n---\n' + handbookBody;
+    const row = mod.auditBody('x.md', body, [], { includeShipped: false });
+    expect(row.proposed_target).toBe('HANDBOOK');
+    expect(row.status).toBe('open');
+  });
+
+  it('missing status → normal target, no crash', () => {
+    const row = mod.auditBody('x.md', handbookBody, [], { includeShipped: false });
+    expect(row.proposed_target).toBe('HANDBOOK');
+    expect(row.status).toBeNull();
+  });
+
+  it('no frontmatter → normal target, no crash', () => {
+    const row = mod.auditBody('x.md', handbookBody, [], { includeShipped: false });
+    expect(row.proposed_target).toBe('HANDBOOK');
+    expect(row.status).toBeNull();
+    expect(row.drop_reason).toBeUndefined();
+  });
+
+  it('rubric<3 + status:open → drop_reason:low_rubric', () => {
+    // plain body with no rubric signals
+    const row = mod.auditBody('x.md', '---\nstatus: open\n---\nplain text', [], { includeShipped: false });
+    expect(row.proposed_target).toBe('DROP');
+    expect(row.drop_reason).toBe('low_rubric');
+  });
+});
+
 describe('CLI smoke', () => {
   it('--help prints usage and exits 0', () => {
     const out = execFileSync('node', [SCRIPT_MJS, '--help'], { encoding: 'utf8' });
     expect(out).toMatch(/audit-memories/);
     expect(out).toMatch(/--candidates-only/);
+  });
+
+  it('--help mentions --include-shipped', () => {
+    const out = execFileSync('node', [SCRIPT_MJS, '--help'], { encoding: 'utf8' });
+    expect(out).toMatch(/--include-shipped/);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #178 (tool shipped) and #181 (default-dir fix). Filters out `status: shipped` / `status: closed` memories from the audit triage by default — they represent already-shipped work with no live invariant to propagate.

## Motivation

On this repo's 193-memory corpus, the tool produced 7 candidates. Reading them revealed 4 were shipped bug fixes (finding_id-in-signals, cross-review-llm-identity, tool-server-cwd) with `status: shipped`/`status: closed` in frontmatter. They train the curator to dismiss candidates rather than strip-and-generalize them.

## Change

- Parse `status:` from frontmatter via regex (no YAML dep).
- `includeShipped: boolean` option, default `false`: records with `status` in `{shipped, closed}` get `proposed_target: 'DROP'` overriding the rubric target.
- New `drop_reason` field on each record: `low_rubric` | `status_shipped` | `status_closed` | `undefined`.
- CLI flag `--include-shipped` bypasses the filter (status → rubric target).
- Table output adds a `status` column (shows `—` for null).

## Verification

- Tests: 43/43 green (12 new cases: 5 `parseFrontmatterStatus`, 7 `auditBody` status-filter cases, plus the `--help` grep).
- tsc exit 0 (workspace rebuild + apps/cli typecheck).
- Live run on 193-memory corpus: **7 → 4 candidates** without `--include-shipped`; `--include-shipped` restores all 7.

## Lineage

| PR | Scope |
|----|-------|
| #178 | audit-memories tool (ikp §6) |
| #181 | worktree default-dir fix (`git-common-dir` chain) |
| this | status filter — drop shipped/closed by default |