### PR TITLE
feat: silent-failure visibility — MFC sentinel, postinstall guard, consensus coverage-degraded signal

### DIFF
--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -2678,6 +2678,21 @@ Return only valid JSON.${skillsBlock}`;
       report.summary = report.summary.split(`${internalConsensusId}:`).join(`${consensusId}:`);
     }
 
+    // Surface round-level coverage degradation (0-char dropouts, e.g. Gemini
+    // MALFORMED_FUNCTION_CALL). Adds ONE round-level signal alongside the
+    // per-task auto-signal at collect.ts:178.
+    const droppedAgents = results.filter(r => !r.result || r.result.trim().length === 0).map(r => r.agentId);
+    const received = results.length - droppedAgents.length;
+    if (results.length > 0 && droppedAgents.length > 0) {
+      const evidence = `Coverage degraded: ${received}/${results.length} agents returned content (dropped: ${droppedAgents.join(', ')})`;
+      report.coverageDegraded = { expected: results.length, received, droppedAgents };
+      report.signals.push({
+        type: 'consensus', taskId: '', consensusId, signal: 'consensus_coverage_degraded',
+        signal_class: 'operational', agentId: '_round', evidence, timestamp: new Date().toISOString(),
+      });
+      report.summary += `\n⚠️  ${evidence}\n`;
+    }
+
     // Surface dropped relay agents so the orchestrator can see who silently
     // failed instead of pretending the round was complete.
     if (relayCrossReviewSkipped && relayCrossReviewSkipped.length > 0) {

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -62,6 +62,14 @@ export interface ConsensusReport {
    */
   relayCrossReviewSkipped?: Array<{ agentId: string; reason: string }>;
   /**
+   * Coverage degraded when an agent dispatched to the round produced an empty
+   * 0-char response (e.g. Gemini MALFORMED_FUNCTION_CALL). The round still
+   * completes but with fewer voices than dispatched; surfaced here so the
+   * orchestrator can see silent dropouts at the round level rather than only
+   * per-task in collect.ts:178 auto-signals.
+   */
+  coverageDegraded?: { expected: number; received: number; droppedAgents: string[] };
+  /**
    * True when at least one finding received fewer cross-reviewers than the
    * target K (e.g. not enough eligible agents). Set by runSelectedCrossReview.
    */
@@ -148,7 +156,8 @@ export interface ConsensusSignal {
     | 'severity_miscalibrated'
     | 'boundary_escape'
     | 'task_timeout'
-    | 'task_empty';
+    | 'task_empty'
+    | 'consensus_coverage_degraded';
   agentId: string;
   counterpartId?: string;
   skill?: string;

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -538,7 +538,9 @@ export class GeminiProvider implements ILLMProvider {
       if (finishReason === 'SAFETY') {
         _log('GeminiProvider', 'Response blocked by safety filter');
       }
-      return { text: finishReason === 'SAFETY' ? '[Response blocked by Gemini safety filter]' : '' };
+      return { text: finishReason === 'SAFETY'
+        ? '[Response blocked by Gemini safety filter]'
+        : `[No response from Gemini: malformed_function_call finishReason=${finishReason ?? 'unknown'}]` };
     }
 
     const textParts: string[] = [];

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -68,6 +68,7 @@ const KNOWN_SIGNALS: Record<ConsensusSignal['signal'], true> = {
   boundary_escape: true,
   task_timeout: true,
   task_empty: true,
+  consensus_coverage_degraded: true,
 };
 
 const SEVERITY_MULTIPLIER: Record<string, number> = {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -49,10 +49,13 @@ const config = {
   },
 };
 
-writeFileSync(mcpConfig, JSON.stringify(config, null, 2) + '\n');
-
-const method = isGlobal ? 'global npm' : isGitClone ? 'git clone' : 'local install';
-console.log(`gossipcat: wrote .mcp.json (${method}) → ${mcpServerPath}`);
+try {
+  writeFileSync(mcpConfig, JSON.stringify(config, null, 2) + '\n');
+  const method = isGlobal ? 'global npm' : isGitClone ? 'git clone' : 'local install';
+  console.log(`gossipcat: wrote .mcp.json (${method}) → ${mcpServerPath}`);
+} catch (e) {
+  console.warn(`gossipcat: postinstall could not write .mcp.json (${e.code || e.message}). Run 'gossipcat setup' after install to configure.`);
+}
 
 if (!existsSync(mcpServerPath)) {
   if (isGitClone) {

--- a/tests/cli/install-packaging.test.ts
+++ b/tests/cli/install-packaging.test.ts
@@ -113,4 +113,13 @@ describe('scripts/postinstall.js — error-path regression guard', () => {
     // postinstall MUST exit non-zero so npm/npx surfaces the failure.
     expect(source).toContain('process.exit(1)');
   });
+
+  it('wraps writeFileSync in try/catch with console.warn (no EACCES abort on RO install dirs)', () => {
+    // Regression guard: global npm installs (root-owned dirs) MUST NOT abort
+    // with EACCES. The writeFileSync call must be wrapped and fall through to
+    // a warn without process.exit on failure.
+    expect(source).toMatch(/try\s*{[\s\S]*writeFileSync\(mcpConfig[\s\S]*}\s*catch/);
+    expect(source).toContain('console.warn');
+    expect(source).toMatch(/could not write \.mcp\.json/);
+  });
 });

--- a/tests/orchestrator/consensus-two-phase.test.ts
+++ b/tests/orchestrator/consensus-two-phase.test.ts
@@ -174,4 +174,28 @@ describe('Two-phase consensus flow', () => {
     expect(report.confirmed.length).toBe(0);
     expect(report.unique.length + report.unverified.length).toBeGreaterThanOrEqual(2);
   });
+
+  it('flags coverageDegraded and emits consensus_coverage_degraded signal for 0-char dropouts', async () => {
+    const config: ConsensusEngineConfig = { llm: mockLlm, registryGet: mockRegistryGet };
+    const engine = new ConsensusEngine(config);
+
+    // Three dispatched agents, one returns empty text (simulating Gemini MFC).
+    const results = [
+      createEntry('native-a', '## Consensus Summary\n<agent_finding type="finding" severity="high">Bug in auth.ts:10 — missing token validation allows bypass</agent_finding>'),
+      createEntry('native-b', '## Consensus Summary\n<agent_finding type="finding" severity="medium">Missing input validation in api-handler.ts:20 for user-supplied query</agent_finding>'),
+      createEntry('native-c', ''),
+    ];
+
+    const nativeIds = new Set(['native-a', 'native-b', 'native-c']);
+    const { consensusId } = await engine.generateCrossReviewPrompts(results, nativeIds);
+    const report = await engine.synthesizeWithCrossReview(results, [], consensusId);
+
+    expect(report.coverageDegraded).toBeDefined();
+    expect(report.coverageDegraded!.expected).toBe(3);
+    expect(report.coverageDegraded!.received).toBe(2);
+    expect(report.coverageDegraded!.droppedAgents).toEqual(['native-c']);
+    const covSignals = report.signals.filter(s => s.signal === 'consensus_coverage_degraded');
+    expect(covSignals).toHaveLength(1);
+    expect(covSignals[0].agentId).toBe('_round');
+  });
 });

--- a/tests/orchestrator/llm-client.test.ts
+++ b/tests/orchestrator/llm-client.test.ts
@@ -300,6 +300,23 @@ describe('Multimodal message formatting', () => {
       expect(result.usage).toEqual({ inputTokens: 150, outputTokens: 42 });
     });
 
+    it('returns malformed_function_call sentinel when finishReason=MALFORMED_FUNCTION_CALL with empty parts', () => {
+      const provider = new GeminiProvider('gemini-pro', 'test-key');
+      const mockResponse = {
+        candidates: [{
+          content: { parts: [] },
+          finishReason: 'MALFORMED_FUNCTION_CALL',
+        }],
+      };
+
+      const result = (provider as any).parseGeminiResponse(mockResponse);
+
+      expect(result.text).toContain('malformed_function_call');
+      expect(result.text).toContain('MALFORMED_FUNCTION_CALL');
+      // Preserves collect.ts:178 substring match for auto-signal.
+      expect(result.text).toContain('[No response from');
+    });
+
     it('returns undefined usage when Gemini has no usageMetadata', () => {
       const provider = new GeminiProvider('gemini-pro', 'test-key');
       const mockResponse = {


### PR DESCRIPTION
## Summary

Three small fixes that surface silent degradation the orchestrator couldn't see today. Each ≤10 LOC of real logic + a dedicated test.

- **Fix A** `packages/orchestrator/src/llm-client.ts:541` — Gemini non-SAFETY empty-parts branch now returns `[No response from Gemini: malformed_function_call finishReason=...]` instead of bare `''`. Preserves existing `[No response from` substring match at `collect.ts:178` so `task_empty` auto-signal still fires, while putting the true root cause (MALFORMED_FUNCTION_CALL / UNEXPECTED_TOOL_CALL) into `r.result` → signal evidence. The finishReason was logged but never reached the signal.
- **Fix B** `scripts/postinstall.js:52` — wraps `writeFileSync` + success log in try/catch. EACCES on root-owned global install dir no longer aborts `npm install -g gossipcat`; emits a `console.warn` (not error, so npm doesn't elevate) and continues. Precedent: `apps/cli/src/mcp-server-sdk.ts:14` uses `try { mkdirSync(...) } catch {}`.
- **Fix C** `packages/orchestrator/src/consensus-engine.ts` `synthesizeWithCrossReview` — adds round-level `coverageDegraded: { expected, received, droppedAgents }` field to the consensus report when one or more dispatched agents return 0 chars. Emits one `consensus_coverage_degraded` operational signal per degraded round. Sits next to the existing `relayCrossReviewSkipped` surface. Type-level companions: signal union in `consensus-types.ts`, `KNOWN_SIGNALS` exhaustiveness in `performance-reader.ts`.

## Why bundled

All three close the same visibility gap: silent 0-char failures that let 3-agent consensus silently become 2-agent. Fix A makes the per-task signal informative, Fix C makes the round-level report reflect the degradation, Fix B is unrelated in subsystem but in the same "surface silent failure" theme.

## Test plan

- [x] `npm test` — 185 suites, 2476 passed, 1 skipped (+3 new tests, one per fix)
- [x] Typecheck clean on orchestrator + apps/cli (pre-existing dashboard-v2 `@/` alias warnings unrelated)
- [x] Fix A test: `tests/orchestrator/llm-client.test.ts` covers MALFORMED_FUNCTION_CALL finishReason → returned text contains `'malformed_function_call'`
- [x] Fix B test: `tests/cli/install-packaging.test.ts` source-scans postinstall.js for the try/catch pattern + `console.warn` (file's convention is source-scanning, not subprocess)
- [x] Fix C test: `tests/orchestrator/consensus-two-phase.test.ts` — 3 agents dispatched, one returns `text: ''` → report has `coverageDegraded.received === 2` and one `consensus_coverage_degraded` signal

## Scope notes

Fix C required two extra type-level touches beyond the three cited files: adding `'consensus_coverage_degraded'` to the `ConsensusSignal['signal']` union in `consensus-types.ts` and the matching `KNOWN_SIGNALS: Record<...>` entry in `performance-reader.ts:68`. Same pattern as the existing `task_empty` / `task_timeout` signals — no logic change, just TS exhaustiveness parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)