### PR TITLE
fix(drift-detector): authorize signal-helpers-pipeline for finding_dropped_format

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2863,10 +2863,15 @@ server.tool(
         const dropBlock = formatDropReceipt(droppedNoCategory);
         if (dropBlock) baseReceipt += dropBlock;
 
-        // PR2: emit finding_dropped_format pipeline signal for each drop so the
-        // record-path category-miss surfaces in the dashboard / signal feed, not
-        // just in stderr + the MCP receipt. Best-effort: failure must NOT break
-        // the record path (secondary observability channel).
+        // Emit finding_dropped_format pipeline signal for each drop so the
+        // record-path category-miss surfaces in the dashboard / signal feed,
+        // not just in stderr + the MCP receipt. This is a deliberate secondary
+        // emit site for finding_dropped_format and is explicitly authorized in
+        // COMPLETION_SIGNAL_AUTHORIZED_PATHS (the L3 drift detector treats
+        // signal-helpers-pipeline as a sanctioned path for this signal — see
+        // packages/orchestrator/src/completion-signals.allowlist.ts and
+        // memory project_drift_bypass_finding_dropped_format).
+        // Best-effort: failure must NOT break the record path.
         try {
           const { emitPipelineSignals } = await import('@gossip/orchestrator');
           const nowIso = new Date().toISOString();

--- a/packages/orchestrator/src/completion-signals.allowlist.ts
+++ b/packages/orchestrator/src/completion-signals.allowlist.ts
@@ -24,6 +24,35 @@ export const COMPLETION_SIGNAL_ALLOWLIST: readonly string[] = [
 ] as const;
 
 /**
+ * COMPLETION_SIGNAL_AUTHORIZED_PATHS — for each allowlisted signal, the closed
+ * set of `_emission_path` values that the L3 drift detector treats as
+ * sanctioned. Any allowlisted signal landing on a path NOT in its authorized
+ * set is flagged as a bypass.
+ *
+ * Default authorized path is `completion-signals-helper` (the canonical
+ * emit surface). A signal may be authorized for additional paths when there
+ * is a deliberate, documented secondary emit site — see
+ * `finding_dropped_format`, which is also emitted from the gossip_signals
+ * record path via `emitPipelineSignals` (signal-helpers-pipeline) so
+ * category-misses on the record path land in the dashboard, not just stderr.
+ *
+ * Adding a path here is a policy change, not a workaround: it widens the
+ * sanctioned emit surface for that specific signal. Pair every entry with a
+ * comment naming the deliberate caller and the reason.
+ */
+export const COMPLETION_SIGNAL_AUTHORIZED_PATHS: Readonly<Record<string, ReadonlySet<string>>> = {
+  task_completed: new Set(['completion-signals-helper']),
+  task_tool_turns: new Set(['completion-signals-helper']),
+  format_compliance: new Set(['completion-signals-helper']),
+  // finding_dropped_format is also emitted from the gossip_signals(record)
+  // path in apps/cli/src/mcp-server-sdk.ts via emitPipelineSignals, so the
+  // record-path category-miss surfaces in the dashboard. The pipeline helper
+  // is signal-helpers-pipeline; see project_drift_bypass_finding_dropped_format.
+  finding_dropped_format: new Set(['completion-signals-helper', 'signal-helpers-pipeline']),
+  citation_fabricated: new Set(['completion-signals-helper']),
+};
+
+/**
  * EMISSION_PATHS — closed enum of code regions permitted to write into
  * `agent-performance.jsonl` via `PerformanceWriter.appendSignal(s)`.
  *

--- a/packages/orchestrator/src/pipeline-drift-detector.ts
+++ b/packages/orchestrator/src/pipeline-drift-detector.ts
@@ -33,7 +33,10 @@ import {
 } from 'fs';
 import { join } from 'path';
 import { createHash } from 'crypto';
-import { COMPLETION_SIGNAL_ALLOWLIST } from './completion-signals.allowlist';
+import {
+  COMPLETION_SIGNAL_ALLOWLIST,
+  COMPLETION_SIGNAL_AUTHORIZED_PATHS,
+} from './completion-signals.allowlist';
 import { rotateJsonlIfNeeded } from './performance-writer';
 
 export interface DriftOffender {
@@ -83,6 +86,19 @@ const DEFAULTS = {
 };
 
 const ALLOWLIST_SET = new Set<string>(COMPLETION_SIGNAL_ALLOWLIST);
+
+/**
+ * For an allowlisted signal, return the set of `_emission_path` values that
+ * are sanctioned for it. Falls back to the canonical helper-only set when a
+ * signal is in the allowlist but missing from the per-signal map (defensive —
+ * the parity test should keep them aligned).
+ */
+function authorizedPathsFor(signal: string): ReadonlySet<string> {
+  return (
+    COMPLETION_SIGNAL_AUTHORIZED_PATHS[signal] ??
+    new Set(['completion-signals-helper'])
+  );
+}
 
 function fingerprint(offender: DriftOffender): string {
   return createHash('sha1')
@@ -223,12 +239,16 @@ export class PipelineDriftDetector {
       return isFinite(ts) && ts >= (tagEpochMs as number);
     });
 
-    // Bypass: allowlisted signal name on any path other than the helper.
+    // Bypass: allowlisted signal name on a path that is NOT in the
+    // signal's authorized path set. Most signals only authorize
+    // `completion-signals-helper`; a few (e.g. finding_dropped_format) have
+    // an additional sanctioned secondary emit site declared in
+    // COMPLETION_SIGNAL_AUTHORIZED_PATHS.
     const bypassRows = postEpoch.filter(r =>
       typeof r.signal === 'string'
       && ALLOWLIST_SET.has(r.signal)
       && typeof r._emission_path === 'string'
-      && r._emission_path !== 'completion-signals-helper',
+      && !authorizedPathsFor(r.signal).has(r._emission_path),
     );
 
     // Unknown: explicit 'unknown' emission-path (NOT "absent" — pre-epoch

--- a/tests/orchestrator/pipeline-drift-detector.test.ts
+++ b/tests/orchestrator/pipeline-drift-detector.test.ts
@@ -292,4 +292,52 @@ describe('PipelineDriftDetector', () => {
   it('statSync is importable from fs (sanity guard for detector test env)', () => {
     expect(typeof statSync).toBe('function');
   });
+
+  // ── Per-signal authorized-path policy ────────────────────────────────────
+  // finding_dropped_format has TWO sanctioned emit sites (the canonical
+  // helper + signal-helpers-pipeline used by gossip_signals(record)). Both
+  // must be treated as non-bypass; a third path must still trigger.
+  it('finding_dropped_format on completion-signals-helper does not trigger bypass', () => {
+    write(root, [
+      { type: 'meta', signal: 'task_completed', agentId: 'a', taskId: 't0', timestamp: iso(0), _emission_path: 'completion-signals-helper' },
+      { type: 'pipeline', signal: 'finding_dropped_format', agentId: 'a', taskId: 't1', timestamp: iso(1), _emission_path: 'completion-signals-helper' },
+    ]);
+    const r = new PipelineDriftDetector(root).run();
+    expect(r.bypassCount).toBe(0);
+    expect(r.triggered).toBe(false);
+  });
+
+  it('finding_dropped_format on signal-helpers-pipeline does not trigger bypass (authorized secondary path)', () => {
+    write(root, [
+      { type: 'meta', signal: 'task_completed', agentId: 'a', taskId: 't0', timestamp: iso(0), _emission_path: 'completion-signals-helper' },
+      { type: 'pipeline', signal: 'finding_dropped_format', agentId: 'a', taskId: 't1', timestamp: iso(1), _emission_path: 'signal-helpers-pipeline' },
+    ]);
+    const r = new PipelineDriftDetector(root).run();
+    expect(r.bypassCount).toBe(0);
+    expect(r.triggered).toBe(false);
+  });
+
+  it('finding_dropped_format on a non-authorized path still triggers bypass', () => {
+    write(root, [
+      { type: 'meta', signal: 'task_completed', agentId: 'a', taskId: 't0', timestamp: iso(0), _emission_path: 'completion-signals-helper' },
+      { type: 'pipeline', signal: 'finding_dropped_format', agentId: 'a', taskId: 't1', timestamp: iso(1), _emission_path: 'native-tasks' },
+    ]);
+    const r = new PipelineDriftDetector(root).run();
+    expect(r.bypassCount).toBe(1);
+    expect(r.triggered).toBe(true);
+    expect(r.sampleOffenders[0]).toMatchObject({
+      signal: 'finding_dropped_format',
+      emissionPath: 'native-tasks',
+    });
+  });
+
+  it('task_completed on signal-helpers-pipeline still triggers (path authorized only for finding_dropped_format)', () => {
+    write(root, [
+      { type: 'meta', signal: 'task_completed', agentId: 'a', taskId: 't0', timestamp: iso(0), _emission_path: 'completion-signals-helper' },
+      { type: 'meta', signal: 'task_completed', agentId: 'a', taskId: 't1', timestamp: iso(1), _emission_path: 'signal-helpers-pipeline' },
+    ]);
+    const r = new PipelineDriftDetector(root).run();
+    expect(r.bypassCount).toBe(1);
+    expect(r.triggered).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
Closes the policy collision in `project_drift_bypass_finding_dropped_format.md`. The drift detector at `pipeline-drift-detector.ts:227-232` flagged every `finding_dropped_format` emission via `signal-helpers-pipeline` as a bypass — but the emission at `mcp-server-sdk.ts:2856` (PR2's "no-category drop" observability path) is deliberate and correct. The allowlist policy hadn't caught up to the deliberate routing.

This PR makes the per-signal authorized paths explicit so the detector recognizes both `completion-signals-helper` AND `signal-helpers-pipeline` as valid emitters of `finding_dropped_format`.

## Changes
- **`completion-signals.allowlist.ts`** — new `COMPLETION_SIGNAL_AUTHORIZED_PATHS` map (per-signal authorized emission paths). `finding_dropped_format` → `{completion-signals-helper, signal-helpers-pipeline}`. Other 4 allowlisted signals → `{completion-signals-helper}` only. `COMPLETION_SIGNAL_ALLOWLIST` unchanged for parity-test back-compat.
- **`pipeline-drift-detector.ts`** — bypass filter now checks `!authorizedPathsFor(signal).has(path)` instead of `path !== 'completion-signals-helper'`. Defensive fallback to helper-only when a signal is in the allowlist but not in the map.
- **`mcp-server-sdk.ts`** — comment-only update at the `emitPipelineSignals` site; replaced the "we apologize for the bypass" tone with a statement that the path is explicitly authorized.
- **tests** — 4 new cases verifying: helper path (no trigger), authorized pipeline path (no trigger), third unauthorized path (still triggers), and `task_completed` on pipeline (still triggers — proves authorization is per-signal, not global).

## Why this matters
Without this fix, the system's own self-telemetry (drift detector) generates noise on its own intentional code paths. New users would see a `[drift]` log line on every category-less hallucination_caught and treat it as a bug. This brings the policy and the implementation back in agreement.

## Test plan
- [x] `npx jest tests/orchestrator/` → 1579/1579 passed across 117 suites
- [x] `npm run build:mcp` → clean (1.9 MB)
- [x] New tests assert `finding_dropped_format` via `signal-helpers-pipeline` does NOT trigger drift; other allowlisted signals on that path still do (per-signal authorization works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)