### PR TITLE
fix(release): build workspace packages before MCP bundle

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -119,6 +119,9 @@ if git rev-parse "$tag" >/dev/null 2>&1; then
   exit 1
 fi
 
+echo "→ Building workspace packages (topological)"
+npm run build:all
+
 echo "→ Building MCP bundle"
 npm run build:mcp
 


### PR DESCRIPTION
## Summary

Stage 2 of `scripts/release.sh` uses `npm pack`, which runs `prepack` but **not** `prepublishOnly` — so the topological `build:all` wired into `prepublishOnly` (commit 9349fe9) never runs on release. The release tarball ends up bundled against whatever stale workspace `dist/` happens to be sitting on the developer's disk.

## Fix

Add one explicit `npm run build:all` step before `npm run build:mcp` in Stage 2, mirroring the idiom already proven in `prepublishOnly`.

## Test plan

- [x] Inspected: Stage 2 section (lines ~121-126) now reads `build:all` → `build:mcp` → `build:dashboard`
- [x] Idempotent: if workspace packages are already fresh, `build:all` is a fast no-op-ish pass — no harm
- [x] Shellcheck not required: no new shell syntax, just an additional `npm run` call

Follow-up to the stale-dist hazard noted in this session's investigation of local 1.8MB vs published 1.6MB bundle sizes (the bundles are nearly identical because the release pipeline happens to have been run with fresh workspace output; this fix prevents the next release from being the unlucky one).