### PR TITLE
feat(memory): citation annotator + archive truncation observability

### DIFF
--- a/packages/orchestrator/src/memory-compactor.ts
+++ b/packages/orchestrator/src/memory-compactor.ts
@@ -81,7 +81,9 @@ export class MemoryCompactor {
             writeFileSync(archivePath, archiveLines.slice(-MAX_ARCHIVE_LINES).join('\n') + '\n');
           }
         }
-      } catch { /* best-effort archive truncation */ }
+      } catch (err) {
+        process.stderr.write(`[memory-compactor] archive truncation failed for ${agentId}: ${(err as Error).message}\n`);
+      }
 
       writeFileSync(tasksPath, toKeep.map(e => e.line).join('\n') + '\n');
 

--- a/packages/orchestrator/src/memory-writer.ts
+++ b/packages/orchestrator/src/memory-writer.ts
@@ -1,5 +1,5 @@
 import { appendFileSync, writeFileSync, readFileSync, existsSync, mkdirSync, readdirSync, unlinkSync, openSync, closeSync, constants } from 'fs';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { TaskMemoryEntry } from './types';
 import { MemoryCompactor } from './memory-compactor';
 import type { ILLMProvider } from './llm-client';
@@ -141,6 +141,7 @@ export class MemoryWriter {
     task: string;
     result: string;
     agentAccuracy?: number;
+    resolutionRoots?: string[];
   }): Promise<void> {
     const memDir = this.ensureDirs(agentId);
     const knowledgeDir = join(memDir, 'knowledge');
@@ -200,6 +201,14 @@ export class MemoryWriter {
     const accuracyLine = data.agentAccuracy !== undefined
       ? `agentAccuracy: ${data.agentAccuracy.toFixed(2)}`
       : null;
+    const citations = this.validateCitations(body, data.resolutionRoots);
+    const citationLines: string[] = [`citationsVerified: ${citations.verified}/${citations.total}`];
+    if (citations.unverified.length > 0) {
+      citationLines.push('citationsFabricated:');
+      for (const u of citations.unverified) {
+        citationLines.push(`  - "${u}"`);
+      }
+    }
     const content = [
       '---',
       `name: ${truncateAtWord(data.task, 80).replace(/\n/g, ' ')}`,
@@ -208,6 +217,7 @@ export class MemoryWriter {
       ...(accuracyLine ? [accuracyLine] : []),
       `lastAccessed: ${today}`,
       `accessCount: 0`,
+      ...citationLines,
       '---',
       '',
       ...(data.agentAccuracy !== undefined && data.agentAccuracy < 0.4
@@ -217,6 +227,66 @@ export class MemoryWriter {
     ].join('\n');
 
     writeFileSync(join(knowledgeDir, filename), content);
+  }
+
+  /**
+   * Annotation-only citation check: scans `body` for file-like tokens (optionally
+   * with a `:NN` line-number suffix), resolves each against `projectRoot` plus any
+   * supplied `resolutionRoots`, and reports how many are real. Never drops or
+   * mutates content — the caller records the counts in frontmatter for later
+   * analysis.
+   */
+  private validateCitations(
+    body: string,
+    resolutionRoots?: string[],
+  ): { total: number; verified: number; unverified: string[] } {
+    // Mirrors extractFacts() regex but also captures an optional :NN suffix.
+    const fileRegex = /(?:^|[\s`"'(\[<])([a-zA-Z0-9_/.-]+\.[a-z]{1,7})(?::(\d+))?(?=[\s`"'):,\]>]|$)/gm;
+    const seen = new Set<string>();
+    const citations: Array<{ path: string; line?: number; key: string }> = [];
+    let m: RegExpExecArray | null;
+    while ((m = fileRegex.exec(body)) !== null) {
+      const path = m[1];
+      // Skip URLs — the extension-ish tail after a URL is not a local citation.
+      // Check the 8 chars before the match for http:// or https:// scheme.
+      const before = body.slice(Math.max(0, m.index - 8), m.index + 1);
+      if (/https?:\/\//.test(before) || /https?:\/\//.test(path)) continue;
+      const line = m[2] ? parseInt(m[2], 10) : undefined;
+      const key = line !== undefined ? `${path}:${line}` : path;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      citations.push({ path, line, key });
+    }
+
+    const roots = [this.projectRoot, ...(resolutionRoots ?? [])];
+    const unverified: string[] = [];
+    let verified = 0;
+    for (const c of citations) {
+      let hit: string | null = null;
+      for (const root of roots) {
+        const abs = resolve(root, c.path);
+        if (existsSync(abs)) { hit = abs; break; }
+      }
+      if (!hit) {
+        unverified.push(c.key);
+        continue;
+      }
+      if (c.line !== undefined) {
+        try {
+          const lineCount = readFileSync(hit, 'utf8').split('\n').length;
+          if (c.line > lineCount || c.line < 1) {
+            unverified.push(c.key);
+            continue;
+          }
+        } catch {
+          unverified.push(c.key);
+          continue;
+        }
+      }
+      verified++;
+    }
+
+    return { total: citations.length, verified, unverified };
   }
 
   /**

--- a/tests/orchestrator/memory-writer-citations.test.ts
+++ b/tests/orchestrator/memory-writer-citations.test.ts
@@ -1,0 +1,103 @@
+import { MemoryWriter } from '@gossip/orchestrator';
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * Tests the private validateCitations method via bracket access. The public
+ * behavior (frontmatter emission) is exercised indirectly — we assert on the
+ * structured result since the caller just renders it.
+ */
+describe('MemoryWriter.validateCitations (annotation-only)', () => {
+  let projectRoot: string;
+  let writer: MemoryWriter;
+  // Helper to invoke the private method without re-typing bracket access everywhere
+  const validate = (body: string, roots?: string[]) =>
+    (writer as any).validateCitations(body, roots) as {
+      total: number;
+      verified: number;
+      unverified: string[];
+    };
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'gossip-citations-'));
+    writer = new MemoryWriter(projectRoot);
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('counts a valid citation as verified with no fabricated list', () => {
+    mkdirSync(join(projectRoot, 'src'), { recursive: true });
+    writeFileSync(join(projectRoot, 'src/foo.ts'), 'line1\nline2\nline3\n');
+    const result = validate('See src/foo.ts for details.');
+    expect(result.total).toBe(1);
+    expect(result.verified).toBe(1);
+    expect(result.unverified).toEqual([]);
+  });
+
+  it('flags non-existent file paths as unverified', () => {
+    const result = validate('Missing path: src/does-not-exist.ts here.');
+    expect(result.total).toBe(1);
+    expect(result.verified).toBe(0);
+    expect(result.unverified).toContain('src/does-not-exist.ts');
+  });
+
+  it('counts out-of-range :NN line suffix as unverified', () => {
+    mkdirSync(join(projectRoot, 'src'), { recursive: true });
+    writeFileSync(join(projectRoot, 'src/small.ts'), 'l1\nl2\n'); // 3 lines (trailing empty)
+    const result = validate('See src/small.ts:999 broken ref.');
+    expect(result.total).toBe(1);
+    expect(result.verified).toBe(0);
+    expect(result.unverified).toContain('src/small.ts:999');
+  });
+
+  it('reports mixed 2/3 verified', () => {
+    mkdirSync(join(projectRoot, 'src'), { recursive: true });
+    writeFileSync(join(projectRoot, 'src/a.ts'), 'x\n');
+    writeFileSync(join(projectRoot, 'src/b.ts'), 'y\n');
+    const body = 'Check src/a.ts and src/b.ts and src/ghost.ts now';
+    const result = validate(body);
+    expect(result.total).toBe(3);
+    expect(result.verified).toBe(2);
+    expect(result.unverified).toEqual(['src/ghost.ts']);
+  });
+
+  it('skips http(s):// URLs as non-citations', () => {
+    const body = 'See https://github.com/x/y.ts#L42 for the upstream.';
+    const result = validate(body);
+    expect(result.total).toBe(0);
+    expect(result.verified).toBe(0);
+    expect(result.unverified).toEqual([]);
+  });
+
+  it('returns 0/0 when body contains no citations', () => {
+    const result = validate('Just prose, no file refs here at all.');
+    expect(result.total).toBe(0);
+    expect(result.verified).toBe(0);
+    expect(result.unverified).toEqual([]);
+  });
+
+  it('resolves against resolutionRoots when file lives in a worktree root', () => {
+    const worktree = mkdtempSync(join(tmpdir(), 'gossip-citations-wt-'));
+    try {
+      mkdirSync(join(worktree, 'pkg'), { recursive: true });
+      writeFileSync(join(worktree, 'pkg/only-here.ts'), 'x\n');
+      const result = validate('Reference pkg/only-here.ts please.', [worktree]);
+      expect(result.total).toBe(1);
+      expect(result.verified).toBe(1);
+      expect(result.unverified).toEqual([]);
+    } finally {
+      rmSync(worktree, { recursive: true, force: true });
+    }
+  });
+
+  it('verifies a bare filename with no :NN when it exists at projectRoot', () => {
+    writeFileSync(join(projectRoot, 'bare.ts'), 'x\n');
+    const result = validate('Look at bare.ts directly.');
+    expect(result.total).toBe(1);
+    expect(result.verified).toBe(1);
+    expect(result.unverified).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Two small memory-layer fixes from consensus `b90e736a-cf2f4876` (3 agents: sonnet-reviewer, gemini-reviewer, gemini-tester).

### 1. Citation annotator (`memory-writer.ts`)

Every knowledge/*.md write now gets a `citationsVerified: N/M` frontmatter line, plus an optional `citationsFabricated:` YAML list when any cited file doesn't exist or the line number is out of range. New private `validateCitations(body, resolutionRoots?)` method reuses the existing `extractFacts` regex extended with an optional `:NN` suffix capture. URLs (`http(s)://…`) are excluded. Optional `resolutionRoots?: string[]` threaded through the `data` param — no existing callers change.

**Annotation-only by design.** The consensus reshape-brief flagged that a hard drop-gate would double-penalize weak agents already docked by `hallucination_caught` scoring. Annotation gives the dashboard + future eviction logic the signal without starving agents of context.

### 2. Archive truncation observability (`memory-compactor.ts:84`)

Empty `catch { /* best-effort */ }` replaced with a stderr log. Archive-truncation failures (disk full, EACCES, racing agent) used to be completely silent — now the operator sees `[memory-compactor] archive truncation failed for <agent>: <err>`. Best-effort semantics preserved; compaction continues.

### Deferred to follow-up PRs (per consensus)
- `knowledge_rejected` signal type for live observability
- `pruneKnowledgeDir` weight update so `citationsVerified < 0.5` penalizes retention
- Apply validator to `writeConsensusKnowledge` + post-LLM `cognitiveSummary` stage

## Test plan

- [x] 8 new cases in `tests/orchestrator/memory-writer-citations.test.ts` — all pass
- [x] 4/4 existing `tests/orchestrator/memory-compactor.test.ts` still pass
- [x] `npx tsc --noEmit -p packages/orchestrator/tsconfig.json` — exit 0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)