### PR TITLE
fix(native-tasks): mark restored tasks as superseded when newer completion exists

### DIFF
--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -327,11 +327,44 @@ export function restoreNativeTaskMap(projectRoot: string): void {
     if (!ex(filePath)) return;
     const raw = JSON.parse(rf(filePath, 'utf-8'));
     const now = Date.now();
+    // Restore results FIRST so the supersession check below sees both
+    // in-memory and on-disk completions when deciding whether to re-arm.
+    if (raw.results) {
+      for (const [id, info] of Object.entries(raw.results) as [string, any][]) {
+        if (now - info.startedAt < NATIVE_TASK_TTL_MS && !ctx.nativeResultMap.has(id)) {
+          ctx.nativeResultMap.set(id, info);
+        }
+      }
+    }
     if (raw.tasks) {
       for (const [id, info] of Object.entries(raw.tasks) as [string, any][]) {
         if (now - info.startedAt >= NATIVE_TASK_TTL_MS) continue;
         if (ctx.nativeTaskMap.has(id)) continue;
         if (ctx.nativeResultMap.has(id)) continue;
+
+        // Supersession check (project_orphaned_task_ids.md): if a NEWER
+        // completion already exists for the same agent, the orchestrator
+        // already moved on after a /mcp reconnect (new gossip_run created
+        // task B for agentId X while task A was still on disk). Re-arming
+        // A would leave a ghost "running" task in the dashboard until TTL
+        // eviction. Mark it 'superseded' instead so dashboards see a
+        // terminal state immediately. Exact-ID dedup above is unchanged.
+        const supersedingResult = (() => {
+          for (const r of ctx.nativeResultMap.values()) {
+            if (r.agentId === info.agentId && r.completedAt > info.startedAt) return r;
+          }
+          return undefined;
+        })();
+        if (supersedingResult) {
+          ctx.nativeResultMap.set(id, {
+            id, agentId: info.agentId, task: info.task,
+            status: 'superseded' as const,
+            error: `Superseded — newer task for ${info.agentId} completed at ${new Date(supersedingResult.completedAt).toISOString()}`,
+            startedAt: info.startedAt, completedAt: now,
+          });
+          process.stderr.write(`[gossipcat] 🔁 restore ← ${info.agentId} [${id}] superseded (newer task completed at ${new Date(supersedingResult.completedAt).toISOString()})\n`);
+          continue;
+        }
 
         ctx.nativeTaskMap.set(id, info);
 
@@ -349,13 +382,6 @@ export function restoreNativeTaskMap(projectRoot: string): void {
         } else {
           spawnTimeoutWatcher(id, { agentId: info.agentId, task: info.task, startedAt: info.startedAt, timeoutMs });
           process.stderr.write(`[gossipcat] 🔁 restore ← ${info.agentId} [${id}] re-armed (${Math.round((timeoutMs - elapsed) / 1000)}s remaining)\n`);
-        }
-      }
-    }
-    if (raw.results) {
-      for (const [id, info] of Object.entries(raw.results) as [string, any][]) {
-        if (now - info.startedAt < NATIVE_TASK_TTL_MS && !ctx.nativeResultMap.has(id)) {
-          ctx.nativeResultMap.set(id, info);
         }
       }
     }

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -69,7 +69,7 @@ export interface NativeResultInfo {
   id: string;
   agentId: string;
   task: string;
-  status: 'completed' | 'failed' | 'timed_out';
+  status: 'completed' | 'failed' | 'timed_out' | 'superseded';
   result?: string;
   error?: string;
   startedAt: number;

--- a/tests/cli/mcp-handlers.test.ts
+++ b/tests/cli/mcp-handlers.test.ts
@@ -977,6 +977,76 @@ describe('persistNativeTaskMap + restore', () => {
     expect(timedOut).toBeDefined();
     expect(timedOut!.status).toBe('timed_out');
   });
+
+  // ── Supersession (project_orphaned_task_ids.md) ──────────────────────────
+  // After /mcp reconnect, if a NEWER completion exists for the same agentId
+  // as a persisted-but-still-running task, the orchestrator already moved
+  // on. Re-arming the orphan would leave a ghost "running" task in the
+  // dashboard until the 2h TTL evicts it. Mark the orphan as 'superseded'
+  // instead (terminal status, no timeout watcher).
+  it('marks restored task as superseded when a newer completion exists for same agent', () => {
+    const TTL = 2 * 60 * 60 * 1000;
+    const now = Date.now();
+    const T1 = now - 60_000;          // task A dispatched 60s ago, still on disk
+    const T2 = now - 10_000;          // task B for SAME agent completed 10s ago
+    const gossipDir = join(testDir, '.gossip');
+    mkdirSync(gossipDir, { recursive: true });
+    writeFileSync(join(gossipDir, 'native-tasks.json'), JSON.stringify({
+      tasks: {
+        'orphan-A': {
+          agentId: 'sonnet-implementer', task: 'first dispatch',
+          startedAt: T1, timeoutMs: TTL,
+        },
+      },
+      results: {
+        'fresh-B': {
+          id: 'fresh-B', agentId: 'sonnet-implementer', task: 'second dispatch',
+          status: 'completed', startedAt: T2 - 1000, completedAt: T2,
+        },
+      },
+    }));
+
+    restoreNativeTaskMap(testDir);
+
+    // orphan-A must NOT be re-armed
+    expect(ctx.nativeTaskMap.has('orphan-A')).toBe(false);
+    // orphan-A gets a superseded result entry under its own id
+    const supersededEntry = ctx.nativeResultMap.get('orphan-A');
+    expect(supersededEntry).toBeDefined();
+    expect(supersededEntry!.status).toBe('superseded');
+    expect(supersededEntry!.agentId).toBe('sonnet-implementer');
+    // The fresh result is still present untouched
+    expect(ctx.nativeResultMap.get('fresh-B')!.status).toBe('completed');
+  });
+
+  it('re-arms restored task normally when newer completion is for a DIFFERENT agent', () => {
+    const TTL = 2 * 60 * 60 * 1000;
+    const now = Date.now();
+    const T1 = now - 60_000;
+    const T2 = now - 10_000;
+    const gossipDir = join(testDir, '.gossip');
+    mkdirSync(gossipDir, { recursive: true });
+    writeFileSync(join(gossipDir, 'native-tasks.json'), JSON.stringify({
+      tasks: {
+        'orphan-A': {
+          agentId: 'sonnet-implementer', task: 'first dispatch',
+          startedAt: T1, timeoutMs: TTL,
+        },
+      },
+      results: {
+        'fresh-B': {
+          id: 'fresh-B', agentId: 'haiku-researcher', task: 'unrelated',
+          status: 'completed', startedAt: T2 - 1000, completedAt: T2,
+        },
+      },
+    }));
+
+    restoreNativeTaskMap(testDir);
+
+    // Different agent → no supersession; orphan-A re-armed normally
+    expect(ctx.nativeTaskMap.has('orphan-A')).toBe(true);
+    expect(ctx.nativeResultMap.has('orphan-A')).toBe(false);
+  });
 });
 
 // ── gossip_run auto-path: NullProvider + claude-code delegation ───────────────


