### PR TITLE
fix(setup): refresh nativeAgentConfigs cache on every sync, not just first

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -37,6 +37,7 @@ import { restorePendingConsensus } from './handlers/relay-cross-review';
 import { persistRelayTasks, restoreRelayTasksAsFailed } from './handlers/relay-tasks';
 import { pickStickyPort, writeStickyPort, RELAY_STICKY_FILE, HTTP_MCP_STICKY_FILE } from './stickyPort';
 import { buildDashboardAdvisory } from './setup-response';
+import { refreshNativeAgentFromDisk } from './native-agent-cache';
 import { generateRulesContent } from './rules-content';
 import { formatDropReceipt } from './format-drop-receipt';
 import { homedir } from 'os';
@@ -841,20 +842,26 @@ async function doSyncWorkers() {
         provider: ac.provider,
         model: ac.model,
       });
-      // [H2 fix] Populate nativeAgentConfigs for config-defined native agents
-      if (ac.native && !ctx.nativeAgentConfigs.has(ac.id)) {
-        const { existsSync: ex, readFileSync: rf } = require('fs');
-        const { join: j } = require('path');
-        const claudeAgentPath = j(process.cwd(), '.claude', 'agents', `${ac.id}.md`);
-        const instrPath = j(process.cwd(), '.gossip', 'agents', ac.id, 'instructions.md');
-        let instructions = '';
-        if (ex(claudeAgentPath)) {
-          instructions = rf(claudeAgentPath, 'utf-8').replace(/^---\n[\s\S]*?\n---\n*/, '').trim();
-        } else if (ex(instrPath)) {
-          instructions = rf(instrPath, 'utf-8');
-        }
-        const modelTier = ac.model.includes('opus') ? 'opus' : ac.model.includes('haiku') ? 'haiku' : 'sonnet';
-        ctx.nativeAgentConfigs.set(ac.id, { model: modelTier, instructions, description: ac.role || ac.preset || '', skills: ac.skills || [] });
+      // [H2 fix] Populate / refresh nativeAgentConfigs for config-defined native
+      // agents. The previous version of this branch was guarded with
+      // `!ctx.nativeAgentConfigs.has(ac.id)` — that meant once an agent was
+      // bootstrapped into the cache, subsequent gossip_setup merge calls would
+      // rewrite .claude/agents/<id>.md on disk but the in-memory cache stayed
+      // stale, and dispatch kept emitting the old AGENT_PROMPT (typically the
+      // bootstrap stub). Workaround was killing the relay PID. The fix is to
+      // re-read from disk and update the cache unconditionally on every sync —
+      // doSyncWorkers is the right consolidation point because every config
+      // mutation flows through it. The read+set is extracted to
+      // refreshNativeAgentFromDisk so the invariant is unit-testable in
+      // isolation (see tests/cli/native-agent-cache.test.ts) — the regression
+      // would otherwise re-appear if anyone re-introduces the guard "as a
+      // perf optimization".
+      if (ac.native) {
+        refreshNativeAgentFromDisk(
+          { id: ac.id, model: ac.model, role: ac.role, preset: ac.preset, skills: ac.skills },
+          ctx.nativeAgentConfigs,
+          process.cwd()
+        );
       }
     }
 

