### PR TITLE
fix(skill-index): prune orphan agent entries on boot

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -684,6 +684,21 @@ async function doBoot() {
       process.stderr.write(`[gossipcat] ⚠️  Global permanent skill auto-seed failed: ${(seedErr as Error).message}\n`);
     }
 
+    // Reconcile against the live agent roster — drop ghost entries for
+    // agents that have been deleted from .gossip/config.json since the
+    // last boot. Without this, getAgentIds().length below over-reports.
+    try {
+      const validIds = agentConfigs
+        .map((ac: any) => ac.id)
+        .filter((id: any) => typeof id === 'string' && id.length > 0);
+      const pruned = skillIndex.prune(validIds);
+      if (pruned.length > 0) {
+        process.stderr.write(`[gossipcat] 🧹 Skill index pruned ${pruned.length} orphan agent(s): ${pruned.join(', ')}\n`);
+      }
+    } catch (pruneErr) {
+      process.stderr.write(`[gossipcat] ⚠️  Skill index prune failed: ${(pruneErr as Error).message}\n`);
+    }
+
     ctx.mainAgent.setSkillIndex(skillIndex);
     process.stderr.write(`[gossipcat] 📚 Skill index loaded (${skillIndex.getAgentIds().length} agents)\n`);
   } catch (err) {
@@ -3046,9 +3061,9 @@ server.tool(
 // ── Unified skill management ─────────────────────────────────────────────
 server.tool(
   'gossip_skills',
-  'Manage agent skills. Actions: list (show skill index), bind (attach skill to agent), unbind (remove skill from agent), build (create skills from gap suggestions), develop (generate skill from ATI competency data).',
+  'Manage agent skills. Actions: list (show skill index), bind (attach skill to agent), unbind (remove skill from agent), build (create skills from gap suggestions), develop (generate skill from ATI competency data), prune (drop skill-index entries for agents no longer in config.json).',
   {
-    action: z.enum(['list', 'bind', 'unbind', 'build', 'develop']).describe('Action to perform'),
+    action: z.enum(['list', 'bind', 'unbind', 'build', 'develop', 'prune']).describe('Action to perform'),
     // bind/unbind/develop params
     agent_id: z.string().optional().describe('Agent ID (required for bind, unbind, develop)'),
     skill: z.string().optional().describe('Skill name (required for bind, unbind)'),
@@ -3117,6 +3132,37 @@ server.tool(
 
       process.stderr.write(`[gossipcat] Skill "${slot.skill}" ${bindAction} for ${agent_id} (v${slot.version})\n`);
       return { content: [{ type: 'text' as const, text: `Skill "${slot.skill}" ${bindAction} for ${agent_id} (v${slot.version}, ${slot.enabled ? 'enabled' : 'disabled'})` }] };
+    }
+
+    // ── prune ──
+    if (action === 'prune') {
+      const index = ctx.mainAgent.getSkillIndex();
+      if (!index) return { content: [{ type: 'text' as const, text: 'Skill index not initialized.' }] };
+
+      const { findConfigPath, loadConfig, configToAgentConfigs } = await import('./config');
+      const configPath = findConfigPath();
+      if (!configPath) {
+        return { content: [{ type: 'text' as const, text: 'No config found. Cannot determine valid agent ids.' }] };
+      }
+      const config = loadConfig(configPath);
+      const agentConfigs = configToAgentConfigs(config);
+      const validIds = agentConfigs
+        .map((ac: any) => ac.id)
+        .filter((id: any): id is string => typeof id === 'string' && id.length > 0);
+
+      const removed = index.prune(validIds);
+      if (removed.length > 0) {
+        process.stderr.write(`[gossipcat] 🧹 Skill index pruned ${removed.length} orphan agent(s): ${removed.join(', ')}\n`);
+      }
+      const summary = removed.length > 0
+        ? `Pruned ${removed.length} orphan agent(s): ${removed.join(', ')}`
+        : 'No orphan agents — skill index already in sync with config.json.';
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `${summary}\n\n${JSON.stringify({ removed }, null, 2)}`,
+        }],
+      };
     }
 
     // ── unbind ──

--- a/packages/orchestrator/src/skill-index.ts
+++ b/packages/orchestrator/src/skill-index.ts
@@ -151,6 +151,40 @@ export class SkillIndex {
   /** Get all agent IDs in the index */
   getAgentIds(): string[] { return Object.keys(this.data); }
 
+  /**
+   * Drop entries for agents not in `validAgentIds`. Returns the list of
+   * removed agent ids. Persists to disk if anything changed.
+   *
+   * Reconciles the on-disk skill index against the live agent roster
+   * (e.g. `Object.keys(config.agents)`). Without this, deleted agents
+   * keep ghost entries forever, inflating `getAgentIds().length` in
+   * boot logs and skewing any downstream count.
+   *
+   * Out of scope: agent memory directories under `.gossip/agents/<id>/`.
+   * This only touches the in-process `data` map and the
+   * `.gossip/skill-index.json` file.
+   */
+  prune(validAgentIds: string[]): string[] {
+    const valid = new Set<string>();
+    for (const id of validAgentIds) {
+      if (typeof id === 'string' && id.length > 0 && !DANGEROUS_KEYS.has(id)) {
+        valid.add(id);
+      }
+    }
+    const removed: string[] = [];
+    for (const agentId of Object.keys(this.data)) {
+      if (!valid.has(agentId)) {
+        delete this.data[agentId];
+        removed.push(agentId);
+      }
+    }
+    if (removed.length > 0) {
+      this.dirty = true;
+      this.save();
+    }
+    return removed;
+  }
+
   /** Check if an index file exists (for backward compat detection) */
   exists(): boolean { return this._exists; }
 

--- a/tests/orchestrator/skill-index.test.ts
+++ b/tests/orchestrator/skill-index.test.ts
@@ -265,4 +265,77 @@ describe('SkillIndex', () => {
       expect(index.getSlot('agent-a', 'typescript')!.version).toBe(2);
     });
   });