### PR DESCRIPTION
## Summary
Closes `project_orphaned_task_ids.md`. After MCP reconnect, `restoreNativeTaskMap` re-arms saved tasks based on exact-ID dedup only — but if the orchestrator (in a fresh context) dispatched a NEW task for the same agent and relayed it, the original task stays "running" in `nativeTaskMap` until TTL eviction (hours later). Dashboard shows ghost tasks.

## Fix
At restore time, after the existing exact-ID dedup, check if any entry in `nativeResultMap` has the same `agentId` AND `completedAt > task.startedAt`. If so, write a `'superseded'` result entry instead of re-arming the timeout watcher.

The restore order was reordered so results land before tasks — the supersession check sees on-disk completions instead of only the in-memory state.

## Changes
- `apps/cli/src/handlers/native-tasks.ts` (+40/-8) — supersession check + restore order swap
- `apps/cli/src/mcp-context.ts` — added `'superseded'` to `NativeResultInfo.status` enum
- `tests/cli/mcp-handlers.test.ts` (+70) — 2 new cases:
  - Positive: same agentId completion at T2>T1 → A NOT re-armed; superseded entry written
  - Negative: completion for DIFFERENT agentId → A re-armed normally

## Test plan
- [x] `npx jest tests/cli/mcp-handlers.test.ts` → 5/5 restore tests pass (3 existing + 2 new)
- [x] Full cli suite → 41 suites / 598 pass / 8 skipped (1 pre-existing unrelated failure in KNOWN_BROKEN_SUITES, verified unrelated by stashing this PR's changes)
- [x] `npm run build:mcp` → clean
- [x] Dashboard switches verified safe — superseded entries don't enter relay log (never relayed, never re-armed); `tasks-command.ts statusColor` falls through to dim; `collect.ts` switches operate on completed/failed/timed_out only.

## Why
Verified FRESH this session. The orphan scenario is real and visible in the dashboard for hours after MCP reconnect cycles. Memory: `project_orphaned_task_ids.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)