### PR TITLE
fix(consensus): surface coverageDegraded for Gemini MALFORMED_FUNCTION_CALL sentinel

### DIFF
--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -2680,8 +2680,12 @@ Return only valid JSON.${skillsBlock}`;
 
     // Surface round-level coverage degradation (0-char dropouts, e.g. Gemini
     // MALFORMED_FUNCTION_CALL). Adds ONE round-level signal alongside the
-    // per-task auto-signal at collect.ts:178.
-    const droppedAgents = results.filter(r => !r.result || r.result.trim().length === 0).map(r => r.agentId);
+    // per-task auto-signal at collect.ts:178. The substring match mirrors
+    // collect.ts:178 so the Gemini sentinel "[No response from Gemini: ...]"
+    // (non-empty, ~50 chars, zero analytical content) is also treated as dropped.
+    const isDropped = (r: { result?: string }): boolean =>
+      !r.result || r.result.trim().length === 0 || r.result.includes('[No response from');
+    const droppedAgents = results.filter(isDropped).map(r => r.agentId);
     const received = results.length - droppedAgents.length;
     if (results.length > 0 && droppedAgents.length > 0) {
       const evidence = `Coverage degraded: ${received}/${results.length} agents returned content (dropped: ${droppedAgents.join(', ')})`;

--- a/tests/orchestrator/consensus-two-phase.test.ts
+++ b/tests/orchestrator/consensus-two-phase.test.ts
@@ -198,4 +198,27 @@ describe('Two-phase consensus flow', () => {
     expect(covSignals).toHaveLength(1);
     expect(covSignals[0].agentId).toBe('_round');
   });
+
+  it('flags coverageDegraded for Gemini MALFORMED_FUNCTION_CALL sentinel (non-empty dropout)', async () => {
+    const config: ConsensusEngineConfig = { llm: mockLlm, registryGet: mockRegistryGet };
+    const engine = new ConsensusEngine(config);
+
+    // One agent returns the Gemini sentinel — non-empty string, zero analytical content.
+    const sentinel = '[No response from Gemini: malformed_function_call finishReason=MALFORMED_FUNCTION_CALL]';
+    const results = [
+      createEntry('native-a', '## Consensus Summary\n<agent_finding type="finding" severity="high">Bug in auth.ts:10 — missing token validation allows bypass</agent_finding>'),
+      createEntry('native-b', '## Consensus Summary\n<agent_finding type="finding" severity="medium">Missing input validation in api-handler.ts:20 for user-supplied query</agent_finding>'),
+      createEntry('gemini-reviewer', sentinel),
+    ];
+
+    const nativeIds = new Set(['native-a', 'native-b']);
+    const { consensusId } = await engine.generateCrossReviewPrompts(results, nativeIds);
+    const report = await engine.synthesizeWithCrossReview(results, [], consensusId);
+
+    expect(report.coverageDegraded).toBeDefined();
+    expect(report.coverageDegraded!.droppedAgents).toEqual(['gemini-reviewer']);
+    expect(report.coverageDegraded!.received).toBe(2);
+    const covSignals = report.signals.filter(s => s.signal === 'consensus_coverage_degraded');
+    expect(covSignals).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Summary

From session 2026-04-22 backlog investigation. The round-level coverage-degradation check at `consensus-engine.ts:2684` used `!r.result || r.result.trim().length === 0` to identify dropped agents, but Gemini's `MALFORMED_FUNCTION_CALL` responses come back as a **non-empty** sentinel string — `[No response from Gemini: malformed_function_call finishReason=...]` — so the round-level filter missed them.

Per-task detection at \`collect.ts:178\` already used a substring match (\`includes('[No response from')\`) and emitted the per-task \`task_empty\` signal correctly. The gap was only at round level: \`coverageDegraded\` wasn't populated, the \`consensus_coverage_degraded\` signal wasn't emitted, and the ⚠ warning line didn't show up in the summary for Gemini dropouts.

This PR mirrors collect.ts's substring check in the round-level filter so both surfaces stay consistent.

## Changes

- `packages/orchestrator/src/consensus-engine.ts` — extract an \`isDropped\` helper that includes the sentinel substring check; comment references collect.ts:178 for provenance.
- `tests/orchestrator/consensus-two-phase.test.ts` — new test case with the Gemini sentinel; keeps the existing empty-string test.

## Test plan

- [x] New test passes: `flags coverageDegraded for Gemini MALFORMED_FUNCTION_CALL sentinel (non-empty dropout)`
- [x] Existing `0-char dropouts` test still passes
- [x] `npx tsc -p packages/orchestrator --noEmit` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)