### PR TITLE
feat(dashboard): unified markdown render for findings + signal evidence

### DIFF
--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -7,7 +7,7 @@ import { AgentActivityTimeline } from './AgentActivityTimeline';
 import { FindingDetailDrawer } from './FindingDetailDrawer';
 import { SignalTimeline } from './SignalTimeline';
 import { TaskRow } from './TaskRow';
-import { timeAgo, cleanFindingTags } from '@/lib/utils';
+import { timeAgo, renderFindingMarkdown } from '@/lib/utils';
 import { getBenchBadgeKind } from '@/lib/bench';
 import { escapeHtml } from '@/lib/sanitize';
 import type { AgentData, TasksData, ConsensusData, ConsensusReport, ConsensusReportsData, MemoryData, MemoryFile, ParseDiagnostic } from '@/lib/types';
@@ -426,7 +426,7 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
                             <div className="flex items-start gap-2 py-1">
                               <span className={`shrink-0 rounded-sm px-1.5 py-0.5 font-mono text-[9px] font-bold ${tag.cls}`}>{tag.label}</span>
                               <div className="min-w-0 flex-1">
-                                <span className="text-xs text-muted-foreground [&_.cite-file]:rounded [&_.cite-file]:bg-blue-500/10 [&_.cite-file]:px-1 [&_.cite-file]:font-mono [&_.cite-file]:text-blue-400 [&_.cite-fn]:rounded [&_.cite-fn]:bg-purple-500/10 [&_.cite-fn]:px-1 [&_.cite-fn]:font-mono [&_.cite-fn]:text-purple-400" dangerouslySetInnerHTML={{ __html: cleanFindingTags(sig.evidence || '') }} />
+                                <span className="finding-md text-xs text-muted-foreground [&_.cite-file]:rounded [&_.cite-file]:bg-blue-500/10 [&_.cite-file]:px-1 [&_.cite-file]:font-mono [&_.cite-file]:text-blue-400 [&_.cite-fn]:rounded [&_.cite-fn]:bg-purple-500/10 [&_.cite-fn]:px-1 [&_.cite-fn]:font-mono [&_.cite-fn]:text-purple-400" dangerouslySetInnerHTML={{ __html: renderFindingMarkdown(sig.evidence || '') }} />
                                 <span className="ml-2 font-mono text-[10px] text-muted-foreground/50">
                                   {sig.agentId}{sig.counterpartId ? ` + ${sig.counterpartId}` : ''}
                                 </span>

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import type { ConsensusData, ConsensusReportsData, ConsensusReportFinding, ConsensusReport, ParseDiagnostic } from '@/lib/types';
 import { api } from '@/lib/api';
-import { timeAgo, cleanFindingTags, agentInitials, agentColor } from '@/lib/utils';
+import { timeAgo, renderFindingMarkdown, agentInitials, agentColor } from '@/lib/utils';
 import { escapeHtml } from '@/lib/sanitize';
 import { EmptyState } from './EmptyState';
 
@@ -197,8 +197,8 @@ function ReportFinding({ f, reviewInfo, diagnostics }: {
         </div>
       )}
       {/* Finding text */}
