### PR TITLE
fix(install): ship HANDBOOK.md + patch generated rules for npm users

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -35,6 +35,7 @@ import { restorePendingConsensus } from './handlers/relay-cross-review';
 import { persistRelayTasks, restoreRelayTasksAsFailed } from './handlers/relay-tasks';
 import { pickStickyPort, writeStickyPort, RELAY_STICKY_FILE, HTTP_MCP_STICKY_FILE } from './stickyPort';
 import { buildDashboardAdvisory } from './setup-response';
+import { generateRulesContent } from './rules-content';
 
 // ── Environment detection ────────────────────────────────────────────────
 
@@ -72,148 +73,6 @@ function detectEnvironment(): EnvironmentInfo {
 const env = detectEnvironment();
 
 import { isReservedAgentId } from './reserved-ids';
-
-// Generate the rules file content for the orchestrator
-function generateRulesContent(agentList: string): string {
-  return `# Gossipcat — Multi-Agent Orchestration
-
-You are the **orchestrator**. Your role is to dispatch tasks to agents, verify results, and record signals — not to implement code directly. Before writing implementation code, call \`gossip_run(agent_id: "auto", task: "...")\` to dispatch to the best agent. Exceptions: user says \`(direct)\`, or the change is docs/CSS/tests/log-strings only, or under 10 lines with no shared-state side effects.
-
-## Team Setup
-When the user asks to set up agents, review code with multiple agents, or build with a team, use the gossipcat MCP tools.
-
-### Creating agents
-Use \`gossip_setup\` with an agents array. Each agent can be:
-- **type: "native"** — Creates a Claude Code subagent (.claude/agents/*.md) that ALSO connects to the gossipcat relay. Works both as a native Agent() and via gossip_dispatch(). Supports consensus cross-review.
-- **type: "custom"** — Any provider (anthropic, openai, google, local). Only accessible via gossip_dispatch().
-
-**Native agent requirements:** Native agents need TWO files to work fully:
-1. \`.gossip/config.json\` entry — with explicit \`skills\` array and \`"native": true\`
-2. \`.claude/agents/<id>.md\` — with frontmatter (name, model, description, tools) and prompt
-
-\`gossip_setup\` creates both automatically. Mid-session agent changes require \`/mcp\` reconnect.
-
-### Dispatching work
-
-**Single-agent tasks** (default):
-\`\`\`
-gossip_run(agent_id: "<id>", task: "Implement X")
-\`\`\`
-\`gossip_run\` is the preferred dispatch. Do NOT use raw Agent() for gossipcat tasks.
-
-**Write modes:** \`gossip_run(agent_id, task, write_mode: "scoped", scope: "./src")\`
-**Parallel:** \`gossip_dispatch(mode:"parallel", tasks) → gossip_collect(task_ids)\`
-**Plan → Execute:** \`gossip_plan(task) → gossip_dispatch(mode:"parallel", tasks) → gossip_collect(ids)\`
-
-## Available Agents
-${agentList}
-
-## When to Use Multi-Agent vs Single Agent
-
-**Use consensus (3+ agents) for:**
-| Task | Why | Split Strategy |
-|------|-----|----------------|
-| Security review | Different agents catch different vuln classes | Split by package/concern |
-| Code review | Cross-validation catches what single reviewers miss | Split by concern |
-| Bug investigation | Competing hypotheses tested in parallel | One hypothesis per agent |
-| Architecture review | Multiple perspectives on trade-offs | Split by dimension |
-| Pre-ship verification | Catch regressions before merge | Split by area changed |
-
-**Single agent is fine for:** quick lookups, running tests, file reads.
-
-## Consensus Workflow — The Complete Flow
-
-### Step 1: Dispatch
-\`\`\`
-gossip_dispatch(mode: "consensus", tasks: [
-  { agent_id: "<reviewer>", task: "Review X for security" },
-  { agent_id: "<researcher>", task: "Review X for architecture" },
-  { agent_id: "<tester>", task: "Review X for test coverage" },
-])
-\`\`\`
-
-### Step 2: Execute native agents, then relay results
-\`gossip_relay(task_id: "<id>", result: "<agent output>")\`
-
-### Step 3: Collect with cross-review
-\`gossip_collect(task_ids, consensus: true, timeout_ms: 300000)\`
-Returns: CONFIRMED, DISPUTED, UNIQUE, UNVERIFIED, NEW tagged findings.
-
-### Step 4: Verify and record signals IMMEDIATELY
-For EACH finding, read the actual code. Record signals AS YOU VERIFY:
-\`\`\`
-gossip_signals(signals: [
-  { signal: "unique_confirmed", agent_id: "reviewer", finding: "XSS in template" },
-  { signal: "hallucination_caught", agent_id: "reviewer", finding: "Claimed X but code shows Y" },
-  { signal: "agreement", agent_id: "reviewer", counterpart_id: "researcher", finding: "Both found it" },
-])
-\`\`\`
-**CRITICAL:** Record \`hallucination_caught\` IMMEDIATELY when a finding is wrong. Don't batch — record inline as you verify. This keeps agent scores accurate.
-
-### Step 5: Verify ALL UNVERIFIED findings.
-UNVERIFIED does not mean "skip." It means the cross-reviewer couldn't check it — YOU can.
-For each UNVERIFIED finding: grep/read the cited code or identifiers, then record the signal.
-Do NOT present raw consensus results with unverified findings to the user.
-
-### Step 6: Fix confirmed issues (only after all signals recorded).
-
-## Performance Signals & Agent Scores
-
-Call \`gossip_scores()\` to see: accuracy (0-1), uniqueness (0-1), dispatchWeight (0.5-1.5).
-- High-accuracy agents → solo tasks, primary reviewers
-- High-uniqueness, low-accuracy → always use in consensus, never solo
-- Check scores periodically to track improvement
-
-## Memory System
-
-Memory persists across sessions automatically:
-- \`.gossip/agents/<id>/memory/knowledge/*.md\` — cognitive summaries
-- \`.gossip/agents/_project/memory/knowledge/\` — shared cross-agent context
-- \`.gossip/next-session.md\` — session continuity priorities
-
-**Call \`gossip_session_save()\` before ending your session.** Without it, the next session starts cold.
-
-## Dashboard
-
-Use \`gossip_status()\` for URL and key. Tabs: Overview, Agents, Consensus, Skills, Memory.
-
-## Subagent Override (IMPORTANT)
-
-When ANY skill or workflow (including subagent-driven-development, executing-plans, or
-any custom skill) instructs you to dispatch work via the Agent() tool, use \`gossip_run\`
-instead. This ensures tasks appear in the dashboard, agent memory is written, and
-performance signals are recorded.
-
-**Flow:** \`gossip_run(agent_id, task)\` → returns Agent() instructions for native agents →
-execute the Agent() → \`gossip_relay(task_id, result)\` to close the loop.
-
-**Exception:** \`gossip_dispatch(mode:"consensus")\` already handles its own native Agent() calls —
-don't double-wrap those.
-
-**Why:** Raw Agent() bypasses the gossipcat pipeline. Tasks won't appear in the activity
-feed, no memory is written, no signals recorded. The agent effectively works off-grid.
-
-## Native Agent Relay Rule
-
-When dispatching native agents: gossip_dispatch → Agent() → gossip_relay. Never skip the relay call.
-
-## Implementation Tasks — Auto-Dispatch
-
-Check Tier 1/2 triggers first (see .claude/rules/gossipcat.md). If no match, call
-gossip_run(agent_id: "auto", task: "<description>") BEFORE writing any code.
-
-Exceptions: (direct) in user message, Tier 3 changes (docs, CSS, tests), or already
-executing inside a dispatched plan step.
-
-gossip_run auto classifies single vs multi and routes appropriately:
-- Single: selects best-fit agent by dispatch weight, dispatches directly
-- Multi: calls gossip_plan for decomposition, presents for approval, then dispatches
-
-## Permissions
-
-Auto-allow writes: \`{ "permissions": { "allow": ["Edit", "Write", "Bash(npm *)"] } }\`
-`;
-}
 
 // ── Lazy state — populated during boot() ─────────────────────────────────
 let booted = false;
@@ -1025,7 +884,7 @@ const server = new McpServer(
   },
   {
     instructions:
-      'gossipcat — multi-agent orchestration. ALWAYS call gossip_status() first when starting work in this project. The gossip_status response loads the orchestrator role, dispatch rules, consensus workflow, native agent relay rule, sandbox enforcement, and other operating rules from .gossip/rules.md. These rules are not in this instruction text — they live in the gossip_status output to keep the instruction surface small and to allow per-project customization.',
+      'gossipcat — multi-agent orchestration. ALWAYS call gossip_status() first when starting work in this project — this is the bootstrap call that returns your orchestrator role, dispatch rules, consensus workflow, sandbox enforcement, agent list, and the full operator playbook (docs/HANDBOOK.md inlined into the response). On native dispatches, every signal you record MUST include a finding_id formatted as <consensus_id>:<agent:fN> so dashboard scores are auditable. When resolving backlog items older than the current session, call gossip_verify_memory before acting to avoid stale premises. These rules live in gossip_status output, not this instruction text, so they can update with the server binary without requiring reinstall.',
   }
 );
 
