### PR TITLE
fix: auto-resolve + correct bug-feedback repo (#136 #137)

### DIFF
--- a/apps/cli/src/auto-resolve-finding.ts
+++ b/apps/cli/src/auto-resolve-finding.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure helper for auto-resolving implementation findings against recent git log.
+ *
+ * Extracted for testability + fix for GH #136: previously read `f.file`, which
+ * is never written by the producer at handlers/collect.ts:659. The file path is
+ * embedded in finding text as `<cite tag="file">path/to/foo.ts[:NN[-MM]]</cite>`.
+ */
+
+/**
+ * Extract the file path (sans line numbers) from a finding's `<cite tag="file">` tag.
+ * Returns '' when no cite tag is present.
+ */
+export function extractCitedFile(findingText: string | undefined | null): string {
+  if (!findingText) return '';
+  const m = /<cite\s+tag="file">([^:<]+?)(?::\d+(?:-\d+)?)?<\/cite>/.exec(findingText);
+  return m?.[1] ?? '';
+}
+
+export interface FindingLike {
+  status?: string;
+  finding?: string;
+  file?: string; // legacy field, usually absent
+  resolvedAt?: string;
+  [k: string]: unknown;
+}
+
+export interface AutoResolveResult {
+  changed: boolean;
+  finding: FindingLike;
+}
+
+/**
+ * Decide whether a finding should be auto-resolved given a git log blob.
+ *
+ * A finding is auto-resolved when ALL of:
+ *   - `status === 'open'`
+ *   - a file basename is derivable (from `<cite tag="file">` or legacy `f.file`)
+ *   - basename length > 2 AND appears in the git log verbatim
+ *   - at least one content word (length > 5) from the finding text appears in the git log
+ *
+ * Returns a copy (never mutates the input) with `status`/`resolvedAt` set when changed.
+ */
+export function tryAutoResolveFinding(
+  f: FindingLike,
+  gitLog: string,
+  now: () => string = () => new Date().toISOString()
+): AutoResolveResult {
+  if (!f || f.status !== 'open') return { changed: false, finding: f };
+
+  // Prefer cite-tag extraction (current producer format). Fall back to legacy `f.file`.
+  const citedPath = extractCitedFile(f.finding);
+  const filePath = citedPath || (typeof f.file === 'string' ? f.file : '');
+  const fileBase = filePath.split('/').pop() || '';
+
+  if (!fileBase || fileBase.length <= 2) return { changed: false, finding: f };
+  if (!gitLog.includes(fileBase)) return { changed: false, finding: f };
+
+  const findingWords = (f.finding || '')
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((w: string) => w.length > 5)
+    .slice(0, 3);
+  const gitLogLower = gitLog.toLowerCase();
+  const contentMatch =
+    findingWords.length > 0 && findingWords.some((w: string) => gitLogLower.includes(w));
+
+  if (!contentMatch) return { changed: false, finding: f };
+
+  return {
+    changed: true,
+    finding: { ...f, status: 'resolved', resolvedAt: now() },
+  };
+}

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -3354,19 +3354,16 @@ server.tool(
         try {
           const { readFileSync: rf, writeFileSync: wf } = require('fs');
           const { join: j } = require('path');
+          const { tryAutoResolveFinding } = require('./auto-resolve-finding');
           const findingsPath = j(process.cwd(), '.gossip', 'implementation-findings.jsonl');
           const lines = rf(findingsPath, 'utf-8').trim().split('\n').filter(Boolean);
           let changed = false;
           const updated = lines.map((line: string) => {
             try {
               const f = JSON.parse(line);
-              const fileBase = f.file?.split('/').pop() || '';
-              const findingWords = (f.finding || '').toLowerCase().split(/\s+/).filter((w: string) => w.length > 5).slice(0, 3);
-              const gitLogLower = summaryData.gitLog.toLowerCase();
-              if (f.status === 'open' && fileBase && fileBase.length > 2 && summaryData.gitLog.includes(fileBase) && findingWords.some((w: string) => gitLogLower.includes(w))) {
-                f.status = 'resolved'; f.resolvedAt = new Date().toISOString(); changed = true;
-              }
-              return JSON.stringify(f);
+              const r = tryAutoResolveFinding(f, summaryData.gitLog);
+              if (r.changed) changed = true;
+              return JSON.stringify(r.finding);
             } catch { return line; }
           });
           if (changed) wf(findingsPath, updated.join('\n') + '\n');
@@ -3516,29 +3513,24 @@ server.tool(
     } catch { /* no git */ }
 
     // 5a. Auto-resolve findings that appear in recent commits (best-effort)
+    //
+    // File path is extracted from the finding text's `<cite tag="file">…</cite>`
+    // tag (see auto-resolve-finding.ts). Producers at handlers/collect.ts do not
+    // populate `f.file`, so the previous `f.file?.split(...)` code never fired.
     if (gitLog) {
       try {
         const { readFileSync: rf, writeFileSync: wf } = require('fs');
         const { join: j } = require('path');
+        const { tryAutoResolveFinding } = require('./auto-resolve-finding');
         const findingsPath = j(process.cwd(), '.gossip', 'implementation-findings.jsonl');
         const lines = rf(findingsPath, 'utf-8').trim().split('\n').filter(Boolean);
         let changed = false;
         const updated = lines.map((line: string) => {
           try {
             const f = JSON.parse(line);
-            const fileBase = f.file?.split('/').pop() || '';
-            // Require both filename AND a content keyword from the finding to match git log
-            // Bare filename matching alone produces false positives (e.g., index.ts matches every session)
-            const findingWords = (f.finding || '').toLowerCase().split(/\s+/).filter((w: string) => w.length > 5).slice(0, 3);
-            const gitLogLower = gitLog.toLowerCase();
-            const fileMatch = fileBase && fileBase.length > 2 && gitLog.includes(fileBase);
-            const contentMatch = findingWords.length > 0 && findingWords.some((w: string) => gitLogLower.includes(w));
-            if (f.status === 'open' && fileMatch && contentMatch) {
-              f.status = 'resolved';
-              f.resolvedAt = new Date().toISOString();
-              changed = true;
-            }
-            return JSON.stringify(f);
+            const r = tryAutoResolveFinding(f, gitLog);
+            if (r.changed) changed = true;
+            return JSON.stringify(r.finding);
           } catch { return line; }
         });
         if (changed) {

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -4014,7 +4014,7 @@ server.tool(
     try {
       const searchResult = await execFile('gh', [
         'issue', 'list',
-        '--repo', 'ataberk-xyz/gossipcat',
+        '--repo', 'gossipcat-ai/gossipcat-ai',
         '--state', 'open',
         '--search', description.slice(0, 50),
         '--json', 'number,title,url',
@@ -4073,7 +4073,7 @@ Filed via gossip_bug_feedback`;
     try {
       const createResult = await execFile('gh', [
         'issue', 'create',
-        '--repo', 'ataberk-xyz/gossipcat',
+        '--repo', 'gossipcat-ai/gossipcat-ai',
         '--title', title,
         '--body', body,
       ]);

--- a/tests/cli/session-save-auto-resolve.test.ts
+++ b/tests/cli/session-save-auto-resolve.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression tests for GH #136 — session-save auto-resolve never fires.
+ *
+ * Root cause: the auto-resolve blocks in mcp-server-sdk.ts read `f.file`, but
+ * producers at handlers/collect.ts never populate that field. The file path
+ * is embedded in finding text as `<cite tag="file">path/to/foo.ts[:NN[-MM]]</cite>`.
+ *
+ * Fix: extract file path via regex from the cite tag (see auto-resolve-finding.ts).
+ */
+import {
+  extractCitedFile,
+  tryAutoResolveFinding,
+} from '../../apps/cli/src/auto-resolve-finding';
+
+describe('extractCitedFile', () => {
+  it('extracts path from basic cite tag with line number', () => {
+    expect(
+      extractCitedFile('See <cite tag="file">packages/orchestrator/src/foo.ts:42</cite> for bug.')
+    ).toBe('packages/orchestrator/src/foo.ts');
+  });
+
+  it('extracts path from cite tag with line range', () => {
+    expect(
+      extractCitedFile('<cite tag="file">path/bar.ts:42-55</cite>')
+    ).toBe('path/bar.ts');
+  });
+
+  it('extracts path from cite tag without line number', () => {
+    expect(
+      extractCitedFile('<cite tag="file">apps/cli/src/index.ts</cite>')
+    ).toBe('apps/cli/src/index.ts');
+  });
+
+  it('returns empty string when no cite tag present', () => {
+    expect(extractCitedFile('Just a plain finding with no tag.')).toBe('');
+  });
+
+  it('returns empty string for null/undefined input', () => {
+    expect(extractCitedFile(null)).toBe('');
+    expect(extractCitedFile(undefined)).toBe('');
+    expect(extractCitedFile('')).toBe('');
+  });
+
+  it('handles whitespace in the tag', () => {
+    expect(
+      extractCitedFile('<cite  tag="file">packages/foo.ts:10</cite>')
+    ).toBe('packages/foo.ts');
+  });
+});
+
+describe('tryAutoResolveFinding', () => {
+  const frozenNow = () => '2026-04-20T00:00:00.000Z';
+
+  it('resolves finding with cite tag + gitLog containing filename + matching word', () => {
+    const f = {
+      status: 'open',
+      finding:
+        'Null dereference in <cite tag="file">packages/orchestrator/src/foo.ts:42</cite> when handler misbehaves.',
+    };
+    const gitLog = 'abc1234 fix(orchestrator): handler null check in foo.ts path\n';
+    const r = tryAutoResolveFinding(f, gitLog, frozenNow);
+    expect(r.changed).toBe(true);
+    expect(r.finding.status).toBe('resolved');
+    expect(r.finding.resolvedAt).toBe('2026-04-20T00:00:00.000Z');
+    // Input not mutated
+    expect(f.status).toBe('open');
+  });
+
+  it('leaves finding open when no cite tag', () => {
+    const f = { status: 'open', finding: 'Some generic finding mentioning foo.ts and handler.' };
+    const gitLog = 'abc1234 fix(foo): handler something';
+    const r = tryAutoResolveFinding(f, gitLog, frozenNow);
+    expect(r.changed).toBe(false);
+    expect(r.finding.status).toBe('open');
+  });
+
+  it('leaves finding open when gitLog does not contain filename', () => {
+    const f = {
+      status: 'open',
+      finding: 'Bug in <cite tag="file">packages/orchestrator/src/foo.ts:42</cite> dereferences handler.',
+    };
+    const gitLog = 'abc1234 docs: update README';
+    const r = tryAutoResolveFinding(f, gitLog, frozenNow);
+    expect(r.changed).toBe(false);
+    expect(r.finding.status).toBe('open');
+  });
+
+  it('extracts line-range cite correctly and resolves', () => {
+    const f = {
+      status: 'open',
+      finding:
+        'Race condition in <cite tag="file">path/bar.ts:42-55</cite> during concurrent dispatch.',
+    };
+    const gitLog = 'def5678 fix(dispatch): bar.ts concurrent race condition';
+    const r = tryAutoResolveFinding(f, gitLog, frozenNow);
+    expect(r.changed).toBe(true);
+    expect(r.finding.status).toBe('resolved');
+  });
+
+  it('leaves already-resolved finding untouched', () => {
+    const f = {
+      status: 'resolved',
+      finding: '<cite tag="file">foo.ts:1</cite> dereferences handler',
+    };
+    const gitLog = 'abc foo.ts handler dereferences';
+    const r = tryAutoResolveFinding(f, gitLog, frozenNow);
+    expect(r.changed).toBe(false);
+  });
+
+  it('requires content word match (not just filename)', () => {
+    const f = {
+      status: 'open',
+      finding: 'Bug at <cite tag="file">index.ts:1</cite>.',
+    };
+    // Filename matches but no content word of length > 5 that also appears
+    const gitLog = 'abc1234 chore: bump deps in index.ts';
+    const r = tryAutoResolveFinding(f, gitLog, frozenNow);
+    expect(r.changed).toBe(false);
+  });
+
+  it('falls back to legacy f.file when no cite tag present', () => {
+    // Backward compat path — if a future producer ever writes f.file, it still works.
+    const f = {
+      status: 'open',
+      finding: 'A dereference issue involving the handler code path.',
+      file: 'packages/orchestrator/src/foo.ts',
+    };
+    const gitLog = 'abc fix(orch): dereference handler guard in foo.ts';
+    const r = tryAutoResolveFinding(f, gitLog, frozenNow);
+    expect(r.changed).toBe(true);
+    expect(r.finding.status).toBe('resolved');
+  });
+});


### PR DESCRIPTION
## Summary

Two small bundled bug fixes in `apps/cli/src/mcp-server-sdk.ts`.

### #137 — `gossip_bug_feedback` targeted wrong repo
- `gh issue list` and `gh issue create` were hardcoded to `ataberk-xyz/gossipcat` (a stale fork).
- Both call sites now point at the canonical `gossipcat-ai/gossipcat-ai`.
- `package.json` / `server.json` are left alone — those are npm / MCP registry names, not GitHub repo paths.

### #136 — session-save auto-resolve never fires
- The two auto-resolve blocks read `f.file?.split('/')` to derive a basename, but producers at `handlers/collect.ts:659` don't populate `f.file`. The file path lives inside finding text as `<cite tag="file">path/to/foo.ts:NN</cite>`.
- Result: auto-resolve branch dead code since the cite-tag migration; open findings kept piling into `next-session.md`.

**Fix:** extract a pure helper `tryAutoResolveFinding` in `apps/cli/src/auto-resolve-finding.ts` that parses the file path from the `<cite tag="file">…</cite>` tag via regex (supports bare paths, `:N`, and `:N-M` ranges). Both call sites (utility-fallback path and normal session-save path) now call the helper. Legacy `f.file` is still honored as a fallback for forward compatibility.

## Test plan

New: `tests/cli/session-save-auto-resolve.test.ts` (13 cases covering the helper). Full suite: **172 suites, 2245 passing, 1 skipped** — no regressions.

- [x] `npm run build --workspaces` exit 0
- [x] `npx tsc --noEmit -p apps/cli/tsconfig.json` exit 0
- [x] `npx jest tests/cli/session-save-auto-resolve` — 13/13 pass
- [x] `npx jest` full suite — 2245/2246 pass (1 pre-existing skip)
- [x] `grep ataberk-xyz` across the tree — 0 matches

Closes #136
Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
