### PR TITLE
fix(mcp): persist utility-task results beyond 2h TTL to preserve skill-develop loop

### DIFF
--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -93,7 +93,14 @@ function recordTimeoutSignal(taskId: string, agentId: string): void {
   } catch { /* best-effort */ }
 }
 
-/** Evict stale entries from nativeTaskMap and nativeResultMap */
+/** 24-hour TTL for utility result map — longer than the 2h normal TTL so
+ * skill_develop dispatch→relay→re-entry chains that span process restarts
+ * don't silently fall back to stale template skills. */
+const UTILITY_RESULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Evict stale entries from nativeTaskMap and nativeResultMap.
+ * nativeUtilityResultMap is NOT swept here — it uses UTILITY_RESULT_TTL_MS
+ * and is only pruned after 24h to protect long-running re-entry chains. */
 export function evictStaleNativeTasks(): void {
   const now = Date.now();
   let changed = false;
@@ -102,6 +109,10 @@ export function evictStaleNativeTasks(): void {
   }
   for (const [id, info] of [...ctx.nativeResultMap]) {
     if (now - info.startedAt > NATIVE_TASK_TTL_MS) { ctx.nativeResultMap.delete(id); changed = true; }
+  }
+  // Prune utility results with the longer 24h TTL — separate from normal eviction
+  for (const [id, info] of [...ctx.nativeUtilityResultMap]) {
+    if (now - info.startedAt > UTILITY_RESULT_TTL_MS) { ctx.nativeUtilityResultMap.delete(id); }
   }
   if (changed) persistNativeTaskMap();
 }
@@ -316,13 +327,21 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
     ? undefined
     : (error ? undefined : (result ? (auditPrefix + result).slice(0, 50000) : result));
   ctx.nativeTaskMap.delete(task_id);
-  ctx.nativeResultMap.set(task_id, {
+  const resultRecord = {
     id: task_id, agentId: taskInfo.agentId, task: taskInfo.task,
-    status: effectiveError ? 'failed' : 'completed',
+    status: effectiveError ? 'failed' as const : 'completed' as const,
     result: effectiveResult,
     error: effectiveError || undefined,
     startedAt: effectiveStart, completedAt: Date.now(),
-  });
+  };
+  // skill_develop utility results go to the separate non-evicted map so that
+  // long-running dispatch→relay→re-entry chains (>2h) don't fall back to stale
+  // template skills. All other tasks use the normal nativeResultMap.
+  if (taskInfo.utilityType === 'skill_develop') {
+    ctx.nativeUtilityResultMap.set(task_id, resultRecord);
+  } else {
+    ctx.nativeResultMap.set(task_id, resultRecord);
+  }
   // If audit blocked, treat the rest of the pipeline as a failed task
   if (auditBlockError) error = auditBlockError;
   persistNativeTaskMap();

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -73,6 +73,14 @@ export interface McpContext {
   skillEngine: any;
   nativeTaskMap: Map<string, NativeTaskInfo>;
   nativeResultMap: Map<string, NativeResultInfo>;
+  /**
+   * Separate result map for skill_develop utility tasks. Unlike nativeResultMap,
+   * entries here are NOT swept by evictStaleNativeTasks() — utility results
+   * represent orchestrator re-entry intent and must survive the 2h TTL window
+   * so that long-running dispatch→relay→re-entry chains don't fall back to
+   * stale template skills.
+   */
+  nativeUtilityResultMap: Map<string, NativeResultInfo>;
   nativeAgentConfigs: Map<string, { model: string; instructions: string; description: string; skills: string[] }>;
   /**
    * Identity registry — agentId → runtime/provider/model. Read by the
@@ -142,6 +150,7 @@ export const ctx: McpContext = {
   skillEngine: null,
   nativeTaskMap: new Map(),
   nativeResultMap: new Map(),
+  nativeUtilityResultMap: new Map(),
   nativeAgentConfigs: new Map(),
   identityRegistry: new Map(),
   pendingConsensusRounds: new Map(),

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -3207,7 +3207,12 @@ server.tool(
       if (_utility_task_id) {
         const stashedMeta = _pendingSkillData.get(_utility_task_id);
         _pendingSkillData.delete(_utility_task_id);
-        const utilityResult = ctx.nativeResultMap.get(_utility_task_id);
+        // Check nativeUtilityResultMap first (skill_develop results are routed
+        // there to survive the 2h nativeResultMap TTL). Fall back to
+        // nativeResultMap for any legacy entries written before this change.
+        const utilityResult = ctx.nativeUtilityResultMap.get(_utility_task_id)
+          ?? ctx.nativeResultMap.get(_utility_task_id);
+        ctx.nativeUtilityResultMap.delete(_utility_task_id);
         ctx.nativeResultMap.delete(_utility_task_id);
         ctx.nativeTaskMap.delete(_utility_task_id);
         // Utility-guard: detect prompt-injection drift in the sub-agent.


### PR DESCRIPTION
## Summary
- Root cause: utility-task results in `nativeResultMap` get evicted by the 2h `NATIVE_TASK_TTL_MS` sweep before the `gossip_skills(..., _utility_task_id)` re-entry can read them. Fallback path then produces a template-shaped skill instead of the freshly-relayed fresh content.
- Net effect: contextual-RL learning loop silently degrades — accumulated failure evidence never produces targeted skills.
- Fix: route utility-task relay writes to a separate `nativeUtilityResultMap` with a 24h TTL, not swept on every relay.

## Evidence
Observed 2026-04-24 during `gossip_skills develop` for gemini-reviewer:
```
[gossipcat] ✅ utility ← skill_develop [4a2d8cc5] OK (7637.1s)
[gossipcat] Skill develop utility 4a2d8cc5 failed/missing, falling back to direct LLM
[gossipcat] Skill developed: "trust-boundaries" for gemini-reviewer
```
First line says relay OK; second line (same `task_id`) says the re-entry can't find the result. Fallback saved an older template-shaped skill.

Traced by `sonnet-reviewer` to:
- `apps/cli/src/mcp-context.ts:165` — `NATIVE_TASK_TTL_MS = 2h`
- `apps/cli/src/handlers/native-tasks.ts` — `evictStaleNativeTasks()` sweeps `nativeResultMap`
- `apps/cli/src/mcp-server-sdk.ts:3210` — re-entry reads `nativeResultMap.get(_utility_task_id)`

## Design choice
Separate map over extending existing entry with a `utility: true` flag:
- Utility-task results represent orchestrator intent to re-enter, not speculative state — a semantic separation.
- `_pendingSkillData` (also a utility-adjacent map) is already structured separately and is already exempt from TTL, so this aligns with existing convention.
- Clean map-level skip in `evictStaleNativeTasks()` vs per-entry branching.

## Change surface
| File | LOC | Purpose |
|------|-----|---------|
| `apps/cli/src/mcp-context.ts` | +9 | Add `nativeUtilityResultMap` to interface + init |
| `apps/cli/src/handlers/native-tasks.ts` | +23 / -4 | `UTILITY_RESULT_TTL_MS = 24h`; separate prune loop; relay write branches on `utilityType === 'skill_develop'` |
| `apps/cli/src/mcp-server-sdk.ts` | +6 / -1 | Re-entry checks utility map first with `??` fallback; delete from both on success |

Net: 38 insertions, 5 deletions.

## Test plan
- [x] 329 tests pass across `(native-tasks|skill|mcp)` patterns locally
- [x] TypeScript compiles clean
- [x] Non-utility task semantics unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)