### PR TITLE
feat(memory): auto-tag MEMORY.md index lines with frontmatter status

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -37,6 +37,18 @@ import { pickStickyPort, writeStickyPort, RELAY_STICKY_FILE, HTTP_MCP_STICKY_FIL
 import { buildDashboardAdvisory } from './setup-response';
 import { generateRulesContent } from './rules-content';
 import { formatDropReceipt } from './format-drop-receipt';
+import { homedir } from 'os';
+
+/**
+ * Resolve the Claude Code auto-memory directory for a project cwd.
+ * Claude Code encodes the absolute cwd by replacing every `/` with `-`
+ * (e.g. `/Users/goku/Desktop/gossip` → `-Users-goku-Desktop-gossip`).
+ * This mirrors `autoMemoryDir` in packages/relay/src/dashboard/api-native-memory.ts
+ * — kept inline here to avoid importing a dashboard module from MCP boot path.
+ */
+function memoryDirForProject(cwd: string): string {
+  return join(homedir(), '.claude', 'projects', cwd.replaceAll('/', '-'), 'memory');
+}
 
 // ── Environment detection ────────────────────────────────────────────────
 
@@ -1296,6 +1308,15 @@ server.tool(
   {},
   async () => {
     const { findConfigPath, loadConfig, configToAgentConfigs, loadClaudeSubagents } = await import('./config');
+
+    // Refresh MEMORY.md status tags BEFORE building the response, so any
+    // MEMORY.md content later loaded into orchestrator context reflects
+    // current `status:` fields of the linked project_*/feedback_* files.
+    try {
+      const { refreshMemoryIndex } = await import('@gossip/orchestrator');
+      const r = await refreshMemoryIndex(memoryDirForProject(process.cwd()));
+      if (r.error) process.stderr.write(`[gossipcat] refreshMemoryIndex: ${r.error}\n`);
+    } catch (err) { process.stderr.write(`[gossipcat] refreshMemoryIndex failed: ${(err as Error).message}\n`); }
 
     // System status
     const claudeSubagentsList = loadClaudeSubagents(process.cwd());
@@ -3449,6 +3470,13 @@ server.tool(
         wf2(j2(process.cwd(), '.gossip', 'bootstrap.md'), result.prompt);
       } catch { /* best-effort */ }
 
+      // Refresh MEMORY.md status tags in Claude Code native-memory dir
+      try {
+        const { refreshMemoryIndex } = await import('@gossip/orchestrator');
+        const r = await refreshMemoryIndex(memoryDirForProject(process.cwd()));
+        if (r.error) process.stderr.write(`[gossipcat] refreshMemoryIndex: ${r.error}\n`);
+      } catch (err) { process.stderr.write(`[gossipcat] refreshMemoryIndex failed: ${(err as Error).message}\n`); }
+
       // Clear consumed gossip
       try {
         const { writeFileSync: wf } = require('fs');
@@ -3694,6 +3722,13 @@ server.tool(
       wf(j(process.cwd(), '.gossip', 'bootstrap.md'), result.prompt);
       process.stderr.write('[gossipcat] 🔄 Bootstrap regenerated with new session context\n');
     } catch { /* best-effort */ }
+
+    // Refresh MEMORY.md status tags in Claude Code native-memory dir
+    try {
+      const { refreshMemoryIndex } = await import('@gossip/orchestrator');
+      const r = await refreshMemoryIndex(memoryDirForProject(process.cwd()));
+      if (r.error) process.stderr.write(`[gossipcat] refreshMemoryIndex: ${r.error}\n`);
+    } catch (err) { process.stderr.write(`[gossipcat] refreshMemoryIndex failed: ${(err as Error).message}\n`); }
 
     let output = `Session saved to .gossip/agents/_project/memory/\n\n${summary}`;
     if (findingsTable) {

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -38,6 +38,8 @@ export type { DedupeKeyInput } from './dedupe-key';
 export { AgentMemoryReader } from './agent-memory';
 export { MemoryWriter } from './memory-writer';
 export type { SessionArtifacts } from './memory-writer';
+export { refreshMemoryIndex, applyStatusTags } from './memory-index';
+export type { RefreshResult, MemoryStatus } from './memory-index';
 export { MemoryCompactor } from './memory-compactor';
 export { TaskGraph } from './task-graph';
 export { TaskGraphSync } from './task-graph-sync';

--- a/packages/orchestrator/src/memory-index.ts
+++ b/packages/orchestrator/src/memory-index.ts
@@ -1,0 +1,187 @@
+/**
+ * Memory-index auto-tagging (Stage 2 of memory-index status surfacing).
+ *
+ * Reads the hand-curated MEMORY.md file in a memory directory and rewrites
+ * its bullet lines so each entry that references a `project_*.md` or
+ * `feedback_*.md` file gets a `[SHIPPED]`, `[OPEN]`, or `[CLOSED]` tag
+ * derived from that file's YAML frontmatter `status:` field.
+ *
+ * Stage 1 (PR #214) landed the upstream warning in docs. Stage 2 injects the
+ * status into the index itself so the orchestrator sees the state in the
+ * same visual scan as the title — impossible to overlook.
+ *
+ * Behavior:
+ *   - `user_*.md` and `reference_*.md` are explicitly excluded (no tag).
+ *   - Files without frontmatter or without a `status:` field get no tag.
+ *   - Lines in MEMORY.md that don't match the bullet shape pass through verbatim
+ *     (section headers, sub-bullets, blank lines, etc).
+ *   - Existing tags are replaced when the file's status changes, or stripped
+ *     when the file no longer exposes a status.
+ *   - Output is written via a temp-file + rename so readers never observe
+ *     a torn file. When the output is identical to the input, no write occurs.
+ *
+ * This file is read-only with respect to the underlying memory files — we
+ * never mutate `project_*.md` or `feedback_*.md`, only rewrite MEMORY.md.
+ */
+
+import { existsSync, readFileSync, readdirSync, renameSync, writeFileSync, openSync, fsyncSync, closeSync, unlinkSync } from 'fs';
+import { join } from 'path';
+
+export type MemoryStatus = 'open' | 'shipped' | 'closed';
+
+export interface RefreshResult {
+  updated: number;
+  skipped: number;
+  error?: string;
+}
+
+// Matches bullet lines like:
+//   - [TAG] [Title text](project_foo.md) — description
+//   - [Title text](feedback_bar.md)
+// Captures: (1) existing tag (with brackets and trailing space) OR empty,
+//           (2) title, (3) filename.
+const BULLET_RE = /^(- )(\[[A-Z]+\] )?\[([^\]]+)\]\(([^)]+\.md)\)/;
+
+// Matches frontmatter `status:` lines. Leading/trailing whitespace and
+// optional quotes are tolerated.
+const STATUS_RE = /^status:\s*["']?(open|shipped|closed)["']?\s*$/i;
+
+/**
+ * Parse the first YAML frontmatter block (between leading `---` fences) and
+ * extract a `status:` value if present and valid. Returns `undefined` when
+ * the file has no frontmatter, no status, or an invalid status value.
+ */
+function extractStatus(content: string): MemoryStatus | undefined {
+  // Frontmatter must be the first non-empty thing in the file.
+  if (!content.startsWith('---')) return undefined;
+  const rest = content.slice(3);
+  // Find the next `---` fence on its own line.
+  const endIdx = rest.indexOf('\n---');
+  if (endIdx === -1) return undefined;
+  const block = rest.slice(0, endIdx);
+  for (const raw of block.split('\n')) {
+    const line = raw.trim();
+    const m = line.match(STATUS_RE);
+    if (m) {
+      return m[1].toLowerCase() as MemoryStatus;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build a map from memory filename (e.g. `project_foo.md`) → status, by
+ * scanning the directory for `project_*.md` / `feedback_*.md` files and
+ * parsing their frontmatter. `user_*.md` and `reference_*.md` are skipped
+ * per contract. Files missing status are omitted from the map (→ caller
+ * strips any existing tag).
+ */
+function buildStatusMap(memoryDir: string): Map<string, MemoryStatus> {
+  const map = new Map<string, MemoryStatus>();
+  let entries: string[];
+  try {
+    entries = readdirSync(memoryDir);
+  } catch {
+    return map;
+  }
+  for (const fname of entries) {
+    if (!fname.endsWith('.md')) continue;
+    if (fname === 'MEMORY.md') continue;
+    if (!(fname.startsWith('project_') || fname.startsWith('feedback_'))) continue;
+    let content: string;
+    try {
+      content = readFileSync(join(memoryDir, fname), 'utf-8');
+    } catch {
+      continue;
+    }
+    const status = extractStatus(content);
+    if (status) map.set(fname, status);
+  }
+  return map;
+}
+
+/**
+ * Rewrite MEMORY.md index lines to reflect the current `status:` of each
+ * linked memory file. Pure string transform — testable in isolation.
+ *
+ * Rules:
+ *   - Lines matching BULLET_RE whose filename is in the status map get the
+ *     tag set (added or replaced) to `[STATUS]` in caps.
+ *   - Lines matching BULLET_RE whose filename is NOT in the map have any
+ *     existing tag stripped (file has no status OR is an excluded user/reference
+ *     memory OR is missing on disk).
+ *   - All other lines pass through unchanged.
+ *
+ * Returns the rewritten text plus count of lines actually changed.
+ */
+export function applyStatusTags(
+  input: string,
+  statusMap: Map<string, MemoryStatus>,
+): { output: string; changed: number } {
+  const lines = input.split('\n');
+  let changed = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const m = line.match(BULLET_RE);
+    if (!m) continue;
+    const [, bullet, existingTag, title, filename] = m;
+    const status = statusMap.get(filename);
+    const desiredTag = status ? `[${status.toUpperCase()}] ` : '';
+    if ((existingTag ?? '') === desiredTag) continue;
+    // Rebuild the prefix up through the `)` of the filename, preserve trailing content verbatim.
+    const rebuilt = `${bullet}${desiredTag}[${title}](${filename})`;
+    const tail = line.slice(m[0].length);
+    lines[i] = rebuilt + tail;
+    changed++;
+  }
+  return { output: lines.join('\n'), changed };
+}
+
+/**
+ * Atomic write: write to `<path>.tmp`, fsync, rename. The rename is atomic on
+ * POSIX, so readers see either the old file or the new one — never a partial
+ * write. If any step throws, attempt to clean up the tmp file.
+ */
+function atomicWrite(path: string, content: string): void {
+  const tmp = `${path}.tmp`;
+  let fd: number | undefined;
+  try {
+    writeFileSync(tmp, content, 'utf-8');
+    fd = openSync(tmp, 'r');
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    renameSync(tmp, path);
+  } catch (err) {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* ignore */ }
+    }
+    try { if (existsSync(tmp)) unlinkSync(tmp); } catch { /* ignore */ }
+    throw err;
+  }
+}
+
+/**
+ * Refresh MEMORY.md in `memoryDir` with `[STATUS]` tags derived from each
+ * linked memory file's frontmatter. Non-fatal: returns an `error` field
+ * rather than throwing.
+ */
+export async function refreshMemoryIndex(memoryDir: string): Promise<RefreshResult> {
+  const indexPath = join(memoryDir, 'MEMORY.md');
+  if (!existsSync(indexPath)) {
+    return { updated: 0, skipped: 0 };
+  }
+  try {
+    const input = readFileSync(indexPath, 'utf-8');
+    const statusMap = buildStatusMap(memoryDir);
+    const { output, changed } = applyStatusTags(input, statusMap);
+    const totalLines = input.split('\n').length;
+    const skipped = totalLines - changed;
+    if (output !== input) {
+      atomicWrite(indexPath, output);
+    }
+    return { updated: changed, skipped };
+  } catch (err) {
+    return { updated: 0, skipped: 0, error: (err as Error).message };
+  }
+}

--- a/tests/orchestrator/memory-index.test.ts
+++ b/tests/orchestrator/memory-index.test.ts
@@ -1,0 +1,191 @@
+import { refreshMemoryIndex, applyStatusTags } from '@gossip/orchestrator';
+import { mkdirSync, writeFileSync, readFileSync, readdirSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+function makeFrontmatter(status?: string): string {
+  const lines = ['---', 'name: Foo', 'description: A memory', 'type: project'];
+  if (status) lines.push(`status: ${status}`);
+  lines.push('originSessionId: abc');
+  lines.push('---');
+  lines.push('');
+  lines.push('Body content here.');
+  return lines.join('\n') + '\n';
+}
+
+describe('memory-index refreshMemoryIndex', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `gossip-memindex-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function writeIndex(body: string) {
+    writeFileSync(join(testDir, 'MEMORY.md'), body);
+  }
+  function readIndex(): string {
+    return readFileSync(join(testDir, 'MEMORY.md'), 'utf-8');
+  }
+
+  it('returns {0,0} when MEMORY.md absent', async () => {
+    const r = await refreshMemoryIndex(testDir);
+    expect(r).toEqual({ updated: 0, skipped: 0 });
+  });
+
+  it('adds a [SHIPPED] tag to a matching line', async () => {
+    writeFileSync(join(testDir, 'project_foo.md'), makeFrontmatter('shipped'));
+    writeIndex('# Index\n\n- [Foo feature](project_foo.md) — did stuff\n');
+    const r = await refreshMemoryIndex(testDir);
+    expect(r.updated).toBe(1);
+    expect(readIndex()).toContain('- [SHIPPED] [Foo feature](project_foo.md) — did stuff');
+  });
+
+  it('handles multiple statuses (shipped/open/closed)', async () => {
+    writeFileSync(join(testDir, 'project_a.md'), makeFrontmatter('shipped'));
+    writeFileSync(join(testDir, 'project_b.md'), makeFrontmatter('open'));
+    writeFileSync(join(testDir, 'feedback_c.md'), makeFrontmatter('closed'));
+    writeIndex([
+      '# Index',
+      '',
+      '## Project',
+      '- [A](project_a.md) — a',
+      '- [B](project_b.md) — b',
+      '',
+      '## Feedback',
+      '- [C](feedback_c.md) — c',
+      '',
+    ].join('\n'));
+    const r = await refreshMemoryIndex(testDir);
+    expect(r.updated).toBe(3);
+    const out = readIndex();
+    expect(out).toContain('- [SHIPPED] [A](project_a.md)');
+    expect(out).toContain('- [OPEN] [B](project_b.md)');
+    expect(out).toContain('- [CLOSED] [C](feedback_c.md)');
+    expect(out).toContain('## Project');
+    expect(out).toContain('## Feedback');
+  });
+
+  it('replaces an existing tag when status changes', async () => {
+    writeFileSync(join(testDir, 'project_foo.md'), makeFrontmatter('shipped'));
+    writeIndex('- [OPEN] [Foo](project_foo.md) — x\n');
+    const r = await refreshMemoryIndex(testDir);
+    expect(r.updated).toBe(1);
+    expect(readIndex()).toContain('- [SHIPPED] [Foo](project_foo.md) — x');
+    expect(readIndex()).not.toContain('[OPEN]');
+  });
+
+  it('strips a tag when the file no longer has a status', async () => {
+    writeFileSync(join(testDir, 'project_foo.md'), makeFrontmatter(undefined));
+    writeIndex('- [SHIPPED] [Foo](project_foo.md) — x\n');
+    const r = await refreshMemoryIndex(testDir);
+    expect(r.updated).toBe(1);
+    const out = readIndex();
+    expect(out).toContain('- [Foo](project_foo.md) — x');
+    expect(out).not.toContain('[SHIPPED]');
+  });
+
+  it('is idempotent: second call reports updated: 0', async () => {
+    writeFileSync(join(testDir, 'project_foo.md'), makeFrontmatter('shipped'));
+    writeIndex('- [Foo](project_foo.md) — x\n');
+    const r1 = await refreshMemoryIndex(testDir);
+    expect(r1.updated).toBe(1);
+    const r2 = await refreshMemoryIndex(testDir);
+    expect(r2.updated).toBe(0);
+  });
+
+  it('leaves unchanged when linked file is missing', async () => {
+    writeIndex('- [Ghost](project_ghost.md) — x\n');
+    const r = await refreshMemoryIndex(testDir);
+    expect(r.updated).toBe(0);
+    expect(readIndex()).toContain('- [Ghost](project_ghost.md) — x');
+  });
+
+  it('does not tag user_*.md or reference_*.md even if they have status', async () => {
+    writeFileSync(join(testDir, 'user_profile.md'), makeFrontmatter('shipped'));
+    writeFileSync(join(testDir, 'reference_x.md'), makeFrontmatter('open'));
+    writeIndex([
+      '- [Profile](user_profile.md) — p',
+      '- [Ref](reference_x.md) — r',
+      '',
+    ].join('\n'));
+    const r = await refreshMemoryIndex(testDir);
+    expect(r.updated).toBe(0);
+    const out = readIndex();
+    expect(out).not.toContain('[SHIPPED]');
+    expect(out).not.toContain('[OPEN]');
+  });
+
+  it('preserves section headers and blank lines verbatim', async () => {
+    writeFileSync(join(testDir, 'project_a.md'), makeFrontmatter('shipped'));
+    const input = [
+      '# MEMORY Index',
+      '',
+      '## Project (most recent)',
+      '',
+      '- [A](project_a.md) — a',
+      '',
+      '## Sessions',
+      'Some free prose.',
+      '',
+    ].join('\n');
+    writeIndex(input);
+    await refreshMemoryIndex(testDir);
+    const out = readIndex();
+    expect(out).toContain('# MEMORY Index');
+    expect(out).toContain('## Project (most recent)');
+    expect(out).toContain('## Sessions');
+    expect(out).toContain('Some free prose.');
+    expect(out).toContain('- [SHIPPED] [A](project_a.md) — a');
+  });
+
+  it('writes atomically: no stray .tmp file after refresh', async () => {
+    writeFileSync(join(testDir, 'project_foo.md'), makeFrontmatter('shipped'));
+    writeIndex('- [Foo](project_foo.md) — x\n');
+    await refreshMemoryIndex(testDir);
+    const entries = readdirSync(testDir);
+    expect(entries).toContain('MEMORY.md');
+    expect(entries).not.toContain('MEMORY.md.tmp');
+    expect(existsSync(join(testDir, 'MEMORY.md.tmp'))).toBe(false);
+  });
+
+  it('skips write when output === input (idempotent no-op)', async () => {
+    // No linked files have status → existing untagged line should not rewrite.
+    writeFileSync(join(testDir, 'project_foo.md'), makeFrontmatter(undefined));
+    writeIndex('- [Foo](project_foo.md) — x\n');
+    const before = readFileSync(join(testDir, 'MEMORY.md'));
+    // Give filesystem a moment, then refresh.
+    const r = await refreshMemoryIndex(testDir);
+    expect(r.updated).toBe(0);
+    const after = readFileSync(join(testDir, 'MEMORY.md'));
+    expect(after.equals(before)).toBe(true);
+  });
+
+  it('passes non-bullet lines through unchanged', () => {
+    // Unit test of the pure transform — exercises header/blank/sub-bullet handling.
+    const input = [
+      '# Heading',
+      '> quote',
+      '  - indented sub-bullet [X](project_x.md)',
+      'plain text [Y](project_y.md)',
+      '- [Real](project_real.md) — ok',
+      '',
+    ].join('\n');
+    const map = new Map<string, 'shipped' | 'open' | 'closed'>([
+      ['project_real.md', 'shipped'],
+      ['project_x.md', 'shipped'],
+      ['project_y.md', 'open'],
+    ]);
+    const { output, changed } = applyStatusTags(input, map);
+    expect(changed).toBe(1);
+    expect(output).toContain('- [SHIPPED] [Real](project_real.md) — ok');
+    // Non-matching lines unchanged.
+    expect(output).toContain('  - indented sub-bullet [X](project_x.md)');
+    expect(output).toContain('plain text [Y](project_y.md)');
+    expect(output).toContain('# Heading');
+  });
+});


### PR DESCRIPTION
## Summary
Stage 2 of the MEMORY.md index-trust fix (Stage 1 = PR #214 docs warning).

Auto-inject `[SHIPPED]` / `[OPEN]` / `[CLOSED]` prefixes into MEMORY.md index lines based on the linked file's frontmatter `status:` field. Fires on every `gossip_status` and `gossip_session_save`. Orchestrators (and fresh users) now see the status inline with the title — impossible to overlook.

## Why
Session 2026-04-21 caught the failure: an orchestrator dispatched `haiku-researcher` on `project_install_drift_audit.md` based on the MEMORY.md index line that described it as open work. The file itself said `status: shipped` with a "verified STALE" note. Result: wasted dispatch + 2 hallucinations + score pollution. Stage 1 added a docs warning; Stage 2 makes the index itself impossible-to-overlook truthful.

## Design (from 3-lens consensus)
- **sonnet-reviewer (DX):** Picked write-time index auto-tag + docs reinforcement.
- **sonnet-designer (UX):** Picked write-time index injection; flagged concurrent-write race.
- **haiku-researcher (plumbing):** Picked docs rule (Stage 1 handled).

Stage 2 implements the write-time mechanism both reviewers wanted. Concurrent-write race handled via atomic tmp+fsync+rename.

## Implementation
- `packages/orchestrator/src/memory-index.ts` (new, 187 lines)
  - Pure `applyStatusTags(input, statusMap)` transform — fully unit-testable
  - `refreshMemoryIndex(memoryDir)` wraps it with file I/O + atomic rename
  - Parses frontmatter `status:` from `project_*.md` and `feedback_*.md`; skips `user_*.md` / `reference_*.md`
  - Idempotent: no write when output matches input
- `apps/cli/src/mcp-server-sdk.ts` — `memoryDirForProject(cwd)` helper + 3 refresh call-sites (gossip_status, gossip_session_save re-entry + normal path), all try/catch with stderr fallback
- `packages/orchestrator/src/index.ts` — re-exports
- `tests/orchestrator/memory-index.test.ts` (new, 191 lines, 12 cases)

## Test plan
- [x] `npx jest tests/orchestrator/memory-index.test.ts` — 12/12 pass
- [x] `npx jest` full suite — 2319/2319 pass, zero regressions
- [x] Manual smoke on real memory dir (copied to tmp) — 126 updated, 73 skipped
- [x] `tsc --noEmit` clean on touched files
- [ ] After merge: verify `gossip_status` on a fresh repo actually mutates MEMORY.md in-place

## Known limitation (follow-up)
`MEMORY.md.tmp` can orphan if the process is SIGKILL'd between `writeFileSync` and `renameSync`. Future PR: startup sweep of stale `.tmp` siblings in memoryDir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)