### PR TITLE
feat(premise): Stage 2 PR C — dispatch wire-up + jsonl logging + modality-scaled signal

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -3,9 +3,18 @@
  * All state accessed via the shared context object.
  */
 import { randomUUID } from 'crypto';
-import { readFileSync } from 'fs';
+import { appendFileSync, mkdirSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { assemblePrompt, loadSkills } from '@gossip/orchestrator';
+import {
+  assemblePrompt,
+  loadSkills,
+  parseClaimBlock,
+  verifyClaims,
+  emitConsensusSignals,
+  type ClaimBlock,
+  type ClaimVerdict,
+  type PerformanceSignal,
+} from '@gossip/orchestrator';
 import { formatIdentityBlock } from '@gossip/tools';
 import { ctx, NATIVE_TASK_TTL_MS } from '../mcp-context';
 
@@ -27,7 +36,9 @@ import {
   recordDispatchMetadata,
   relativizeProjectPaths,
   readSandboxMode,
+  rotateIfNeeded,
   shouldSanitize,
+  MAX_PREMISE_VERIFICATION_BYTES,
 } from '../sandbox';
 
 /**
@@ -46,6 +57,232 @@ function maybeApplyUnverifiedNote(
     `[gossipcat] ⚠️ unverified-claim detected for ${agentId}: matched "${annotation.matchedText}" (pattern #${annotation.matchedPattern})\n`,
   );
   return prependUnverifiedNote(agentPrompt, annotation.reason || annotation.matchedText || '');
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Stage 2 premise-verification — structured claim-block wire-up.
+//
+// Spec: docs/specs/2026-04-22-premise-verification-stage-2.md
+//   §"Verifier" (invariants), §"Wire-up" (flow), §"Rotation" (jsonl),
+//   §"Signal integration" (signal emission on falsified).
+//
+// Flow per native dispatch:
+//   1. Extract fenced ```premise-claims block from task body — skip if absent.
+//   2. parseClaimBlock(rawJson) — fail-soft; bad JSON → schema-lint prefix only.
+//   3. verifyClaims(block, projectRoot) — in-process rg, 500ms wallclock cap,
+//      no sub-agent dispatch (load-bearing invariant).
+//   4. Falsified verdicts → ⚠ PREMISE-MISMATCH prefix on task.
+//   5. Log JSONL row to .gossip/premise-verification.jsonl with single-slot
+//      rotation at MAX_PREMISE_VERIFICATION_BYTES (mirrors boundary-escapes).
+//   6. Each falsified claim → one hallucination_caught:premise_mismatch signal
+//      carrying the claim's modality for the Stage 2 scaled multiplier.
+//
+// Warn-not-block: dispatch always proceeds regardless of outcome.
+// Relay-path: skipped — mirrors Stage 1; deferred to Stage 2a per spec
+// §Open questions #2.
+// ──────────────────────────────────────────────────────────────────────────
+
+const PREMISE_CLAIMS_FENCE_RE = /```premise-claims\s*\n([\s\S]*?)\n```/;
+const PREMISE_VERIFICATION_LOG = '.gossip/premise-verification.jsonl';
+
+function extractPremiseClaimsBlock(task: string): string | null {
+  if (!task) return null;
+  const m = PREMISE_CLAIMS_FENCE_RE.exec(task);
+  return m ? m[1] : null;
+}
+
+interface PremiseVerificationResult {
+  /** Task body with ⚠ PREMISE-MISMATCH / schema-lint prefix applied (if any). */
+  annotatedTask: string;
+  /** Per-falsified-claim signals ready for emitConsensusSignals. */
+  signals: PerformanceSignal[];
+  /** Whether verification actually ran (a claim block existed + parsed). */
+  ran: boolean;
+  /** Aggregate counts for the JSONL log row. */
+  counts: {
+    claims_total: number;
+    claims_verified: number;
+    claims_falsified: number;
+    claims_unverifiable: number;
+    timeout_fraction: number;
+  };
+}
+
+function summarizeVerdicts(verdicts: ClaimVerdict[]): PremiseVerificationResult['counts'] {
+  let verified = 0;
+  let falsified = 0;
+  let unverifiable = 0;
+  let timeouts = 0;
+  for (const v of verdicts) {
+    if (v.status === 'verified') verified++;
+    else if (v.status === 'falsified') falsified++;
+    else {
+      unverifiable++;
+      if (v.reason === 'timeout') timeouts++;
+    }
+  }
+  return {
+    claims_total: verdicts.length,
+    claims_verified: verified,
+    claims_falsified: falsified,
+    claims_unverifiable: unverifiable,
+    timeout_fraction: verdicts.length > 0 ? timeouts / verdicts.length : 0,
+  };
+}
+
+function formatFalsifiedNote(
+  block: ClaimBlock,
+  verdicts: ClaimVerdict[],
+): string {
+  const lines: string[] = ['⚠ PREMISE-MISMATCH — one or more structured claims were falsified by grep:'];
+  for (const v of verdicts) {
+    if (v.status !== 'falsified') continue;
+    const claim = block.claims[v.claim_index];
+    const type = claim?.type ?? 'unknown';
+    lines.push(
+      `  • claim[${v.claim_index}] (${type}): expected ${JSON.stringify(v.expected)}, observed ${JSON.stringify(v.observed)} [modality=${v.modality}]`,
+    );
+  }
+  lines.push('');
+  lines.push('Re-verify the cited code before writing any patch. See spec §"Signal integration" — a hallucination_caught:premise_mismatch signal has been recorded.');
+  return lines.join('\n');
+}
+
+function writePremiseVerificationLog(
+  projectRoot: string,
+  taskId: string,
+  result: PremiseVerificationResult,
+  opts: { had_stage1_annotation: boolean; skill_bound: string | null; schema_lint?: string },
+): void {
+  try {
+    const logPath = join(projectRoot, PREMISE_VERIFICATION_LOG);
+    // Rotation BEFORE append (same precedent as boundary-escapes.jsonl, PR #135).
+    rotateIfNeeded(logPath, MAX_PREMISE_VERIFICATION_BYTES);
+    mkdirSync(join(projectRoot, '.gossip'), { recursive: true });
+    const row: Record<string, unknown> = {
+      ts: new Date().toISOString(),
+      consensus_id: null,
+      task_id: taskId,
+      claims_total: result.counts.claims_total,
+      claims_verified: result.counts.claims_verified,
+      claims_falsified: result.counts.claims_falsified,
+      claims_unverifiable: result.counts.claims_unverifiable,
+      timeout_fraction: result.counts.timeout_fraction,
+      had_stage1_annotation: opts.had_stage1_annotation,
+      skill_bound: opts.skill_bound,
+    };
+    if (opts.schema_lint) row.schema_lint = opts.schema_lint;
+    appendFileSync(logPath, JSON.stringify(row) + '\n');
+  } catch {
+    /* best-effort; dispatch must never fail on logging */
+  }
+}
+
+/**
+ * Parse + verify any ```premise-claims block in a native dispatch task.
+ *
+ * Safe to call on any task string — returns a no-op result when no block is
+ * present. Never throws; dispatch must never fail on verification.
+ *
+ * Caller is responsible for:
+ *   - Gating on native-path only (skip for relay dispatches — spec §Wire-up #6).
+ *   - Passing `annotatedTask` into `assemblePrompt` (not the raw task).
+ *   - Calling `emitConsensusSignals(projectRoot, signals)` once per dispatch.
+ *   - Calling `writePremiseVerificationLog(...)` for the JSONL row.
+ */
+async function maybeVerifyPremiseClaims(
+  task: string,
+  projectRoot: string,
+  taskId: string,
+  agentId: string,
+): Promise<PremiseVerificationResult> {
+  const empty: PremiseVerificationResult = {
+    annotatedTask: task,
+    signals: [],
+    ran: false,
+    counts: {
+      claims_total: 0,
+      claims_verified: 0,
+      claims_falsified: 0,
+      claims_unverifiable: 0,
+      timeout_fraction: 0,
+    },
+  };
+  const rawJson = extractPremiseClaimsBlock(task);
+  if (!rawJson) return empty;
+
+  const { block, errors } = parseClaimBlock(rawJson);
+  if (!block) {
+    // Malformed JSON / shape — prepend schema-lint warning, prose path runs.
+    process.stderr.write(
+      `[gossipcat] ⚠ premise-claims schema violation for ${agentId}: ${errors.map(e => e.message).slice(0, 3).join('; ')}\n`,
+    );
+    const note =
+      '⚠ premise-claims block failed schema validation — treating task as prose-only. ' +
+      `Errors: ${errors.map(e => e.message).slice(0, 3).join('; ')}`;
+    writePremiseVerificationLog(projectRoot, taskId, empty, {
+      had_stage1_annotation: maybeAnnotateUnverifiedClaims(task).annotated,
+      skill_bound: null,
+      schema_lint: 'parse_failed',
+    });
+    return {
+      ...empty,
+      annotatedTask: `${note}\n\n${task}`,
+    };
+  }
+
+  let verdicts: ClaimVerdict[] = [];
+  try {
+    verdicts = await verifyClaims(block, projectRoot);
+  } catch (err) {
+    process.stderr.write(
+      `[gossipcat] ⚠ verifyClaims threw for ${agentId}: ${(err as Error).message}\n`,
+    );
+    return empty;
+  }
+
+  const counts = summarizeVerdicts(verdicts);
+  const falsified = verdicts.filter(v => v.status === 'falsified') as Extract<
+    ClaimVerdict,
+    { status: 'falsified' }
+  >[];
+
+  // Build hallucination_caught signals — one per falsified claim.
+  const signals: PerformanceSignal[] = falsified.map(v => ({
+    type: 'consensus',
+    taskId,
+    signal: 'hallucination_caught',
+    agentId,
+    outcome: 'premise_mismatch',
+    modality: v.modality,
+    evidence: `premise-claim[${v.claim_index}] falsified: expected ${JSON.stringify(
+      v.expected,
+    )}, observed ${JSON.stringify(v.observed)}`,
+    timestamp: new Date().toISOString(),
+  }));
+
+  const annotatedTask = falsified.length > 0
+    ? `${formatFalsifiedNote(block, verdicts)}\n\n${task}`
+    : task;
+
+  const result: PremiseVerificationResult = {
+    annotatedTask,
+    signals,
+    ran: true,
+    counts,
+  };
+
+  // Record schema-lint warnings from the parser (e.g. missing_modality) so
+  // retrospective audit can see silent downgrades. Errors is additive — a
+  // non-null block may still carry per-claim errors.
+  const schemaLint = errors.length > 0 ? errors[0].message : undefined;
+  writePremiseVerificationLog(projectRoot, taskId, result, {
+    had_stage1_annotation: maybeAnnotateUnverifiedClaims(task).annotated,
+    skill_bound: null,
+    schema_lint: schemaLint,
+  });
+
+  return result;
 }
 
 function agentPreset(agentId: string): string | undefined {
@@ -173,6 +410,19 @@ export async function handleDispatchSingle(
     const taskId = randomUUID().slice(0, 8);
     const relayToken = randomUUID().slice(0, 12);
     const timeoutMs = timeout_ms ?? NATIVE_TASK_TTL_MS;
+
+    // Stage 2 premise-verification — parse + verify any ```premise-claims
+    // block in the task. Runs BEFORE assemblePrompt so the PREMISE-MISMATCH
+    // prefix travels inline with the task payload, yielding final ordering
+    // SCOPE > UNVERIFIED > PREMISE-MISMATCH (Stage 1 UNVERIFIED sentinel is
+    // prepended later by maybeApplyUnverifiedNote). Warn-not-block: dispatch
+    // always proceeds.
+    const premiseResult = await maybeVerifyPremiseClaims(task, process.cwd(), taskId, agent_id);
+    task = premiseResult.annotatedTask;
+    if (premiseResult.signals.length > 0) {
+      emitConsensusSignals(process.cwd(), premiseResult.signals);
+    }
+
     ctx.nativeTaskMap.set(taskId, { agentId: agent_id, task, startedAt: Date.now(), timeoutMs, planId: plan_id, step, writeMode: write_mode, relayToken });
     spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
     persistNativeTaskMap();
@@ -386,6 +636,16 @@ export async function handleDispatchParallel(
     const nativeConfig = ctx.nativeAgentConfigs.get(def.agent_id)!;
     const taskId = randomUUID().slice(0, 8);
     const relayToken = randomUUID().slice(0, 12);
+
+    // Stage 2 premise-verification — parse + verify any ```premise-claims
+    // block. See handleDispatchSingle for rationale; same warn-not-block
+    // semantics and ordering rules.
+    const premiseResult = await maybeVerifyPremiseClaims(def.task, process.cwd(), taskId, def.agent_id);
+    def.task = premiseResult.annotatedTask;
+    if (premiseResult.signals.length > 0) {
+      emitConsensusSignals(process.cwd(), premiseResult.signals);
+    }
+
     ctx.nativeTaskMap.set(taskId, { agentId: def.agent_id, task: def.task, startedAt: Date.now(), timeoutMs: NATIVE_TASK_TTL_MS, relayToken });
     spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
     try { ctx.mainAgent.recordNativeTask(taskId, def.agent_id, def.task); } catch { /* best-effort */ }
@@ -584,6 +844,15 @@ export async function handleDispatchConsensus(
     const nativeConfig = ctx.nativeAgentConfigs.get(def.agent_id)!;
     const taskId = randomUUID().slice(0, 8);
     const relayToken = randomUUID().slice(0, 12);
+
+    // Stage 2 premise-verification — parse + verify any ```premise-claims
+    // block. Same warn-not-block semantics as handleDispatchSingle.
+    const premiseResult = await maybeVerifyPremiseClaims(def.task, process.cwd(), taskId, def.agent_id);
+    def.task = premiseResult.annotatedTask;
+    if (premiseResult.signals.length > 0) {
+      emitConsensusSignals(process.cwd(), premiseResult.signals);
+    }
+
     ctx.nativeTaskMap.set(taskId, { agentId: def.agent_id, task: def.task, startedAt: Date.now(), timeoutMs: NATIVE_TASK_TTL_MS, relayToken });
     spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
     try { ctx.mainAgent.recordNativeTask(taskId, def.agent_id, def.task); } catch { /* best-effort */ }

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -171,6 +171,13 @@ export interface ConsensusSignal {
     | 'confirmed_hallucination'
     | 'orchestrator_disputed'
     | 'premise_mismatch';
+  /**
+   * Modality of the claim that produced this signal, from Stage 2
+   * premise-verification. Absent on legacy / non-premise signals — scored
+   * as `'asserted'` for back-compat. See
+   * `docs/specs/2026-04-22-premise-verification-stage-2.md` §Signal integration.
+   */
+  modality?: 'asserted' | 'hedged' | 'vague';
   category?: string;
   findingId?: string;
   severity?: 'critical' | 'high' | 'medium' | 'low';

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -658,11 +658,24 @@ export class PerformanceReader {
           break;
         }
         case 'hallucination_caught': {
-          const severity = (
+          // Base 3.0× for citation/hallucination outcomes. Stage 2
+          // premise-verification scales ONLY the `premise_mismatch` arm by
+          // `signal.modality` — hedged/vague claims carry less penalty than
+          // asserted ones. Missing modality defaults to 'asserted' (strictest
+          // path / back-compat for pre-Stage-2 signals).
+          // Spec: docs/specs/2026-04-22-premise-verification-stage-2.md §Signal integration.
+          let severity: number;
+          if (signal.outcome === 'premise_mismatch') {
+            const modality = signal.modality ?? 'asserted';
+            severity = modality === 'hedged' ? 1.5 : modality === 'vague' ? 1.0 : 3.0;
+          } else if (
             signal.outcome === 'fabricated_citation' ||
-            signal.outcome === 'confirmed_hallucination' ||
-            signal.outcome === 'premise_mismatch'
-          ) ? 3.0 : 1.0;
+            signal.outcome === 'confirmed_hallucination'
+          ) {
+            severity = 3.0;
+          } else {
+            severity = 1.0;
+          }
           // Use a dedicated (shorter) half-life for the hallucination counter so
           // past mistakes can be outrun by recent good behavior. `weightedTotal`
           // keeps the original DECAY_HALF_LIFE so the denominator that defines

--- a/tests/cli/dispatch-native-prompt.test.ts
+++ b/tests/cli/dispatch-native-prompt.test.ts
@@ -13,9 +13,19 @@
  * output so a future drift is caught in CI.
  */
 
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { execSync } from 'child_process';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+
+// Stage 2 premise-verification tests rely on `rg` being on PATH; gate the
+// whole block when it is not available so CI without ripgrep still passes.
+let rgAvailable = true;
+try {
+  execSync('which rg', { stdio: 'ignore' });
+} catch {
+  rgAvailable = false;
+}
 
 import { ctx } from '../../apps/cli/src/mcp-context';
 import {
@@ -442,3 +452,325 @@ describe('native dispatch — premise verification (Component B)', () => {
     expect(dispatched.task ?? '').not.toContain('═══ UNVERIFIED CLAIM DETECTED ═══');
   });
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// Stage 2 premise-verification — structured ```premise-claims block wire-up.
+//
+// Spec: docs/specs/2026-04-22-premise-verification-stage-2.md §Wire-up.
+// Covers: parse+verify+annotate, all-verified clean path, malformed JSON
+// schema-lint, SCOPE > UNVERIFIED > PREMISE-MISMATCH ordering, relay skip,
+// Stage 1 regex co-existence.
+// ────────────────────────────────────────────────────────────────────────────
+
+function buildClaimsBlock(
+  claims: Record<string, unknown>[],
+): string {
+  const payload = {
+    schema_version: '1',
+    verifier: 'orchestrator',
+    claims,
+  };
+  return '```premise-claims\n' + JSON.stringify(payload, null, 2) + '\n```';
+}
+
+(rgAvailable ? describe : describe.skip)(
+  'native dispatch — Stage 2 premise-verification (structured claims)',
+  () => {
+    let sandboxDir: string;
+    let prevCwd: string;
+
+    beforeEach(() => {
+      prevCwd = process.cwd();
+      sandboxDir = mkdtempSync(join(tmpdir(), 'gossip-premise-stage2-'));
+      mkdirSync(join(sandboxDir, '.gossip', 'skills'), { recursive: true });
+      mkdirSync(join(sandboxDir, 'src'), { recursive: true });
+      // Fixture source: `alpha` appears once in target.ts (for falsified=expected-5 path
+      // and verified=expected-1 path).
+      writeFileSync(
+        join(sandboxDir, 'src', 'target.ts'),
+        "export function alpha(): void { /* single definition of alpha */ }\n",
+      );
+      process.chdir(sandboxDir);
+      resetCtx();
+    });
+
+    afterEach(() => {
+      restoreCtx();
+      process.chdir(prevCwd);
+      rmSync(sandboxDir, { recursive: true, force: true });
+    });
+
+    it('parses + verifies a claim block and prepends PREMISE-MISMATCH on falsified', async () => {
+      ctx.nativeAgentConfigs.set('opus-implementer', {
+        model: 'claude-opus-4-7',
+        instructions: 'You implement.',
+        description: 'Native implementer',
+        skills: [],
+      });
+      const block = buildClaimsBlock([
+        {
+          type: 'callsite_count',
+          symbol: 'alpha',
+          scope: 'src/target.ts',
+          expected: 5,
+          modality: 'asserted',
+        },
+      ]);
+      const task = `Patch the five alpha sites.\n\n${block}`;
+
+      const result = await handleDispatchSingle('opus-implementer', task);
+      const prompt = extractAgentPrompt(result.content);
+
+      expect(prompt).toContain('⚠ PREMISE-MISMATCH');
+      expect(prompt).toMatch(/observed 1/);
+      expect(prompt).toMatch(/modality=asserted/);
+    });
+
+    it('does NOT prepend PREMISE-MISMATCH when all claims verify', async () => {
+      ctx.nativeAgentConfigs.set('opus-implementer', {
+        model: 'claude-opus-4-7',
+        instructions: 'You implement.',
+        description: 'Native implementer',
+        skills: [],
+      });
+      const block = buildClaimsBlock([
+        {
+          type: 'callsite_count',
+          symbol: 'alpha',
+          scope: 'src/target.ts',
+          expected: 1, // matches fixture
+          modality: 'asserted',
+        },
+      ]);
+      const task = `Patch the one alpha site.\n\n${block}`;
+
+      const result = await handleDispatchSingle('opus-implementer', task);
+      const prompt = extractAgentPrompt(result.content);
+
+      expect(prompt).not.toContain('⚠ PREMISE-MISMATCH');
+    });
+
+    it('falls back to prose path with schema-lint warning on malformed JSON', async () => {
+      ctx.nativeAgentConfigs.set('opus-implementer', {
+        model: 'claude-opus-4-7',
+        instructions: 'You implement.',
+        description: 'Native implementer',
+        skills: [],
+      });
+      // Intentionally malformed — truncated JSON inside the fence.
+      const task =
+        'Something about 3 callers of alpha.\n\n' +
+        '```premise-claims\n{"schema_version": "1", "claims": [\n```\n';
+
+      const result = await handleDispatchSingle('opus-implementer', task);
+      const prompt = extractAgentPrompt(result.content);
+
+      expect(prompt).toContain('⚠ premise-claims block failed schema validation');
+      // Prose path still runs — the rest of the task text is preserved.
+      expect(prompt).toContain('Something about 3 callers of alpha.');
+      // And no PREMISE-MISMATCH is emitted (we never got a valid block to verify).
+      expect(prompt).not.toContain('⚠ PREMISE-MISMATCH');
+    });
+
+    it('preserves ordering SCOPE > UNVERIFIED > PREMISE-MISMATCH when all three fire', async () => {
+      ctx.nativeAgentConfigs.set('opus-implementer', {
+        model: 'claude-opus-4-7',
+        instructions: 'You implement.',
+        description: 'Native implementer',
+        skills: [],
+      });
+      const block = buildClaimsBlock([
+        {
+          type: 'callsite_count',
+          symbol: 'alpha',
+          scope: 'src/target.ts',
+          expected: 5,
+          modality: 'asserted',
+        },
+      ]);
+      // Absolute project path triggers sanitization + SCOPE NOTE.
+      // "we identified 5 sites" triggers Stage 1 UNVERIFIED regex.
+      // The premise-claims block (expected 5, observed 1) triggers PREMISE-MISMATCH.
+      const task = `Edit ${process.cwd()}/src/target.ts — we identified 5 sites that lack alpha.\n\n${block}`;
+
+      const result = await handleDispatchSingle('opus-implementer', task, 'scoped', './src');
+      const prompt = extractAgentPrompt(result.content);
+
+      const scopeIdx = prompt.indexOf('SCOPE NOTE:');
+      const unverifiedIdx = prompt.indexOf('═══ UNVERIFIED CLAIM DETECTED ═══');
+      const premiseIdx = prompt.indexOf('⚠ PREMISE-MISMATCH');
+
+      expect(scopeIdx).toBeGreaterThan(-1);
+      expect(unverifiedIdx).toBeGreaterThan(-1);
+      expect(premiseIdx).toBeGreaterThan(-1);
+      expect(scopeIdx).toBeLessThan(unverifiedIdx);
+      expect(unverifiedIdx).toBeLessThan(premiseIdx);
+    });
+
+    it('relay-path dispatch does NOT run the verifier (load-bearing, mirrors Stage 1)', async () => {
+      // No nativeAgentConfig → handleDispatchSingle takes the relay branch.
+      // Stage 2 verifier runs only inside the native branch; the relay worker
+      // path is deferred to Stage 2a per spec §Open questions #2.
+      const dispatched: { task?: string } = {};
+      ctx.mainAgent = makeMainAgent({
+        dispatch: jest.fn((_agentId: string, task: string) => {
+          dispatched.task = task;
+          return { taskId: 'relay-task-xyz' };
+        }),
+      });
+      const block = buildClaimsBlock([
+        {
+          type: 'callsite_count',
+          symbol: 'alpha',
+          scope: 'src/target.ts',
+          expected: 99,
+          modality: 'asserted',
+        },
+      ]);
+      const task = `Relay task with falsifiable claims.\n\n${block}`;
+
+      const result = await handleDispatchSingle('relay-impl', task);
+
+      // No AGENT_PROMPT content item for relay path.
+      const promptItem = result.content.find(c => c.text.startsWith('AGENT_PROMPT:'));
+      expect(promptItem).toBeUndefined();
+      // And the task handed to the relay MUST NOT have been wrapped with the
+      // PREMISE-MISMATCH preamble — the verifier stayed quiet on this branch.
+      expect(dispatched.task ?? '').not.toContain('⚠ PREMISE-MISMATCH');
+      // The premise-verification log should not exist (no JSONL row emitted
+      // from the relay branch).
+      expect(existsSync(join(process.cwd(), '.gossip', 'premise-verification.jsonl'))).toBe(false);
+    });
+
+    it('co-exists with Stage 1 regex during Phase 0 (both fire in the same dispatch)', async () => {
+      ctx.nativeAgentConfigs.set('opus-implementer', {
+        model: 'claude-opus-4-7',
+        instructions: 'You implement.',
+        description: 'Native implementer',
+        skills: [],
+      });
+      const block = buildClaimsBlock([
+        {
+          type: 'callsite_count',
+          symbol: 'alpha',
+          scope: 'src/target.ts',
+          expected: 7,
+          modality: 'hedged',
+        },
+      ]);
+      const task =
+        'We identified 5 sites that lack the helper — fix each.\n\n' + block;
+
+      const result = await handleDispatchSingle('opus-implementer', task);
+      const prompt = extractAgentPrompt(result.content);
+
+      // Stage 1 regex fires on the prose "5 sites" claim.
+      expect(prompt).toContain('═══ UNVERIFIED CLAIM DETECTED ═══');
+      // Stage 2 verifier fires on the structured claim (expected 7 vs observed 1).
+      expect(prompt).toContain('⚠ PREMISE-MISMATCH');
+      // Modality is propagated through the annotation.
+      expect(prompt).toMatch(/modality=hedged/);
+    });
+  },
+);
+
+// ────────────────────────────────────────────────────────────────────────────
+// Stage 2 — .gossip/premise-verification.jsonl logging + rotation.
+// ────────────────────────────────────────────────────────────────────────────
+
+(rgAvailable ? describe : describe.skip)(
+  'native dispatch — premise-verification.jsonl log + rotation',
+  () => {
+    let sandboxDir: string;
+    let prevCwd: string;
+
+    beforeEach(() => {
+      prevCwd = process.cwd();
+      sandboxDir = mkdtempSync(join(tmpdir(), 'gossip-premise-jsonl-'));
+      mkdirSync(join(sandboxDir, '.gossip', 'skills'), { recursive: true });
+      mkdirSync(join(sandboxDir, 'src'), { recursive: true });
+      writeFileSync(
+        join(sandboxDir, 'src', 'target.ts'),
+        "export function alpha(): void {}\n",
+      );
+      process.chdir(sandboxDir);
+      resetCtx();
+    });
+
+    afterEach(() => {
+      restoreCtx();
+      process.chdir(prevCwd);
+      rmSync(sandboxDir, { recursive: true, force: true });
+    });
+
+    it('writes a JSONL row to .gossip/premise-verification.jsonl on claim-bearing dispatch', async () => {
+      ctx.nativeAgentConfigs.set('opus-implementer', {
+        model: 'claude-opus-4-7',
+        instructions: 'You implement.',
+        description: 'Native implementer',
+        skills: [],
+      });
+      const block = buildClaimsBlock([
+        {
+          type: 'callsite_count',
+          symbol: 'alpha',
+          scope: 'src/target.ts',
+          expected: 1,
+          modality: 'asserted',
+        },
+      ]);
+      const task = `Verify alpha.\n\n${block}`;
+
+      await handleDispatchSingle('opus-implementer', task);
+
+      const logPath = join(process.cwd(), '.gossip', 'premise-verification.jsonl');
+      expect(existsSync(logPath)).toBe(true);
+      const lines = readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean);
+      expect(lines.length).toBeGreaterThanOrEqual(1);
+      const row = JSON.parse(lines[lines.length - 1]);
+      expect(row.claims_total).toBe(1);
+      expect(row.claims_verified).toBe(1);
+      expect(row.claims_falsified).toBe(0);
+      expect(row.task_id).toMatch(/^[a-f0-9-]+$/i);
+      expect(row).toHaveProperty('ts');
+      expect(row).toHaveProperty('had_stage1_annotation');
+      expect(row).toHaveProperty('timeout_fraction');
+    });
+
+    it('rotates the log file when size exceeds MAX_PREMISE_VERIFICATION_BYTES', async () => {
+      // Import the constant by reading from sandbox.ts — we don't inline 5MB
+      // because the assertion only cares about the rotate-before-append
+      // behavior. Pre-seed a 5.1MB file so the next append triggers rotation.
+      const { MAX_PREMISE_VERIFICATION_BYTES } = await import('../../apps/cli/src/sandbox');
+      const logPath = join(process.cwd(), '.gossip', 'premise-verification.jsonl');
+      mkdirSync(join(process.cwd(), '.gossip'), { recursive: true });
+      const padding = 'x'.repeat(1024);
+      const lines = Math.ceil((MAX_PREMISE_VERIFICATION_BYTES + 1024) / padding.length);
+      writeFileSync(logPath, padding.repeat(lines) + '\n');
+
+      ctx.nativeAgentConfigs.set('opus-implementer', {
+        model: 'claude-opus-4-7',
+        instructions: 'You implement.',
+        description: 'Native implementer',
+        skills: [],
+      });
+      const block = buildClaimsBlock([
+        {
+          type: 'callsite_count',
+          symbol: 'alpha',
+          scope: 'src/target.ts',
+          expected: 1,
+          modality: 'asserted',
+        },
+      ]);
+      await handleDispatchSingle('opus-implementer', `Verify alpha.\n\n${block}`);
+
+      // Rotation renames the oversized file to <path>.1 and starts a fresh slot.
+      expect(existsSync(logPath + '.1')).toBe(true);
+      // The fresh slot holds the new row only (not the 5MB padding).
+      const freshContent = readFileSync(logPath, 'utf8');
+      expect(freshContent.length).toBeLessThan(MAX_PREMISE_VERIFICATION_BYTES / 2);
+      expect(freshContent.split('\n').filter(Boolean).length).toBeGreaterThanOrEqual(1);
+    });
+  },
+);

--- a/tests/orchestrator/signal-modality.test.ts
+++ b/tests/orchestrator/signal-modality.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Stage 2 premise-verification — modality-scaled hallucination multiplier.
+ *
+ * Confirms that `signal.modality` on a `hallucination_caught` with
+ * `outcome: 'premise_mismatch'` scales the penalty baked into
+ * `weightedHallucinations`:
+ *   - asserted (or missing) → 3.0×
+ *   - hedged              → 1.5×
+ *   - vague               → 1.0×
+ *
+ * `fabricated_citation` and `confirmed_hallucination` stay at flat 3.0×
+ * regardless of modality — Stage 2 explicitly only scales `premise_mismatch`.
+ *
+ * The reader exposes `weightedHallucinations` on the score row, so we assert
+ * on that field directly rather than back-deriving from `accuracy`.
+ *
+ * Spec: docs/specs/2026-04-22-premise-verification-stage-2.md §Signal integration.
+ */
+
+import { writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { PerformanceReader } from '../../packages/orchestrator/src/performance-reader';
+
+const TMP = join(__dirname, '..', '..', '.test-tmp-signal-modality');
+
+function writeSignals(signals: object[]): void {
+  mkdirSync(join(TMP, '.gossip'), { recursive: true });
+  writeFileSync(
+    join(TMP, '.gossip', 'agent-performance.jsonl'),
+    signals.map(s => JSON.stringify(s)).join('\n'),
+  );
+}
+
+function premiseMismatch(
+  agentId: string,
+  modality: 'asserted' | 'hedged' | 'vague' | undefined,
+) {
+  const base: Record<string, unknown> = {
+    type: 'consensus',
+    taskId: `task-${agentId}`,
+    signal: 'hallucination_caught',
+    outcome: 'premise_mismatch',
+    agentId,
+    evidence: 'premise mismatch test',
+    timestamp: new Date().toISOString(),
+  };
+  if (modality !== undefined) base.modality = modality;
+  return base;
+}
+
+afterEach(() => {
+  try { rmSync(TMP, { recursive: true }); } catch { /* noop */ }
+});
+
+describe('hallucination_caught — modality-scaled multiplier (Stage 2)', () => {
+  test('premise_mismatch + modality=asserted → 3.0× (base)', () => {
+    writeSignals([premiseMismatch('a-asserted', 'asserted')]);
+    const reader = new PerformanceReader(TMP);
+    const score = reader.getScores().get('a-asserted')!;
+    // HALLUCINATION_DECAY_HALF_LIFE applies — with a single signal and
+    // tasksSince = 0 at the trailing edge, the decay factor is 1.0 and
+    // weightedHallucinations equals the raw multiplier.
+    expect(score.weightedHallucinations).toBeCloseTo(3.0, 5);
+  });
+
+  test('premise_mismatch + modality=hedged → 1.5×', () => {
+    writeSignals([premiseMismatch('a-hedged', 'hedged')]);
+    const reader = new PerformanceReader(TMP);
+    const score = reader.getScores().get('a-hedged')!;
+    expect(score.weightedHallucinations).toBeCloseTo(1.5, 5);
+  });
+
+  test('premise_mismatch + modality=vague → 1.0×', () => {
+    writeSignals([premiseMismatch('a-vague', 'vague')]);
+    const reader = new PerformanceReader(TMP);
+    const score = reader.getScores().get('a-vague')!;
+    expect(score.weightedHallucinations).toBeCloseTo(1.0, 5);
+  });
+
+  test('premise_mismatch + missing modality → 3.0× (back-compat fallback to asserted)', () => {
+    writeSignals([premiseMismatch('a-missing', undefined)]);
+    const reader = new PerformanceReader(TMP);
+    const score = reader.getScores().get('a-missing')!;
+    // Pre-Stage-2 signals have no modality field; strictest path preserves the
+    // 3.0× penalty the Stage 1 ship already applied, so old data keeps scoring
+    // identically.
+    expect(score.weightedHallucinations).toBeCloseTo(3.0, 5);
+  });
+
+  test('fabricated_citation stays flat 3.0× even with modality set', () => {
+    // Stage 2 only scales the premise_mismatch arm — modality on a
+    // fabricated_citation signal is ignored for scaling (forward-compat, not
+    // semantically meaningful yet).
+    writeSignals([
+      {
+        type: 'consensus',
+        taskId: 'task-fab',
+        signal: 'hallucination_caught',
+        outcome: 'fabricated_citation',
+        agentId: 'a-fab',
+        modality: 'hedged', // should be ignored for scaling
+        evidence: 'fab test',
+        timestamp: new Date().toISOString(),
+      },
+    ]);
+    const reader = new PerformanceReader(TMP);
+    const score = reader.getScores().get('a-fab')!;
+    expect(score.weightedHallucinations).toBeCloseTo(3.0, 5);
+  });
+});


### PR DESCRIPTION
## Summary

**Stage 2 PR C** of premise-verification. Depends on [PR #241](https://github.com/gossipcat-ai/gossipcat-ai/pull/241) (PR A, merged). Atomic with [PR #242](https://github.com/gossipcat-ai/gossipcat-ai/pull/242) (PR B) — merge together.

Wires the claim-verifier from PR A into the dispatch boundary, logs per-dispatch claim outcomes to `.gossip/premise-verification.jsonl` (with 5 MB single-slot rotation), extends the signal schema with a `modality?` field, and applies modality-scaled multipliers to the `premise_mismatch` outcome.

## What ships

- **`packages/orchestrator/src/consensus-types.ts`** — adds `modality?: 'asserted' | 'hedged' | 'vague'` to `ConsensusSignal`. Optional; absent signals score as `asserted` (3.0×) for back-compat.
- **`packages/orchestrator/src/performance-reader.ts`** (+21 LOC) — `premise_mismatch` outcome now scales by `signal.modality`: asserted/missing → 3.0×, hedged → 1.5×, vague → 1.0×. `fabricated_citation` and `confirmed_hallucination` stay flat 3.0× unchanged.
- **`apps/cli/src/handlers/dispatch.ts`** (+273 LOC) — new `maybeVerifyPremiseClaims(task, projectRoot, taskId, agentId)` helper, wired into `handleDispatchSingle`, `handleDispatchParallel`, `handleDispatchConsensus`. Extracts fenced \\`premise-claims\\` block, calls `parseClaimBlock` + `verifyClaims` (from PR A), prepends `⚠ PREMISE-MISMATCH` on falsified claims, logs JSONL row via `rotateIfNeeded(logPath, MAX_PREMISE_VERIFICATION_BYTES)` + `appendFileSync`, and emits `hallucination_caught:premise_mismatch` signals with propagated modality. Relay path naturally skipped (helper only runs inside native-config branch).
- **`tests/orchestrator/signal-modality.test.ts`** (new, 110 LOC) — 5 tests covering the modality multiplier matrix.
- **`tests/cli/dispatch-native-prompt.test.ts`** (+334 LOC / 8 new tests) — rg-gated, matches PR A's claim-verifier.test.ts precedent.

## Test plan

- [x] `tsc --noEmit` clean on all 5 changed files.
- [x] `tests/orchestrator/signal-modality.test.ts` — 5/5 pass (no rg dependency):
  - `premise_mismatch` + `modality: asserted` → 3.0×
  - `premise_mismatch` + `modality: hedged` → 1.5×
  - `premise_mismatch` + `modality: vague` → 1.0×
  - `premise_mismatch` + missing modality → 3.0× (back-compat)
  - `fabricated_citation` → flat 3.0× unchanged
- [x] `tests/cli/dispatch-native-prompt.test.ts` — 13 pass + 8 rg-skipped locally; will run in CI:
  - Claim block parsed + verified + annotation on falsified
  - All-verified block → no PREMISE-MISMATCH annotation
  - Malformed JSON → schema-lint warning, prose path runs
  - Ordering: SCOPE > UNVERIFIED > PREMISE-MISMATCH when all fire
  - Relay-path does NOT run verifier
  - Co-existence with Stage 1 regex (both fire in Phase 0)
  - JSONL row written on claim-bearing dispatch
  - Rotation fires when file exceeds MAX_PREMISE_VERIFICATION_BYTES
- [x] Full suite: 187 suites / 2490 passing / 25 skipped. No regressions.

## Design notes

- **PREMISE-MISMATCH note is prepended to the task string**, not the assembled prompt. Spec-mandated ordering (SCOPE > UNVERIFIED > PREMISE-MISMATCH) holds because SCOPE/UNVERIFIED prepend to the outer assembled prompt while PREMISE-MISMATCH rides with the task payload (inner layer, rendered after outer prefixes).
- **Relay-path skip is natural**, not a separate branch — `maybeVerifyPremiseClaims` only runs inside the `nativeConfig` branch of the dispatch handlers.
- **Schema-lint warnings** from `parseClaimBlock` (e.g. `missing_modality`) are surfaced in the JSONL `schema_lint` field per spec §Modality field. Malformed-JSON and empty-claims dispatches also log a row so the Phase-1 dogfood gate captures every claim-bearing dispatch.

## Merge order

**Atomic with PR #242 (PR B)**. Do not merge this without PR B also being green — PR C's wire-up calls `parseClaimBlock` from PR A (already merged) and processes blocks emitted by PR B's skill. Merging C without B = verifier runs but no skill tells agents to emit blocks. Merging B without C = emit-without-verifier (the loophole consensus flagged).

## Consensus refs

Spec §Wire-up + §Signal integration + §Measurement. Driven by consensus findings `76b36ecd-722c4ed4:sonnet-reviewer:f9` (signal schema modality), `:f13` (PR-order), `:haiku-researcher:f15` (rotation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)