### PR TITLE
chore(tests): drop stale z-test language post-Wilson migration

### DIFF
--- a/packages/orchestrator/src/check-effectiveness.ts
+++ b/packages/orchestrator/src/check-effectiveness.ts
@@ -198,7 +198,8 @@ export function resolveVerdict(
   //       first relevant task arrives.
   //   (b) 0 < postTotal < MIN_EVIDENCE — some history, but below the
   //       statistical gate (MIN_EVIDENCE = 120). Skill is active but
-  //       hasn't accumulated enough signals for the z-test to fire.
+  //       hasn't accumulated enough signals for the Wilson regime check to
+  //       reach a verdict.
   //
   // Both surface as `pending` because the action is the same: wait. The
   // distinction is informational only — dashboards can compute it from

--- a/tests/orchestrator/skill-effectiveness-e2e.test.ts
+++ b/tests/orchestrator/skill-effectiveness-e2e.test.ts
@@ -498,13 +498,14 @@ describe('skill-effectiveness E2E — graduation pipeline', () => {
   //
   // Baseline 18c/2h (baselineP = 0.9). Post-bind delta has MIN_EVIDENCE=120
   // signals with a high hallucination share so postP drops well below
-  // baselineP - 0.10. The one-sided negative z-test should reject and the
-  // verdict should land at `failed` via verdict_method: 'z-test'.
+  // baselineP - 0.10. Under the unified Wilson path (post full-replacement),
+  // the typical regime's Wilson CI lands entirely below baselineP and the
+  // verdict should land at `failed` via verdict_method: 'wilson_typical'.
   //
   // Locks the symmetric "negative direction" branch of resolveVerdict that
   // mirrors variant A's positive-direction graduation.
   // -------------------------------------------------------------------------
-  test("Variant F — 120 post-bind signals decline below baseline → failed via z-test", async () => {
+  test("Variant F — 120 post-bind signals decline below baseline → failed via Wilson", async () => {
     const boundAt = Date.now() - 1000;
     const skillPath = writeSkillFixture(projectRoot, AGENT, CATEGORY, {
       name: CATEGORY,
@@ -539,16 +540,19 @@ describe('skill-effectiveness E2E — graduation pipeline', () => {
   // Variant G — inconclusive rotation → flagged_for_manual_review terminal.
   //
   // Three checkEffectiveness calls where each window's postP lands within
-  // ±3pp of baselineP (so neither z-test direction rejects). Each call bumps
+  // ±3pp of baselineP (so Wilson intervals overlap in the typical regime —
+  // neither direction crosses the α threshold). Each call bumps
   // inconclusive_strikes and rotates inconclusive_at to now, so the next call
   // reads counters from the new anchor. On the 3rd strike, resolveVerdict
-  // transitions to `flagged_for_manual_review` with verdict_method='z-test'.
+  // transitions to `flagged_for_manual_review` with the regime's
+  // verdict_method stamped on the return.
   //
   // To keep every round within the ±3pp band we use baselineP = 0.5
   // (60c/60h) and append exactly 60 correct + 60 hallucinated post-anchor
-  // for each round (postP = 0.5 = baselineP → zero effect, can't reject
-  // either direction). The 3-strike terminal check is PR #228's verdict_method
-  // stamp on the flagged_for_manual_review return.
+  // for each round (postP = 0.5 = baselineP → Wilson CIs fully overlap,
+  // resolveVerdict returns pending → inconclusive). The 3-strike terminal
+  // check is PR #228's verdict_method stamp on the flagged_for_manual_review
+  // return.
   // -------------------------------------------------------------------------
   test('Variant G — 3× inconclusive rotation → flagged_for_manual_review', async () => {
     const boundAt = Date.now() - 90 * 86400_000 + 86400_000; // within TIMEOUT_MS


### PR DESCRIPTION
## Summary

Resolves three cosmetic findings from consensus \`8c424e64-f2a34d14\` (Wilson runtime-wiring review). Comments and test names still referenced the legacy z-test mechanism after PR #234 replaced it with the unified Wilson path.

- \`packages/orchestrator/src/check-effectiveness.ts:201\` — pending-state comment: "z-test to fire" → "Wilson regime check to reach a verdict"
- \`tests/orchestrator/skill-effectiveness-e2e.test.ts\` Variant F test name + comment block: "failed via z-test" → "failed via Wilson"
- \`tests/orchestrator/skill-effectiveness-e2e.test.ts\` Variant G comment block: "neither z-test direction rejects" → "Wilson intervals overlap in the typical regime"

Finding IDs addressed (from consensus \`8c424e64-f2a34d14\`):
- \`sonnet-reviewer:f14\` — stale comment at check-effectiveness.ts:199
- \`sonnet-reviewer:f15\` — Variant G test prose at skill-effectiveness-e2e.test.ts:544
- \`sonnet-reviewer:f16\` — Variant F test name

Behavior unchanged — strings only. Test assertions still use \`stringMatching(/^(z-test|wilson_typical)$/)\` to remain compatible with legacy snapshots, per spec \`docs/specs/2026-04-22-wilson-full-replacement.md\`.

## Test plan

- [x] \`npx jest tests/orchestrator/skill-effectiveness-e2e.test.ts --testNamePattern='Variant F'\` — passes with new test name
- [x] No dependents on the old test name outside locked worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)