### PR TITLE
test(uncategorized-logger): extract status reader + cold-start coverage

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -29,7 +29,7 @@ import { createServer as createHttpServer, IncomingMessage, ServerResponse } fro
 import { ctx } from './mcp-context';
 import { getGossipcatVersion } from './version';
 import { captureGitStatus, checkUnexpectedChanges } from './utility-guard';
-import { buildUtilityAgentPrompt } from '@gossip/orchestrator';
+import { buildUtilityAgentPrompt, getUncategorizedStatusLine } from '@gossip/orchestrator';
 import { restoreNativeTaskMap, handleNativeRelay, spawnTimeoutWatcher, scheduleNativeTaskEviction } from './handlers/native-tasks';
 import { handleDispatchSingle, handleDispatchParallel, handleDispatchConsensus } from './handlers/dispatch';
 import { handleCollect } from './handlers/collect';
@@ -1632,53 +1632,11 @@ server.tool(
           : '');
     } catch { if (!handbookCandidates.some((p: string) => exHB(p))) { process.stderr.write('[gossipcat] gossip_status: HANDBOOK.md not found in any candidate path — add docs/HANDBOOK.md to capture operator wisdom\n'); } }
 
-    // Surface uncategorized-findings count. Streaming line-count (no full-file
-    // read) so a large file doesn't blow up the status response. 7-day window
-    // matches skill-gap decay semantics. Skip entirely when count is 0.
-    // Scans both the current file and the single-slot rotation backup (.jsonl.1)
-    // so recent entries aren't lost after rotation.
+    // Surface uncategorized-findings count via extracted helper (testable).
+    // 7-day window matches skill-gap decay semantics. Skip entirely when count is 0.
     let uncategorizedSection = '';
     try {
-      const { createReadStream, existsSync: fsExistsSync } = await import('fs');
-      const { createInterface } = await import('readline');
-      const uncatPath = join(process.cwd(), '.gossip', 'uncategorized-findings.jsonl');
-      const WINDOW_7D_MS = 7 * 24 * 60 * 60 * 1000;
-      const cutoff = Date.now() - WINDOW_7D_MS;
-      let count = 0;
-      let mostRecentText = '';
-      let mostRecentTs = 0;
-
-      // Helper: stream one file and accumulate into shared count/mostRecent state.
-      const scanFile = (filePath: string): Promise<void> =>
-        new Promise<void>((resolve) => {
-          const stream = createReadStream(filePath, { encoding: 'utf8' });
-          stream.on('error', () => resolve()); // absent or unreadable — skip
-          const rl = createInterface({ input: stream, crlfDelay: Infinity });
-          rl.on('line', (line) => {
-            if (!line) return;
-            try {
-              const rec = JSON.parse(line) as { timestamp_iso?: string; text?: string };
-              const ts = rec.timestamp_iso ? Date.parse(rec.timestamp_iso) : 0;
-              if (ts >= cutoff) {
-                count++;
-                if (ts > mostRecentTs) {
-                  mostRecentTs = ts;
-                  mostRecentText = (rec.text ?? '').slice(0, 80);
-                }
-              }
-            } catch { /* skip malformed line */ }
-          });
-          rl.on('close', resolve);
-          rl.on('error', () => resolve());
-        });
-
-      // Scan current file first, then rotation backup if present.
-      await scanFile(uncatPath);
-      if (fsExistsSync(uncatPath + '.1')) await scanFile(uncatPath + '.1');
-
-      if (count > 0) {
-        uncategorizedSection = `\n  Uncategorized findings: ${count} in last 7d (sample: "${mostRecentText}...")`;
-      }
+      uncategorizedSection = await getUncategorizedStatusLine(process.cwd());
     } catch { /* unexpected error — skip */ }
 
     // Surface Layer-3 signal-pipeline drift inline on the banner. Cheap (single

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -80,7 +80,7 @@ export { normalizeSkillName } from './skill-name';
 export { parseSkillFrontmatter } from './skill-parser';
 export type { SkillFrontmatter } from './skill-parser';
 export { extractCategories } from './category-extractor';
-export { logUncategorizedFinding } from './uncategorized-logger';
+export { logUncategorizedFinding, getUncategorizedStatusLine } from './uncategorized-logger';
 export type { UncategorizedFindingContext, UncategorizedFindingRecord } from './uncategorized-logger';
 export { selectCrossReviewers } from './cross-reviewer-selection';
 export type { FindingForSelection, AgentCandidate } from './cross-reviewer-selection';

