### PR TITLE
fix(dashboard): consensus presentation polish — color semantics + contrast

### DIFF
--- a/packages/dashboard-v2/src/components/FindingDetailDrawer.tsx
+++ b/packages/dashboard-v2/src/components/FindingDetailDrawer.tsx
@@ -21,12 +21,12 @@ const SEVERITY_COLORS: Record<string, string> = {
 };
 
 const TAG_COLORS: Record<string, string> = {
-  confirmed: 'bg-confirmed',
-  disputed: 'bg-disputed',
-  unverified: 'bg-unverified',
-  unique: 'bg-unique',
-  insight: 'bg-muted',
-  newFinding: 'bg-unique',
+  confirmed: 'text-confirmed bg-confirmed/10 border border-confirmed/20',
+  disputed: 'text-disputed bg-disputed/10 border border-disputed/20',
+  unverified: 'text-unverified bg-unverified/10 border border-unverified/20',
+  unique: 'text-unique bg-unique/10 border border-unique/20',
+  insight: 'text-muted-foreground bg-muted border border-border/40',
+  newFinding: 'text-unique bg-unique/10 border border-unique/20',
 };
 
 export function FindingDetailDrawer({ open, onOpenChange, consensusId, findingId }: Props) {

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -31,7 +31,7 @@ const TAG_MAP: Record<string, { label: string; filter: FilterType; cls: string }
   hallucination_caught: { label: 'DISPUTED', filter: 'disputed', cls: 'text-disputed bg-disputed/10' },
   unverified: { label: 'UNVERIFIED', filter: 'unverified', cls: 'text-unverified bg-unverified/10' },
   unique_confirmed: { label: 'UNIQUE', filter: 'unique', cls: 'text-unique bg-unique/10' },
-  unique_unconfirmed: { label: 'UNIQUE', filter: 'unique', cls: 'text-unique bg-unique/10' },
+  unique_unconfirmed: { label: 'UNIQUE?', filter: 'unique', cls: 'text-unverified bg-unverified/10' },
   new_finding: { label: 'NEW', filter: 'unique', cls: 'text-unique bg-unique/10' },
 };
 
@@ -95,7 +95,7 @@ function ReportFinding({ f, reviewInfo, diagnostics }: {
     : f.tag === 'unverified' ? 'text-unverified bg-unverified/10 border-unverified/20'
     : 'text-unique bg-unique/10 border-unique/20';
   const sevCls = f.severity ? SEVERITY_CLS[f.severity] || '' : '';
-  const typeLabel = f.findingType === 'suggestion' ? '💡 SUGGESTION'
+  const typeLabel = f.findingType === 'suggestion' ? 'SUGGESTION'
     : f.findingType === 'insight' ? 'INSIGHT'
     : null;
   const typeCls = f.findingType === 'suggestion' ? 'text-blue-400 bg-blue-500/10'
@@ -206,7 +206,7 @@ function ReportFinding({ f, reviewInfo, diagnostics }: {
             <span
               key={rid}
               title={rid}
-              className="inline-flex h-4 w-4 items-center justify-center rounded-full font-mono text-[7px] font-bold text-background opacity-70"
+              className="inline-flex h-5 w-5 items-center justify-center rounded-full font-mono text-[8px] font-bold text-background opacity-70"
               style={{ backgroundColor: agentColor(rid) }}
             >
               {agentInitials(rid)}
@@ -714,15 +714,15 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
                 title={isRunRetracted && run.retractionReason ? `Retracted: ${run.retractionReason}` : undefined}
               >
                 {isRunRetracted && (
-                  <div className="rounded-t-md border-b border-disputed/30 bg-disputed/50 px-3 py-1.5 font-mono text-[10px] text-disputed-foreground" style={{ textDecoration: 'none' }}>
+                  <div className="rounded-t-md border-b border-disputed/30 bg-disputed/10 px-3 py-1.5 font-mono text-[10px] text-disputed" style={{ textDecoration: 'none' }}>
                     <span className="font-bold uppercase tracking-wider">⚠ Retracted</span>
                     {run.retractedAt && (
-                      <span className="ml-2 text-disputed-foreground/80">
+                      <span className="ml-2 text-disputed/70">
                         on {run.retractedAt.slice(0, 10)}
                       </span>
                     )}
                     {run.retractionReason && (
-                      <span className="ml-2 text-muted-foreground/90">— {run.retractionReason}</span>
+                      <span className="ml-2 text-muted-foreground/80">— {run.retractionReason}</span>
                     )}
                   </div>
                 )}


### PR DESCRIPTION
## Summary

PR-A from the consensus presentation overhaul plan. Surgical visual fixes from a sonnet-designer audit of the dashboard's consensus rendering. 12 lines changed across 2 files; eliminates 2 CRITICAL + 2 HIGH visual issues.

## Changes

### Color semantics (CRITICAL)

1. **Retraction banner alignment** — legacy path at `FindingsMetrics.tsx:717` used `bg-disputed/50` + `text-disputed-foreground` (an **undefined CSS variable** that silently fell back to inherited foreground → near-zero contrast on the red fill). The reports-path equivalent at `:476` already uses `bg-disputed/10` + `text-disputed`. Same retraction event was rendering with two different visual weights in the same scroll region. Aligned the legacy banner to the reports-path styling.

2. **`unique_unconfirmed` differentiation** — `FindingsMetrics.tsx:34`: both `unique_confirmed` and `unique_unconfirmed` rendered identically as `text-unique bg-unique/10` with label "UNIQUE", conflating "novel confirmed unique" with "orphan unreviewed". Now `unique_unconfirmed` renders as **"UNIQUE?"** in `text-unverified bg-unverified/10` to signal reduced confidence. Filter wiring untouched (same bucket).

### Contrast (HIGH)

3. **`FindingDetailDrawer` tag badges** — `FindingDetailDrawer.tsx:23-30`: solid `bg-confirmed` / `bg-disputed` / etc. fills with no paired `text-*` class meant light text inherited from body sat on a mid-tone fill. Switched to the tinted pattern already used by `FindingsMetrics:93`: each tag carries `text-{color} bg-{color}/10 border border-{color}/20`.

### Polish (MEDIUM/LOW)

4. **Drop emoji from SUGGESTION** — `FindingsMetrics.tsx:98`: `'💡 SUGGESTION'` → `'SUGGESTION'`. The `text-blue-400 bg-blue-500/10` color already differentiates it; the emoji broke mono baseline alignment.

5. **Avatar size bump** — `FindingsMetrics.tsx:209`: per-finding-card reviewer avatars from `h-4 w-4 text-[7px]` to `h-5 w-5 text-[8px]`. Two-letter initials at 7px in a 16px circle were below legible threshold.

## What's next (deferred to follow-up PRs)

- **PR-B** "Surface what's already there": render `coverageDegraded`, `relayCrossReviewSkipped`, cross-reviewer tool-turn counts.
- **PR-C** Selection rationale: new `selectionRationale` field on `ConsensusReport` populated by the consensus engine.
- **PR-D** Unify legacy + reports rendering paths into shared `<RoundCard>`. Eliminates the drift surface that caused the contrast bug fixed here.

## Test plan
- [x] `npx tsc --noEmit -p packages/dashboard-v2` — only pre-existing `useElementWidth.ts` error.
- [x] `npx jest tests/dashboard` — 45/45 pass.
- [ ] Visual check: open a recent retracted consensus round on master vs this branch, confirm banner contrast is consistent across legacy + reports paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)