### PR TITLE
fix(signals): PR #222 polish — taskId collision + citation byte cap

### DIFF
--- a/packages/orchestrator/src/completion-signals.ts
+++ b/packages/orchestrator/src/completion-signals.ts
@@ -166,6 +166,31 @@ export function emitCompletionSignals(projectRoot: string, input: CompletionSign
   }
 }
 
+/**
+ * Truncate a string to at most `maxBytes` UTF-8 bytes, appending a short
+ * marker when truncation occurred. Respects multi-byte boundaries so we
+ * never emit mojibake in the signal payload.
+ */
+function truncateUtf8(s: string, maxBytes: number): string {
+  const marker = '...[truncated]';
+  if (Buffer.byteLength(s, 'utf8') <= maxBytes) return s;
+  const budget = Math.max(0, maxBytes - Buffer.byteLength(marker, 'utf8'));
+  const buf = Buffer.from(s, 'utf8').subarray(0, budget);
+  // Drop trailing incomplete UTF-8 continuation bytes (10xxxxxx).
+  let end = buf.length;
+  while (end > 0 && (buf[end - 1] & 0b11000000) === 0b10000000) end--;
+  // If we stopped just after a multi-byte lead byte, back off too.
+  if (end > 0) {
+    const lead = buf[end - 1];
+    if ((lead & 0b11100000) === 0b11000000 /* 2-byte lead */
+      || (lead & 0b11110000) === 0b11100000 /* 3-byte lead */
+      || (lead & 0b11111000) === 0b11110000 /* 4-byte lead */) {
+      end--;
+    }
+  }
+  return buf.subarray(0, end).toString('utf8') + marker;
+}
+
 export interface CitationFabricatedInput {
   agentId: string;
   taskId: string;
@@ -207,7 +232,10 @@ export function emitCitationFabricatedSignal(
         total,
         verified,
         unverifiedCount,
-        unverifiedCitations: unverifiedCitations.slice(0, 10),
+        // Per-entry cap: 512 UTF-8 bytes, preserving the 10-entry list cap.
+        // Prevents a single fabricated citation string from bloating the
+        // signal payload (JSONL line size is I/O sensitive).
+        unverifiedCitations: unverifiedCitations.slice(0, 10).map(c => truncateUtf8(c, 512)),
       },
       timestamp: new Date().toISOString(),
     };

--- a/packages/orchestrator/src/memory-writer.ts
+++ b/packages/orchestrator/src/memory-writer.ts
@@ -1,5 +1,6 @@
 import { appendFileSync, writeFileSync, readFileSync, existsSync, mkdirSync, readdirSync, unlinkSync, openSync, closeSync, constants } from 'fs';
 import { join, resolve } from 'path';
+import { randomBytes } from 'crypto';
 import { TaskMemoryEntry } from './types';
 import { MemoryCompactor } from './memory-compactor';
 import type { ILLMProvider } from './llm-client';
@@ -1042,7 +1043,9 @@ Only mark a file STALE if the git log clearly shows the described work has shipp
       // thread one; signal validator requires a non-empty taskId.
       emitCitationFabricatedSignal(this.projectRoot, {
         agentId,
-        taskId: taskId ?? `consensus-${timestamp}`,
+        // Append random suffix to the synthetic taskId so two annotator
+        // rejections landing in the same millisecond don't collide.
+        taskId: taskId ?? `consensus-${timestamp}-${randomBytes(3).toString('hex')}`,
         total: citations.total,
         verified: citations.verified,
         unverifiedCitations: citations.unverified,

--- a/tests/orchestrator/completion-signals.test.ts
+++ b/tests/orchestrator/completion-signals.test.ts
@@ -277,4 +277,29 @@ describe('emitCitationFabricatedSignal', () => {
       })
     ).not.toThrow();
   });
