### PR TITLE
feat(dashboard): surface coverageDegraded + relayCrossReviewSkipped banners

### DIFF
--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -588,6 +588,28 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
                         </button>
                       ))}
                     </div>
+                    {report.coverageDegraded && (
+                      <div className="mb-3 rounded-md border border-unverified/20 bg-unverified/8 px-3 py-2">
+                        <p className="font-mono text-[10px] font-semibold text-unverified">
+                          ⚠ Coverage degraded — {report.coverageDegraded.received} of {report.coverageDegraded.expected} agents responded
+                        </p>
+                        {report.coverageDegraded.droppedAgents.length > 0 && (
+                          <p className="mt-0.5 font-mono text-[9px] text-muted-foreground/70">
+                            Dropped: {report.coverageDegraded.droppedAgents.join(', ')}
+                          </p>
+                        )}
+                      </div>
+                    )}
+                    {report.relayCrossReviewSkipped && report.relayCrossReviewSkipped.length > 0 && (
+                      <div className="mb-3 rounded-md border border-unverified/20 bg-unverified/8 px-3 py-2">
+                        <p className="font-mono text-[10px] font-semibold text-unverified">
+                          ⚠ Cross-review skipped: {report.relayCrossReviewSkipped.length} relay agent{report.relayCrossReviewSkipped.length === 1 ? '' : 's'} failed Phase 2
+                        </p>
+                        <p className="mt-0.5 font-mono text-[9px] text-muted-foreground/70">
+                          {report.relayCrossReviewSkipped.map(s => s.agentId).join(', ')}
+                        </p>
+                      </div>
+                    )}
                     {(report.crossReviewAssignments || report.crossReviewCoverage) && (() => {
                       // Invert assignments: reviewerId → findingIds
                       const assignments = report.crossReviewAssignments || {};

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -165,6 +165,16 @@ export interface ConsensusReport {
   crossReviewCoverage?: Array<{ findingId: string; assigned: number; targetK: number }>;
   partialReview?: boolean;
   /**
+   * Relay agents whose cross-review LLM call failed (quota / parse / network).
+   * Matches orchestrator ConsensusReport shape exactly.
+   */
+  relayCrossReviewSkipped?: Array<{ agentId: string; reason: string }>;
+  /**
+   * Coverage degraded when a dispatched agent produced a 0-char response.
+   * The round still completes but with fewer voices than dispatched.
+   */
+  coverageDegraded?: { expected: number; received: number; droppedAgents: string[] };
+  /**
    * Unknown type values (lowercased) → total drop count. Populated by the
    * strict `<agent_finding>` parser when an agent uses an invented type
    * ("approval", "concern", etc). Surfaces silent type-drift that would


### PR DESCRIPTION
## Summary

PR-B (slice 1 of 2) from the consensus presentation overhaul plan. Surfaces two existing-but-unrendered fields on `ConsensusReport`. Pure UI addition, ~32 lines.

The orchestrator has been populating `coverageDegraded` and `relayCrossReviewSkipped` on every consensus round, but the dashboard ignored both — silent agent dropouts were effectively invisible to operators.

## What surfaces now

When either field has content, `FindingsMetrics.tsx` renders a banner above the cross-review assignments block:

```
⚠ Coverage degraded — 2 of 3 agents responded
Dropped: openclaw-agent

⚠ Cross-review skipped: 1 relay agent failed Phase 2
gemini-reviewer
```

- **`coverageDegraded`** = Phase 1 silent dropouts (agents that produced 0-length responses).
- **`relayCrossReviewSkipped`** = Phase 2 cross-review LLM call failures (quota / parse / network).

Both banners use the same `unverified` palette as the existing `partialReview` banner. They stack independently when both fire — different failure modes, separate signals.

## Type changes

`packages/dashboard-v2/src/lib/types.ts` extended to match the orchestrator's `consensus-types.ts` shape:
- `coverageDegraded?: { expected: number; received: number; droppedAgents: string[] }`
- `relayCrossReviewSkipped?: Array<{ agentId: string; reason: string }>`

The `reason` string on each skipped entry is in the type but not currently rendered — could surface in a tooltip in a follow-up.

## What's NOT in this PR (deferred)

- Cross-reviewer `task_tool_turns` counts — needs API plumbing on `api-consensus.ts` to expose meta-signals; separate scope.
- `authorDiagnostics` on the live signals timeline — same.
- Selection rationale (`PR-C` in the overhaul plan).
- `<RoundCard>` shared-component refactor (`PR-D`).

## Test plan
- [x] `npx tsc --noEmit -p packages/dashboard-v2` — only pre-existing `useElementWidth.ts` error.
- [x] `npx jest tests/dashboard` — 45/45 pass.
- [ ] Visual: open a consensus round with a known dropout (e.g. when openclaw-agent quota hits) and confirm the banner appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)