### PR TITLE
feat(category-extractor): log uncategorized findings + surface count

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -734,7 +734,7 @@ export async function handleCollect(
 
     // Auto-record provisional signals for consensus findings NOT already covered by engine signals
     try {
-      const { emitConsensusSignals, extractCategories } = await import('@gossip/orchestrator');
+      const { emitConsensusSignals, extractCategories, logUncategorizedFinding } = await import('@gossip/orchestrator');
       const timestamp = new Date().toISOString();
 
       const tagToSignal: Record<string, 'unique_confirmed' | 'disagreement' | 'unique_unconfirmed'> = {
@@ -795,7 +795,15 @@ export async function handleCollect(
       const provisionalSignals = allFindings
         .filter((f: any) => !alreadySignaled.has(f.originalAgentId))
         .map((f: any) => {
-          const category = f.category || extractCategories(f.finding || '')[0] || undefined;
+          const extracted = extractCategories(f.finding || '');
+          const category = f.category || extracted[0] || undefined;
+          if (!category) {
+            logUncategorizedFinding(f.finding || '', {
+              finding_id: typeof f.id === 'string' ? f.id : f.findingId,
+              agent_id: f.originalAgentId,
+              taskId: provisionalConsensusId || undefined,
+            }, process.cwd());
+          }
           return {
             type: 'consensus' as const,
             taskId: provisionalConsensusId || '',

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1632,6 +1632,45 @@ server.tool(
           : '');
     } catch { if (!handbookCandidates.some((p: string) => exHB(p))) { process.stderr.write('[gossipcat] gossip_status: HANDBOOK.md not found in any candidate path — add docs/HANDBOOK.md to capture operator wisdom\n'); } }
 
+    // Surface uncategorized-findings count. Streaming line-count (no full-file
+    // read) so a large file doesn't blow up the status response. 7-day window
+    // matches skill-gap decay semantics. Skip entirely when count is 0.
+    let uncategorizedSection = '';
+    try {
+      const { createReadStream } = await import('fs');
+      const { createInterface } = await import('readline');
+      const uncatPath = join(process.cwd(), '.gossip', 'uncategorized-findings.jsonl');
+      const WINDOW_7D_MS = 7 * 24 * 60 * 60 * 1000;
+      const cutoff = Date.now() - WINDOW_7D_MS;
+      let count = 0;
+      let mostRecentText = '';
+      let mostRecentTs = 0;
+      await new Promise<void>((resolve, reject) => {
+        const stream = createReadStream(uncatPath, { encoding: 'utf8' });
+        stream.on('error', reject);
+        const rl = createInterface({ input: stream, crlfDelay: Infinity });
+        rl.on('line', (line) => {
+          if (!line) return;
+          try {
+            const rec = JSON.parse(line) as { timestamp_iso?: string; text?: string };
+            const ts = rec.timestamp_iso ? Date.parse(rec.timestamp_iso) : 0;
+            if (ts >= cutoff) {
+              count++;
+              if (ts > mostRecentTs) {
+                mostRecentTs = ts;
+                mostRecentText = (rec.text ?? '').slice(0, 80);
+              }
+            }
+          } catch { /* skip malformed line */ }
+        });
+        rl.on('close', resolve);
+        rl.on('error', reject);
+      });
+      if (count > 0) {
+        uncategorizedSection = `\n  Uncategorized findings: ${count} in last 7d (sample: "${mostRecentText}...")`;
+      }
+    } catch { /* file absent or unreadable — skip */ }
+
     // Surface Layer-3 signal-pipeline drift inline on the banner. Cheap (single
     // readFileSync of the last row of pipeline-drift.jsonl), and makes drift
     // visible to the orchestrator LLM without requiring dashboard access.
@@ -1660,7 +1699,7 @@ server.tool(
       }
     } catch { /* drift surface is best-effort */ }
 
-    return { content: [{ type: 'text' as const, text: lines.join('\n') + '\n\n' + agentSections.join('\n') + sessionContextSection + handbookSection + driftSection }] };
+    return { content: [{ type: 'text' as const, text: lines.join('\n') + uncategorizedSection + '\n\n' + agentSections.join('\n') + sessionContextSection + handbookSection + driftSection }] };
   }
 );
 
@@ -2564,7 +2603,7 @@ server.tool(
       // loses the signal; aggregate accuracy (performance-reader.ts:581-585) still
       // counts it. droppedNoCategory + stderr + finding_dropped_format pipeline
       // signal provide observability that the category couldn't be derived.
-      const { extractCategories } = await import('@gossip/orchestrator');
+      const { extractCategories, logUncategorizedFinding } = await import('@gossip/orchestrator');
       const droppedNoCategory: Array<{ agentId: string; taskId: string; findingId?: string; finding: string }> = [];
       const categoryEnforced = formatted.filter((s, i) => {
         if (s.type !== 'consensus' || s.signal !== 'hallucination_caught') return true;
@@ -2585,6 +2624,11 @@ server.tool(
         process.stderr.write(
           `[gossip_signals] persisted hallucination_caught without category for ${s.agentId}: no category could be derived. finding="${srcFinding.slice(0, 80)}"\n`,
         );
+        logUncategorizedFinding(srcFinding, {
+          agent_id: s.agentId,
+          taskId: s.taskId,
+          finding_id: s.findingId,
+        }, process.cwd());
         return true;
       });
 

--- a/packages/orchestrator/src/consensus-coordinator.ts
+++ b/packages/orchestrator/src/consensus-coordinator.ts
@@ -7,6 +7,7 @@ import { AgentConfig, TaskEntry } from './types';
 import { GossipPublisher } from './gossip-publisher';
 import { extractCategories } from './category-extractor';
 import { emitConsensusSignals } from './signal-helpers';
+import { logUncategorizedFinding } from './uncategorized-logger';
 
 import { gossipLog as log } from './log';
 
@@ -127,6 +128,13 @@ export class ConsensusCoordinator {
         let i = 0;
         for (const finding of consensusReport.confirmed) {
           const categories = extractCategories(finding.finding);
+          if (categories.length === 0) {
+            logUncategorizedFinding(finding.finding, {
+              finding_id: finding.id,
+              agent_id: finding.originalAgentId,
+              taskId: finding.id || undefined,
+            }, this.projectRoot);
+          }
           for (const category of categories) {
             emitConsensusSignals(this.projectRoot, [{
               type: 'consensus',

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -971,6 +971,7 @@ Return only valid JSON.${skillsBlock}`;
     // "fabricated from the start".
     const emitFabricationHallucinationIfDetected = async (
       entry: { originalAgentId: string; finding: string; severity?: 'critical' | 'high' | 'medium' | 'low'; category?: string },
+      findingId?: string,
     ): Promise<boolean> => {
       const hasFabricatedCitation = await this.verifyCitations(entry.finding, { strict: true });
       if (!hasFabricatedCitation) return false;
@@ -990,6 +991,7 @@ Return only valid JSON.${skillsBlock}`;
           logUncategorizedFinding(entry.finding, {
             agent_id: entry.originalAgentId,
             taskId: getTaskId(entry.originalAgentId),
+            finding_id: findingId,
           }, this.config.projectRoot);
         }
       }
@@ -1235,7 +1237,7 @@ Return only valid JSON.${skillsBlock}`;
         // stale-file downgrade, which only makes sense when peers have
         // confirmed the finding (outside that context we cannot tell
         // "stale after refactor" from "fabricated from the start").
-        if (await emitFabricationHallucinationIfDetected(entry)) {
+        if (await emitFabricationHallucinationIfDetected(entry, finding.id)) {
           finding.tag = 'unique';
           unique.push(finding);
           continue;
@@ -1305,7 +1307,7 @@ Return only valid JSON.${skillsBlock}`;
         // cites non-existent code and contains hallucination keywords, it's
         // an author fabrication even though peers couldn't verify. Fire
         // hallucination_caught instead of the soft unique_unconfirmed.
-        if (await emitFabricationHallucinationIfDetected(entry)) {
+        if (await emitFabricationHallucinationIfDetected(entry, finding.id)) {
           finding.tag = 'unique';
           unique.push(finding);
           continue;
@@ -1327,7 +1329,7 @@ Return only valid JSON.${skillsBlock}`;
       } else {
         // Tier 2: broadened pre-filter. Same fabrication check for findings
         // that fell through without confirmation, dispute, or unverified mark.
-        if (await emitFabricationHallucinationIfDetected(entry)) {
+        if (await emitFabricationHallucinationIfDetected(entry, finding.id)) {
           finding.tag = 'unique';
           unique.push(finding);
           continue;

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -16,6 +16,7 @@ import { ConsensusReport, ConsensusFinding, ConsensusNewFinding, ConsensusSignal
 import { selectCrossReviewers, FindingForSelection, AgentCandidate } from './cross-reviewer-selection';
 import { parseAgentFindingsStrict, PARSE_FINDINGS_LIMITS } from './parse-findings';
 import { extractCategories } from './category-extractor';
+import { logUncategorizedFinding } from './uncategorized-logger';
 
 export type {
   ConsensusReport,
@@ -985,6 +986,12 @@ Return only valid JSON.${skillsBlock}`;
         process.stderr.write(
           `[consensus-engine] hallucination_caught for ${entry.originalAgentId}: category resolution failed, recorded with undefined. finding="${entry.finding.slice(0, 80)}"\n`,
         );
+        if (this.config.projectRoot) {
+          logUncategorizedFinding(entry.finding, {
+            agent_id: entry.originalAgentId,
+            taskId: getTaskId(entry.originalAgentId),
+          }, this.config.projectRoot);
+        }
       }
       signals.push({
         type: 'consensus',
@@ -1107,6 +1114,13 @@ Return only valid JSON.${skillsBlock}`;
               process.stderr.write(
                 `[consensus-engine] hallucination_caught for ${entry.agentId}: category resolution failed, recorded with undefined. evidence="${(entry.evidence || '').slice(0, 80)}"\n`,
               );
+              if (this.config.projectRoot) {
+                logUncategorizedFinding(f.finding, {
+                  agent_id: entry.agentId,
+                  taskId: getTaskId(entry.agentId),
+                  finding_id: entry.findingId,
+                }, this.config.projectRoot);
+              }
             }
             signals.push({
               type: 'consensus',

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -80,6 +80,8 @@ export { normalizeSkillName } from './skill-name';
 export { parseSkillFrontmatter } from './skill-parser';
 export type { SkillFrontmatter } from './skill-parser';
 export { extractCategories } from './category-extractor';
+export { logUncategorizedFinding } from './uncategorized-logger';
+export type { UncategorizedFindingContext, UncategorizedFindingRecord } from './uncategorized-logger';
 export { selectCrossReviewers } from './cross-reviewer-selection';
 export type { FindingForSelection, AgentCandidate } from './cross-reviewer-selection';
 export { DispatchDifferentiator } from './dispatch-differentiator';

--- a/packages/orchestrator/src/uncategorized-logger.ts
+++ b/packages/orchestrator/src/uncategorized-logger.ts
@@ -6,6 +6,19 @@
 import { appendFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 
+/** Redact common secret patterns to prevent leaking credentials into the log. */
+function redactSecrets(text: string): string {
+  return text
+    .replace(/sk[-_]live[-_][a-zA-Z0-9]{20,}/g, '[REDACTED_STRIPE_KEY]')
+    .replace(/sk[-_]ant[-_][a-zA-Z0-9]{20,}/g, '[REDACTED_ANTHROPIC_KEY]')
+    .replace(/sk[-_][a-zA-Z0-9]{40,}/g, '[REDACTED_API_KEY]')
+    .replace(/ghp_[a-zA-Z0-9]{36,}/g, '[REDACTED_GITHUB_TOKEN]')
+    .replace(/gho_[a-zA-Z0-9]{36,}/g, '[REDACTED_GITHUB_OAUTH]')
+    .replace(/AIza[a-zA-Z0-9_-]{35}/g, '[REDACTED_GOOGLE_KEY]')
+    .replace(/eyJ[a-zA-Z0-9_-]{50,}\.[a-zA-Z0-9_-]{50,}\.[a-zA-Z0-9_-]{50,}/g, '[REDACTED_JWT]')
+    .replace(/-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----[\s\S]*?-----END (RSA |EC |DSA )?PRIVATE KEY-----/g, '[REDACTED_PRIVATE_KEY]');
+}
+
 export interface UncategorizedFindingContext {
   finding_id?: string;
   agent_id?: string;
@@ -33,11 +46,15 @@ export function logUncategorizedFinding(
 
   const record: UncategorizedFindingRecord = {
     timestamp_iso: new Date().toISOString(),
-    text: text.slice(0, MAX_TEXT_LEN),
+    text: redactSecrets(text).slice(0, MAX_TEXT_LEN),
   };
   if (ctx.finding_id !== undefined) record.finding_id = ctx.finding_id;
   if (ctx.agent_id !== undefined) record.agent_id = ctx.agent_id;
   if (ctx.taskId !== undefined) record.taskId = ctx.taskId;
 
-  appendFileSync(logPath, JSON.stringify(record) + '\n');
+  try {
+    appendFileSync(logPath, JSON.stringify(record) + '\n');
+  } catch (err) {
+    process.stderr.write(`[uncategorized-logger] write failed: ${(err as Error).message}\n`);
+  }
 }

--- a/packages/orchestrator/src/uncategorized-logger.ts
+++ b/packages/orchestrator/src/uncategorized-logger.ts
@@ -1,0 +1,43 @@
+/**
+ * UncategorizedLogger — appends a JSONL record when extractCategories returns []
+ * for a finding. Phase 1: visibility only. No scoring impact.
+ */
+
+import { appendFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+export interface UncategorizedFindingContext {
+  finding_id?: string;
+  agent_id?: string;
+  taskId?: string;
+}
+
+export interface UncategorizedFindingRecord {
+  timestamp_iso: string;
+  finding_id?: string;
+  agent_id?: string;
+  taskId?: string;
+  text: string;
+}
+
+const MAX_TEXT_LEN = 600;
+
+export function logUncategorizedFinding(
+  text: string,
+  ctx: UncategorizedFindingContext,
+  projectRoot: string,
+): void {
+  const gossipDir = join(projectRoot, '.gossip');
+  mkdirSync(gossipDir, { recursive: true });
+  const logPath = join(gossipDir, 'uncategorized-findings.jsonl');
+
+  const record: UncategorizedFindingRecord = {
+    timestamp_iso: new Date().toISOString(),
+    text: text.slice(0, MAX_TEXT_LEN),
+  };
+  if (ctx.finding_id !== undefined) record.finding_id = ctx.finding_id;
+  if (ctx.agent_id !== undefined) record.agent_id = ctx.agent_id;
+  if (ctx.taskId !== undefined) record.taskId = ctx.taskId;
+
+  appendFileSync(logPath, JSON.stringify(record) + '\n');
+}

--- a/tests/orchestrator/uncategorized-logger.test.ts
+++ b/tests/orchestrator/uncategorized-logger.test.ts
@@ -73,6 +73,55 @@ describe('logUncategorizedFinding', () => {
   });
 });
 
+describe('logUncategorizedFinding — error resilience', () => {
+  test('does not throw when appendFileSync throws (e.g. EACCES)', () => {
+    // Mock appendFileSync to simulate a permission error
+    const fs = require('fs');
+    const original = fs.appendFileSync;
+    fs.appendFileSync = () => {
+      const err = new Error('EACCES: permission denied');
+      (err as any).code = 'EACCES';
+      throw err;
+    };
+    try {
+      // Should not throw — error is swallowed to stderr
+      expect(() =>
+        logUncategorizedFinding('some finding', { agent_id: 'a1' }, '/tmp/test-dir'),
+      ).not.toThrow();
+    } finally {
+      fs.appendFileSync = original;
+    }
+  });
+});
+
+describe('logUncategorizedFinding — secret redaction', () => {
+  test('redacts OpenAI key before writing', () => {
+    const dir = join(tmpdir(), 'uncat-redact-' + Date.now());
+    const openaiKey = 'sk-' + 'A'.repeat(48); // matches sk-[40+] pattern
+    const finding = `API key exposed: ${openaiKey} in config`;
+    logUncategorizedFinding(finding, {}, dir);
+
+    const logPath = join(dir, '.gossip', 'uncategorized-findings.jsonl');
+    const record = JSON.parse(readFileSync(logPath, 'utf-8').trim());
+    expect(record.text).not.toContain(openaiKey);
+    expect(record.text).toContain('[REDACTED_API_KEY]');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('redacts GitHub token before writing', () => {
+    const dir = join(tmpdir(), 'uncat-redact-gh-' + Date.now());
+    const ghToken = 'ghp_' + 'B'.repeat(36);
+    const finding = `Token leaked: ${ghToken}`;
+    logUncategorizedFinding(finding, {}, dir);
+
+    const logPath = join(dir, '.gossip', 'uncategorized-findings.jsonl');
+    const record = JSON.parse(readFileSync(logPath, 'utf-8').trim());
+    expect(record.text).not.toContain(ghToken);
+    expect(record.text).toContain('[REDACTED_GITHUB_TOKEN]');
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
 describe('extractCategories empty → logUncategorizedFinding integration', () => {
   test('CSRF/Origin/Sec-Fetch vocabulary produces no category', () => {
     // Vocabulary from the task description's Clerk-auth review example that

--- a/tests/orchestrator/uncategorized-logger.test.ts
+++ b/tests/orchestrator/uncategorized-logger.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { logUncategorizedFinding } from '../../packages/orchestrator/src/uncategorized-logger';
+import { extractCategories } from '../../packages/orchestrator/src/category-extractor';
+
+describe('logUncategorizedFinding', () => {
+  const testDir = join(tmpdir(), 'uncat-logger-' + Date.now());
+
+  afterAll(() => rmSync(testDir, { recursive: true, force: true }));
+
+  test('writes a valid JSONL line to .gossip/uncategorized-findings.jsonl', () => {
+    const text = 'CSRF missing Origin validation in middleware';
+    logUncategorizedFinding(text, { agent_id: 'sonnet-reviewer', taskId: 'task-abc', finding_id: 'c1:sonnet-reviewer:f1' }, testDir);
+
+    const logPath = join(testDir, '.gossip', 'uncategorized-findings.jsonl');
+    expect(existsSync(logPath)).toBe(true);
+
+    const lines = readFileSync(logPath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+
+    const record = JSON.parse(lines[0]);
+    expect(record.text).toBe(text);
+    expect(record.agent_id).toBe('sonnet-reviewer');
+    expect(record.taskId).toBe('task-abc');
+    expect(record.finding_id).toBe('c1:sonnet-reviewer:f1');
+    expect(typeof record.timestamp_iso).toBe('string');
+    expect(new Date(record.timestamp_iso).getTime()).toBeGreaterThan(0);
+  });
+
+  test('creates .gossip dir if it does not exist', () => {
+    const freshDir = join(tmpdir(), 'uncat-fresh-' + Date.now());
+    logUncategorizedFinding('some finding', {}, freshDir);
+    const logPath = join(freshDir, '.gossip', 'uncategorized-findings.jsonl');
+    expect(existsSync(logPath)).toBe(true);
+    rmSync(freshDir, { recursive: true, force: true });
+  });
+
+  test('truncates text longer than 600 chars', () => {
+    const longText = 'x'.repeat(700);
+    logUncategorizedFinding(longText, {}, testDir);
+
+    const logPath = join(testDir, '.gossip', 'uncategorized-findings.jsonl');
+    const lines = readFileSync(logPath, 'utf-8').trim().split('\n');
+    const last = JSON.parse(lines[lines.length - 1]);
+    expect(last.text.length).toBe(600);
+  });
+
+  test('appends multiple lines without overwriting', () => {
+    const appendDir = join(tmpdir(), 'uncat-append-' + Date.now());
+    logUncategorizedFinding('finding one', { agent_id: 'a1' }, appendDir);
+    logUncategorizedFinding('finding two', { agent_id: 'a2' }, appendDir);
+
+    const logPath = join(appendDir, '.gossip', 'uncategorized-findings.jsonl');
+    const lines = readFileSync(logPath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).text).toBe('finding one');
+    expect(JSON.parse(lines[1]).text).toBe('finding two');
+    rmSync(appendDir, { recursive: true, force: true });
+  });
+
+  test('omits optional fields when not provided', () => {
+    const emptyCtxDir = join(tmpdir(), 'uncat-empty-' + Date.now());
+    logUncategorizedFinding('bare finding', {}, emptyCtxDir);
+
+    const logPath = join(emptyCtxDir, '.gossip', 'uncategorized-findings.jsonl');
+    const record = JSON.parse(readFileSync(logPath, 'utf-8').trim());
+    expect(record.text).toBe('bare finding');
+    expect('agent_id' in record).toBe(false);
+    expect('taskId' in record).toBe(false);
+    expect('finding_id' in record).toBe(false);
+    rmSync(emptyCtxDir, { recursive: true, force: true });
+  });
+});
+
+describe('extractCategories empty → logUncategorizedFinding integration', () => {
+  test('CSRF/Origin/Sec-Fetch vocabulary produces no category', () => {
+    // Vocabulary from the task description's Clerk-auth review example that
+    // doesn't match any built-in regex patterns.
+    const uncategorizedFindings = [
+      'CSRF token missing from middleware handler',
+      'Origin header not checked in Sec-Fetch flow',
+      'Clerk session cookie missing SameSite attribute',
+    ];
+    for (const text of uncategorizedFindings) {
+      expect(extractCategories(text)).toHaveLength(0);
+    }
+  });
+
+  test('when extractCategories returns empty, logUncategorizedFinding writes JSONL', () => {
+    const integDir = join(tmpdir(), 'uncat-integ-' + Date.now());
+    const finding = 'CSRF token missing from middleware handler';
+    const categories = extractCategories(finding);
+    if (categories.length === 0) {
+      logUncategorizedFinding(finding, { agent_id: 'test-agent', taskId: 'task-123' }, integDir);
+    }
+
+    const logPath = join(integDir, '.gossip', 'uncategorized-findings.jsonl');
+    expect(existsSync(logPath)).toBe(true);
+    const record = JSON.parse(readFileSync(logPath, 'utf-8').trim());
+    expect(record.text).toBe(finding);
+    expect(record.agent_id).toBe('test-agent');
+    rmSync(integDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of a 3-phase visibility pass on the auto-categorizer. When `extractCategories(text)` returns `[]` the signal still records against overall accuracy but contributes zero per-category competency, so `MIN_EVIDENCE=120` never advances on findings outside the 14 built-in patterns. The miss is silent today — this PR makes it observable without changing scoring math.

## What this changes

- **New** `packages/orchestrator/src/uncategorized-logger.ts` — `logUncategorizedFinding(text, ctx, projectRoot)` appends one JSONL record to `.gossip/uncategorized-findings.jsonl` per silent miss. Schema: `{timestamp_iso, text (≤600 chars), finding_id?, agent_id?, taskId?}`.
- **Wired** into 3 previously silent branches:
  - `consensus-engine.ts` `emitFabricationHallucinationIfDetected` (~L985)
  - `consensus-engine.ts` cross-review hallucination path (~L1113)
  - `mcp-server-sdk.ts` `gossip_signals` record path category-enforced filter (~L2585)
- **Surfaced** in `gossip_status`: streaming readline scan with 7d window emits `Uncategorized findings: N in last 7d (sample: "...")` when N > 0; skipped cleanly otherwise.
- **Tests** (`tests/orchestrator/uncategorized-logger.test.ts`) — 7 passing, cover JSONL write, dir creation, 600-char truncation, append-only, optional-field omission, and the integration path.

## Why

Real impact triggered by a sibling Claude orchestrator hitting 7/31 uncategorized findings on a Clerk-auth review (CSRF / Origin / Sec-Fetch / middleware vocabulary not in current patterns). The categorizer has dev-quality buckets (observability, cli_ergonomics, performance, testing) but no web-auth wedge — and silently dropping these into the void was hiding the gap entirely.

## Out of scope (Phase 2/3)

- `.gossip/categories.jsonl` loader for project-extended patterns
- LLM-driven category suggestion engine
- New `gossip_categories` tool
- Dashboard panel

## Why this needs consensus

Per `docs/HANDBOOK.md` "When to gate merges on consensus — impact-adjacency, not just LOC", this touches the **signal pipeline** (one of the listed impact-adjacent areas). LOC is small (~210) but blast radius is non-trivial: the new write happens on every signal-record path with no category match. Pre-merge consensus round planned: sonnet-reviewer + gemini-reviewer + haiku-researcher.

## Test plan

- [x] `npx jest tests/orchestrator/uncategorized-logger.test.ts` — 7/7 pass
- [x] `tsc --noEmit` orchestrator + cli — clean
- [ ] Pre-merge consensus round
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)