### PR TITLE
test(orchestrator): #199 template-literal computed-key bypass

### DIFF
--- a/tests/orchestrator/_ast-walker-utils.ts
+++ b/tests/orchestrator/_ast-walker-utils.ts
@@ -208,16 +208,17 @@ export function collectSymbolBindings(sf: ts.SourceFile): Set<string> {
       }
       // Gap 3: ObjectBindingPattern with computed key from a tracked symbol.
       // Pattern: `const { [sym]: internal } = someObj;`
+      // Issue #199: also accept computed keys whose expression is a
+      // TemplateExpression where any substitution references a tracked name.
       if (ts.isObjectBindingPattern(node.name)) {
         for (const el of node.name.elements) {
           const propName = el.propertyName;
           if (
             propName &&
             ts.isComputedPropertyName(propName) &&
-            ts.isIdentifier(propName.expression) &&
-            bound.has(propName.expression.text) &&
             ts.isIdentifier(el.name) &&
-            !bound.has(el.name.text)
+            !bound.has(el.name.text) &&
+            computedKeyReferencesBound(propName.expression, bound)
           ) {
             bound.add(el.name.text);
             changed = true;
@@ -228,6 +229,33 @@ export function collectSymbolBindings(sf: ts.SourceFile): Set<string> {
   }
 
   return bound;
+}
+
+// ---------------------------------------------------------------------------
+// computedKeyReferencesBound (issue #199)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when `expr` is a tracked reference, either directly or through
+ * a TemplateExpression whose substitutions include a tracked identifier.
+ *
+ * Issue #199: `const { [`${sym}`]: internal } = writer` and
+ * `writer[`${sym}`](...)` must both track `internal` / flag the call when
+ * `sym` is a tracked reflection-derived binding.
+ */
+export function computedKeyReferencesBound(
+  expr: ts.Expression,
+  bound: Set<string>,
+): boolean {
+  const node = stripNonNull(expr);
+  if (ts.isIdentifier(node) && bound.has(node.text)) return true;
+  if (ts.isTemplateExpression(node)) {
+    for (const span of node.templateSpans) {
+      const e = stripNonNull(span.expression);
+      if (ts.isIdentifier(e) && bound.has(e.text)) return true;
+    }
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -265,6 +293,8 @@ export function scanReflectionBypass(
     // F1 rest-element: `writer[syms[0]](...)` — argument is a chained
     // ElementAccess/method-call whose root is a tracked binding (e.g. `syms`).
     if (arg && isChainedFromTracked(arg as ts.Expression, bound)) return true;
+    // Issue #199: template-literal computed key, e.g. `writer[`${sym}`](...)`.
+    if (arg && computedKeyReferencesBound(arg as ts.Expression, bound)) return true;
     return false;
   }
 

--- a/tests/orchestrator/ast-walker-bypass-hardening.test.ts
+++ b/tests/orchestrator/ast-walker-bypass-hardening.test.ts
@@ -654,3 +654,62 @@ describe('Batch A: IIFE and await bypass patterns', () => {
     expect(offenders.length).toBeGreaterThanOrEqual(1);
   });
 });
+
+describe('Issue #199: template-literal computed-key bypass', () => {
+  it('(a) destructuring with template-literal computed key is tracked', () => {
+    const src = [
+      'declare const writer: any;',
+      'const syms = Object.getOwnPropertySymbols(writer);',
+      'const sym = syms[0];',
+      'const { [`${sym}`]: internal } = writer;',
+      'internal.appendSignal({});',
+    ].join('\n');
+    const sf = parseSf('issue-199-destructure.ts', src);
+    const bound = collectSymbolBindings(sf);
+    expect(bound.has('internal')).toBe(true);
+  });
+
+  it('(b) direct writer[`${sym}`]() call is flagged', () => {
+    const src = [
+      'declare const writer: any;',
+      'const sym = Object.getOwnPropertySymbols(writer)[0];',
+      'writer[`${sym}`](\'event\');',
+    ].join('\n');
+    const sf = parseSf('issue-199-direct.ts', src);
+    const offenders = scanReflectionBypass(sf, 'issue-199-direct.ts');
+    expect(offenders.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('(c) template with prefix/suffix substitution is flagged', () => {
+    const src = [
+      'declare const writer: any;',
+      'const sym = Object.getOwnPropertySymbols(writer)[0];',
+      'writer[`prefix_${sym}_suffix`](\'event\');',
+    ].join('\n');
+    const sf = parseSf('issue-199-prefix-suffix.ts', src);
+    const offenders = scanReflectionBypass(sf, 'issue-199-prefix-suffix.ts');
+    expect(offenders.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('(d) NEGATIVE: no-substitution literal key is NOT flagged', () => {
+    const src = [
+      'declare const writer: any;',
+      'writer[`literal_key`](\'event\');',
+    ].join('\n');
+    const sf = parseSf('issue-199-nc-literal.ts', src);
+    const offenders = scanReflectionBypass(sf, 'issue-199-nc-literal.ts');
+    expect(offenders).toEqual([]);
+  });
+
+  it('(e) NEGATIVE: template substitution of untracked variable is NOT flagged', () => {
+    const src = [
+      'declare const obj: any;',
+      'const plain = "x";',
+      'const { [`${plain}`]: extracted } = obj;',
+      'extracted();',
+    ].join('\n');
+    const sf = parseSf('issue-199-nc-untracked.ts', src);
+    const offenders = scanReflectionBypass(sf, 'issue-199-nc-untracked.ts');
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #199. Detect reflection-bypass via template-literal computed keys — a pattern that was previously invisible because the walker only recognized bare `Identifier` computed keys.

**Blocked patterns:**
```ts
const syms = Object.getOwnPropertySymbols(writer);
const sym = syms[0];
const { [`${sym}`]: internal } = writer;           // destructure
writer[`${sym}`]('event');                          // direct call
writer[`prefix_${sym}_suffix`]('event');            // prefix/suffix
```

## Changes
- `tests/orchestrator/_ast-walker-utils.ts`:
  - New `computedKeyReferencesBound` helper — matches bare tracked identifier **or** a `TemplateExpression` whose spans substitute a tracked identifier.
  - Called from `collectSymbolBindings`'s ObjectBindingPattern seed (replaces the identifier-only check).
  - Called from `scanReflectionBypass`'s `isBypassElementAccess` to flag `writer[\`\${sym}\`](...)` forms.
- `tests/orchestrator/ast-walker-bypass-hardening.test.ts`: 5 new fixtures — destructure, direct call, prefix/suffix, and two negative controls (literal-only template, untracked-var substitution).

Diagnostic note: previous dispatch attempt stalled (no-progress watchdog). Implemented directly — change is mechanical (extend two existing check-sites + 1 helper), test-layer only, verified via jest.

## Test plan
- [x] `npx jest tests/orchestrator/ast-walker-bypass-hardening.test.ts` → 42/42 pass
- [x] Negative controls (literal template, untracked var) confirm no over-flagging
- [x] Scope: tests/orchestrator/ only

🤖 Generated with [Claude Code](https://claude.com/claude-code)