### PR TITLE
fix(cross-reviewer-selection): rename starvation→poolStarvationPressure, document intent

### DIFF
--- a/packages/orchestrator/src/cross-reviewer-selection.ts
+++ b/packages/orchestrator/src/cross-reviewer-selection.ts
@@ -147,14 +147,33 @@ export function selectCrossReviewers(
     }
 
     if (belowMedian.length > 0) {
-      // Signal starvation — look at the most signal-starved below-median candidate
-      // Note: belowMedian is already filtered to score > 0 in the filter above
+      // Pool-level signal-starvation pressure — sized from the most starved
+      // below-median candidate, NOT from the candidate ultimately picked by
+      // the weighted draw further down.
+      //
+      // This is intentional, not the bug it might appear to be (cf. issue
+      // #259). Epsilon must be set BEFORE the draw to gate whether
+      // exploration fires at all for this finding; the gate must therefore
+      // measure pool-level pressure, not an individual pick that doesn't
+      // exist yet. Once the gate fires, the weighted draw below uses
+      // 1/(1+signalCount) weights to concentrate the actual selection on
+      // the starved candidate(s) that justified firing in the first place.
+      //
+      // Net behavior: a well-fed agent CAN be selected when the pool has at
+      // least one starved peer pulling epsilon up — but the weighted draw
+      // makes that a low-probability outcome, and the selection is still
+      // a coherent below-median exploration pick. See issue #259 for the
+      // three alternatives considered (compute on selectedIndex post-draw
+      // breaks the gate semantics; hybrid gate/size is architecturally
+      // confused; rename + document is what we picked).
+      //
+      // Note: belowMedian is already filtered to score > 0 in the filter above.
       const signalCounts = belowMedian.map(c =>
         performanceReader.getRecentCrossReviewCount(c.agent.agentId, 30),
       );
-      const minSignals = signalCounts.reduce((m, v) => v < m ? v : m, Infinity);
-      const starvation = minSignals < 10 ? 0.30
-        : minSignals > 50 ? 0.05
+      const poolMinSignals = signalCounts.reduce((m, v) => v < m ? v : m, Infinity);
+      const poolStarvationPressure = poolMinSignals < 10 ? 0.30
+        : poolMinSignals > 50 ? 0.05
         : 0.15;
 
       const SEV_SCALE: Record<FindingForSelection['severity'], number> = {
@@ -162,7 +181,7 @@ export function selectCrossReviewers(
       };
       const sevScale = SEV_SCALE[finding.severity];
 
-      const epsilon = starvation * sevScale;
+      const epsilon = poolStarvationPressure * sevScale;
 
       if (topK.length > 0 && secureRandom() < epsilon) {
         // Weighted selection toward most signal-starved candidate


### PR DESCRIPTION
Closes #259.

## Summary

The starvation scalar that gates epsilon-greedy exploration in `selectCrossReviewers` is sized from the pool-min signal count of the below-median candidate set, not from the candidate ultimately picked by the weighted draw. The issue framed this as a possible bug; the proper fix is documentation, not behavior.

## Why pool-level is correct

Epsilon must be set **before** the random draw to gate whether exploration fires at all for the current finding. The gate therefore necessarily measures pool-level starvation pressure — there is no "selected candidate" yet to measure against. Once the gate fires, the weighted draw uses `1/(1+signalCount)` weights to concentrate the actual selection on the starved candidate(s) that justified firing.

Net behavior is unchanged. The original `starvation` name implied a per-candidate measure; rename to `poolStarvationPressure` and add a block comment explaining the design choice.

## Alternatives rejected (per #259)

- **Option 1 — compute on `selectedIndex` post-draw:** breaks the gate semantics. You can't know the candidate before the draw, and you can't draw before computing the gate probability. Order is fixed.
- **Option 3 — hybrid gate/size:** architecturally confused. Epsilon IS the gate (`secureRandom() < epsilon`); there's no separate "gate" and "size" to combine.
- **Option 2 — rename + document:** what this PR does.

## Variable renames

| Before | After |
|---|---|
| `minSignals` | `poolMinSignals` |
| `starvation` | `poolStarvationPressure` |

## Test plan

- [x] `npx jest tests/orchestrator/cross-reviewer-selection.test.ts` — 20/20 pass
- [x] `tsc --noEmit` orchestrator + cli — clean
- [ ] CI green

## Why no consensus round despite impact-adjacency

Pure rename + comment, zero behavioral change. The diff is mechanical (5 LOC of identifier rename + ~20 LOC of comment). Consensus on a doc-only change costs more than it gains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)