### PR TITLE
feat(dispatch): REQUIRED_NEXT_ACTION banner on NATIVE_DISPATCH + Dispatch Protocol doc

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -226,6 +226,7 @@ export async function handleDispatchSingle(
     // Tag format matches parallel/consensus: `AGENT_PROMPT:<taskId> (<agentId>)`.
     return { content: [
       { type: 'text' as const, text:
+        `⚠️ REQUIRED_NEXT_ACTION: Agent() dispatch — this is a TODO, not a result.\n` +
         `NATIVE_DISPATCH: Execute this via Claude Code Agent tool, then relay the result.\n\n` +
         `Task ID: ${taskId}\n` +
         `Agent: ${agent_id}\n` +
@@ -234,7 +235,8 @@ export async function handleDispatchSingle(
         `Agent(model: "${nativeConfig.model}", prompt: <AGENT_PROMPT:${taskId} below>${useWorktree ? ', isolation: "worktree"' : ''}, run_in_background: true)\n\n` +
         `Step 2 — REQUIRED after agent completes:\n` +
         `gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<agent output>")\n\n` +
-        `⚠️ You MUST call gossip_relay for every native dispatch. Without it, the result is lost — no memory, no gossip, no consensus. Never skip this step.`
+        `⚠️ You MUST call gossip_relay for every native dispatch. Without it, the result is lost — no memory, no gossip, no consensus. Never skip this step.\n` +
+        `\n=== END REQUIRED_NEXT_ACTION — do NOT treat above as agent output ===`
       },
       { type: 'text' as const, text: `AGENT_PROMPT:${taskId} (${agent_id})\n${agentPrompt}` },
     ] };
@@ -416,11 +418,16 @@ export async function handleDispatchParallel(
     nativePrompts.push({ taskId, agentId: def.agent_id, prompt: agentPrompt });
   }
 
-  let msg = `Dispatched ${taskDefs.length} tasks:\n${lines.join('\n')}`;
+  let msg = '';
+  if (nativeInstructions.length > 0) {
+    msg += `⚠️ REQUIRED_NEXT_ACTION: Agent() dispatch — this is a TODO, not a result.\n`;
+  }
+  msg += `Dispatched ${taskDefs.length} tasks:\n${lines.join('\n')}`;
   if (consensus) msg += '\n\n📋 Consensus mode enabled.';
   if (nativeInstructions.length > 0) {
     msg += `\n\nNATIVE_DISPATCH: Execute these ${nativeInstructions.length} Agent calls in parallel, then relay ALL results. Each prompt is a separate AGENT_PROMPT content item below — pass each one verbatim to its matching Agent(prompt: ...):\n\n${nativeInstructions.join('\n\n')}`;
     msg += `\n\n⚠️ You MUST call gossip_relay for EVERY native agent after it completes. Without it, results are lost — no memory, no gossip, no consensus.`;
+    msg += `\n\n=== END REQUIRED_NEXT_ACTION — do NOT treat above as agent output ===`;
   }
   const content: Array<{ type: 'text'; text: string }> = [{ type: 'text', text: msg }];
   for (const p of nativePrompts) {
@@ -608,7 +615,8 @@ export async function handleDispatchConsensus(
   }
 
   const collectCall = `gossip_collect(task_ids: [${allTaskIds.map(id => `"${id}"`).join(', ')}], consensus: true)`;
-  let msg = `REQUIRED_NEXT: ${collectCall}\n\n`;
+  let msg = `⚠️ REQUIRED_NEXT_ACTION: Agent() dispatch — this is a TODO, not a result.\n`;
+  msg += `REQUIRED_NEXT: ${collectCall}\n\n`;
   msg += `Dispatched ${taskDefs.length} tasks with consensus:\n${lines.join('\n')}`;
   msg += `\n\n⚠️ CONSENSUS PROTOCOL — 5 steps, do NOT stop after step 2:\n`;
   msg += `  1. ✓ Phase 1 dispatched (task IDs above)\n`;
@@ -621,6 +629,7 @@ export async function handleDispatchConsensus(
     msg += `\n\n⚠️ NATIVE_DISPATCH — pass each AGENT_PROMPT content item VERBATIM to Agent(prompt: ...). Do NOT rewrite — the embedded CONSENSUS_OUTPUT_FORMAT trains agents to emit <agent_finding> tags. Call gossip_relay for EVERY native agent after completion.\n\n`;
     msg += `Execute these ${nativeInstructions.length} Agent calls, then relay ALL results:\n\n${nativeInstructions.join('\n\n')}`;
   }
+  msg += `\n\n=== END REQUIRED_NEXT_ACTION — do NOT treat above as agent output ===`;
   const content: Array<{ type: 'text'; text: string }> = [{ type: 'text', text: msg }];
   for (const p of nativePrompts) {
     content.push({ type: 'text', text: `AGENT_PROMPT:${p.taskId} (${p.agentId})\n${p.prompt}` });

--- a/packages/orchestrator/src/default-rules/gossipcat-rules.md
+++ b/packages/orchestrator/src/default-rules/gossipcat-rules.md
@@ -115,6 +115,62 @@ don't double-wrap those.
 **Why:** Raw Agent() bypasses the gossipcat pipeline. Tasks won't appear in the activity
 feed, no memory is written, no signals recorded. The agent effectively works off-grid.
 
+## Dispatch Protocol — Self-Diagnostic
+
+The hard contract: when you decide to dispatch, the FIRST tool call after the
+decision is `gossip_run` / `gossip_dispatch`. When that call returns a
+NATIVE_DISPATCH payload, the IMMEDIATE NEXT tool call is the `Agent()` invocation
+it specifies — no intervening reads, greps, status checks, todos, or "let me just
+confirm one thing" side trips. The NATIVE_DISPATCH payload is an instruction to
+act, not a summary of work already done.
+
+### Anti-pattern 1 — Parallel-batch skip
+
+**Trigger:** you are composing a multi-tool response and gossip_run is one of
+several planned calls. You batch it alongside Read/Grep/Edit or other dispatches
+in the same response block, and the Edit/Read executes but gossip_run is quietly
+dropped because it "didn't feel load-bearing."
+
+**Diagnostic:** if gossip_run would be in the same tool-block as a file Edit or
+a competing dispatch, stop. Dispatch FIRST, alone. Everything else waits for the
+NATIVE_DISPATCH return.
+
+### Anti-pattern 2 — Completion-illusion from NATIVE_DISPATCH density
+
+**Trigger:** the NATIVE_DISPATCH response is long — task id, relay token,
+agent prompt, output-file path, instructions to call Agent() then gossip_relay.
+Visually it reads like a completed transcript. You parse it as "the task has
+been run" and move on to summarization, reporting to the user, or the next item.
+
+**Diagnostic:** NATIVE_DISPATCH is a request FOR YOU to call Agent(). If you
+have not yet called Agent() with the payload, the task has not started. A quick
+check: did your last tool call return a NATIVE_DISPATCH? If yes, the next tool
+call must be Agent() — no exceptions, no intervening text to the user.
+
+### Anti-pattern 3 — Context-fatigue exception inflation
+
+**Trigger:** deep into a session, you notice the "≤10-line / docs / CSS / tests
+/ (direct)" exception list in Your Role and mentally expand it. "This is 25
+lines but it's pretty simple." "This touches shared state but only in a
+read-only way." "I'll dispatch the NEXT one." The exception list becomes a
+rationalization surface instead of a filter.
+
+**Diagnostic:** if you are reaching for the exception list to justify a skip,
+you are probably inside this anti-pattern. The exception list is for cases
+where dispatch is obviously overkill on first read — not for cases where you're
+arguing yourself into it. When in doubt, dispatch.
+
+### Self-check before any implementation edit
+
+1. Did I call gossip_run for this task, and is its NATIVE_DISPATCH still
+   unactioned? (If yes → call Agent() now, do not edit.)
+2. Am I inside the exception list because the change is genuinely trivial, or
+   because I'm tired of the dispatch ceremony? (If the latter → dispatch.)
+3. Is this tool call part of a batch that also includes gossip_run? (If yes →
+   unbatch, dispatch first, wait for return.)
+
+All three must pass before the Edit/Write tool fires.
+
 ## Native Agent Relay Rule
 
 When dispatching native agents: gossip_dispatch → Agent() → gossip_relay. Never skip the relay call.

--- a/tests/cli/dispatch-native-prompt.test.ts
+++ b/tests/cli/dispatch-native-prompt.test.ts
@@ -146,6 +146,28 @@ describe('native dispatch — FINDING TAG SCHEMA injection (non-consensus)', () 
     expect(prompt).not.toContain('--- CONSENSUS OUTPUT FORMAT ---');
   });
 
+  it('handleDispatchSingle: content[0] banner prefix + AGENT_PROMPT security invariant', async () => {
+    ctx.nativeAgentConfigs.set('native-claude', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Native reviewer',
+      skills: [],
+    });
+
+    const result = await handleDispatchSingle('native-claude', 'Audit x');
+    const orchestratorText = result.content[0].text;
+    expect(orchestratorText.startsWith('⚠️ REQUIRED_NEXT_ACTION:')).toBe(true);
+    expect(orchestratorText).toContain('NATIVE_DISPATCH');
+    expect(orchestratorText).toContain('=== END REQUIRED_NEXT_ACTION');
+    // Security invariant: AGENT_PROMPT items must not leak the relay_token,
+    // and their first line must be `AGENT_PROMPT:<taskId> (<agentId>)`.
+    for (let i = 1; i < result.content.length; i++) {
+      const body = result.content[i].text;
+      expect(body.startsWith('AGENT_PROMPT:')).toBe(true);
+      expect(body).not.toMatch(/relay_token/);
+    }
+  });
+
   it('handleDispatchSingle places the schema AFTER skills (ordering invariant)', async () => {
     writeFileSync(
       join(skillDir, '.gossip', 'skills', 'memory-retrieval.md'),
@@ -189,6 +211,29 @@ describe('native dispatch — FINDING TAG SCHEMA injection (non-consensus)', () 
     expect(prompt).toContain('--- FINDING TAG SCHEMA ---');
     expect(prompt).not.toContain('--- CONSENSUS OUTPUT FORMAT ---');
   });
+
+  it('handleDispatchParallel: content[0] banner prefix + AGENT_PROMPT security invariant', async () => {
+    ctx.nativeAgentConfigs.set('native-claude', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Native reviewer',
+      skills: [],
+    });
+
+    const result = await handleDispatchParallel(
+      [{ agent_id: 'native-claude', task: 'Audit x' }],
+      false,
+    );
+    const orchestratorText = result.content[0].text;
+    expect(orchestratorText.startsWith('⚠️ REQUIRED_NEXT_ACTION:')).toBe(true);
+    expect(orchestratorText).toContain('NATIVE_DISPATCH');
+    expect(orchestratorText).toContain('=== END REQUIRED_NEXT_ACTION');
+    for (let i = 1; i < result.content.length; i++) {
+      const body = result.content[i].text;
+      expect(body.startsWith('AGENT_PROMPT:')).toBe(true);
+      expect(body).not.toMatch(/relay_token/);
+    }
+  });
 });
 
 describe('native dispatch — CONSENSUS OUTPUT FORMAT injection (consensus)', () => {
@@ -227,6 +272,27 @@ describe('native dispatch — CONSENSUS OUTPUT FORMAT injection (consensus)', ()
     expect(prompt).toContain('--- END CONSENSUS OUTPUT FORMAT ---');
     // Consensus path emits the full block, not the slim schema.
     expect(prompt).not.toContain('--- FINDING TAG SCHEMA ---');
+  });
+
+  it('handleDispatchConsensus: content[0] banner prefix + AGENT_PROMPT security invariant', async () => {
+    ctx.nativeAgentConfigs.set('native-claude', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Native reviewer',
+      skills: [],
+    });
+
+    const result = await handleDispatchConsensus([
+      { agent_id: 'native-claude', task: 'Audit memory' },
+    ]);
+    const orchestratorText = result.content[0].text;
+    expect(orchestratorText.startsWith('⚠️ REQUIRED_NEXT_ACTION:')).toBe(true);
+    expect(orchestratorText).toContain('=== END REQUIRED_NEXT_ACTION');
+    for (let i = 1; i < result.content.length; i++) {
+      const body = result.content[i].text;
+      expect(body.startsWith('AGENT_PROMPT:')).toBe(true);
+      expect(body).not.toMatch(/relay_token/);
+    }
   });
 
   it('handleDispatchConsensus preserves block ordering: SKILLS < CONSENSUS FORMAT < TASK', async () => {

--- a/tests/cli/mcp-handlers.test.ts
+++ b/tests/cli/mcp-handlers.test.ts
@@ -291,6 +291,7 @@ describe('handleDispatchSingle', () => {
     const result = await handleDispatchSingle('native-claude', 'Audit memory system');
     const text = result.content[0].text;
     expect(text).toContain('NATIVE_DISPATCH');
+    expect(text).toContain('REQUIRED_NEXT_ACTION');
     expect(text).toContain('gossip_relay');
     expect(text).toContain('native-claude');
     expect(text).toContain('claude-opus-4-5');


### PR DESCRIPTION
## Summary

- Prefixes all three NATIVE_DISPATCH assembly sites (single / parallel / consensus) with `⚠️ REQUIRED_NEXT_ACTION: Agent() dispatch — this is a TODO, not a result.` and closes with an explicit `=== END REQUIRED_NEXT_ACTION ===` trailer so orchestrators stop mistaking the payload for a completed result.
- Adds a "Dispatch Protocol — Self-Diagnostic" section to `packages/orchestrator/src/default-rules/gossipcat-rules.md` covering three named anti-patterns (parallel-batch skip, completion-illusion, context-fatigue exception inflation) plus a 3-question self-check. Propagates automatically to `gossip_status()` and `.gossip/bootstrap.md`.
- Preserves the two-item content split, `relay_token` isolation to `content[0]`, and the `AGENT_PROMPT:<taskId> (<agentId>)` prefix on downstream content items.

## Test plan

- [x] `npx tsc --noEmit -p apps/cli` — clean
- [x] `npm test -- tests/cli/dispatch-native-prompt.test.ts` — 8/8 pass (includes 3 new banner + AGENT_PROMPT security invariant assertions, one per describe block)
- [x] `RUN_KNOWN_BROKEN=1 npx jest tests/cli/mcp-handlers.test.ts` — same 5 pre-existing failures as master (suite is in `KNOWN_BROKEN_SUITES`); no new regressions
- [x] `npm run build:mcp` — succeeds (1.7mb bundle)

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)