### PR TITLE
feat(mcp): surface hallucination_caught drops in gossip_signals receipt (PR1/3)

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2458,6 +2458,7 @@ server.tool(
       // and have grown into a 47% data gap — stop writing new ones at the source.
       // Write-time only; legacy signals are not backfilled.
       const { extractCategories } = await import('@gossip/orchestrator');
+      const droppedNoCategory: Array<{ agentId: string; findingId?: string; finding: string }> = [];
       const categoryEnforced = formatted.filter((s, i) => {
         if (s.type !== 'consensus' || s.signal !== 'hallucination_caught') return true;
         if (s.category) return true;
@@ -2468,6 +2469,11 @@ server.tool(
           (s as { category?: string }).category = extracted;
           return true;
         }
+        droppedNoCategory.push({
+          agentId: s.agentId,
+          findingId: s.findingId,
+          finding: srcFinding.slice(0, 80),
+        });
         process.stderr.write(
           `[gossip_signals] dropped hallucination_caught for ${s.agentId}: no category could be derived. finding="${srcFinding.slice(0, 80)}"\n`,
         );
@@ -2756,6 +2762,9 @@ server.tool(
       let baseReceipt = `Recorded ${deduped.length} consensus signals:\n${summary}\n\nTask IDs (for retraction):\n${taskIdList}\n\nThese will influence future agent selection via dispatch weighting.`;
       if (dupes.length > 0) {
         baseReceipt += `\n\n⚠️ ${dupes.length} duplicate signal(s) skipped (cross-round content match or exact finding_id):\n  ${dupes.join('\n  ')}`;
+      }
+      if (droppedNoCategory.length > 0) {
+        baseReceipt += `\n\n⚠️ ${droppedNoCategory.length} hallucination_caught signal(s) dropped (no category could be derived):\n  ${droppedNoCategory.map(d => `${d.agentId}:${d.findingId ?? '?'} finding="${d.finding.slice(0, 60)}"`).join('\n  ')}`;
       }
 
       // Post-write check: nudge orchestrator toward skill development when this batch


### PR DESCRIPTION
PR1/3 of the receipt-truth rollout. Surfaces previously-silent drops of hallucination_caught signals that lack a derivable category in the gossip_signals record receipt.

## The problem

At apps/cli/src/mcp-server-sdk.ts:2461-2475, the categoryEnforced filter drops any hallucination_caught signal for which inferCategory + fallback extractCategories both fail. The only evidence of the drop was process.stderr.write — the caller's "Recorded N" receipt at :2756 gave no indication the drop happened, so the orchestrator had no way to know a signal they'd just recorded had been silently tossed.

Consensus round 3edbdec8-02684caa flagged this as the first of three receipt-truth gaps.

## What changed

- Declared droppedNoCategory array before the filter.
- On each drop, push {agentId, findingId, finding (truncated)} into the array (stderr.write retained for ops back-compat).
- After receipt assembly, if the array is non-empty, append a warning block to baseReceipt listing every dropped entry — mirrors the existing dupes block at :2757-2759.

Diff: +9/-0 in apps/cli/src/mcp-server-sdk.ts, single file, no new types, no new tools, no schema migration.

## Scope out

- PR2: consensus-engine.ts drop-gate visibility (separate surface).
- PR3: memory-writer.ts / collect.ts drop-visibility follow-ups.

## Test plan

- [x] npm run build --workspaces — clean tsc
- [x] npm run build:mcp — bundle rebuilt (1.8mb)
- [x] npx jest tests/cli/ — 36 suites, 526 tests passing
- [ ] Manual smoke: record a hallucination_caught with a nonsense finding and confirm the warning block appears in the MCP receipt

Generated with Claude Code
