### PR TITLE
feat(dashboard): show raw signal ratio alongside adjusted accuracy

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -240,13 +240,40 @@ function TeamPage({ agents, tasks }: { agents: AgentData[]; tasks: import('@/lib
                     <span className={`font-mono text-sm font-bold tabular-nums ${weightColor}`}>{s.dispatchWeight.toFixed(2)}</span>
                   </td>
 
-                  {/* Metrics: three mini bars stacked */}
+                  {/* Metrics: four mini bars stacked */}
                   <td className="py-3 pr-4 align-top">
-                    <div className="space-y-1">
-                      <MiniBar label="A" value={s.accuracy} fillClass={s.accuracy >= 0.7 ? 'bg-confirmed' : s.accuracy >= 0.4 ? 'bg-unverified' : 'bg-disputed'} />
-                      <MiniBar label="U" value={s.uniqueness} fillClass="bg-unique" />
-                      <MiniBar label="I" value={s.impactScore} fillClass="bg-[var(--color-impact)]" />
-                    </div>
+                    {(() => {
+                      const rawDenom = s.agreements + s.uniqueFindings + s.disagreements + s.hallucinations;
+                      const rawRatio = rawDenom > 0
+                        ? (s.agreements + s.uniqueFindings) / rawDenom
+                        : null;
+                      return (
+                        <div className="space-y-1">
+                          <MiniBar
+                            label="A"
+                            value={s.accuracy}
+                            fillClass={s.accuracy >= 0.7 ? 'bg-confirmed' : s.accuracy >= 0.4 ? 'bg-unverified' : 'bg-disputed'}
+                            tooltip="Adjusted accuracy = raw signal ratio × 1/(1 + weighted hallucinations × 0.3). The penalty is recoverable via skill-gated multiplier in the same category."
+                          />
+                          <MiniBar label="U" value={s.uniqueness} fillClass="bg-unique" />
+                          <MiniBar label="I" value={s.impactScore} fillClass="bg-[var(--color-impact)]" />
+                          {rawRatio !== null ? (
+                            <MiniBar
+                              label="R"
+                              value={rawRatio}
+                              fillClass={rawRatio >= 0.7 ? 'bg-confirmed/60' : rawRatio >= 0.4 ? 'bg-unverified/60' : 'bg-disputed/60'}
+                              tooltip="(agreements + unique) / (agreements + unique + disagreements + hallucinations). Unweighted base ratio before the hallucination penalty."
+                            />
+                          ) : (
+                            <div className="flex items-center gap-2">
+                              <span className="w-2 font-mono text-[8px] uppercase text-muted-foreground/50">R</span>
+                              <div className="h-1 flex-1 overflow-hidden rounded-full bg-background/60" />
+                              <span className="w-8 text-right font-mono text-[10px] tabular-nums text-muted-foreground/30">—</span>
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })()}
                   </td>
 
                   {/* Signals */}
@@ -290,9 +317,9 @@ function TeamPage({ agents, tasks }: { agents: AgentData[]; tasks: import('@/lib
   );
 }
 
-function MiniBar({ label, value, fillClass }: { label: string; value: number; fillClass: string }) {
+function MiniBar({ label, value, fillClass, tooltip }: { label: string; value: number; fillClass: string; tooltip?: string }) {
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2" data-tooltip={tooltip} data-tooltip-pos="top">
       <span className="w-2 font-mono text-[8px] uppercase text-muted-foreground/50">{label}</span>
       <div className="h-1 flex-1 overflow-hidden rounded-full bg-background/60">
         <div className={`h-full rounded-full ${fillClass}`} style={{ width: `${Math.max(0, Math.min(100, value * 100))}%` }} />

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -77,7 +77,7 @@ export interface AgentData {
   scores: {
     accuracy: number; uniqueness: number; reliability: number;
     impactScore: number; dispatchWeight: number; signals: number;
-    agreements: number; disagreements: number; hallucinations: number;
+    agreements: number; disagreements: number; hallucinations: number; uniqueFindings: number;
     unverifiedsEmitted?: number; unverifiedsReceived?: number;
     consecutiveFailures: number; circuitOpen: boolean;
     bench: {

--- a/packages/relay/src/dashboard/api-agents.ts
+++ b/packages/relay/src/dashboard/api-agents.ts
@@ -156,6 +156,7 @@ export interface AgentResponse {
     agreements: number;
     disagreements: number;
     hallucinations: number;
+    uniqueFindings: number;
     unverifiedsEmitted: number;
     unverifiedsReceived: number;
     bench: {
@@ -322,6 +323,7 @@ export async function agentsHandler(
         agreements: score.agreements,
         disagreements: score.disagreements,
         hallucinations: score.hallucinations,
+        uniqueFindings: score.uniqueFindings ?? 0,
         unverifiedsEmitted: score.unverifiedsEmitted ?? 0,
         unverifiedsReceived: score.unverifiedsReceived ?? 0,
         consecutiveFailures: score.consecutiveFailures ?? 0,


### PR DESCRIPTION
## Summary

Adds a "Raw Signal Ratio" indicator to the Agents leaderboard so users can see both the unweighted base ratio and the formula-adjusted accuracy side-by-side.

Direct outcome of meta-issue #3 audit (this morning, consensus `8fce64a8` follow-up): the formula at `packages/orchestrator/src/performance-reader.ts:952-962` correctly compresses raw 0.91 → adjusted 0.24 for gemini-reviewer via the documented logarithmic hallucination penalty `1/(1 + weightedHallu × 0.3)`. The compression is intentional and recoverable via skill-gated multiplier — but it's invisible in the dashboard, leading to "the score looks wrong" confusion.

This PR surfaces the raw ratio without touching the formula.

## What changed

**`App.tsx`** (frontend) — 4th MiniBar row labeled "R" under the existing `A`/`U`/`I` stack in the metrics column. 60%-opacity fill marks it as a baseline reference rather than a competing accuracy score. Tooltips on both:
- "A" → *"Adjusted accuracy = raw signal ratio × 1/(1 + weighted hallucinations × 0.3). The penalty is recoverable via skill-gated multiplier in the same category."*
- "R" → *"(agreements + unique) / (agreements + unique + disagreements + hallucinations). Unweighted base ratio before the hallucination penalty."*

**`MiniBar`** — gains an optional `tooltip` prop, rendered via the existing `data-tooltip` / `data-tooltip-pos="top"` CSS pattern. No new tooltip dependency.

**`types.ts`** (frontend) — adds `uniqueFindings: number` to the `AgentData.scores` shape.

**`api-agents.ts`** (relay) — adds `uniqueFindings` to the `AgentResponse` type and serializes it from `score.uniqueFindings`. **This field was previously absent from the response** despite being in `DEFAULT_SCORE` and produced by `PerformanceReader` — `s.uniqueFindings` would have been `undefined` on the frontend, NaN-ing the rawRatio. The new column wouldn't have worked without this fix.

## Visual

`A` = Accuracy (adjusted, with formula tooltip)
`U` = Uniqueness
`I` = Impact
`R` = **Raw signal ratio (new — 60% opacity)**

Empty-state agents (no signals) render `—` to keep column heights consistent.

## Test plan
- [x] `npx tsc --noEmit -p packages/dashboard-v2` — only pre-existing `useElementWidth.ts` error remains; no new errors.
- [x] `npx tsc --noEmit -p packages/relay` — clean.
- [x] `npx jest tests/dashboard tests/relay` — 200/200 pass.
- [ ] Manual visual inspection in browser (dashboard build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)