### PR TITLE
test(orchestrator): #195 Batch A — await + IIFE taint unwrap

### DIFF
--- a/tests/orchestrator/_ast-walker-utils.ts
+++ b/tests/orchestrator/_ast-walker-utils.ts
@@ -55,8 +55,20 @@ export const REFLECTION_METHODS = new Set<string>([
  */
 export function initializerInvolvesGetOwnPropertySymbols(node: ts.Expression): boolean {
   let cur: ts.Node = node;
+  // Unwrap any number of AwaitExpression / ParenthesizedExpression layers first.
+  // This handles `await Object.getOwnPropertySymbols(x)` and `(Object.getOwnPropertySymbols(x))`.
+  // Order matters: unwrap before the single ElementAccess strip so that
+  // `(await f())[0]` — where ElementAccess wraps the await — is handled in the
+  // next branch, not here.
+  while (ts.isAwaitExpression(cur) || ts.isParenthesizedExpression(cur)) {
+    cur = (cur as ts.AwaitExpression | ts.ParenthesizedExpression).expression;
+  }
   if (ts.isElementAccessExpression(cur)) {
     cur = cur.expression;
+    // Unwrap again after stripping ElementAccess, e.g. `(await f())[0]`.
+    while (ts.isAwaitExpression(cur) || ts.isParenthesizedExpression(cur)) {
+      cur = (cur as ts.AwaitExpression | ts.ParenthesizedExpression).expression;
+    }
   }
   if (!ts.isCallExpression(cur)) return false;
   const callee = cur.expression;

--- a/tests/orchestrator/ast-walker-bypass-hardening.test.ts
+++ b/tests/orchestrator/ast-walker-bypass-hardening.test.ts
@@ -518,3 +518,51 @@ describe('F2: NonNull alias does not break tracking chain', () => {
     expect(offenders.some(o => /reflection-bypass/.test(o.reason))).toBe(true);
   });
 });
+
+// ===========================================================================
+// Batch A: AwaitExpression / ParenthesizedExpression unwrap + IIFE fixtures
+// ===========================================================================
+describe('Batch A: IIFE and await bypass patterns', () => {
+  it('(a) sync IIFE — reflection bypass inside sync IIFE is flagged', () => {
+    const src = `
+      declare const writer: any;
+      (() => { const sym = Object.getOwnPropertySymbols(writer)[0]; writer[sym]('event'); })();
+    `;
+    const sf = parseSf('batcha-sync-iife.ts', src);
+    const offenders = scanReflectionBypass(sf, 'batcha-sync-iife.ts');
+    expect(offenders.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('(b) async IIFE — reflection bypass inside async IIFE with await is flagged', () => {
+    const src = `
+      declare const writer: any;
+      (async () => { const sym = Object.getOwnPropertySymbols(writer)[0]; await writer[sym]('event'); })();
+    `;
+    const sf = parseSf('batcha-async-iife.ts', src);
+    const offenders = scanReflectionBypass(sf, 'batcha-async-iife.ts');
+    expect(offenders.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('(c) await chain — awaited reflection call seeds binding and downstream call is flagged', () => {
+    const src = `
+      declare const writer: any;
+      const sym = await Object.getOwnPropertySymbols(writer);
+      writer[sym[0]]('event');
+    `;
+    const sf = parseSf('batcha-await-chain.ts', src);
+    const bound = collectSymbolBindings(sf);
+    expect(bound.has('sym')).toBe(true);
+    const offenders = scanReflectionBypass(sf, 'batcha-await-chain.ts');
+    expect(offenders.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('(d) await inside async IIFE — awaited reflection call inside async IIFE is flagged', () => {
+    const src = `
+      declare const writer: any;
+      (async () => { const sym = await Object.getOwnPropertySymbols(writer); writer[sym[0]]('event'); })();
+    `;
+    const sf = parseSf('batcha-await-iife.ts', src);
+    const offenders = scanReflectionBypass(sf, 'batcha-await-iife.ts');
+    expect(offenders.length).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Unwrap `AwaitExpression` and `ParenthesizedExpression` layers in `initializerInvolvesGetOwnPropertySymbols` at `tests/orchestrator/_ast-walker-utils.ts:56` so `await Object.getOwnPropertySymbols(...)` seeds the taint set the same way as the bare call.
- Two unwrap loops: before and after the existing `ElementAccess` strip, to handle both `await f()` and `(await f())[0]` shapes.
- Add four fixtures covering Patterns 1 & 2 from Issue #195: sync IIFE, async IIFE, await chain, await-in-async-IIFE.

Addresses Patterns 1 (IIFE wrapping) and 2 (await chains) from #195. Patterns 3–5 (object hops, constructor/accessor, inter-procedural) deferred to follow-up PRs.

## Test plan
- [x] `npx jest tests/orchestrator/ast-walker-bypass-hardening.test.ts` — 31/31 pass (27 pre-existing + 4 new)
- [x] `npx tsc --noEmit` clean
- [x] Scope confirmed: no changes under `packages/orchestrator/src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)