### PR TITLE
feat(audit-memories): --hygiene flag for frontmatter validation

### DIFF
--- a/scripts/audit-memories.lib.cjs
+++ b/scripts/audit-memories.lib.cjs
@@ -11,6 +11,10 @@ const { execSync } = require('node:child_process');
 
 const DEFAULT_CODENAMES = ['crab-language', 'gossip-v2'];
 
+const VALID_TYPES = ['user', 'feedback', 'project', 'reference'];
+const VALID_STATUSES = ['open', 'shipped', 'closed'];
+const REQUIRED_FIELDS = ['name', 'description', 'type'];
+
 const HELP = `audit-memories — triage Claude Code auto-memory files.
 
 Usage:
@@ -23,6 +27,12 @@ Options:
   --codenames a,b,c     Extra codename strings to count as provenance.
   --include-shipped     Include files with status:shipped or status:closed
                         (default: those files are forced to DROP).
+  --hygiene             Read-only frontmatter hygiene scan. Validates required
+                        fields (name, description, type), valid type/status
+                        enum, and flags missing status/originSessionId.
+                        Different output; ignores triage flags.
+  --clean-only          With --hygiene: show only files with no issues.
+  --issues-only         With --hygiene: show only files with at least one issue.
   --help                Show this message and exit.
 
 Default dir is derived from the main project root (first success wins):
@@ -43,6 +53,9 @@ function parseArgs(argv) {
     candidatesOnly: false,
     codenames: [],
     includeShipped: false,
+    hygiene: false,
+    cleanOnly: false,
+    issuesOnly: false,
     help: false,
   };
   for (let i = 0; i < argv.length; i++) {
@@ -51,6 +64,9 @@ function parseArgs(argv) {
     else if (a === '--json') out.json = true;
     else if (a === '--candidates-only') out.candidatesOnly = true;
     else if (a === '--include-shipped') out.includeShipped = true;
+    else if (a === '--hygiene') out.hygiene = true;
+    else if (a === '--clean-only') out.cleanOnly = true;
+    else if (a === '--issues-only') out.issuesOnly = true;
     else if (a === '--dir') out.dir = argv[++i];
     else if (a.startsWith('--dir=')) out.dir = a.slice('--dir='.length);
     else if (a === '--codenames') out.codenames = (argv[++i] || '').split(',').filter(Boolean);
@@ -95,6 +111,87 @@ function parseFrontmatterStatus(body) {
   const fm = m[1];
   const statusMatch = fm.match(/^status:\s*(\w+)\s*$/m);
   return statusMatch ? statusMatch[1] : null;
+}
+
+function auditHygiene(body) {
+  const report = {
+    has_frontmatter: false,
+    missing_fields: [],
+    invalid_type: null,
+    invalid_status: null,
+    missing_status: false,
+    missing_origin: false,
+    malformed: null,
+  };
+  if (!body.startsWith('---')) return report;
+  const firstLineEnd = body.indexOf('\n');
+  const firstLine = body.slice(0, firstLineEnd).replace(/\s+$/, '');
+  if (firstLine !== '---') return report;
+  const rest = body.slice(firstLineEnd + 1);
+  const closeMatch = rest.match(/\r?\n---\s*(?:\r?\n|$)/);
+  if (!closeMatch) {
+    report.has_frontmatter = false;
+    report.malformed = 'missing closing delimiter';
+    return report;
+  }
+  const fm = rest.slice(0, closeMatch.index);
+  report.has_frontmatter = true;
+  if (!fm.trim()) {
+    report.malformed = 'empty frontmatter';
+    return report;
+  }
+  const fields = {};
+  const lineRe = /^(\w+):[ \t]*(.*?)\s*$/gm;
+  let m;
+  while ((m = lineRe.exec(fm)) !== null) {
+    fields[m[1]] = m[2];
+  }
+  for (const f of REQUIRED_FIELDS) {
+    if (!(f in fields) || fields[f].length === 0) report.missing_fields.push(f);
+  }
+  if ('type' in fields && !VALID_TYPES.includes(fields.type)) {
+    report.invalid_type = fields.type;
+  }
+  if ('status' in fields && !VALID_STATUSES.includes(fields.status)) {
+    report.invalid_status = fields.status;
+  }
+  const hasType = 'type' in fields && fields.type.length > 0;
+  if (hasType) {
+    report.missing_status = !('status' in fields);
+    report.missing_origin = !('originSessionId' in fields);
+  }
+  return report;
+}
+
+function hygieneHasIssues(report) {
+  if (!report.has_frontmatter) return true;
+  if (report.malformed) return true;
+  if (report.missing_fields.length > 0) return true;
+  if (report.invalid_type) return true;
+  if (report.invalid_status) return true;
+  if (report.missing_status) return true;
+  if (report.missing_origin) return true;
+  return false;
+}
+
+function summarizeHygiene(report) {
+  const parts = [];
+  if (!report.has_frontmatter) parts.push('no frontmatter');
+  if (report.malformed) parts.push(report.malformed);
+  if (report.missing_fields.length > 0) parts.push(`missing: ${report.missing_fields.join(',')}`);
+  if (report.invalid_type) parts.push(`invalid_type=${report.invalid_type}`);
+  if (report.invalid_status) parts.push(`invalid_status=${report.invalid_status}`);
+  if (report.missing_status) parts.push('missing_status');
+  if (report.missing_origin) parts.push('missing_origin');
+  return parts.length ? parts.join('; ') : '—';
+}
+
+function parseFrontmatterField(body, field) {
+  const m = body.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  const re = new RegExp('^' + field + ':[ \\t]*(.*?)\\s*$', 'm');
+  const match = m[1].match(re);
+  return match ? match[1] : null;
 }
 
 function scoreRubric(body) {
@@ -263,13 +360,78 @@ function auditDir(dir, opts) {
   return { rows: sortRows(rows), warnings, dir };
 }
 
+function hygieneDir(dir) {
+  const warnings = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(dir);
+  } catch (err) {
+    const e = new Error(`memory dir not readable: ${dir}`);
+    e.cause = err;
+    e.resolvedDir = dir;
+    throw e;
+  }
+  const rows = [];
+  for (const name of entries.sort()) {
+    if (!name.endsWith('.md')) continue;
+    if (name === 'MEMORY.md') continue;
+    const full = path.join(dir, name);
+    let body;
+    try {
+      const stat = fs.statSync(full);
+      if (!stat.isFile()) continue;
+      body = fs.readFileSync(full, 'utf8');
+    } catch (err) {
+      warnings.push(`warn: skipping unreadable file ${name}: ${err.message}`);
+      continue;
+    }
+    const report = auditHygiene(body);
+    rows.push({
+      file: name,
+      type: parseFrontmatterField(body, 'type'),
+      status: parseFrontmatterField(body, 'status'),
+      ...report,
+      has_issues: hygieneHasIssues(report),
+    });
+  }
+  rows.sort((a, b) => {
+    if (a.has_issues !== b.has_issues) return a.has_issues ? -1 : 1;
+    return a.file.localeCompare(b.file);
+  });
+  return { rows, warnings, dir };
+}
+
+function renderHygieneTable(rows) {
+  const header = ['file', 'type', 'status', 'has_frontmatter', 'issues'];
+  const data = rows.map((r) => [
+    r.file,
+    r.type || '—',
+    r.status || '—',
+    String(r.has_frontmatter),
+    summarizeHygiene(r),
+  ]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...data.map((row) => row[i].length))
+  );
+  const fmt = (cells) => cells.map((c, i) => c.padEnd(widths[i])).join('  ');
+  const sep = widths.map((w) => '-'.repeat(w)).join('  ');
+  return [fmt(header), sep].concat(data.map(fmt)).join('\n');
+}
+
 module.exports = {
   HELP,
   DEFAULT_CODENAMES,
+  VALID_TYPES,
+  VALID_STATUSES,
+  REQUIRED_FIELDS,
   parseArgs,
   resolveProjectRoot,
   defaultMemoryDir,
   parseFrontmatterStatus,
+  parseFrontmatterField,
+  auditHygiene,
+  hygieneHasIssues,
+  summarizeHygiene,
   scoreRubric,
   classify,
   provenanceHits,
@@ -278,4 +440,6 @@ module.exports = {
   sortRows,
   renderTable,
   auditDir,
+  hygieneDir,
+  renderHygieneTable,
 };

--- a/scripts/audit-memories.mjs
+++ b/scripts/audit-memories.mjs
@@ -27,6 +27,27 @@ async function main() {
     return 0;
   }
   const dir = args.dir ?? lib.defaultMemoryDir(process.cwd(), os.homedir());
+  if (args.hygiene) {
+    let result;
+    try {
+      result = lib.hygieneDir(dir);
+    } catch (err) {
+      process.stderr.write(`error: ${err.message}\n`);
+      return 1;
+    }
+    for (const w of result.warnings) process.stderr.write(w + '\n');
+    let rows = result.rows;
+    if (args.cleanOnly) rows = rows.filter((r) => !r.has_issues);
+    if (args.issuesOnly) rows = rows.filter((r) => r.has_issues);
+    if (args.json) {
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+    } else {
+      process.stdout.write(`# audit-memories --hygiene — ${dir}\n`);
+      process.stdout.write(`# rows: ${rows.length}\n`);
+      process.stdout.write(lib.renderHygieneTable(rows) + '\n');
+    }
+    return 0;
+  }
   let result;
   try {
     result = lib.auditDir(dir, { codenames: args.codenames, includeShipped: args.includeShipped });

--- a/tests/scripts/audit-memories.test.ts
+++ b/tests/scripts/audit-memories.test.ts
@@ -322,4 +322,151 @@ describe('CLI smoke', () => {
     const out = execFileSync('node', [SCRIPT_MJS, '--help'], { encoding: 'utf8' });
     expect(out).toMatch(/--include-shipped/);
   });
+
+  it('--help mentions --hygiene', () => {
+    const out = execFileSync('node', [SCRIPT_MJS, '--help'], { encoding: 'utf8' });
+    expect(out).toMatch(/--hygiene/);
+  });
+});
+
+describe('auditHygiene', () => {
+  it('well-formed file with all fields is clean', () => {
+    const body = [
+      '---',
+      'name: Some memory',
+      'description: A thing',
+      'type: feedback',
+      'status: open',
+      'originSessionId: abc-123',
+      '---',
+      'Body text.',
+    ].join('\n');
+    const r = mod.auditHygiene(body);
+    expect(r.has_frontmatter).toBe(true);
+    expect(r.missing_fields).toEqual([]);
+    expect(r.invalid_type).toBeNull();
+    expect(r.invalid_status).toBeNull();
+    expect(r.missing_status).toBe(false);
+    expect(r.missing_origin).toBe(false);
+    expect(r.malformed).toBeNull();
+    expect(mod.hygieneHasIssues(r)).toBe(false);
+  });
+
+  it('missing closing delimiter flags malformed', () => {
+    const body = '---\nname: X\ntype: project\n\nbody here never closes frontmatter';
+    const r = mod.auditHygiene(body);
+    expect(r.has_frontmatter).toBe(false);
+    expect(r.malformed).toBe('missing closing delimiter');
+    expect(mod.hygieneHasIssues(r)).toBe(true);
+  });
+
+  it('no frontmatter at all returns defaults without throwing', () => {
+    const r = mod.auditHygiene('Just body text, no frontmatter.\n');
+    expect(r.has_frontmatter).toBe(false);
+    expect(r.malformed).toBeNull();
+    expect(mod.hygieneHasIssues(r)).toBe(true);
+  });
+
+  it('invalid type is flagged', () => {
+    const body = '---\nname: X\ndescription: Y\ntype: invalid_value\n---\nbody';
+    const r = mod.auditHygiene(body);
+    expect(r.invalid_type).toBe('invalid_value');
+    expect(mod.hygieneHasIssues(r)).toBe(true);
+  });
+
+  it('invalid status is flagged', () => {
+    const body = '---\nname: X\ndescription: Y\ntype: feedback\nstatus: halfclosed\n---\nbody';
+    const r = mod.auditHygiene(body);
+    expect(r.invalid_status).toBe('halfclosed');
+    expect(mod.hygieneHasIssues(r)).toBe(true);
+  });
+
+  it('typed entry without status flags missing_status', () => {
+    const body = '---\nname: X\ndescription: Y\ntype: project\noriginSessionId: abc\n---\nbody';
+    const r = mod.auditHygiene(body);
+    expect(r.missing_status).toBe(true);
+    expect(mod.hygieneHasIssues(r)).toBe(true);
+  });
+
+  it('typed entry without originSessionId flags missing_origin', () => {
+    const body = '---\nname: X\ndescription: Y\ntype: project\nstatus: open\n---\nbody';
+    const r = mod.auditHygiene(body);
+    expect(r.missing_origin).toBe(true);
+    expect(mod.hygieneHasIssues(r)).toBe(true);
+  });
+
+  it('missing required fields are reported', () => {
+    const body = '---\ntype: feedback\n---\nbody';
+    const r = mod.auditHygiene(body);
+    expect(r.missing_fields).toEqual(expect.arrayContaining(['name', 'description']));
+    expect(mod.hygieneHasIssues(r)).toBe(true);
+  });
+
+  it('summarizeHygiene yields em-dash when clean', () => {
+    const r = mod.auditHygiene(
+      '---\nname: X\ndescription: Y\ntype: feedback\nstatus: open\noriginSessionId: abc\n---\nbody'
+    );
+    expect(mod.summarizeHygiene(r)).toBe('—');
+  });
+});
+
+describe('hygieneDir + --hygiene CLI', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-mem-hyg-'));
+    fs.writeFileSync(
+      path.join(tmp, 'clean.md'),
+      '---\nname: Clean\ndescription: Y\ntype: feedback\nstatus: open\noriginSessionId: abc\n---\nbody',
+    );
+    fs.writeFileSync(
+      path.join(tmp, 'dirty-missing-status.md'),
+      '---\nname: Dirty\ndescription: Y\ntype: project\noriginSessionId: abc\n---\nbody',
+    );
+    fs.writeFileSync(
+      path.join(tmp, 'dirty-malformed.md'),
+      '---\nname: Dirty\ntype: project\nno closing delimiter',
+    );
+    fs.writeFileSync(path.join(tmp, 'MEMORY.md'), 'ignored index');
+    fs.writeFileSync(path.join(tmp, 'not-md.txt'), 'ignored');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('hygieneDir returns one row per .md (excluding MEMORY.md)', () => {
+    const r = mod.hygieneDir(tmp);
+    expect(r.rows).toHaveLength(3);
+    expect(r.rows.map((x: any) => x.file).sort()).toEqual([
+      'clean.md',
+      'dirty-malformed.md',
+      'dirty-missing-status.md',
+    ]);
+  });
+
+  it('dirty files sort before clean files', () => {
+    const r = mod.hygieneDir(tmp);
+    expect(r.rows[0].has_issues).toBe(true);
+    expect(r.rows[r.rows.length - 1].file).toBe('clean.md');
+  });
+
+  it('CLI --hygiene --issues-only filters to dirty rows', () => {
+    const out = execFileSync('node', [SCRIPT_MJS, '--hygiene', '--dir', tmp, '--issues-only', '--json'], {
+      encoding: 'utf8',
+    });
+    const rows = JSON.parse(out);
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r: any) => r.has_issues)).toBe(true);
+  });
+
+  it('CLI --hygiene --clean-only filters to clean rows', () => {
+    const out = execFileSync('node', [SCRIPT_MJS, '--hygiene', '--dir', tmp, '--clean-only', '--json'], {
+      encoding: 'utf8',
+    });
+    const rows = JSON.parse(out);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].file).toBe('clean.md');
+    expect(rows[0].has_issues).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Read-only frontmatter hygiene scanner for memory files. Fourth in the institutional-knowledge-propagation follow-up chain after #178 (tool), #181 (default-dir), and #182 (status filter).

