### PR TITLE
feat(premise): Stage 2 PR B — emit-structured-claims skill + auto-bind

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -650,6 +650,12 @@ async function doBoot() {
     // in `-implementer`. Convention documented in .claude/rules/gossipcat.md.
     // Spec: docs/specs/2026-04-22-premise-verification.md (Component C).
     const IMPLEMENTER_PERMANENT_DEFAULTS = ['verify-the-premise'];
+    // Researcher/Reviewer permanent defaults — bound to any agent whose id
+    // ends in `-researcher` or `-reviewer`. Disjoint from the implementer
+    // filter: hybrid ids like `foo-researcher-implementer` match BOTH filters
+    // independently and inherit each suffix's defaults once.
+    // Spec: docs/specs/2026-04-22-premise-verification-stage-2.md (PR B).
+    const RESEARCHER_REVIEWER_PERMANENT_DEFAULTS = ['emit-structured-claims'];
     try {
       const allAgentIds = agentConfigs.map((ac: any) => ac.id).filter((id: any) => typeof id === 'string' && id.length > 0);
       if (allAgentIds.length > 0) {
@@ -660,6 +666,13 @@ async function doBoot() {
       if (implementerIds.length > 0) {
         skillIndex.ensureBoundWithMode(IMPLEMENTER_PERMANENT_DEFAULTS, implementerIds, 'permanent');
         process.stderr.write(`[gossipcat] 📚 Implementer permanent defaults seeded: ${IMPLEMENTER_PERMANENT_DEFAULTS.join(', ')} → ${implementerIds.length} agents\n`);
+      }
+      const researcherReviewerIds = allAgentIds.filter(
+        (id: string) => id.endsWith('-researcher') || id.endsWith('-reviewer'),
+      );
+      if (researcherReviewerIds.length > 0) {
+        skillIndex.ensureBoundWithMode(RESEARCHER_REVIEWER_PERMANENT_DEFAULTS, researcherReviewerIds, 'permanent');
+        process.stderr.write(`[gossipcat] 📚 Researcher/Reviewer permanent defaults seeded: ${RESEARCHER_REVIEWER_PERMANENT_DEFAULTS.join(', ')} → ${researcherReviewerIds.length} agents\n`);
       }
     } catch (seedErr) {
       process.stderr.write(`[gossipcat] ⚠️  Global permanent skill auto-seed failed: ${(seedErr as Error).message}\n`);

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -58,6 +58,18 @@ this convention will inherit the skill automatically. An implementer named
 otherwise (e.g. `claude-writer`) will silently miss the skill — name it
 `claude-writer-implementer` to opt in.
 
+Investigation agents follow the same convention. The `emit-structured-claims`
+skill (premise-verification Stage 2) auto-binds to any agent whose `id` ends
+in `-researcher` or `-reviewer`. Name custom research / review agents with
+one of those suffixes (e.g. `foo-researcher`, `foo-reviewer`) so they inherit
+the skill automatically.
+
+Auto-bind bindings are disjoint by suffix — an agent id may match multiple
+suffixes and will inherit each suffix's defaults once. A hybrid id like
+`foo-researcher-implementer` receives BOTH the `-researcher` defaults
+(`emit-structured-claims`) AND the `-implementer` defaults
+(`verify-the-premise`).
+
 ## When to Use Multi-Agent vs Single Agent
 
 **Use consensus (3+ agents) for:**

--- a/packages/orchestrator/src/default-skills/emit-structured-claims.md
+++ b/packages/orchestrator/src/default-skills/emit-structured-claims.md
@@ -1,0 +1,140 @@
+---
+name: emit-structured-claims
+description: Emit a structured premise-claims JSON block alongside prose findings so the orchestrator can grep-verify code-shape claims and close the four Stage-1 bypass classes.
+keywords: []
+category: trust_boundaries
+mode: permanent
+status: active
+---
+
+## When this skill activates
+Always — this is a permanent-mode skill for investigation agents
+(`-researcher`, `-reviewer`). Your finding must include a `premise-claims`
+JSON block whenever it contains ANY of:
+
+1. **A file path + line number** — *"at `apps/cli/src/handlers/dispatch.ts:42`"*.
+2. **A count of callers / sites / handlers / files** — *"5 sites call X"*,
+   *"3 handlers emit Y"*, *"2 files reference Z"*.
+3. **A claim of absence** — *"X is not called"*, *"no handler emits Y"*,
+   *"Z is missing from scope"*.
+4. **Any bypass-class phrase** — *"several"*, *"a few"*, *"most"*,
+   *"probably"*, *"I think"*, *"it looks like"*, *"all but"*, *"only N of M"*,
+   *"none of"*. These are the vague / hedged / inverted classes Stage 1
+   regex cannot see; structured claims are the ONLY way they get verified.
+
+## Iron law
+Prose alone is not verifiable. If your finding rests on code shape — counts,
+line numbers, presence, absence — emit it as a structured claim too. The
+orchestrator will `rg`-check every claim before dispatch. Claims that
+falsify mean your premise is wrong; ship the claim block and let the
+pipeline catch the mistake before an implementer inherits it.
+
+## How to emit
+Append a fenced code block with the `premise-claims` info string AFTER your
+prose finding and BEFORE any suggested code. The block is JSON with a
+`schema_version`, `verifier`, and `claims` array. Spec:
+`docs/specs/2026-04-22-premise-verification-stage-2.md`.
+
+### Worked example
+
+Given finding prose like:
+
+> *"Five dispatch sites call `assembleUtilityPrompt` in
+> `apps/cli/src/mcp-server-sdk.ts`; none of them pass the sentinel flag.
+> `maybeAnnotateUnverifiedClaims` lives at `apps/cli/src/sandbox.ts:207`."*
+
+Emit alongside:
+
+```premise-claims
+{
+  "schema_version": "1",
+  "verifier": "orchestrator",
+  "claims": [
+    { "type": "callsite_count", "symbol": "assembleUtilityPrompt",
+      "scope": "apps/cli/src/mcp-server-sdk.ts", "expected": 5,
+      "modality": "asserted" },
+    { "type": "absence_of_symbol", "symbol": "SCOPE_NOTE",
+      "scope": "apps/cli/src/handlers/dispatch.ts",
+      "context": "preamble emission path", "modality": "asserted" },
+    { "type": "file_line", "path": "apps/cli/src/sandbox.ts",
+      "line": 207, "expected_symbol": "maybeAnnotateUnverifiedClaims",
+      "modality": "asserted" }
+  ]
+}
+```
+
+## Claim types (v1 — see spec for full table)
+
+- `callsite_count` — `symbol`, `scope`, `expected` (int). Verifier sums
+  `rg --count-matches` across scope; compares against `expected`.
+- `file_line` — `path`, `line` (int), `expected_symbol` (string). Verifier
+  reads the file ±2 lines and string-matches `expected_symbol`.
+- `absence_of_symbol` — `symbol`, `scope`, `context` (≤120 chars).
+  Verifier requires `rg --count-matches` summed total of 0.
+- `presence_of_symbol` — `symbol`, `scope`. Verifier requires total ≥ 1.
+- `count_relation` — `symbol`, `scope`, `relation` (`>`, `<`, `=`, `≥`, `≤`),
+  `value` (int). Use this for SUBSET forms like *"all but one of 5"* or
+  *"only 1 of 5 is safe"* — NOT `negated:true`, which only encodes simple
+  inequality against a total (bypass class I).
+
+## Modality (required on every claim)
+
+Classify your confidence at emit time — the verifier uses modality to scale
+the falsification penalty.
+
+- `asserted` — *"5 sites call X"* — you checked; verifier runs full strictness.
+- `hedged` — *"~5 sites call X; not re-checked"* — you saw a number but
+  didn't re-verify. Verifier still runs, falsification penalty is halved.
+- `vague` — *"several sites call X"* — no numeric commitment. Pair with
+  `range_hint: { min, max }` only when you have grounded reason to believe
+  a range. If `range_hint` is absent, the verifier records the observed
+  count but returns `unverifiable_by_grep` — it will NOT fabricate a
+  falsification. Omitting `range_hint` is the honest choice when you do
+  not know the count; inventing bounds to satisfy the schema is worse
+  than staying prose-vague.
+
+Omitting the `modality` field entirely is a schema-lint warning; the
+verifier treats a missing field as `asserted` (strictest path) and logs
+the violation. Always include `modality` explicitly.
+
+## When to use `count_relation` vs `negated:true`
+
+- `negated: true` on `callsite_count` — encodes "observed count ≠ expected".
+  Use only for simple inequality claims.
+- `count_relation` — use for subset forms. *"All but one of the 5 sites"* →
+  `{ type: "count_relation", symbol: "...", scope: "...", relation: "=",
+  value: 4 }` (4 of 5). *"Only 2 of 5 are safe"* → `relation: "="`,
+  `value: 2`. *"None of 5"* → `relation: "="`, `value: 0`.
+
+## Compound sentences → multiple claim objects
+
+One prose sentence can pack count + file:line + absence. Decompose into N
+separate claim objects in the `claims` array. The verifier reports
+per-claim outcomes; dispatch annotation cites only the subset that failed
+or could not be verified.
+
+## Anti-patterns
+
+- **Do NOT fabricate counts** to satisfy the schema. If you did not grep,
+  use `modality: "vague"` without `range_hint`. A `vague`-unverifiable
+  verdict is 0× penalty; a fabricated `asserted` that falsifies is 3×.
+- **Do NOT emit claims for untestable scopes.** The verifier runs local
+  `rg` inside the project root; claims about remote repos, runtime
+  behavior, or semantic intent cannot be verified and will return
+  `unverifiable_by_grep`. Keep those as prose.
+- **Do NOT omit modality.** Missing field triggers a schema-lint warning
+  and is scored as `asserted` (strictest) — you lose the hedge discount.
+- **Do NOT combine `absence_of_symbol` with `negated: true`.** That is
+  just `presence_of_symbol`; schema-lint rejects on emit.
+
+## Why this skill exists
+
+Stage 1 regex catches literal-numeral + TARGETS-noun patterns over prose
+("5 sites call X"). It silently passes four bypass classes: **vague**
+(*"several sites"* — no numeric anchor), **hedged** (*"probably 5"* — no
+uncertainty marker to the regex), **inverted** (*"all but 1 of 5"* — the
+count matches, the semantically load-bearing negation doesn't), and
+**compound** (one sentence, three claims — regex fires once). Structured
+claims give each of these an explicit schema representation. See
+`docs/specs/2026-04-22-premise-verification-stage-2.md` for the full
+rationale and the adoption plan toward Stage 1 sunset.

--- a/tests/cli/mcp-handlers.test.ts
+++ b/tests/cli/mcp-handlers.test.ts
@@ -1244,6 +1244,94 @@ describe('handleDispatchSingle — native skill injection', () => {
     const prompt = result.content.find(c => c.text.startsWith('AGENT_PROMPT:'))?.text ?? '';
     expect(prompt).not.toContain('verify-the-premise');
   });
+
+  // ── PR B: emit-structured-claims auto-bind (Stage 2) ──
+  // Spec: docs/specs/2026-04-22-premise-verification-stage-2.md
+  // Binds to `-researcher` / `-reviewer` via RESEARCHER_REVIEWER_PERMANENT_DEFAULTS,
+  // disjoint from the `-implementer` filter. These tests assert the dispatch
+  // prompt reflects the expected bound skills — the invariant a hybrid id like
+  // `foo-researcher-implementer` inherits BOTH skills (not one, not neither).
+
+  it('emit-structured-claims skill appears in *-researcher agent prompt when bound', async () => {
+    ctx.mainAgent = makeMainAgent({
+      getSkillIndex: jest.fn().mockReturnValue(makeSkillIndex(['emit-structured-claims'])),
+    });
+    ctx.nativeAgentConfigs.set('haiku-researcher', {
+      model: 'claude-haiku-4-5',
+      instructions: 'You research.',
+      description: 'Native researcher',
+      skills: ['emit-structured-claims'],
+    });
+    const result = await handleDispatchSingle('haiku-researcher', 'Investigate utility dispatch sites.');
+    const prompt = result.content.find(c => c.text.startsWith('AGENT_PROMPT:'))?.text ?? '';
+    expect(prompt).toContain('--- SKILLS ---');
+    expect(prompt).toContain('emit-structured-claims');
+    expect(prompt).toContain('premise-claims');
+  });
+
+  it('emit-structured-claims skill appears in *-reviewer agent prompt when bound', async () => {
+    ctx.mainAgent = makeMainAgent({
+      getSkillIndex: jest.fn().mockReturnValue(makeSkillIndex(['emit-structured-claims'])),
+    });
+    ctx.nativeAgentConfigs.set('sonnet-reviewer', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You review.',
+      description: 'Native reviewer',
+      skills: ['emit-structured-claims'],
+    });
+    const result = await handleDispatchSingle('sonnet-reviewer', 'Review this change.');
+    const prompt = result.content.find(c => c.text.startsWith('AGENT_PROMPT:'))?.text ?? '';
+    expect(prompt).toContain('--- SKILLS ---');
+    expect(prompt).toContain('emit-structured-claims');
+    expect(prompt).toContain('premise-claims');
+  });
+
+  it('emit-structured-claims skill does NOT appear in *-implementer agent prompt (disjoint-suffix filter)', async () => {
+    // A pure implementer receives only verify-the-premise — emit-structured-claims
+    // is a researcher/reviewer default and must not leak across the suffix
+    // boundary. Guards against accidental multi-suffix extension of the
+    // implementer filter.
+    ctx.mainAgent = makeMainAgent({
+      getSkillIndex: jest.fn().mockReturnValue(makeSkillIndex(['verify-the-premise'])),
+    });
+    ctx.nativeAgentConfigs.set('opus-implementer', {
+      model: 'claude-opus-4-7',
+      instructions: 'You implement.',
+      description: 'Native implementer',
+      skills: ['verify-the-premise'],
+    });
+    const result = await handleDispatchSingle('opus-implementer', 'Add a helper.');
+    const prompt = result.content.find(c => c.text.startsWith('AGENT_PROMPT:'))?.text ?? '';
+    expect(prompt).toContain('verify-the-premise');
+    expect(prompt).not.toContain('emit-structured-claims');
+  });
+
+  it('hybrid *-researcher-implementer agent inherits BOTH emit-structured-claims AND verify-the-premise', async () => {
+    // Load-bearing invariant: disjoint suffix sets mean a hybrid id matches
+    // both filters and gets each suffix's defaults once. Simulates the post-
+    // seed SkillIndex state by declaring both skills enabled.
+    ctx.mainAgent = makeMainAgent({
+      getSkillIndex: jest
+        .fn()
+        .mockReturnValue(makeSkillIndex(['emit-structured-claims', 'verify-the-premise'])),
+    });
+    ctx.nativeAgentConfigs.set('foo-researcher-implementer', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'Hybrid researcher-implementer.',
+      description: 'Hybrid native agent',
+      skills: ['emit-structured-claims', 'verify-the-premise'],
+    });
+    const result = await handleDispatchSingle(
+      'foo-researcher-implementer',
+      'Investigate then implement.',
+    );
+    const prompt = result.content.find(c => c.text.startsWith('AGENT_PROMPT:'))?.text ?? '';
+    expect(prompt).toContain('--- SKILLS ---');
+    expect(prompt).toContain('emit-structured-claims');
+    expect(prompt).toContain('verify-the-premise');
+    expect(prompt).toContain('premise-claims');
+    expect(prompt.toLowerCase()).toContain('iron law');
+  });
 });
 
 // ── handleNativeRelay — compact return payload (consensus 2f25318c/634c3c43) ──


### PR DESCRIPTION
## Summary

**Stage 2 PR B** of premise-verification. Depends on [PR #241](https://github.com/gossipcat-ai/gossipcat-ai/pull/241) (PR A, merged). Atomic with **PR C** (dispatch wire-up, in flight).

Adds the `emit-structured-claims` default skill that instructs investigation skills to emit structured `premise-claims` JSON blocks when findings contain quantitative claims. Auto-binds to every agent whose id ends in `-researcher` or `-reviewer`.

## What ships

- **`packages/orchestrator/src/default-skills/emit-structured-claims.md`** (new, 140 LOC) — permanent-mode default skill with frontmatter, "when fires" criteria, modality guidance (asserted/hedged/vague + when to use `count_relation` vs `negated:true` for class-I subset forms), and a worked `premise-claims` JSON example.
- **`apps/cli/src/mcp-server-sdk.ts`** (+14 LOC) — new constant `RESEARCHER_REVIEWER_PERMANENT_DEFAULTS = ['emit-structured-claims']` alongside existing `IMPLEMENTER_PERMANENT_DEFAULTS`. Separate disjoint filter `id.endsWith('-researcher') || id.endsWith('-reviewer')`. **Intentionally not** extended onto the `-implementer` filter — spec invariant: disjoint suffix sets, so hybrid ids (`foo-researcher-implementer`) inherit each suffix's defaults once.
- **`docs/RULES.md`** (+11 LOC) — extended "Implementer naming convention" section to cover `-researcher` / `-reviewer`, with a note: *"Auto-bind bindings are disjoint by suffix — an agent id may match multiple suffixes and will inherit each suffix's defaults once."* `.claude/rules/gossipcat.md` is regenerated from `docs/RULES.md` at runtime via `apps/cli/src/rules-content.ts` (PR #238 pattern), so only `docs/RULES.md` is edited.

## Tests

\`tests/cli/mcp-handlers.test.ts\` (+4, +88 LOC):

- [x] \`emit-structured-claims\` appears in \`*-researcher\` prompt
- [x] appears in \`*-reviewer\` prompt
- [x] does NOT appear in \`*-implementer\` prompt (disjoint-suffix invariant)
- [x] hybrid \`*-researcher-implementer\` inherits BOTH \`emit-structured-claims\` AND \`verify-the-premise\`

All 4 pass locally with \`RUN_KNOWN_BROKEN=1 npx jest tests/cli/mcp-handlers.test.ts --testNamePattern='emit-structured-claims|RESEARCHER_REVIEWER|hybrid'\`. File is in \`KNOWN_BROKEN_SUITES\` for unrelated pre-existing reasons.

Typecheck clean on all touched files.

## Merge order

Must land atomically with **PR C** (dispatch wire-up + logging + signal schema extension) — per spec §Rollout merge-order constraint, shipping this skill without PR C creates emit-without-verifier: agents emit structured claims that no one parses. Do not merge until PR C is also green.

## Consensus refs

Driven by findings:
- \`76b36ecd-722c4ed4:haiku-researcher:f14\` (invariant collision on auto-bind)
- \`76b36ecd-722c4ed4:sonnet-reviewer:f10\` (mechanism missing, docs missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)