+
+  describe('prune()', () => {
+    it('removes orphan agent entries and returns their ids', () => {
+      const index = new SkillIndex(testDir);
+      index.bind('agent-a', 'typescript');
+      index.bind('agent-b', 'security-audit');
+      index.bind('agent-c', 'code-review');
+
+      const removed = index.prune(['agent-a', 'agent-c']);
+
+      expect(removed.sort()).toEqual(['agent-b']);
+      expect(index.getAgentIds().sort()).toEqual(['agent-a', 'agent-c']);
+      expect(index.getSlot('agent-b', 'security-audit')).toBeUndefined();
+    });
+
+    it('is a no-op when every indexed agent is in the valid list', () => {
+      const index = new SkillIndex(testDir);
+      index.bind('agent-a', 'typescript');
+      index.bind('agent-b', 'security-audit');
+
+      const filePath = join(testDir, '.gossip', 'skill-index.json');
+      const before = readFileSync(filePath, 'utf-8');
+
+      const removed = index.prune(['agent-a', 'agent-b', 'agent-c-not-yet-bound']);
+
+      expect(removed).toEqual([]);
+      expect(index.getAgentIds().sort()).toEqual(['agent-a', 'agent-b']);
+      // File contents unchanged — no rewrite happened
+      expect(readFileSync(filePath, 'utf-8')).toBe(before);
+    });
+
+    it('persists pruned state to disk', () => {
+      const index = new SkillIndex(testDir);
+      index.bind('agent-a', 'typescript');
+      index.bind('ghost-agent', 'security-audit');
+
+      index.prune(['agent-a']);
+
+      // New instance reloads from disk — ghost-agent must be gone
+      const reloaded = new SkillIndex(testDir);
+      expect(reloaded.getAgentIds()).toEqual(['agent-a']);
+      expect(reloaded.getSlot('ghost-agent', 'security-audit')).toBeUndefined();
+
+      // Raw file inspection
+      const filePath = join(testDir, '.gossip', 'skill-index.json');
+      const data = JSON.parse(readFileSync(filePath, 'utf-8'));
+      expect(data['ghost-agent']).toBeUndefined();
+      expect(data['agent-a']).toBeDefined();
+    });
+
+    it('handles empty valid list by removing all entries', () => {
+      const index = new SkillIndex(testDir);
+      index.bind('agent-a', 'typescript');
+      index.bind('agent-b', 'security-audit');
+
+      const removed = index.prune([]);
+
+      expect(removed.sort()).toEqual(['agent-a', 'agent-b']);
+      expect(index.getAgentIds()).toEqual([]);
+    });
+
+    it('ignores invalid ids in valid list (empty / dangerous keys)', () => {
+      const index = new SkillIndex(testDir);
+      index.bind('agent-a', 'typescript');
+
+      // __proto__ etc. should not whitelist anything; agent-a is not in the
+      // sanitized valid list, so it should be pruned.
+      const removed = index.prune(['', '__proto__', 'constructor']);
+
+      expect(removed).toEqual(['agent-a']);
+      expect(index.getAgentIds()).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- `SkillIndex.prune(validAgentIds)` reconciles `.gossip/skill-index.json` against the live agent roster, dropping ghost entries from agents deleted from `config.json`. Sanitizes invalid/dangerous keys; persists only when something changed.
- Boot path (`apps/cli/src/mcp-server-sdk.ts`) calls `prune(validIds)` before the "Skill index loaded (N agents)" log, with a `🧹 Skill index pruned N orphan agent(s)` notice on removal.
- New `gossip_skills(action: "prune")` op returns `{ removed: string[] }` for ops use.

## Why
User just hit this — boot reported 9 agents while only 7 were configured (`gemini-implementer`, `openclaw-agent` had been deleted from config but persisted in the index). `load()` never reconciled.

## Test plan
- [x] `npx jest tests/orchestrator/skill-index.test.ts` → 36/36 (5 new, 31 existing)
- [x] Full orchestrator suite → 1572/1572 across 117 suites
- [x] `npm run build:mcp` → clean (1.9 MB bundle)
- [x] `npx tsc --noEmit` → only pre-existing errors in `packages/dashboard-v2/*` and unrelated test files
- [x] Live tool check after `/mcp` reconnect: `gossip_skills(action: "prune")` returns `{removed: []}` (already in sync)

## Out of scope
Agent memory directories under `.gossip/agents/<id>/` are intentionally left alone — `prune()` is purely skill-index reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)