### PR TITLE
fix(postinstall): add recovery instructions to FATAL error message

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -121,7 +121,7 @@ if (!existsSync(mcpServerPath)) {
       process.exit(1);
     }
   } else {
-    console.error('gossipcat: FATAL — dist-mcp/mcp-server.js missing from package. Install is corrupted.');
+    console.error('gossipcat: FATAL — dist-mcp/mcp-server.js missing from package. Install is corrupted; reinstall with `npm install -g gossipcat` or clone the repo and run `npm install && npm run build:mcp`.');
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- Medium-severity follow-up from consensus round `ce53c4ee-042444c3`
- FATAL branch for missing `dist-mcp/mcp-server.js` in local-dep install now suggests concrete recovery: global reinstall OR clone + build from source

## Deferred
`.mcp.json` user-entry clobber (the second medium from the same consensus round) requires careful design to avoid another regression like our first-pass process.exit(1) revert. Tracked for follow-up.

## Test plan
- [x] Syntax: `node -c scripts/postinstall.js`
- [x] Regression tests: `npx jest tests/cli/install-packaging.test.ts` — 14/14 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)