### PR TITLE
feat(scoring): skill-gated hallucination recovery

### DIFF
--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -5,10 +5,25 @@
  * Closes the feedback loop: consensus signals → agent scores → dispatch preference.
  */
 
-import { readFileSync, existsSync, statSync } from 'fs';
+import { readFileSync, existsSync, statSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { ConsensusSignal, ImplSignal, PerformanceSignal } from './consensus-types';
 import { normalizeSkillName } from './skill-name';
+
+/**
+ * Skill-gated hallucination recovery — minimum clean-signal count in the
+ * matching category required (alongside a bound skill) to apply the recovery
+ * multiplier. Volume of unrelated positive signals must not wash away
+ * category-specific mistakes; see project_skill_gated_recovery.md.
+ */
+const SKILL_GATED_RECOVERY_MIN_CLEAN_SIGNALS = 3;
+/**
+ * Multiplier applied to the per-signal hallucination weight contribution when
+ * BOTH the bound-skill AND clean-signal-count conditions are met. 0.4 = 60%
+ * penalty reduction. Stacks ON TOP of the existing tasks-elapsed decay; does
+ * not replace it.
+ */
+const SKILL_GATED_RECOVERY_MULTIPLIER = 0.4;
 
 export interface AgentScore {
   agentId: string;
@@ -84,12 +99,61 @@ function getSeverityMultiplier(severity?: string): number {
 
 export class PerformanceReader {
   private readonly filePath: string;
+  private readonly projectRoot: string;
   // Cache: avoid re-reading file on every dispatch call
   private cachedScores: Map<string, AgentScore> | null = null;
   private cachedMtimeMs = 0;
 
   constructor(projectRoot: string) {
+    this.projectRoot = projectRoot;
     this.filePath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+  }
+
+  /**
+   * Skill-gated hallucination recovery — does this agent have a bound skill
+   * file whose `category:` frontmatter matches `category` (after
+   * `normalizeSkillName`)? Skill files live at
+   * `.gossip/agents/<agentId>/skills/*.md`. Cached per `(agentId,category)` for
+   * the lifetime of the cache map passed in so a single computeScores() pass
+   * does not re-walk the filesystem for every hallucination_caught signal.
+   *
+   * Returns false on any IO/parse error — recovery defaults to "no relief"
+   * when we can't prove a skill is bound.
+   */
+  private hasSkillForCategory(
+    agentId: string,
+    category: string,
+    cache: Map<string, boolean>,
+  ): boolean {
+    if (!agentId || !category) return false;
+    const normalizedTarget = normalizeSkillName(category);
+    const cacheKey = agentId + '\x00' + normalizedTarget;
+    const cached = cache.get(cacheKey);
+    if (cached !== undefined) return cached;
+
+    let result = false;
+    try {
+      const dir = join(this.projectRoot, '.gossip', 'agents', agentId, 'skills');
+      if (existsSync(dir)) {
+        for (const entry of readdirSync(dir)) {
+          if (!entry.endsWith('.md')) continue;
+          let body = '';
+          try { body = readFileSync(join(dir, entry), 'utf-8'); } catch { continue; }
+          // Front-matter only: bail if the file does not start with `---`.
+          if (!body.startsWith('---')) continue;
+          const end = body.indexOf('\n---', 3);
+          if (end < 0) continue;
+          const fm = body.slice(3, end);
+          // Match `category: <value>` on its own line, allowing optional quotes.
+          const m = fm.match(/^[ \t]*category:[ \t]*['"]?([^'"\n\r]+?)['"]?[ \t]*$/m);
+          if (!m) continue;
+          if (normalizeSkillName(m[1]) === normalizedTarget) { result = true; break; }
+        }
+      }
+    } catch { /* fall through to false */ }
+
+    cache.set(cacheKey, result);
+    return result;
   }
 
   /** Read all signals and compute per-agent scores (cached by file mtime) */
@@ -521,6 +585,42 @@ export class PerformanceReader {
 
     const peerDiversity = this.computePeerDiversity(consensusSignals);
 
+    // Skill-gated hallucination recovery — pre-index per-agent positive
+    // signals (agreement + unique_confirmed) with their normalized category +
+    // timestamp so the hallucination_caught arm can ask "how many clean
+    // signals in THIS category landed AFTER this hallucination?" in O(K) per
+    // hallucination instead of rescanning the global corpus. Per task spec:
+    // operate on per-agent accumulation, do not traverse the global corpus.
+    // Cache for the bound-skill filesystem lookup is also fresh-per-run so a
+    // newly-bound skill takes effect on the next score computation without
+    // process restart.
+    const positiveByAgent = new Map<string, Array<{ category: string; ts: number }>>();
+    for (const s of consensusSignals) {
+      if (s.signal !== 'agreement' && s.signal !== 'unique_confirmed') continue;
+      if (!s.category) continue;
+      const ts = s.timestamp ? new Date(s.timestamp).getTime() : 0;
+      if (!isFinite(ts) || ts === 0) continue;
+      const list = positiveByAgent.get(s.agentId) || [];
+      list.push({ category: normalizeSkillName(s.category), ts });
+      positiveByAgent.set(s.agentId, list);
+    }
+    const skillCache = new Map<string, boolean>();
+    const categoryCleanSignalsAfter = (
+      agentId: string,
+      category: string,
+      hallucinationTs: number,
+    ): number => {
+      const list = positiveByAgent.get(agentId);
+      if (!list || list.length === 0) return 0;
+      const target = normalizeSkillName(category);
+      let count = 0;
+      for (const s of list) {
+        if (s.category !== target) continue;
+        if (s.ts > hallucinationTs) count++;
+      }
+      return count;
+    };
+
     // Build per-agent retraction index so computeScores skips retracted signals
     // even when called with a raw (unfiltered) signal array (e.g. directly from tests).
     const retractedKeys = new Set<string>();
@@ -682,7 +782,27 @@ export class PerformanceReader {
           // "overall cross-review activity" stays stable — only the numerator on
           // the penalty side fades faster.
           const hallucDecay = Math.pow(0.5, tasksSince / HALLUCINATION_DECAY_HALF_LIFE);
-          a.weightedHallucinations += severity * hallucDecay;
+
+          // Skill-gated hallucination recovery — applied ON TOP of the
+          // tasks-elapsed decay above, never replacing it. Both conditions
+          // must hold: (a) agent has a bound skill file with matching
+          // category frontmatter, AND (b) >=3 positive signals (agreement
+          // or unique_confirmed) in the SAME category landed AFTER this
+          // hallucination's timestamp. Forces the skill development loop:
+          // hallucinate → develop skill → prove it works → recover.
+          // See project_skill_gated_recovery.md (verified FRESH 2026-04-25).
+          let gatedMultiplier = 1.0;
+          const hallucTs = signal.timestamp ? new Date(signal.timestamp).getTime() : 0;
+          if (signal.category && isFinite(hallucTs) && hallucTs > 0) {
+            const skillBound = this.hasSkillForCategory(signal.agentId, signal.category, skillCache);
+            if (skillBound) {
+              const cleanCount = categoryCleanSignalsAfter(signal.agentId, signal.category, hallucTs);
+              if (cleanCount >= SKILL_GATED_RECOVERY_MIN_CLEAN_SIGNALS) {
+                gatedMultiplier = SKILL_GATED_RECOVERY_MULTIPLIER;
+              }
+            }
+          }
+          a.weightedHallucinations += severity * hallucDecay * gatedMultiplier;
           a.weightedTotal += decay;
           a.hallucinations++;
           if (signal.category) {

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -103,6 +103,8 @@ export class PerformanceReader {
   // Cache: avoid re-reading file on every dispatch call
   private cachedScores: Map<string, AgentScore> | null = null;
   private cachedMtimeMs = 0;
+  // Cached parsed skill-index.json (per computeScores pass — see getSkillIndexEnabledMap).
+  private skillIndexCache: Record<string, Record<string, boolean>> | null | undefined = undefined;
 
   constructor(projectRoot: string) {
     this.projectRoot = projectRoot;
@@ -131,6 +133,11 @@ export class PerformanceReader {
     const cached = cache.get(cacheKey);
     if (cached !== undefined) return cached;
 
+    // Per-pass cache of skill-index.json — read once per computeScores() so a
+    // disabled skill takes effect on next score computation without restart.
+    const indexMap = this.getSkillIndexEnabledMap();
+    const agentIndex = indexMap?.[agentId];
+
     let result = false;
     try {
       const dir = join(this.projectRoot, '.gossip', 'agents', agentId, 'skills');
@@ -139,21 +146,76 @@ export class PerformanceReader {
           if (!entry.endsWith('.md')) continue;
           let body = '';
           try { body = readFileSync(join(dir, entry), 'utf-8'); } catch { continue; }
+          // Normalize CRLF → LF so the front-matter terminator regex/index works
+          // for skill files authored on Windows or saved by editors that emit \r\n.
+          body = body.replace(/\r\n/g, '\n');
           // Front-matter only: bail if the file does not start with `---`.
           if (!body.startsWith('---')) continue;
           const end = body.indexOf('\n---', 3);
           if (end < 0) continue;
           const fm = body.slice(3, end);
+          // KNOWN LIMITATION: this regex matches only single-line `category: value`
+          // entries. Multi-line YAML (block scalars `|`/`>`, lists, anchors) for the
+          // category field is not supported — skill files use a single string here
+          // by convention, so we keep parsing cheap and avoid pulling in a YAML lib.
           // Match `category: <value>` on its own line, allowing optional quotes.
           const m = fm.match(/^[ \t]*category:[ \t]*['"]?([^'"\n\r]+?)['"]?[ \t]*$/m);
           if (!m) continue;
-          if (normalizeSkillName(m[1]) === normalizedTarget) { result = true; break; }
+          if (normalizeSkillName(m[1]) !== normalizedTarget) continue;
+          // Skill-index gate: deny ONLY when skill-index.json explicitly marks
+          // this slot disabled (enabled === false). Missing entry / missing
+          // file / parse failure all default to "enabled" so pre-existing
+          // skills not yet recorded in the index keep working (back-compat).
+          const skillName = entry.slice(0, -3); // strip .md
+          if (agentIndex && agentIndex[skillName] === false) continue;
+          result = true;
+          break;
         }
       }
     } catch { /* fall through to false */ }
 
     cache.set(cacheKey, result);
     return result;
+  }
+
+  /**
+   * Read and parse `.gossip/skill-index.json` once per computeScores() pass,
+   * returning a flattened `{ agentId: { skillName: enabled } }` map. Returns
+   * `null` when the file is missing OR malformed — callers must treat null as
+   * "no opinion" (back-compat: skills not in the index are assumed enabled).
+   *
+   * Cache is reset by `getScores()` whenever the perf-jsonl mtime changes, so a
+   * fresh disable via `gossip_skills(action:'disable')` is picked up on the
+   * next scoring pass after the next signal write — same TTL behavior as the
+   * rest of the score cache.
+   */
+  private getSkillIndexEnabledMap(): Record<string, Record<string, boolean>> | null {
+    if (this.skillIndexCache !== undefined) return this.skillIndexCache;
+    const path = join(this.projectRoot, '.gossip', 'skill-index.json');
+    let parsed: any;
+    try {
+      if (!existsSync(path)) { this.skillIndexCache = null; return null; }
+      parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    } catch {
+      this.skillIndexCache = null;
+      return null;
+    }
+    if (!parsed || typeof parsed !== 'object') { this.skillIndexCache = null; return null; }
+    const out: Record<string, Record<string, boolean>> = {};
+    for (const agentId of Object.keys(parsed)) {
+      const slots = parsed[agentId];
+      if (!slots || typeof slots !== 'object') continue;
+      const inner: Record<string, boolean> = {};
+      for (const skill of Object.keys(slots)) {
+        const slot = slots[skill];
+        if (slot && typeof slot === 'object' && typeof slot.enabled === 'boolean') {
+          inner[skill] = slot.enabled;
+        }
+      }
+      out[agentId] = inner;
+    }
+    this.skillIndexCache = out;
+    return out;
   }
 
   /** Read all signals and compute per-agent scores (cached by file mtime) */
@@ -164,6 +226,9 @@ export class PerformanceReader {
     if (this.cachedScores && mtimeMs === this.cachedMtimeMs) {
       return this.cachedScores;
     }
+    // Reset per-pass skill-index cache so disable/enable via `gossip_skills`
+    // takes effect on the next score computation (HIGH #1).
+    this.skillIndexCache = undefined;
     const signals = this.readSignals();
     this.cachedScores = this.computeScores(signals);
     this.cachedMtimeMs = mtimeMs;
@@ -585,25 +650,15 @@ export class PerformanceReader {
 
     const peerDiversity = this.computePeerDiversity(consensusSignals);
 
-    // Skill-gated hallucination recovery — pre-index per-agent positive
-    // signals (agreement + unique_confirmed) with their normalized category +
-    // timestamp so the hallucination_caught arm can ask "how many clean
-    // signals in THIS category landed AFTER this hallucination?" in O(K) per
-    // hallucination instead of rescanning the global corpus. Per task spec:
-    // operate on per-agent accumulation, do not traverse the global corpus.
-    // Cache for the bound-skill filesystem lookup is also fresh-per-run so a
-    // newly-bound skill takes effect on the next score computation without
-    // process restart.
+    // Skill-gated hallucination recovery — per-agent positive-signal index
+    // (agreement + unique_confirmed) with normalized category + timestamp so
+    // the hallucination_caught arm can ask "how many clean signals in THIS
+    // category landed AFTER this hallucination?" in O(K). Built BELOW after
+    // the retraction index, so retracted positive signals are excluded
+    // (HIGH #2 — PR #272 v1 review). Building this earlier than the
+    // retraction index allowed retracted positives to grant unwarranted
+    // recovery.
     const positiveByAgent = new Map<string, Array<{ category: string; ts: number }>>();
-    for (const s of consensusSignals) {
-      if (s.signal !== 'agreement' && s.signal !== 'unique_confirmed') continue;
-      if (!s.category) continue;
-      const ts = s.timestamp ? new Date(s.timestamp).getTime() : 0;
-      if (!isFinite(ts) || ts === 0) continue;
-      const list = positiveByAgent.get(s.agentId) || [];
-      list.push({ category: normalizeSkillName(s.category), ts });
-      positiveByAgent.set(s.agentId, list);
-    }
     const skillCache = new Map<string, boolean>();
     const categoryCleanSignalsAfter = (
       agentId: string,
@@ -639,6 +694,36 @@ export class PerformanceReader {
           retractedKeys.add(signal.agentId + ':' + taskKey + ':*');
         }
       }
+    }
+
+    // Populate positiveByAgent AFTER retraction index is built (HIGH #2).
+    // Apply the same retraction filter the main loop applies, so positive
+    // signals that were retracted (round-level OR signal-level) cannot grant
+    // skill-gated recovery to a later hallucination.
+    for (const s of consensusSignals) {
+      if (s.signal !== 'agreement' && s.signal !== 'unique_confirmed') continue;
+      if (!s.category) continue;
+      if (s.agentId === '_system') continue;
+      // Round-level retraction
+      const fid = (s as any).findingId;
+      if (typeof fid === 'string' && fid.length > 0) {
+        let dropped = false;
+        for (const retractedId of retractedConsensusIds) {
+          if (fid.startsWith(retractedId + ':')) { dropped = true; break; }
+        }
+        if (dropped) continue;
+      }
+      // Signal-level retraction
+      const taskKey = s.taskId || s.timestamp;
+      if (
+        retractedKeys.has(s.agentId + ':' + taskKey + ':' + s.signal) ||
+        retractedKeys.has(s.agentId + ':' + taskKey + ':*')
+      ) continue;
+      const ts = s.timestamp ? new Date(s.timestamp).getTime() : 0;
+      if (!isFinite(ts) || ts === 0) continue;
+      const list = positiveByAgent.get(s.agentId) || [];
+      list.push({ category: normalizeSkillName(s.category), ts });
+      positiveByAgent.set(s.agentId, list);
     }
 
     for (const signal of consensusSignals) {

--- a/tests/orchestrator/performance-reader.test.ts
+++ b/tests/orchestrator/performance-reader.test.ts
@@ -903,24 +903,28 @@ describe('PerformanceReader — hallucination decay tune (HALLUCINATION_DECAY_HA
       const gatedScore = reader.getAgentScore('rev')!;
 
       // Compare against the no-skill baseline by recreating signals in a sibling dir.
+      // try/finally guarantees temp-dir cleanup even when an assertion below throws (LOW #5).
       const SIBLING = TEST_DIR + '-noskill';
-      if (existsSync(SIBLING)) rmSync(SIBLING, { recursive: true });
-      mkdirSync(join(SIBLING, '.gossip'), { recursive: true });
-      const data = [
-        { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 't1', evidence: '', timestamp: ts(10) },
-        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't2', evidence: '', timestamp: ts(5) },
-        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't3', evidence: '', timestamp: ts(4) },
-        { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', category: 'concurrency', taskId: 't4', evidence: '', timestamp: ts(3) },
-      ].map(s => JSON.stringify(s)).join('\n') + '\n';
-      writeFileSync(join(SIBLING, '.gossip', 'agent-performance.jsonl'), data);
-      const baselineScore = new PerformanceReader(SIBLING).getAgentScore('rev')!;
-      rmSync(SIBLING, { recursive: true });
+      try {
+        if (existsSync(SIBLING)) rmSync(SIBLING, { recursive: true });
+        mkdirSync(join(SIBLING, '.gossip'), { recursive: true });
+        const data = [
+          { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 't1', evidence: '', timestamp: ts(10) },
+          { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't2', evidence: '', timestamp: ts(5) },
+          { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't3', evidence: '', timestamp: ts(4) },
+          { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', category: 'concurrency', taskId: 't4', evidence: '', timestamp: ts(3) },
+        ].map(s => JSON.stringify(s)).join('\n') + '\n';
+        writeFileSync(join(SIBLING, '.gossip', 'agent-performance.jsonl'), data);
+        const baselineScore = new PerformanceReader(SIBLING).getAgentScore('rev')!;
 
-      // Gated should be ~0.4 of baseline (multiplier applied on top of identical decay).
-      expect(gatedScore.weightedHallucinations).toBeLessThan(baselineScore.weightedHallucinations);
-      const ratio = gatedScore.weightedHallucinations / baselineScore.weightedHallucinations;
-      expect(ratio).toBeGreaterThan(0.35);
-      expect(ratio).toBeLessThan(0.45);
+        // Gated should be ~0.4 of baseline (multiplier applied on top of identical decay).
+        expect(gatedScore.weightedHallucinations).toBeLessThan(baselineScore.weightedHallucinations);
+        const ratio = gatedScore.weightedHallucinations / baselineScore.weightedHallucinations;
+        expect(ratio).toBeGreaterThan(0.35);
+        expect(ratio).toBeLessThan(0.45);
+      } finally {
+        if (existsSync(SIBLING)) rmSync(SIBLING, { recursive: true });
+      }
     });
 
     it('does NOT reduce penalty with only 2 matching clean signals (need 3+)', () => {
@@ -962,6 +966,182 @@ describe('PerformanceReader — hallucination decay tune (HALLUCINATION_DECAY_HA
       expect(score.hallucinations).toBe(2);
       expect(score.weightedHallucinations).toBeGreaterThan(0);
       expect(score.weightedHallucinations).toBeLessThanOrEqual(2.0);
+    });
+
+    // PR #272 v2 — orchestrator-verified consensus follow-ups.
+
+    it('HIGH #1: skill-index.json enabled:false suppresses recovery (gate does NOT fire)', () => {
+      // Bound skill exists on disk AND 3 matching clean signals — but the
+      // skill-index.json marks the slot disabled. Recovery must NOT apply.
+      writeBoundSkill('rev', 'concurrency');
+      const indexPath = join(TEST_DIR, '.gossip', 'skill-index.json');
+      writeFileSync(indexPath, JSON.stringify({
+        rev: {
+          'test-skill': {
+            skill: 'test-skill',
+            enabled: false,
+            source: 'manual',
+            mode: 'permanent',
+            version: 2,
+            boundAt: new Date().toISOString(),
+          },
+        },
+      }));
+      const sigs = [
+        { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 't1', evidence: '', timestamp: ts(10) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't2', evidence: '', timestamp: ts(5) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't3', evidence: '', timestamp: ts(4) },
+        { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', category: 'concurrency', taskId: 't4', evidence: '', timestamp: ts(3) },
+      ];
+      writeSignals(sigs);
+      const disabledScore = new PerformanceReader(TEST_DIR).getAgentScore('rev')!;
+
+      // Compare against an enabled-baseline run (no skill-index.json → assumed enabled).
+      const SIBLING = TEST_DIR + '-enabled';
+      try {
+        if (existsSync(SIBLING)) rmSync(SIBLING, { recursive: true });
+        mkdirSync(join(SIBLING, '.gossip', 'agents', 'rev', 'skills'), { recursive: true });
+        writeFileSync(
+          join(SIBLING, '.gossip', 'agents', 'rev', 'skills', 'test-skill.md'),
+          `---\nname: test-skill\ncategory: concurrency\nagent: rev\n---\n\n# test-skill\n`,
+        );
+        writeFileSync(
+          join(SIBLING, '.gossip', 'agent-performance.jsonl'),
+          sigs.map(s => JSON.stringify(s)).join('\n') + '\n',
+        );
+        const enabledScore = new PerformanceReader(SIBLING).getAgentScore('rev')!;
+        // Disabled slot → recovery suppressed → weightedHallucinations matches the
+        // baseline (no-recovery) path, which is strictly greater than the enabled (0.4×) run.
+        expect(disabledScore.weightedHallucinations).toBeGreaterThan(enabledScore.weightedHallucinations);
+        const ratio = enabledScore.weightedHallucinations / disabledScore.weightedHallucinations;
+        // Enabled path applies 0.4× multiplier; ratio should land in the recovery window.
+        expect(ratio).toBeGreaterThan(0.35);
+        expect(ratio).toBeLessThan(0.45);
+      } finally {
+        if (existsSync(SIBLING)) rmSync(SIBLING, { recursive: true });
+      }
+    });
+
+    it('HIGH #1: skill-index.json missing entry is treated as enabled (back-compat)', () => {
+      // skill-index.json exists but has no entry for this agent's skill → must
+      // default to enabled so pre-existing skills not yet indexed keep working.
+      writeBoundSkill('rev', 'concurrency');
+      const indexPath = join(TEST_DIR, '.gossip', 'skill-index.json');
+      writeFileSync(indexPath, JSON.stringify({ 'other-agent': {} }));
+      writeSignals([
+        { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 't1', evidence: '', timestamp: ts(10) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't2', evidence: '', timestamp: ts(5) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't3', evidence: '', timestamp: ts(4) },
+        { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', category: 'concurrency', taskId: 't4', evidence: '', timestamp: ts(3) },
+      ]);
+      const score = new PerformanceReader(TEST_DIR).getAgentScore('rev')!;
+      // Recovery should fire (skill not explicitly disabled). Compare against a
+      // raw-baseline (no skill at all) sibling to confirm.
+      const SIBLING = TEST_DIR + '-noskill';
+      try {
+        if (existsSync(SIBLING)) rmSync(SIBLING, { recursive: true });
+        mkdirSync(join(SIBLING, '.gossip'), { recursive: true });
+        writeFileSync(
+          join(SIBLING, '.gossip', 'agent-performance.jsonl'),
+          [
+            { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 't1', evidence: '', timestamp: ts(10) },
+            { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't2', evidence: '', timestamp: ts(5) },
+            { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't3', evidence: '', timestamp: ts(4) },
+            { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', category: 'concurrency', taskId: 't4', evidence: '', timestamp: ts(3) },
+          ].map(s => JSON.stringify(s)).join('\n') + '\n',
+        );
+        const baseline = new PerformanceReader(SIBLING).getAgentScore('rev')!;
+        expect(score.weightedHallucinations).toBeLessThan(baseline.weightedHallucinations);
+      } finally {
+        if (existsSync(SIBLING)) rmSync(SIBLING, { recursive: true });
+      }
+    });
+
+    it('HIGH #2: retracted positive signals do NOT count toward recovery threshold', () => {
+      // 3 positive signals exist BUT all sit inside a retracted consensus round.
+      // Plus one outside → only 1 valid clean signal → below threshold (3+) → no recovery.
+      writeBoundSkill('rev', 'concurrency');
+      const cid = 'cid-retracted-1';
+      writeSignals([
+        { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 't1', evidence: '', timestamp: ts(10) },
+        // Three retracted positives — findingId begins with the retracted consensus_id.
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', findingId: `${cid}:rev:f1`, taskId: 't2', evidence: '', timestamp: ts(5) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', findingId: `${cid}:rev:f2`, taskId: 't3', evidence: '', timestamp: ts(4) },
+        { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', category: 'concurrency', findingId: `${cid}:rev:f3`, taskId: 't4', evidence: '', timestamp: ts(3) },
+        // One non-retracted positive — alone, below the 3+ threshold.
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't5', evidence: '', timestamp: ts(2) },
+        // Round-retraction tombstone.
+        { type: 'consensus', signal: 'consensus_round_retracted', agentId: '_system', consensus_id: cid, reason: 'test retraction', taskId: 'tomb', evidence: '', timestamp: ts(1) },
+      ]);
+      const score = new PerformanceReader(TEST_DIR).getAgentScore('rev')!;
+
+      // Compare to a sibling with NO retraction — same data should yield recovery.
+      const SIBLING = TEST_DIR + '-noretract';
+      try {
+        if (existsSync(SIBLING)) rmSync(SIBLING, { recursive: true });
+        mkdirSync(join(SIBLING, '.gossip', 'agents', 'rev', 'skills'), { recursive: true });
+        writeFileSync(
+          join(SIBLING, '.gossip', 'agents', 'rev', 'skills', 'test-skill.md'),
+          `---\nname: test-skill\ncategory: concurrency\nagent: rev\n---\n\n# test-skill\n`,
+        );
+        writeFileSync(
+          join(SIBLING, '.gossip', 'agent-performance.jsonl'),
+          [
+            { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 't1', evidence: '', timestamp: ts(10) },
+            { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't2', evidence: '', timestamp: ts(5) },
+            { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't3', evidence: '', timestamp: ts(4) },
+            { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', category: 'concurrency', taskId: 't4', evidence: '', timestamp: ts(3) },
+            { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't5', evidence: '', timestamp: ts(2) },
+          ].map(s => JSON.stringify(s)).join('\n') + '\n',
+        );
+        const recovered = new PerformanceReader(SIBLING).getAgentScore('rev')!;
+        // Retracted positives blocked recovery → score's hallucination weight is HIGHER.
+        expect(score.weightedHallucinations).toBeGreaterThan(recovered.weightedHallucinations);
+        const ratio = recovered.weightedHallucinations / score.weightedHallucinations;
+        expect(ratio).toBeGreaterThan(0.35);
+        expect(ratio).toBeLessThan(0.45);
+      } finally {
+        if (existsSync(SIBLING)) rmSync(SIBLING, { recursive: true });
+      }
+    });
+
+    it('MEDIUM #3: skill file with CRLF line endings still triggers recovery', () => {
+      // Authored on Windows / saved with \r\n — the front-matter parser must
+      // normalize CRLF before locating the `\n---` terminator.
+      const dir = join(TEST_DIR, '.gossip', 'agents', 'rev', 'skills');
+      mkdirSync(dir, { recursive: true });
+      const crlfBody = `---\r\nname: crlf-skill\r\ncategory: concurrency\r\nagent: rev\r\n---\r\n\r\n# crlf-skill\r\n`;
+      writeFileSync(join(dir, 'crlf-skill.md'), crlfBody);
+      writeSignals([
+        { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 't1', evidence: '', timestamp: ts(10) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't2', evidence: '', timestamp: ts(5) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't3', evidence: '', timestamp: ts(4) },
+        { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', category: 'concurrency', taskId: 't4', evidence: '', timestamp: ts(3) },
+      ]);
+      const score = new PerformanceReader(TEST_DIR).getAgentScore('rev')!;
+
+      // Compare to a no-skill baseline → CRLF skill must produce a strictly lower penalty.
+      const SIBLING = TEST_DIR + '-noskill-crlf';
+      try {
+        if (existsSync(SIBLING)) rmSync(SIBLING, { recursive: true });
+        mkdirSync(join(SIBLING, '.gossip'), { recursive: true });
+        writeFileSync(
+          join(SIBLING, '.gossip', 'agent-performance.jsonl'),
+          [
+            { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 't1', evidence: '', timestamp: ts(10) },
+            { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't2', evidence: '', timestamp: ts(5) },
+            { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't3', evidence: '', timestamp: ts(4) },
+            { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', category: 'concurrency', taskId: 't4', evidence: '', timestamp: ts(3) },
+          ].map(s => JSON.stringify(s)).join('\n') + '\n',
+        );
+        const baseline = new PerformanceReader(SIBLING).getAgentScore('rev')!;
+        expect(score.weightedHallucinations).toBeLessThan(baseline.weightedHallucinations);
+        const ratio = score.weightedHallucinations / baseline.weightedHallucinations;
+        expect(ratio).toBeGreaterThan(0.35);
+        expect(ratio).toBeLessThan(0.45);
+      } finally {
+        if (existsSync(SIBLING)) rmSync(SIBLING, { recursive: true });
+      }
     });
   });
 });

--- a/tests/orchestrator/performance-reader.test.ts
+++ b/tests/orchestrator/performance-reader.test.ts
@@ -2,6 +2,19 @@ import { PerformanceReader } from '../../packages/orchestrator/src/performance-r
 import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 
+/**
+ * Skill-gated hallucination recovery test helpers — write a bound skill file
+ * with the given category frontmatter under
+ * `<TEST_DIR>/.gossip/agents/<agentId>/skills/<name>.md`. Mirrors the
+ * production layout `hasSkillForCategory` walks.
+ */
+function writeBoundSkill(agentId: string, category: string, skillName = 'test-skill'): void {
+  const dir = join(TEST_DIR, '.gossip', 'agents', agentId, 'skills');
+  mkdirSync(dir, { recursive: true });
+  const body = `---\nname: ${skillName}\ncategory: ${category}\nagent: ${agentId}\n---\n\n# ${skillName}\n`;
+  writeFileSync(join(dir, `${skillName}.md`), body);
+}
+
 const TEST_DIR = join(__dirname, '..', '..', '.test-perf-reader');
 
 function writeSignals(signals: any[]): void {
@@ -835,5 +848,120 @@ describe('PerformanceReader — hallucination decay tune (HALLUCINATION_DECAY_HA
     // is pulled toward 0 by the multiplier even with no category attached.
     expect(score.hallucinations).toBe(3);
     expect(score.accuracy).toBeLessThan(0.5);
+  });
+
+  describe('skill-gated hallucination recovery', () => {
+    // Spec: project_skill_gated_recovery.md (verified FRESH 2026-04-25).
+    // Recovery requires BOTH: (a) bound skill matching the hallucination's
+    // category, AND (b) >=3 positive signals (agreement|unique_confirmed)
+    // in the SAME category, timestamped AFTER the hallucination. Multiplier
+    // is 0.4 (60% reduction) on top of existing tasks-elapsed decay.
+
+    function ts(daysAgo: number): string {
+      return new Date(Date.now() - daysAgo * 86400000).toISOString();
+    }
+
+    it('does NOT reduce penalty when 3 clean signals are in a DIFFERENT category (skill bound for halluc category)', () => {
+      writeBoundSkill('rev', 'concurrency');
+      writeSignals([
+        { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 't1', evidence: '', timestamp: ts(10) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'trust_boundaries', taskId: 't2', evidence: '', timestamp: ts(5) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'trust_boundaries', taskId: 't3', evidence: '', timestamp: ts(4) },
+        { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', category: 'trust_boundaries', taskId: 't4', evidence: '', timestamp: ts(3) },
+      ]);
+      const reader = new PerformanceReader(TEST_DIR);
+      const score = reader.getAgentScore('rev')!;
+      // Full hallucination weight retained — clean signals were in unrelated category.
+      // weightedHallucinations should reflect base severity (3.0 for confirmed_hallucination
+      // default arm) * tasks-elapsed decay, NOT scaled by 0.4.
+      expect(score.weightedHallucinations).toBeGreaterThan(0.4);
+    });
+
+    it('does NOT reduce penalty when 3 clean signals match category but NO skill is bound', () => {
+      // Note: no writeBoundSkill() call — agent has no skill file at all.
+      writeSignals([
+        { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 't1', evidence: '', timestamp: ts(10) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't2', evidence: '', timestamp: ts(5) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't3', evidence: '', timestamp: ts(4) },
+        { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', category: 'concurrency', taskId: 't4', evidence: '', timestamp: ts(3) },
+      ]);
+      const reader = new PerformanceReader(TEST_DIR);
+      const score = reader.getAgentScore('rev')!;
+      // No skill → no recovery, even with 3+ clean signals in matching category.
+      expect(score.weightedHallucinations).toBeGreaterThan(0.4);
+    });
+
+    it('REDUCES penalty (0.4x) when 3+ clean signals match category AND skill is bound', () => {
+      writeBoundSkill('rev', 'concurrency');
+      writeSignals([
+        { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 't1', evidence: '', timestamp: ts(10) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't2', evidence: '', timestamp: ts(5) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't3', evidence: '', timestamp: ts(4) },
+        { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', category: 'concurrency', taskId: 't4', evidence: '', timestamp: ts(3) },
+      ]);
+      const reader = new PerformanceReader(TEST_DIR);
+      const gatedScore = reader.getAgentScore('rev')!;
+
+      // Compare against the no-skill baseline by recreating signals in a sibling dir.
+      const SIBLING = TEST_DIR + '-noskill';
+      if (existsSync(SIBLING)) rmSync(SIBLING, { recursive: true });
+      mkdirSync(join(SIBLING, '.gossip'), { recursive: true });
+      const data = [
+        { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 't1', evidence: '', timestamp: ts(10) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't2', evidence: '', timestamp: ts(5) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't3', evidence: '', timestamp: ts(4) },
+        { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', category: 'concurrency', taskId: 't4', evidence: '', timestamp: ts(3) },
+      ].map(s => JSON.stringify(s)).join('\n') + '\n';
+      writeFileSync(join(SIBLING, '.gossip', 'agent-performance.jsonl'), data);
+      const baselineScore = new PerformanceReader(SIBLING).getAgentScore('rev')!;
+      rmSync(SIBLING, { recursive: true });
+
+      // Gated should be ~0.4 of baseline (multiplier applied on top of identical decay).
+      expect(gatedScore.weightedHallucinations).toBeLessThan(baselineScore.weightedHallucinations);
+      const ratio = gatedScore.weightedHallucinations / baselineScore.weightedHallucinations;
+      expect(ratio).toBeGreaterThan(0.35);
+      expect(ratio).toBeLessThan(0.45);
+    });
+
+    it('does NOT reduce penalty with only 2 matching clean signals (need 3+)', () => {
+      writeBoundSkill('rev', 'concurrency');
+      writeSignals([
+        { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 't1', evidence: '', timestamp: ts(10) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't2', evidence: '', timestamp: ts(5) },
+        { type: 'consensus', signal: 'agreement', agentId: 'rev', category: 'concurrency', taskId: 't3', evidence: '', timestamp: ts(4) },
+      ]);
+      const reader = new PerformanceReader(TEST_DIR);
+      const score = reader.getAgentScore('rev')!;
+      expect(score.weightedHallucinations).toBeGreaterThan(0.4);
+    });
+
+    it('time-only decay path still works when neither skill nor clean-signal condition applies', () => {
+      // Two hallucinations, no skill, no clean signals — verify the
+      // tasks-elapsed decay still produces weightedHallucinations > 0 and
+      // < raw severity sum (i.e. decay is observably applied).
+      const sigs: any[] = [];
+      for (let i = 0; i < 10; i++) {
+        sigs.push({
+          type: 'consensus',
+          signal: 'agreement',
+          agentId: 'rev',
+          category: 'unrelated',
+          taskId: `pad${i}`,
+          evidence: '',
+          timestamp: ts(20 - i),
+        });
+      }
+      sigs.push({ type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 'h1', evidence: '', timestamp: ts(9) });
+      sigs.push({ type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', category: 'concurrency', taskId: 'h2', evidence: '', timestamp: ts(1) });
+      writeSignals(sigs);
+      const reader = new PerformanceReader(TEST_DIR);
+      const score = reader.getAgentScore('rev')!;
+      // Both hallucinations contribute, decayed by tasks-elapsed factor.
+      // Default severity for hallucination_caught (no outcome) = 1.0; with two
+      // hallucinations weightedHallucinations should be in (0, 2.0] range.
+      expect(score.hallucinations).toBe(2);
+      expect(score.weightedHallucinations).toBeGreaterThan(0);
+      expect(score.weightedHallucinations).toBeLessThanOrEqual(2.0);
+    });
   });
 });


### PR DESCRIPTION
## Summary
Implements `project_skill_gated_recovery.md` (verified FRESH this session). Hallucination penalty is no longer relieved purely by tasks-elapsed decay — agents must additionally have a bound skill in the offending category AND demonstrate ≥3 clean signals in that same category to get the additional 0.6 reduction.

## Why
Before this PR: an agent that hallucinates on `concurrency` and gets unrelated positive signals on `security` still gets full penalty relief over time. Pure forgiveness rewards lucky volume, not systematic improvement.

After: skill-gated reduction forces the development loop — hallucinate → develop skill → prove it works on the same category → recover. Volume of unrelated positive signals can't wash away category-specific mistakes.

## Design
ADD a multiplier on TOP of existing decay; do NOT remove the decay. Eligibility:
- Agent has a bound skill at `.gossip/agents/<id>/skills/*.md` whose frontmatter `category:` matches the hallucination's category
- ≥3 positive signals (`agreement` or `unique_confirmed`) with matching category and timestamp > hallucination ts

When eligible: `weightedHallucinations += severity * hallucDecay * 0.4`. Otherwise existing time-decay alone applies (no behavioral change).

## Changes
- `packages/orchestrator/src/performance-reader.ts` (+124 LOC) — `hasSkillForCategory` helper with per-scoring-run cache, per-agent positive-signal pre-index, `categoryCleanSignalsAfter` closure, `gatedMultiplier` applied to hallucination weight contribution
- `tests/orchestrator/performance-reader.test.ts` (+128 LOC) — 5 cases covering all corners: matching skill+matching positives → reduce; matching skill+wrong category positives → no reduce; no skill+matching positives → no reduce; matching skill+only 2 positives → no reduce; time-only decay path unchanged.

## Test plan
- [x] `npx jest tests/orchestrator/performance-reader.test.ts` → 53/53 (5 new + 48 existing)
- [x] Full orchestrator suite → 1580/1580 green
- [x] `npm run build:mcp` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)