### PR TITLE
fix(task-graph): apply redactSecrets to recordCreated for parity

### DIFF
--- a/packages/orchestrator/src/task-graph.ts
+++ b/packages/orchestrator/src/task-graph.ts
@@ -74,7 +74,7 @@ export class TaskGraph {
 
   recordCreated(taskId: string, agentId: string, task: string, skills: string[], parentId?: string): void {
     const event: TaskCreatedEvent = {
-      type: 'task.created', taskId, agentId, task, skills,
+      type: 'task.created', taskId, agentId, task: this.redactSecrets(task), skills,
       ...(parentId ? { parentId } : {}),
       timestamp: new Date().toISOString(),
     };

--- a/tests/orchestrator/task-graph.test.ts
+++ b/tests/orchestrator/task-graph.test.ts
@@ -228,6 +228,27 @@ describe('TaskGraph', () => {
       expect(task!.error).toContain('[REDACTED_API_KEY]');
     });
 
+    it('redacts secrets from all record* methods (parity)', () => {
+      // Sentinel embeds an sk-<40+ alnum> run that matches redactSecrets sk[-_][a-zA-Z0-9]{40,}
+      const sentinel = 'SECRET_sk-testDEADBEEF1234567890abcdefghijklmnopqrstuvwxyz0123456789';
+      const graph = new TaskGraph(testDir);
+      graph.recordCreated('p1', 'agent', `plan: do thing with ${sentinel}`, ['skill1']);
+      graph.recordCompleted('p1', `result includes ${sentinel}`, 100);
+      graph.recordCreated('p2', 'agent', `another plan ${sentinel}`, []);
+      graph.recordFailed('p2', `failure with ${sentinel}`, 100);
+
+      const lines = readFileSync(graphPath, 'utf-8').trim().split('\n');
+      expect(lines.length).toBe(4);
+      for (const line of lines) {
+        expect(line).not.toContain(sentinel);
+      }
+      // Confirm record types covered
+      const types = lines.map(l => JSON.parse(l).type);
+      expect(types).toEqual([
+        'task.created', 'task.completed', 'task.created', 'task.failed',
+      ]);
+    });
+
     it('persists index and loads on new instance', () => {
       const graph = new TaskGraph(testDir);
       graph.recordCreated('idx-1', 'agent', 'indexed task', ['test']);


### PR DESCRIPTION
## Summary
`recordCreated` did not apply `redactSecrets()` to the `task` field, while sibling methods `recordCompleted` and `recordFailed` did. PR #264 made this asymmetry observable by introducing user-prompt content (`plan:${task.slice(0,120)}`) into the `task` field of `task.created` events, so any sensitive token in the first 120 chars of a user's plan-task prompt landed unredacted in `.gossip/task-graph.jsonl`.

This PR closes the gap: 1 LOC change in `packages/orchestrator/src/task-graph.ts:77` wrapping `task` with `this.redactSecrets(task)`, plus a parity test that asserts none of the three `record*` methods emit a verbatim sentinel.

## Why
Discovered by sonnet-reviewer in consensus round `58a7377b-0e464b69` (PR #264 review) as a HIGH finding, deferred at the time because the fix had broader blast radius than the PR scope. Memory file: `project_task_graph_record_created_redact.md`.

## Test plan
- [x] New parity test seeds an `sk-test-DEADBEEF...` sentinel into all 3 `record*` methods and asserts no JSONL line contains it verbatim
- [x] `npx jest tests/orchestrator/task-graph.test.ts` → 25/25
- [x] Full orchestrator suite → 1573 passed, 0 failed
- [x] `npm run build:mcp` → clean (1.9 MB)
- [x] `recordCompleted` and `recordFailed` bodies untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)