### PR TITLE
fix(skill-parser): strip surrounding quotes from frontmatter scalar values

### DIFF
--- a/packages/orchestrator/src/skill-parser.ts
+++ b/packages/orchestrator/src/skill-parser.ts
@@ -56,7 +56,17 @@ export function parseSkillFrontmatter(content: string): SkillFrontmatter | null 
     const colonIdx = line.indexOf(':');
     if (colonIdx === -1) continue;
     const key = line.slice(0, colonIdx).trim();
-    const value = line.slice(colonIdx + 1).trim();
+    let value = line.slice(colonIdx + 1).trim();
+    // Strip surrounding "..." or '...' so `status: "pending"` matches the
+    // enum the same way `status: pending` does. Mirrors the quote handling
+    // in skill-engine.ts:parseSkillFile — this parser is the loader's path
+    // and drifted. Inline arrays (keywords) keep their form via the [] check
+    // below, so stripping here is safe.
+    if (value.length >= 2 &&
+        ((value.startsWith('"') && value.endsWith('"')) ||
+         (value.startsWith("'") && value.endsWith("'")))) {
+      value = value.slice(1, -1);
+    }
     fields[key] = value;
   }
 

--- a/tests/orchestrator/skill-parser.test.ts
+++ b/tests/orchestrator/skill-parser.test.ts
@@ -61,4 +61,16 @@ Check endpoints.`;
     const result = parseSkillFrontmatter(md);
     expect(result?.name).toBe('dos-resilience');
   });
+
+  it('strips surrounding double quotes from scalar values', () => {
+    const md = `---\nname: t\ndescription: d\nkeywords: [k]\nstatus: "pending"\n---\nBody`;
+    const result = parseSkillFrontmatter(md);
+    expect(result?.status).toBe('pending');
+  });
+
+  it('strips surrounding single quotes from scalar values', () => {
+    const md = `---\nname: t\ndescription: d\nkeywords: [k]\nstatus: 'pending'\n---\nBody`;
+    const result = parseSkillFrontmatter(md);
+    expect(result?.status).toBe('pending');
+  });
 });


### PR DESCRIPTION
## Summary

MCP log noise spotted while running \`gossip_skills develop\` in session 2026-04-22:

\`\`\`
[gossipcat] skill-engine: invalid status "\"pending\"" remapped to pending
\`\`\`

Root cause: two parsers read the same skill frontmatter.
- \`skill-engine.ts:parseSkillFile:924\` strips surrounding \`"..."\` correctly.
- \`skill-parser.ts:parseSkillFrontmatter:60\` stored \`fields[key] = value\` verbatim, so \`status: "pending"\` became the 9-char string with quote chars → fails the enum check in \`coerceStatus\` → warning.

Many gemini-* skill files were written by an older path that quoted the status value; every load triggered the warning. The coercion itself kept things working, just noisily.

## Fix

Mirror the quote-stripping from \`skill-engine.ts:924\` in the parser's scalar-value path. Handles both \`"..."\` and \`'...'\`. Inline-array detection (keywords) runs after, so it's unaffected.

## Test plan

- [x] 2 new tests for double- and single-quoted status values
- [x] Existing 6 parser tests still pass
- [x] \`npx tsc -p packages/orchestrator --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)