### PR TITLE
test(orchestrator): #200 NewExpression Pattern B

### DIFF
--- a/tests/orchestrator/_ast-walker-utils.ts
+++ b/tests/orchestrator/_ast-walker-utils.ts
@@ -268,6 +268,15 @@ export function scanReflectionBypass(
     return false;
   }
 
+  // Walk a PropertyAccess chain down to the leftmost non-PropertyAccess node
+  // and return true when that root is a bypass ElementAccess. Supports the
+  // nested Pattern B shape `writer[sym].A.B.Foo()` / `new writer[sym].A.B()`.
+  function propertyChainRootsAtBypass(pa: ts.PropertyAccessExpression): boolean {
+    let cur: ts.Expression = pa.expression;
+    while (ts.isPropertyAccessExpression(cur)) cur = cur.expression;
+    return isBypassElementAccess(cur);
+  }
+
   function visit(node: ts.Node): void {
     if (ts.isCallExpression(node) || ts.isNewExpression(node)) {
       const callee = node.expression;
@@ -281,14 +290,17 @@ export function scanReflectionBypass(
           reason: 'reflection-bypass call',
           raw: node.getText(sf).slice(0, 120),
         });
-      } else if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(callee) && isBypassElementAccess(callee.expression)) {
-        // Pattern B: writer[sym].method(...)
+      } else if (ts.isPropertyAccessExpression(callee) && propertyChainRootsAtBypass(callee)) {
+        // Pattern B: writer[sym].method(...) AND new writer[sym].Cls()
+        // Walk any depth of PropertyAccess chain (issue #200).
         const pos = sf.getLineAndCharacterOfPosition(node.getStart(sf));
         offenders.push({
           file: fileLabel,
           line: pos.line + 1,
           col: pos.character + 1,
-          reason: 'reflection-bypass method call',
+          reason: ts.isNewExpression(node)
+            ? 'reflection-bypass new-expression method call'
+            : 'reflection-bypass method call',
           raw: node.getText(sf).slice(0, 120),
         });
       }

--- a/tests/orchestrator/ast-walker-bypass-hardening.test.ts
+++ b/tests/orchestrator/ast-walker-bypass-hardening.test.ts
@@ -654,3 +654,38 @@ describe('Batch A: IIFE and await bypass patterns', () => {
     expect(offenders.length).toBeGreaterThanOrEqual(1);
   });
 });
+
+describe('Issue #200: NewExpression Pattern B (new writer[sym].Cls())', () => {
+  it('new writer[sym].Foo() is flagged as reflection-bypass new-expression', () => {
+    const src = `
+      declare const writer: any;
+      const sym = Object.getOwnPropertySymbols(writer)[0];
+      new writer[sym].Foo();
+    `;
+    const sf = parseSf('issue-200-new-pattern-b.ts', src);
+    const offenders = scanReflectionBypass(sf, 'issue-200-new-pattern-b.ts');
+    expect(offenders.length).toBeGreaterThanOrEqual(1);
+    expect(offenders.some(o => /new-expression/.test(o.reason))).toBe(true);
+  });
+
+  it('new writer[sym].Nested.Foo() is flagged through chained property access', () => {
+    const src = `
+      declare const writer: any;
+      const sym = Object.getOwnPropertySymbols(writer)[0];
+      new writer[sym].Nested.Foo();
+    `;
+    const sf = parseSf('issue-200-new-nested.ts', src);
+    const offenders = scanReflectionBypass(sf, 'issue-200-new-nested.ts');
+    expect(offenders.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('negative control: new Foo[staticKey].Bar() without reflection is NOT flagged', () => {
+    const src = `
+      declare const Registry: any;
+      new Registry['literalKey'].Foo();
+    `;
+    const sf = parseSf('issue-200-nc-static.ts', src);
+    const offenders = scanReflectionBypass(sf, 'issue-200-nc-static.ts');
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #200. Extend the walker to flag `new writer[sym].Foo()` and the nested `new writer[sym].A.B.Foo()` form that slipped through because Pattern B was gated to `CallExpression` only.

## Changes
- `tests/orchestrator/_ast-walker-utils.ts`:
  - Lift the `ts.isCallExpression(node) &&` gate from Pattern B so both `CallExpression` and `NewExpression` share the path.
  - New helper `propertyChainRootsAtBypass` walks any depth of `PropertyAccessExpression` down to the leftmost non-PropertyAccess node, then tests for bypass `ElementAccess`. This fixes the multi-hop case (`new writer[sym].A.B.Foo()`).
- `tests/orchestrator/ast-walker-bypass-hardening.test.ts`: 3 Issue #200 fixtures — single-hop, multi-hop nested, negative control.

## Test plan
- [x] `npx jest tests/orchestrator/ast-walker-bypass-hardening.test.ts` → 40/40 pass
- [x] Negative control (`new Registry['literalKey'].Foo()`) confirms no over-flagging
- [x] Scope: tests/orchestrator/ only

🤖 Generated with [Claude Code](https://claude.com/claude-code)