### PR TITLE
fix(postinstall): merge existing .mcp.json entries instead of clobbering

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -6,7 +6,7 @@
  * Never shipped in the package tarball — always regenerated per machine.
  */
 const { join, resolve } = require('path');
-const { existsSync, writeFileSync, statSync } = require('fs');
+const { existsSync, readFileSync, writeFileSync, statSync } = require('fs');
 
 const scriptDir = __dirname;          // .../gossipcat/scripts/
 const packageRoot = resolve(scriptDir, '..'); // .../gossipcat/
@@ -77,8 +77,37 @@ if (!isGlobal && !isGitClone) {
 
 const mcpConfig = join(outputDir, '.mcp.json');
 
+// Preserve existing user-added MCP server entries. An existing .mcp.json may
+// carry servers other than gossipcat (e.g. another MCP tool the user has
+// installed). Unconditional overwrite would silently clobber those entries
+// on every npm install. Merge strategy:
+//   - Parse existing file if present. On JSON error, skip the write (don't
+//     destroy what we can't parse; user can fix manually).
+//   - Preserve every top-level field via spread, preserve every existing
+//     mcpServers entry, and refresh (or insert) the gossipcat entry.
+let existing = {};
+if (existsSync(mcpConfig)) {
+  try {
+    const raw = readFileSync(mcpConfig, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      existing = parsed;
+    }
+  } catch (_) {
+    console.warn(`gossipcat: existing .mcp.json at ${mcpConfig} is malformed — skipping update to avoid clobbering user config`);
+    process.exit(0);
+  }
+}
+
+const existingServers =
+  existing.mcpServers && typeof existing.mcpServers === 'object' && !Array.isArray(existing.mcpServers)
+    ? existing.mcpServers
+    : {};
+
 const config = {
+  ...existing,
   mcpServers: {
+    ...existingServers,
     gossipcat: {
       command: 'node',
       args: [mcpServerPath],

--- a/tests/cli/install-packaging.test.ts
+++ b/tests/cli/install-packaging.test.ts
@@ -138,4 +138,17 @@ describe('scripts/postinstall.js — error-path regression guard', () => {
     expect(source).toContain('console.warn');
     expect(source).toMatch(/could not write \.mcp\.json/);
   });
+
+  it('preserves existing .mcp.json entries via merge (no clobber)', () => {
+    // Regression guard (2026-04-24, consensus ce53c4ee-042444c3): postinstall
+    // must read an existing .mcp.json and merge the gossipcat entry, preserving
+    // user-added MCP server entries and unrelated top-level fields. Earlier
+    // behavior unconditionally overwrote the file on every npm install.
+    expect(source).toMatch(/readFileSync\([^)]*mcpConfig/);
+    expect(source).toMatch(/\.\.\.existing\b/);
+    expect(source).toMatch(/\.\.\.existingServers\b/);
+    // Malformed existing config must skip the write, not exit(1) — otherwise
+    // npm install breaks on a corrupt user file we can't parse.
+    expect(source).toMatch(/malformed[\s\S]*process\.exit\(0\)/);
+  });
 });


### PR DESCRIPTION
## Summary
- Final medium from consensus round `ce53c4ee-042444c3` (2026-04-24)
- `writeFileSync` unconditionally overwrote `.mcp.json` on every `npm install`, silently wiping any user-added MCP server entries alongside the gossipcat entry
- Now merges: preserves existing top-level fields and mcpServers entries, refreshes the gossipcat entry

## Merge strategy
1. Parse existing `.mcp.json` if present
2. Spread top-level fields (`...existing`) and existing mcpServers (`...existingServers`)
3. Refresh/insert the gossipcat entry on top
4. On JSON parse error → `console.warn` + `process.exit(0)`. Skipping the write preserves the user's file for manual fix; `exit(0)` avoids breaking `npm install` the way a hard-exit(1) would (same rationale as the EACCES soft-fail path)

## Preserves existing regression guards
- `console.error` and `process.exit(1)` still in FATAL and build-fail branches
- `writeFileSync` still wrapped in try/catch with `console.warn` on failure

## Adds a new regression guard
Source-scan test asserts:
- `readFileSync` reads existing config
- Spread operators (`...existing`, `...existingServers`) are present
- Malformed branch uses `process.exit(0)`, not `process.exit(1)`

Catches future reverts to unconditional overwrite at test time.

## Test plan
- [x] `node -c scripts/postinstall.js` — syntax valid
- [x] `npx jest tests/cli/install-packaging.test.ts` — 15/15 pass (was 14, +1 regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)