--- a/apps/cli/src/native-agent-cache.ts
+++ b/apps/cli/src/native-agent-cache.ts
@@ -1,0 +1,92 @@
+/**
+ * Native agent in-memory cache refresh helper.
+ *
+ * Extracted from doSyncWorkers (mcp-server-sdk.ts) so the read-from-disk +
+ * cache-set behavior is testable in isolation. The previous inline version
+ * was guarded with `!ctx.nativeAgentConfigs.has(ac.id)` — that meant once an
+ * agent was bootstrapped into the cache, subsequent gossip_setup merge calls
+ * would rewrite .claude/agents/<id>.md on disk but the in-memory cache stayed
+ * stale, and dispatch kept emitting the old AGENT_PROMPT. The fix is to
+ * re-read from disk and update the cache unconditionally on every sync.
+ *
+ * Keeping this as a pure function (with `fs` and `path` injected via the
+ * thin wrappers below) means a unit test can exercise the refresh-on-update
+ * invariant without mocking the entire syncWorkersViaKeychain pipeline
+ * (MainAgent, keychain, identityRegistry, workers, mainProvider mirror).
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export interface NativeAgentCacheEntry {
+  model: string;
+  instructions: string;
+  description: string;
+  skills: string[];
+}
+
+export interface NativeAgentInput {
+  id: string;
+  model: string;
+  role?: string;
+  preset?: string;
+  skills?: string[];
+}
+
+export interface FsLike {
+  existsSync: (p: string) => boolean;
+  readFileSync: (p: string, enc: 'utf-8') => string;
+}
+
+const realFs: FsLike = { existsSync, readFileSync };
+
+/**
+ * Map a model id to a Claude tier label. Mirrors the inline logic that was
+ * previously duplicated across the bootstrap and config-sync paths.
+ */
+export function modelTierFromId(modelId: string): 'opus' | 'sonnet' | 'haiku' {
+  if (modelId.includes('opus')) return 'opus';
+  if (modelId.includes('haiku')) return 'haiku';
+  return 'sonnet';
+}
+
+/**
+ * Refresh the in-memory cache entry for a single native agent from its
+ * on-disk source of truth (.claude/agents/<id>.md, or
+ * .gossip/agents/<id>/instructions.md as fallback). Idempotent and
+ * unconditional — call on every sync; the read+set runs even when the
+ * agent already has an entry, because that is the whole point of the fix.
+ *
+ * Frontmatter is stripped from the .claude/agents/<id>.md content. The
+ * fallback .gossip/agents/<id>/instructions.md is consumed as-is.
+ *
+ * If neither file exists, the cache is set with empty instructions —
+ * matches the previous inline behavior so downstream code does not see
+ * an undefined entry for a config-defined native agent.
+ */
+export function refreshNativeAgentFromDisk(
+  ac: NativeAgentInput,
+  cache: Map<string, NativeAgentCacheEntry>,
+  projectRoot: string,
+  fs: FsLike = realFs
+): void {
+  const claudeAgentPath = join(projectRoot, '.claude', 'agents', `${ac.id}.md`);
+  const instrPath = join(projectRoot, '.gossip', 'agents', ac.id, 'instructions.md');
+
+  let instructions = '';
+  if (fs.existsSync(claudeAgentPath)) {
+    instructions = fs
+      .readFileSync(claudeAgentPath, 'utf-8')
+      .replace(/^---\n[\s\S]*?\n---\n*/, '')
+      .trim();
+  } else if (fs.existsSync(instrPath)) {
+    instructions = fs.readFileSync(instrPath, 'utf-8');
+  }
+
+  cache.set(ac.id, {
+    model: modelTierFromId(ac.model),
+    instructions,
+    description: ac.role || ac.preset || '',
+    skills: ac.skills || [],
+  });
+}

