### PR TITLE
fix(premise): harden claim-verifier path resolution and input bounds

### DIFF
--- a/packages/orchestrator/src/claim-types.ts
+++ b/packages/orchestrator/src/claim-types.ts
@@ -99,6 +99,13 @@ export interface ParseClaimBlockResult {
 const VALID_MODALITIES: Modality[] = ['asserted', 'hedged', 'vague'];
 const VALID_RELATIONS: Relation[] = ['>', '<', '=', '≥', '≤'];
 const MAX_CONTEXT_CHARS = 120;
+/** Upper bound for symbol / scope / expected_symbol regex inputs. Prevents
+ *  megabyte-long pathological regexes from burning CPU before the 500ms
+ *  verifier wallclock fires. */
+export const MAX_CLAIM_STRING_CHARS = 256;
+/** Upper bound for file_line path strings. Paths can reasonably be longer
+ *  than a symbol, but still bounded. */
+export const MAX_PATH_CHARS = 1024;
 
 function isObject(x: unknown): x is Record<string, unknown> {
   return typeof x === 'object' && x !== null && !Array.isArray(x);
@@ -135,8 +142,16 @@ function validateClaim(raw: unknown, idx: number, errors: ParseError[]): Claim |
         errors.push({ claim_index: idx, message: 'callsite_count: symbol must be non-empty string' });
         return null;
       }
+      if (raw.symbol.length > MAX_CLAIM_STRING_CHARS) {
+        errors.push({ claim_index: idx, message: `callsite_count: symbol_too_long (max ${MAX_CLAIM_STRING_CHARS})` });
+        return null;
+      }
       if (typeof raw.scope !== 'string' || raw.scope.length === 0) {
         errors.push({ claim_index: idx, message: 'callsite_count: scope must be non-empty string' });
+        return null;
+      }
+      if (raw.scope.length > MAX_CLAIM_STRING_CHARS) {
+        errors.push({ claim_index: idx, message: `callsite_count: scope_too_long (max ${MAX_CLAIM_STRING_CHARS})` });
         return null;
       }
       if (typeof raw.expected !== 'number' || !Number.isInteger(raw.expected)) {
@@ -170,12 +185,20 @@ function validateClaim(raw: unknown, idx: number, errors: ParseError[]): Claim |
         errors.push({ claim_index: idx, message: 'file_line: path must be non-empty string' });
         return null;
       }
+      if (raw.path.length > MAX_PATH_CHARS) {
+        errors.push({ claim_index: idx, message: `file_line: path_too_long (max ${MAX_PATH_CHARS})` });
+        return null;
+      }
       if (typeof raw.line !== 'number' || !Number.isInteger(raw.line) || raw.line < 1) {
         errors.push({ claim_index: idx, message: 'file_line: line must be positive integer' });
         return null;
       }
       if (typeof raw.expected_symbol !== 'string' || raw.expected_symbol.length === 0) {
         errors.push({ claim_index: idx, message: 'file_line: expected_symbol must be non-empty string' });
+        return null;
+      }
+      if (raw.expected_symbol.length > MAX_CLAIM_STRING_CHARS) {
+        errors.push({ claim_index: idx, message: `file_line: expected_symbol_too_long (max ${MAX_CLAIM_STRING_CHARS})` });
         return null;
       }
       const out: FileLineClaim = {
@@ -193,8 +216,16 @@ function validateClaim(raw: unknown, idx: number, errors: ParseError[]): Claim |
         errors.push({ claim_index: idx, message: 'absence_of_symbol: symbol must be non-empty string' });
         return null;
       }
+      if (raw.symbol.length > MAX_CLAIM_STRING_CHARS) {
+        errors.push({ claim_index: idx, message: `absence_of_symbol: symbol_too_long (max ${MAX_CLAIM_STRING_CHARS})` });
+        return null;
+      }
       if (typeof raw.scope !== 'string' || raw.scope.length === 0) {
         errors.push({ claim_index: idx, message: 'absence_of_symbol: scope must be non-empty string' });
+        return null;
+      }
+      if (raw.scope.length > MAX_CLAIM_STRING_CHARS) {
+        errors.push({ claim_index: idx, message: `absence_of_symbol: scope_too_long (max ${MAX_CLAIM_STRING_CHARS})` });
         return null;
       }
       if (typeof raw.context !== 'string') {
@@ -225,8 +256,16 @@ function validateClaim(raw: unknown, idx: number, errors: ParseError[]): Claim |
         errors.push({ claim_index: idx, message: 'presence_of_symbol: symbol must be non-empty string' });
         return null;
       }
+      if (raw.symbol.length > MAX_CLAIM_STRING_CHARS) {
+        errors.push({ claim_index: idx, message: `presence_of_symbol: symbol_too_long (max ${MAX_CLAIM_STRING_CHARS})` });
+        return null;
+      }
       if (typeof raw.scope !== 'string' || raw.scope.length === 0) {
         errors.push({ claim_index: idx, message: 'presence_of_symbol: scope must be non-empty string' });
+        return null;
+      }
+      if (raw.scope.length > MAX_CLAIM_STRING_CHARS) {
+        errors.push({ claim_index: idx, message: `presence_of_symbol: scope_too_long (max ${MAX_CLAIM_STRING_CHARS})` });
         return null;
       }
       const out: PresenceOfSymbolClaim = {
@@ -243,8 +282,16 @@ function validateClaim(raw: unknown, idx: number, errors: ParseError[]): Claim |
         errors.push({ claim_index: idx, message: 'count_relation: symbol must be non-empty string' });
         return null;
       }
+      if (raw.symbol.length > MAX_CLAIM_STRING_CHARS) {
+        errors.push({ claim_index: idx, message: `count_relation: symbol_too_long (max ${MAX_CLAIM_STRING_CHARS})` });
+        return null;
+      }
       if (typeof raw.scope !== 'string' || raw.scope.length === 0) {
         errors.push({ claim_index: idx, message: 'count_relation: scope must be non-empty string' });
+        return null;
+      }
+      if (raw.scope.length > MAX_CLAIM_STRING_CHARS) {
+        errors.push({ claim_index: idx, message: `count_relation: scope_too_long (max ${MAX_CLAIM_STRING_CHARS})` });
         return null;
       }
       if (typeof raw.relation !== 'string' || !(VALID_RELATIONS as string[]).includes(raw.relation)) {

--- a/packages/orchestrator/src/claim-verifier.ts
+++ b/packages/orchestrator/src/claim-verifier.ts
@@ -17,8 +17,8 @@
  */
 
 import { spawn } from 'child_process';
-import { existsSync, readFileSync, statSync } from 'fs';
-import { resolve } from 'path';
+import { existsSync, readFileSync, realpathSync, statSync } from 'fs';
+import { resolve, sep } from 'path';
 import type {
   AbsenceOfSymbolClaim,
   CallsiteCountClaim,
@@ -34,6 +34,55 @@ import type {
 
 export const MAX_CLAIMS_PER_BLOCK = 16;
 export const PER_BLOCK_DEADLINE_MS = 500;
+
+/**
+ * Containment helper: resolve `input` against `projectRoot` and ensure the final
+ * path stays inside `projectRoot`. Protects against two attack vectors:
+ *
+ *  1. Absolute paths — `path.resolve(root, '/etc/shadow')` returns `/etc/shadow`
+ *     because an absolute second arg discards the first.
+ *  2. `../..` escape — `path.resolve(root, '../../etc')` escapes above root.
+ *  3. Symlink escape — an in-tree symlink that points outside the tree is
+ *     detected via `fs.realpathSync`.
+ *
+ * Returns the resolved absolute path on success, or `null` on containment
+ * violation. Callers must map `null` to `missing_path` / `file_not_found`
+ * WITHOUT leaking the attempted input in the reason field.
+ */
+function containWithinProject(projectRoot: string, input: string): string | null {
+  let resolved: string;
+  try {
+    resolved = resolve(projectRoot, input);
+  } catch {
+    return null;
+  }
+  // If the path exists on disk, collapse symlinks to detect escape via link.
+  // If it doesn't exist yet (caller will then emit file_not_found), fall back
+  // to the lexical resolve.
+  let finalPath = resolved;
+  try {
+    if (existsSync(resolved)) {
+      finalPath = realpathSync(resolved);
+    }
+  } catch {
+    // realpath failure — treat as containment failure, safer than permitting.
+    return null;
+  }
+  // Also collapse symlinks inside the root itself (e.g. macOS /var -> /private/var)
+  // so the prefix comparison works.
+  let rootReal = projectRoot;
+  try {
+    if (existsSync(projectRoot)) {
+      rootReal = realpathSync(projectRoot);
+    }
+  } catch {
+    // If we can't resolve root, bail — nothing is safe.
+    return null;
+  }
+  if (finalPath === rootReal) return finalPath;
+  if (finalPath.startsWith(rootReal + sep)) return finalPath;
+  return null;
+}
 
 interface RgResult {
   /** Sum of per-file match counts. 0 if no hits. */
@@ -68,8 +117,8 @@ function runRg(
       resolvePromise({ total: 0, error: 'timeout' });
       return;
     }
-    const scopePath = resolve(projectRoot, scope);
-    if (!existsSync(scopePath)) {
+    const scopePath = containWithinProject(projectRoot, scope);
+    if (scopePath === null || !existsSync(scopePath)) {
       resolvePromise({ total: 0, error: 'missing_path' });
       return;
     }
@@ -190,9 +239,9 @@ async function verifyFileLine(
   projectRoot: string,
 ): Promise<ClaimVerdict> {
   const modality = getModality(claim);
-  const filePath = resolve(projectRoot, claim.path);
+  const filePath = containWithinProject(projectRoot, claim.path);
 
-  if (!existsSync(filePath)) {
+  if (filePath === null || !existsSync(filePath)) {
     return { claim_index: idx, status: 'unverifiable_by_grep', reason: 'file_not_found' };
   }
   let st;

--- a/tests/orchestrator/claim-types.test.ts
+++ b/tests/orchestrator/claim-types.test.ts
@@ -1,4 +1,8 @@
-import { parseClaimBlock } from '../../packages/orchestrator/src/claim-types';
+import {
+  MAX_CLAIM_STRING_CHARS,
+  MAX_PATH_CHARS,
+  parseClaimBlock,
+} from '../../packages/orchestrator/src/claim-types';
 
 describe('parseClaimBlock — fail-soft parser', () => {
   it('accepts a valid block with all five claim types', () => {
@@ -108,6 +112,62 @@ describe('parseClaimBlock — fail-soft parser', () => {
     const { block, errors } = parseClaimBlock(raw);
     expect(block!.claims).toHaveLength(2);
     expect(errors.some((e) => e.claim_index === 1)).toBe(true);
+  });
+
+  it('rejects symbol longer than MAX_CLAIM_STRING_CHARS (256) — schema-lint, skipped', () => {
+    const longSymbol = 'a'.repeat(MAX_CLAIM_STRING_CHARS + 1);
+    const raw = JSON.stringify({
+      schema_version: '1',
+      verifier: 'orchestrator',
+      claims: [
+        { type: 'presence_of_symbol', symbol: longSymbol, scope: 'src', modality: 'asserted' },
+      ],
+    });
+    const { block, errors } = parseClaimBlock(raw);
+    expect(block!.claims).toHaveLength(0);
+    expect(errors.some((e) => /symbol_too_long/.test(e.message))).toBe(true);
+  });
+
+  it('rejects file_line path longer than MAX_PATH_CHARS (1024) — schema-lint, skipped', () => {
+    const longPath = 'a/'.repeat(MAX_PATH_CHARS); // length ≫ 1024
+    const raw = JSON.stringify({
+      schema_version: '1',
+      verifier: 'orchestrator',
+      claims: [
+        { type: 'file_line', path: longPath, line: 1, expected_symbol: 'x', modality: 'asserted' },
+      ],
+    });
+    const { block, errors } = parseClaimBlock(raw);
+    expect(block!.claims).toHaveLength(0);
+    expect(errors.some((e) => /path_too_long/.test(e.message))).toBe(true);
+  });
+
+  it('rejects over-long scope across all grep-using claim types', () => {
+    const longScope = 's'.repeat(MAX_CLAIM_STRING_CHARS + 1);
+    for (const type of ['callsite_count', 'absence_of_symbol', 'presence_of_symbol', 'count_relation']) {
+      const claim: Record<string, unknown> = { type, symbol: 'foo', scope: longScope, modality: 'asserted' };
+      if (type === 'callsite_count') claim.expected = 1;
+      if (type === 'count_relation') { claim.relation = '>'; claim.value = 0; }
+      if (type === 'absence_of_symbol') claim.context = 'ctx';
+      const raw = JSON.stringify({ schema_version: '1', verifier: 'orchestrator', claims: [claim] });
+      const { block, errors } = parseClaimBlock(raw);
+      expect(block!.claims).toHaveLength(0);
+      expect(errors.some((e) => /scope_too_long/.test(e.message))).toBe(true);
+    }
+  });
+
+  it('rejects over-long file_line expected_symbol', () => {
+    const longSym = 'x'.repeat(MAX_CLAIM_STRING_CHARS + 1);
+    const raw = JSON.stringify({
+      schema_version: '1',
+      verifier: 'orchestrator',
+      claims: [
+        { type: 'file_line', path: 'src/a.ts', line: 1, expected_symbol: longSym, modality: 'asserted' },
+      ],
+    });
+    const { block, errors } = parseClaimBlock(raw);
+    expect(block!.claims).toHaveLength(0);
+    expect(errors.some((e) => /expected_symbol_too_long/.test(e.message))).toBe(true);
   });
 
   it('accepts an empty claims array', () => {

--- a/tests/orchestrator/claim-verifier.test.ts
+++ b/tests/orchestrator/claim-verifier.test.ts
@@ -1,5 +1,7 @@
 import { execSync } from 'child_process';
-import { resolve } from 'path';
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
 import {
   verifyClaims,
   MAX_CLAIMS_PER_BLOCK,
@@ -228,6 +230,92 @@ function mkBlock(claims: Claim[]): ClaimBlock {
     expect(verdict.status).toBe('verified');
     // `verified` verdict shape is { claim_index, status: 'verified' } only.
     expect(Object.keys(verdict).sort()).toEqual(['claim_index', 'status']);
+  });
+});
+
+(rgAvailable ? describe : describe.skip)('verifyClaims — path containment (hardening)', () => {
+  it('absolute scope path is rejected as scope_not_found, no file read', async () => {
+    const block = mkBlock([
+      {
+        type: 'presence_of_symbol',
+        symbol: 'root',
+        // Absolute path — `resolve(projectRoot, '/etc')` would yield `/etc`
+        // without the containment helper.
+        scope: '/etc',
+        modality: 'asserted',
+      },
+    ]);
+    const [verdict] = await verifyClaims(block, PROJECT_ROOT);
+    expect(verdict.status).toBe('unverifiable_by_grep');
+    if (verdict.status === 'unverifiable_by_grep') {
+      expect(verdict.reason).toBe('scope_not_found');
+    }
+  });
+
+  it('../../etc/passwd scope escape → scope_not_found', async () => {
+    const block = mkBlock([
+      {
+        type: 'presence_of_symbol',
+        symbol: 'root',
+        scope: '../../etc/passwd',
+        modality: 'asserted',
+      },
+    ]);
+    const [verdict] = await verifyClaims(block, PROJECT_ROOT);
+    expect(verdict.status).toBe('unverifiable_by_grep');
+    if (verdict.status === 'unverifiable_by_grep') {
+      expect(verdict.reason).toBe('scope_not_found');
+    }
+  });
+
+  it('absolute file_line path is rejected as file_not_found', async () => {
+    const block = mkBlock([
+      {
+        type: 'file_line',
+        path: '/etc/hosts',
+        line: 1,
+        expected_symbol: 'localhost',
+        modality: 'asserted',
+      },
+    ]);
+    const [verdict] = await verifyClaims(block, PROJECT_ROOT);
+    expect(verdict.status).toBe('unverifiable_by_grep');
+    if (verdict.status === 'unverifiable_by_grep') {
+      expect(verdict.reason).toBe('file_not_found');
+    }
+  });
+
+  it('symlink inside project pointing outside → file_not_found', async () => {
+    // Build a scratch project root that contains a symlink → /tmp/<other>.
+    const scratch = mkdtempSync(join(tmpdir(), 'claim-verifier-contain-'));
+    const outside = mkdtempSync(join(tmpdir(), 'claim-verifier-outside-'));
+    try {
+      const projectRoot = join(scratch, 'proj');
+      mkdirSync(projectRoot);
+      // Put a real file outside so the symlink target actually exists.
+      const targetFile = join(outside, 'secret.txt');
+      writeFileSync(targetFile, 'top secret\n', 'utf-8');
+      // Symlink inside project points at an out-of-tree file.
+      symlinkSync(targetFile, join(projectRoot, 'leak.txt'));
+
+      const block = mkBlock([
+        {
+          type: 'file_line',
+          path: 'leak.txt',
+          line: 1,
+          expected_symbol: 'secret',
+          modality: 'asserted',
+        },
+      ]);
+      const [verdict] = await verifyClaims(block, projectRoot);
+      expect(verdict.status).toBe('unverifiable_by_grep');
+      if (verdict.status === 'unverifiable_by_grep') {
+        expect(verdict.reason).toBe('file_not_found');
+      }
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Three HIGH-severity findings from consensus round `1879db26-7e6a4074` on Stage 2 PRs A/B/C (#241/#242/#243):

- **f1/f2 — Path containment**: `runRg` and `verifyFileLine` at `claim-verifier.ts:71,193` called `resolve(projectRoot, agentInput)` with only an `existsSync` gate. `path.resolve('/proj','/etc/x')` returns `/etc/x`, so an agent-supplied absolute `path`/`scope` bypassed the project root entirely; relative `../../` escapes were also uncaught.
- **f3 — Unbounded regex input**: `symbol`/`scope`/`expected_symbol` in `claim-types.ts` validated non-empty but had no length cap. A megabyte-long regex passed to `rg` could CPU-blow before the 500ms wall-clock fires.

## Fix

- New `containWithinProject(projectRoot, input)` helper in `claim-verifier.ts`: resolves lexically, collapses symlinks on both sides via `realpathSync` (handles macOS `/var → /private/var`), prefix-compares, fails safely to `null` without leaking the attempted input.
- Applied at both call sites — `null` maps to the existing `missing_path` / `file_not_found` verdicts.
- `MAX_CLAIM_STRING_CHARS = 256` (symbol/scope/expected_symbol), `MAX_PATH_CHARS = 1024` (file_line path) across all 5 claim types. Oversize claims rejected via schema-lint (`symbol_too_long` / `path_too_long`).

## Not in this PR

- f4 (exception-message injection into prompt via `formatFalsifiedNote`) and f5 (`schema_lint` stderr/JSONL injection) — MEDIUM severity, separate PR.
- Modality signal wiring — verified correct in the consensus round, no changes needed.

## Test plan

- [x] 4 containment tests added: absolute scope, `../../` scope, absolute path, symlink escape
- [x] 4 length-cap tests added: symbol, scope, path, expected_symbol too long
- [x] `npm test` in orchestrator: 1556 passed / 20 pre-existing rg-gated skips / 0 failed
- [x] `tsc --noEmit` on orchestrator: clean
- [ ] CI green

Note: `apps/cli` typecheck surfaces pre-existing errors (stale `packages/orchestrator/dist/` from PRs A/B/C landing without a rebuild). Verified identical on master — unrelated to this PR. Follow-up issue to be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)