-      <div className={`font-inter text-xs leading-relaxed text-muted-foreground ${CITE_STYLES}`}
-        dangerouslySetInnerHTML={{ __html: cleanFindingTags(f.finding) }} />
+      <div className={`finding-md font-inter text-xs leading-relaxed text-muted-foreground ${CITE_STYLES}`}
+        dangerouslySetInnerHTML={{ __html: renderFindingMarkdown(f.finding) }} />
       {/* Cross-review coverage badge row */}
       {reviewInfo && (
         <div className="mt-1.5 flex items-center gap-1.5">
@@ -801,7 +801,7 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
                               </span>
                               <div className="min-w-0 flex-1">
                                 <span className="text-xs text-muted-foreground [&_.cite-file]:rounded [&_.cite-file]:bg-blue-500/10 [&_.cite-file]:px-1 [&_.cite-file]:font-mono [&_.cite-file]:text-blue-400 [&_.cite-fn]:rounded [&_.cite-fn]:bg-purple-500/10 [&_.cite-fn]:px-1 [&_.cite-fn]:font-mono [&_.cite-fn]:text-purple-400">
-                                  <span dangerouslySetInnerHTML={{ __html: cleanFindingTags(sig.evidence || '') }} />
+                                  <span className="finding-md" dangerouslySetInnerHTML={{ __html: renderFindingMarkdown(sig.evidence || '') }} />
                                 </span>
                                 <span className="ml-2 font-mono text-[10px] text-muted-foreground/50">
                                   {sig.agentId}{sig.counterpartId ? ` + ${sig.counterpartId}` : ''}

--- a/packages/dashboard-v2/src/components/TaskDetailModal.tsx
+++ b/packages/dashboard-v2/src/components/TaskDetailModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import type { TaskItem } from '@/lib/types';
-import { timeAgo, formatDuration, cleanFindingTags, renderMarkdown } from '@/lib/utils';
+import { timeAgo, formatDuration, renderFindingMarkdown, renderMarkdown } from '@/lib/utils';
 
 interface TaskDetailModalProps {
   task: TaskItem | null;
@@ -96,8 +96,8 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
                 Result
               </h3>
               <div
-                className="rounded-md border border-border/40 bg-background/40 p-3 font-mono text-xs leading-relaxed text-foreground/90 whitespace-pre-wrap [&_.cite-file]:rounded [&_.cite-file]:bg-blue-500/10 [&_.cite-file]:px-1 [&_.cite-file]:text-blue-400 [&_.cite-fn]:rounded [&_.cite-fn]:bg-purple-500/10 [&_.cite-fn]:px-1 [&_.cite-fn]:text-purple-400 [&_.inline-code]:rounded [&_.inline-code]:bg-muted/40 [&_.inline-code]:px-1 [&_.inline-code-block]:my-2 [&_.inline-code-block]:block [&_.inline-code-block]:rounded [&_.inline-code-block]:bg-muted/30 [&_.inline-code-block]:p-2"
-                dangerouslySetInnerHTML={{ __html: cleanFindingTags(task.result) }}
+                className="finding-md rounded-md border border-border/40 bg-background/40 p-3 font-mono text-xs leading-relaxed text-foreground/90 whitespace-pre-wrap [&_.cite-file]:rounded [&_.cite-file]:bg-blue-500/10 [&_.cite-file]:px-1 [&_.cite-file]:text-blue-400 [&_.cite-fn]:rounded [&_.cite-fn]:bg-purple-500/10 [&_.cite-fn]:px-1 [&_.cite-fn]:text-purple-400 [&_.inline-code]:rounded [&_.inline-code]:bg-muted/40 [&_.inline-code]:px-1 [&_.inline-code-block]:my-2 [&_.inline-code-block]:block [&_.inline-code-block]:rounded [&_.inline-code-block]:bg-muted/30 [&_.inline-code-block]:p-2"
+                dangerouslySetInnerHTML={{ __html: renderFindingMarkdown(task.result) }}
               />
             </section>
           ) : (

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -310,3 +310,74 @@ html::after {
   padding: 0;
   font-size: inherit;
 }
+
+/* ── finding-md: compact markdown scope for agent findings and signal evidence ── */
+
+.finding-md h1.md-h1 {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--color-foreground);
+  margin-top: 0.5rem;
+  margin-bottom: 0.25rem;
+  line-height: 1.4;
+}
+
+.finding-md h2.md-h2 {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--color-foreground);
+  margin-top: 0.4rem;
+  margin-bottom: 0.2rem;
+  line-height: 1.4;
+}
+
+.finding-md h3.md-h3 {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--color-foreground);
+  margin-top: 0.3rem;
+  margin-bottom: 0.15rem;
+  line-height: 1.4;
+}
+
+.finding-md ul.md-list {
+  list-style: disc;
+  padding-left: 1rem;
+  margin: 0.25rem 0;
+}
+
+.finding-md ul.md-list li {
+  margin: 0.1rem 0;
+  line-height: 1.5;
+}
+
+.finding-md code.md-inline-code {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  background: rgba(139, 92, 246, 0.12);
+  border: 1px solid rgba(139, 92, 246, 0.15);
+  border-radius: 3px;
+  padding: 0.1em 0.3em;
+  color: var(--color-foreground);
+}
+
+.finding-md pre.md-code-block {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(139, 92, 246, 0.12);
+  border-radius: 4px;
+  padding: 0.4rem 0.6rem;
+  margin: 0.35rem 0;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--color-foreground);
+  line-height: 1.5;
+}
+
+.finding-md pre.md-code-block code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}

