### PR TITLE
test(install): regression guards for tarball integrity + rules drift

### DIFF
--- a/tests/cli/install-packaging.test.ts
+++ b/tests/cli/install-packaging.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tarball integrity regression guard — install-packaging.test.ts
+ *
+ * Verifies that the root package.json `files` array includes every artifact
+ * required for a working npm install, and that those artifacts are
+ * structurally sound (present, non-empty, contain expected markers).
+ *
+ * All assertions use fs.readFileSync / existsSync / statSync only.
+ * No exec, no spawnSync, no network calls.
+ */
+
+import { readFileSync, existsSync, statSync } from 'fs';
+import { resolve } from 'path';
+
+// Resolve project root from tests/cli/ → ../../
+const PROJECT_ROOT = resolve(__dirname, '..', '..');
+
+function pkgFiles(): string[] {
+  const raw = readFileSync(resolve(PROJECT_ROOT, 'package.json'), 'utf-8');
+  const pkg = JSON.parse(raw) as { files?: string[] };
+  return pkg.files ?? [];
+}
+
+// ── package.json `files` membership ───────────────────────────────────────
+
+describe('package.json `files` — required tarball entries', () => {
+  let files: string[];
+
+  beforeAll(() => {
+    files = pkgFiles();
+  });
+
+  it('includes docs/HANDBOOK.md', () => {
+    expect(files).toContain('docs/HANDBOOK.md');
+  });
+
+  it('includes dist-mcp/', () => {
+    expect(files).toContain('dist-mcp/');
+  });
+
+  it('includes dist-dashboard/', () => {
+    expect(files).toContain('dist-dashboard/');
+  });
+
+  it('includes scripts/postinstall.js', () => {
+    expect(files).toContain('scripts/postinstall.js');
+  });
+});
+
+// ── docs/HANDBOOK.md integrity ────────────────────────────────────────────
+
+describe('docs/HANDBOOK.md — file integrity', () => {
+  const handbookPath = resolve(PROJECT_ROOT, 'docs', 'HANDBOOK.md');
+
+  it('exists on disk', () => {
+    expect(existsSync(handbookPath)).toBe(true);
+  });
+
+  it('is larger than 5 000 bytes (catches silent truncation)', () => {
+    // Handbook is ~28 KB; a 5 KB floor catches accidental truncation or
+    // replacement with a stub while still being generous enough not to
+    // break when non-essential sections are trimmed.
+    const { size } = statSync(handbookPath);
+    expect(size).toBeGreaterThan(5000);
+  });
+});
+
+// ── scripts/postinstall.js integrity ─────────────────────────────────────
+
+describe('scripts/postinstall.js — error-path regression guard', () => {
+  let source: string;
+
+  beforeAll(() => {
+    source = readFileSync(resolve(PROJECT_ROOT, 'scripts', 'postinstall.js'), 'utf-8');
+  });
+
+  it('contains console.error (fatal error reporting path present)', () => {
+    // Guards against a silent-warn revert where console.error is replaced
+    // with console.log, masking install corruption from users.
+    expect(source).toContain('console.error');
+  });
+
+  it('contains process.exit(1) (hard-exit on fatal install failure)', () => {
+    // Guards against the error path being softened to a warning-only exit.
+    // If dist-mcp/mcp-server.js is missing in a non-git-clone install, the
+    // postinstall MUST exit non-zero so npm/npx surfaces the failure.
+    expect(source).toContain('process.exit(1)');
+  });
+});