## Motivation

The audit tool scores memories for propagation but doesn't flag frontmatter hygiene issues. On this repo's 193-memory corpus:

- **73 files (37%)** have at least one hygiene issue
- **120 files (63%)** are clean
- Most common issue: \`project_*\` memories missing the \`status:\` field documented in CLAUDE.md §Memory-hygiene

These are invisible to the current curator workflow.

## Change

New CLI modes:

| Flag | Behavior |
|------|----------|
| \`--hygiene\` | Scans frontmatter, reports issues per file |
| \`--clean-only\` | With \`--hygiene\`, show only files with zero issues |
| \`--issues-only\` | With \`--hygiene\`, show only files with \u22651 issue |

Hygiene rules (spec §1 strip-and-generalize defaults):

- \`has_frontmatter\` — file starts with \`---\` followed by a closing \`---\`
- \`missing_fields\` — \`name\`, \`description\`, \`type\` required
- \`invalid_type\` — type must be one of \`user|feedback|project|reference\`
- \`invalid_status\` — if present, must be \`open|shipped|closed\`
- \`missing_status\` — typed entry without status field (signal, not error)
- \`missing_origin\` — typed entry without originSessionId (signal, not error)
- \`malformed\` — structural issues (missing closing delimiter, empty frontmatter)

Remains **strictly read-only** by design. Hygiene fixes are human-in-the-loop per IKP spec §1.

## Sample output

\`\`\`
# audit-memories --hygiene --issues-only
file                                           type      status  has_frontmatter  issues
project_foo.md                                 project   \u2014       true             missing_status; missing_origin
feedback_bar.md                                feedback  \u2014       true             missing_status
\`\`\`

## Verification

- Tests: **57/57 green** (14 new cases: 9 \`auditHygiene\` + 4 \`hygieneDir\`/CLI + 1 \`--help\` mention)
- tsc exit 0 (workspace rebuild + apps/cli typecheck)
- Live run on 193-memory corpus: 73 issues, 120 clean

## Lineage

| PR | Scope |
|----|-------|
| #178 | audit-memories tool (ikp §6) |
| #181 | default-dir fix (git-common-dir chain) |
| #182 | status filter (drop shipped/closed from triage) |
| **this** | frontmatter hygiene scan |