--- a/apps/cli/src/native-agent-cache.ts
+++ b/apps/cli/src/native-agent-cache.ts
@@ -15,7 +15,7 @@
  * (MainAgent, keychain, identityRegistry, workers, mainProvider mirror).
  */
 
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
 
 export interface NativeAgentCacheEntry {
@@ -23,6 +23,15 @@ export interface NativeAgentCacheEntry {
   instructions: string;
   description: string;
   skills: string[];
+  /**
+   * Modification time (ms since epoch) of the source-of-truth file the
+   * `instructions` value was last read from (.claude/agents/<id>.md when
+   * present, the .gossip fallback otherwise). Used by refreshNativeAgentFromDisk
+   * to skip the readFileSync when the file is unchanged since the last refresh.
+   * Undefined when the entry was created from a disk-empty state (no source
+   * file exists), so the next refresh always re-attempts the read.
+   */
+  cachedMtimeMs?: number;
 }
 
 export interface NativeAgentInput {
@@ -36,9 +45,19 @@ export interface NativeAgentInput {
 export interface FsLike {
   existsSync: (p: string) => boolean;
   readFileSync: (p: string, enc: 'utf-8') => string;
+  /**
+   * mtime in ms since epoch for the given path. Wrapped in the FsLike
+   * interface so unit tests can drive the mtime-skip path deterministically
+   * without touching the real filesystem.
+   */
+  statSync: (p: string) => { mtimeMs: number };
 }
 
-const realFs: FsLike = { existsSync, readFileSync };
+const realFs: FsLike = {
+  existsSync,
+  readFileSync,
+  statSync: (p: string) => ({ mtimeMs: statSync(p).mtimeMs }),
+};
 
 /**
  * Map a model id to a Claude tier label. Mirrors the inline logic that was
@@ -53,16 +72,35 @@ export function modelTierFromId(modelId: string): 'opus' | 'sonnet' | 'haiku' {
 /**
  * Refresh the in-memory cache entry for a single native agent from its
  * on-disk source of truth (.claude/agents/<id>.md, or
- * .gossip/agents/<id>/instructions.md as fallback). Idempotent and
- * unconditional — call on every sync; the read+set runs even when the
- * agent already has an entry, because that is the whole point of the fix.
+ * .gossip/agents/<id>/instructions.md as fallback).
  *
  * Frontmatter is stripped from the .claude/agents/<id>.md content. The
  * fallback .gossip/agents/<id>/instructions.md is consumed as-is.
  *
- * If neither file exists, the cache is set with empty instructions —
- * matches the previous inline behavior so downstream code does not see
- * an undefined entry for a config-defined native agent.
+ * Three guards address regressions identified during PR #266 review:
+ *
+ *  1. **mtime skip (perf)**: if the source file's mtime equals the cached
+ *     entry's `cachedMtimeMs`, the readFileSync is skipped and the existing
+ *     entry is preserved. Closes the "refresh storm" where every dispatch
+ *     triggered N synchronous file reads even when nothing had changed.
+ *
+ *  2. **empty-file clobber guard**: if the on-disk file exists but yields an
+ *     empty `instructions` string after frontmatter strip + trim, AND a
+ *     non-empty cached entry already exists, the cached value is preserved.
+ *     Closes the race where doSyncWorkers reads .claude/agents/<id>.md mid-
+ *     write (file truncated to 0 bytes by the writer), which would otherwise
+ *     overwrite a previously-good entry with an empty system prompt.
+ *
+ *  3. **missing-file clobber guard**: if neither source file exists AND a
+ *     non-empty cached entry already exists, the cached value is preserved.
+ *     Closes the race where doSyncWorkers reads .claude/agents/<id>.md
+ *     during the brief window when the writer has unlinked the old file
+ *     and not yet renamed the temp file into place (atomic-replace pattern).
+ *
+ * Backward-compat: if neither source file exists AND no cached entry exists,
+ * the cache is set with empty `instructions` — matches the prior inline
+ * behavior so downstream code does not see an undefined entry for a
+ * config-defined native agent that has not yet been written to disk.
  */
 export function refreshNativeAgentFromDisk(
   ac: NativeAgentInput,
@@ -72,15 +110,73 @@ export function refreshNativeAgentFromDisk(
 ): void {
   const claudeAgentPath = join(projectRoot, '.claude', 'agents', `${ac.id}.md`);
   const instrPath = join(projectRoot, '.gossip', 'agents', ac.id, 'instructions.md');
+  const prev = cache.get(ac.id);
 
-  let instructions = '';
+  // Determine which source file to consult, in preference order.
+  let sourcePath: string | null = null;
+  let stripFrontmatter = false;
   if (fs.existsSync(claudeAgentPath)) {
-    instructions = fs
-      .readFileSync(claudeAgentPath, 'utf-8')
-      .replace(/^---\n[\s\S]*?\n---\n*/, '')
-      .trim();
+    sourcePath = claudeAgentPath;
+    stripFrontmatter = true;
   } else if (fs.existsSync(instrPath)) {
-    instructions = fs.readFileSync(instrPath, 'utf-8');
+    sourcePath = instrPath;
+    stripFrontmatter = false;
+  }
+
+  // Guard 3: missing-file clobber — neither source exists, but we have a
+  // good cached entry. Preserve it rather than overwriting with ''.
+  if (sourcePath === null) {
+    if (prev && prev.instructions.length > 0) {
+      return;
+    }
+    // No prior good entry: preserve backward compat by writing an empty
+    // entry so downstream code can find SOMETHING for a config-defined agent.
+    cache.set(ac.id, {
+      model: modelTierFromId(ac.model),
+      instructions: '',
+      description: ac.role || ac.preset || '',
+      skills: ac.skills || [],
+      // No cachedMtimeMs — next refresh will always retry the read.
+    });
+    return;
+  }
+
+  // Guard 1: mtime skip — file is unchanged since last refresh.
+  // statSync is cheap (single inode lookup) compared to readFileSync of
+  // a multi-KB instructions file, especially on networked filesystems.
+  let currentMtimeMs: number;
+  try {
+    currentMtimeMs = fs.statSync(sourcePath).mtimeMs;
+  } catch {
+    // If statSync fails (race with delete between existsSync and statSync),
+    // fall through to the missing-file guard logic — preserve prev if good,
+    // else write empty entry.
+    if (prev && prev.instructions.length > 0) {
+      return;
+    }
+    cache.set(ac.id, {
+      model: modelTierFromId(ac.model),
+      instructions: '',
+      description: ac.role || ac.preset || '',
+      skills: ac.skills || [],
+    });
+    return;
+  }
+  if (prev && prev.cachedMtimeMs === currentMtimeMs) {
+    return;
+  }
+
+  // Read the source file.
+  let instructions = fs.readFileSync(sourcePath, 'utf-8');
+  if (stripFrontmatter) {
+    instructions = instructions.replace(/^---\n[\s\S]*?\n---\n*/, '').trim();
+  }
+
+  // Guard 2: empty-file clobber — the read produced an empty string but a
+  // good cached entry exists. Likely a mid-write race (writer truncated the
+  // file to 0 bytes before writing new content).
+  if (instructions.length === 0 && prev && prev.instructions.length > 0) {
+    return;
   }
 
   cache.set(ac.id, {
@@ -88,5 +184,6 @@ export function refreshNativeAgentFromDisk(
     instructions,
     description: ac.role || ac.preset || '',
     skills: ac.skills || [],
+    cachedMtimeMs: currentMtimeMs,
   });
 }

--- a/tests/cli/native-agent-cache.test.ts
+++ b/tests/cli/native-agent-cache.test.ts
@@ -1,0 +1,174 @@
+import { join } from 'path';
+import {
+  refreshNativeAgentFromDisk,
+  modelTierFromId,
+  type NativeAgentCacheEntry,
+  type FsLike,
+} from '../../apps/cli/src/native-agent-cache';
+
+/**
+ * In-memory FsLike fake. Records all reads / existence checks so tests can
+ * assert what disk path was consulted, and lets each test seed a virtual file
+ * tree without touching the real filesystem.
+ */
+function makeFakeFs(files: Record<string, string>): FsLike {
+  return {
+    existsSync: (p: string) => Object.prototype.hasOwnProperty.call(files, p),
+    readFileSync: (p: string) => {
+      if (!Object.prototype.hasOwnProperty.call(files, p)) {
+        throw new Error(`fake fs: ENOENT ${p}`);
+      }
+      return files[p];
+    },
+  };
+}
+
+const ROOT = '/proj';
+// Build the fake-fs keys with the same `join` the production function uses,
+// so the test fixture works cross-platform (path.join produces backslashes
+// on Windows; hand-built '/proj/.claude/agents/foo.md' wouldn't match).
+const CLAUDE_PATH = join(ROOT, '.claude', 'agents', 'foo.md');
+const FALLBACK_PATH = join(ROOT, '.gossip', 'agents', 'foo', 'instructions.md');
+
+const FRONTMATTER = [
+  '---',
+  'name: foo',
+  'model: sonnet',
+  'description: a foo',
+  '---',
+  '',
+].join('\n');
+
+describe('refreshNativeAgentFromDisk', () => {
+  it('writes a fresh cache entry from .claude/agents/<id>.md (no prior entry)', () => {
+    const cache = new Map<string, NativeAgentCacheEntry>();
+    const fs = makeFakeFs({ [CLAUDE_PATH]: FRONTMATTER + 'INITIAL body' });
+
+    refreshNativeAgentFromDisk(
+      { id: 'foo', model: 'claude-sonnet-4-6', role: 'reviewer', skills: ['code_review'] },
+      cache,
+      ROOT,
+      fs
+    );
+
+    const entry = cache.get('foo');
+    expect(entry).toBeDefined();
+    expect(entry!.instructions).toBe('INITIAL body');
+    expect(entry!.model).toBe('sonnet');
+    expect(entry!.description).toBe('reviewer');
+    expect(entry!.skills).toEqual(['code_review']);
+  });
+
+  // The core regression: gossipcat-ai/gossipcat-ai#266. Before the fix, the
+  // refresh path was guarded by `!cache.has(id)`, so an existing entry would
+  // never be updated even when the on-disk source had changed. Dispatch kept
+  // emitting the stale instructions.
+  it('overwrites an existing cache entry on subsequent calls (the #266 regression)', () => {
+    const cache = new Map<string, NativeAgentCacheEntry>();
+    const fs1 = makeFakeFs({ [CLAUDE_PATH]: FRONTMATTER + 'INITIAL body' });
+
+    refreshNativeAgentFromDisk(
+      { id: 'foo', model: 'claude-sonnet-4-6', role: 'reviewer', skills: ['code_review'] },
+      cache,
+      ROOT,
+      fs1
+    );
+    expect(cache.get('foo')!.instructions).toBe('INITIAL body');
+
+    // Simulate what gossip_setup mode:"merge" does on disk: rewrite the
+    // .claude/agents/<id>.md with new instructions. Then call refresh again
+    // — which is what doSyncWorkers does after writing .gossip/config.json.
+    const fs2 = makeFakeFs({ [CLAUDE_PATH]: FRONTMATTER + 'UPDATED body' });
+    refreshNativeAgentFromDisk(
+      { id: 'foo', model: 'claude-sonnet-4-6', role: 'reviewer', skills: ['code_review'] },
+      cache,
+      ROOT,
+      fs2
+    );
+
+    expect(cache.get('foo')!.instructions).toBe('UPDATED body');
+  });
+
+  it('strips frontmatter from .claude/agents/<id>.md', () => {
+    const cache = new Map<string, NativeAgentCacheEntry>();
+    const fs = makeFakeFs({
+      [CLAUDE_PATH]: FRONTMATTER + 'body line 1\nbody line 2',
+    });
+
+    refreshNativeAgentFromDisk(
+      { id: 'foo', model: 'claude-sonnet-4-6' },
+      cache,
+      ROOT,
+      fs
+    );
+
+    expect(cache.get('foo')!.instructions).toBe('body line 1\nbody line 2');
+    expect(cache.get('foo')!.instructions).not.toContain('---');
+    expect(cache.get('foo')!.instructions).not.toContain('description:');
+  });
+
+  it('falls back to .gossip/agents/<id>/instructions.md when .claude/agents is absent', () => {
+    const cache = new Map<string, NativeAgentCacheEntry>();
+    const fs = makeFakeFs({ [FALLBACK_PATH]: 'fallback instructions' });
+
+    refreshNativeAgentFromDisk(
+      { id: 'foo', model: 'claude-sonnet-4-6' },
+      cache,
+      ROOT,
+      fs
+    );
+
+    expect(cache.get('foo')!.instructions).toBe('fallback instructions');
+  });
+
+  it('writes an empty-instructions entry when neither source file exists', () => {
+    const cache = new Map<string, NativeAgentCacheEntry>();
+    const fs = makeFakeFs({});
+
+    refreshNativeAgentFromDisk(
+      { id: 'foo', model: 'claude-sonnet-4-6', role: 'reviewer', skills: ['code_review'] },
+      cache,
+      ROOT,
+      fs
+    );
+
+    // Matches the prior inline behavior: downstream code expects the entry
+    // to exist for any config-defined native agent, even if disk is empty.
+    expect(cache.get('foo')).toEqual({
+      model: 'sonnet',
+      instructions: '',
+      description: 'reviewer',
+      skills: ['code_review'],
+    });
+  });
+
+  it('prefers role over preset for description when both are present', () => {
+    const cache = new Map<string, NativeAgentCacheEntry>();
+    const fs = makeFakeFs({ [CLAUDE_PATH]: FRONTMATTER + 'b' });
+
+    refreshNativeAgentFromDisk(
+      { id: 'foo', model: 'claude-sonnet-4-6', role: 'r', preset: 'p' },
+      cache,
+      ROOT,
+      fs
+    );
+
+    expect(cache.get('foo')!.description).toBe('r');
+  });
+});
+
+describe('modelTierFromId', () => {
+  it('maps opus models to "opus"', () => {
+    expect(modelTierFromId('claude-opus-4-7')).toBe('opus');
+  });
+
+  it('maps haiku models to "haiku"', () => {
+    expect(modelTierFromId('claude-haiku-4-5')).toBe('haiku');
+  });
+
+  it('defaults everything else to "sonnet"', () => {
+    expect(modelTierFromId('claude-sonnet-4-6')).toBe('sonnet');
+    expect(modelTierFromId('gemini-2.5-pro')).toBe('sonnet');
+    expect(modelTierFromId('')).toBe('sonnet');
+  });
+});

--- a/tests/cli/native-agent-cache.test.ts
+++ b/tests/cli/native-agent-cache.test.ts
@@ -10,15 +10,32 @@ import {
  * In-memory FsLike fake. Records all reads / existence checks so tests can
  * assert what disk path was consulted, and lets each test seed a virtual file
  * tree without touching the real filesystem.
+ *
+ * Files can be specified as a plain string (default mtime: 1000ms) or as a
+ * { content, mtimeMs } object when a test needs to control mtime explicitly
+ * (mtime-skip guard tests).
  */
-function makeFakeFs(files: Record<string, string>): FsLike {
+type FileEntry = string | { content: string; mtimeMs: number };
+
+function makeFakeFs(files: Record<string, FileEntry>): FsLike {
+  const get = (p: string): { content: string; mtimeMs: number } => {
+    const v = files[p];
+    if (typeof v === 'string') return { content: v, mtimeMs: 1000 };
+    return v;
+  };
   return {
     existsSync: (p: string) => Object.prototype.hasOwnProperty.call(files, p),
     readFileSync: (p: string) => {
       if (!Object.prototype.hasOwnProperty.call(files, p)) {
         throw new Error(`fake fs: ENOENT ${p}`);
       }
-      return files[p];
+      return get(p).content;
+    },
+    statSync: (p: string) => {
+      if (!Object.prototype.hasOwnProperty.call(files, p)) {
+        throw new Error(`fake fs: ENOENT ${p}`);
+      }
+      return { mtimeMs: get(p).mtimeMs };
     },
   };
 }
@@ -76,9 +93,12 @@ describe('refreshNativeAgentFromDisk', () => {
     expect(cache.get('foo')!.instructions).toBe('INITIAL body');
 
     // Simulate what gossip_setup mode:"merge" does on disk: rewrite the
-    // .claude/agents/<id>.md with new instructions. Then call refresh again
-    // — which is what doSyncWorkers does after writing .gossip/config.json.
-    const fs2 = makeFakeFs({ [CLAUDE_PATH]: FRONTMATTER + 'UPDATED body' });
+    // .claude/agents/<id>.md with new instructions. mtime advances because
+    // the writer touched the file. Then call refresh again — which is what
+    // doSyncWorkers does after writing .gossip/config.json.
+    const fs2 = makeFakeFs({
+      [CLAUDE_PATH]: { content: FRONTMATTER + 'UPDATED body', mtimeMs: 2000 },
+    });
     refreshNativeAgentFromDisk(
       { id: 'foo', model: 'claude-sonnet-4-6', role: 'reviewer', skills: ['code_review'] },
       cache,
@@ -154,6 +174,115 @@ describe('refreshNativeAgentFromDisk', () => {
     );
 
     expect(cache.get('foo')!.description).toBe('r');
+  });
+
+  // Guard 2: empty-file clobber. The maintainer flagged a HIGH-severity race
+  // where doSyncWorkers reads .claude/agents/<id>.md while a writer has
+  // truncated it to 0 bytes (mid-write window). Without this guard, the
+  // empty read would overwrite a previously-good cache entry, and the next
+  // dispatch would emit an empty system prompt.
+  it('preserves prev cache entry when on-disk file is empty (mid-write race)', () => {
+    const cache = new Map<string, NativeAgentCacheEntry>();
+    const fs1 = makeFakeFs({ [CLAUDE_PATH]: FRONTMATTER + 'GOOD body' });
+    refreshNativeAgentFromDisk(
+      { id: 'foo', model: 'claude-sonnet-4-6', role: 'reviewer', skills: ['code_review'] },
+      cache,
+      ROOT,
+      fs1
+    );
+    expect(cache.get('foo')!.instructions).toBe('GOOD body');
+
+    // Simulate mid-write race: writer truncated file to empty (frontmatter
+    // gone, body gone). mtime advances because the writer touched the file.
+    const fs2 = makeFakeFs({ [CLAUDE_PATH]: { content: '', mtimeMs: 2000 } });
+    refreshNativeAgentFromDisk(
+      { id: 'foo', model: 'claude-sonnet-4-6', role: 'reviewer', skills: ['code_review'] },
+      cache,
+      ROOT,
+      fs2
+    );
+
+    // Cache must NOT be overwritten with empty instructions — preserve prev.
+    expect(cache.get('foo')!.instructions).toBe('GOOD body');
+  });
+
+  // Guard 3: missing-file clobber. The maintainer flagged the same race
+  // pattern with atomic-replace writers (writer unlinks old file before
+  // renaming temp into place). Without this guard, the brief existsSync=false
+  // window would overwrite a good entry with empty.
+  it('preserves prev cache entry when source file disappears between syncs', () => {
+    const cache = new Map<string, NativeAgentCacheEntry>();
+    const fs1 = makeFakeFs({ [CLAUDE_PATH]: FRONTMATTER + 'GOOD body' });
+    refreshNativeAgentFromDisk(
+      { id: 'foo', model: 'claude-sonnet-4-6', role: 'reviewer', skills: ['code_review'] },
+      cache,
+      ROOT,
+      fs1
+    );
+    expect(cache.get('foo')!.instructions).toBe('GOOD body');
+
+    // Simulate atomic-replace mid-window: source file is briefly absent.
+    const fs2 = makeFakeFs({});
+    refreshNativeAgentFromDisk(
+      { id: 'foo', model: 'claude-sonnet-4-6', role: 'reviewer', skills: ['code_review'] },
+      cache,
+      ROOT,
+      fs2
+    );
+
+    // Cache must NOT be overwritten with empty instructions — preserve prev.
+    expect(cache.get('foo')!.instructions).toBe('GOOD body');
+  });
+
+  // Guard 1: mtime-skip. The maintainer flagged a MEDIUM perf concern about
+  // refresh storm — syncWorkersViaKeychain fires from 7 callsites and the
+  // mutex coalesces concurrent calls but not sequential ones. So every
+  // dispatch was triggering N synchronous readFileSync calls even when
+  // nothing had changed on disk. The mtime guard short-circuits the read
+  // when the source file's mtime equals the cached entry's mtime.
+  it('skips readFileSync when source mtime is unchanged since last refresh (perf)', () => {
+    const cache = new Map<string, NativeAgentCacheEntry>();
+
+    // Spy on readFileSync to assert it is NOT called on the second refresh.
+    let readCount = 0;
+    let statCount = 0;
+    const baseFs = makeFakeFs({
+      [CLAUDE_PATH]: { content: FRONTMATTER + 'STABLE body', mtimeMs: 1500 },
+    });
+    const fs: FsLike = {
+      existsSync: baseFs.existsSync,
+      readFileSync: (p: string, enc: 'utf-8') => {
+        readCount++;
+        return baseFs.readFileSync(p, enc);
+      },
+      statSync: (p: string) => {
+        statCount++;
+        return baseFs.statSync(p);
+      },
+    };
+
+    refreshNativeAgentFromDisk(
+      { id: 'foo', model: 'claude-sonnet-4-6', role: 'reviewer', skills: ['code_review'] },
+      cache,
+      ROOT,
+      fs
+    );
+    expect(readCount).toBe(1);
+    expect(statCount).toBe(1);
+    expect(cache.get('foo')!.instructions).toBe('STABLE body');
+    expect(cache.get('foo')!.cachedMtimeMs).toBe(1500);
+
+    // Second refresh with the same file (same mtime) should hit the mtime
+    // guard: statSync still runs (cheap), readFileSync does NOT.
+    refreshNativeAgentFromDisk(
+      { id: 'foo', model: 'claude-sonnet-4-6', role: 'reviewer', skills: ['code_review'] },
+      cache,
+      ROOT,
+      fs
+    );
+    expect(readCount).toBe(1);
+    expect(statCount).toBe(2);
+    expect(cache.get('foo')!.instructions).toBe('STABLE body');
   });
 });
 


### PR DESCRIPTION
## Problem

`gossip_setup mode: \"merge\"` correctly rewrites `.claude/agents/<id>.md` on disk when the caller passes new instructions for an existing native agent. However, `doSyncWorkers` (which fires after the file write via `syncWorkersViaKeychain`) populated `ctx.nativeAgentConfigs` only when the agent was NOT already in the cache:

```ts
if (ac.native && !ctx.nativeAgentConfigs.has(ac.id)) {
  // read .claude/agents/<id>.md from disk
  ctx.nativeAgentConfigs.set(ac.id, { ..., instructions, ... });
}
```

After the first bootstrap, every subsequent merge skipped the read+set, leaving the in-memory cache pointing at the stale instructions. Dispatch constructs the AGENT_PROMPT from `nativeConfig.instructions` retrieved from that same cache, so the bug surfaced at dispatch time as **\"the agent ignores the new instructions\"**. Workaround was killing the relay PID so the next MCP call respawned it and re-read from disk.

## Reproduction

1. `gossip_setup` with native agent, `instructions: \"INITIAL\"`.
2. Verify `.claude/agents/<id>.md` body contains `INITIAL`.
3. `gossip_setup mode: \"merge\"` for the same agent with `instructions: \"UPDATED\"`.
4. Verify `.claude/agents/<id>.md` body contains `UPDATED` ✓ (the file is correctly rewritten).
5. `gossip_dispatch` for the same agent → AGENT_PROMPT still contains `INITIAL`. **BUG.**
6. Kill relay PID, repeat dispatch → AGENT_PROMPT now contains `UPDATED`. Confirms cache stale.

## Fix

Extract the read-from-disk + cache-set into a pure function `refreshNativeAgentFromDisk` in a new module `apps/cli/src/native-agent-cache.ts`, and call it unconditionally for every config-defined native agent on every sync. The `!has()` guard is gone — `doSyncWorkers` is the right consolidation point because every config mutation (merge/replace) flows through `syncWorkersViaKeychain` after writing `.gossip/config.json`, so the cache update naturally tracks the disk state.

The pure function takes an `FsLike` for fs injection. The thin wrappers add ~3 lines of boilerplate and pay back the entire test setup.

## Test

`tests/cli/native-agent-cache.test.ts` — 9 isolated cases against the extracted function, including the **exact regression that triggered this PR** (`overwrites an existing cache entry on subsequent calls`). The `FsLike` injection lets the test exercise the full code path with virtual files, no real filesystem, and no mocking of the broader `syncWorkersViaKeychain` pipeline (`MainAgent`, keychain, `identityRegistry`, workers, `mainProvider` mirror — all out of scope for verifying this branch).

```
Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
```

Adjacent suites (`dispatch-native-prompt.test.ts`, `mcp-server-sdk.test.ts`, `config.test.ts`) continue to pass.

## Out of scope (intentional, follow-up candidate)

The companion path at the `loadClaudeSubagents` loop (further down in `doSyncWorkers`) is intentionally **not** changed in this PR. That branch picks up subagents discovered from `.claude/agents/*.md` whose IDs are NOT already in `agentConfigs`/`workers`/`nativeAgentConfigs`. After this fix, agents in `agentConfigs` are refreshed on every sync via the extracted function, so the `existingIds` filter on the discovery branch behaves correctly for the common case (agent in config). A follow-up PR could collapse the two paths into a single read-from-disk-as-source-of-truth pass, but that is a refactor, not a bugfix.

## Companion PR

PR #265 fixes a related but independent schema↔runtime drift bug discovered in the same session (`main_provider` enum / `VALID_PROVIDERS`). The two are split per CONTRIBUTING — \"one concern per PR\".

---

*Disclaimer: this PR description, the code changes in this PR, and the accompanying tests were drafted by Kloud AI assistant (kloud@gravya.it) under human review and approval. Human in the loop: GravyaDev.*
