### PR TITLE
fix(validate-resolution-root): include locked worktrees on explicit-path check

### DIFF
--- a/packages/orchestrator/src/validate-resolution-root.ts
+++ b/packages/orchestrator/src/validate-resolution-root.ts
@@ -88,15 +88,22 @@ export async function gitCommonDir(path: string): Promise<string | null> {
  * List worktree paths via `git -C projectRoot worktree list -z --porcelain`.
  * Skips bare / locked / prunable. Capped at 100 entries. Returns realpath'd
  * absolute paths. Never throws.
+ *
+ * Pass `includeLocked: true` to include locked worktrees (needed when
+ * validating explicit user-supplied resolutionRoots — agent worktrees are
+ * always locked and must not be silently rejected).
  */
-export async function listWorktreePaths(projectRoot: string): Promise<string[]> {
+export async function listWorktreePaths(
+  projectRoot: string,
+  { includeLocked = false }: { includeLocked?: boolean } = {},
+): Promise<string[]> {
   try {
     const { stdout } = await execFileP(
       'git',
       ['worktree', 'list', '-z', '--porcelain'],
       { ...GIT_EXEC_OPTS, cwd: projectRoot },
     );
-    return parseWorktreePorcelain(stdout);
+    return parseWorktreePorcelain(stdout, { includeLocked });
   } catch {
     return [];
   }
@@ -110,9 +117,17 @@ export async function listWorktreePaths(projectRoot: string): Promise<string[]> 
  * Skips bare / locked-* / prunable-* entries (they emit `locked <why>` —
  * prefix match, not equality).
  *
+ * Pass `includeLocked: true` to include locked worktrees in the output
+ * (bare and prunable are still excluded). Required when validating
+ * explicit user-supplied resolutionRoots — active agent worktrees are
+ * always locked and must not be silently dropped on the explicit path.
+ *
  * Cap at 100 entries to bound fanout on pathological repos.
  */
-export function parseWorktreePorcelain(stdout: string): string[] {
+export function parseWorktreePorcelain(
+  stdout: string,
+  { includeLocked = false }: { includeLocked?: boolean } = {},
+): string[] {
   const out: string[] = [];
   const records = stdout.split('\0\0');
   for (const rec of records) {
@@ -125,7 +140,7 @@ export function parseWorktreePorcelain(stdout: string): string[] {
       fields.some(
         (f) =>
           f === 'bare' ||
-          f.startsWith('locked') ||
+          (!includeLocked && f.startsWith('locked')) ||
           f.startsWith('prunable'),
       )
     ) {
@@ -244,7 +259,10 @@ export async function validateResolutionRoot(
   }
 
   // 7. Must appear in `git worktree list`.
-  const worktrees = await listWorktreePaths(projectRoot);
+  // includeLocked: true — active agent worktrees are always locked by git;
+  // rejecting them here would silently break all explicit resolutionRoots
+  // that point at in-use worktrees (root cause of consensus 3aa4a6ef regression).
+  const worktrees = await listWorktreePaths(projectRoot, { includeLocked: true });
   // Project root itself is always a valid worktree by convention — include it.
   let projectRootReal = projectRoot;
   try {

--- a/tests/orchestrator/validate-resolution-root.test.ts
+++ b/tests/orchestrator/validate-resolution-root.test.ts
@@ -103,6 +103,20 @@ describe('validateResolutionRoot', () => {
     expect(r.valid).toBe(false);
   });
 
+  it('locked worktree — accepted on explicit-path validation (regression: 3aa4a6ef)', async () => {
+    const wt = join(tmp, 'wt-locked');
+    execFileSync('git', ['checkout', '-qb', 'locked-branch'], { cwd: repo });
+    execFileSync('git', ['checkout', '-q', 'main'], { cwd: repo });
+    execFileSync('git', ['worktree', 'add', '-q', wt, 'locked-branch'], { cwd: repo });
+    // Lock the worktree to simulate an in-use agent worktree.
+    execFileSync('git', ['worktree', 'lock', wt], { cwd: repo });
+    const r = await validateResolutionRoot(wt, repo);
+    expect(r.valid).toBe(true);
+    if (r.valid) {
+      expect(r.canonical).toBe(realpathSync(wt));
+    }
+  });
+
   it('hashPath produces sha256:<8 hex>', () => {
     const h = hashPath('anything');
     expect(h).toMatch(/^sha256:[0-9a-f]{8}$/);
@@ -128,6 +142,17 @@ describe('parseWorktreePorcelain', () => {
   it('Test 7 (locked with reason) — skipped', () => {
     const rec = ['worktree /x', 'locked for maintenance'].join('\0');
     expect(parseWorktreePorcelain(rec)).toHaveLength(0);
+  });
+
+  it('includeLocked: true — locked entries are included, bare still excluded', () => {
+    const recLocked = ['worktree /locked-wt', 'HEAD deadbeef', 'locked agent in use'].join('\0');
+    const recBare = ['worktree /bare-wt', 'bare'].join('\0');
+    const recNormal = ['worktree /normal-wt', 'HEAD deadbeef', 'branch refs/heads/main'].join('\0');
+    const stdout = [recLocked, recBare, recNormal].join('\0\0');
+    const paths = parseWorktreePorcelain(stdout, { includeLocked: true });
+    expect(paths.some((p) => p.endsWith('/locked-wt'))).toBe(true);
+    expect(paths.some((p) => p.endsWith('/normal-wt'))).toBe(true);
+    expect(paths.some((p) => p.endsWith('/bare-wt'))).toBe(false);
   });
 
   it('handles trailing \\0\\0 gracefully', () => {


### PR DESCRIPTION
## Summary

Active agent worktrees are always locked by git. `parseWorktreePorcelain` silently skipped any record with a `locked` field, and `listWorktreePaths` reused that parser. `validateResolutionRoot` step 7 then emitted *"not found in 'git worktree list'"* — the same message as a genuinely absent worktree — for every explicit `resolutionRoots` pointing at an in-use agent worktree.

This caused consensus `3aa4a6ef-c8974235`'s cross-reviewers to miss new files on the PR branch and fabricate a "core logic review is blocked by missing files" finding (recorded as `hallucination_caught`, but it ate a cross-review slot).

## Root cause

The locked-skip was authored for auto-discovery (`discoverGitWorktrees`, spec test 7 in `docs/specs/2026-04-17-issue-126.md:355`) where it's a safe default. Explicit-path membership check has the opposite intent — *"is this a valid worktree in this repo right now"* — and locking is a runtime coordination signal, not a validity signal.

Two distinct intents shared one parser.

## Fix

- `parseWorktreePorcelain` accepts `{ includeLocked?: boolean }` (default `false`)
- `listWorktreePaths` threads it through
- `validateResolutionRoot` step 7 passes `includeLocked: true`
- `discoverGitWorktrees` unchanged — spec test 7 invariant preserved

## Tests

- New `parseWorktreePorcelain` sibling: `includeLocked: true` includes locked entries, still excludes `bare`
- New `validateResolutionRoot` integration: a real `git worktree lock`'d worktree now passes validation (labelled `regression: 3aa4a6ef`)
- Existing locked-skip test untouched
- 1627/1627 orchestrator tests pass

## Test plan
- [x] `npx jest tests/orchestrator/validate-resolution-root tests/orchestrator/discover-git-worktrees` — 16/16 pass
- [x] Full orchestrator suite — 1627/1627 pass
- [ ] CI green (typecheck + jest + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)