--- a/packages/dashboard-v2/src/lib/utils.ts
+++ b/packages/dashboard-v2/src/lib/utils.ts
@@ -113,6 +113,95 @@ export function cleanFindingTags(text: string): string {
   return cleaned;
 }
 
+/**
+ * Unified markdown renderer for agent findings, signal evidence, and task results.
+ * Superset of both cleanFindingTags (cite tags, prefix strip) and renderMarkdown
+ * (headings, lists). Use this for all agent-authored content.
+ */
+export function renderFindingMarkdown(text: string): string {
+  // Step 1: HTML-escape everything
+  let out = text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+  // Step 2: Strip [FINDING]/[SUGGESTION]/[INSIGHT] prefixes
+  out = out.replace(/^\[(FINDING|SUGGESTION|INSIGHT)\]\s*/i, '');
+
+  // Step 3: Strip <agent_finding> wrapper tags (escaped)
+  out = out.replace(/&lt;agent_finding[^&]*&gt;/g, '');
+  out = out.replace(/&lt;\/agent_finding&gt;/g, '');
+
+  // Step 4: Re-apply safe cite tags (on the now-escaped text)
+  // <cite tag="file"> → blue code span
+  out = out.replace(/&lt;cite\s+tag=&quot;file&quot;&gt;([^&]+)&lt;\/cite&gt;/g, '<code class="cite-file">$1</code>');
+  // <cite tag="fn"> → purple code span
+  out = out.replace(/&lt;cite\s+tag=&quot;fn&quot;&gt;([^&]+)&lt;\/cite&gt;/g, '<code class="cite-fn">$1</code>');
+  // Legacy <fn> → purple code span
+  out = out.replace(/&lt;fn&gt;([^&]+)&lt;\/fn&gt;/g, '<code class="cite-fn">$1</code>');
+
+  // Step 5: Code fences (must run before inline backtick pass)
+  out = out.replace(/```(\w*)\n?([\s\S]*?)```/g, '<pre class="md-code-block"><code>$2</code></pre>');
+
+  // Step 6: Inline code
+  out = out.replace(/`([^`\n]+)`/g, '<code class="md-inline-code">$1</code>');
+
+  // Step 7: Bold then italic (order matters — ** before *)
+  out = out.replace(/\*\*([^*\n]+)\*\*/g, '<strong class="font-semibold text-foreground">$1</strong>');
+  out = out.replace(/(^|[^*])\*([^*\n]+)\*(?!\*)/g, '$1<em>$2</em>');
+
+  // Step 8: Headings and lists — process line by line
+  const lines = out.split('\n');
+  const processedLines: string[] = [];
+  let inList = false;
+
+  for (const line of lines) {
+    const h3 = line.match(/^###\s+(.+)$/);
+    const h2 = line.match(/^##\s+(.+)$/);
+    const h1 = line.match(/^#\s+(.+)$/);
+
+    if (h3) {
+      if (inList) { processedLines.push('</ul>'); inList = false; }
+      processedLines.push(`<h3 class="md-h3">${h3[1]}</h3>`);
+      continue;
+    }
+    if (h2) {
+      if (inList) { processedLines.push('</ul>'); inList = false; }
+      processedLines.push(`<h2 class="md-h2">${h2[1]}</h2>`);
+      continue;
+    }
+    if (h1) {
+      if (inList) { processedLines.push('</ul>'); inList = false; }
+      processedLines.push(`<h1 class="md-h1">${h1[1]}</h1>`);
+      continue;
+    }
+
+    // Unordered list items: "- " or "* "
+    const li = line.match(/^(\s*)[*-]\s+(.+)$/);
+    if (li) {
+      if (!inList) { processedLines.push('<ul class="md-list">'); inList = true; }
+      processedLines.push(`<li>${li[2]}</li>`);
+      continue;
+    }
+
+    // Blank line closes an open list
+    if (line.trim() === '') {
+      if (inList) { processedLines.push('</ul>'); inList = false; }
+      processedLines.push('');
+      continue;
+    }
+
+    // Regular line — close list if open
+    if (inList) { processedLines.push('</ul>'); inList = false; }
+    processedLines.push(line);
+  }
+
+  if (inList) processedLines.push('</ul>');
+
+  return processedLines.join('\n');
+}
+
 export function timeAgo(ts: string | number): string {
   const now = Date.now();
   const then = typeof ts === 'string' ? new Date(ts).getTime() : ts;


### PR DESCRIPTION
## Summary

Closes the long-standing markdown leakage on agent findings (`feedback_dashboard_markdown.md`, originally observed 2026-04-04). Findings rendered via `cleanFindingTags` previously leaked raw `# Heading` and `- list` markdown — bold/italic/code worked but structured content didn't.