--- a/packages/orchestrator/src/uncategorized-logger.ts
+++ b/packages/orchestrator/src/uncategorized-logger.ts
@@ -1,9 +1,12 @@
 /**
  * UncategorizedLogger — appends a JSONL record when extractCategories returns []
  * for a finding. Phase 1: visibility only. No scoring impact.
+ *
+ * Also exports getUncategorizedStatusLine for use in gossip_status banners.
  */
 
-import { appendFileSync, mkdirSync, statSync, renameSync } from 'fs';
+import { appendFileSync, mkdirSync, statSync, renameSync, createReadStream, existsSync } from 'fs';
+import { createInterface } from 'readline';
 import { join } from 'path';
 
 /** Max bytes for `.gossip/uncategorized-findings.jsonl` before single-slot rotation. */
@@ -80,4 +83,66 @@ export function logUncategorizedFinding(
   } catch (err) {
     process.stderr.write(`[uncategorized-logger] write failed: ${(err as Error).message}\n`);
   }
+}
+
+/**
+ * Scans uncategorized-findings.jsonl files for recent entries and returns a
+ * formatted status line for gossip_status.
+ *
+ * @param projectRoot The root of the project directory.
+ * @param opts Optional parameters for window and current time.
+ * @returns A formatted string or an empty string if no recent findings.
+ */
+export async function getUncategorizedStatusLine(
+  projectRoot: string,
+  opts?: { windowMs?: number; nowMs?: number }
+): Promise<string> {
+  const WINDOW_7D_MS = 7 * 24 * 60 * 60 * 1000;
+  const now = opts?.nowMs ?? Date.now();
+  const cutoff = now - (opts?.windowMs ?? WINDOW_7D_MS);
+  let count = 0;
+  let mostRecentText = '';
+  let mostRecentTs = 0;
+
+  const uncatPath = join(projectRoot, '.gossip', 'uncategorized-findings.jsonl');
+
+  const scanFile = (filePath: string): Promise<void> =>
+    new Promise<void>((resolve) => {
+      if (!existsSync(filePath)) {
+        return resolve();
+      }
+      const stream = createReadStream(filePath, { encoding: 'utf8' });
+      stream.on('error', () => resolve()); // absent or unreadable — skip
+      const rl = createInterface({ input: stream, crlfDelay: Infinity });
+      rl.on('line', (line) => {
+        if (!line) return;
+        try {
+          const rec = JSON.parse(line) as { timestamp_iso?: string; text?: string };
+          const ts = rec.timestamp_iso ? Date.parse(rec.timestamp_iso) : 0;
+          if (ts >= cutoff) {
+            count++;
+            if (ts > mostRecentTs) {
+              mostRecentTs = ts;
+              mostRecentText = (rec.text ?? '').slice(0, 80);
+            }
+          }
+        } catch {
+          /* skip malformed line */
+        }
+      });
+      rl.on('close', resolve);
+      rl.on('error', () => resolve());
+    });
+
+  // Scan current file first, then rotation backup if present.
+  await scanFile(uncatPath);
+  if (existsSync(uncatPath + '.1')) {
+    await scanFile(uncatPath + '.1');
+  }
+
+  if (count > 0) {
+    return `\n  Uncategorized findings: ${count} in last 7d (sample: "${mostRecentText}...")`;
+  }
+
+  return '';
 }

