### PR TITLE
fix(skills): runOneTimeStatusMigration skips non-skill markdown

### DIFF
--- a/packages/orchestrator/src/skill-engine.ts
+++ b/packages/orchestrator/src/skill-engine.ts
@@ -339,6 +339,13 @@ export class SkillEngine {
           const raw = readFileSync(skillPath, 'utf-8');
           const { frontmatter, body } = this.parseSkillFile(raw);
 
+          // Skip non-skill markdown files (README, notes, etc.) that happen to live in
+          // this directory. Skill files always carry a `name` field in frontmatter;
+          // rewriting status on a file without that field would corrupt non-skill content.
+          if (typeof frontmatter.name !== 'string' || frontmatter.name.trim() === '') {
+            continue;
+          }
+
           const current = frontmatter.status;
           const isMissing = current === undefined || current === null || current === '';
           const isInvalid =

--- a/tests/orchestrator/skill-engine-orphan-cleanup.test.ts
+++ b/tests/orchestrator/skill-engine-orphan-cleanup.test.ts
@@ -3,6 +3,7 @@ import {
   mkdirSync,
   writeFileSync,
   readFileSync,
+  statSync,
   existsSync,
   readdirSync,
 } from 'fs';
@@ -129,6 +130,35 @@ describe('SkillEngine orphan cleanup', () => {
     expect(existsSync(regularPath)).toBe(true);
     expect(readFileSync(readmePath, 'utf-8')).toBe(readmeBody);
     expect(readFileSync(regularPath, 'utf-8')).toBe(SKILL_BODY);
+  });
+
+  it('does not rewrite a frontmatter-less README co-located in skills dir', () => {
+    const skillsDir = makeSkillsDir(tmpDir, 'agent-readme');
+    const readmePath = join(skillsDir, 'README.md');
+    const skillPath = join(skillsDir, 'trust-boundaries.md');
+
+    // Plain markdown body — no frontmatter at all. The migration bug would
+    // parse empty frontmatter, see status is missing, and emit a synthesized
+    // { status: 'pending', version: 1 } header that corrupts the file.
+    const readmeBody = `# Skills directory\n\nNotes go here.\n`;
+    writeFile(readmePath, readmeBody);
+
+    // A real skill with missing status so the migration DOES have real work.
+    const skillBody = `---\nname: trust-boundaries\ncategory: trust_boundaries\n---\n\n## Body\nReal skill.\n`;
+    writeFile(skillPath, skillBody);
+
+    const readmeBefore = readFileSync(readmePath, 'utf-8');
+    const readmeMtimeBefore = statSync(readmePath).mtimeMs;
+
+    new SkillEngine(makeStubLLM(), makeStubPerfReader(tmpDir), tmpDir);
+
+    // README must be byte-for-byte untouched.
+    expect(readFileSync(readmePath, 'utf-8')).toBe(readmeBefore);
+    expect(statSync(readmePath).mtimeMs).toBe(readmeMtimeBefore);
+
+    // Real skill file DID get its status rewritten.
+    const skillAfter = readFileSync(skillPath, 'utf-8');
+    expect(skillAfter).toMatch(/status:\s*"?pending"?/);
   });
 
   it('does not throw when no .gossip/agents dir exists', () => {


### PR DESCRIPTION
## Summary

- Follow-up to the skills-pipeline-repair work (branch `feat/skills-pipeline-repair`; commits b0828b5 / 2255828 / 9349fe9 et al.) and the `.gossip/next-session.md` backlog item.
- `runOneTimeStatusMigration` in `packages/orchestrator/src/skill-engine.ts` walked every `.md` in `.gossip/agents/<id>/skills/` and rewrote frontmatter when `status:` was missing or invalid. A plain README or notes file with no frontmatter would be corrupted into `{ status: 'pending', version: 1 }` + empty body-parsed fields.
- Fix: gate the rewrite on the skill-file invariant — frontmatter.name must be a non-empty string. Silent continue otherwise (expected, not an error).
- Regression test in `tests/orchestrator/skill-engine-orphan-cleanup.test.ts` writes a frontmatter-less `README.md` next to a real skill, constructs `SkillEngine`, and asserts byte-for-byte preservation of README (plus mtime) while the real skill still gets its status rewritten.

## Test plan

- [x] `npx tsc --noEmit -p apps/cli` — clean
- [x] `npm test -- tests/orchestrator/skill-engine-orphan-cleanup.test.ts tests/orchestrator/skill-engine-concurrency.test.ts tests/orchestrator/skill-effectiveness-e2e.test.ts` — 18/18 pass (3 suites)
- [x] `npm run build -w @gossip/orchestrator` — clean

Generated with [Claude Code](https://claude.com/claude-code)