### PR TITLE
chore(deps): bump postcss 8.5.8 → 8.5.10 (Dependabot #22)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gossipcat",
-  "version": "0.4.18",
+  "version": "0.4.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gossipcat",
-      "version": "0.4.18",
+      "version": "0.4.20",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -5640,9 +5640,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
Resolves [Dependabot alert #22](https://github.com/gossipcat-ai/gossipcat-ai/security/dependabot/22) — postcss XSS via unescaped \`</style>\` in CSS stringify output (CVE-2026-41305, GHSA-qx2v-qp2m-jg93). Severity: medium.

## Exposure
**Zero practical impact for this repo.** Postcss is an indirect build-time dep via vite (used by \`packages/dashboard-v2\`). The vulnerability requires \`postcss.parse(userCSS) → toResult().css → embed in <style>\` flow, which we never do — vite uses postcss on our own build-time CSS. Bumping anyway because the patch is free (the patched version is already inside vite's \`^8.5.3\` range).

## Test plan
- [x] \`npm update postcss\` → 8.5.8 → 8.5.10
- [x] \`npm audit\` → 0 vulnerabilities
- [x] Diff is package-lock.json only, 5 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)