### PR TITLE
fix(memory): extend citation validator to writeConsensusKnowledge

### DIFF
--- a/packages/orchestrator/src/consensus-coordinator.ts
+++ b/packages/orchestrator/src/consensus-coordinator.ts
@@ -160,7 +160,7 @@ export class ConsensusCoordinator {
           }));
           const participants = new Set(results.filter(r => r.status === 'completed').map(r => r.agentId));
           for (const agentId of participants) {
-            this.memWriter.writeConsensusKnowledge(agentId, findings);
+            this.memWriter.writeConsensusKnowledge(agentId, findings, this.resolutionRoots ? [...this.resolutionRoots] : undefined);
           }
           for (const agentId of participants) {
             try { this.memWriter.rebuildIndex(agentId); } catch { /* best-effort */ }

--- a/packages/orchestrator/src/memory-writer.ts
+++ b/packages/orchestrator/src/memory-writer.ts
@@ -986,7 +986,11 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
     return Math.min(0.85, (scores.relevance + scores.accuracy + scores.uniqueness) / 15);
   }
 
-  writeConsensusKnowledge(agentId: string, findings: Array<{ originalAgentId: string; finding: string; tag?: string }>): void {
+  writeConsensusKnowledge(
+    agentId: string,
+    findings: Array<{ originalAgentId: string; finding: string; tag?: string }>,
+    resolutionRoots?: string[],
+  ): void {
     if (findings.length === 0) return;
     const memDir = this.ensureDirs(agentId);
     const knowledgeDir = join(memDir, 'knowledge');
@@ -1004,15 +1008,7 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
       confirmed: '✓', disputed: '⚡', unverified: '?', unique: '◇',
     };
 
-    const content = [
-      '---',
-      `name: Peer findings from consensus review`,
-      `description: ${peerFindings.length} findings from peer agents`,
-      `importance: 0.8`,
-      `lastAccessed: ${today}`,
-      `accessCount: 0`,
-      '---',
-      '',
+    const bodyLines = [
       '## Peer Findings (learn from these)',
       '',
       ...peerFindings.map(f => {
@@ -1020,6 +1016,29 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
         const status = f.tag ? ` [${f.tag.toUpperCase()}]` : '';
         return `- ${emoji} [${f.originalAgentId}]${status} ${f.finding}`;
       }),
+    ];
+    const body = bodyLines.join('\n');
+
+    const citations = this.validateCitations(body, resolutionRoots);
+    const citationLines: string[] = [`citationsVerified: ${citations.verified}/${citations.total}`];
+    if (citations.unverified.length > 0) {
+      citationLines.push('citationsFabricated:');
+      for (const u of citations.unverified) {
+        citationLines.push(`  - "${u}"`);
+      }
+    }
+
+    const content = [
+      '---',
+      `name: Peer findings from consensus review`,
+      `description: ${peerFindings.length} findings from peer agents`,
+      `importance: 0.8`,
+      `lastAccessed: ${today}`,
+      `accessCount: 0`,
+      ...citationLines,
+      '---',
+      '',
+      body,
     ].join('\n');
 
     // Warmth-aware pruning — same as writeKnowledgeFromResult


### PR DESCRIPTION
## Summary
- Symmetrically applies PR #218's citation validator to the second memory write path (`writeConsensusKnowledge`), which assembled peer-finding knowledge files without `citationsVerified` / `citationsFabricated` frontmatter.
- Threads `resolutionRoots` through from `consensus-coordinator.ts` so the worktree/sandbox resolution hardening from PR #129 applies here too.
- Audited the `cognitiveSummary` flow — no second write path exists; it already feeds `validateCitations` via the primary path. Documented in the commit.

## Test plan
- [x] `npx tsc --noEmit -p packages/orchestrator/tsconfig.json` → exit 0
- [ ] Next consensus round: verify new peer-findings knowledge files emit `citationsVerified:` in frontmatter
- [ ] Verify `citationsFabricated:` list appears when a peer finding cites a non-existent file

🤖 Generated with [Claude Code](https://claude.com/claude-code)