### PR TITLE
fix(self-telemetry): exclude insights + per-finding dedup + empty-findings gate (PR #284 follow-ups, part 2)

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -33,6 +33,87 @@ export function extractConsensusIdFromFindingId(findingId: unknown): string | un
   return isValidConsensusId(first) ? first : undefined;
 }
 
+// ── Reconciler helpers (spec 2026-04-27-self-telemetry-remediation) ─────────
+//
+// These pure helpers are extracted so the post-collect reconciler logic is
+// directly testable without spinning up the full handleCollect integration.
+// They mirror the logic embedded in handleCollect's reconciler block; the
+// inline copy MUST stay in sync with these — the tests assert on these
+// exports.
+
+/**
+ * Build the expected-count baseline for the round-counter reconciler.
+ *
+ * Fix 3a: insights are intentionally excluded — the consensus engine skips
+ * signal emission for them at consensus-engine.ts via `continue`, so counting
+ * them here produces spurious shortfalls on every insight-bearing round.
+ * (sonnet-reviewer:f6 in round 2416d1d5-06ca445b.)
+ */
+export function reconcilerFindingsAll(consensusReport: any): any[] {
+  return [
+    ...(consensusReport?.confirmed ?? []),
+    ...(consensusReport?.disputed ?? []),
+    ...(consensusReport?.unverified ?? []),
+    ...(consensusReport?.unique ?? []),
+    ...(consensusReport?.newFindings ?? []),
+  ];
+}
+
+/**
+ * Count of findings that *can* have signals emitted by the consensus engine.
+ *
+ * Cosmetic C: when this is 0, the round produced only ephemeral findings
+ * (newFindings, insights). The shortfall comparison is meaningless because the
+ * engine never emits signals for those buckets — the reconciler must skip.
+ * (haiku-researcher:f6 in round f21444f3-a6294a51.)
+ */
+export function reconcilerReviewableCount(consensusReport: any): number {
+  return (consensusReport?.confirmed?.length ?? 0)
+    + (consensusReport?.disputed?.length ?? 0)
+    + (consensusReport?.unverified?.length ?? 0)
+    + (consensusReport?.unique?.length ?? 0);
+}
+
+/**
+ * Build the dedup set of (agent, finding) pairs already signaled by the
+ * consensus engine.
+ *
+ * Fix 3b: keying by `${agentId}:${findingId}` lets each finding be evaluated
+ * independently. The previous agentId-only key caused undercount when one
+ * agent had findings with mixed verdicts (e.g. confirmed + disputed) — the
+ * confirmed signal made the agent land in the set, and the disputed finding
+ * was skipped here even though no signal had been emitted for it.
+ * (sonnet-reviewer:f8 in round 2416d1d5-06ca445b.)
+ *
+ * Legacy fallback: signals lacking findingId still register as agentId-only.
+ * This partially reintroduces the bug for any agent with even one old-format
+ * signal in the round; remove the fallback once schema migration confirms all
+ * persisted consensus signals carry findingId.
+ */
+export function buildAlreadySignaledSet(signals: any[] | undefined): Set<string> {
+  const out = new Set<string>();
+  for (const s of (signals || [])) {
+    if (s && s.findingId) {
+      out.add(`${s.agentId}:${s.findingId}`);
+    } else if (s) {
+      out.add(s.agentId);
+    }
+  }
+  return out;
+}
+
+/**
+ * Check whether a finding was already signaled by the consensus engine.
+ * Honours both the modern composite key and the legacy agentId-only fallback.
+ */
+export function isFindingAlreadySignaled(
+  alreadySignaled: Set<string>,
+  finding: { originalAgentId: string; id?: string }
+): boolean {
+  const composite = `${finding.originalAgentId}:${finding.id}`;
+  return alreadySignaled.has(composite) || alreadySignaled.has(finding.originalAgentId);
+}
+
 export async function handleCollect(
   task_ids: string[],
   timeout_ms: number,
@@ -744,11 +825,10 @@ export async function handleCollect(
         unique: 'unique_unconfirmed',
       };
 
-      // Build set of agents already signaled by the consensus engine
-      const alreadySignaled = new Set<string>();
-      for (const s of (consensusReport.signals || [])) {
-        alreadySignaled.add(s.agentId);
-      }
+      // Fix 3b (spec 2026-04-27-self-telemetry-remediation): see
+      // buildAlreadySignaledSet — composite (agent, finding) keys, with a
+      // legacy agentId-only fallback for signals that lack findingId.
+      const alreadySignaled = buildAlreadySignaledSet(consensusReport.signals);
 
       const allFindings = [
         ...(consensusReport.confirmed || []),
@@ -793,7 +873,7 @@ export async function handleCollect(
       // the finding text has no matchable vocabulary (rare); those are logged by
       // performance-reader for observability.
       const provisionalSignals = allFindings
-        .filter((f: any) => !alreadySignaled.has(f.originalAgentId))
+        .filter((f: any) => !isFindingAlreadySignaled(alreadySignaled, f))
         .map((f: any) => {
           const extracted = extractCategories(f.finding || '');
           const category = f.category || extracted[0] || undefined;
@@ -833,14 +913,9 @@ export async function handleCollect(
   if (consensusReport) {
     try {
       const { getRoundCounter, resetRoundCounter, emitPipelineSignals } = await import('@gossip/orchestrator');
-      const findingsAll = [
-        ...(consensusReport.confirmed ?? []),
-        ...(consensusReport.disputed ?? []),
-        ...(consensusReport.unverified ?? []),
-        ...(consensusReport.unique ?? []),
-        ...(consensusReport.newFindings ?? []),
-        ...(consensusReport.insights ?? []),
-      ];
+      // Fix 3a (spec 2026-04-27-self-telemetry-remediation): see
+      // reconcilerFindingsAll — insights are excluded from the baseline.
+      const findingsAll = reconcilerFindingsAll(consensusReport);
       // Fall back to any finding's id prefix when signals[] is empty (the
       // low-signal rounds most likely to mask real loss). See consensus
       // 3aa4a6ef-c8974235:sonnet-reviewer F1.
@@ -852,9 +927,19 @@ export async function handleCollect(
         // whole if-block in try/finally so the counter never leaks past
         // collect-end regardless of whether signal_loss_suspected was emitted.
         try {
+          // Cosmetic C (spec 2026-04-27-self-telemetry-remediation,
+          // haiku-researcher:f6 in round f21444f3-a6294a51): suppress the
+          // diagnostic when the round produced only ephemeral findings (i.e.
+          // newFindings, insights). Those don't have signals emitted, so the
+          // shortfall comparison is meaningless and would fire spuriously.
+          // The reviewable bucket = confirmed + disputed + unverified + unique;
+          // when it is empty there is nothing for the engine to have signaled.
+          // Must run BEFORE the shortfall check; the outer try/finally still
+          // calls resetRoundCounter so the counter never leaks.
+          const reviewableCount = reconcilerReviewableCount(consensusReport);
           const findingsCount = findingsAll.length;
           const actual = getRoundCounter(process.cwd(), authId);
-          if (actual < findingsCount) {
+          if (reviewableCount > 0 && actual < findingsCount) {
             const shortfall = findingsCount - actual;
             process.stderr.write(
               `[round-reconcile] consensusId=${authId} expected_min=${findingsCount} actual=${actual} shortfall=${shortfall}\n`

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -37,9 +37,13 @@ export function extractConsensusIdFromFindingId(findingId: unknown): string | un
 //
 // These pure helpers are extracted so the post-collect reconciler logic is
 // directly testable without spinning up the full handleCollect integration.
-// They mirror the logic embedded in handleCollect's reconciler block; the
-// inline copy MUST stay in sync with these — the tests assert on these
-// exports.
+//
+// Note: the inline `allFindings` at the provisional signaling path (~line 753)
+// uses 4 buckets (confirmed/disputed/unverified/unique) and serves a different
+// purpose from `reconcilerFindingsAll` (which also includes newFindings for
+// authId derivation). The shortfall comparison in the reconciler block uses
+// `reviewableCount` — the 4-bucket count — not `findingsAll.length`. The two
+// paths are intentionally different and must NOT be collapsed.
 
 /**
  * Build the expected-count baseline for the round-counter reconciler.
@@ -937,12 +941,18 @@ export async function handleCollect(
           // Must run BEFORE the shortfall check; the outer try/finally still
           // calls resetRoundCounter so the counter never leaks.
           const reviewableCount = reconcilerReviewableCount(consensusReport);
-          const findingsCount = findingsAll.length;
+          // MEDIUM fix (abb91e2d-ce7c478f): use reviewableCount (not
+          // findingsAll.length) as the shortfall baseline. findingsAll includes
+          // newFindings for authId derivation, but the consensus engine never
+          // emits signals for newFindings — comparing against findingsAll.length
+          // on mixed rounds (e.g. 1 confirmed + 3 newFindings) produced
+          // shortfall=3 even when the engine correctly emitted 1 signal.
+          // reviewableCount = confirmed + disputed + unverified + unique only.
           const actual = getRoundCounter(process.cwd(), authId);
-          if (reviewableCount > 0 && actual < findingsCount) {
-            const shortfall = findingsCount - actual;
+          if (reviewableCount > 0 && actual < reviewableCount) {
+            const shortfall = reviewableCount - actual;
             process.stderr.write(
-              `[round-reconcile] consensusId=${authId} expected_min=${findingsCount} actual=${actual} shortfall=${shortfall}\n`
+              `[round-reconcile] consensusId=${authId} expected_min=${reviewableCount} actual=${actual} shortfall=${shortfall}\n`
             );
             emitPipelineSignals(process.cwd(), [{
               type: 'pipeline',
@@ -951,7 +961,7 @@ export async function handleCollect(
               taskId: authId,
               consensusId: authId,
               value: shortfall,
-              metadata: { expected_min: findingsCount, actual },
+              metadata: { expected_min: reviewableCount, actual },
               timestamp: new Date().toISOString(),
             }]);
           }

--- a/tests/cli/collect-reconciler.test.ts
+++ b/tests/cli/collect-reconciler.test.ts
@@ -158,10 +158,12 @@ describe('Reconciler decision matrix — integration of the three fixes', () => 
   // (reviewableCount > 0 && actual < findingsCount). These cases pin the
   // decision boundaries the three fixes were designed to enforce.
 
+  // MEDIUM fix (abb91e2d-ce7c478f): shortfall comparison now uses reviewableCount
+  // (not findingsAll.length) so newFindings in a mixed round don't inflate the
+  // expected count and produce false-positive signal_loss_suspected emissions.
   function shouldEmit(report: any, actualSignalsRecorded: number): boolean {
-    const findingsCount = reconcilerFindingsAll(report).length;
     const reviewable = reconcilerReviewableCount(report);
-    return reviewable > 0 && actualSignalsRecorded < findingsCount;
+    return reviewable > 0 && actualSignalsRecorded < reviewable;
   }
 
   it('Fix 3a: round with confirmed + insights does NOT emit when actual matches confirmed count', () => {
@@ -178,6 +180,18 @@ describe('Reconciler decision matrix — integration of the three fixes', () => 
   it('Cosmetic C: round with newFindings only does NOT emit even with actual=0', () => {
     const report = { newFindings: [{ id: 'n1' }, { id: 'n2' }] };
     expect(shouldEmit(report, 0)).toBe(false);
+  });
+
+  it('MEDIUM fix: mixed round (1 confirmed + 3 newFindings) does NOT emit when engine emitted 1 signal', () => {
+    // Regression test for abb91e2d-ce7c478f MEDIUM finding:
+    // reviewableCount=1 (confirmed), findingsAll.length=4 (confirmed + newFindings).
+    // Pre-fix: compared actual(1) < findingsAll.length(4) → shortfall=3 → false-positive emit.
+    // Post-fix: compares actual(1) < reviewableCount(1) → no shortfall → no emit.
+    const report = {
+      confirmed: [{ id: 'c1' }],
+      newFindings: [{ id: 'n1' }, { id: 'n2' }, { id: 'n3' }],
+    };
+    expect(shouldEmit(report, 1)).toBe(false);
   });
 
   it('Cosmetic C: insights-only round does NOT emit', () => {

--- a/tests/cli/collect-reconciler.test.ts
+++ b/tests/cli/collect-reconciler.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for the post-collect reconciler helpers (PR #2 of spec
+ * 2026-04-27-self-telemetry-remediation).
+ *
+ * Covers:
+ *   - Fix 3a: insights are excluded from `reconcilerFindingsAll`, so
+ *     insight-only and insight-bearing rounds no longer trip a spurious
+ *     `signal_loss_suspected` (sonnet-reviewer:f6 round 2416d1d5-06ca445b).
+ *   - Fix 3b: `buildAlreadySignaledSet` keys per-finding, so an agent with
+ *     mixed-verdict findings doesn't have its un-signaled findings dropped
+ *     by the dedup filter (sonnet-reviewer:f8 round 2416d1d5-06ca445b).
+ *   - Cosmetic C: `reconcilerReviewableCount` returns 0 for rounds that
+ *     produced only ephemeral findings, gating the diagnostic away from
+ *     meaningless shortfalls (haiku-researcher:f6 round f21444f3-a6294a51).
+ */
+import {
+  reconcilerFindingsAll,
+  reconcilerReviewableCount,
+  buildAlreadySignaledSet,
+  isFindingAlreadySignaled,
+} from '../../apps/cli/src/handlers/collect';
+
+describe('reconcilerFindingsAll — Fix 3a: insights excluded', () => {
+  it('counts confirmed findings', () => {
+    const report = { confirmed: [{ id: 'a', finding: 'x' }] };
+    expect(reconcilerFindingsAll(report)).toHaveLength(1);
+  });
+
+  it('counts confirmed + disputed + unverified + unique + newFindings', () => {
+    const report = {
+      confirmed: [{ id: 'c1' }],
+      disputed: [{ id: 'd1' }],
+      unverified: [{ id: 'u1' }],
+      unique: [{ id: 'q1' }],
+      newFindings: [{ id: 'n1' }],
+    };
+    expect(reconcilerFindingsAll(report)).toHaveLength(5);
+  });
+
+  it('does NOT count insights — they are observations, not signal-bearing findings', () => {
+    const report = {
+      confirmed: [{ id: 'c1' }],
+      insights: [{ id: 'i1' }, { id: 'i2' }, { id: 'i3' }],
+    };
+    // 1 confirmed; the 3 insights are intentionally dropped.
+    expect(reconcilerFindingsAll(report)).toHaveLength(1);
+  });
+
+  it('insight-only round produces an empty findingsAll baseline', () => {
+    const report = { insights: [{ id: 'i1' }, { id: 'i2' }] };
+    expect(reconcilerFindingsAll(report)).toHaveLength(0);
+  });
+
+  it('handles a fully empty / undefined report shape without throwing', () => {
+    expect(reconcilerFindingsAll({})).toEqual([]);
+    expect(reconcilerFindingsAll(undefined)).toEqual([]);
+    expect(reconcilerFindingsAll(null)).toEqual([]);
+  });
+});
+
+describe('reconcilerReviewableCount — Cosmetic C: empty-findings gate', () => {
+  it('returns 0 when no reviewable buckets are populated (insights-only)', () => {
+    const report = { insights: [{ id: 'i1' }, { id: 'i2' }] };
+    expect(reconcilerReviewableCount(report)).toBe(0);
+  });
+
+  it('returns 0 when only newFindings is populated (no signals emitted for it)', () => {
+    const report = { newFindings: [{ id: 'n1' }, { id: 'n2' }] };
+    expect(reconcilerReviewableCount(report)).toBe(0);
+  });
+
+  it('counts the four reviewable buckets (confirmed/disputed/unverified/unique)', () => {
+    const report = {
+      confirmed: [{ id: 'c1' }, { id: 'c2' }],
+      disputed: [{ id: 'd1' }],
+      unverified: [{ id: 'u1' }],
+      unique: [{ id: 'q1' }, { id: 'q2' }, { id: 'q3' }],
+      // newFindings + insights MUST NOT be counted in the reviewable bucket.
+      newFindings: [{ id: 'n1' }],
+      insights: [{ id: 'i1' }],
+    };
+    expect(reconcilerReviewableCount(report)).toBe(2 + 1 + 1 + 3);
+  });
+
+  it('returns 0 for an empty / undefined report', () => {
+    expect(reconcilerReviewableCount({})).toBe(0);
+    expect(reconcilerReviewableCount(undefined)).toBe(0);
+  });
+});
+
+describe('buildAlreadySignaledSet + isFindingAlreadySignaled — Fix 3b: per-finding dedup', () => {
+  it('keys signals by composite "agentId:findingId" when findingId is present', () => {
+    const set = buildAlreadySignaledSet([
+      { agentId: 'sonnet-reviewer', findingId: 'aaa-bbb:sonnet-reviewer:f1' },
+    ]);
+    expect(set.has('sonnet-reviewer:aaa-bbb:sonnet-reviewer:f1')).toBe(true);
+    // The bare agentId is NOT in the set when findingId is present — that's
+    // the whole point of Fix 3b.
+    expect(set.has('sonnet-reviewer')).toBe(false);
+  });
+
+  it('legacy fallback: signals without findingId register as agentId-only', () => {
+    const set = buildAlreadySignaledSet([
+      { agentId: 'old-agent' /* no findingId */ },
+    ]);
+    expect(set.has('old-agent')).toBe(true);
+  });
+
+  it('mixed-verdict findings: confirmed signaled, disputed correctly NOT skipped', () => {
+    // Round shape: agent X has two findings, f1 (confirmed, signaled by engine)
+    // and f2 (disputed, NOT signaled by engine in this hypothetical bucket).
+    // Pre-Fix-3b behavior: agentId-only key meant f2 was wrongly skipped.
+    // Post-Fix-3b: f2 should pass through the dedup filter so the provisional
+    // path can emit a signal for it.
+    const consensusEngineSignals = [
+      { agentId: 'sonnet-reviewer', findingId: 'cid-1234:sonnet-reviewer:f1' },
+    ];
+    const set = buildAlreadySignaledSet(consensusEngineSignals);
+
+    const f1 = { originalAgentId: 'sonnet-reviewer', id: 'cid-1234:sonnet-reviewer:f1' };
+    const f2 = { originalAgentId: 'sonnet-reviewer', id: 'cid-1234:sonnet-reviewer:f2' };
+
+    expect(isFindingAlreadySignaled(set, f1)).toBe(true);  // already covered → skip
+    expect(isFindingAlreadySignaled(set, f2)).toBe(false); // un-signaled → emit
+  });
+
+  it('legacy agentId-only signal still drops all findings for that agent (documented caveat)', () => {
+    // Caveat noted in the inline comment + spec: any agent with even one
+    // old-format (findingId-less) signal partially reintroduces the bug.
+    // This test pins the documented behavior so the fallback isn't quietly
+    // tightened without a schema migration.
+    const set = buildAlreadySignaledSet([
+      { agentId: 'legacy-agent' /* no findingId */ },
+    ]);
+    const f1 = { originalAgentId: 'legacy-agent', id: 'cid-xyz:legacy-agent:f1' };
+    const f2 = { originalAgentId: 'legacy-agent', id: 'cid-xyz:legacy-agent:f2' };
+
+    expect(isFindingAlreadySignaled(set, f1)).toBe(true);
+    expect(isFindingAlreadySignaled(set, f2)).toBe(true);
+  });
+
+  it('different agents are independent', () => {
+    const set = buildAlreadySignaledSet([
+      { agentId: 'agent-a', findingId: 'cid:agent-a:f1' },
+    ]);
+    const f = { originalAgentId: 'agent-b', id: 'cid:agent-b:f1' };
+    expect(isFindingAlreadySignaled(set, f)).toBe(false);
+  });
+
+  it('empty / undefined signals input yields an empty set', () => {
+    expect(buildAlreadySignaledSet(undefined).size).toBe(0);
+    expect(buildAlreadySignaledSet([]).size).toBe(0);
+  });
+});
+
+describe('Reconciler decision matrix — integration of the three fixes', () => {
+  // The reconciler in handleCollect emits `signal_loss_suspected` only when
+  // (reviewableCount > 0 && actual < findingsCount). These cases pin the
+  // decision boundaries the three fixes were designed to enforce.
+
+  function shouldEmit(report: any, actualSignalsRecorded: number): boolean {
+    const findingsCount = reconcilerFindingsAll(report).length;
+    const reviewable = reconcilerReviewableCount(report);
+    return reviewable > 0 && actualSignalsRecorded < findingsCount;
+  }
+
+  it('Fix 3a: round with confirmed + insights does NOT emit when actual matches confirmed count', () => {
+    // 1 confirmed + 5 insights, engine emitted 1 signal for the confirmed.
+    // Pre-Fix-3a: findingsCount=6, actual=1 → spurious shortfall=5 → emit.
+    // Post-Fix-3a: findingsCount=1, actual=1 → no shortfall → no emit.
+    const report = {
+      confirmed: [{ id: 'c1' }],
+      insights: [{ id: 'i1' }, { id: 'i2' }, { id: 'i3' }, { id: 'i4' }, { id: 'i5' }],
+    };
+    expect(shouldEmit(report, 1)).toBe(false);
+  });
+
+  it('Cosmetic C: round with newFindings only does NOT emit even with actual=0', () => {
+    const report = { newFindings: [{ id: 'n1' }, { id: 'n2' }] };
+    expect(shouldEmit(report, 0)).toBe(false);
+  });
+
+  it('Cosmetic C: insights-only round does NOT emit', () => {
+    const report = { insights: [{ id: 'i1' }] };
+    expect(shouldEmit(report, 0)).toBe(false);
+  });
+
+  it('genuine shortfall on a reviewable round still emits', () => {
+    const report = {
+      confirmed: [{ id: 'c1' }, { id: 'c2' }, { id: 'c3' }],
+    };
+    // Engine wrote only 1 signal for 3 confirmed findings → real shortfall.
+    expect(shouldEmit(report, 1)).toBe(true);
+  });
+
+  it('happy path: actual >= findingsCount on reviewable round does NOT emit', () => {
+    const report = {
+      confirmed: [{ id: 'c1' }],
+      disputed: [{ id: 'd1' }],
+    };
+    expect(shouldEmit(report, 2)).toBe(false);
+    // Tolerate-double-log path: actual > findingsCount also does not emit.
+    expect(shouldEmit(report, 3)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

PR #2 of self-telemetry remediation, co-shipping Fix 3a + Fix 3b + Cosmetic C from spec `docs/specs/2026-04-27-self-telemetry-remediation.md`. Cosmetic C must co-ship to prevent Fix 3a from blinding the reconciler on insight-only rounds (per spec rollout note).

Follow-up to #293.

## What changed

- **Fix 3a** (MEDIUM) — `findingsAll` in shortfall reconciler no longer includes `consensusReport.insights`. Insights skip signal emission at consensus-engine.ts via `continue`; counting them in expected produces spurious `signal_loss_suspected`.
- **Fix 3b** (MEDIUM) — `alreadySignaled` now keys on `${agentId}:${findingId}` composite. Per-agent dedup was skipping multi-finding agents whose first finding got signaled. Legacy `agentId`-only fallback preserved for old-format signals; documented caveat that it partially reintroduces the bug for any agent with one legacy signal in a round (pinned by regression test).
- **Cosmetic C** (MEDIUM) — empty-findings noise gate: shortfall reconciler now early-returns when `confirmed + disputed + unverified + unique === 0`. `resetRoundCounter` still fires via outer try/finally.
- **Refactor** — extracted 4 pure helpers (`reconcilerFindingsAll`, `reconcilerReviewableCount`, `buildAlreadySignaledSet`, `isFindingAlreadySignaled`) so reconciler logic has single source of truth.

## Findings addressed

- sonnet-reviewer:f6 + f8 (round 2, consensus `2416d1d5-06ca445b`)
- haiku-researcher:f6 (round 1, consensus `f21444f3-a6294a51`)

## Test plan

- [x] `npm run build` clean across all packages
- [x] 20 new tests in `tests/cli/collect-reconciler.test.ts`, all passing
- [x] Full suite: 2629 passing, 27 pre-existing failures in `worktree-sandbox-hook.test.ts` (verified unrelated, same on master)
- [ ] Consensus review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)