### PR TITLE
feat(self-telemetry): write-time signal counter + collect-end shortfall reconciler

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -826,6 +826,42 @@ export async function handleCollect(
     } catch { /* best-effort */ }
   }
 
+  // Phase A self-telemetry: round-counter reconciliation.
+  // After all signal write paths complete, check whether the count of signals
+  // bumped during this process matches the number of findings in the report.
+  // Fires only when actual < expected (tolerate double-log). Non-fatal.
+  if (consensusReport) {
+    try {
+      const { getRoundCounter, emitPipelineSignals } = await import('@gossip/orchestrator');
+      const authId = consensusReport?.signals?.[0]?.consensusId;
+      if (authId) {
+        const findingsCount =
+          (consensusReport.confirmed?.length ?? 0) +
+          (consensusReport.disputed?.length ?? 0) +
+          (consensusReport.unverified?.length ?? 0) +
+          (consensusReport.unique?.length ?? 0) +
+          (consensusReport.newFindings?.length ?? 0);
+        const actual = getRoundCounter(authId);
+        if (actual < findingsCount) {
+          const shortfall = findingsCount - actual;
+          process.stderr.write(
+            `[round-reconcile] consensusId=${authId} expected_min=${findingsCount} actual=${actual} shortfall=${shortfall}\n`
+          );
+          emitPipelineSignals(process.cwd(), [{
+            type: 'pipeline',
+            signal: 'signal_loss_suspected',
+            agentId: '_system',
+            taskId: authId,
+            consensusId: authId,
+            value: shortfall,
+            metadata: { expected_min: findingsCount, actual },
+            timestamp: new Date().toISOString(),
+          }]);
+        }
+      }
+    } catch { /* best-effort */ }
+  }
+
   // Step 6: Format output
   let output = resultTexts.join('\n\n---\n\n');
 

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -832,13 +832,14 @@ export async function handleCollect(
   // Fires only when actual < expected (tolerate double-log). Non-fatal.
   if (consensusReport) {
     try {
-      const { getRoundCounter, emitPipelineSignals } = await import('@gossip/orchestrator');
+      const { getRoundCounter, resetRoundCounter, emitPipelineSignals } = await import('@gossip/orchestrator');
       const findingsAll = [
         ...(consensusReport.confirmed ?? []),
         ...(consensusReport.disputed ?? []),
         ...(consensusReport.unverified ?? []),
         ...(consensusReport.unique ?? []),
         ...(consensusReport.newFindings ?? []),
+        ...(consensusReport.insights ?? []),
       ];
       // Fall back to any finding's id prefix when signals[] is empty (the
       // low-signal rounds most likely to mask real loss). See consensus
@@ -863,6 +864,8 @@ export async function handleCollect(
             metadata: { expected_min: findingsCount, actual },
             timestamp: new Date().toISOString(),
           }]);
+          // Clear the counter so a retry / Phase B reader sees fresh state, not the diagnostic's own bump.
+          resetRoundCounter(authId);
         }
       }
     } catch { /* best-effort */ }

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -833,14 +833,20 @@ export async function handleCollect(
   if (consensusReport) {
     try {
       const { getRoundCounter, emitPipelineSignals } = await import('@gossip/orchestrator');
-      const authId = consensusReport?.signals?.[0]?.consensusId;
+      const findingsAll = [
+        ...(consensusReport.confirmed ?? []),
+        ...(consensusReport.disputed ?? []),
+        ...(consensusReport.unverified ?? []),
+        ...(consensusReport.unique ?? []),
+        ...(consensusReport.newFindings ?? []),
+      ];
+      // Fall back to any finding's id prefix when signals[] is empty (the
+      // low-signal rounds most likely to mask real loss). See consensus
+      // 3aa4a6ef-c8974235:sonnet-reviewer F1.
+      const authId = consensusReport?.signals?.[0]?.consensusId
+        ?? findingsAll.find(f => /^[0-9a-f]{8}-[0-9a-f]{8}:/.test(f.id ?? ''))?.id?.split(':')[0];
       if (authId) {
-        const findingsCount =
-          (consensusReport.confirmed?.length ?? 0) +
-          (consensusReport.disputed?.length ?? 0) +
-          (consensusReport.unverified?.length ?? 0) +
-          (consensusReport.unique?.length ?? 0) +
-          (consensusReport.newFindings?.length ?? 0);
+        const findingsCount = findingsAll.length;
         const actual = getRoundCounter(authId);
         if (actual < findingsCount) {
           const shortfall = findingsCount - actual;

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -237,7 +237,13 @@ export interface PipelineSignal {
     /** Path A relay-lint hardening (docs/specs/2026-04-25-relay-lint-hardening.md):
      * orchestrator paraphrased a consensus-dispatched native agent's result,
      * dropping all `<agent_finding>` tags. Observability-only — never gates. */
-    | 'relay_findings_dropped';
+    | 'relay_findings_dropped'
+    /**
+     * Phase A system self-telemetry: round-counter detected that fewer signals
+     * were written than findings collected. Observability-only — never blocks.
+     * Emitted by the collect handler after consensus report is persisted.
+     */
+    | 'signal_loss_suspected';
   /** Real agentId for agent-scoped events; '_system' for system-scoped events. */
   agentId: string;
   taskId: string;

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -125,3 +125,4 @@ export type {
 } from './claim-types';
 export { verifyClaims, MAX_CLAIMS_PER_BLOCK, PER_BLOCK_DEADLINE_MS } from './claim-verifier';
 export { sanitizeForLog } from './_sanitize';
+export { bump as bumpRoundCounter, get as getRoundCounter, reset as resetRoundCounter, deriveConsensusId } from './round-counter';

--- a/packages/orchestrator/src/performance-writer.ts
+++ b/packages/orchestrator/src/performance-writer.ts
@@ -37,6 +37,9 @@ const VALID_CONSENSUS_SIGNALS = new Set([
   // Pre-existing runtime bug fix (spec §4, consensus 78bc92ef-23464bde:f11):
   // this signal was previously rejected by validateSignal and silently dropped.
   'severity_miscalibrated',
+  // Emitted by consensus-engine when relay cross-review coverage drops;
+  // previously rejected by validateSignal and silently dropped.
+  'consensus_coverage_degraded',
   // Sandbox policy violation — recorded for observability, zero weight in scoring.
   // Consensus round bb03845d-64264402 (7/7 confirmed).
   'boundary_escape',

--- a/packages/orchestrator/src/performance-writer.ts
+++ b/packages/orchestrator/src/performance-writer.ts
@@ -3,6 +3,7 @@ import { appendFileSync, mkdirSync, existsSync, statSync, renameSync } from 'fs'
 import { join } from 'path';
 import { PerformanceSignal, classifySignal } from './consensus-types';
 import type { EmissionPath } from './completion-signals.allowlist';
+import { bump as bumpRoundCounter, deriveConsensusId } from './round-counter';
 
 export type { EmissionPath } from './completion-signals.allowlist';
 
@@ -59,6 +60,9 @@ const VALID_PIPELINE_SIGNALS = new Set([
   // instead of pasting verbatim, dropping all findings. Pre-fix: validateSignal
   // threw on this name and the catch silently swallowed every emission.
   'relay_findings_dropped',
+  // Phase A self-telemetry: collect-end reconciliation detected fewer signals
+  // written than findings in the consensus report. Observability-only.
+  'signal_loss_suspected',
 ]);
 
 /**
@@ -206,6 +210,12 @@ export class PerformanceWriter {
       const row = { ...stamped, _emission_path: emissionPath };
       appendFileSync(this.filePath, JSON.stringify(row) + '\n');
       bumpSampleCounter(this.projectRoot, 1);
+      // Phase A self-telemetry: count signals per consensus round so
+      // collect-end can detect shortfalls. Non-throwing by design.
+      try {
+        const cid = deriveConsensusId(signal as { consensusId?: string; findingId?: string });
+        if (cid) bumpRoundCounter(cid);
+      } catch { /* non-fatal */ }
     },
 
     /**
@@ -221,6 +231,13 @@ export class PerformanceWriter {
       rotateJsonlIfNeeded(this.filePath);
       appendFileSync(this.filePath, data);
       bumpSampleCounter(this.projectRoot, signals.length);
+      // Phase A self-telemetry: count each signal toward its consensus round.
+      try {
+        for (const s of signals) {
+          const cid = deriveConsensusId(s as { consensusId?: string; findingId?: string });
+          if (cid) bumpRoundCounter(cid);
+        }
+      } catch { /* non-fatal */ }
     },
   };
 

--- a/packages/orchestrator/src/round-counter.ts
+++ b/packages/orchestrator/src/round-counter.ts
@@ -1,0 +1,43 @@
+// packages/orchestrator/src/round-counter.ts
+//
+// In-memory per-round signal counter for Phase A system self-telemetry.
+// Catches silent signal-loss bugs (like the historical 6-drop-gate bug) at
+// the moment of loss rather than after the fact. TTL eviction is omitted in
+// favour of explicit reset() — rounds complete in under a minute so memory
+// pressure is negligible; test isolation is simpler with explicit cleanup.
+
+const counts = new Map<string, number>();
+
+/** Increment the signal count for `consensusId` by 1. */
+export function bump(consensusId: string): void {
+  counts.set(consensusId, (counts.get(consensusId) ?? 0) + 1);
+}
+
+/** Return the current signal count for `consensusId` (0 if never bumped). */
+export function get(consensusId: string): number {
+  return counts.get(consensusId) ?? 0;
+}
+
+/** Reset the counter for `consensusId`. Used in tests and explicit cleanup. */
+export function reset(consensusId: string): void {
+  counts.delete(consensusId);
+}
+
+/**
+ * Derive a consensusId from a signal record. Returns the consensusId if
+ * present, else extracts the prefix from a findingId that matches
+ * `<8hex>-<8hex>:...`. Returns undefined when neither is available (meta,
+ * impl, ad-hoc signals that don't belong to a consensus round).
+ */
+export function deriveConsensusId(record: {
+  consensusId?: string;
+  findingId?: string;
+}): string | undefined {
+  if (record.consensusId) return record.consensusId;
+  if (typeof record.findingId === 'string') {
+    const prefix = record.findingId.split(':')[0];
+    // Validate canonical shape: <8hex>-<8hex>
+    if (/^[0-9a-f]{8}-[0-9a-f]{8}$/.test(prefix)) return prefix;
+  }
+  return undefined;
+}

--- a/tests/orchestrator/round-counter.test.ts
+++ b/tests/orchestrator/round-counter.test.ts
@@ -1,0 +1,176 @@
+// tests/orchestrator/round-counter.test.ts
+//
+// Unit and integration-lite tests for Phase A self-telemetry: round-counter
+// module (bump / get / reset / deriveConsensusId) + performanceWriter wiring.
+
+import * as roundCounter from '../../packages/orchestrator/src/round-counter';
+import { PerformanceWriter } from '@gossip/orchestrator';
+import { WRITER_INTERNAL } from '../../packages/orchestrator/src/_writer-internal';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// ── Unit: bump / get / reset ──────────────────────────────────────────────────
+
+describe('roundCounter — bump / get / reset', () => {
+  const CID = 'aabbccdd-11223344';
+
+  afterEach(() => {
+    roundCounter.reset(CID);
+  });
+
+  it('get returns 0 for an unknown consensusId', () => {
+    expect(roundCounter.get(CID)).toBe(0);
+  });
+
+  it('bump increments by 1 each call', () => {
+    roundCounter.bump(CID);
+    expect(roundCounter.get(CID)).toBe(1);
+    roundCounter.bump(CID);
+    expect(roundCounter.get(CID)).toBe(2);
+  });
+
+  it('reset removes the entry', () => {
+    roundCounter.bump(CID);
+    roundCounter.bump(CID);
+    roundCounter.reset(CID);
+    expect(roundCounter.get(CID)).toBe(0);
+  });
+
+  it('different consensusIds are tracked independently', () => {
+    const CID2 = 'deadbeef-cafebabe';
+    try {
+      roundCounter.bump(CID);
+      roundCounter.bump(CID);
+      roundCounter.bump(CID2);
+      expect(roundCounter.get(CID)).toBe(2);
+      expect(roundCounter.get(CID2)).toBe(1);
+    } finally {
+      roundCounter.reset(CID2);
+    }
+  });
+});
+
+// ── Unit: deriveConsensusId ───────────────────────────────────────────────────
+
+describe('roundCounter — deriveConsensusId', () => {
+  it('returns consensusId when present', () => {
+    expect(roundCounter.deriveConsensusId({ consensusId: 'aabbccdd-11223344' }))
+      .toBe('aabbccdd-11223344');
+  });
+
+  it('extracts consensusId from modern findingId (with consensusId absent)', () => {
+    expect(roundCounter.deriveConsensusId({ findingId: 'aabbccdd-11223344:sonnet-reviewer:f1' }))
+      .toBe('aabbccdd-11223344');
+  });
+
+  it('extracts consensusId from legacy findingId (two-segment)', () => {
+    expect(roundCounter.deriveConsensusId({ findingId: 'aabbccdd-11223344:f3' }))
+      .toBe('aabbccdd-11223344');
+  });
+
+  it('returns undefined when neither field is present', () => {
+    expect(roundCounter.deriveConsensusId({})).toBeUndefined();
+  });
+
+  it('returns undefined for malformed findingId (free-form string)', () => {
+    expect(roundCounter.deriveConsensusId({ findingId: 'not-a-real-id:f1' })).toBeUndefined();
+  });
+
+  it('returns undefined for findingId with no colon (bare string)', () => {
+    expect(roundCounter.deriveConsensusId({ findingId: 'barestring' })).toBeUndefined();
+  });
+
+  it('prefers consensusId over findingId when both are present', () => {
+    expect(
+      roundCounter.deriveConsensusId({
+        consensusId: 'aabbccdd-11223344',
+        findingId: 'deadbeef-cafebabe:f1',
+      })
+    ).toBe('aabbccdd-11223344');
+  });
+});
+
+// ── Integration-lite: performanceWriter bumps counter on append ───────────────
+
+describe('PerformanceWriter — round counter wiring', () => {
+  let tmpDir: string;
+  let writer: PerformanceWriter;
+  const CID = 'cafef00d-beefdead';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gossip-rc-'));
+    fs.mkdirSync(path.join(tmpDir, '.gossip'), { recursive: true });
+    writer = new PerformanceWriter(tmpDir);
+    roundCounter.reset(CID);
+  });
+
+  afterEach(() => {
+    roundCounter.reset(CID);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const makeSignal = (consensusId: string) => ({
+    type: 'consensus' as const,
+    taskId: `task-${consensusId}`,
+    signal: 'agreement' as const,
+    agentId: 'test-agent',
+    consensusId,
+    evidence: 'test',
+    timestamp: new Date().toISOString(),
+  });
+
+  it('bumps counter once per appendSignal with consensusId', () => {
+    writer[WRITER_INTERNAL].appendSignal(makeSignal(CID));
+    expect(roundCounter.get(CID)).toBe(1);
+    writer[WRITER_INTERNAL].appendSignal(makeSignal(CID));
+    expect(roundCounter.get(CID)).toBe(2);
+  });
+
+  it('bumps counter for each signal in appendSignals', () => {
+    const signals = [makeSignal(CID), makeSignal(CID), makeSignal(CID)];
+    writer[WRITER_INTERNAL].appendSignals(signals);
+    expect(roundCounter.get(CID)).toBe(3);
+  });
+
+  it('does NOT bump counter for signals without consensusId or findingId', () => {
+    const metaSignal = {
+      type: 'meta' as const,
+      signal: 'task_completed' as const,
+      agentId: 'test-agent',
+      taskId: 'task-123',
+      timestamp: new Date().toISOString(),
+    };
+    writer[WRITER_INTERNAL].appendSignal(metaSignal);
+    // Counter for CID stays at 0 — meta signals have no consensusId
+    expect(roundCounter.get(CID)).toBe(0);
+  });
+
+  it('shortfall detection: writing N signals → counter == N, dropping one → shortfall', () => {
+    // Simulate writing 3 signals for a round with 4 findings
+    const N = 3;
+    for (let i = 0; i < N; i++) {
+      writer[WRITER_INTERNAL].appendSignal(makeSignal(CID));
+    }
+    const actual = roundCounter.get(CID);
+    const findings_count = 4;
+    expect(actual).toBe(N);
+    expect(actual).toBeLessThan(findings_count); // shortfall detected
+    expect(findings_count - actual).toBe(1); // one signal dropped
+  });
+
+  it('bumps counter for signal with findingId prefix (no consensusId field)', () => {
+    const signalWithFindingId = {
+      type: 'consensus' as const,
+      taskId: 'task-bulk',
+      signal: 'unique_confirmed' as const,
+      agentId: 'test-agent',
+      // no consensusId — only findingId carrying the prefix
+      findingId: `${CID}:test-agent:f1`,
+      evidence: 'test',
+      timestamp: new Date().toISOString(),
+    };
+    writer[WRITER_INTERNAL].appendSignal(signalWithFindingId);
+    expect(roundCounter.get(CID)).toBe(1);
+  });
+});

--- a/tests/orchestrator/round-counter.test.ts
+++ b/tests/orchestrator/round-counter.test.ts
@@ -173,4 +173,25 @@ describe('PerformanceWriter — round counter wiring', () => {
     writer[WRITER_INTERNAL].appendSignal(signalWithFindingId);
     expect(roundCounter.get(CID)).toBe(1);
   });
+
+  it('reset after signal_loss_suspected emit leaves counter at 0 (Fix 2 — counter reset)', () => {
+    // Simulate the shortfall path from collect.ts: 3 signals written for a
+    // round that had 4 findings → shortfall detected → signal_loss_suspected
+    // emitted (which self-bumps the counter) → resetRoundCounter called.
+    // After the reset a retry / Phase B reader must see a fresh counter (0).
+    const N = 3;
+    for (let i = 0; i < N; i++) {
+      writer[WRITER_INTERNAL].appendSignal(makeSignal(CID));
+    }
+    expect(roundCounter.get(CID)).toBe(N);
+
+    // Mimic the self-bump that emitPipelineSignals causes when it writes the
+    // signal_loss_suspected diagnostic (pipeline signal carries consensusId).
+    roundCounter.bump(CID);
+    expect(roundCounter.get(CID)).toBe(N + 1);
+
+    // Fix 2: resetRoundCounter is called immediately after emitPipelineSignals.
+    roundCounter.reset(CID);
+    expect(roundCounter.get(CID)).toBe(0);
+  });
 });

--- a/tests/orchestrator/signal-type-snapshot.test.ts
+++ b/tests/orchestrator/signal-type-snapshot.test.ts
@@ -37,6 +37,7 @@ const DOCUMENTED_PATH_SPECIFIC = new Map<string, string>([
   ['signal_retracted',          'performance-writer.ts / gossip_signals'],
   ['consensus_round_retracted', 'performance-writer.ts / gossip_signals'],
   ['severity_miscalibrated',    'consensus-engine.ts'],
+  ['consensus_coverage_degraded', 'consensus-engine.ts (post-round dropouts)'],
   ['task_timeout',              'dispatch-pipeline.ts (timeout path)'],
   ['task_empty',                'dispatch-pipeline.ts (empty result path)'],
   // Impl signals — emitted by verify_write / auto-record in native-tasks.ts
@@ -65,7 +66,7 @@ const ALL_KNOWN_SIGNAL_NAMES: string[] = [
   'agreement', 'disagreement', 'unverified', 'unique_confirmed', 'unique_unconfirmed',
   'new_finding', 'hallucination_caught', 'category_confirmed', 'consensus_verified',
   'signal_retracted', 'consensus_round_retracted', 'severity_miscalibrated',
-  'task_timeout', 'task_empty',
+  'task_timeout', 'task_empty', 'consensus_coverage_degraded',
   // ImplSignal
   'impl_test_pass', 'impl_test_fail', 'impl_peer_approved', 'impl_peer_rejected',
   // MetaSignal

--- a/tests/orchestrator/signal-type-snapshot.test.ts
+++ b/tests/orchestrator/signal-type-snapshot.test.ts
@@ -50,6 +50,10 @@ const DOCUMENTED_PATH_SPECIFIC = new Map<string, string>([
   ['synthesis_completed',       'consensus-coordinator.ts'],
   ['circuit_open_fired',        'performance-reader.ts / dispatch-pipeline.ts'],
   ['skill_injection_skipped',   'prompt-assembler.ts / skill-loader.ts (ikp §4 kill-switch)'],
+  // Path A relay-lint — PR #270
+  ['relay_findings_dropped',    'collect.ts / relay-tasks.ts (relay-lint Path A)'],
+  // Phase A self-telemetry: collect-end reconciliation shortfall
+  ['signal_loss_suspected',     'collect.ts (round-reconcile assertion, Phase A self-telemetry)'],
 ]);
 
 // ── Exhaustive union of all known signal names ─────────────────────────────
@@ -69,7 +73,9 @@ const ALL_KNOWN_SIGNAL_NAMES: string[] = [
   // PipelineSignal
   'dispatch_started', 'relay_received', 'finding_dropped_format',
   'synthesis_completed', 'circuit_open_fired', 'skill_injection_skipped',
-  'citation_fabricated',
+  'citation_fabricated', 'relay_findings_dropped',
+  // Phase A self-telemetry
+  'signal_loss_suspected',
   // signal_retracted appears in both ConsensusSignal and PipelineSignal
 ];
 


### PR DESCRIPTION
## Summary

Phase A of system self-telemetry — a write-time per-round signal counter and a collect-end shortfall assertion. Designed to catch silent signal-loss bugs (like the historical 6-drop-gate) **at the moment of loss** instead of after the fact. Pure in-memory; no schema migration; non-blocking, non-fatal.

## Why this and not `gossip_verify_round`

The original sketch was a post-hoc reconciliation tool. Consensus-time stress-test (`3aa4a6ef-c8974235`) surfaced two prerequisites for that approach:

- `crossReviewAssignments` is computed in-memory but never serialized — the "expected signals" set cannot be reconstructed from a saved report.
- `consensusId` is sparse on signal records (missing from `bulk_from_consensus`, meta-signals, impl_*).

A write-time counter sidesteps both. It fires at the exact moment of drop, needs no schema, and is strictly easier to reason about for the bug class we care about (silent shortfalls).

## What landed

- **`packages/orchestrator/src/round-counter.ts`** (new) — module-level `Map<consensusId, count>` with `bump`/`get`/`reset`/`deriveConsensusId`. Explicit reset, not TTL.
- **`performance-writer.ts`** — non-throwing bump in both `appendSignal` and `appendSignals`. Bumps from `consensusId` field, falls back to `findingId` prefix (covers `bulk_from_consensus`).
- **`collect.ts`** — shortfall assertion after the provisional-signals path. authId derives from `signals[0].consensusId` with fallback to scanning all five finding buckets for a `8hex-8hex:` prefix (so empty-signal rounds still reconcile).
- **`consensus-types.ts` + `performance-writer.ts`** — closed-set enum extension for `signal_loss_suspected` (mirrors `relay_findings_dropped`; invariant #8 preserved).
- **Tests** — 16 new in `round-counter.test.ts` + snapshot fix for `consensus_coverage_degraded`.

Total: 9 files, ~302 +, ~10 -.

## Consensus review (`3aa4a6ef-c8974235`)

- **gemini-reviewer f1 (snapshot test)** — half-right; `consensus_coverage_degraded` gap is real, fixed in 910e786. `relay_findings_dropped` claim was a hallucination.
- **gemini-reviewer f2 (multi-process counter)** — confirmed; out of scope (single-process MCP today). Backlog.
- **gemini-reviewer f3 (`coverageDegraded.expected` ambiguity)** — pre-existing in adjacent code; not introduced here. Backlog.
- **gemini-reviewer f4** — hallucination (claimed files missing, both exist).
- **sonnet-reviewer F1 (authId source)** — real HIGH; fixed in 910e786 with finding-id prefix fallback.

## Known follow-ups (filing separately)

- **resolutionRoots false-rejection** — the consensus round above had its `resolutionRoots` rejected (`not found in git worktree list`) even though the worktree IS registered. Possible normalization/cwd mismatch in the validator. Real bug; will file.
- **sonnet-reviewer prose-only output** — log warned `emitted ZERO tags — falling back to bullet parsing. Check if skill Output Format conflicts with FINDING TAG SCHEMA`. The substantive critique was rescued from conversation context; in production it would have been silently lost. Skill-prompt conflict, will file.
- **gemini cross-review JSON malformed** — `Empty response parts (finishReason: STOP)`; transient.

## Test plan

- [x] 16 unit + integration-lite tests in `tests/orchestrator/round-counter.test.ts` (bump/get/reset, `deriveConsensusId` 7 cases, real-writer shortfall sim, meta-signal no-bump)
- [x] `tests/orchestrator/signal-type-snapshot.test.ts` updated for `signal_loss_suspected` + `consensus_coverage_degraded`
- [x] Local run: 21/21 pass on the touched test files; full orchestrator suite was 1624/1624 before fix patches
- [ ] CI typecheck + full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)