### PR TITLE
docs(rules): warn against trusting MEMORY.md index line

### DIFF
--- a/apps/cli/src/rules-content.ts
+++ b/apps/cli/src/rules-content.ts
@@ -144,6 +144,8 @@ Every \`project_*\` memory MUST include a \`status\` field in frontmatter:
 - \`status: shipped\` — work has landed. Reference only; don't mutate.
 - \`status: closed\` — decided not to pursue. Archive semantics.
 
+**Do NOT trust the MEMORY.md index line.** The index snippet is frozen text; the linked file's frontmatter \`status:\` is the truth. Before dispatching work on any \`project_*.md\` backlog item: (1) open the file, (2) read the \`status:\` field, (3) if it's not obviously fresh, call \`gossip_verify_memory(path, claim)\` per "Backlog Hygiene" above. Skipping this re-dispatches shipped work, wastes agent quota, and pollutes scores.
+
 ## Memory System
 
 Memory persists across sessions automatically:


### PR DESCRIPTION
## Summary
- Adds a 1-paragraph warning to the Memory Hygiene section of `generateRulesContent()` so fresh npm users are told NOT to dispatch work on `project_*.md` backlog items based on the MEMORY.md index line alone — the linked file's `status:` frontmatter is the truth.
- Reaches every fresh user immediately because `rules-content.ts` regenerates `.claude/rules/gossipcat.md` on every `gossip_setup`.

## Why
Session 2026-04-21 caught the failure mode: orchestrator dispatched a `haiku-researcher` install-drift audit based on the MEMORY.md index line for `project_install_drift_audit.md`. The actual file header said `status: shipped` with a "Verified STALE via gossip_verify_memory" note. Result: wasted dispatch + 2 hallucinations trying to find drift that didn't exist + agent-score pollution.

The rule already lived in dev-repo `CLAUDE.md` and `docs/HANDBOOK.md:193-200`, but neither reaches fresh npm users at the right moment. The rules file is the first operator-facing doc a new user sees after `gossip_setup`.

## Follow-up (Stage 2, separate PR)
Write-time MEMORY.md index injection — auto-prepend `[SHIPPED]` / `[OPEN]` prefix to index lines based on linked file's frontmatter. Fixes the lie at its source. Needs file-lock or atomic-rename to handle concurrent memory writes.

## Test plan
- [x] Read back the generated section — wording is actionable
- [ ] Manual: run `gossip_setup` in a scratch dir, verify `.claude/rules/gossipcat.md` contains the new paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)