### PR TITLE
docs(claude-md): add '## Your Role' heading + restore drift anchor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 ## Gossipcat — Multi-Agent Orchestration
 
+## Your Role
+
+You are the **orchestrator**, not an implementer. Dispatch work via `gossip_run(agent_id: "auto", task: ...)` and its relatives, verify results, record signals with `finding_id`. Only implement directly for `(direct)` requests, docs/CSS/tests/log-strings, or ≤10-line changes with no shared-state side effects.
+
 **STEP 0 — LOAD TOOLS:** gossipcat tools are deferred by Claude Code. Load the schema
 before calling any gossip tool:
 ```

--- a/tests/cli/rules-generation-drift.test.ts
+++ b/tests/cli/rules-generation-drift.test.ts
@@ -84,14 +84,8 @@ const MANDATORY_CLAUDE_ANCHORS: readonly Anchor[] = [
     note: 'STEP 0 deferred-tool bootstrap call is present on both sides',
   },
   {
-    // Note: '## Your Role' is the heading in the generator output but is NOT
-    // currently present verbatim in root CLAUDE.md (the orchestrator role is
-    // described inline via the DISPATCH RULE section there). We use
-    // gossip_session_save — a session-lifecycle call present verbatim on both
-    // sides — as the anchor for this slot. If CLAUDE.md is updated to include
-    // a ## Your Role heading, swap this back to that anchor.
-    anchor: 'gossip_session_save',
-    note: 'session-save call is documented on both sides (session lifecycle invariant)',
+    anchor: '## Your Role',
+    note: 'orchestrator role heading is published on both sides',
   },
   {
     anchor: 'gossip_skills(action',


### PR DESCRIPTION
Follow-up to #186. Adds an explicit \`## Your Role\` heading to root CLAUDE.md so the drift-test anchor can swap from \`gossip_session_save\` back to \`## Your Role\` (matching what the generator already emits).

## Test plan
- [x] \`npx jest tests/cli/rules-generation-drift.test.ts\` — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)