### PR TITLE
test(signal-pipeline): PR C — parity walker + helper matrix + reflection guard

### DIFF
--- a/tests/orchestrator/completion-signals-parity.test.ts
+++ b/tests/orchestrator/completion-signals-parity.test.ts
@@ -67,6 +67,224 @@ function extractSignalsFromHelper(filePath: string): ExtractedSignal[] {
   return found;
 }
 
+/**
+ * Walk a TypeScript source file and return every call site matching the
+ * reflection-bypass pattern:
+ *
+ *   const sym = Object.getOwnPropertySymbols(<expr>)[<idx>];
+ *   <writer>[sym].<method>(...);
+ *   <writer>[sym](...);
+ *
+ * Handles the intermediate-variable binding case: first pass tracks the
+ * names of variables initialised from `Object.getOwnPropertySymbols(...)` at
+ * any depth in the same source file. Second pass flags any CallExpression
+ * whose callee is an ElementAccessExpression whose argumentExpression is an
+ * Identifier whose name matches a tracked binding, OR whose callee is a
+ * PropertyAccessExpression whose `.expression` is such an ElementAccess.
+ */
+interface ReflectionOffender {
+  file: string;
+  line: number;
+  col: number;
+  reason: string;
+  raw: string;
+}
+
+function collectSymbolBindings(sf: ts.SourceFile): Set<string> {
+  const bound = new Set<string>();
+  function visit(node: ts.Node): void {
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.initializer &&
+      ts.isIdentifier(node.name)
+    ) {
+      if (initializerInvolvesGetOwnPropertySymbols(node.initializer)) {
+        bound.add(node.name.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sf);
+  return bound;
+}
+
+function initializerInvolvesGetOwnPropertySymbols(node: ts.Expression): boolean {
+  // Match either the direct call `Object.getOwnPropertySymbols(x)` or the
+  // indexed form `Object.getOwnPropertySymbols(x)[N]`.
+  let cur: ts.Node = node;
+  if (ts.isElementAccessExpression(cur)) {
+    cur = cur.expression;
+  }
+  if (!ts.isCallExpression(cur)) return false;
+  const callee = cur.expression;
+  if (!ts.isPropertyAccessExpression(callee)) return false;
+  if (!ts.isIdentifier(callee.expression)) return false;
+  if (callee.expression.text !== 'Object') return false;
+  return callee.name.text === 'getOwnPropertySymbols';
+}
+
+function scanReflectionBypass(
+  sf: ts.SourceFile,
+  fileLabel: string,
+): ReflectionOffender[] {
+  const bound = collectSymbolBindings(sf);
+  const offenders: ReflectionOffender[] = [];
+
+  function isBypassElementAccess(node: ts.Node): node is ts.ElementAccessExpression {
+    if (!ts.isElementAccessExpression(node)) return false;
+    const arg = node.argumentExpression;
+    if (arg && ts.isIdentifier(arg) && bound.has(arg.text)) return true;
+    // Also flag direct inlined form `writer[Object.getOwnPropertySymbols(writer)[0]]`.
+    if (arg && initializerInvolvesGetOwnPropertySymbols(arg)) return true;
+    return false;
+  }
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      // Pattern A: writer[sym](...)
+      if (isBypassElementAccess(callee)) {
+        const pos = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+        offenders.push({
+          file: fileLabel,
+          line: pos.line + 1,
+          col: pos.character + 1,
+          reason: 'reflection-bypass call via Object.getOwnPropertySymbols binding',
+          raw: node.getText(sf).slice(0, 120),
+        });
+      } else if (ts.isPropertyAccessExpression(callee) && isBypassElementAccess(callee.expression)) {
+        // Pattern B: writer[sym].method(...)
+        const pos = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+        offenders.push({
+          file: fileLabel,
+          line: pos.line + 1,
+          col: pos.character + 1,
+          reason: 'reflection-bypass method call via Object.getOwnPropertySymbols binding',
+          raw: node.getText(sf).slice(0, 120),
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sf);
+  return offenders;
+}
+
+/**
+ * Find identifier bindings that reference WRITER_INTERNAL, including:
+ *   import { WRITER_INTERNAL } from '...'
+ *   import { WRITER_INTERNAL as Alias } from '...'
+ *   export { WRITER_INTERNAL } from '...'
+ *   export { WRITER_INTERNAL as Alias } from '...'
+ *
+ * Returns the local names under which the symbol is bound in this source file
+ * (or the re-export alias names, for export-only files).
+ */
+function collectWriterInternalAliases(sf: ts.SourceFile): Set<string> {
+  const aliases = new Set<string>();
+  for (const stmt of sf.statements) {
+    if (ts.isImportDeclaration(stmt) && stmt.importClause?.namedBindings) {
+      const bindings = stmt.importClause.namedBindings;
+      if (ts.isNamedImports(bindings)) {
+        for (const el of bindings.elements) {
+          // `propertyName` is the original name when there's an alias.
+          // Without an alias, `propertyName` is undefined and `name` is both.
+          const originalName = el.propertyName?.text ?? el.name.text;
+          if (originalName === 'WRITER_INTERNAL') {
+            aliases.add(el.name.text);
+          }
+        }
+      }
+    }
+    if (ts.isExportDeclaration(stmt) && stmt.exportClause && ts.isNamedExports(stmt.exportClause)) {
+      for (const el of stmt.exportClause.elements) {
+        const originalName = el.propertyName?.text ?? el.name.text;
+        if (originalName === 'WRITER_INTERNAL') {
+          aliases.add(el.name.text);
+        }
+      }
+    }
+  }
+  return aliases;
+}
+
+interface WriterInternalOffender {
+  file: string;
+  line: number;
+  col: number;
+  reason: string;
+  raw: string;
+}
+
+function scanWriterInternalBypass(
+  sf: ts.SourceFile,
+  fileLabel: string,
+): WriterInternalOffender[] {
+  const aliases = collectWriterInternalAliases(sf);
+  if (aliases.size === 0) return [];
+  const offenders: WriterInternalOffender[] = [];
+
+  function isAliasElementAccess(node: ts.Node): node is ts.ElementAccessExpression {
+    if (!ts.isElementAccessExpression(node)) return false;
+    const arg = node.argumentExpression;
+    return !!arg && ts.isIdentifier(arg) && aliases.has(arg.text);
+  }
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      if (isAliasElementAccess(callee)) {
+        const pos = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+        offenders.push({
+          file: fileLabel,
+          line: pos.line + 1,
+          col: pos.character + 1,
+          reason: 'WRITER_INTERNAL-alias bypass call',
+          raw: node.getText(sf).slice(0, 120),
+        });
+      } else if (ts.isPropertyAccessExpression(callee) && isAliasElementAccess(callee.expression)) {
+        const pos = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+        offenders.push({
+          file: fileLabel,
+          line: pos.line + 1,
+          col: pos.character + 1,
+          reason: 'WRITER_INTERNAL-alias method bypass call',
+          raw: node.getText(sf).slice(0, 120),
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sf);
+  return offenders;
+}
+
+/**
+ * Returns true if `node` is transitively inside a ClassDeclaration's
+ * MethodDeclaration whose identifier text matches `methodName`. Uses AST
+ * parent pointers only — no regex, no source-text inspection.
+ */
+function isInsideMethod(node: ts.Node, methodName: string): boolean {
+  let cur: ts.Node | undefined = node.parent;
+  while (cur) {
+    if (ts.isMethodDeclaration(cur)) {
+      const name = cur.name;
+      if (name && ts.isIdentifier(name) && name.text === methodName) {
+        // Confirm the method lives inside a ClassDeclaration, not an object literal.
+        let p: ts.Node | undefined = cur.parent;
+        while (p) {
+          if (ts.isClassDeclaration(p)) return true;
+          p = p.parent;
+        }
+        return false;
+      }
+      return false;
+    }
+    cur = cur.parent;
+  }
+  return false;
+}
+
 describe('completion-signals parity (Layer 1 drift guard)', () => {
   it('helper emissions exactly match COMPLETION_SIGNAL_ALLOWLIST', () => {
     const extracted = extractSignalsFromHelper(HELPER_PATH);
@@ -137,19 +355,18 @@ describe('completion-signals parity (Layer 1 drift guard)', () => {
       const source = readFileSync(file, 'utf8');
       const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true);
       const rel = relative(repoRoot, file);
+      const isPerformanceWriter = rel.endsWith('packages/orchestrator/src/performance-writer.ts');
       visit(sf);
 
       function visit(node: ts.Node): void {
         if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
           const methodName = node.expression.name.text;
           if (methodName === 'appendSignal' || methodName === 'appendSignals') {
-            // Skip the definition site itself (method declaration, not a call).
-            // Skip writer test helpers that intentionally exercise the default
-            // `'unknown'` path (validateSignal unit tests).
-            if (rel.endsWith('packages/orchestrator/src/performance-writer.ts')) {
-              // The only calls inside the writer are the implementation — no
-              // .appendSignal(s) invocations exist on `this.` beyond method bodies.
-              // Guard is defensive: parity check applies only to external callers.
+            // Narrow performance-writer.ts skip to method-scope: only
+            // call sites inside the `recordConsensusRoundRetraction`
+            // MethodDeclaration are exempt. All other methods in that
+            // file remain subject to the parity check.
+            if (isPerformanceWriter && isInsideMethod(node, 'recordConsensusRoundRetraction')) {
               return;
             }
             // L2: signal-helpers.ts is the sanctioned internal caller module.
@@ -162,10 +379,6 @@ describe('completion-signals parity (Layer 1 drift guard)', () => {
             if (rel.endsWith('packages/orchestrator/src/signal-helpers.ts')) {
               return;
             }
-            // Ignore the interface-shape declaration in tool-server.ts. That
-            // file declares a minimal duck-typed interface and does not call
-            // the real PerformanceWriter; its one invocation is a separate
-            // local writer and is wired below.
             const args = node.arguments;
             if (args.length < 2) {
               const pos = sf.getLineAndCharacterOfPosition(node.getStart(sf));
@@ -215,5 +428,192 @@ describe('completion-signals parity (Layer 1 drift guard)', () => {
       throw new Error(msg);
     }
     expect(offenders).toEqual([]);
+  });
+
+  it('no reflection bypass on PerformanceWriter', () => {
+    // Real-tree scan: no file under the scan roots may use
+    // Object.getOwnPropertySymbols() to reach into a PerformanceWriter and
+    // call internal methods, bypassing the emission-path contract.
+    // signal-helpers.ts is the sanctioned surface and is exempt.
+    const repoRoot = join(__dirname, '../..');
+    const scanRoots = [
+      join(repoRoot, 'apps/cli/src'),
+      join(repoRoot, 'packages/orchestrator/src'),
+    ];
+    const exempt = new Set<string>([
+      'packages/orchestrator/src/signal-helpers.ts',
+    ]);
+    const offenders: ReflectionOffender[] = [];
+
+    function walkTsFiles(dir: string): string[] {
+      const out: string[] = [];
+      let entries: string[] = [];
+      try { entries = readdirSync(dir); } catch { return out; }
+      for (const name of entries) {
+        const full = join(dir, name);
+        let st;
+        try { st = statSync(full); } catch { continue; }
+        if (st.isDirectory()) {
+          out.push(...walkTsFiles(full));
+        } else if (st.isFile() && (name.endsWith('.ts') || name.endsWith('.tsx')) && !name.endsWith('.d.ts')) {
+          out.push(full);
+        }
+      }
+      return out;
+    }
+
+    for (const root of scanRoots) {
+      for (const file of walkTsFiles(root)) {
+        const rel = relative(repoRoot, file);
+        if (exempt.has(rel)) continue;
+        const source = readFileSync(file, 'utf8');
+        const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true);
+        offenders.push(...scanReflectionBypass(sf, rel));
+      }
+    }
+
+    if (offenders.length > 0) {
+      const msg = [
+        `Reflection-bypass drift — ${offenders.length} offending call site(s).`,
+        `No code outside signal-helpers.ts may reach into PerformanceWriter via`,
+        `Object.getOwnPropertySymbols(). Route writes through the sanctioned helper path.`,
+        '',
+        ...offenders.map(o => `  ${o.file}:${o.line}:${o.col}  ${o.reason}\n    > ${o.raw}`),
+      ].join('\n');
+      throw new Error(msg);
+    }
+    expect(offenders).toEqual([]);
+
+    // In-test fixture: verify the walker DOES flag the synthetic bypass
+    // pattern. Parsed with ts.createSourceFile so the fixture lives in this
+    // spec file without touching real source.
+    const fixture = `
+      declare const writer: any;
+      const sym = Object.getOwnPropertySymbols(writer)[0];
+      writer[sym].appendSignal({});
+      writer[sym]({});
+    `;
+    const fixtureSf = ts.createSourceFile(
+      'fixture-reflection.ts',
+      fixture,
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    const fixtureOffenders = scanReflectionBypass(fixtureSf, 'fixture-reflection.ts');
+    expect(fixtureOffenders.length).toBeGreaterThanOrEqual(2);
+    expect(fixtureOffenders.some(o => /reflection-bypass method call/.test(o.reason))).toBe(true);
+    expect(fixtureOffenders.some(o => /^reflection-bypass call/.test(o.reason))).toBe(true);
+  });
+
+  it('no WRITER_INTERNAL alias-import or re-export bypass on PerformanceWriter', () => {
+    // Real-tree scan: match `import { WRITER_INTERNAL as X }` and
+    // `export { WRITER_INTERNAL as X }` and flag any subsequent
+    // `writer[X](...)` / `writer[X].method(...)` call site.
+    // signal-helpers.ts is the sanctioned surface and is exempt.
+    const repoRoot = join(__dirname, '../..');
+    const scanRoots = [
+      join(repoRoot, 'apps/cli/src'),
+      join(repoRoot, 'packages/orchestrator/src'),
+    ];
+    const exempt = new Set<string>([
+      'packages/orchestrator/src/signal-helpers.ts',
+      // The defining module itself re-exports WRITER_INTERNAL; call-site
+      // scanning there is moot since any calls are internal implementation.
+      'packages/orchestrator/src/_writer-internal.ts',
+      // emitCompletionSignals is a sanctioned internal caller that writes
+      // via the WRITER_INTERNAL accessor with a typed EmissionPath; it is
+      // part of the Layer 1 sanctioned emit surface alongside signal-helpers.
+      'packages/orchestrator/src/completion-signals.ts',
+    ]);
+    const offenders: WriterInternalOffender[] = [];
+
+    function walkTsFiles(dir: string): string[] {
+      const out: string[] = [];
+      let entries: string[] = [];
+      try { entries = readdirSync(dir); } catch { return out; }
+      for (const name of entries) {
+        const full = join(dir, name);
+        let st;
+        try { st = statSync(full); } catch { continue; }
+        if (st.isDirectory()) {
+          out.push(...walkTsFiles(full));
+        } else if (st.isFile() && (name.endsWith('.ts') || name.endsWith('.tsx')) && !name.endsWith('.d.ts')) {
+          out.push(full);
+        }
+      }
+      return out;
+    }
+
+    for (const root of scanRoots) {
+      for (const file of walkTsFiles(root)) {
+        const rel = relative(repoRoot, file);
+        if (exempt.has(rel)) continue;
+        const source = readFileSync(file, 'utf8');
+        const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true);
+        offenders.push(...scanWriterInternalBypass(sf, rel));
+      }
+    }
+
+    if (offenders.length > 0) {
+      const msg = [
+        `WRITER_INTERNAL-alias drift — ${offenders.length} offending call site(s).`,
+        `No code outside signal-helpers.ts may import WRITER_INTERNAL (under any`,
+        `alias) and call into the writer's internal surface.`,
+        '',
+        ...offenders.map(o => `  ${o.file}:${o.line}:${o.col}  ${o.reason}\n    > ${o.raw}`),
+      ].join('\n');
+      throw new Error(msg);
+    }
+    expect(offenders).toEqual([]);
+
+    // In-test fixture: alias-import case.
+    const aliasImportFixture = `
+      import { WRITER_INTERNAL as Secret } from './_writer-internal';
+      declare const writer: any;
+      writer[Secret].appendSignal({});
+      writer[Secret]({});
+    `;
+    const aliasSf = ts.createSourceFile(
+      'fixture-alias-import.ts',
+      aliasImportFixture,
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    const aliasOffenders = scanWriterInternalBypass(aliasSf, 'fixture-alias-import.ts');
+    expect(aliasOffenders.length).toBeGreaterThanOrEqual(2);
+
+    // In-test fixture: re-export alias chain. The file re-exports
+    // WRITER_INTERNAL under an alias and also exercises a bypass call
+    // through the re-export alias itself.
+    const reExportFixture = `
+      export { WRITER_INTERNAL as Inner } from './_writer-internal';
+      declare const writer: any;
+      writer[Inner].appendSignal({});
+    `;
+    const reExportSf = ts.createSourceFile(
+      'fixture-re-export.ts',
+      reExportFixture,
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    const reExportAliases = collectWriterInternalAliases(reExportSf);
+    expect(reExportAliases.has('Inner')).toBe(true);
+    const reExportOffenders = scanWriterInternalBypass(reExportSf, 'fixture-re-export.ts');
+    expect(reExportOffenders.length).toBeGreaterThanOrEqual(1);
+
+    // Plain (non-aliased) import should still be caught as the base case.
+    const plainFixture = `
+      import { WRITER_INTERNAL } from './_writer-internal';
+      declare const writer: any;
+      writer[WRITER_INTERNAL].appendSignal({});
+    `;
+    const plainSf = ts.createSourceFile(
+      'fixture-plain-import.ts',
+      plainFixture,
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    const plainOffenders = scanWriterInternalBypass(plainSf, 'fixture-plain-import.ts');
+    expect(plainOffenders.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/tests/orchestrator/reflection-bypass.test.ts
+++ b/tests/orchestrator/reflection-bypass.test.ts
@@ -1,0 +1,212 @@
+/**
+ * reflection-bypass.test.ts — Stream C defense-in-depth for the signal-pipeline
+ * boundary. Complements Stream A's AST walker
+ * (tests/orchestrator/completion-signals-parity.test.ts) with:
+ *
+ *  1. A dumb literal-string scan for `Object.getOwnPropertySymbols` across
+ *     packages/orchestrator/src/** and apps/cli/src/**. Redundant with the AST
+ *     walker but fails faster and is trivial to audit.
+ *
+ *  2. A runtime witness: synthesise a symbol-reflection bypass against a real
+ *     PerformanceWriter in a tmpdir and assert the L3 PipelineDriftDetector's
+ *     `bypassCount` goes up.
+ *
+ *  3. A negative control: the same writer instance invoked via the sanctioned
+ *     `emitConsensusSignals` helper must NOT raise the bypass count. Proves
+ *     the detector actually distinguishes reflection writes from helper-routed
+ *     writes.
+ *
+ * Addresses gemini-reviewer f1 HIGH from consensus fb3ea8fc-6e674462 — without
+ * this test the WRITER_INTERNAL Symbol gate is a purely static boundary that
+ * any call site can circumvent via `Object.getOwnPropertySymbols(writer)[0]`.
+ */
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join, relative, resolve, basename } from 'path';
+import { PerformanceWriter } from '../../packages/orchestrator/src/performance-writer';
+import { WRITER_INTERNAL } from '../../packages/orchestrator/src/_writer-internal';
+import { emitConsensusSignals } from '../../packages/orchestrator/src/signal-helpers';
+import { PipelineDriftDetector } from '../../packages/orchestrator/src/pipeline-drift-detector';
+import type { PerformanceSignal } from '../../packages/orchestrator/src/consensus-types';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+const SCAN_ROOTS = [
+  join(REPO_ROOT, 'packages/orchestrator/src'),
+  join(REPO_ROOT, 'apps/cli/src'),
+];
+
+/**
+ * Files that are permitted to mention `Object.getOwnPropertySymbols` because
+ * they are part of the sanctioned boundary itself, documentation, or this
+ * very test. Any NEW occurrence outside this list is a bypass and fails.
+ */
+const EXEMPT_BASENAMES = new Set<string>([
+  'signal-helpers.ts',
+  '_writer-internal.ts',
+  'completion-signals.ts',
+]);
+
+function walkTs(dir: string, acc: string[] = []): string[] {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) {
+      // Skip build output and node_modules defensively.
+      if (entry === 'node_modules' || entry === 'dist' || entry === 'build') continue;
+      walkTs(full, acc);
+    } else if (st.isFile() && entry.endsWith('.ts') && !entry.endsWith('.d.ts')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function iso(offsetMs = 0): string {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+describe('reflection-bypass defense-in-depth', () => {
+  describe('source-scan (Layer 1 sibling)', () => {
+    it('no source file outside the sanctioned boundary references Object.getOwnPropertySymbols', () => {
+      const offenders: Array<{ file: string; line: number; text: string }> = [];
+      const files: string[] = [];
+      for (const root of SCAN_ROOTS) walkTs(root, files);
+
+      for (const file of files) {
+        const base = basename(file);
+        if (EXEMPT_BASENAMES.has(base)) continue;
+        const src = readFileSync(file, 'utf8');
+        if (!src.includes('Object.getOwnPropertySymbols')) continue;
+        const lines = src.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+          if (lines[i].includes('Object.getOwnPropertySymbols')) {
+            offenders.push({
+              file: relative(REPO_ROOT, file),
+              line: i + 1,
+              text: lines[i].trim(),
+            });
+          }
+        }
+      }
+
+      if (offenders.length > 0) {
+        const pretty = offenders
+          .map(o => `  ${o.file}:${o.line}: ${o.text}`)
+          .join('\n');
+        throw new Error(
+          `Found ${offenders.length} unsanctioned Object.getOwnPropertySymbols ` +
+          `reference(s). Only ${[...EXEMPT_BASENAMES].join(', ')} may use the ` +
+          `Symbol accessor — every other call site must go through ` +
+          `signal-helpers.ts:\n${pretty}`,
+        );
+      }
+      expect(offenders).toEqual([]);
+    });
+  });
+
+  describe('runtime witness (Layer 3 sibling)', () => {
+    let root: string;
+
+    beforeEach(() => {
+      root = mkdtempSync(join(tmpdir(), 'gossip-test-'));
+    });
+
+    afterEach(() => {
+      try { rmSync(root, { recursive: true, force: true }); } catch { /* ignore */ }
+    });
+
+    /**
+     * Emit enough helper-routed rows to establish the drift detector's tagging
+     * epoch. Without this, the detector's bypass-detection path cannot fire
+     * because it refuses to look at pre-epoch rows.
+     */
+    function seedEpoch(writer: PerformanceWriter, n = 5, startOffset = 0): void {
+      for (let i = 0; i < n; i++) {
+        writer[WRITER_INTERNAL].appendSignals(
+          [{
+            type: 'meta',
+            signal: 'task_completed',
+            agentId: 'seed',
+            taskId: `seed-${i}`,
+            value: 0,
+            timestamp: iso(startOffset + i),
+          } as unknown as PerformanceSignal],
+          'completion-signals-helper',
+        );
+      }
+    }
+
+    it('synthetic reflection bypass increments drift-detector bypassCount', () => {
+      const writer = new PerformanceWriter(root);
+      seedEpoch(writer, 5, 0);
+
+      // Reach the internal writer exactly the way a hostile call site would —
+      // via the Symbol exposed by Object.getOwnPropertySymbols, bypassing the
+      // typed `WRITER_INTERNAL` import path that signal-helpers.ts uses.
+      const syms = Object.getOwnPropertySymbols(writer);
+      expect(syms.length).toBeGreaterThan(0);
+      const sym = syms[0];
+      const internal = (writer as unknown as Record<symbol, {
+        appendSignals: (s: PerformanceSignal[], path?: string) => void;
+      }>)[sym];
+      expect(typeof internal.appendSignals).toBe('function');
+
+      // Reflection call — no emissionPath argument → stamped as 'unknown'.
+      // Use an allowlisted completion-signal name so the bypass check fires,
+      // not the unknown-rate check (which is gated by a 100-row minimum).
+      internal.appendSignals([
+        {
+          type: 'meta',
+          signal: 'task_completed',
+          agentId: 'attacker',
+          taskId: 'reflect-1',
+          value: 1,
+          timestamp: iso(100),
+        } as unknown as PerformanceSignal,
+      ]);
+
+      const result = new PipelineDriftDetector(root).run();
+      expect(result.bypassCount).toBeGreaterThanOrEqual(1);
+      expect(result.triggered).toBe(true);
+      expect(result.sampleOffenders.some(o =>
+        o.taskId === 'reflect-1' && o.signal === 'task_completed',
+      )).toBe(true);
+    });
+
+    it('negative control: emitConsensusSignals does NOT increment bypassCount', () => {
+      const writer = new PerformanceWriter(root);
+      // Establish epoch with helper-path writes using the same writer instance
+      // the synthetic-bypass test uses. That instance shares the .gossip/ dir
+      // with the helper, so the detector sees a unified window.
+      seedEpoch(writer, 5, 0);
+
+      // Route a legitimate consensus signal through the sanctioned helper.
+      // This stamps `_emission_path: 'signal-helpers-consensus'`, which is
+      // NOT the helper path but IS in EMISSION_PATHS — and the allowlist
+      // check only trips on completion-signal names, not on consensus names
+      // like 'agreement'. So bypassCount must stay at 0.
+      emitConsensusSignals(root, [
+        {
+          type: 'consensus',
+          signal: 'agreement',
+          agentId: 'reviewer-a',
+          taskId: 'legit-1',
+          value: 1,
+          timestamp: iso(200),
+        } as unknown as PerformanceSignal,
+      ]);
+
+      const result = new PipelineDriftDetector(root).run();
+      expect(result.bypassCount).toBe(0);
+    });
+  });
+});

--- a/tests/orchestrator/signal-helpers.test.ts
+++ b/tests/orchestrator/signal-helpers.test.ts
@@ -1,0 +1,318 @@
+// tests/orchestrator/signal-helpers.test.ts
+//
+// PR C Stream B — coverage for the L2 typed signal helpers
+// (packages/orchestrator/src/signal-helpers.ts). Addresses carried finding
+// gemini-tester f1 MED (consensus fb3ea8fc-6e674462): the helper matrix
+// previously lacked explicit cases for 'unverified' and
+// 'consensus_round_retracted'. Both are exercised by name below.
+//
+// Companion to tests/orchestrator/completion-signals-parity.test.ts (Stream A)
+// and tests/orchestrator/performance-writer.test.ts (Step 1/1a writer guards).
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  emitConsensusSignals,
+  emitSandboxSignals,
+  emitImplSignals,
+  emitScoringAdjustmentSignals,
+  emitPipelineSignals,
+} from '@gossip/orchestrator';
+import type {
+  ConsensusSignal,
+  ImplSignal,
+  PipelineSignal,
+  PerformanceSignal,
+} from '../../packages/orchestrator/src/consensus-types';
+
+// Mirror of VALID_CONSENSUS_SIGNALS in performance-writer.ts L30-39.
+// Kept inline so the test fails loudly if the writer allowlist shrinks.
+const CONSENSUS_SIGNAL_VARIANTS: ConsensusSignal['signal'][] = [
+  'agreement',
+  'disagreement',
+  'unverified',
+  'unique_confirmed',
+  'unique_unconfirmed',
+  'new_finding',
+  'hallucination_caught',
+  'category_confirmed',
+  'consensus_verified',
+  'signal_retracted',
+  'consensus_round_retracted',
+  'task_timeout',
+  'task_empty',
+  'severity_miscalibrated',
+];
+
+const JSONL = '.gossip/agent-performance.jsonl';
+
+function readRows(tmpDir: string): any[] {
+  const p = path.join(tmpDir, JSONL);
+  if (!fs.existsSync(p)) return [];
+  return fs
+    .readFileSync(p, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line));
+}
+
+function baseConsensus(
+  signal: ConsensusSignal['signal'],
+  overrides: Partial<ConsensusSignal> = {},
+): ConsensusSignal {
+  return {
+    type: 'consensus',
+    signal,
+    agentId: 'sonnet-reviewer',
+    taskId: 'task-consensus-1',
+    evidence: `test: ${signal}`,
+    timestamp: '2026-04-20T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('signal-helpers — typed emission surface (L2)', () => {
+  let tmpDir: string;
+  let stderrSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gossip-test-'));
+    // Silence expected "[gossipcat] ... failed" lines from negative cases so
+    // jest output stays readable. Captured for assertions where relevant.
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── 1. Full VALID_CONSENSUS_SIGNALS matrix ─────────────────────────────────
+  describe('emitConsensusSignals — full VALID_CONSENSUS_SIGNALS matrix', () => {
+    it.each(CONSENSUS_SIGNAL_VARIANTS)(
+      "persists a '%s' consensus signal to agent-performance.jsonl",
+      variant => {
+        const signal = baseConsensus(variant, { taskId: `task-${variant}` });
+        emitConsensusSignals(tmpDir, [signal]);
+
+        const rows = readRows(tmpDir);
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+          type: 'consensus',
+          signal: variant,
+          agentId: 'sonnet-reviewer',
+          taskId: `task-${variant}`,
+        });
+      },
+    );
+
+    it("explicitly covers the 'unverified' variant (carried finding gemini-tester f1)", () => {
+      emitConsensusSignals(tmpDir, [baseConsensus('unverified')]);
+      const rows = readRows(tmpDir);
+      expect(rows[0].signal).toBe('unverified');
+      expect(rows[0].type).toBe('consensus');
+    });
+
+    it("explicitly covers the 'consensus_round_retracted' variant (carried finding gemini-tester f1)", () => {
+      emitConsensusSignals(tmpDir, [baseConsensus('consensus_round_retracted')]);
+      const rows = readRows(tmpDir);
+      expect(rows[0].signal).toBe('consensus_round_retracted');
+      expect(rows[0].type).toBe('consensus');
+    });
+  });
+
+  // ── 2. _emission_path stamping across all five helpers ────────────────────
+  describe('_emission_path stamping', () => {
+    it('emitConsensusSignals stamps _emission_path = signal-helpers-consensus', () => {
+      emitConsensusSignals(tmpDir, [baseConsensus('agreement')]);
+      expect(readRows(tmpDir)[0]._emission_path).toBe('signal-helpers-consensus');
+    });
+
+    it('emitSandboxSignals stamps _emission_path = signal-helpers-sandbox', () => {
+      const sandbox: ConsensusSignal = baseConsensus('new_finding', {
+        agentId: 'sandbox',
+        taskId: 'boundary-escape-1',
+        evidence: 'worktree_boundary_escape test',
+      });
+      emitSandboxSignals(tmpDir, sandbox);
+      expect(readRows(tmpDir)[0]._emission_path).toBe('signal-helpers-sandbox');
+    });
+
+    it('emitImplSignals stamps _emission_path = signal-helpers-impl', () => {
+      const impl: ImplSignal = {
+        type: 'impl',
+        signal: 'impl_test_pass',
+        agentId: 'sonnet-implementer',
+        taskId: 'impl-1',
+        timestamp: '2026-04-20T10:00:00Z',
+      };
+      emitImplSignals(tmpDir, [impl]);
+      expect(readRows(tmpDir)[0]._emission_path).toBe('signal-helpers-impl');
+    });
+
+    it('emitScoringAdjustmentSignals stamps _emission_path = signal-helpers-scoring', () => {
+      const scoring: ConsensusSignal = baseConsensus('severity_miscalibrated', {
+        claimedSeverity: 'critical',
+        severity: 'medium',
+      });
+      emitScoringAdjustmentSignals(tmpDir, scoring);
+      expect(readRows(tmpDir)[0]._emission_path).toBe('signal-helpers-scoring');
+    });
+
+    it('emitPipelineSignals stamps _emission_path = signal-helpers-pipeline', () => {
+      const pipeline: PipelineSignal = {
+        type: 'pipeline',
+        signal: 'skill_injection_skipped',
+        agentId: 'sonnet-reviewer',
+        taskId: 'pipeline-1',
+        timestamp: '2026-04-20T10:00:00Z',
+      };
+      emitPipelineSignals(tmpDir, [pipeline]);
+      expect(readRows(tmpDir)[0]._emission_path).toBe('signal-helpers-pipeline');
+    });
+  });
+
+  // ── 3. finding_id / findingId preservation ────────────────────────────────
+  describe('findingId preservation', () => {
+    it('emitConsensusSignals round-trips findingId exactly', () => {
+      const findingId = 'abc-123:sonnet-reviewer:f1';
+      emitConsensusSignals(tmpDir, [
+        baseConsensus('unique_confirmed', { findingId }),
+      ]);
+      const rows = readRows(tmpDir);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].findingId).toBe(findingId);
+    });
+
+    it('emitImplSignals preserves arbitrary extra fields on the envelope', () => {
+      // ImplSignal has no findingId in the TS union, but writers should not
+      // strip unknown fields that pass validateSignal's structural checks.
+      const impl = {
+        type: 'impl' as const,
+        signal: 'impl_peer_approved' as const,
+        agentId: 'sonnet-implementer',
+        taskId: 'impl-42',
+        timestamp: '2026-04-20T10:00:00Z',
+        evidence: 'peer approved',
+      };
+      emitImplSignals(tmpDir, [impl]);
+      const rows = readRows(tmpDir);
+      expect(rows[0]).toMatchObject({
+        type: 'impl',
+        signal: 'impl_peer_approved',
+        agentId: 'sonnet-implementer',
+        taskId: 'impl-42',
+      });
+    });
+  });
+
+  // ── 4. Empty-batch short-circuit ──────────────────────────────────────────
+  describe('empty batches are a no-op', () => {
+    it('emitConsensusSignals([]) does not create the jsonl file', () => {
+      emitConsensusSignals(tmpDir, []);
+      expect(fs.existsSync(path.join(tmpDir, JSONL))).toBe(false);
+    });
+
+    it('emitImplSignals([]) does not create the jsonl file', () => {
+      emitImplSignals(tmpDir, []);
+      expect(fs.existsSync(path.join(tmpDir, JSONL))).toBe(false);
+    });
+
+    it('emitPipelineSignals([]) does not create the jsonl file', () => {
+      emitPipelineSignals(tmpDir, []);
+      expect(fs.existsSync(path.join(tmpDir, JSONL))).toBe(false);
+    });
+  });
+
+  // ── 5. Negative cases — swallowed errors, no throw to caller ──────────────
+  describe('invalid input is swallowed and logged to stderr (never thrown)', () => {
+    it('emitConsensusSignals rejects a batch whose items are not type=consensus', () => {
+      const mixed: PerformanceSignal[] = [
+        baseConsensus('agreement'),
+        {
+          type: 'impl',
+          signal: 'impl_test_pass',
+          agentId: 'a',
+          taskId: 't',
+          timestamp: '2026-04-20T10:00:00Z',
+        },
+      ];
+      // Must not throw — helpers are try/catch wrapped end-to-end.
+      expect(() => emitConsensusSignals(tmpDir, mixed)).not.toThrow();
+      // And the file must NOT have been partially written — guard throws
+      // before the writer runs.
+      expect(fs.existsSync(path.join(tmpDir, JSONL))).toBe(false);
+      // Stderr gets a single diagnostic line.
+      const calls = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(calls).toMatch(/emitConsensusSignals failed/);
+      expect(calls).toMatch(/type='consensus'/);
+    });
+
+    it('emitImplSignals rejects a batch whose items are not type=impl', () => {
+      const mixed: PerformanceSignal[] = [
+        baseConsensus('agreement'),
+      ];
+      expect(() => emitImplSignals(tmpDir, mixed)).not.toThrow();
+      expect(fs.existsSync(path.join(tmpDir, JSONL))).toBe(false);
+      const calls = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(calls).toMatch(/emitImplSignals failed/);
+    });
+
+    it('emitPipelineSignals rejects a batch whose items are not type=pipeline', () => {
+      const mixed: PerformanceSignal[] = [baseConsensus('agreement')];
+      expect(() => emitPipelineSignals(tmpDir, mixed)).not.toThrow();
+      expect(fs.existsSync(path.join(tmpDir, JSONL))).toBe(false);
+      const calls = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(calls).toMatch(/emitPipelineSignals failed/);
+    });
+
+    it('emitConsensusSignals swallows writer-level validation errors (unknown signal name)', () => {
+      const bogus = baseConsensus('agreement');
+      (bogus as any).signal = 'made_up_signal';
+      expect(() => emitConsensusSignals(tmpDir, [bogus])).not.toThrow();
+      expect(fs.existsSync(path.join(tmpDir, JSONL))).toBe(false);
+      const calls = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(calls).toMatch(/emitConsensusSignals failed/);
+    });
+
+    it('emitSandboxSignals swallows writer-level validation errors', () => {
+      const bad = baseConsensus('agreement', { agentId: '' });
+      expect(() => emitSandboxSignals(tmpDir, bad)).not.toThrow();
+      expect(fs.existsSync(path.join(tmpDir, JSONL))).toBe(false);
+      const calls = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(calls).toMatch(/emitSandboxSignals failed/);
+    });
+
+    it('emitScoringAdjustmentSignals swallows writer-level validation errors', () => {
+      const bad = baseConsensus('severity_miscalibrated', { taskId: '' });
+      expect(() => emitScoringAdjustmentSignals(tmpDir, bad)).not.toThrow();
+      expect(fs.existsSync(path.join(tmpDir, JSONL))).toBe(false);
+      const calls = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(calls).toMatch(/emitScoringAdjustmentSignals failed/);
+    });
+  });
+
+  // ── 6. Batch write preserves ordering ─────────────────────────────────────
+  describe('batch write ordering', () => {
+    it('emitConsensusSignals persists all rows in call order', () => {
+      const batch: ConsensusSignal[] = [
+        baseConsensus('unverified', { taskId: 't-1' }),
+        baseConsensus('unique_confirmed', { taskId: 't-2' }),
+        baseConsensus('consensus_round_retracted', { taskId: 't-3' }),
+      ];
+      emitConsensusSignals(tmpDir, batch);
+      const rows = readRows(tmpDir);
+      expect(rows.map(r => r.taskId)).toEqual(['t-1', 't-2', 't-3']);
+      expect(rows.map(r => r.signal)).toEqual([
+        'unverified',
+        'unique_confirmed',
+        'consensus_round_retracted',
+      ]);
+      // Every row gets the same emission_path stamp.
+      expect(new Set(rows.map(r => r._emission_path))).toEqual(
+        new Set(['signal-helpers-consensus']),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes 3 carried findings from consensus `fb3ea8fc-6e674462`:

- **gemini-reviewer f1 HIGH** — `Object.getOwnPropertySymbols` reflection bypass of `WRITER_INTERNAL` accessor (Stream A static + Stream C runtime)
- **gemini-reviewer f7 MED** — file-scoped `performance-writer.ts` allowlist narrowed to method `recordConsensusRoundRetraction` (Stream A)
- **gemini-tester f1 MED** — `emitConsensusSignals` test matrix missing `'unverified'` and `'consensus_round_retracted'` variants (Stream B)

## Streams

| Commit | Stream | New/Changed | Tests |
|---|---|---|---|
| `94f8ea3` | A — AST walker + method-scoped allowlist + alias/re-export | `completion-signals-parity.test.ts` (+411) | 4/4 |
| `8551377` | B — `signal-helpers.test.ts` full matrix | NEW 318 lines | 33/33 |
| `c50d3af` | C — `reflection-bypass.test.ts` runtime drift-detector witness | NEW 212 lines | 3/3 |

Full suite: **2232 passed / 1 skipped**, `tsc --noEmit -p packages/orchestrator` exit 0.

## Consensus round `b049681f-d1f34692`

3 agents (sonnet-reviewer, haiku-researcher, gemini-reviewer) — 7 confirmed, 2 disputed. All three carried findings resolved at functional level. 3 follow-up medium AST-walker coverage gaps identified for future hardening (see follow-up issue).

## Test plan

- [x] `npx jest --config jest.config.base.js` — 2232 pass / 1 skipped
- [x] `npx tsc --noEmit -p packages/orchestrator/tsconfig.json` — exit 0
- [x] `npx jest -- completion-signals-parity` — 4/4
- [x] `npx jest -- signal-helpers` — 33/33
- [x] `npx jest -- reflection-bypass` — 3/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)