--- a/tests/orchestrator/uncategorized-logger.test.ts
+++ b/tests/orchestrator/uncategorized-logger.test.ts
@@ -1,7 +1,7 @@
-import { readFileSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { logUncategorizedFinding, MAX_FILE_SIZE } from '../../packages/orchestrator/src/uncategorized-logger';
+import { logUncategorizedFinding, getUncategorizedStatusLine, MAX_FILE_SIZE } from '../../packages/orchestrator/src/uncategorized-logger';
 import { extractCategories } from '../../packages/orchestrator/src/category-extractor';
 
 describe('logUncategorizedFinding', () => {
@@ -197,5 +197,84 @@ describe('extractCategories empty → logUncategorizedFinding integration', () =
     expect(record.text).toBe(finding);
     expect(record.agent_id).toBe('test-agent');
     rmSync(integDir, { recursive: true, force: true });
+  });
+});
+
+describe('getUncategorizedStatusLine — cold-start and happy-path', () => {
+  // Helper: make a JSONL line with a timestamp offset from nowMs.
+  const makeLine = (text: string, offsetMs: number, nowMs: number) =>
+    JSON.stringify({ text, timestamp_iso: new Date(nowMs + offsetMs).toISOString() });
+
+  test('cold start — no .gossip dir → empty string, no throw', async () => {
+    const dir = join(tmpdir(), 'uncat-status-cold-' + Date.now());
+    // dir intentionally not created
+    const result = await getUncategorizedStatusLine(dir);
+    expect(result).toBe('');
+  });
+
+  test('cold start — .gossip dir exists but no file → empty string', async () => {
+    const dir = join(tmpdir(), 'uncat-status-nofile-' + Date.now());
+    mkdirSync(join(dir, '.gossip'), { recursive: true });
+    const result = await getUncategorizedStatusLine(dir);
+    expect(result).toBe('');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('all entries outside 7d window → empty string', async () => {
+    const dir = join(tmpdir(), 'uncat-status-old-' + Date.now());
+    mkdirSync(join(dir, '.gossip'), { recursive: true });
+    const nowMs = Date.now();
+    const logPath = join(dir, '.gossip', 'uncategorized-findings.jsonl');
+    // Write entries 8 days ago
+    writeFileSync(logPath, makeLine('stale finding', -(8 * 24 * 60 * 60 * 1000), nowMs) + '\n');
+    const result = await getUncategorizedStatusLine(dir, { nowMs });
+    expect(result).toBe('');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('3 fresh entries → line containing "3 in last 7d" and sample text', async () => {
+    const dir = join(tmpdir(), 'uncat-status-fresh-' + Date.now());
+    mkdirSync(join(dir, '.gossip'), { recursive: true });
+    const nowMs = Date.now();
+    const logPath = join(dir, '.gossip', 'uncategorized-findings.jsonl');
+    const lines = [
+      makeLine('first finding', -1000, nowMs),
+      makeLine('second finding', -2000, nowMs),
+      makeLine('most recent finding', -500, nowMs),
+    ];
+    writeFileSync(logPath, lines.join('\n') + '\n');
+    const result = await getUncategorizedStatusLine(dir, { nowMs });
+    expect(result).toContain('3 in last 7d');
+    expect(result).toContain('most recent finding');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('entries split across .jsonl and .jsonl.1 → combined count', async () => {
+    const dir = join(tmpdir(), 'uncat-status-split-' + Date.now());
+    mkdirSync(join(dir, '.gossip'), { recursive: true });
+    const nowMs = Date.now();
+    const logPath = join(dir, '.gossip', 'uncategorized-findings.jsonl');
+    writeFileSync(logPath, makeLine('from main file', -1000, nowMs) + '\n');
+    writeFileSync(logPath + '.1', makeLine('from backup file', -2000, nowMs) + '\n');
+    const result = await getUncategorizedStatusLine(dir, { nowMs });
+    expect(result).toContain('2 in last 7d');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('malformed JSON line interleaved with valid → count excludes garbage', async () => {
+    const dir = join(tmpdir(), 'uncat-status-malformed-' + Date.now());
+    mkdirSync(join(dir, '.gossip'), { recursive: true });
+    const nowMs = Date.now();
+    const logPath = join(dir, '.gossip', 'uncategorized-findings.jsonl');
+    const content = [
+      makeLine('valid one', -1000, nowMs),
+      'this is not json at all',
+      makeLine('valid two', -2000, nowMs),
+      '{broken json',
+    ].join('\n') + '\n';
+    writeFileSync(logPath, content);
+    const result = await getUncategorizedStatusLine(dir, { nowMs });
+    expect(result).toContain('2 in last 7d');
+    rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
Reopen of #280 (auto-closed when stacked-base `feat/uncategorized-log-rotation` was deleted on #279's merge).

## Summary

Resolves consensus `3549fe5a-16fa4830:f4` (haiku-researcher, MEDIUM — cold-start error handler exists but lacks explicit test).

The `gossip_status` uncategorized-section reader was inline inside an MCP handler closure, untestable directly. Extract it into an exported helper so the cold-start path can be verified.

## What changes

- **`packages/orchestrator/src/uncategorized-logger.ts`** — new `getUncategorizedStatusLine(projectRoot, opts?)` helper. Returns the formatted status line or empty string. `opts.nowMs` injectable for deterministic tests.
- **`apps/cli/src/mcp-server-sdk.ts`** — replace the 43-line inline reader with a single call to the helper, keeping the surrounding try/catch.
- **`tests/orchestrator/uncategorized-logger.test.ts`** — 6 new tests:
  - No `.gossip` dir → empty
  - `.gossip` exists but no file → empty
  - All entries outside 7d window → empty
  - 3 fresh entries → line with "3 in last 7d"
  - Entries split across `.jsonl` and `.jsonl.1` → combined count
  - Malformed JSON line interleaved with valid → count excludes garbage

## Test plan

- [x] `npx jest tests/orchestrator/uncategorized-logger.test.ts` — 19/19 pass
- [x] `tsc --noEmit` orchestrator + cli — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)