### PR TITLE
feat(mcp): extract formatDropReceipt + surface relay auto-signals (PR3/3)

### DIFF
--- a/apps/cli/src/format-drop-receipt.ts
+++ b/apps/cli/src/format-drop-receipt.ts
@@ -1,0 +1,23 @@
+/**
+ * Formats the hallucination_caught drop receipt appended to gossip_signals
+ * responses when signals are dropped for missing categories.
+ *
+ * Extracted from mcp-server-sdk.ts to keep the output shape a reusable,
+ * single-source concept (DropCounter). Consumers must not rebuild the string
+ * inline — byte-identical output is a pipeline invariant (consensus
+ * 3edbdec8-02684caa:sonnet-reviewer:f3).
+ */
+export interface DroppedEntry {
+  agentId: string;
+  findingId?: string;
+  finding: string;
+  reason?: string;
+}
+
+export function formatDropReceipt(drops: readonly DroppedEntry[]): string | null {
+  if (drops.length === 0) return null;
+  const lines = drops.map(d =>
+    `  ${d.agentId}:${d.findingId ?? '?'} finding="${d.finding.slice(0, 60)}"`
+  );
+  return `\n\n⚠️ ${drops.length} hallucination_caught signal(s) dropped (no category could be derived):\n${lines.join('\n')}`;
+}

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -218,6 +218,11 @@ export function computeRelayDuration(
 export async function handleNativeRelay(task_id: string, result: string, error?: string, agentStartedAt?: number, relayToken?: string) {
   await ctx.boot(); // [H3 fix] ensure mainAgent/pipeline are available
 
+  // PR3: per-invocation auto-signal counters — surface silent emissions in the
+  // relay receipt. Receipt consumers were previously blind to impl/completion
+  // auto-signals (consensus 3edbdec8-02684caa). Never-emitted buckets stay 0.
+  const autoSignalsEmitted = { timeout: 0, impl: 0, completion: 0 };
+
   // Cancel timeout watcher if still running
   cancelTimeoutWatcher(task_id);
 
@@ -378,6 +383,7 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
         evidence: error || undefined,
         timestamp: new Date().toISOString(),
       }]);
+      autoSignalsEmitted.impl++;
     } catch { /* best-effort */ }
   }
 
@@ -400,6 +406,7 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
       memoryQueryCalled: taskInfo.memoryQueryCalled,
       error: error ? true : undefined,
     });
+    autoSignalsEmitted.completion++;
   }
 
   // 0b. Record plan step result so subsequent steps get chain context
@@ -572,6 +579,17 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
   }
 
   let responseText = payloadLines.join('\n');
+  // PR3: surface auto-signal emissions so receipt consumers aren't blind to
+  // silent pipeline writes. Only nonzero buckets show; line omitted entirely
+  // when all buckets are 0 (utility tasks, error-skipped paths).
+  const totalAuto = autoSignalsEmitted.timeout + autoSignalsEmitted.impl + autoSignalsEmitted.completion;
+  if (totalAuto > 0) {
+    const parts: string[] = [];
+    if (autoSignalsEmitted.timeout > 0) parts.push(`timeout=${autoSignalsEmitted.timeout}`);
+    if (autoSignalsEmitted.impl > 0) parts.push(`impl=${autoSignalsEmitted.impl}`);
+    if (autoSignalsEmitted.completion > 0) parts.push(`completion=${autoSignalsEmitted.completion}`);
+    responseText += `\n⚡ ${totalAuto} auto-signal(s) emitted (${parts.join(', ')})`;
+  }
   if (utilityBlocks.length > 0) {
     responseText += `\n\n⚠️ EXECUTE NOW — ${utilityBlocks.length} utility task(s) queued:\n\n${utilityBlocks.join('\n\n')}`;
   }

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -36,6 +36,7 @@ import { persistRelayTasks, restoreRelayTasksAsFailed } from './handlers/relay-t
 import { pickStickyPort, writeStickyPort, RELAY_STICKY_FILE, HTTP_MCP_STICKY_FILE } from './stickyPort';
 import { buildDashboardAdvisory } from './setup-response';
 import { generateRulesContent } from './rules-content';
+import { formatDropReceipt } from './format-drop-receipt';
 
 // ── Environment detection ────────────────────────────────────────────────
 
