### PR TITLE
fix(security): sanitize agent-controlled strings before log/prompt interpolation

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -11,6 +11,7 @@ import {
   parseClaimBlock,
   verifyClaims,
   emitConsensusSignals,
+  sanitizeForLog,
   type ClaimBlock,
   type ClaimVerdict,
   type PerformanceSignal,
@@ -215,11 +216,11 @@ async function maybeVerifyPremiseClaims(
   if (!block) {
     // Malformed JSON / shape — prepend schema-lint warning, prose path runs.
     process.stderr.write(
-      `[gossipcat] ⚠ premise-claims schema violation for ${agentId}: ${errors.map(e => e.message).slice(0, 3).join('; ')}\n`,
+      `[gossipcat] ⚠ premise-claims schema violation for ${agentId}: ${errors.map(e => sanitizeForLog(e.message)).slice(0, 3).join('; ')}\n`,
     );
     const note =
       '⚠ premise-claims block failed schema validation — treating task as prose-only. ' +
-      `Errors: ${errors.map(e => e.message).slice(0, 3).join('; ')}`;
+      `Errors: ${errors.map(e => sanitizeForLog(e.message)).slice(0, 3).join('; ')}`;
     writePremiseVerificationLog(projectRoot, taskId, empty, {
       had_stage1_annotation: maybeAnnotateUnverifiedClaims(task).annotated,
       skill_bound: null,
@@ -236,7 +237,7 @@ async function maybeVerifyPremiseClaims(
     verdicts = await verifyClaims(block, projectRoot);
   } catch (err) {
     process.stderr.write(
-      `[gossipcat] ⚠ verifyClaims threw for ${agentId}: ${(err as Error).message}\n`,
+      `[gossipcat] ⚠ verifyClaims threw for ${agentId}: ${sanitizeForLog((err as Error).message ?? String(err))}\n`,
     );
     return empty;
   }
@@ -275,7 +276,7 @@ async function maybeVerifyPremiseClaims(
   // Record schema-lint warnings from the parser (e.g. missing_modality) so
   // retrospective audit can see silent downgrades. Errors is additive — a
   // non-null block may still carry per-claim errors.
-  const schemaLint = errors.length > 0 ? errors[0].message : undefined;
+  const schemaLint = errors.length > 0 ? sanitizeForLog(errors[0].message) : undefined;
   writePremiseVerificationLog(projectRoot, taskId, result, {
     had_stage1_annotation: maybeAnnotateUnverifiedClaims(task).annotated,
     skill_bound: null,

--- a/packages/orchestrator/src/_sanitize.ts
+++ b/packages/orchestrator/src/_sanitize.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared sanitizer for agent-controlled strings before they reach log output,
+ * JSONL rows, or are interpolated into downstream prompt text.
+ *
+ * Design choices:
+ *  - Control chars (U+0000–U+001F, U+007F) except \t (\x09) and \n (\x0A) are
+ *    replaced with U+FFFD (REPLACEMENT CHARACTER). This makes the substitution
+ *    visible in log readers while clearly marking tampered input, unlike
+ *    silently stripping or hex-encoding. \t and \n are kept because they are
+ *    structurally meaningful in both log lines and ANSI-aware terminals.
+ *  - Length is capped with a trailing '…' so a single crafted field cannot
+ *    flood stderr or a JSONL row.
+ */
+
+const CONTROL_CHAR_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+
+/**
+ * Sanitize an agent-supplied string for safe interpolation into log messages,
+ * JSONL fields, or prompt text.
+ *
+ * @param raw     The untrusted string.
+ * @param maxChars Maximum character length before truncation (default 200).
+ */
+export function sanitizeForLog(raw: string, maxChars = 200): string {
+  let s = raw.replace(CONTROL_CHAR_RE, '�');
+  if (s.length > maxChars) {
+    s = s.slice(0, maxChars) + '…';
+  }
+  return s;
+}

--- a/packages/orchestrator/src/claim-types.ts
+++ b/packages/orchestrator/src/claim-types.ts
@@ -9,6 +9,8 @@
  * Pure types + fail-soft parser. No I/O, no process spawns.
  */
 
+import { sanitizeForLog } from './_sanitize';
+
 export type Modality = 'asserted' | 'hedged' | 'vague';
 
 export type Relation = '>' | '<' | '=' | '≥' | '≤';
@@ -314,7 +316,7 @@ function validateClaim(raw: unknown, idx: number, errors: ParseError[]): Claim |
       return out;
     }
     default:
-      errors.push({ claim_index: idx, message: `unknown_type: ${t}` });
+      errors.push({ claim_index: idx, message: `unknown_type: ${sanitizeForLog(t)}` });
       return null;
   }
 }

--- a/packages/orchestrator/src/claim-verifier.ts
+++ b/packages/orchestrator/src/claim-verifier.ts
@@ -19,6 +19,7 @@
 import { spawn } from 'child_process';
 import { existsSync, readFileSync, realpathSync, statSync } from 'fs';
 import { resolve, sep } from 'path';
+import { sanitizeForLog } from './_sanitize';
 import type {
   AbsenceOfSymbolClaim,
   CallsiteCountClaim,
@@ -437,7 +438,7 @@ export async function verifyClaims(
       verdicts.push({
         claim_index: i,
         status: 'unverifiable_by_grep',
-        reason: `verifier_error: ${e instanceof Error ? e.message : String(e)}`,
+        reason: `verifier_error: ${sanitizeForLog(e instanceof Error ? e.message : String(e))}`,
       });
     }
   }

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -122,3 +122,4 @@ export type {
   ParseError,
 } from './claim-types';
 export { verifyClaims, MAX_CLAIMS_PER_BLOCK, PER_BLOCK_DEADLINE_MS } from './claim-verifier';
+export { sanitizeForLog } from './_sanitize';

--- a/tests/orchestrator/claim-types.test.ts
+++ b/tests/orchestrator/claim-types.test.ts
@@ -181,4 +181,19 @@ describe('parseClaimBlock — fail-soft parser', () => {
     expect(block!.claims).toHaveLength(0);
     expect(errors).toHaveLength(0);
   });
+
+  it('truncates unknown_type message when agent-supplied type is very long', () => {
+    const longType = 'a'.repeat(5000);
+    const raw = JSON.stringify({
+      schema_version: '1',
+      verifier: 'orchestrator',
+      claims: [{ type: longType, symbol: 'x', scope: 'src', modality: 'asserted' }],
+    });
+    const { errors } = parseClaimBlock(raw);
+    const unknownErr = errors.find(e => e.message.startsWith('unknown_type:'));
+    expect(unknownErr).toBeDefined();
+    // 'unknown_type: ' prefix (15 chars) + up to 200 sanitized chars + '…' = at most 216 chars
+    expect(unknownErr!.message.length).toBeLessThanOrEqual(216);
+    expect(unknownErr!.message).toContain('…');
+  });
 });

--- a/tests/orchestrator/claim-verifier.test.ts
+++ b/tests/orchestrator/claim-verifier.test.ts
@@ -6,6 +6,7 @@ import {
   verifyClaims,
   MAX_CLAIMS_PER_BLOCK,
 } from '../../packages/orchestrator/src/claim-verifier';
+import { sanitizeForLog } from '../../packages/orchestrator/src/_sanitize';
 import type {
   ClaimBlock,
   CallsiteCountClaim,
@@ -373,5 +374,45 @@ function mkBlock(claims: Claim[]): ClaimBlock {
     } finally {
       Date.now = realNow;
     }
+  });
+});
+
+// ─── sanitizeForLog unit tests ────────────────────────────────────────────────
+
+describe('sanitizeForLog', () => {
+  it('passes through a short, clean string unchanged', () => {
+    expect(sanitizeForLog('file not found')).toBe('file not found');
+  });
+
+  it('truncates a 1000-char message to 200 chars + ellipsis', () => {
+    const long = 'a'.repeat(1000);
+    const result = sanitizeForLog(long);
+    expect(result).toHaveLength(201); // 200 + '…'
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('replaces NUL byte (\\x00) with U+FFFD', () => {
+    const result = sanitizeForLog('bad\x00byte');
+    expect(result).toBe('bad�byte');
+    expect(result).not.toContain('\x00');
+  });
+
+  it('replaces ANSI escape (\\x1b[31m) with U+FFFD placeholders', () => {
+    const result = sanitizeForLog('\x1b[31mred\x1b[0m');
+    // \x1b and [ are both control chars replaced; printable chars kept
+    expect(result).not.toContain('\x1b');
+    expect(result).toContain('red');
+  });
+
+  it('preserves \\t and \\n (allowed control chars)', () => {
+    expect(sanitizeForLog('line1\nline2\ttabbed')).toBe('line1\nline2\ttabbed');
+  });
+
+  it('truncates a long string even when it contains control chars', () => {
+    const long = '\x00'.repeat(500) + 'suffix';
+    const result = sanitizeForLog(long);
+    // After replacement each \x00 → U+FFFD (1 char each), total 506 chars → truncated
+    expect(result.length).toBeLessThanOrEqual(201);
+    expect(result.endsWith('…')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #244 covering the two MEDIUM-severity findings from consensus `1879db26-7e6a4074` deferred from that PR (f4, f5).

- **f4** — `verifier_error` exception text flowed unsanitized into `formatFalsifiedNote`, which prepends to the next agent's task prompt via `annotatedTask`. Crafted error content → prompt injection surface.
- **f5** — `unknown_type: ${t}` interpolated the agent-supplied `type` field (unbounded length, control chars allowed) into stderr and the `schema_lint` JSONL field.

## Fix

New `packages/orchestrator/src/_sanitize.ts` (30 LOC): `sanitizeForLog(raw, maxChars=200)`
- Replaces control chars (U+0000–U+001F, U+007F) except `\t` and `\n` with U+FFFD so tampered input is visible in log readers.
- Truncates with trailing `…` when over `maxChars`.

Applied at 5 sites:
- `claim-verifier.ts:391` — wrap `e.message` before `reason:` interpolation
- `claim-types.ts:270` — wrap `type` value before `unknown_type:` interpolation
- `dispatch.ts:218-219` — sanitize each error message in stderr write + the `note` prepended to `annotatedTask`
- `dispatch.ts:240` — sanitize `verifyClaims`-threw stderr message
- `dispatch.ts:279` — sanitize `errors[0].message` stored in `schema_lint` JSONL field

Exported `sanitizeForLog` from the orchestrator barrel.

## Test plan

- [x] 7 new tests: pass-through short string, 1000-char truncation, NUL replacement, ANSI escape (`\x1b[31m`) replacement, `\t`/`\n` preserved, combined truncation+replacement, 5000-char `type` field truncated at 216 chars.
- [x] Full suite: 2497 passed / 0 failed.
- [x] `npx tsc -p packages/orchestrator --noEmit` clean.
- [ ] CI green.

## Not in this PR

- Path containment / length caps — shipped in #244.
- Modality signal wiring — verified correct in the consensus round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)