### PR TITLE
feat(signals): citation_fabricated PipelineSignal

### DIFF
--- a/packages/dashboard-v2/src/components/SignalTimeline.tsx
+++ b/packages/dashboard-v2/src/components/SignalTimeline.tsx
@@ -20,6 +20,9 @@ const SIGNAL_COLORS: Record<string, string> = {
   hallucination_caught: 'bg-disputed',
   new_finding: 'bg-unique',
   unverified: 'bg-unverified',
+  // Amber/orange — fabricated citations are write-time warnings, not consensus
+  // errors; keep visually distinct from the red disputed bucket.
+  citation_fabricated: 'bg-amber-500',
 };
 
 const SIGNAL_LABELS: Record<string, string> = {
@@ -31,6 +34,7 @@ const SIGNAL_LABELS: Record<string, string> = {
   hallucination_caught: 'Hallucination',
   new_finding: 'New finding',
   unverified: 'Unverified',
+  citation_fabricated: 'Fabricated citation',
 };
 
 // Pill sizing budget. MIN_PILL_WIDTH gives a slight breathing margin above the
@@ -86,7 +90,7 @@ export function SignalTimeline({ agentId }: { agentId: string }) {
   // `total` population). With a capped window the counts still reflect only
   // the most recent slice. Label explicitly says "Last N" so users don't
   // divide counts by total and get a wrong ratio.
-  const counts = { confirmed: 0, disputed: 0, unique: 0, unverified: 0 };
+  const counts = { confirmed: 0, disputed: 0, unique: 0, unverified: 0, fabricated: 0 };
   for (const s of signals) {
     if (s.signal === 'agreement' || s.signal === 'consensus_verified') counts.confirmed++;
     // The "disputed" bucket covers both disagreement AND hallucination_caught
@@ -95,6 +99,9 @@ export function SignalTimeline({ agentId }: { agentId: string }) {
     else if (s.signal === 'disagreement' || s.signal === 'hallucination_caught') counts.disputed++;
     else if (s.signal === 'unique_confirmed' || s.signal === 'unique_unconfirmed' || s.signal === 'new_finding') counts.unique++;
     else if (s.signal === 'unverified') counts.unverified++;
+    // Separate bucket from consensus-UNVERIFIED: fabricated citations are
+    // write-time annotator rejections, not consensus cross-review outcomes.
+    else if (s.signal === 'citation_fabricated') counts.fabricated++;
   }
 
   const windowSize = signals.length;
@@ -128,6 +135,7 @@ export function SignalTimeline({ agentId }: { agentId: string }) {
           {counts.disputed > 0 && <span className="text-disputed">{counts.disputed} disputed</span>}
           {counts.unique > 0 && <span className="text-unique">{counts.unique} unique</span>}
           {counts.unverified > 0 && <span className="text-unverified">{counts.unverified} unverified</span>}
+          {counts.fabricated > 0 && <span className="text-amber-500">{counts.fabricated} fabricated</span>}
         </div>
       </div>
       <div className="flex items-center gap-0.5">
@@ -162,6 +170,7 @@ export function SignalTimeline({ agentId }: { agentId: string }) {
           { color: 'bg-unique', label: 'Unique (confirmed)' },
           { color: 'bg-unique/50', label: 'Unique (unconfirmed)' },
           { color: 'bg-unverified', label: 'Unverified' },
+          { color: 'bg-amber-500', label: 'Fabricated citation' },
         ].map((l) => (
           <div key={l.label} className="flex items-center gap-1">
             <div className={`h-2 w-2 rounded-sm ${l.color}`} />

--- a/packages/orchestrator/src/completion-signals.allowlist.ts
+++ b/packages/orchestrator/src/completion-signals.allowlist.ts
@@ -20,6 +20,7 @@ export const COMPLETION_SIGNAL_ALLOWLIST: readonly string[] = [
   'task_tool_turns',
   'format_compliance',
   'finding_dropped_format',
+  'citation_fabricated',
 ] as const;
 
 /**

--- a/packages/orchestrator/src/completion-signals.ts
+++ b/packages/orchestrator/src/completion-signals.ts
@@ -165,3 +165,56 @@ export function emitCompletionSignals(projectRoot: string, input: CompletionSign
     process.stderr.write(`[gossipcat] emitCompletionSignals failed: ${(err as Error).message}\n`);
   }
 }
+
+export interface CitationFabricatedInput {
+  agentId: string;
+  taskId: string;
+  total: number;
+  verified: number;
+  unverifiedCitations: string[];
+}
+
+/**
+ * Emit `citation_fabricated` (type='pipeline') when the citation annotator
+ * finds unverified file-like tokens in knowledge-file body at write time.
+ *
+ * Mirrors `finding_dropped_format` — telemetry only, never gates the write.
+ * Truncates `unverifiedCitations` to the first 10 entries to bound metadata
+ * size (knowledge bodies can cite many paths; we only need a sample for
+ * observability). `value` carries the count so downstream time-series
+ * aggregators can track fabrication volume without parsing metadata.
+ */
+export function emitCitationFabricatedSignal(
+  projectRoot: string,
+  input: CitationFabricatedInput,
+): void {
+  try {
+    const { agentId, taskId, total, verified, unverifiedCitations } = input;
+    if (agentId === '_system') {
+      process.stderr.write(`[gossipcat] emitCitationFabricatedSignal refused reserved agentId '_system' (taskId=${taskId})\n`);
+      return;
+    }
+    const unverifiedCount = unverifiedCitations.length;
+    if (unverifiedCount === 0) return;
+
+    const signal: PipelineSignal = {
+      type: 'pipeline',
+      signal: 'citation_fabricated',
+      agentId,
+      taskId,
+      value: unverifiedCount,
+      metadata: {
+        total,
+        verified,
+        unverifiedCount,
+        unverifiedCitations: unverifiedCitations.slice(0, 10),
+      },
+      timestamp: new Date().toISOString(),
+    };
+
+    const writer = new PerformanceWriter(projectRoot);
+    writer[WRITER_INTERNAL].appendSignal(signal, 'completion-signals-helper');
+  } catch (err) {
+    process.stderr.write(`[gossipcat] emitCitationFabricatedSignal failed: ${(err as Error).message}\n`);
+  }
+}

--- a/packages/orchestrator/src/consensus-coordinator.ts
+++ b/packages/orchestrator/src/consensus-coordinator.ts
@@ -160,7 +160,7 @@ export class ConsensusCoordinator {
           }));
           const participants = new Set(results.filter(r => r.status === 'completed').map(r => r.agentId));
           for (const agentId of participants) {
-            this.memWriter.writeConsensusKnowledge(agentId, findings, this.resolutionRoots ? [...this.resolutionRoots] : undefined);
+            this.memWriter.writeConsensusKnowledge(agentId, findings, this.resolutionRoots ? [...this.resolutionRoots] : undefined, consensusId);
           }
           for (const agentId of participants) {
             try { this.memWriter.rebuildIndex(agentId); } catch { /* best-effort */ }

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -186,7 +186,8 @@ export interface PipelineSignal {
     | 'synthesis_completed'
     | 'circuit_open_fired'
     | 'skill_injection_skipped'
-    | 'signal_retracted';
+    | 'signal_retracted'
+    | 'citation_fabricated';
   /** Real agentId for agent-scoped events; '_system' for system-scoped events. */
   agentId: string;
   taskId: string;

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -91,8 +91,8 @@ export { MemorySearcher } from './memory-searcher';
 export type { SearchResult } from './memory-searcher';
 export { oneSidedZTest, resolveVerdict, MIN_EVIDENCE, ALPHA, Z_CRITICAL, TIMEOUT_DAYS, TIMEOUT_MS } from './check-effectiveness';
 export type { VerdictStatus, SkillSnapshot, CategoryCounters, VerdictResult } from './check-effectiveness';
-export { emitCompletionSignals } from './completion-signals';
-export type { CompletionSignalInput } from './completion-signals';
+export { emitCompletionSignals, emitCitationFabricatedSignal } from './completion-signals';
+export type { CompletionSignalInput, CitationFabricatedInput } from './completion-signals';
 export {
   emitConsensusSignals,
   emitSandboxSignals,

--- a/packages/orchestrator/src/memory-writer.ts
+++ b/packages/orchestrator/src/memory-writer.ts
@@ -6,6 +6,7 @@ import type { ILLMProvider } from './llm-client';
 import type { LLMMessage } from '@gossip/types';
 import { discoverProjectStructure } from './project-structure';
 import { gossipLog } from './log';
+import { emitCitationFabricatedSignal } from './completion-signals';
 
 /** Truncate text at a word boundary, appending "..." if truncated */
 function truncateAtWord(text: string, maxLen: number): string {
@@ -208,6 +209,15 @@ export class MemoryWriter {
       for (const u of citations.unverified) {
         citationLines.push(`  - "${u}"`);
       }
+      // Pipeline telemetry — annotator rejections are observability only,
+      // they do NOT gate the write. Helper truncates to first 10 entries.
+      emitCitationFabricatedSignal(this.projectRoot, {
+        agentId,
+        taskId: data.taskId,
+        total: citations.total,
+        verified: citations.verified,
+        unverifiedCitations: citations.unverified,
+      });
     }
     const content = [
       '---',
@@ -990,6 +1000,7 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
     agentId: string,
     findings: Array<{ originalAgentId: string; finding: string; tag?: string }>,
     resolutionRoots?: string[],
+    taskId?: string,
   ): void {
     if (findings.length === 0) return;
     const memDir = this.ensureDirs(agentId);
@@ -1026,6 +1037,16 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
       for (const u of citations.unverified) {
         citationLines.push(`  - "${u}"`);
       }
+      // Pipeline telemetry — observability only, never gates the write.
+      // Fall back to a synthetic per-file taskId when the caller doesn't
+      // thread one; signal validator requires a non-empty taskId.
+      emitCitationFabricatedSignal(this.projectRoot, {
+        agentId,
+        taskId: taskId ?? `consensus-${timestamp}`,
+        total: citations.total,
+        verified: citations.verified,
+        unverifiedCitations: citations.unverified,
+      });
     }
 
     const content = [

--- a/packages/orchestrator/src/performance-writer.ts
+++ b/packages/orchestrator/src/performance-writer.ts
@@ -52,7 +52,7 @@ const VALID_META_SIGNALS = new Set([
 const VALID_PIPELINE_SIGNALS = new Set([
   'dispatch_started', 'relay_received', 'finding_dropped_format',
   'synthesis_completed', 'circuit_open_fired', 'skill_injection_skipped',
-  'signal_retracted',
+  'signal_retracted', 'citation_fabricated',
 ]);
 
 /**

--- a/tests/orchestrator/completion-signals.test.ts
+++ b/tests/orchestrator/completion-signals.test.ts
@@ -12,7 +12,7 @@
  * - never throws on write failure
  */
 
-import { emitCompletionSignals } from '@gossip/orchestrator';
+import { emitCompletionSignals, emitCitationFabricatedSignal } from '@gossip/orchestrator';
 import { readFileSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -182,5 +182,99 @@ More content here to ensure we exceed the minimum length threshold for rejection
     expect(completed.value).toBe(0);
     expect(completed.metadata?.estimated).toBe(true);
     expect(completed.metadata?.error).toBe(true);
+  });
+});
+
+describe('emitCitationFabricatedSignal', () => {
+  const testDir = join(tmpdir(), 'gossip-citation-fab-' + Date.now());
+  const gossipDir = join(testDir, '.gossip');
+  const perfFile = join(gossipDir, 'agent-performance.jsonl');
+
+  beforeAll(() => mkdirSync(gossipDir, { recursive: true }));
+  afterAll(() => rmSync(testDir, { recursive: true, force: true }));
+
+  const readSignals = () =>
+    readFileSync(perfFile, 'utf-8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map(l => JSON.parse(l));
+
+  beforeEach(() => {
+    try { rmSync(perfFile); } catch { /* may not exist */ }
+  });
+
+  test('emits citation_fabricated pipeline signal with correct shape', () => {
+    emitCitationFabricatedSignal(testDir, {
+      agentId: 'sonnet-reviewer',
+      taskId: 'task-xyz',
+      total: 5,
+      verified: 3,
+      unverifiedCitations: ['fake/one.ts:10', 'fake/two.ts:20'],
+    });
+    const sigs = readSignals();
+    expect(sigs).toHaveLength(1);
+    const sig = sigs[0];
+    expect(sig.type).toBe('pipeline');
+    expect(sig.signal).toBe('citation_fabricated');
+    expect(sig.agentId).toBe('sonnet-reviewer');
+    expect(sig.taskId).toBe('task-xyz');
+    expect(sig.value).toBe(2);
+    expect(sig.metadata.total).toBe(5);
+    expect(sig.metadata.verified).toBe(3);
+    expect(sig.metadata.unverifiedCount).toBe(2);
+    expect(sig.metadata.unverifiedCitations).toEqual(['fake/one.ts:10', 'fake/two.ts:20']);
+  });
+
+  test('does NOT emit when unverifiedCitations is empty (no-op path)', () => {
+    emitCitationFabricatedSignal(testDir, {
+      agentId: 'sonnet-reviewer',
+      taskId: 'task-clean',
+      total: 3,
+      verified: 3,
+      unverifiedCitations: [],
+    });
+    // File should not exist — no signal written.
+    expect(() => readFileSync(perfFile, 'utf-8')).toThrow();
+  });
+
+  test('truncates unverifiedCitations to first 10 entries', () => {
+    const many = Array.from({ length: 25 }, (_, i) => `f${i}.ts:${i}`);
+    emitCitationFabricatedSignal(testDir, {
+      agentId: 'agent-x',
+      taskId: 'task-many',
+      total: 25,
+      verified: 0,
+      unverifiedCitations: many,
+    });
+    const sigs = readSignals();
+    expect(sigs[0].value).toBe(25);
+    expect(sigs[0].metadata.unverifiedCount).toBe(25);
+    expect(sigs[0].metadata.unverifiedCitations).toHaveLength(10);
+    expect(sigs[0].metadata.unverifiedCitations[0]).toBe('f0.ts:0');
+    expect(sigs[0].metadata.unverifiedCitations[9]).toBe('f9.ts:9');
+  });
+
+  test('refuses reserved _system agentId', () => {
+    emitCitationFabricatedSignal(testDir, {
+      agentId: '_system',
+      taskId: 't',
+      total: 1,
+      verified: 0,
+      unverifiedCitations: ['x.ts'],
+    });
+    expect(() => readFileSync(perfFile, 'utf-8')).toThrow();
+  });
+
+  test('never throws on write failure', () => {
+    expect(() =>
+      emitCitationFabricatedSignal('/nonexistent-path-that-cannot-exist/gossip', {
+        agentId: 'a',
+        taskId: 't',
+        total: 1,
+        verified: 0,
+        unverifiedCitations: ['x'],
+      })
+    ).not.toThrow();
   });
 });

--- a/tests/orchestrator/signal-type-snapshot.test.ts
+++ b/tests/orchestrator/signal-type-snapshot.test.ts
@@ -17,6 +17,7 @@ const COMPLETION_SIGNALS_EMITTED = new Set<string>([
   'task_tool_turns',   // conditionally (when toolCalls defined)
   'format_compliance',
   'finding_dropped_format',
+  'citation_fabricated', // emitCitationFabricatedSignal (memory-writer call sites)
 ]);
 
 // ── Path-specific signals: not emitted by emitCompletionSignals ──────────────
@@ -68,6 +69,7 @@ const ALL_KNOWN_SIGNAL_NAMES: string[] = [
   // PipelineSignal
   'dispatch_started', 'relay_received', 'finding_dropped_format',
   'synthesis_completed', 'circuit_open_fired', 'skill_injection_skipped',
+  'citation_fabricated',
   // signal_retracted appears in both ConsensusSignal and PipelineSignal
 ];
 


### PR DESCRIPTION
## Summary
- Adds `citation_fabricated` PipelineSignal — observability for citation-annotator rejections, emitted at both memory write paths when `unverified.length > 0`. Memory still writes; the signal is observability, not a gate.
- Mirrors the `finding_dropped_format` pattern: try/catch, `_system` guard, truncates `unverifiedCitations` to first 10 to avoid jsonl bloat.
- Dashboard gets a new `fabricated` bucket (amber-500, label "Fabricated citation"), intentionally distinct from the consensus-UNVERIFIED bucket — conflating write-time annotator rejections with cross-review verdicts would muddy both.

**Stacked on #221** (which adds the annotator to `writeConsensusKnowledge`). Merge #221 first.

## Design decisions worth flagging
- **Naming:** `citation_fabricated` over `knowledge_rejected` — the memory is written, so "rejected" was misleading. Past-tense verb matches `finding_dropped_format`.
- **Pipeline vs Consensus signal:** Pipeline — no `finding_id` needed. Precedent: `finding_dropped_format`.
- **New bucket vs fold into `unverified`:** New. Consensus-UNVERIFIED means "cross-reviewer couldn't check"; citation fabrication is a distinct failure mode at write-time.

## Test plan
- [x] Orchestrator suite: 108 suites / 1425 tests PASS
- [x] Orchestrator `tsc --noEmit` exit 0
- [x] 5 new unit tests for the helper (shape, empty no-emit, 25→10 truncation, `_system` refusal, never-throws)
- [ ] Dashboard `tsc --noEmit` has one pre-existing error (`useElementWidth.ts:23`, last touched in 5ed7a95 — unrelated, not introduced here)
- [ ] Consensus review pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)