### PR TITLE
fix(sandbox): #176 orchestrator-role marker — auto-distinguish orchestrator from subagent

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1889,11 +1889,19 @@ server.tool(
     // hook can't be materialized for any reason.
     let hookSummary = '';
     try {
-      const { installWorktreeSandboxHook } = require('@gossip/orchestrator') as typeof import('@gossip/orchestrator');
+      const { installWorktreeSandboxHook, writeOrchestratorRoleMarker } = require('@gossip/orchestrator') as typeof import('@gossip/orchestrator');
       const hookResult = installWorktreeSandboxHook(root);
       hookSummary = hookResult.installed
         ? 'Sandbox hook: .claude/hooks/worktree-sandbox.sh installed (Layer 2)'
         : `Sandbox hook: skipped (${hookResult.reason ?? 'unknown'})`;
+      // Issue #176: write orchestrator-role marker so the hook auto-exempts
+      // the orchestrator when it cd's into a worktree. Idempotent no-op if
+      // the file already exists. Never throws — best-effort.
+      try {
+        writeOrchestratorRoleMarker(root);
+      } catch (markerErr) {
+        process.stderr.write(`[gossipcat] gossip_setup: orchestrator-role marker write failed: ${markerErr}\n`);
+      }
     } catch (e) {
       hookSummary = `Sandbox hook: skipped (${(e as Error).message})`;
       process.stderr.write(`[gossipcat] gossip_setup: sandbox hook install failed: ${e}\n`);
@@ -1973,10 +1981,9 @@ server.tool(
     }
     if (hookSummary) {
       lines.push(hookSummary);
-      lines.push('  ⚠ If the orchestrator cd\'s into a worktree to inspect/commit subagent work,');
-      lines.push('    the hook will gate it as a subagent. Exempt the orchestrator shell with:');
-      lines.push('      export GOSSIPCAT_ORCHESTRATOR_ROLE=1   # add to ~/.zshrc or ~/.bashrc');
-      lines.push('    Then relaunch Claude Code. See issue #162 for rationale.');
+      lines.push('  Orchestrator-role marker: .gossip/orchestrator-role written (issue #176)');
+      lines.push('  The hook now auto-exempts the orchestrator when it cd\'s into a worktree.');
+      lines.push('  (No manual GOSSIPCAT_ORCHESTRATOR_ROLE env var needed.)');
     }
     lines.push('Agents will connect to relay on first gossip_dispatch() call.');
     if (nativeCreated.length > 0) {

--- a/assets/hooks/worktree-sandbox.sh
+++ b/assets/hooks/worktree-sandbox.sh
@@ -188,9 +188,14 @@ fi
 # GOSSIPCAT_ORCHESTRATOR_ROLE=1 on the top-level orchestrator session to
 # short-circuit the gate.
 #
-# The harness does not yet set this env automatically — users must opt in.
-# Setup docs should describe the flag. Subagent harnesses must NOT inherit
-# this env; if that ever breaks, the cwd-glob fallback still applies.
+# NOTE: gossip_setup (issue #176) now auto-creates a marker file at
+# $CLAUDE_PROJECT_DIR/.gossip/orchestrator-role so this env var no longer
+# needs to be set manually. The marker-file check below fires after
+# IS_SUBAGENT=1 is determined and is safe because each session's
+# CLAUDE_PROJECT_DIR points to its own project root (worktree sessions
+# point to the worktree, not the parent project), so subagents cannot
+# accidentally resolve the orchestrator's marker file.
+# The env var check is kept for backward compatibility (manual opt-in).
 case "$GOSSIPCAT_ORCHESTRATOR_ROLE" in
   1|true|TRUE|yes|YES) exit 0 ;;
 esac
@@ -240,6 +245,25 @@ fi
 
 # Orchestrator (or non-gossipcat cwd) → pass through without gating.
 [ "$IS_SUBAGENT" -eq 0 ] && exit 0
+
+# Marker-file orchestrator exemption (issue #176).
+#
+# gossip_setup writes $CLAUDE_PROJECT_DIR/.gossip/orchestrator-role at the
+# PROJECT ROOT. When the orchestrator cd's into a worktree, IS_SUBAGENT was
+# set to 1 above, but we can still detect the orchestrator because:
+#   - Orchestrator session: CLAUDE_PROJECT_DIR = <project root>
+#     → marker = <project root>/.gossip/orchestrator-role  ← exists
+#   - Subagent session:     CLAUDE_PROJECT_DIR = <worktree root>
+#     → marker = <worktree>/.gossip/orchestrator-role      ← does NOT exist
+# This is naturally self-policing: subagents cannot see the orchestrator's
+# marker file without explicitly reading outside their worktree.
+# Only check when CLAUDE_PROJECT_DIR is set; skip silently when absent.
+if [ -n "$CLAUDE_PROJECT_DIR" ]; then
+  if [ -f "${CLAUDE_PROJECT_DIR}/.gossip/orchestrator-role" ]; then
+    exit 0
+  fi
+fi
+
 # Subagent falls through to existing path-gating logic below (unchanged).
 
 # Case-insensitive tool-name match (portable: no bash 4+ ${var,,}).
@@ -373,7 +397,7 @@ while IFS= read -r path_arg; do
   fi
 
   if ! path_is_inside "$cwd_norm" "$path_norm"; then
-    emit_deny "BOUNDARY ESCAPE: ${tool_name} targets '${path_arg}' (normalized: '${path_norm}') outside worktree cwd '${cwd_norm}'. Use a relative path (./...) inside the worktree. If you are the orchestrator (not a subagent) and cd'd into a worktree, exempt this shell with: export GOSSIPCAT_ORCHESTRATOR_ROLE=1 and relaunch Claude Code (issue #162)."
+    emit_deny "BOUNDARY ESCAPE: ${tool_name} targets '${path_arg}' (normalized: '${path_norm}') outside worktree cwd '${cwd_norm}'. Use a relative path (./...) inside the worktree. If you are the orchestrator, re-run gossip_setup to auto-write the orchestrator-role marker (issue #176). Fallback: export GOSSIPCAT_ORCHESTRATOR_ROLE=1 and relaunch Claude Code."
   fi
 done <<EOF
 $candidates

--- a/packages/orchestrator/src/hook-installer.ts
+++ b/packages/orchestrator/src/hook-installer.ts
@@ -83,6 +83,34 @@ function mergePreToolUseEntry(settings: Record<string, any>): boolean {
   return true;
 }
 
+/** Path to the orchestrator-role marker file relative to projectRoot. */
+const ORCHESTRATOR_ROLE_MARKER = '.gossip/orchestrator-role';
+
+/**
+ * Write `.gossip/orchestrator-role` at `projectRoot` so the worktree-sandbox
+ * hook can identify the orchestrator session without relying on a manually set
+ * env variable (issue #176).
+ *
+ * Idempotent — no-ops if the file already exists. Returns the file path.
+ * Never throws; the caller should handle errors gracefully.
+ */
+export function writeOrchestratorRoleMarker(projectRoot: string): string {
+  const markerPath = join(projectRoot, ORCHESTRATOR_ROLE_MARKER);
+  const markerDir = dirname(markerPath);
+  mkdirSync(markerDir, { recursive: true });
+  if (!existsSync(markerPath)) {
+    writeFileSync(
+      markerPath,
+      '# Written by gossip_setup (issue #176).\n' +
+      '# Presence of this file tells the worktree-sandbox hook that the\n' +
+      '# project root is the orchestrator context, not a subagent worktree.\n' +
+      '# Do not copy this file into worktree dirs.\n',
+      'utf-8',
+    );
+  }
+  return markerPath;
+}
+
 /**
  * Install the worktree sandbox hook at `<projectRoot>/.claude/hooks/` and
  * register it in `<projectRoot>/.claude/settings.json`.

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -53,7 +53,7 @@ export { WorktreeManager } from './worktree-manager';
 export { BootstrapGenerator } from './bootstrap';
 export type { BootstrapResult } from './bootstrap';
 export { findBundledRules, ensureRulesFile, readRulesContent } from './rules-loader';
-export { installWorktreeSandboxHook, findBundledHook } from './hook-installer';
+export { installWorktreeSandboxHook, findBundledHook, writeOrchestratorRoleMarker } from './hook-installer';
 export type { HookInstallResult } from './hook-installer';
 export { OverlapDetector } from './overlap-detector';
 export { LensGenerator } from './lens-generator';

--- a/tests/cli/worktree-sandbox-hook.test.ts
+++ b/tests/cli/worktree-sandbox-hook.test.ts
@@ -643,6 +643,88 @@ runIfJq('worktree-sandbox.sh', () => {
     expect(stdout.trim()).toBe('');
   });
 
+  // Issue #176: marker-file orchestrator exemption.
+  // gossip_setup writes <project_root>/.gossip/orchestrator-role. The hook
+  // exempts sessions where CLAUDE_PROJECT_DIR points to a directory that
+  // contains this file. Subagents have CLAUDE_PROJECT_DIR set to their
+  // worktree dir and cannot see the parent project's marker file.
+
+  it('[marker] orchestrator cd into worktree is allowed when marker file exists at project root', () => {
+    // Simulate: orchestrator session cd'd into a worktree, so cwd matches the
+    // worktree pattern (IS_SUBAGENT=1). CLAUDE_PROJECT_DIR still points to the
+    // project root where gossip_setup wrote .gossip/orchestrator-role.
+    const tmpProject = mkdtempSync(join(tmpdir(), 'hook-marker-test-'));
+    try {
+      // Create the marker file at the project root.
+      mkdirSync(join(tmpProject, '.gossip'), { recursive: true });
+      writeFileSync(join(tmpProject, '.gossip', 'orchestrator-role'), 'marker\n');
+
+      const { stdout, status } = runHook(
+        {
+          tool_name: 'Write',
+          tool_input: { file_path: '/Users/someone/outside.txt' },
+          // cwd looks like a worktree → IS_SUBAGENT=1
+          cwd: `${tmpProject}/.claude/worktrees/agent-abc`,
+        },
+        { CLAUDE_PROJECT_DIR: tmpProject },
+      );
+      expect(status).toBe(0);
+      // Marker file present → allow (empty stdout = no JSON deny).
+      expect(stdout.trim()).toBe('');
+    } finally {
+      rmSync(tmpProject, { recursive: true, force: true });
+    }
+  });
+
+  it('[marker] subagent is still denied when marker exists only at project root (CLAUDE_PROJECT_DIR = worktree)', () => {
+    // Simulate: subagent session. CLAUDE_PROJECT_DIR is the WORKTREE dir.
+    // The marker file lives at the actual project root, which the subagent
+    // cannot see via its CLAUDE_PROJECT_DIR.
+    const tmpProject = mkdtempSync(join(tmpdir(), 'hook-marker-subagent-test-'));
+    try {
+      // Create marker at project root (simulates gossip_setup).
+      mkdirSync(join(tmpProject, '.gossip'), { recursive: true });
+      writeFileSync(join(tmpProject, '.gossip', 'orchestrator-role'), 'marker\n');
+
+      // Worktree dir: the subagent's CLAUDE_PROJECT_DIR (does NOT have the marker).
+      const worktreePath = join(tmpProject, '.claude', 'worktrees', 'agent-abc');
+      mkdirSync(worktreePath, { recursive: true });
+
+      const { stdout, status } = runHook(
+        {
+          tool_name: 'Write',
+          // Target is outside the subagent worktree.
+          tool_input: { file_path: '/etc/passwd' },
+          cwd: worktreePath,
+        },
+        // CLAUDE_PROJECT_DIR points to the WORKTREE, not the project root.
+        { CLAUDE_PROJECT_DIR: worktreePath },
+      );
+      expect(status).toBe(0);
+      // Marker not found at worktree/.gossip/orchestrator-role → subagent falls
+      // through to path-gating → deny.
+      const parsed = JSON.parse(stdout);
+      expect(parsed.hookSpecificOutput.permissionDecision).toBe('deny');
+    } finally {
+      rmSync(tmpProject, { recursive: true, force: true });
+    }
+  });
+
+  it('[marker] missing marker file does not affect normal subagent deny (no regression)', () => {
+    // No marker file anywhere. Subagent cwd → IS_SUBAGENT=1 → path gating → deny.
+    const { stdout, status } = runHook(
+      {
+        tool_name: 'Write',
+        tool_input: { file_path: '/etc/passwd' },
+        cwd: '/fake/project/.claude/worktrees/agent-abc',
+      },
+      { CLAUDE_PROJECT_DIR: '/fake/project' },
+    );
+    expect(status).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.hookSpecificOutput.permissionDecision).toBe('deny');
+  });
+
   // Issue #162 problem 2 / #161: quoted-string false-positive mitigation.
   it('[quotes] allows git commit -m with quoted body containing absolute path', () => {
     const { stdout, status } = runHook({
@@ -686,7 +768,7 @@ runIfJq('worktree-sandbox.sh', () => {
     expect(parsed.hookSpecificOutput.permissionDecision).toBe('deny');
   });
 
-  it('[hints] BOUNDARY ESCAPE deny reason mentions GOSSIPCAT_ORCHESTRATOR_ROLE remediation', () => {
+  it('[hints] BOUNDARY ESCAPE deny reason mentions orchestrator-role remediation', () => {
     const { stdout } = runHook({
       tool_name: 'Write',
       tool_input: { file_path: '/Users/someone/secrets.txt' },
@@ -695,8 +777,11 @@ runIfJq('worktree-sandbox.sh', () => {
     const parsed = JSON.parse(stdout);
     const reason = parsed.hookSpecificOutput.permissionDecisionReason;
     expect(reason).toContain('BOUNDARY ESCAPE');
+    // Issue #176: deny message now points to gossip_setup auto-mechanism first,
+    // then the fallback env var.
+    expect(reason).toContain('gossip_setup');
+    expect(reason).toContain('issue #176');
     expect(reason).toContain('GOSSIPCAT_ORCHESTRATOR_ROLE=1');
-    expect(reason).toContain('issue #162');
   });
 
   it('[quotes] sh -c absolute path also keeps quoted body — deny unchanged', () => {


### PR DESCRIPTION
## Summary

L2 worktree sandbox hook identifies "subagent" purely by cwd matching the worktree glob. When the orchestrator legitimately `cd`s into a worktree, it trips the same gate and writes are blocked (issue #176).

**Option A (env var in `settings.local.json`) is unsafe** — Claude Code subagents inherit parent env, which would exempt them too and break Case 3 (subagent-in-worktree must still be gated).

**Option C (marker file at project root)** exploits that `$CLAUDE_PROJECT_DIR` differs between sessions:

| Session | `CLAUDE_PROJECT_DIR` | Marker lookup | Result |
|---|---|---|---|
| Orchestrator | `<project root>` | `<project>/.gossip/orchestrator-role` exists | ✓ exempt |
| Subagent | `<worktree dir>` | `<worktree>/.gossip/orchestrator-role` absent | ✗ still gated |

Self-policing: subagents cannot see the orchestrator's marker without reading outside their worktree, which the hook already blocks.

## Changes

- `assets/hooks/worktree-sandbox.sh` — add marker-file exemption after the existing env-var exemption, before path-gating
- `packages/orchestrator/src/hook-installer.ts` — export `writeOrchestratorRoleMarker()` (idempotent, writes `.gossip/orchestrator-role`)
- `apps/cli/src/mcp-server-sdk.ts` — `gossip_setup` calls the marker writer after installing the hook
- `tests/cli/worktree-sandbox-hook.test.ts` — 3 `[marker]` tests

## Test plan
- [x] `npx jest tests/cli/worktree-sandbox-hook.test.ts` → 47/47 pass
- [x] Case 1 — orchestrator, no worktree: allowed (unchanged)
- [x] Case 2 — orchestrator cd into worktree: **now allowed** (the fix)
- [x] Case 3 — subagent in worktree: still gated (marker at worktree path absent)
- [x] Backward compat: existing `GOSSIPCAT_ORCHESTRATOR_ROLE=1` env still works for manual opt-in

Closes #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)