### PR TITLE
fix(dashboard): align unique_unconfirmed label + stretch timeline pills

### DIFF
--- a/packages/dashboard-v2/src/components/SignalTimeline.tsx
+++ b/packages/dashboard-v2/src/components/SignalTimeline.tsx
@@ -29,7 +29,7 @@ const SIGNAL_LABELS: Record<string, string> = {
   agreement: 'Confirmed',
   consensus_verified: 'Confirmed',
   unique_confirmed: 'Unique (confirmed)',
-  unique_unconfirmed: 'Unique',
+  unique_unconfirmed: 'Unique (unconfirmed)',
   disagreement: 'Disputed',
   hallucination_caught: 'Hallucination',
   new_finding: 'New finding',
@@ -152,7 +152,11 @@ export function SignalTimeline({ agentId }: { agentId: string }) {
                   setDrawerOpen(true);
                 }
               }}
-              className={`h-4 min-w-[4px] max-w-[12px] flex-1 rounded-sm transition-opacity hover:opacity-80 ${
+              // No max-width cap: pills stretch to fill the row regardless of
+              // viewport so the timeline never has trailing whitespace when
+              // signals.length < the visual width budget. See agent-page UX
+              // memo (project_agent_page_timeline_ux.md).
+              className={`h-4 min-w-[4px] flex-1 rounded-sm transition-opacity hover:opacity-80 ${
                 SIGNAL_COLORS[s.signal] || 'bg-muted'
               } ${clickable ? 'cursor-pointer' : 'cursor-default'}`}
               title={`${SIGNAL_LABELS[s.signal] || s.signal} — ${timeAgo(s.timestamp)}${clickable ? ' (click for detail)' : ''}`}


### PR DESCRIPTION
## Summary
Two small UX fixes per `project_agent_page_timeline_ux.md`.

## Changes
**1. Tooltip label inconsistency** (`SignalTimeline.tsx:32`)
The legend swatch already shows "Unique (confirmed)" / "Unique (unconfirmed)" (added in PR #172), but the pill tooltip rendered `unique_unconfirmed` as just "Unique" — contradicting the legend. Aligned to "Unique (unconfirmed)".

**2. Trailing whitespace on wide viewports** (`SignalTimeline.tsx:155`)
Pills had `max-w-[12px]`, so a row of 100 pills capped at 1200px regardless of container width. On wide viewports the timeline left visible whitespace on the right despite the row being "full". Removed the cap so `flex-1` stretches each pill to fill the available row.

## Why
Discovered 2026-04-18 on the agent page. Both issues silently degraded at-a-glance pattern detection (consecutive disputed/unverified streaks are easier to spot when pills fill the row, and the legend mismatch hid the confirmed-vs-unconfirmed distinction that matters for scoring interpretation).

## Test plan
- [x] `npx tsc --noEmit` clean for `SignalTimeline.tsx` (one pre-existing React-19 RefObject warning in `useElementWidth.ts` is unrelated)
- [ ] No component test infra exists for `packages/dashboard-v2/src/components/`. Visual verification recommended via dev server.

## Out of scope
`FindingsMetrics.tsx:41` uses 'Unique' as a filter chip label — different concept (filter category), left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)