### PR TITLE
feat(uncategorized-logger): single-slot 5MB rotation + reader for backup file

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1635,9 +1635,11 @@ server.tool(
     // Surface uncategorized-findings count. Streaming line-count (no full-file
     // read) so a large file doesn't blow up the status response. 7-day window
     // matches skill-gap decay semantics. Skip entirely when count is 0.
+    // Scans both the current file and the single-slot rotation backup (.jsonl.1)
+    // so recent entries aren't lost after rotation.
     let uncategorizedSection = '';
     try {
-      const { createReadStream } = await import('fs');
+      const { createReadStream, existsSync: fsExistsSync } = await import('fs');
       const { createInterface } = await import('readline');
       const uncatPath = join(process.cwd(), '.gossip', 'uncategorized-findings.jsonl');
       const WINDOW_7D_MS = 7 * 24 * 60 * 60 * 1000;
@@ -1645,31 +1647,39 @@ server.tool(
       let count = 0;
       let mostRecentText = '';
       let mostRecentTs = 0;
-      await new Promise<void>((resolve, reject) => {
-        const stream = createReadStream(uncatPath, { encoding: 'utf8' });
-        stream.on('error', reject);
-        const rl = createInterface({ input: stream, crlfDelay: Infinity });
-        rl.on('line', (line) => {
-          if (!line) return;
-          try {
-            const rec = JSON.parse(line) as { timestamp_iso?: string; text?: string };
-            const ts = rec.timestamp_iso ? Date.parse(rec.timestamp_iso) : 0;
-            if (ts >= cutoff) {
-              count++;
-              if (ts > mostRecentTs) {
-                mostRecentTs = ts;
-                mostRecentText = (rec.text ?? '').slice(0, 80);
+
+      // Helper: stream one file and accumulate into shared count/mostRecent state.
+      const scanFile = (filePath: string): Promise<void> =>
+        new Promise<void>((resolve) => {
+          const stream = createReadStream(filePath, { encoding: 'utf8' });
+          stream.on('error', () => resolve()); // absent or unreadable — skip
+          const rl = createInterface({ input: stream, crlfDelay: Infinity });
+          rl.on('line', (line) => {
+            if (!line) return;
+            try {
+              const rec = JSON.parse(line) as { timestamp_iso?: string; text?: string };
+              const ts = rec.timestamp_iso ? Date.parse(rec.timestamp_iso) : 0;
+              if (ts >= cutoff) {
+                count++;
+                if (ts > mostRecentTs) {
+                  mostRecentTs = ts;
+                  mostRecentText = (rec.text ?? '').slice(0, 80);
+                }
               }
-            }
-          } catch { /* skip malformed line */ }
+            } catch { /* skip malformed line */ }
+          });
+          rl.on('close', resolve);
+          rl.on('error', () => resolve());
         });
-        rl.on('close', resolve);
-        rl.on('error', reject);
-      });
+
+      // Scan current file first, then rotation backup if present.
+      await scanFile(uncatPath);
+      if (fsExistsSync(uncatPath + '.1')) await scanFile(uncatPath + '.1');
+
       if (count > 0) {
         uncategorizedSection = `\n  Uncategorized findings: ${count} in last 7d (sample: "${mostRecentText}...")`;
       }
-    } catch { /* file absent or unreadable — skip */ }
+    } catch { /* unexpected error — skip */ }
 
     // Surface Layer-3 signal-pipeline drift inline on the banner. Cheap (single
     // readFileSync of the last row of pipeline-drift.jsonl), and makes drift

--- a/packages/orchestrator/src/uncategorized-logger.ts
+++ b/packages/orchestrator/src/uncategorized-logger.ts
@@ -3,8 +3,30 @@
  * for a finding. Phase 1: visibility only. No scoring impact.
  */
 
-import { appendFileSync, mkdirSync } from 'fs';
+import { appendFileSync, mkdirSync, statSync, renameSync } from 'fs';
 import { join } from 'path';
+
+/** Max bytes for `.gossip/uncategorized-findings.jsonl` before single-slot rotation. */
+export const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+/**
+ * Best-effort single-slot rotation. Mirrors sandbox.ts rotateIfNeeded.
+ * If the file exists and exceeds maxBytes, rename to `<path>.1` (overwrites).
+ * Errors are silently ignored — this is best-effort telemetry.
+ */
+function rotateIfNeeded(filePath: string, maxBytes: number): void {
+  try {
+    const st = statSync(filePath); // throws ENOENT when file absent — skip rotation
+    if (st.size < maxBytes) return;
+    try {
+      renameSync(filePath, filePath + '.1');
+    } catch (err) {
+      process.stderr.write(`[uncategorized-logger] rotation failed: ${(err as Error).message}\n`);
+    }
+  } catch {
+    /* file absent or unreadable — no rotation needed */
+  }
+}
 
 /** Redact common secret patterns to prevent leaking credentials into the log. */
 function redactSecrets(text: string): string {
@@ -52,6 +74,7 @@ export function logUncategorizedFinding(
   if (ctx.agent_id !== undefined) record.agent_id = ctx.agent_id;
   if (ctx.taskId !== undefined) record.taskId = ctx.taskId;
 
+  rotateIfNeeded(logPath, MAX_FILE_SIZE);
   try {
     appendFileSync(logPath, JSON.stringify(record) + '\n');
   } catch (err) {

--- a/tests/orchestrator/uncategorized-logger.test.ts
+++ b/tests/orchestrator/uncategorized-logger.test.ts
@@ -1,7 +1,7 @@
-import { readFileSync, rmSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { logUncategorizedFinding } from '../../packages/orchestrator/src/uncategorized-logger';
+import { logUncategorizedFinding, MAX_FILE_SIZE } from '../../packages/orchestrator/src/uncategorized-logger';
 import { extractCategories } from '../../packages/orchestrator/src/category-extractor';
 
 describe('logUncategorizedFinding', () => {
@@ -70,6 +70,51 @@ describe('logUncategorizedFinding', () => {
     expect('taskId' in record).toBe(false);
     expect('finding_id' in record).toBe(false);
     rmSync(emptyCtxDir, { recursive: true, force: true });
+  });
+});
+
+describe('logUncategorizedFinding — log rotation', () => {
+  test('rotation triggers when file exceeds threshold', () => {
+    const dir = join(tmpdir(), 'uncat-rotate-' + Date.now());
+    const logPath = join(dir, '.gossip', 'uncategorized-findings.jsonl');
+    // Seed file above 5MB threshold
+    logUncategorizedFinding('seed', {}, dir); // creates .gossip dir
+    writeFileSync(logPath, Buffer.alloc(MAX_FILE_SIZE + 100, 'x').toString());
+    logUncategorizedFinding('after rotation', { agent_id: 'test' }, dir);
+    // Original file should now be the fresh one (single record)
+    const lines = readFileSync(logPath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const rec = JSON.parse(lines[0]);
+    expect(rec.text).toBe('after rotation');
+    // Rotated backup should exist
+    expect(existsSync(logPath + '.1')).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('no rotation when file is under threshold', () => {
+    const dir = join(tmpdir(), 'uncat-norotate-' + Date.now());
+    logUncategorizedFinding('first', {}, dir);
+    logUncategorizedFinding('second', {}, dir);
+    const logPath = join(dir, '.gossip', 'uncategorized-findings.jsonl');
+    expect(existsSync(logPath + '.1')).toBe(false);
+    const lines = readFileSync(logPath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('rotation overwrites existing .1 (single-slot semantic)', () => {
+    const dir = join(tmpdir(), 'uncat-overwrite-' + Date.now());
+    const logPath = join(dir, '.gossip', 'uncategorized-findings.jsonl');
+    // Seed main file above threshold and .1 with sentinel
+    logUncategorizedFinding('seed', {}, dir);
+    writeFileSync(logPath, Buffer.alloc(MAX_FILE_SIZE + 100, 'x').toString());
+    writeFileSync(logPath + '.1', 'sentinel-content\n');
+    logUncategorizedFinding('fresh', { agent_id: 'a1' }, dir);
+    // .1 should now hold the oversized content, not the sentinel
+    const backup = readFileSync(logPath + '.1', 'utf-8');
+    expect(backup).not.toBe('sentinel-content\n');
+    expect(backup.length).toBeGreaterThan(MAX_FILE_SIZE);
+    rmSync(dir, { recursive: true, force: true });
   });
 });
 


### PR DESCRIPTION
## Summary

Add log rotation to `.gossip/uncategorized-findings.jsonl` to address the unbounded-growth concern flagged in PR #277's consensus round.

Mirrors the established single-slot rotation in `apps/cli/src/sandbox.ts` (boundary-escapes.jsonl): when the file exceeds `MAX_FILE_SIZE = 5 * 1024 * 1024`, rename to `<file>.1` (overwriting any existing `.1`) and start fresh. Rotation errors go to stderr; never abort the caller.

The `gossip_status` reader is updated to scan both the current file and the rotation backup so the 7-day window stays accurate after a rotation event.

## What changes

- **`packages/orchestrator/src/uncategorized-logger.ts`** — exported `MAX_FILE_SIZE`, added `rotateIfNeeded()` helper called before each `appendFileSync`.
- **`apps/cli/src/mcp-server-sdk.ts:1635-1673`** — extracted the streaming readline into a `scanFile(filePath)` helper; now scans both `.jsonl` and `.jsonl.1` (when present), accumulating count + mostRecentText.
- **`tests/orchestrator/uncategorized-logger.test.ts`** — 3 new tests:
  - rotation triggers above 5MB threshold
  - no rotation under threshold
  - single-slot semantic (existing `.1` is overwritten on next rotation)

## Resolves

Consensus `3549fe5a-16fa4830:f3` — gemini-reviewer MEDIUM finding "unbounded log file growth, DoS risk", confirmed by both peers.

## Test plan

- [x] `npx jest tests/orchestrator/uncategorized-logger.test.ts` — 13/13 pass (10 prior + 3 rotation)
- [x] `tsc --noEmit` orchestrator + cli — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)