### PR TITLE
fix(mcp): persist category-miss hallucinations (match consensus-engine policy) (PR5/5)

### DIFF
--- a/apps/cli/src/format-drop-receipt.ts
+++ b/apps/cli/src/format-drop-receipt.ts
@@ -19,5 +19,5 @@ export function formatDropReceipt(drops: readonly DroppedEntry[]): string | null
   const lines = drops.map(d =>
     `  ${d.agentId}:${d.findingId ?? '?'} finding="${d.finding.slice(0, 60)}"`
   );
-  return `\n\n⚠️ ${drops.length} hallucination_caught signal(s) dropped (no category could be derived):\n${lines.join('\n')}`;
+  return `\n\n⚠️ ${drops.length} hallucination_caught signal(s) persisted without category (category could not be derived):\n${lines.join('\n')}`;
 }

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2459,12 +2459,12 @@ server.tool(
         };
       });
 
-      // Category enforcement for hallucination_caught: if inferCategory failed
-      // above AND we can't derive from the finding text via extractCategories,
-      // drop the signal rather than persist it without a category. Category-less
-      // hallucinations are invisible to getCountersSince / skill-gap analysis
-      // and have grown into a 47% data gap — stop writing new ones at the source.
-      // Write-time only; legacy signals are not backfilled.
+      // Category enforcement for hallucination_caught: if both inferCategory
+      // and extractCategories fail, we PERSIST the signal with category:undefined
+      // (matching consensus-engine.ts:983-999). Per-category skill-gap routing
+      // loses the signal; aggregate accuracy (performance-reader.ts:581-585) still
+      // counts it. droppedNoCategory + stderr + finding_dropped_format pipeline
+      // signal provide observability that the category couldn't be derived.
       const { extractCategories } = await import('@gossip/orchestrator');
       const droppedNoCategory: Array<{ agentId: string; taskId: string; findingId?: string; finding: string }> = [];
       const categoryEnforced = formatted.filter((s, i) => {
@@ -2484,9 +2484,9 @@ server.tool(
           finding: srcFinding.slice(0, 80),
         });
         process.stderr.write(
-          `[gossip_signals] dropped hallucination_caught for ${s.agentId}: no category could be derived. finding="${srcFinding.slice(0, 80)}"\n`,
+          `[gossip_signals] persisted hallucination_caught without category for ${s.agentId}: no category could be derived. finding="${srcFinding.slice(0, 80)}"\n`,
         );
-        return false;
+        return true;
       });
 
       // Dedup gate: two-layer.
@@ -2773,6 +2773,8 @@ server.tool(
         baseReceipt += `\n\n⚠️ ${dupes.length} duplicate signal(s) skipped (cross-round content match or exact finding_id):\n  ${dupes.join('\n  ')}`;
       }
       if (droppedNoCategory.length > 0) {
+        // Note: signals are persisted (category:undefined), not dropped; the
+        // droppedNoCategory name is retained for continuity with earlier PRs.
         const dropBlock = formatDropReceipt(droppedNoCategory);
         if (dropBlock) baseReceipt += dropBlock;
 


### PR DESCRIPTION
PR5/5 of the receipt-truth work. Stacked on #208.

Fixes the actual signal loss. PRs #206/#207/#208 surfaced the drops (receipt + dashboard pipeline signal). This PR stops dropping them.

## The problem

The filter at `apps/cli/src/mcp-server-sdk.ts:2461-2483` (introduced pre-session as the "category enforcement" gate) drops any hallucination_caught signal where neither explicit `signal.category` nor keyword-matched `extractCategories` yielded a category. Intent was to prevent a 47% data gap in per-category skill-gap analysis.

Audit (this session, via haiku-researcher consensus 3edbdec8-02684caa follow-up) measured the real cost:

- 33 of 133 hallucination_caught entries in `.gossip/agent-performance.jsonl` (24.8%) lacked a category
- Sample of 5 dropped signals: 4 were REAL caught hallucinations in `citation_grounding`, `scope`, `input_validation`, `data_integrity` — the kind of signal that should most influence scoring. 1 was infra noise (relay-timeout miscoded).

So the filter was dropping ~80% of real caught-hallucination signal to avoid ~20% noise. The "47% skill-gap" that motivated the filter also overstated: backfill + filter together had already compressed the active rate to ~0 post-April-10.

## The asymmetry

`packages/orchestrator/src/consensus-engine.ts:983-999` handles the same case by logging stderr and **persisting** the signal with `category: undefined`. `packages/orchestrator/src/performance-reader.ts:581-585` increments `weightedImpact` / `weightedConfirmedCount` **before** the per-category guard at `:586`, so undefined-category signals still contribute to aggregate accuracy scoring.

Two write paths, opposite policies, same data shape. MCP was the outlier.

## What changed

- `apps/cli/src/mcp-server-sdk.ts:2479-2482`: `return false` → `return true`. Signal now flows through filter with `s.category` undefined. stderr + receipt block + PR2 pipeline signal all still fire for observability. stderr verb and receipt verb updated from "dropped" to "persisted without category" to stay truthful.
- `apps/cli/src/mcp-server-sdk.ts:2455-2460`: comment block rewritten to describe the persist policy and cite the consensus-engine parity.
- `apps/cli/src/mcp-server-sdk.ts:2768-2770`: one-line comment noting the `droppedNoCategory` variable name is retained for continuity; the signals are persisted, not dropped.
- `apps/cli/src/format-drop-receipt.ts:22`: receipt wording updated to "persisted without category (category could not be derived)".

## Impact

- Aggregate accuracy numbers will reflect ~25% more hallucination_caught signal that was previously invisible. Scoring becomes more accurate.
- Per-category skill-gap analysis still ignores these entries (as before) — they have no category to route into. That's acceptable; PR2's `finding_dropped_format` pipeline signal gives explicit observability.
- No schema change, no new types, no new tools.

## Diff

2 files, +11/-9 (net 20 changed lines; logic change is 2 lines, the rest is comment/wording).

## Test plan

- [x] `npm run build --workspaces` — clean tsc
- [x] `npm run build:mcp` — bundle rebuilt (1.8mb, 27ms)
- [x] `npx jest tests/cli/` — 37 suites / 530 tests passing
- [x] Verified no existing tests assert drop-semantics on this filter (grep for `categoryEnforced`, `droppedNoCategory`, "dropped", "no category could be derived" — no matches on expectations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
