### PR TITLE
fix(default-skills): code-review prose-shaping leaks past FINDING TAG SCHEMA

### DIFF
--- a/packages/orchestrator/src/default-skills/code-review.md
+++ b/packages/orchestrator/src/default-skills/code-review.md
@@ -10,20 +10,21 @@
 - Prioritize findings so the author knows what must change vs. what is optional
 
 ## Approach
-1. Read the full diff before commenting on any single line
+1. Read the full diff before emitting any finding
 2. Check correctness first: does it do what it claims?
 3. Check edge cases: null, empty, concurrent, large input
 4. Check error handling: are errors surfaced or silently swallowed?
 5. Check test coverage: are the new paths tested?
 6. Check naming and structure: will this make sense in 6 months?
-7. Summarize findings at the top before inline comments
+7. Order findings critical → low within your response — every finding still ships as one `<agent_finding>` tag, never as a Markdown heading, `**F1 —**` numbering, or top-of-output summary prose
 
 ## Output Format
-Use the FINDING TAG SCHEMA from the system prompt. Do NOT invent skill-specific output formats; they break parsing and cross-review.
+Use the FINDING TAG SCHEMA from the system prompt. Do NOT invent skill-specific output formats; they break parsing and cross-review. The natural shape of a "code review" is prose with bullets and a summary — resist that shape; the parser only sees `<agent_finding>` tags.
 
 ## Don't
 - Don't nitpick style issues that a linter should catch
-- Don't leave vague comments like "this could be better" — say how
+- Don't write vague findings like "this could be better" — say how
 - Don't approve PRs with unresolved critical findings
-- Don't comment on every line — group related issues
+- Don't emit a finding for every line — group related issues into one tag
 - Don't skip reading the tests
+- Don't open or close your response with summary prose; the orchestrator synthesises across agents


### PR DESCRIPTION
## Summary

The default `code-review` skill prose primed sonnet-reviewer (and any agent that binds it) to emit Markdown-shaped reviews — top summary + `**F1 —**` numbered bullets — even though the Output Format section says "Use the FINDING TAG SCHEMA from the system prompt."

On consensus `3aa4a6ef-c8974235`, sonnet-reviewer emitted **6 substantive findings as prose with zero `<agent_finding>` tags**. Parser fell back to bullet parsing and recovered nothing. The reviewer effectively didn't review.

Root cause: Approach step 7 — *"Summarize findings at the top before inline comments"* — explicitly described prose structure, contradicting the schema. Plus several "comment(s)" references in the Don't list reinforced the same prose-output bias.

## Changes (skill prose only)

- Approach #7: replaced with explicit anti-pattern guidance — order critical→low **within** the response, but every finding still ships as one `<agent_finding>` tag (no headings, no `**F1 —**`, no top-of-output summary prose).
- Output Format: added a "natural shape vs parser shape" caveat — *"the natural shape of a code review is prose with bullets and a summary — resist that shape"*.
- Don't list: reworded "leave vague comments" → "write vague findings"; "comment on every line" → "emit a finding for every line"; added "Don't open or close your response with summary prose".

No code change. Invariant #8 (default-skills point to system-prompt schema) preserved.

## Why this is hard to verify empirically

The failure mode is intermittent — sonnet-reviewer DID emit proper tags in consensus `8fce64a8-488f4f01` (PR #284 review, this morning) with the same skill bundle. So this PR is a probabilistic improvement, not a hard fix. The honest claim is: we removed the most prose-suggesting language; the schema/skill conflict surface is now smaller.

Long-term: the strict-parser already counts dropped tags via `format_compliance` signals; if `sonnet-reviewer` keeps slipping post-merge, the next move is the diagnostic experiment (single-skill dispatch + additive bind) outlined in [`project_sonnet_reviewer_format_skill_conflict.md`](https://github.com/.../memory).

## Test plan
- [x] No code path changes — skill is markdown only.
- [ ] CI green (typecheck + jest + build).
- [ ] Watch next ~3 consensus rounds in dashboard for sonnet-reviewer `format_compliance` signal trend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)