@@ -2772,7 +2773,8 @@ server.tool(
         baseReceipt += `\n\n⚠️ ${dupes.length} duplicate signal(s) skipped (cross-round content match or exact finding_id):\n  ${dupes.join('\n  ')}`;
       }
       if (droppedNoCategory.length > 0) {
-        baseReceipt += `\n\n⚠️ ${droppedNoCategory.length} hallucination_caught signal(s) dropped (no category could be derived):\n  ${droppedNoCategory.map(d => `${d.agentId}:${d.findingId ?? '?'} finding="${d.finding.slice(0, 60)}"`).join('\n  ')}`;
+        const dropBlock = formatDropReceipt(droppedNoCategory);
+        if (dropBlock) baseReceipt += dropBlock;
 
         // PR2: emit finding_dropped_format pipeline signal for each drop so the
         // record-path category-miss surfaces in the dashboard / signal feed, not

--- a/tests/cli/format-drop-receipt.test.ts
+++ b/tests/cli/format-drop-receipt.test.ts
@@ -1,0 +1,32 @@
+/**
+ * PR3: formatDropReceipt helper — extracted from mcp-server-sdk.ts to make
+ * the drop-receipt shape a single-sourced pipeline invariant.
+ * Output must be byte-identical with the prior inline template.
+ */
+import { formatDropReceipt } from '../../apps/cli/src/format-drop-receipt';
+
+describe('formatDropReceipt', () => {
+  it('returns null for empty array', () => {
+    expect(formatDropReceipt([])).toBeNull();
+  });
+
+  it('formats a single entry with agent/finding/id', () => {
+    const out = formatDropReceipt([{ agentId: 'x', findingId: 'f1', finding: 'test' }]);
+    expect(out).toContain('⚠️ 1 hallucination_caught');
+    expect(out).toContain('x:f1');
+    expect(out).toContain('finding="test"');
+  });
+
+  it('lists multiple entries one per line', () => {
+    const out = formatDropReceipt([
+      { agentId: 'a', findingId: 'f1', finding: 'one' },
+      { agentId: 'b', findingId: 'f2', finding: 'two' },
+    ]);
+    expect(out!.split('\n').filter(l => l.includes('finding='))).toHaveLength(2);
+  });
+
+  it('uses ? when findingId missing', () => {
+    const out = formatDropReceipt([{ agentId: 'x', finding: 'y' }]);
+    expect(out).toContain('x:?');
+  });
+});


### PR DESCRIPTION
PR3/3 — final PR in the receipt-truth rollout. Stacked on #207 (which is stacked on #206).

## The problem

PR1 surfaced record-path drops in the MCP receipt. PR2 emitted the pipeline signal for dashboard visibility. PR3 closes the remaining gaps identified in consensus `3edbdec8-02684caa`:

1. The receipt-block string from PR1 was inline in `mcp-server-sdk.ts`, not reusable. Consensus sonnet-reviewer:f3 called out that every write-path tool building its own receipt = max rediscovery when the next drop-gate lands.
2. `gossip_relay` hides all auto-signal emissions (timeout retract, impl signals, emitCompletionSignals). The caller sees only `"relay: X completed (Yms)"`.

## What changed

### `apps/cli/src/format-drop-receipt.ts` (new, +23 LOC)

Single-responsibility helper with a typed `DroppedEntry` interface. Returns the `⚠️ N dropped (...)` block if non-empty, else null. Byte-identical to PR1's inline format (verified against PR1 output).

### `apps/cli/src/mcp-server-sdk.ts` (+4/-1)

Replaces PR1's inline append with `const dropBlock = formatDropReceipt(droppedNoCategory); if (dropBlock) baseReceipt += dropBlock;`. PR2's pipeline-signal emission untouched.

### `apps/cli/src/handlers/native-tasks.ts` (+18)

Scoped `autoSignalsEmitted = {timeout, impl, completion}` counter incremented at each emit site (PR3 only reads the counter, does NOT modify the emit sites themselves). Appends `⚡ N auto-signal(s) emitted (impl=X, completion=Y)` to the relay receipt when any bucket is nonzero. Only nonzero buckets render.

### `tests/cli/format-drop-receipt.test.ts` (new, +32)

Four tests: null-on-empty, single-entry formatting, multi-entry newline separation, `?` for missing findingId.

## Consensus reference

Design from consensus round `3edbdec8-02684caa` — this PR completes the 3-PR stack that implements Option B (DropCounter helper) + narrow Option C (scoped counter for relay) as decided in the cross-reviewed synthesis.

## Diff

- +76/-1 (including test file)
- Production LOC: 44 (under 50-LOC budget)
- Test LOC: 32

## Test plan

- [x] `npm run build --workspaces` — clean tsc (4 workspaces)
- [x] `npm run build:mcp` — bundle rebuilt (1.8mb, 27ms)
- [x] `npx jest tests/cli/format-drop-receipt.test.ts` — 4/4 pass
- [x] `npx jest tests/cli/` — 530/530 across 37 suites
- [x] Byte-identical PR1 output format confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
