### PR TITLE
fix(default-skills): explicit type allowlist in code-review skill

### DIFF
--- a/packages/orchestrator/src/default-skills/code-review.md
+++ b/packages/orchestrator/src/default-skills/code-review.md
@@ -19,7 +19,7 @@
 7. Order findings critical → low within your response — every finding still ships as one `<agent_finding>` tag, never as a Markdown heading, `**F1 —**` numbering, or top-of-output summary prose
 
 ## Output Format
-Use the FINDING TAG SCHEMA from the system prompt. Do NOT invent skill-specific output formats; they break parsing and cross-review. The natural shape of a "code review" is prose with bullets and a summary — resist that shape; the parser only sees `<agent_finding>` tags.
+Use the FINDING TAG SCHEMA from the system prompt. Your response MUST contain only `<agent_finding>` tags. Each tag MUST have a `type` attribute set to one of: `finding`, `suggestion`, or `insight`. Any other type (CONFIRMED, BUG, INFO, ISSUE, RISK, etc.) will be silently dropped by the parser. Do NOT use prose, summaries, or markdown headings outside of the tags.
 
 ## Don't
 - Don't nitpick style issues that a linter should catch


### PR DESCRIPTION
## Summary

Hardens the `code-review.md` default skill to eliminate the soft "resist that shape" wording that lets `sonnet-reviewer` drift into invalid type tags.

## Why

PR #285 (commit 23a2317) was the prior soft-prose fix. It told reviewers the natural shape of a code review (prose with bullets and a summary) was wrong and asked them to "resist that shape" — guidance, not a rule.

In post-merge consensus `9e2d6c06-98014474` on PRs #284–290, `sonnet-reviewer` emitted 8 phase-1 findings, **all** with invalid types (`CONFIRMED`, `BUG`, `INFO`). The strict parser silently dropped every one — the substantive review happened, but the consensus synthesis missed it. Empirically, the soft anchor wasn't strong enough to override pretraining bias toward "code review = numbered prose with verdicts."

This PR replaces the soft wording with an explicit type allowlist and a named denylist (`CONFIRMED`, `BUG`, `INFO`, `ISSUE`, `RISK`), so the skill is unambiguous about what the parser will accept.

## Invariant preserved

Handbook invariant #8 (parsers strict, drops loud) is unchanged. `finding-tag-schema.ts` is untouched. Only the skill prose became explicit.

## Test plan

- [x] Source and `dist-mcp` rebuilt in sync (`diff` exits 0)
- [ ] Next consensus round on a real diff shows zero dropped findings from `sonnet-reviewer`
- [ ] If drift persists, follow-up adds explicit WRONG-example counter-examples per implementer suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)