### PR TITLE
fix(skills): address PR #225 consensus follow-ups (8 items)

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -188,6 +188,9 @@ export async function handleCollect(
           : r.status === 'timed_out' ? 'task_timeout' as const
           : 'task_empty' as const,
         agentId: r.agentId,
+        // Hardens the safety guard at performance-reader.ts:607 via a second
+        // axis (class, not just category-absence).
+        signal_class: 'operational' as const,
         evidence: r.status === 'failed' ? `Task failed: ${r.error || 'unknown error'}`
           : r.status === 'timed_out' ? 'Task timed out — no response'
           : 'Empty response — agent produced no output',

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -33,7 +33,7 @@ Every finding must cite `file:line`. Peers verify the citation exists and says w
 
 ### 2. `MIN_EVIDENCE = 120` is a real statistical gate, not a bug
 
-The skill effectiveness z-test at `check-effectiveness.ts:15` requires ≥120 post-bind signals before issuing a `passed`/`failed` verdict. This is calibrated for 80% power detecting a +10pp shift at p=0.75 baseline under Bonferroni α=0.025.
+The skill effectiveness z-test at `check-effectiveness.ts:15` requires ≥120 post-bind signals before issuing a `passed`/`failed` verdict. This is calibrated for ≈75.5% power detecting a +10pp shift at p=0.75 baseline under Bonferroni α=0.025 (raising to ~148 signals reaches ≥80% power).
 
 Skills will sit in `pending` for a long time. That is **correct behavior**, not a bug. If you see "stuck at pending" and your first instinct is to lower MIN_EVIDENCE, stop — lowering it weakens the statistical power claim that the whole effectiveness loop depends on. For paper evidence, build a curated eval suite with paired before/after testing (smaller N, McNemar's test, ~15 per category) instead.
 

--- a/packages/orchestrator/src/check-effectiveness.ts
+++ b/packages/orchestrator/src/check-effectiveness.ts
@@ -24,7 +24,7 @@ export const ALPHA = 0.025;
  *
  * Grounded in Wilson-vs-z-test parity testing: at baselineTotal=20, Wilson CI
  * width at alpha=0.025 is ~0.4 on a 0.5 proportion; z-test variance becomes
- * reliable. See docs/specs/2026-04-21-skills-pipeline-repair.md PR 3.
+ * reliable.
  */
 export const MIN_BASELINE_FOR_ZTEST = 20;
 export const Z_CRITICAL = 1.96; // one-sided, α=0.025
@@ -137,7 +137,7 @@ export function resolveVerdict(
       return {
         status,
         shouldUpdate: true,
-        newSnapshotFields: { status },
+        newSnapshotFields: { status, verdict_method: 'z-test' },
       };
     }
     return { status: 'pending', shouldUpdate: false };
@@ -145,9 +145,12 @@ export function resolveVerdict(
 
   // Degenerate-baseline path: z-test cannot reject when baselineP ∈ {0, 1}
   // because se === 0 (zero variance). Wilson score intervals handle this
-  // naturally. See docs/specs/2026-04-21-skills-pipeline-repair.md PR 2.
+  // naturally.
   if (baselineP === 0 || baselineP === 1) {
-    const WILSON_ALPHA = 0.025; // matches oneSidedZTest Z_CRITICAL calibration
+    const WILSON_ALPHA = 0.025;
+    // Intentionally stricter than z-test (z=2.24 vs 1.96) — degenerate/sparse
+    // baselines deserve extra conservatism; we'd rather under-graduate than
+    // wrongly flip a skill based on thin baseline evidence.
     const wilson = wilsonVerdict(
       { correct: snapshot.baseline_accuracy_correct, total: baselineTotal },
       { correct: delta.correct, total: postTotal },
@@ -171,9 +174,11 @@ export function resolveVerdict(
   // score intervals instead. Note: baselineTotal===0 reaches here with
   // baselineP fallback of 0.5; Wilson on baseline {0,0} has interval [0,1]
   // so it's guaranteed to return 'pending' → falls through to z-test.
-  // See docs/specs/2026-04-21-skills-pipeline-repair.md PR 3.
   if (baselineTotal < MIN_BASELINE_FOR_ZTEST) {
-    const WILSON_SPARSE_ALPHA = 0.025; // matches oneSidedZTest Z_CRITICAL calibration
+    const WILSON_SPARSE_ALPHA = 0.025;
+    // Intentionally stricter than z-test (z=2.24 vs 1.96) — degenerate/sparse
+    // baselines deserve extra conservatism; we'd rather under-graduate than
+    // wrongly flip a skill based on thin baseline evidence.
     const wilson = wilsonVerdict(
       { correct: snapshot.baseline_accuracy_correct, total: baselineTotal },
       { correct: delta.correct, total: postTotal },
@@ -236,7 +241,7 @@ export function resolveVerdict(
     return {
       status: 'flagged_for_manual_review',
       shouldUpdate: true,
-      newSnapshotFields: { status: 'flagged_for_manual_review', inconclusive_strikes: strikes },
+      newSnapshotFields: { status: 'flagged_for_manual_review', inconclusive_strikes: strikes, verdict_method: 'z-test' },
     };
   }
   return {
@@ -247,6 +252,7 @@ export function resolveVerdict(
       status: 'inconclusive',
       inconclusive_at: new Date(nowMs).toISOString(),
       inconclusive_strikes: strikes,
+      verdict_method: 'z-test',
     },
   };
 }

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -241,18 +241,18 @@ export type PerformanceSignal = ConsensusSignal | ImplSignal | MetaSignal | Pipe
  * Categorisation follows docs/specs/ signal-class spec (spec author: Option
  * 5B discriminator, 2026-04-21):
  *   performance:  agreement, disagreement, unique_confirmed, unique_unconfirmed,
- *                 new_finding, hallucination_caught, and all impl_* signals.
+ *                 new_finding, hallucination_caught, category_confirmed,
+ *                 consensus_verified, and all impl_* signals.
  *   operational:  task_completed, task_tool_turns, format_compliance,
  *                 signal_retracted, task_timeout, task_empty,
  *                 citation_fabricated, finding_dropped_format,
  *                 consensus_round_retracted, unverified.
  *
  * Deliberately conservative: signals not covered by the spec list
- * (category_confirmed, consensus_verified, severity_miscalibrated,
- * boundary_escape, dispatch_started, relay_received, synthesis_completed,
- * circuit_open_fired, skill_injection_skipped) return `undefined`. This keeps
- * the rollout safe — new callers opt in by updating this map, not by inheriting
- * a guess.
+ * (severity_miscalibrated, boundary_escape, dispatch_started, relay_received,
+ * synthesis_completed, circuit_open_fired, skill_injection_skipped) return
+ * `undefined`. This keeps the rollout safe — new callers opt in by updating
+ * this map, not by inheriting a guess.
  */
 const PERFORMANCE_SIGNAL_NAMES: ReadonlySet<string> = new Set([
   'agreement',
@@ -261,6 +261,8 @@ const PERFORMANCE_SIGNAL_NAMES: ReadonlySet<string> = new Set([
   'unique_unconfirmed',
   'new_finding',
   'hallucination_caught',
+  'category_confirmed',
+  'consensus_verified',
   'impl_test_pass',
   'impl_test_fail',
   'impl_peer_approved',

--- a/packages/orchestrator/src/performance-writer.ts
+++ b/packages/orchestrator/src/performance-writer.ts
@@ -255,8 +255,9 @@ export class PerformanceWriter {
       timestamp: new Date().toISOString(),
       evidence: `Consensus round ${consensusId} retracted: ${reason}`,
     };
-    validateSignal(row as PerformanceSignal);
-    const stamped = { ...row, _emission_path: 'mcp-server-signals' as EmissionPath };
+    const classStamped = stampSignalClass(row as PerformanceSignal);
+    validateSignal(classStamped);
+    const stamped = { ...classStamped, _emission_path: 'mcp-server-signals' as EmissionPath };
     appendFileSync(this.filePath, JSON.stringify(stamped) + '\n');
   }
 }

--- a/packages/orchestrator/src/skill-freshness.ts
+++ b/packages/orchestrator/src/skill-freshness.ts
@@ -12,6 +12,7 @@
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { normalizeSkillName } from './skill-name';
+import { coerceStatus } from './skill-engine';
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -117,7 +118,11 @@ export function readSkillFreshness(
   }
 
   const boundAt = extractFrontmatterField(content, 'bound_at');
-  const status = extractFrontmatterField(content, 'status');
+  const rawStatus = extractFrontmatterField(content, 'status');
+  // Coerce unknown / legacy values (e.g. "active") to 'pending' so downstream
+  // cooldown logic never sees strings outside the VerdictStatus enum.
+  // Preserve null (absent field) as-is so computeCooldown returns pre_schema.
+  const status = rawStatus === null ? null : coerceStatus(rawStatus);
 
   return { boundAt, status, path };
 }

--- a/tests/orchestrator/signal-class.test.ts
+++ b/tests/orchestrator/signal-class.test.ts
@@ -77,11 +77,16 @@ describe('signal_class discriminator (PR 5)', () => {
       expect(classifySignal('unverified')).toBe('operational');
     });
 
+    it('classifies category_confirmed / consensus_verified as performance', () => {
+      // These are evidence-of-correctness signals — they affect agent accuracy
+      // and belong in the performance bucket alongside agreement / hallucination_caught.
+      expect(classifySignal('category_confirmed')).toBe('performance');
+      expect(classifySignal('consensus_verified')).toBe('performance');
+    });
+
     it('returns undefined for unclassified (spec-silent) signal names', () => {
       // Intentional: conservative rollout. Leaving ambiguous names undefined
       // avoids committing to a class before a downstream consumer needs it.
-      expect(classifySignal('category_confirmed')).toBeUndefined();
-      expect(classifySignal('consensus_verified')).toBeUndefined();
       expect(classifySignal('severity_miscalibrated')).toBeUndefined();
       expect(classifySignal('boundary_escape')).toBeUndefined();
       expect(classifySignal('dispatch_started')).toBeUndefined();
@@ -198,13 +203,13 @@ describe('signal_class discriminator (PR 5)', () => {
 
   describe('(c) signal_class undefined + category undefined → no regression', () => {
     it('leaves signal_class absent when the classifier cannot decide', () => {
-      // `category_confirmed` is intentionally unclassified for this PR.
+      // `boundary_escape` is intentionally unclassified (observability-only).
       // Write-forward safety: the row still lands, existing reader code still
       // aggregates it exactly as before, signal_class just isn't populated.
       const signal: ConsensusSignal = {
         type: 'consensus',
         taskId: 't1',
-        signal: 'category_confirmed',
+        signal: 'boundary_escape',
         agentId: 'a',
         evidence: 'e',
         timestamp: '2026-04-21T10:00:00Z',
@@ -212,7 +217,7 @@ describe('signal_class discriminator (PR 5)', () => {
       writer[WRITER_INTERNAL].appendSignal(signal);
 
       const [row] = readRows(tmpDir);
-      expect(row.signal).toBe('category_confirmed');
+      expect(row.signal).toBe('boundary_escape');
       expect(row.signal_class).toBeUndefined();
       // Existing fields round-trip untouched — no regression in pre-existing shape.
       expect(row.type).toBe('consensus');
@@ -275,5 +280,25 @@ describe('signal_class discriminator (PR 5)', () => {
   it('exports SignalClass as a reusable type alias', () => {
     const cls: SignalClass = 'performance';
     expect(cls).toBe('performance');
+  });
+
+  // Consensus 466933ec-548b45cf f12: the failed-task bridge in collect.ts
+  // explicitly stamps signal_class:'operational' on disagreement rows emitted
+  // for failed tasks. This hardens the reader guard via a second axis.
+  it('preserves explicit signal_class:operational on a disagreement signal (failed-task bridge)', () => {
+    const signal: ConsensusSignal = {
+      type: 'consensus',
+      signal_class: 'operational',
+      taskId: 't-failed',
+      signal: 'disagreement',
+      agentId: 'gemini-reviewer',
+      evidence: 'Task failed: provider error',
+      timestamp: '2026-04-22T10:00:00Z',
+    };
+    writer[WRITER_INTERNAL].appendSignal(signal);
+
+    const [row] = readRows(tmpDir);
+    expect(row.signal).toBe('disagreement');
+    expect(row.signal_class).toBe('operational');
   });
 });

--- a/tests/orchestrator/skill-freshness.test.ts
+++ b/tests/orchestrator/skill-freshness.test.ts
@@ -99,6 +99,31 @@ describe('readSkillFreshness — file present', () => {
     expect(result.boundAt).toBeNull();
     expect(result.status).toBeNull();
   });
+
+  it('normalizes legacy "active" status to pending via coerceStatus', () => {
+    // Consensus round 466933ec-548b45cf f16: readSkillFreshness must not leak
+    // legacy / unknown status strings to callers. coerceStatus remaps them.
+    const boundAt = '2026-04-10T00:00:00.000Z';
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(makeSkillContent(boundAt, 'active') as any);
+    // Silence the expected stderr warning.
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    const result = readSkillFreshness(AGENT_ID, CATEGORY, SKILL_ROOT);
+    expect(result.status).toBe('pending');
+
+    stderrSpy.mockRestore();
+  });
+
+  it('preserves null status (no coerce) when status field is absent', () => {
+    // Null must round-trip so computeCooldown can return pre_schema.
+    const boundAt = '2026-04-10T00:00:00.000Z';
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(makeSkillContent(boundAt, null) as any);
+
+    const result = readSkillFreshness(AGENT_ID, CATEGORY, SKILL_ROOT);
+    expect(result.status).toBeNull();
+  });
 });
 
 // ── computeCooldown — discriminated union ─────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to consensus round `466933ec-548b45cf` on #225. Batched 8 small fixes flagged by cross-review:

- **f4** docs: `HANDBOOK.md` power claim 80% → ≈75.5% (sync with `check-effectiveness.ts`)
- **f5** fix: stamp `verdict_method: 'z-test'` on `insufficient_evidence` / `silent_skill` / `flagged_for_manual_review` / `inconclusive` return sites
- **f16** fix: `readSkillFreshness` now applies `coerceStatus` so legacy `active` → `pending` never leaks to callers
- **f13** fix: classify `category_confirmed` and `consensus_verified` as `'performance'` in `classifySignal`
- **f17** fix: `recordConsensusRoundRetraction` now calls `stampSignalClass` so tombstones carry `signal_class:'operational'`
- **f12** fix: failed-task bridge in `collect.ts` explicitly stamps `signal_class:'operational'` (defense-in-depth with the reader guard at `performance-reader.ts:607`)
- **f3** docs: rewrite Wilson α comment — value stays `0.025` (stricter z=2.24 vs 1.96 is intentional for degenerate/sparse baselines)
- **f10** chore: strip citations to `docs/specs/2026-04-21-skills-pipeline-repair.md` (unshipped spec file)

**No behavior change** on the Wilson α value.

Consensus round: `466933ec-548b45cf`
Parent PR: #225

## Test plan

- [x] `npx tsc --noEmit -p apps/cli` clean
- [x] `npx tsc --noEmit -p packages/orchestrator` clean
- [x] Targeted tests: 125/125 pass (check-effectiveness, performance-writer, skill-freshness, signal-class, collect-consensus-id, post-collect-pipeline)
- [x] `npm run build -w @gossip/orchestrator` clean
- [x] `npm run build:mcp` clean
