### PR TITLE
fix: 3 follow-ups from consensus 9e2d6c06 review of today's PRs

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -854,18 +854,21 @@ export async function handleCollect(
           process.stderr.write(
             `[round-reconcile] consensusId=${authId} expected_min=${findingsCount} actual=${actual} shortfall=${shortfall}\n`
           );
-          emitPipelineSignals(process.cwd(), [{
-            type: 'pipeline',
-            signal: 'signal_loss_suspected',
-            agentId: '_system',
-            taskId: authId,
-            consensusId: authId,
-            value: shortfall,
-            metadata: { expected_min: findingsCount, actual },
-            timestamp: new Date().toISOString(),
-          }]);
-          // Clear the counter so a retry / Phase B reader sees fresh state, not the diagnostic's own bump.
-          resetRoundCounter(authId);
+          try {
+            emitPipelineSignals(process.cwd(), [{
+              type: 'pipeline',
+              signal: 'signal_loss_suspected',
+              agentId: '_system',
+              taskId: authId,
+              consensusId: authId,
+              value: shortfall,
+              metadata: { expected_min: findingsCount, actual },
+              timestamp: new Date().toISOString(),
+            }]);
+          } finally {
+            // Clear the counter so a retry / Phase B reader sees fresh state, not the diagnostic's own bump.
+            resetRoundCounter(authId);
+          }
         }
       }
     } catch { /* best-effort */ }

--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -22,7 +22,7 @@ import { TaskRow } from '@/components/TaskRow';
 import { useAuth } from '@/hooks/useAuth';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import { useDashboardData } from '@/hooks/useDashboardData';
-import { timeAgo, cleanFindingTags } from '@/lib/utils';
+import { timeAgo } from '@/lib/utils';
 import { getBenchBadgeKind, needsAttention } from '@/lib/bench';
 import type { DashboardEvent, AgentData } from '@/lib/types';
 

--- a/packages/orchestrator/src/validate-resolution-root.ts
+++ b/packages/orchestrator/src/validate-resolution-root.ts
@@ -123,6 +123,15 @@ export async function listWorktreePaths(
  * always locked and must not be silently dropped on the explicit path.
  *
  * Cap at 100 entries to bound fanout on pathological repos.
+ *
+ * Behavioral split — readers should know:
+ * - Auto-discovery (`discoverGitWorktrees`) calls without `includeLocked` →
+ *   locked entries are skipped (spec test 7 invariant). Locking is treated
+ *   as a "do not auto-pick this worktree" signal.
+ * - Explicit-path validation (`validateResolutionRoot` step 7) passes
+ *   `includeLocked: true` → locked entries are included. Active agent worktrees
+ *   are always locked by git, and explicit user-supplied resolutionRoots
+ *   pointing at them must not be silently rejected (consensus 3aa4a6ef regression).
  */
 export function parseWorktreePorcelain(
   stdout: string,


### PR DESCRIPTION
## Summary

Post-merge consensus review (`9e2d6c06-98014474`) of today's PRs (#284-#290) surfaced three confirmed follow-ups. Each is small and self-contained.

## Changes

### 1. Drop unused `cleanFindingTags` import — `App.tsx:25` (gemini-reviewer:f2)

PR #288 migrated all dashboard call sites to `renderFindingMarkdown`. The import on `App.tsx:25` is dead.

### 2. Reset-on-throw safety — `collect.ts:856-869` (sonnet-reviewer:f3)

PR #284 follow-up #2 added `resetRoundCounter(authId)` after `emitPipelineSignals(...)` to clear the counter inflated by the diagnostic's own self-bump. But if `emitPipelineSignals` throws — despite its own internal try/catch, a thrown error from the dynamic `import('@gossip/orchestrator')` could propagate — the reset is skipped and the outer `catch { /* best-effort */ }` swallows silently. The counter stays inflated for any subsequent retry or hypothetical Phase B reader.

Fix: wrap the emit in `try { … } finally { resetRoundCounter(authId); }`. The outer best-effort catch is unchanged.

Both reviewers (sonnet phase-1, haiku cross-review) confirmed this is real.

### 3. Document the `includeLocked` behavioral split centrally — `validate-resolution-root.ts:127` (haiku-researcher:f7)

PR #286 introduced an asymmetry: auto-discovery (`discoverGitWorktrees`) skips locked worktrees (spec test 7 invariant), while explicit-path validation (`validateResolutionRoot` step 7) passes `includeLocked: true` to accept active agent worktrees (consensus 3aa4a6ef regression fix). Intent was inline-documented at the call site (line 262-264) but not on the parser's JSDoc. Future callers reading the function definition would miss the asymmetry.

Fix: extend `parseWorktreePorcelain`'s JSDoc with a "Behavioral split" section explaining both code paths. No behavior change.

## Notable consensus-round signal

The cross-review surfaced an empirical observation worth flagging: **all 8 of sonnet-reviewer's phase-1 findings were silently dropped** by the parser because they used `type="CONFIRMED"` / `"BUG"` / `"INFO"` instead of the schema's `finding | suggestion | insight`. Same shape that PR #285 was supposed to mitigate. The skill update either hasn't propagated to the running native subagent (dist-mcp not rebuilt + `/mcp` reconnect needed), or the new prose isn't strong enough to override the model's prior. Worth a follow-up investigation.

## Test plan
- [x] `npx jest tests/orchestrator/round-counter tests/orchestrator/validate-resolution-root tests/dashboard` — 78/78 pass
- [x] `npx tsc --noEmit -p packages/dashboard-v2 -p packages/orchestrator` — only pre-existing useElementWidth.ts error
- [ ] Visual / runtime inspection on next consensus round

🤖 Generated with [Claude Code](https://claude.com/claude-code)