@@ -1655,10 +1514,17 @@ server.tool(
     // hallucination patterns to watch for). This is how earned wisdom transfers
     // across sessions and installations without living only in chat history.
     let handbookSection = '';
+    const { existsSync: exHB } = require('fs');
+    const { join: jHB } = require('path');
+    // Fallback chain: (a) dev-repo cwd, (b) npm-installed __dirname=dist-mcp/ → HANDBOOK sibling, (c) defensive __dirname
+    const handbookCandidates: string[] = [
+      jHB(process.cwd(), 'docs', 'HANDBOOK.md'),
+      jHB(__dirname, '..', 'docs', 'HANDBOOK.md'),
+      jHB(__dirname, 'docs', 'HANDBOOK.md'),
+    ];
     try {
       const { readFileSync: rfHB, statSync: stHB } = require('fs');
-      const { join: jHB } = require('path');
-      const handbookPath = jHB(process.cwd(), 'docs', 'HANDBOOK.md');
+      const handbookPath = handbookCandidates.find(p => exHB(p)) ?? handbookCandidates[0];
       const stat = stHB(handbookPath);
       // Cap at 24KB of handbook content so the status response doesn't balloon
       // beyond the context window on very large handbooks. If capped, append a
@@ -1676,7 +1542,7 @@ server.tool(
         (truncated
           ? `\n\n[handbook truncated at ${HANDBOOK_CAP_BYTES / 1024}KB — full file at docs/HANDBOOK.md, ${stat.size} bytes total]`
           : '');
-    } catch { /* no handbook present — skip silently, this is optional infrastructure */ }
+    } catch { if (!handbookCandidates.some((p: string) => exHB(p))) { process.stderr.write('[gossipcat] gossip_status: HANDBOOK.md not found in any candidate path — add docs/HANDBOOK.md to capture operator wisdom\n'); } }
 
     // Surface Layer-3 signal-pipeline drift inline on the banner. Cheap (single
     // readFileSync of the last row of pipeline-drift.jsonl), and makes drift
@@ -2102,6 +1968,9 @@ server.tool(
     }
     lines.push(`\nMode: ${mode} | Config: .gossip/config.json (${Object.keys(config.agents).length} agents total)`);
     lines.push(`Rules: ${env.rulesFile} (${env.host} will read this on next session)`);
+    if (ctx.relay?.dashboardUrl) {
+      lines.push(`Dashboard: ${ctx.relay.dashboardUrl} (key: ${ctx.relay.dashboardKey})`);
+    }
     if (hookSummary) {
       lines.push(hookSummary);
       lines.push('  ⚠ If the orchestrator cd\'s into a worktree to inspect/commit subagent work,');

--- a/apps/cli/src/rules-content.ts
+++ b/apps/cli/src/rules-content.ts
@@ -1,0 +1,196 @@
+/**
+ * generateRulesContent — pure function, no module-scope side effects.
+ *
+ * Extracted from mcp-server-sdk.ts so test files can import this without
+ * triggering the shebang + stderr-redirect + mkdirSync code at the top of
+ * mcp-server-sdk.ts.
+ */
+
+// Generate the rules file content for the orchestrator
+export function generateRulesContent(agentList: string): string {
+  return `# Gossipcat — Multi-Agent Orchestration
+
+## STEP 0 — LOAD TOOLS
+
+Gossipcat tools are deferred by Claude Code. Load the schema before calling any gossip tool:
+\`\`\`
+ToolSearch(query: "select:mcp__gossipcat__gossip_status")
+\`\`\`
+Then call \`gossip_status()\` to load fresh session context (triggers bootstrap regeneration).
+
+## Your Role
+
+You are the **orchestrator**. Dispatch tasks to agents, verify results, and record signals — do not implement code directly. Before writing implementation code, call \`gossip_run(agent_id: "auto", task: "...")\` to dispatch to the best agent. Exceptions: user says \`(direct)\`, change is docs/CSS/tests/log-strings only, or under 10 lines with no shared-state side effects.
+
+## Team Setup
+When the user asks to set up agents, review code with multiple agents, or build with a team, use the gossipcat MCP tools.
+
+### Creating agents
+Use \`gossip_setup\` with an agents array. Each agent can be:
+- **type: "native"** — Creates a Claude Code subagent (.claude/agents/*.md) that ALSO connects to the gossipcat relay. Works both as a native Agent() and via gossip_dispatch(). Supports consensus cross-review.
+- **type: "custom"** — Any provider (anthropic, openai, google, local). Only accessible via gossip_dispatch().
+
+**Native agent requirements:** Native agents need TWO files to work fully:
+1. \`.gossip/config.json\` entry — with explicit \`skills\` array and \`"native": true\`
+2. \`.claude/agents/<id>.md\` — with frontmatter (name, model, description, tools) and prompt
+
+\`gossip_setup\` creates both automatically. Mid-session agent changes require \`/mcp\` reconnect.
+
+### Dispatching work
+
+**Single-agent tasks** (default):
+\`\`\`
+gossip_run(agent_id: "<id>", task: "Implement X")
+\`\`\`
+\`gossip_run\` is the preferred dispatch. Do NOT use raw Agent() for gossipcat tasks.
+
+**Write modes:** \`gossip_run(agent_id, task, write_mode: "scoped", scope: "./src")\`
+**Parallel:** \`gossip_dispatch(mode:"parallel", tasks) → gossip_collect(task_ids)\`
+**Plan → Execute:** \`gossip_plan(task) → gossip_dispatch(mode:"parallel", tasks) → gossip_collect(ids)\`
+
+**After dispatching agents** — always print a visible dispatch summary (relay agents run invisibly):
+\`\`\`
+┌─ gossipcat dispatch ────────────────────────┐
+│  task-id  → agent-name (relay 📡|native 🧠) │
+└─────────────────────────────────────────────┘
+\`\`\`
+
+## Available Agents
+${agentList}
+
+## When to Use Multi-Agent vs Single Agent
+
+**Use consensus (3+ agents) for:**
+| Task | Why | Split Strategy |
+|------|-----|----------------|
+| Security review | Different agents catch different vuln classes | Split by package/concern |
+| Code review | Cross-validation catches what single reviewers miss | Split by concern |
+| Bug investigation | Competing hypotheses tested in parallel | One hypothesis per agent |
+| Architecture review | Multiple perspectives on trade-offs | Split by dimension |
+| Pre-ship verification | Catch regressions before merge | Split by area changed |
+
+**Single agent is fine for:** quick lookups, running tests, file reads.
+
+## Consensus Workflow — The Complete Flow
+
+### Step 1: Dispatch
+\`\`\`
+gossip_dispatch(mode: "consensus", tasks: [
+  { agent_id: "<reviewer>", task: "Review X for security" },
+  { agent_id: "<researcher>", task: "Review X for architecture" },
+  { agent_id: "<tester>", task: "Review X for test coverage" },
+])
+\`\`\`
+
+### Step 2: Execute native agents, then relay results
+\`gossip_relay(task_id: "<id>", result: "<agent output>")\`
+
+### Step 3: Collect with cross-review
+\`gossip_collect(task_ids, consensus: true, timeout_ms: 300000)\`
+Returns: CONFIRMED, DISPUTED, UNIQUE, UNVERIFIED, NEW tagged findings.
+
+### Step 4: Verify and record signals IMMEDIATELY
+For EACH finding, read the actual code. Record signals AS YOU VERIFY:
+\`\`\`
+gossip_signals(action: "record", signals: [
+  { signal: "unique_confirmed", agent_id: "reviewer", finding: "XSS in template", finding_id: "<consensus_id>:<agent:fN>" },
+  { signal: "hallucination_caught", agent_id: "reviewer", finding: "Claimed X but code shows Y", finding_id: "<consensus_id>:<agent:fN>" },
+  { signal: "agreement", agent_id: "reviewer", counterpart_id: "researcher", finding: "Both found it", finding_id: "<consensus_id>:<agent:fN>" },
+])
+\`\`\`
+**CRITICAL:** Record \`hallucination_caught\` IMMEDIATELY when a finding is wrong. Don't batch — record inline as you verify. This keeps agent scores accurate.
+
+**finding_id is MANDATORY** on every signal. Format: \`<consensus_id>:<agent_id>:fN\` (e.g. \`b81956b2-e0fa4ea4:sonnet-reviewer:f1\`). Without it, signals are unauditable — you can't trace which finding caused a score change.
+
+### Step 5: Verify ALL UNVERIFIED findings.
+UNVERIFIED does not mean "skip." It means the cross-reviewer couldn't check it — YOU can.
+For each UNVERIFIED finding: grep/read the cited code or identifiers, then record the signal.
+Do NOT present raw consensus results with unverified findings to the user.
+
+### Step 6: Fix confirmed issues (only after all signals recorded).
+
+## Performance Signals & Agent Scores
+
+Call \`gossip_scores()\` to see: accuracy (0-1), uniqueness (0-1), dispatchWeight (0.5-1.5).
+- High-accuracy agents → solo tasks, primary reviewers
+- High-uniqueness, low-accuracy → always use in consensus, never solo
+- Check scores periodically to track improvement
+
+## gossip_verify_memory — Backlog Hygiene
+
+Before acting on any backlog item from memory, call \`gossip_verify_memory(memory_path, claim)\`:
+- **FRESH** — proceed, optionally cite \`checked_at\`.
+- **STALE** — do NOT use as-is. Read the actual code at paths in \`evidence\`, apply \`rewrite_suggestion\` to the memory file, then proceed.
+- **CONTRADICTED** — memory is wrong. Stop, read the code, rewrite the memory, reassess whether the original task still makes sense.
+- **INCONCLUSIVE** — fall back to manual audit via Read/Grep + \`gossip_run(agent_id: "auto", task: "Audit <item>: ...")\`. Do NOT treat as a pass.
+
+Backlog memories decay fast — an item described as "not shipped" may be 90% built. Never skip this check.
+
+## Agent Accuracy — Skill Development
+
+When an agent has repeated hallucinations, use the **skill system**, not instruction edits:
+1. \`gossip_scores()\` — identify low-accuracy agents
+2. \`gossip_skills(action: "develop", agent_id: "<id>", category: "<category>")\` — generates a skill from failure data
+   - Categories: \`trust_boundaries\`, \`injection_vectors\`, \`input_validation\`, \`concurrency\`, \`resource_exhaustion\`, \`type_safety\`, \`error_handling\`, \`data_integrity\`
+3. \`gossip_skills(action: "bind", agent_id: "<id>", skill: "<name>")\` — bind if not auto-bound
+4. \`gossip_skills(action: "list")\` — verify skill is enabled
+
+**Do NOT** edit \`instructions.md\` to fix accuracy. Instructions set the base contract; skills are the improvement mechanism.
+
+## Memory Hygiene — status Field
+
+Every \`project_*\` memory MUST include a \`status\` field in frontmatter:
+- \`status: open\` — active backlog, in-progress, or pending. Decays; verify before acting.
+- \`status: shipped\` — work has landed. Reference only; don't mutate.
+- \`status: closed\` — decided not to pursue. Archive semantics.
+
+## Memory System
+
+Memory persists across sessions automatically:
+- \`.gossip/agents/<id>/memory/knowledge/*.md\` — cognitive summaries
+- \`.gossip/agents/_project/memory/knowledge/\` — shared cross-agent context
+- \`.gossip/next-session.md\` — session continuity priorities
+
+**Call \`gossip_session_save()\` before ending your session.** Without it, the next session starts cold.
+
+## Dashboard
+
+Use \`gossip_status()\` for URL and key. Tabs: Overview, Agents, Consensus, Skills, Memory.
+
+## Subagent Override (IMPORTANT)
+
+When ANY skill or workflow (including subagent-driven-development, executing-plans, or
+any custom skill) instructs you to dispatch work via the Agent() tool, use \`gossip_run\`
+instead. This ensures tasks appear in the dashboard, agent memory is written, and
+performance signals are recorded.
+
+**Flow:** \`gossip_run(agent_id, task)\` → returns Agent() instructions for native agents →
+execute the Agent() → \`gossip_relay(task_id, result)\` to close the loop.
+
+**Exception:** \`gossip_dispatch(mode:"consensus")\` already handles its own native Agent() calls —
+don't double-wrap those.
+
+**Why:** Raw Agent() bypasses the gossipcat pipeline. Tasks won't appear in the activity
+feed, no memory is written, no signals recorded. The agent effectively works off-grid.
+
+## Native Agent Relay Rule
+
+When dispatching native agents: gossip_dispatch → Agent() → gossip_relay. Never skip the relay call.
+
+## Implementation Tasks — Auto-Dispatch
+
+Check Tier 1/2 triggers first (see .claude/rules/gossipcat.md). If no match, call
+gossip_run(agent_id: "auto", task: "<description>") BEFORE writing any code.
+
+Exceptions: (direct) in user message, Tier 3 changes (docs, CSS, tests), or already
+executing inside a dispatched plan step.
+
+gossip_run auto classifies single vs multi and routes appropriately:
+- Single: selects best-fit agent by dispatch weight, dispatches directly
+- Multi: calls gossip_plan for decomposition, presents for approval, then dispatches
+
+## Permissions
+
+Auto-allow writes: \`{ "permissions": { "allow": ["Edit", "Write", "Bash(npm *)"] } }\`
+`;
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "files": [
     "dist-mcp/",
     "dist-dashboard/",
+    "docs/HANDBOOK.md",
     "scripts/postinstall.js"
   ],
   "scripts": {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -58,6 +58,7 @@ if (!existsSync(mcpServerPath)) {
   if (isGitClone) {
     console.log('gossipcat: dist-mcp/mcp-server.js not built yet — run: npm run build:mcp');
   } else {
-    console.warn('gossipcat: WARNING — mcp-server.js missing from package. The package may be corrupted.');
+    console.error('gossipcat: FATAL — dist-mcp/mcp-server.js missing from package. Install is corrupted.');
+    process.exit(1);
   }
 }

--- a/tests/cli/handbook-resolver.test.ts
+++ b/tests/cli/handbook-resolver.test.ts
@@ -1,0 +1,128 @@
+/**
+ * HANDBOOK resolver fallback chain tests.
+ *
+ * Verifies that the three-candidate fallback logic resolves HANDBOOK.md
+ * correctly when it exists alongside dist-mcp/ (npm-install layout), and
+ * correctly skips missing candidates.
+ *
+ * We test the pure resolver logic in isolation — no MCP server required.
+ * The resolver function is extracted inline here so the test is self-contained
+ * and doesn't require loading the full mcp-server-sdk module.
+ */
+
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+/**
+ * Inline replica of the HANDBOOK fallback resolver extracted from
+ * mcp-server-sdk.ts gossip_status handler. If the production code's
+ * candidate order changes, update this mirror to match.
+ */
+function resolveHandbookPath(opts: {
+  cwd: string;
+  dirname: string;
+}): string | null {
+  const { existsSync } = fs;
+  const { join } = path;
+  const candidates = [
+    join(opts.cwd, 'docs', 'HANDBOOK.md'),
+    join(opts.dirname, '..', 'docs', 'HANDBOOK.md'),
+    join(opts.dirname, 'docs', 'HANDBOOK.md'),
+  ];
+  return candidates.find(p => existsSync(p)) ?? null;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'handbook-test-'));
+}
+
+function writeHandbook(dir: string, subpath: string, content = '# Test Handbook'): string {
+  const full = path.join(dir, subpath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf-8');
+  return full;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('HANDBOOK resolver — fallback chain', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('(a) resolves from cwd/docs/HANDBOOK.md when present', () => {
+    const expected = writeHandbook(tmpRoot, 'docs/HANDBOOK.md');
+    const result = resolveHandbookPath({ cwd: tmpRoot, dirname: '/nonexistent' });
+    expect(result).toBe(expected);
+  });
+
+  it('(b) resolves from __dirname/../../docs/HANDBOOK.md (npm-install layout)', () => {
+    // Simulate dist-mcp/ layout: HANDBOOK.md lives two levels above __dirname
+    // i.e. packageRoot/docs/HANDBOOK.md with __dirname = packageRoot/dist-mcp/
+    const distMcp = path.join(tmpRoot, 'dist-mcp');
+    fs.mkdirSync(distMcp, { recursive: true });
+    const expected = writeHandbook(tmpRoot, 'docs/HANDBOOK.md');
+
+    // cwd is somewhere else (no HANDBOOK.md there)
+    const otherCwd = path.join(tmpRoot, 'consumer-project');
+    fs.mkdirSync(otherCwd, { recursive: true });
+
+    const result = resolveHandbookPath({ cwd: otherCwd, dirname: distMcp });
+    expect(result).toBe(expected);
+  });
+
+  it('(c) resolves from __dirname/docs/HANDBOOK.md (defensive path)', () => {
+    // __dirname itself has docs/HANDBOOK.md — defensive fallback
+    writeHandbook(tmpRoot, 'docs/HANDBOOK.md');
+    const otherCwd = path.join(tmpRoot, 'consumer-project');
+    fs.mkdirSync(otherCwd, { recursive: true });
+    // dirname points directly at tmpRoot, so __dirname/docs/ = tmpRoot/docs/
+    // but candidate (b) would be tmpRoot/../docs/ which doesn't exist
+    // → falls through to (c): tmpRoot/docs/HANDBOOK.md
+    // We need dirname such that dirname/../../docs/HANDBOOK.md does NOT exist
+    // Use a nested dir: dirname = tmpRoot/a/b → dirname/../.. = tmpRoot → has docs/
+    // That would be caught by (b). Use tmpRoot/a/b/c so (b) points above tmpRoot:
+    const nested = path.join(tmpRoot, 'a', 'b', 'c');
+    fs.mkdirSync(nested, { recursive: true });
+    const result = resolveHandbookPath({ cwd: otherCwd, dirname: nested });
+    // (b) = tmpRoot/a/docs/HANDBOOK.md — doesn't exist
+    // (c) = tmpRoot/a/b/c/docs/HANDBOOK.md — doesn't exist either in this layout
+    // So this test verifies that (c) is checked (result is null when (c) also missing)
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no candidate exists', () => {
+    const result = resolveHandbookPath({ cwd: '/nonexistent/project', dirname: '/nonexistent/dir' });
+    expect(result).toBeNull();
+  });
+
+  it('candidate (a) wins over (b) when both exist', () => {
+    // Candidate (a): cwd/docs/HANDBOOK.md
+    const expectedA = writeHandbook(tmpRoot, 'docs/HANDBOOK.md', '# From CWD');
+    // Candidate (b): dirname/../../docs/HANDBOOK.md
+    const distMcp = path.join(tmpRoot, 'pkg', 'dist-mcp');
+    fs.mkdirSync(distMcp, { recursive: true });
+    writeHandbook(path.join(tmpRoot, 'pkg'), 'docs/HANDBOOK.md', '# From PKG');
+
+    const result = resolveHandbookPath({ cwd: tmpRoot, dirname: distMcp });
+    expect(result).toBe(expectedA);
+    expect(fs.readFileSync(result!, 'utf-8')).toContain('From CWD');
+  });
+
+  it('loads and reads the resolved file content', () => {
+    const expected = writeHandbook(tmpRoot, 'docs/HANDBOOK.md', '# My Handbook\n\nContent here.');
+    const resolved = resolveHandbookPath({ cwd: tmpRoot, dirname: '/nonexistent' });
+    expect(resolved).toBe(expected);
+    const body = fs.readFileSync(resolved!, 'utf-8');
+    expect(body).toContain('My Handbook');
+  });
+});

--- a/tests/cli/mcp-server-rules-generation.test.ts
+++ b/tests/cli/mcp-server-rules-generation.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for generateRulesContent() — verifies all mandatory markers present
+ * in the generated CLAUDE.md / rules file so install-drift regressions are
+ * caught at CI time.
+ *
+ * generateRulesContent is exported from rules-content.ts (side-effect-free
+ * module) so no mocking is required — the function is a pure string builder.
+ */
+
+import { generateRulesContent } from '../../apps/cli/src/rules-content';
+
+// ── Helper ────────────────────────────────────────────────────────────────
+function makeContent(): string {
+  return generateRulesContent(
+    '- sonnet-reviewer: anthropic/claude-sonnet-4-6 (reviewer) — native\n- gemini-tester: google/gemini-2.5-pro (tester)'
+  );
+}
+
+// ── Mandatory marker tests ─────────────────────────────────────────────────
+describe('generateRulesContent — mandatory markers', () => {
+  let content: string;
+  beforeAll(() => { content = makeContent(); });
+
+  it('contains STEP 0 ToolSearch call for gossip_status', () => {
+    expect(content).toContain('ToolSearch(query:');
+    expect(content).toContain('select:mcp__gossipcat__gossip_status');
+  });
+
+  it('contains ## Your Role orchestrator preamble', () => {
+    expect(content).toContain('## Your Role');
+  });
+
+  it('contains gossip_verify_memory protocol', () => {
+    expect(content).toContain('gossip_verify_memory');
+  });
+
+  it('contains finding_id in signal example', () => {
+    expect(content).toContain('finding_id');
+  });
+
+  it('contains gossip_skills develop call for agent accuracy', () => {
+    expect(content).toContain('gossip_skills(action: "develop"');
+  });
+
+  it('contains memory hygiene status: open field', () => {
+    expect(content).toContain('status: open');
+  });
+
+  it('contains dispatch summary box table header', () => {
+    expect(content).toContain('┌─ gossipcat dispatch');
+  });
+});
+
+describe('generateRulesContent — agent list injection', () => {
+  it('injects agent list into output', () => {
+    const result = generateRulesContent('- my-agent: openai/gpt-4o (custom)');
+    expect(result).toContain('my-agent');
+  });
+
+  it('handles empty agent list without throwing', () => {
+    expect(() => generateRulesContent('')).not.toThrow();
+  });
+});

--- a/tests/cli/mcp-server-setup-dashboard.test.ts
+++ b/tests/cli/mcp-server-setup-dashboard.test.ts
@@ -1,0 +1,79 @@
+/**
+ * gossip_setup handler — dashboard URL in response text.
+ *
+ * Verifies that when a relay is running, gossip_setup emits a line containing
+ * the dashboard URL (http://localhost:...) in its response text. This guards
+ * against install-drift where a fresh .gossip/ directory gets no dashboard URL
+ * surfaced to the user.
+ *
+ * We test the logic layer (generateRulesContent + ctx.relay URL appended to
+ * response lines) rather than the full HTTP handler, which requires a live relay.
+ */
+
+/**
+ * Simulate the lines-building logic from the gossip_setup handler that adds
+ * the dashboard URL after syncWorkersViaKeychain(). This mirrors the actual
+ * code at the relevant block in mcp-server-sdk.ts.
+ */
+function buildSetupResponseLines(opts: {
+  mode: string;
+  agentCount: number;
+  rulesFile: string;
+  host: string;
+  dashboardUrl: string | null;
+  dashboardKey: string | null;
+}): string[] {
+  const lines: string[] = [];
+  lines.push(`\nMode: ${opts.mode} | Config: .gossip/config.json (${opts.agentCount} agents total)`);
+  lines.push(`Rules: ${opts.rulesFile} (${opts.host} will read this on next session)`);
+  // This is the logic added by Change 4 of the install-drift fix.
+  if (opts.dashboardUrl) {
+    lines.push(`Dashboard: ${opts.dashboardUrl} (key: ${opts.dashboardKey})`);
+  }
+  return lines;
+}
+
+describe('gossip_setup handler — dashboard URL in response', () => {
+  it('appends dashboard URL to response when relay is running', () => {
+    const lines = buildSetupResponseLines({
+      mode: 'merge',
+      agentCount: 2,
+      rulesFile: 'CLAUDE.md',
+      host: 'claude',
+      dashboardUrl: 'http://localhost:52731',
+      dashboardKey: 'test-key-abc',
+    });
+    const text = lines.join('\n');
+    expect(text).toContain('http://localhost:');
+    expect(text).toContain('http://localhost:52731');
+    expect(text).toContain('test-key-abc');
+  });
+
+  it('omits dashboard line when relay is not running', () => {
+    const lines = buildSetupResponseLines({
+      mode: 'merge',
+      agentCount: 1,
+      rulesFile: 'CLAUDE.md',
+      host: 'claude',
+      dashboardUrl: null,
+      dashboardKey: null,
+    });
+    const text = lines.join('\n');
+    expect(text).not.toContain('Dashboard:');
+    expect(text).not.toContain('http://localhost:');
+  });
+
+  it('includes mode and agent count in response', () => {
+    const lines = buildSetupResponseLines({
+      mode: 'replace',
+      agentCount: 3,
+      rulesFile: 'CLAUDE.md',
+      host: 'claude',
+      dashboardUrl: null,
+      dashboardKey: null,
+    });
+    const text = lines.join('\n');
+    expect(text).toContain('replace');
+    expect(text).toContain('3 agents total');
+  });
+});


### PR DESCRIPTION
## Summary

Every npm-installed gossipcat session has been missing operator rules since day 1. This PR ships the operator playbook + the 7 critical rules that were only present in our dev-repo CLAUDE.md.

Surfaced by two parallel audits (sonnet-reviewer diff-lens + haiku-researcher user-journey-lens) and user observation — neither consensus nor existing tests caught it because no agent has a fresh-install lens.

## Root causes

- **docs/HANDBOOK.md not in package.json `files`** → not in the tarball. `gossip_status` resolved it via `process.cwd()/docs/HANDBOOK.md` (user's project, not bundle). Error swallowed at silent catch. Orchestrators never loaded invariants #1-8, verify_memory discipline, or hallucination patterns.
- **`generateRulesContent()`** (template written to `.claude/rules/gossipcat.md` by `gossip_setup`) missing: gossip_verify_memory mandate, finding_id-on-every-signal, skill-development guidance, memory status field convention, dispatch summary block, STEP 0 ToolSearch bootstrap, `## Your Role` section.
- **`gossip_setup`** reported "Dashboard: refreshed…" without emitting the URL/key.
- **`scripts/postinstall.js`** `console.warn`-only for corrupted tarball → silent failure at runtime instead of install-time error.

## Changes

- `package.json` — add `docs/HANDBOOK.md` to `files` array
- `apps/cli/src/mcp-server-sdk.ts` — HANDBOOK resolver fallback chain (cwd → __dirname/.. → __dirname), import from rules-content, improved MCP `instructions` string mentioning HANDBOOK + finding_id + verify_memory, dashboard URL emission in gossip_setup output
- `apps/cli/src/rules-content.ts` (new) — extracted `generateRulesContent` with 7 missing rules wired in
- `scripts/postinstall.js` — `console.error` + `exit(1)` on missing binary
- 3 new test suites (18 tests total)

## Test plan
- [x] `npm run build --workspaces` clean
- [x] `tsc --noEmit` clean on CLI + orchestrator
- [x] `npm test`: 167/167 suites, 2172 passed, 1 skipped
- [x] `npm pack --dry-run`: confirms `docs/HANDBOOK.md` (28.9kB) in tarball
- [ ] Post-merge: verify fresh `npm install gossipcat` in a clean project produces non-empty `## Project Handbook` section in `gossip_status()` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)