+
+  test('Item B: truncates each unverifiedCitation entry to 512 UTF-8 bytes', () => {
+    // Two entries, both over the per-entry cap. The 10-entry list cap still
+    // applies; we only exercise per-entry truncation here.
+    const huge = 'x'.repeat(2000); // 2000 ASCII bytes
+    const multibyte = 'é'.repeat(1000); // 2 bytes/char → 2000 bytes, boundary-sensitive
+    emitCitationFabricatedSignal(testDir, {
+      agentId: 'agent-cap',
+      taskId: 'task-cap',
+      total: 2,
+      verified: 0,
+      unverifiedCitations: [huge, multibyte],
+    });
+    const sigs = readSignals();
+    expect(sigs).toHaveLength(1);
+    const out: string[] = sigs[0].metadata.unverifiedCitations;
+    expect(out).toHaveLength(2);
+    for (const entry of out) {
+      expect(Buffer.byteLength(entry, 'utf8')).toBeLessThanOrEqual(512);
+      // Truncation marker present on entries that exceeded the budget.
+      expect(entry.endsWith('...[truncated]')).toBe(true);
+    }
+    // Multi-byte entry must remain valid UTF-8 after truncation (no mojibake).
+    expect(out[1].includes('�')).toBe(false);
+  });
 });

--- a/tests/orchestrator/memory-writer-citations.test.ts
+++ b/tests/orchestrator/memory-writer-citations.test.ts
@@ -1,5 +1,5 @@
 import { MemoryWriter } from '@gossip/orchestrator';
-import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'fs';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, mkdtempSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -99,5 +99,33 @@ describe('MemoryWriter.validateCitations (annotation-only)', () => {
     expect(result.total).toBe(1);
     expect(result.verified).toBe(1);
     expect(result.unverified).toEqual([]);
+  });
+
+  // Item A regression: when writeConsensusKnowledge is invoked without a
+  // caller-provided taskId, the synthetic fallback was `consensus-${timestamp}`
+  // which collides for two rejections landing in the same millisecond. The fix
+  // appends a short crypto-random suffix so each emitted citation_fabricated
+  // signal gets a distinct taskId even within a single ms.
+  it('Item A: synthetic taskId fallback is collision-distinct within same millisecond', () => {
+    const perfFile = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+    // Body references a fabricated path so validateCitations produces
+    // unverified entries and emitCitationFabricatedSignal fires.
+    const findings = [
+      { originalAgentId: 'peer-a', finding: 'See src/ghost-one.ts for details.', tag: 'unverified' },
+    ];
+    // Two back-to-back calls — same agent, same findings, no taskId passed.
+    // On a fast machine both land within the same millisecond; the format
+    // strip in writeConsensusKnowledge slices to second precision so even
+    // cross-ms this test asserts on the full fallback, not ms drift.
+    writer.writeConsensusKnowledge('opus-implementer', findings);
+    writer.writeConsensusKnowledge('opus-implementer', findings);
+
+    const lines = readFileSync(perfFile, 'utf-8').trim().split('\n').filter(Boolean);
+    const emitted = lines.map(l => JSON.parse(l)).filter(s => s.signal === 'citation_fabricated');
+    expect(emitted.length).toBe(2);
+    const [a, b] = emitted;
+    expect(a.taskId).toMatch(/^consensus-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-[0-9a-f]{6}$/);
+    expect(b.taskId).toMatch(/^consensus-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-[0-9a-f]{6}$/);
+    expect(a.taskId).not.toBe(b.taskId);
   });
 });


### PR DESCRIPTION
## Summary

Two targeted hardening fixes to the `citation_fabricated` signal pipeline, carried over from PR #222 review.

- **Item A** — `memory-writer.ts:1045` synthetic taskId fallback now appends a 6-hex random suffix (`consensus-<timestamp>-<6hex>`), so two annotator rejections landing in the same millisecond can no longer collide.
- **Item B** — `completion-signals.ts` caps each `unverifiedCitations` entry at 512 UTF-8 bytes via a `truncateUtf8` helper that respects multi-byte boundaries (no mojibake, no U+FFFD). The 10-entry list cap is preserved; only per-entry length is bounded.

## Test plan

- [x] `tests/orchestrator/memory-writer-citations.test.ts` — new case asserts two back-to-back `writeConsensusKnowledge` calls produce distinct synthetic taskIds matching `^consensus-…-[0-9a-f]{6}$`
- [x] `tests/orchestrator/completion-signals.test.ts` — new case asserts 2000-byte ASCII and `é`×1000 inputs both emit ≤512 UTF-8 bytes, end in the truncation marker, contain no U+FFFD
- [x] 30/30 tests pass
- [x] `tsc --noEmit` clean in orchestrator package

Change size: ~30 LOC src + ~35 LOC tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)