Root cause: two split helpers in `lib/utils.ts`. `cleanFindingTags` handled cite tags + bold/italic/code but **not** headings/lists. `renderMarkdown` handled headings/lists but **not** `<cite>` tags. Naively swapping the two would have broken citation rendering on findings.

## Changes

**`renderFindingMarkdown`** — new function in `lib/utils.ts` that's a strict superset of both. Order of passes:

1. HTML-escape everything (XSS guard)
2. Strip `[FINDING]` / `[SUGGESTION]` / `[INSIGHT]` prefixes
3. Strip `<agent_finding>` wrapper tags
4. Re-apply `<cite tag="file">` / `<cite tag="fn">` / legacy `<fn>` → blue/purple code spans
5. Code fences + inline code
6. Bold (`**`) before italic (`*`)
7. Line-by-line: ATX headings (`#`/`##`/`###`) + unordered lists (`-`/`*`), with blank-line list-close

**Migrated 4 call sites** to the new function:
- `FindingsMetrics.tsx` finding card + signal timeline evidence
- `AgentPage.tsx` signal list evidence
- `TaskDetailModal.tsx` task result (agent output may include cite tags)

**Left alone** (intentional):
- TaskDetailModal task description — `renderMarkdown` (task prompts have no cite tags)
- MemoryDialog content — `renderMarkdown` (user-authored memory files)
- FindingDetailDrawer — custom `whitespace-pre-wrap` (different render shape)

**CSS** — added `.finding-md` scoped variants in `globals.css` for `md-h1`/`h2`/`h3`/`list`/`inline-code`/`code-block`. Smaller than `.task-md` equivalents (h3=0.7rem vs 0.8rem) to fit the dense card layout.

`cleanFindingTags` kept untouched for backwards compat.

## Test plan
- [x] `npx tsc --noEmit -p packages/dashboard-v2` — only pre-existing `useElementWidth.ts` error remains.
- [x] `npx jest tests/dashboard` — 45/45 pass.
- [ ] Manual: open a recent consensus round (e.g. `8fce64a8`) in the dashboard and confirm finding bodies with `# Heading` + `- list items` + `<cite tag="file">` all render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)