### PR TITLE
feat(mcp): emit finding_dropped_format for record-path category-miss (PR2/3)

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2465,7 +2465,7 @@ server.tool(
       // and have grown into a 47% data gap — stop writing new ones at the source.
       // Write-time only; legacy signals are not backfilled.
       const { extractCategories } = await import('@gossip/orchestrator');
-      const droppedNoCategory: Array<{ agentId: string; findingId?: string; finding: string }> = [];
+      const droppedNoCategory: Array<{ agentId: string; taskId: string; findingId?: string; finding: string }> = [];
       const categoryEnforced = formatted.filter((s, i) => {
         if (s.type !== 'consensus' || s.signal !== 'hallucination_caught') return true;
         if (s.category) return true;
@@ -2478,6 +2478,7 @@ server.tool(
         }
         droppedNoCategory.push({
           agentId: s.agentId,
+          taskId: s.taskId,
           findingId: s.findingId,
           finding: srcFinding.slice(0, 80),
         });
@@ -2772,6 +2773,34 @@ server.tool(
       }
       if (droppedNoCategory.length > 0) {
         baseReceipt += `\n\n⚠️ ${droppedNoCategory.length} hallucination_caught signal(s) dropped (no category could be derived):\n  ${droppedNoCategory.map(d => `${d.agentId}:${d.findingId ?? '?'} finding="${d.finding.slice(0, 60)}"`).join('\n  ')}`;
+
+        // PR2: emit finding_dropped_format pipeline signal for each drop so the
+        // record-path category-miss surfaces in the dashboard / signal feed, not
+        // just in stderr + the MCP receipt. Best-effort: failure must NOT break
+        // the record path (secondary observability channel).
+        try {
+          const { emitPipelineSignals } = await import('@gossip/orchestrator');
+          const nowIso = new Date().toISOString();
+          const pipelineSignals = droppedNoCategory.map(d => {
+            const consensusId = d.findingId?.match(/^([0-9a-f]{8}-[0-9a-f]{8}):/)?.[1];
+            return {
+              type: 'pipeline' as const,
+              signal: 'finding_dropped_format' as const,
+              agentId: d.agentId,
+              taskId: d.taskId,
+              ...(consensusId ? { consensusId } : {}),
+              metadata: {
+                reason: 'missing_category',
+                findingId: d.findingId,
+                finding: d.finding,
+              },
+              timestamp: nowIso,
+            };
+          });
+          emitPipelineSignals(process.cwd(), pipelineSignals);
+        } catch (err) {
+          process.stderr.write(`[gossip_signals] pipeline signal emit failed: ${(err as Error).message}\n`);
+        }
       }
 
       // Post-write check: nudge orchestrator toward skill development when this batch


### PR DESCRIPTION
PR2/3 of the receipt-truth rollout. Stacked on #206 (PR1).

## The problem

PR1 surfaces hallucination_caught-without-category drops in the gossip_signals MCP receipt, but only the orchestrator calling the tool sees them. The dashboard signal feed — the primary observability surface for the pipeline — is still blind to these drops, so drift across sessions or agents is invisible.

## What changed

Emits one `finding_dropped_format` pipeline signal per dropped entry via `emitPipelineSignals` from `@gossip/orchestrator`, matching the canonical `PipelineSignal` shape at `packages/orchestrator/src/consensus-types.ts:179`.

- `type: 'pipeline'`
- `signal: 'finding_dropped_format'` (already in allowlist at `completion-signals.allowlist.ts:22`)
- `metadata: { reason: 'missing_category', findingId, finding }` — reason is a plain string, no new enum, no schema change. Seeds the PR3 taxonomy.
- `consensusId` derived from the `<8hex>-<8hex>:` prefix of findingId when present.
- Wrapped in try/catch; emit failure does not break the record path (secondary observability channel). stderr fallback preserved.

After PR2, each drop surfaces in three places: ops stderr (back-compat), MCP receipt (PR1), dashboard signal feed (this PR).

Consensus round `3edbdec8-02684caa`.

## Diff

- +31/-1 in `apps/cli/src/mcp-server-sdk.ts` (PR2-only, excluding PR1's +9)
- Total stack (PR1 + PR2): ~40 LOC net

## Scope out

- PR3: `formatDropReceipt()` helper + `gossip_relay` auto-signal visibility.
- Taxonomy values for future drops (`parse_fail`, `content_empty`, `invalid_payload`, `security_violation`) seed on the same `reason` field with no schema work required.

## Test plan

- [x] `npm run build --workspaces` — clean tsc
- [x] `npm run build:mcp` — bundle rebuilt (1.8mb, 27ms)
- [x] `npx jest` on signal/mcp-server suites — 22/22 passing
- [ ] Manual smoke: record a hallucination_caught with nonsense finding, confirm the pipeline signal lands in `.gossip/agent-performance.jsonl` AND in the dashboard feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