--- a/tests/cli/rules-generation-drift.test.ts
+++ b/tests/cli/rules-generation-drift.test.ts
@@ -1,0 +1,156 @@
+/**
+ * CLAUDE.md ↔ generateRulesContent drift detector
+ * ─────────────────────────────────────────────────
+ * This file is a Layer 1 drift guard, analogous to
+ * tests/orchestrator/completion-signals-parity.test.ts.
+ *
+ * It maintains a curated allowlist of anchors that MUST be present in BOTH:
+ *   (a) the root CLAUDE.md (source of truth for humans reading the repo), and
+ *   (b) the output of generateRulesContent() (source of truth for the
+ *       generated .claude/rules/gossipcat.md that every Claude Code session
+ *       reads on startup).
+ *
+ * When the two drift — e.g. a protocol section is added to CLAUDE.md but
+ * never wired into the generator, or the generator is refactored and a
+ * section silently drops — this test fails at CI time before users are
+ * affected.
+ *
+ * ── How to extend ────────────────────────────────────────────────────────
+ *
+ * When you add a new mandatory protocol section:
+ *
+ *   (1) Update CLAUDE.md — add or update the section in the root CLAUDE.md
+ *       file. This is the human-readable contract.
+ *
+ *   (2) Update generateRulesContent in apps/cli/src/rules-content.ts — wire
+ *       the same section into the generator so installed copies also receive
+ *       it. The generator output is what Claude Code actually reads per session.
+ *
+ *   (3) Append an anchor entry to MANDATORY_CLAUDE_ANCHORS below — add a
+ *       `{ anchor, note }` object whose `anchor` is a stable substring
+ *       present in both CLAUDE.md and the generator output. The `note` string
+ *       becomes the `it()` description and should explain WHY the anchor
+ *       matters (what protocol break it would catch).
+ *
+ * ── Design notes ─────────────────────────────────────────────────────────
+ *
+ * Anchors are human-curated, NOT auto-discovered from markdown. Auto-
+ * discovery is brittle: formatting changes produce false failures, and
+ * section headings are too coarse to guard specific protocol invariants.
+ * A curated allowlist is an explicit contract: reviewers can see exactly
+ * what is considered mandatory and why.
+ *
+ * Use the most specific stable substring that is unlikely to appear
+ * accidentally in unrelated text. Prefer function-call fragments
+ * (e.g. `gossip_skills(action`) over section headings alone.
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { generateRulesContent } from '../../apps/cli/src/rules-content';
+
+// ── Anchor registry ───────────────────────────────────────────────────────
+
+interface Anchor {
+  /** Substring that must be present in both CLAUDE.md and generator output. */
+  anchor: string;
+  /**
+   * Human-readable description of what protocol invariant this anchor guards.
+   * Becomes the `it()` label.
+   */
+  note: string;
+}
+
+/**
+ * The committed set of mandatory anchors.
+ *
+ * Each entry represents a protocol invariant that MUST be present in both
+ * the root CLAUDE.md and the generated rules file. A missing anchor on
+ * either side indicates drift that can silently degrade session behaviour.
+ *
+ * See top-of-file block comment for the 3-step extension process.
+ */
+const MANDATORY_CLAUDE_ANCHORS: readonly Anchor[] = [
+  {
+    anchor: 'gossip_verify_memory',
+    note: 'backlog memory verification protocol is present on both sides',
+  },
+  {
+    anchor: 'finding_id',
+    note: 'finding_id mandatory signal field is documented on both sides',
+  },
+  {
+    anchor: 'ToolSearch(query:',
+    note: 'STEP 0 deferred-tool bootstrap call is present on both sides',
+  },
+  {
+    // Note: '## Your Role' is the heading in the generator output but is NOT
+    // currently present verbatim in root CLAUDE.md (the orchestrator role is
+    // described inline via the DISPATCH RULE section there). We use
+    // gossip_session_save — a session-lifecycle call present verbatim on both
+    // sides — as the anchor for this slot. If CLAUDE.md is updated to include
+    // a ## Your Role heading, swap this back to that anchor.
+    anchor: 'gossip_session_save',
+    note: 'session-save call is documented on both sides (session lifecycle invariant)',
+  },
+  {
+    anchor: 'gossip_skills(action',
+    note: 'skill development workflow call is present on both sides',
+  },
+  {
+    anchor: 'status: open',
+    note: 'memory hygiene status field convention is present on both sides',
+  },
+  {
+    anchor: '┌─ gossipcat dispatch',
+    note: 'dispatch summary box format is present on both sides',
+  },
+] as const;
+
+// ── Setup ─────────────────────────────────────────────────────────────────
+
+const PROJECT_ROOT = resolve(__dirname, '..', '..');
+
+/** Stable sample agent list — kept minimal; content doesn't affect anchor tests. */
+const SAMPLE_AGENT_LIST =
+  '- sonnet-reviewer: anthropic/claude-sonnet-4-6 (reviewer) — native\n' +
+  '- gemini-tester: google/gemini-2.5-pro (tester)';
+
+let claudeMdContent: string;
+let generatorOutput: string;
+
+beforeAll(() => {
+  claudeMdContent = readFileSync(resolve(PROJECT_ROOT, 'CLAUDE.md'), 'utf-8');
+  generatorOutput = generateRulesContent(SAMPLE_AGENT_LIST);
+});
+
+// ── Dual-side anchor assertions ───────────────────────────────────────────
+
+describe('CLAUDE.md ↔ generateRulesContent drift detector', () => {
+  for (const { anchor, note } of MANDATORY_CLAUDE_ANCHORS) {
+    // Each anchor gets two sub-assertions: one per side. Using a single it()
+    // per anchor keeps the failure message readable — you see exactly which
+    // anchor failed and on which side.
+    it(note, () => {
+      expect(claudeMdContent).toContain(anchor);
+      expect(generatorOutput).toContain(anchor);
+    });
+  }
+});
+
+// ── Generator smoke test ──────────────────────────────────────────────────
+
+describe('generateRulesContent — baseline contract', () => {
+  it('returns a non-empty string', () => {
+    expect(generatorOutput.length).toBeGreaterThan(0);
+  });
+
+  it('injects the agent list verbatim', () => {
+    expect(generatorOutput).toContain('sonnet-reviewer');
+    expect(generatorOutput).toContain('gemini-tester');
+  });
+
+  it('handles empty agent list without throwing', () => {
+    expect(() => generateRulesContent('')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #184 (v0.4.14). Two CI-side tests so the install-path fix can't silently regress.

- `install-packaging.test.ts` — pins `package.json` files array, HANDBOOK size, postinstall fatal-path behavior.
- `rules-generation-drift.test.ts` — drift detector between root `CLAUDE.md` and `generateRulesContent()` output. Human-curated allowlist (same pattern as `completion-signals.allowlist.ts`). Fails loudly when a new correctness rule lands in one but not the other.

Addresses the meta-gap surfaced this session: three consensus rounds on other topics caught nothing about a critical install bug, and it took human observation to find it. These tests close that specific blind spot.

## Test plan
- [x] `npm test` on both new suites — 18/18 pass locally, runs in <2s
- [x] Pure `fs.readFileSync` / `existsSync` / `statSync` — no shell exec, no network
- [x] Follow-up noted in commit message: one anchor (`## Your Role`) substituted with `gossip_session_save` because CLAUDE.md describes the orchestrator role in prose rather than a labeled heading. Revert once CLAUDE.md adds the heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)