### PR TITLE
test(config): import provider lists from source instead of hardcoding

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -76,7 +76,7 @@ export function loadConfig(configPath: string): GossipConfig {
 // enabled". Drift between these two lists means some values pass schema but
 // fail validateConfig (or vice versa) — that is a hard-to-diagnose user-facing
 // bug. If you change one, change the other.
-const VALID_PROVIDERS = ['anthropic', 'openai', 'openclaw', 'google', 'local', 'native', 'none'];
+export const VALID_PROVIDERS = ['anthropic', 'openai', 'openclaw', 'google', 'local', 'native', 'none'];
 
 // Subset for `main_agent.provider`: 'native' is excluded because the main
 // agent must be able to invoke a real LLM (the orchestrator that dispatches
@@ -88,7 +88,7 @@ const VALID_PROVIDERS = ['anthropic', 'openai', 'openclaw', 'google', 'local', '
 // `case 'native'`, so a config with `main_agent.provider: 'native'` would
 // throw "Unknown provider: native" at boot. 'native' remains valid for
 // `utility_model.provider` and `agents[*].provider` where it's design-correct.
-const VALID_MAIN_PROVIDERS = VALID_PROVIDERS.filter(p => p !== 'native');
+export const VALID_MAIN_PROVIDERS = VALID_PROVIDERS.filter(p => p !== 'native');
 
 const CLAUDE_MODEL_MAP: Record<string, { provider: string; model: string }> = {
   opus:   { provider: 'anthropic', model: 'claude-opus-4-6' },

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -626,6 +626,13 @@ class NullProvider implements ILLMProvider {
 
 // ─── Factory ────────────────────────────────────────────────────────────────
 
+// Runtime-side mirror of the providers the switch below knows how to build.
+// Keep in sync with the `case` arms in createProvider — the parity test in
+// tests/cli/config.test.ts asserts this matches VALID_MAIN_PROVIDERS in
+// apps/cli/src/config.ts so a provider can never pass schema validation but
+// fail at runtime (or vice versa).
+export const CREATE_PROVIDER_CASES = ['anthropic', 'openai', 'openclaw', 'google', 'local', 'none'] as const;
+
 export function createProvider(provider: string, model: string, apiKey?: string, projectRoot?: string, baseUrl?: string): ILLMProvider {
   switch (provider) {
     case 'anthropic': return new AnthropicProvider(apiKey!, model, projectRoot);

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -1,7 +1,8 @@
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { validateConfig, findConfigPath } from '../../apps/cli/src/config';
+import { validateConfig, findConfigPath, VALID_MAIN_PROVIDERS } from '../../apps/cli/src/config';
+import { CREATE_PROVIDER_CASES } from '../../packages/orchestrator/src/llm-client';
 
 describe('Config Validation', () => {
   it('accepts valid config', () => {
@@ -98,13 +99,11 @@ describe('Config Validation', () => {
   // that createProvider knows how to construct. If a future change adds a
   // provider to one list but not the other, this test fails immediately.
   it('main_agent providers form a subset of createProvider runtime cases', () => {
-    // Mirror of the cases in packages/orchestrator/src/llm-client.ts
-    // createProvider() switch statement. Update both lists together when
-    // adding a provider.
-    const CREATE_PROVIDER_CASES = ['anthropic', 'openai', 'openclaw', 'google', 'local', 'none'];
-    const VALID_MAIN_PROVIDERS = ['anthropic', 'openai', 'openclaw', 'google', 'local', 'none'];
-
-    // Every accepted main_agent provider must be constructible at runtime.
+    // VALID_MAIN_PROVIDERS comes from apps/cli/src/config.ts (schema-side).
+    // CREATE_PROVIDER_CASES comes from packages/orchestrator/src/llm-client.ts
+    // (runtime-side, kept aligned with the createProvider switch). Importing
+    // both ensures this test fails the moment either source-of-truth drifts —
+    // no third hardcoded list to forget to update.
     for (const p of VALID_MAIN_PROVIDERS) {
       expect(CREATE_PROVIDER_CASES).toContain(p);
     }


### PR DESCRIPTION
## Summary

- Export `VALID_MAIN_PROVIDERS` from `apps/cli/src/config.ts` and add `CREATE_PROVIDER_CASES` alongside the `createProvider` switch in `packages/orchestrator/src/llm-client.ts`.
- Refactor the parity test in `tests/cli/config.test.ts` to import both authoritative lists instead of carrying its own third hardcoded copy.

The original parity test was meant to fail on schema↔runtime drift, but it had a duplicated inline list of its own — drift between the test and either source-of-truth went silently. With the constants imported, adding a provider to one side without the other fails the test immediately.

Follow-up to #265.

## Test plan

- [x] `npx jest tests/cli/config.test.ts` — 17/17 pass
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)