### PR TITLE
fix(log): clarify utility-task duration label as 'since dispatch'

### DIFF
--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -521,7 +521,10 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
     const utilityLabel = taskInfo.utilityType === 'summary' ? 'cognitive-summary'
       : taskInfo.utilityType === 'gossip' ? 'gossip-publish'
       : taskInfo.utilityType;
-    const utilDurationLabel = elapsed !== null ? `${(elapsed / 1000).toFixed(1)}s` : 'duration=unknown';
+    // Utility tasks don't pass agentStartedAt, so elapsed measures wall-clock
+    // since dispatch — NOT agent execution time. The orchestrator may delay
+    // gossip_relay long after the agent finished, inflating this number.
+    const utilDurationLabel = elapsed !== null ? `${(elapsed / 1000).toFixed(1)}s since dispatch` : 'duration=unknown';
     process.stderr.write(`[gossipcat] ✅ utility ← ${utilityLabel} [${task_id}] OK (${utilDurationLabel})\n`);
   }
 


### PR DESCRIPTION
## Summary
- Utility-task duration in stderr was reported as bare \`Ns\` even though it measures wall-clock since dispatch (not agent runtime).
- Relabel to \`Ns since dispatch\` and add a 3-line comment explaining why utility tasks land in this branch.
- Pure log-string change. No behavior change. \`computeRelayDuration\` unchanged.

## Why
Observed 2026-04-24: \`skill_develop\` logged \`OK (7637.1s)\` for a task whose Agent() reported \`duration_ms: 11930\`. Both numbers were correct — they measure different things — but the bare seconds-suffix invited the assumption that this was agent execution time. The orchestrator can delay calling \`gossip_relay\` long after the underlying Agent() finishes (other tasks in flight, etc.), inflating the elapsed count without a corresponding agent-side anomaly. The relabel removes the ambiguity at zero cost.

This addresses \`project_relay_timing_duration_bug.md\` from the local memory backlog. Investigation confirmed it's a labeling clarity issue, not a measurement bug.

## Test plan
- [x] No code behavior change — only the log string text.
- [ ] Run \`gossip_skills(action: "develop")\` on a dev instance, confirm new log shape \`[gossipcat] ✅ utility ← skill_develop [id] OK (Ns since dispatch)\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)