### PR TITLE
fix(dispatch): explicit output-delivery protocol in agent prompts

### DIFF
--- a/packages/orchestrator/src/finding-tag-schema.ts
+++ b/packages/orchestrator/src/finding-tag-schema.ts
@@ -20,6 +20,20 @@ export const FINDING_TAG_SCHEMA = `FINDING TAG SCHEMA (output parsing requires t
 - Do NOT invent new types (e.g., "approval", "concern", "risk", "recommendation", "confirmed", "issue", "bug", "warning") — they will not appear in any dashboard, score, or signal.
 - Cite source files inline: <cite tag="file">path:line</cite>`;
 
+/**
+ * Output-delivery protocol — kept separate from FINDING_TAG_SCHEMA so changes
+ * here don't shift the schema's byte-size (which is load-bearing for suffix
+ * budget tests in assemblePrompt). Injected as its own priority-0 block by
+ * the prompt assembler.
+ *
+ * Why this exists: a sibling-project dispatch observed an `architect` agent
+ * attempt to call `gossip_relay` itself, discover the tool isn't exposed to
+ * subagents, burn 67K tokens flailing, and return no findings. The subagent
+ * is a writer, not a relay caller — the orchestrator handles relay. This
+ * message makes that contract explicit at dispatch time.
+ */
+export const OUTPUT_DELIVERY_PROTOCOL = `OUTPUT DELIVERY — emit findings as TEXT in your response. The orchestrator captures your response and calls gossip_relay on your behalf. Do NOT call gossip_relay, gossip_relay_cross_review, or any gossip_* tool yourself — these are orchestrator-only. Stop when your findings are written; do not try to "submit" or "finalize".`;
+
 export const CONSENSUS_OUTPUT_FORMAT = `⚠ UNKNOWN TYPES ARE SILENTLY DROPPED — only type="finding", type="suggestion", type="insight" are accepted. Any other type value (e.g. approval, concern, risk, recommendation, confirmed) will NOT appear in the dashboard, scores, or signals.
 
 ${FINDING_TAG_SCHEMA}

--- a/packages/orchestrator/src/prompt-assembler.ts
+++ b/packages/orchestrator/src/prompt-assembler.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
-import { FINDING_TAG_SCHEMA, CONSENSUS_OUTPUT_FORMAT } from './finding-tag-schema';
+import { FINDING_TAG_SCHEMA, CONSENSUS_OUTPUT_FORMAT, OUTPUT_DELIVERY_PROTOCOL } from './finding-tag-schema';
 
 // Re-exported so existing import sites (`@gossip/orchestrator`) keep working.
-export { FINDING_TAG_SCHEMA, CONSENSUS_OUTPUT_FORMAT };
+export { FINDING_TAG_SCHEMA, CONSENSUS_OUTPUT_FORMAT, OUTPUT_DELIVERY_PROTOCOL };
 
 const DOC_EXTENSIONS = new Set(['.md', '.txt', '.rst']);
 const SPEC_PATH_PATTERN = /(?:docs\/|specs\/|[\w-]+-(?:design|spec)\.md)/;
@@ -213,6 +213,7 @@ export function assemblePrompt(parts: {
   if (parts.consensusSummary) {
     // Consensus dispatches need the full cross-review framing.
     suffix.push({ priority: 0, text: `\n\n--- CONSENSUS OUTPUT FORMAT ---\n${CONSENSUS_OUTPUT_FORMAT}\n\nThis section will be used for cross-review with peer agents.\n--- END CONSENSUS OUTPUT FORMAT ---` });
+    suffix.push({ priority: 0, text: `\n\n${OUTPUT_DELIVERY_PROTOCOL}` });
   } else {
     // Non-consensus dispatches still need the type enum + anti-invention rule
     // so agent output is parseable when the dashboard retroactively shows it.
@@ -230,6 +231,7 @@ export function assemblePrompt(parts: {
     );
     if (hasAnyMeaningfulPart) {
       suffix.push({ priority: 0, text: `\n\n--- FINDING TAG SCHEMA ---\n${FINDING_TAG_SCHEMA}\n--- END FINDING TAG SCHEMA ---` });
+      suffix.push({ priority: 0, text: `\n\n${OUTPUT_DELIVERY_PROTOCOL}` });
     }
   }
 

--- a/tests/orchestrator/prompt-assembler.test.ts
+++ b/tests/orchestrator/prompt-assembler.test.ts
@@ -243,9 +243,10 @@ describe('assemblePrompt suffix cap (F14 — priority-ordered drop)', () => {
 
   it('drops AGENT MEMORY before MEMORY when only one drop is needed (priority 4 > priority 3)', () => {
     // Size MEMORY just over the reserve budget so AGENT_MEMORY's removal
-    // alone brings total back under reserve. Schema ~600 + AGENT_MEMORY ~500
-    // + task tiny → memory body of ~17100 pushes total just over 18K reserve.
-    const memoryBlock = 'actual memory: ' + 'y'.repeat(17_100);
+    // alone brings total back under reserve. Schema ~600 + OUTPUT_DELIVERY ~400
+    // + AGENT_MEMORY ~500 + task tiny → memory body of ~16700 pushes total
+    // just over 18K reserve.
+    const memoryBlock = 'actual memory: ' + 'y'.repeat(16_700);
     const result = assemblePrompt({
       task: 'x',
       memory: memoryBlock,


### PR DESCRIPTION
## Summary

Fixes a subagent self-relay failure mode observed on a fresh install: an `architect` agent was dispatched, attempted to call `gossip_relay` itself, discovered the tool wasn't exposed to subagents, and burned 67K tokens + 36 tool uses flailing without returning findings.

The subagent contract has always been:

> emit findings as text; the orchestrator captures the response and calls `gossip_relay` on the subagent's behalf.

That contract wasn't written anywhere the subagent could see — only the orchestrator-facing dispatch instructions mentioned `gossip_relay`, so some agents assumed the instruction was for them.

Now every assembled dispatch prompt (native + relay, consensus + solo) carries a priority-0 `OUTPUT_DELIVERY_PROTOCOL` block that explicitly states:

- emit findings as TEXT in your response
- orchestrator calls `gossip_relay` on your behalf
- do NOT call `gossip_relay`, `gossip_relay_cross_review`, or any `gossip_*` tool yourself
- stop when findings are written; don't try to \"submit\" or \"finalize\"

Kept as a separate constant (not merged into `FINDING_TAG_SCHEMA`) so the schema's byte size stays stable — budget-tuning tests in prompt-assembler depend on it.

## Changes

- `packages/orchestrator/src/finding-tag-schema.ts` — new `OUTPUT_DELIVERY_PROTOCOL` constant with rationale docblock
- `packages/orchestrator/src/prompt-assembler.ts` — inject as priority-0 suffix block alongside FINDING_TAG_SCHEMA (both consensus and non-consensus paths)
- `tests/orchestrator/prompt-assembler.test.ts` — F14 budget test fixture memory block bumped by ~400 chars to account for the new priority-0 block

## Test plan

- [x] 1420/1420 orchestrator tests pass (including prompt-assembler suffix-budget suite)
- [x] `npx tsc --noEmit -p packages/orchestrator/tsconfig.json` — exit 0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)