### PR TITLE
chore(settings): allow gh read-only commands for sub-agents

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,20 @@
 {
   "enabledPlugins": {
     "agent-orchestration@claude-code-workflows": true
+  },
+  "permissions": {
+    "allow": [
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr status:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh repo view:*)",
+      "mcp__gossipcat__gossip_verify_memory"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
Dispatched sub-agents (sonnet-reviewer, haiku-researcher) repeatedly hit permission walls on `gh pr diff` / `gh pr view` despite docs listing them as auto-allowed. Adding the patterns explicitly to project `.claude/settings.json` unblocks future review dispatches without requiring orchestrator-side diff pre-fetching.

## Patterns added
- `Bash(gh pr diff:*)`, `gh pr view:*`, `gh pr list:*`, `gh pr checks:*`, `gh pr status:*`
- `Bash(gh issue view:*)`, `gh issue list:*`
- `Bash(gh run list:*)`, `gh run view:*`
- `Bash(gh repo view:*)`
- `mcp__gossipcat__gossip_verify_memory` (only read-only gossip MCP tool)

## What I deliberately did NOT add
- `gh api:*` — can POST/DELETE
- `pnpm/npx/node/python3` — arbitrary code execution
- `git push/add/commit/checkout` — mutating; covered loosely by existing `Bash(git *)` in `settings.local.json`
- Other gossipcat MCP tools (`gossip_relay`, `gossip_dispatch`, `gossip_run`, `gossip_signals`, `gossip_session_save`, `gossip_relay_cross_review`) — all write state

`settings.local.json` (per-developer, already broader) is untouched.

## Why now
Identified during the relay-lint hardening session (PRs #270 / #272 / #265 / #266). Multiple consensus dispatches hit the wall when reviewing PR diffs and required orchestrator-side `/tmp/pr*.diff` workarounds.

## Test plan
- [x] No code changes; settings file is JSON-valid
- [ ] Confirm in next dispatched-agent PR-review round that the wall is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)