### PR TITLE
fix(llm-client): bump Gemini per-call timeout 120s → 300s

### DIFF
--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -457,11 +457,15 @@ export class GeminiProvider implements ILLMProvider {
 
     if (process.env.GOSSIP_DEBUG) _log('Gemini', `${this.model} — ${messages.length} messages, tools=${toolMode}`);
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:generateContent?key=${this.apiKey}`;
+    // 5-minute per-call timeout. gemini-tester / gemini-reviewer run agentic
+    // loops where a single big-context turn (refactor + multi-test plan) can
+    // exceed 120s wall-clock. Matches the 600s budget given to openclaw and
+    // the 300_000 default for gossip_dispatch write tasks.
     const res = await fetchWithRetry503(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(120_000),
+      signal: AbortSignal.timeout(300_000),
     }, 'google');
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary

Bump the per-call `AbortSignal.timeout` for `GeminiProvider.generate` from 120s to 300s. Matches the 600s budget already given to openclaw and the 300_000 default for `gossip_dispatch` write tasks.

## Why

`gemini-tester` and `gemini-reviewer` run agentic loops (up to 15 tool turns). A single big-context turn — e.g. a refactor + multi-test extraction plan — can exceed 120s wall-clock. This session observed a hard 147s timeout on a cold-start-test extraction dispatched by the auto-router; the per-call cap was the bottleneck.

## Why not Anthropic

Native Anthropic agents (sonnet/opus implementers, sonnet-reviewer, haiku-researcher) are invoked via Claude Code `Agent()` and don't go through this code path — they have their own host-managed timeout. Bumping Anthropic here would only affect users running custom Anthropic relay workers, of which there are none today.

## Test plan

- [x] `tsc --noEmit -p packages/orchestrator` — clean
- [ ] CI green
- Empirically: a re-run of the cold-start extraction task (which timed out previously) completed under the new ceiling on the next dispatch this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)