### PR TITLE
fix(consensus): resolve cross-reviewer file citations to the correct duplicate

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -261,26 +261,6 @@ export async function handleCollect(
         return { content: [{ type: 'text' as const, text: 'Error: No LLM configured for consensus. Check gossip_setup.' }] };
       }
 
-      // Hoisted so verifierToolRunner callback can close over it when building the engine config.
-      const verifierFs = new FileTools(new Sandbox(process.cwd()));
-      const verifierGit = new GitTools(process.cwd());
-      const verifierMemory = new MemorySearcher(process.cwd());
-
-      // Resolve short file paths (e.g. "cross-reviewer-selection.ts") to full project-relative
-      // paths. LLMs often cite just the filename without the directory prefix.
-      const resolveToolPath = async (filePath: string): Promise<string> => {
-        if (!filePath) return filePath;
-        // Try as-is first — if Sandbox validates it, the file exists
-        try { new Sandbox(process.cwd()).validatePath(filePath); return filePath; } catch { /* not found */ }
-        // Search via file_search for the bare filename
-        const fileName = filePath.split('/').pop() ?? filePath;
-        try {
-          const searchResult = await verifierFs.fileSearch({ pattern: fileName });
-          const firstMatch = searchResult.split('\n')[0]?.trim();
-          if (firstMatch && firstMatch !== 'No files found') return firstMatch;
-        } catch { /* search failed */ }
-        return filePath; // return original, let fileRead produce a clear error
-      };
       const { PerformanceReader, discoverGitWorktrees } = await import('@gossip/orchestrator');
       const performanceReader = new PerformanceReader(process.cwd());
 
@@ -310,6 +290,41 @@ export async function handleCollect(
       } catch (err) {
         process.stderr.write(`[consensus] auto-discovery failed: ${(err as Error).message}\n`);
       }
