### PR TITLE
test(orchestrator): #195 Batch B — constructor + accessor taint

### DIFF
--- a/tests/orchestrator/_ast-walker-utils.ts
+++ b/tests/orchestrator/_ast-walker-utils.ts
@@ -257,9 +257,9 @@ export function scanReflectionBypass(
   }
 
   function visit(node: ts.Node): void {
-    if (ts.isCallExpression(node)) {
+    if (ts.isCallExpression(node) || ts.isNewExpression(node)) {
       const callee = node.expression;
-      // Pattern A: writer[sym](...)
+      // Pattern A: writer[sym](...) or new writer[sym](...)
       if (isBypassElementAccess(callee)) {
         const pos = sf.getLineAndCharacterOfPosition(node.getStart(sf));
         offenders.push({
@@ -269,7 +269,7 @@ export function scanReflectionBypass(
           reason: 'reflection-bypass call',
           raw: node.getText(sf).slice(0, 120),
         });
-      } else if (ts.isPropertyAccessExpression(callee) && isBypassElementAccess(callee.expression)) {
+      } else if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(callee) && isBypassElementAccess(callee.expression)) {
         // Pattern B: writer[sym].method(...)
         const pos = sf.getLineAndCharacterOfPosition(node.getStart(sf));
         offenders.push({
@@ -314,12 +314,16 @@ export function extractSignalsFromSource(filePath: string, source: string): Extr
   const sf = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true);
   const found: ExtractedSignal[] = [];
 
-  function isFunctionLike(node: ts.Node): node is ts.FunctionLikeDeclaration {
+  function isFunctionLike(
+    node: ts.Node,
+  ): node is ts.FunctionLikeDeclaration | ts.GetAccessorDeclaration | ts.SetAccessorDeclaration {
     return (
       ts.isFunctionDeclaration(node) ||
       ts.isFunctionExpression(node) ||
       ts.isArrowFunction(node) ||
-      ts.isMethodDeclaration(node)
+      ts.isMethodDeclaration(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node)
     );
   }
 

--- a/tests/orchestrator/ast-walker-bypass-hardening.test.ts
+++ b/tests/orchestrator/ast-walker-bypass-hardening.test.ts
@@ -494,6 +494,94 @@ describe('F1: ArrayBindingPattern seed in reflection initializer', () => {
 });
 
 // ===========================================================================
+// Batch B: constructor and accessor bypass patterns
+// ===========================================================================
+describe('Batch B: constructor and accessor bypass patterns', () => {
+  it('(a) NewExpression element-access call is flagged', () => {
+    // new PerformanceWriter(sym)[sym]('event')
+    const src = `
+      declare const writer: any;
+      const sym = Object.getOwnPropertySymbols(writer)[0];
+      new PerformanceWriter(sym)[sym]('event');
+    `;
+    const sf = parseSf('batchb-new-expression.ts', src);
+    const bound = collectSymbolBindings(sf);
+    expect(bound.has('sym')).toBe(true);
+    const offenders = scanReflectionBypass(sf, 'batchb-new-expression.ts');
+    expect(offenders.length).toBeGreaterThanOrEqual(1);
+    expect(offenders.some(o => /reflection-bypass/.test(o.reason))).toBe(true);
+  });
+
+  it('(b) reflection bypass inside getter body is flagged', () => {
+    const src = `
+      declare const writer: any;
+      class Foo {
+        get bad() {
+          const sym = Object.getOwnPropertySymbols(writer)[0];
+          writer[sym]('event');
+          return sym;
+        }
+      }
+    `;
+    const sf = parseSf('batchb-getter-bypass.ts', src);
+    const offenders = scanReflectionBypass(sf, 'batchb-getter-bypass.ts');
+    expect(offenders.length).toBeGreaterThanOrEqual(1);
+    expect(offenders.some(o => /reflection-bypass/.test(o.reason))).toBe(true);
+  });
+
+  it('(c) reflection bypass inside setter body is flagged', () => {
+    const src = `
+      declare const writer: any;
+      class Foo {
+        set bad(v: any) {
+          const sym = Object.getOwnPropertySymbols(writer)[0];
+          writer[sym]('event');
+        }
+      }
+    `;
+    const sf = parseSf('batchb-setter-bypass.ts', src);
+    const offenders = scanReflectionBypass(sf, 'batchb-setter-bypass.ts');
+    expect(offenders.length).toBeGreaterThanOrEqual(1);
+    expect(offenders.some(o => /reflection-bypass/.test(o.reason))).toBe(true);
+  });
+
+  it('(b-signal) signal inside getter body is extracted by extractSignalsFromSource', () => {
+    const src = `
+      class Foo {
+        get bad() {
+          signals.push({ signal: 'getter_bypass_signal', value: 1 });
+          return 1;
+        }
+      }
+    `;
+    const extracted = extractSignalsFromHelper_patched(src);
+    expect(extracted.map(s => s.name)).toContain('getter_bypass_signal');
+  });
+
+  it('(c-signal) signal inside setter body is extracted by extractSignalsFromSource', () => {
+    const src = `
+      class Foo {
+        set bad(v: any) {
+          signals.push({ signal: 'setter_bypass_signal', value: 1 });
+        }
+      }
+    `;
+    const extracted = extractSignalsFromHelper_patched(src);
+    expect(extracted.map(s => s.name)).toContain('setter_bypass_signal');
+  });
+
+  it('negative control: new expression without reflection key is not flagged', () => {
+    const src = `
+      declare const writer: any;
+      const result = new PerformanceWriter('literal')['knownMethod']('event');
+    `;
+    const sf = parseSf('batchb-new-no-reflection-control.ts', src);
+    const offenders = scanReflectionBypass(sf, 'batchb-new-no-reflection-control.ts');
+    expect(offenders).toEqual([]);
+  });
+});
+
+// ===========================================================================
 // F2: NonNull alias tracking (consensus finding)
 // ===========================================================================
 describe('F2: NonNull alias does not break tracking chain', () => {


### PR DESCRIPTION
## Summary
- Widen `scanReflectionBypass` visit() at `tests/orchestrator/_ast-walker-utils.ts:259` to cover `NewExpression` alongside `CallExpression` — handles `new Foo(sym)[sym]()` constructor-bypass shape.
- Extend `isFunctionLike` at `tests/orchestrator/_ast-walker-utils.ts:317` to include `GetAccessorDeclaration` and `SetAccessorDeclaration` so getter/setter bodies are walked.
- Add six Batch B fixtures: constructor bypass, getter bypass, setter bypass, two signal-assignment variants, and a negative control (`new X('literal')['knownMethod']()`).

Addresses Pattern 4 from Issue #195. Complements #196 (Patterns 1 & 2). Patterns 3 (object hops) and 5 (inter-procedural) deferred to follow-up PRs.

## Test plan
- [x] `npx jest tests/orchestrator/ast-walker-bypass-hardening.test.ts` — 33/33 pass
- [x] `npx tsc --noEmit` clean
- [x] Negative control confirms no over-flagging
- [x] Scope confirmed: no changes under `packages/orchestrator/src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)