### PR TITLE
fix(skill-freshness): strip surrounding quotes in extractFrontmatterField

### DIFF
--- a/packages/orchestrator/src/skill-freshness.ts
+++ b/packages/orchestrator/src/skill-freshness.ts
@@ -80,7 +80,17 @@ function extractFrontmatterField(content: string, field: string): string | null 
     if (colonIdx === -1) continue;
     const key = line.slice(0, colonIdx).trim();
     if (key !== field) continue;
-    const value = line.slice(colonIdx + 1).trim();
+    let value = line.slice(colonIdx + 1).trim();
+    // Strip surrounding "..." or '...' so `status: "pending"` matches the
+    // enum the same way `status: pending` does. Mirrors the quote handling
+    // in skill-parser.ts:65-69 — that fix (commit 8164472) did not propagate
+    // to this loader path, producing stderr "invalid status" noise on every
+    // skill read with quoted scalar values.
+    if (value.length >= 2 &&
+        ((value.startsWith('"') && value.endsWith('"')) ||
+         (value.startsWith("'") && value.endsWith("'")))) {
+      value = value.slice(1, -1);
+    }
     return value.length > 0 ? value : null;
   }
   return null;

--- a/tests/orchestrator/skill-freshness.test.ts
+++ b/tests/orchestrator/skill-freshness.test.ts
@@ -115,6 +115,24 @@ describe('readSkillFreshness — file present', () => {
     stderrSpy.mockRestore();
   });
 
+  it('strips surrounding double-quotes on scalar values so `status: "pending"` parses as pending', () => {
+    // Regression guard (2026-04-24): extractFrontmatterField lacked the
+    // quote-stripping that landed in skill-parser.ts via 8164472. A quoted
+    // status value was returned as `"pending"` (with quotes), then coerced
+    // to pending with a stderr warning on every skill read.
+    const boundAt = '2026-04-10T00:00:00.000Z';
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(makeSkillContent(boundAt, '"pending"') as any);
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    const result = readSkillFreshness(AGENT_ID, CATEGORY, SKILL_ROOT);
+    expect(result.status).toBe('pending');
+    // The quote-stripping must happen before coerceStatus, so no warning fires.
+    expect(stderrSpy).not.toHaveBeenCalled();
+
+    stderrSpy.mockRestore();
+  });
+
   it('preserves null status (no coerce) when status field is absent', () => {
     // Null must round-trip so computeCooldown can return pre_schema.
     const boundAt = '2026-04-10T00:00:00.000Z';


### PR DESCRIPTION
## Summary
- Commit 8164472 fixed quote-stripping in `skill-parser.ts` but the parallel loader path in `skill-freshness.ts:extractFrontmatterField` drifted — it returned the raw value unchanged.
- Effect: `status: \"pending\"` in YAML surfaced as the literal string `\"pending\"` (with quotes), failed `coerceStatus`'s enum check, and produced stderr noise on every skill read.
- Cosmetic (coerceStatus correctly falls back to `pending`) but defeats the status-enum contract's ability to surface genuine drift.

## Evidence
Observed 2026-04-24 — fires 3× per `gossip_skills develop` cycle:
```
[gossipcat] skill-engine: invalid status \"\\\"pending\\\"\" remapped to pending
```

## Change
4 LOC in `packages/orchestrator/src/skill-freshness.ts` mirroring the exact strip logic at `skill-parser.ts:65-69`. Plus a new regression test in `tests/orchestrator/skill-freshness.test.ts` that asserts (a) quoted status parses correctly as `pending`, and (b) no stderr warning fires.

## Test plan
- [x] `npx jest tests/orchestrator/skill-freshness.test.ts` — 20/20 pass (was 19, +1 regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)