+
+      // Hoisted so verifierToolRunner callback can close over it when building the engine config.
+      // Constructed AFTER effectiveRoots so fileSearch can prioritize matches under a
+      // resolution root (e.g. sibling worktrees) instead of blindly taking the first hit.
+      const verifierFs = new FileTools(new Sandbox(process.cwd()));
+      const verifierGit = new GitTools(process.cwd());
+      const verifierMemory = new MemorySearcher(process.cwd());
+
+      // Resolve short file paths (e.g. "cross-reviewer-selection.ts") to full project-relative
+      // paths. LLMs often cite just the filename without the directory prefix.
+      // Disambiguation rules when multiple matches exist:
+      //   1. Prefer a match whose absolute path starts with any effectiveRoots entry
+      //   2. Else prefer paths inside process.cwd() over paths outside
+      //   3. On ambiguity, emit a stderr warning with the chosen + all candidates
+      const resolveToolPath = async (filePath: string): Promise<string> => {
+        if (!filePath) return filePath;
+        // Try as-is first — if Sandbox validates it, the file exists
+        try { new Sandbox(process.cwd()).validatePath(filePath); return filePath; } catch { /* not found */ }
+        // Search via file_search for the bare filename, passing resolutionRoots so
+        // fileSearch ranks matches inside a resolution root ahead of stray duplicates.
+        const fileName = filePath.split('/').pop() ?? filePath;
+        try {
+          const searchResult = await verifierFs.fileSearch({ pattern: fileName, resolutionRoots: effectiveRoots });
+          const candidates = searchResult.split('\n').map(s => s.trim()).filter(s => s && s !== 'No files found');
+          if (candidates.length === 0) return filePath;
+          const resolved = candidates[0];
+          if (candidates.length > 1) {
+            process.stderr.write(
+              `[consensus] ambiguous filename resolution for "${fileName}": chose "${resolved}" among [${candidates.join(', ')}]\n`,
+            );
+          }
+          return resolved;
+        } catch { /* search failed */ }
+        return filePath; // return original, let fileRead produce a clear error
+      };
 
       const engine = new ConsensusEngine({
         llm: mainLlm,

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -348,7 +348,12 @@ export async function handleCollect(
                 result = await verifierFs.fileGrep({ ...args, ...(grepPath ? { path: grepPath } : {}) } as any);
                 break;
               }
-              case 'file_search': result = await verifierFs.fileSearch(args as any); break;
+              case 'file_search':
+                result = await verifierFs.fileSearch({
+                  ...(args as any),
+                  resolutionRoots: effectiveRoots,
+                });
+                break;
               case 'memory_query': {
                 const results = verifierMemory.search(agentId, (args as any).query ?? '', 5);
                 result = results.length ? results.map(r => `[${r.source}] ${r.name}: ${r.snippets.join(' | ')}`).join('\n---\n') : 'No memory results found.';

--- a/packages/tools/src/file-tools.ts
+++ b/packages/tools/src/file-tools.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile, readdir, stat, mkdir, unlink } from 'fs/promises';
 import { resolve, relative, join } from 'path';
+import { existsSync, realpathSync } from 'fs';
 import { Sandbox } from './sandbox';
 
 export class FileTools {
@@ -47,11 +48,55 @@ export class FileTools {
     return `Deleted ${args.path}`;
   }
 
-  async fileSearch(args: { pattern: string }, agentRoot?: string): Promise<string> {
+  async fileSearch(
+    args: { pattern: string; resolutionRoots?: readonly string[] },
+    agentRoot?: string,
+  ): Promise<string> {
     const results: string[] = [];
     const root = agentRoot || this.sandbox.projectRoot;
     await this.walkDir(root, args.pattern, results, 0, 10);
-    return results.join('\n') || 'No files found';
+    if (results.length === 0) return 'No files found';
+    // Optional ranking: when resolutionRoots are supplied (cross-review path
+    // disambiguation, see apps/cli/src/handlers/collect.ts), prefer matches
+    // whose absolute path sits inside one of those roots, then matches under
+    // the sandbox's projectRoot. Order within each bucket is preserved so the
+    // ranking is deterministic and the no-roots path matches previous output.
+    const roots = (args.resolutionRoots ?? []).filter(Boolean);
+    if (roots.length === 0) return results.join('\n');
+    const projectRoot = this.sandbox.projectRoot;
+    // Realpath roots to match sandbox.projectRoot (which was realpath'd in the
+    // constructor). Without this, on darwin `/tmp/...` vs `/private/tmp/...`
+    // mismatches cause startsWith to always miss, silently disabling ranking.
+    const absRoots = roots.map(r => {
+      const abs = resolve(r);
+      try {
+        return existsSync(abs) ? realpathSync(abs) : abs;
+      } catch {
+        return abs;
+      }
+    });
+    const bucketed: string[][] = absRoots.map(() => []);
+    const projectBucket: string[] = [];
+    const otherBucket: string[] = [];
+    for (const rel of results) {
+      const abs = resolve(projectRoot, rel);
+      let placed = false;
+      for (let i = 0; i < absRoots.length; i++) {
+        const r = absRoots[i];
+        if (abs === r || abs.startsWith(r.endsWith('/') ? r : r + '/')) {
+          bucketed[i].push(rel);
+          placed = true;
+          break;
+        }
+      }
+      if (placed) continue;
+      if (abs === projectRoot || abs.startsWith(projectRoot.endsWith('/') ? projectRoot : projectRoot + '/')) {
+        projectBucket.push(rel);
+      } else {
+        otherBucket.push(rel);
+      }
+    }
+    return [...bucketed.flat(), ...projectBucket, ...otherBucket].join('\n');
   }
 
   async fileGrep(

--- a/tests/tools/file-tools.test.ts
+++ b/tests/tools/file-tools.test.ts
@@ -106,6 +106,90 @@ describe('FileTools', () => {
     });
   });
 
+  // ─── fileSearch — resolutionRoots ranking ─────────────────────────────────
+  // Two sandbox.ts files exist in the real repo (packages/tools + apps/cli).
+  // Cross-reviewers cite bare filenames; without ranking, fileSearch returns
+  // whichever the walk hit first — which for "sandbox.ts" is the wrong one
+  // (utility vs. main sandbox). Ranking must prefer matches under an
+  // effectiveRoots entry, then under projectRoot, then deterministic order.
+  describe('fileSearch — resolutionRoots ranking', () => {
+    const rankDir = resolve(tmpdir(), 'gossip-file-tools-rank-' + Date.now());
+    const outsideDir = resolve(tmpdir(), 'gossip-file-tools-outside-' + Date.now());
+    let rankSandbox: Sandbox;
+    let rankTools: FileTools;
+
+    beforeAll(() => {
+      mkdirSync(resolve(rankDir, 'packages/tools/src'), { recursive: true });
+      mkdirSync(resolve(rankDir, 'apps/cli/src'), { recursive: true });
+      mkdirSync(outsideDir, { recursive: true });
+      writeFileSync(resolve(rankDir, 'packages/tools/src/sandbox.ts'), '// utility sandbox\n');
+      writeFileSync(resolve(rankDir, 'apps/cli/src/sandbox.ts'), '// main sandbox\n');
+      writeFileSync(resolve(outsideDir, 'sandbox.ts'), '// outside sandbox\n');
+      rankSandbox = new Sandbox(rankDir);
+      rankTools = new FileTools(rankSandbox);
+    });
+
+    afterAll(() => {
+      try {
+        const { rmSync } = require('fs');
+        rmSync(rankDir, { recursive: true, force: true });
+        rmSync(outsideDir, { recursive: true, force: true });
+      } catch { /* ignore */ }
+    });
+
+    it('no resolutionRoots → behavior matches current (first walk hit)', async () => {
+      const result = await rankTools.fileSearch({ pattern: 'sandbox.ts' });
+      const lines = result.split('\n');
+      // Both in-project matches returned; no ranking applied.
+      expect(lines).toHaveLength(2);
+      expect(lines).toEqual(expect.arrayContaining([
+        'apps/cli/src/sandbox.ts',
+        'packages/tools/src/sandbox.ts',
+      ]));
+    });
+
+    it('one candidate inside a resolutionRoot → inside-root wins', async () => {
+      const insideRoot = resolve(rankDir, 'apps/cli');
+      const result = await rankTools.fileSearch({
+        pattern: 'sandbox.ts',
+        resolutionRoots: [insideRoot],
+      });
+      const lines = result.split('\n');
+      // apps/cli/src/sandbox.ts must be first — it sits under the root.
+      expect(lines[0]).toBe('apps/cli/src/sandbox.ts');
+    });
+
+    it('two candidates both inside resolutionRoots → first root wins', async () => {
+      const rootA = resolve(rankDir, 'apps/cli');
+      const rootB = resolve(rankDir, 'packages/tools');
+      const result = await rankTools.fileSearch({
+        pattern: 'sandbox.ts',
+        resolutionRoots: [rootA, rootB],
+      });
+      const lines = result.split('\n');
+      // Deterministic: the first resolution root takes priority.
+      expect(lines[0]).toBe('apps/cli/src/sandbox.ts');
+      expect(lines[1]).toBe('packages/tools/src/sandbox.ts');
+    });
+
+    it('first root wins is deterministic when order reverses', async () => {
+      const rootA = resolve(rankDir, 'packages/tools');
+      const rootB = resolve(rankDir, 'apps/cli');
+      const result = await rankTools.fileSearch({
+        pattern: 'sandbox.ts',
+        resolutionRoots: [rootA, rootB],
+      });
+      const lines = result.split('\n');
+      expect(lines[0]).toBe('packages/tools/src/sandbox.ts');
+      expect(lines[1]).toBe('apps/cli/src/sandbox.ts');
+    });
+
+    it('empty resolutionRoots array behaves like omitted param', async () => {
+      const result = await rankTools.fileSearch({ pattern: 'sandbox.ts', resolutionRoots: [] });
+      expect(result.split('\n')).toHaveLength(2);
+    });
+  });
+
   // ─── fileGrep ──────────────────────────────────────────────────────────────
 
   describe('fileGrep', () => {


### PR DESCRIPTION
## Summary
- **Root cause:** Two `sandbox.ts` files exist (`packages/tools/src/sandbox.ts` 103 lines, `apps/cli/src/sandbox.ts` 1361 lines). Cross-reviewer's `fileSearch` took the first walk hit and cited the wrong one — reviewers have been flagging lines in phantom code.
- **Fix:** `fileSearch` now accepts optional `resolutionRoots` and bucket-sorts results (root bucket → projectRoot bucket → other). `collect.ts` threads `effectiveRoots` through both `resolveToolPath` (internal) and the `case 'file_search'` tool-loop branch (LLM-facing).
- **Diff:** 3 files, 2 commits, +178/-27 lines.

## Commits
- `5c273e9` main fix — `fileSearch` ranking + verifierFs reorder + 5 unit tests
- `6c94302` consensus follow-up — inject `resolutionRoots` at `collect.ts:351` for LLM tool loop

## Consensus review
3-agent round `12817ad8-08f44eed` (sonnet-reviewer, sonnet-implementer, gemini-reviewer). 11 findings CONFIRMED across both reviewers; 1 DISPUTED (regex recompile) resolved in sonnet-implementer's favor after orchestrator verification. Medium-severity gap (file_search case branch missing roots) was caught and patched in 6c94302 before submission.

## Test plan
- [x] `npm test` — 2312 passed, 1 pre-existing skip, 176 suites, no regressions
- [x] `tsc --noEmit` clean on touched files
- [x] 5 new unit tests cover: no-roots baseline, single-root wins, two-root deterministic (both orderings), empty-array == omitted
- [ ] Manual: dispatch a consensus round on a duplicate-basename citation, verify reviewer reads the correct file

## Deferred (separate PRs — flagged in consensus)
- `walkDir` RegExp recompile per entry (low, pre-existing)
- Symlink realpath on walk-side path reconstruction (low)
- `outsideDir` fixture — third-tier test assertion
- Extract `rankByResolutionRoots` helper for readability
- `runToolCalls` at `collect.ts:446` bypassing `resolveToolPath` (pre-existing, relay cross-review path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)