### PR TITLE
fix(self-telemetry): filter operational signals from round-counter bump (PR #284 follow-ups, part 3)

### DIFF
--- a/packages/orchestrator/src/performance-writer.ts
+++ b/packages/orchestrator/src/performance-writer.ts
@@ -215,9 +215,19 @@ export class PerformanceWriter {
       bumpSampleCounter(this.projectRoot, 1);
       // Phase A self-telemetry: count signals per consensus round so
       // collect-end can detect shortfalls. Non-throwing by design.
+      // Fix 4 (spec 2026-04-27-self-telemetry-remediation §Fix 4):
+      // Only count performance-class signals toward the round expected count.
+      // Operational signals (task_timeout, task_empty, consensus_coverage_degraded)
+      // are diagnostic and should not inflate the shortfall comparison. signal_class
+      // is "optional, write-forward-only, no historical backfill" per consensus-types.ts —
+      // when classifySignal returns undefined (unknown signal name), preserve as
+      // performance-equivalent for backwards compatibility.
       try {
-        const cid = deriveConsensusId(signal as { consensusId?: string; findingId?: string });
-        if (cid) bumpRoundCounter(this.projectRoot, cid);
+        const cls = classifySignal(signal.signal);
+        if (cls === undefined || cls === 'performance') {
+          const cid = deriveConsensusId(signal as { consensusId?: string; findingId?: string });
+          if (cid) bumpRoundCounter(this.projectRoot, cid);
+        }
       } catch { /* non-fatal */ }
     },
 
@@ -235,8 +245,12 @@ export class PerformanceWriter {
       appendFileSync(this.filePath, data);
       bumpSampleCounter(this.projectRoot, signals.length);
       // Phase A self-telemetry: count each signal toward its consensus round.
+      // Fix 4: skip operational-class signals at the bump site (same rationale
+      // as appendSignal — see comment above).
       try {
         for (const s of signals) {
+          const cls = classifySignal(s.signal);
+          if (cls !== undefined && cls !== 'performance') continue;
           const cid = deriveConsensusId(s as { consensusId?: string; findingId?: string });
           if (cid) bumpRoundCounter(this.projectRoot, cid);
         }

--- a/tests/orchestrator/round-counter.test.ts
+++ b/tests/orchestrator/round-counter.test.ts
@@ -475,14 +475,13 @@ describe('PerformanceWriter — Fix 4: operational signals do not bump counter',
   const CID = 'f4f4f4f4-deadc0de';
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gossip-fix4-'));
-    fs.mkdirSync(path.join(tmpDir, '.gossip'), { recursive: true });
+    tmpDir = makeTmpProjectRoot();
     writer = new PerformanceWriter(tmpDir);
-    roundCounter.reset(CID);
+    roundCounter.__resetForTests();
   });
 
   afterEach(() => {
-    roundCounter.reset(CID);
+    roundCounter.__resetForTests();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -508,14 +507,14 @@ describe('PerformanceWriter — Fix 4: operational signals do not bump counter',
 
   it('Fix 4 — performance signals bump counter normally (appendSignal)', () => {
     writer[WRITER_INTERNAL].appendSignal(makePerformanceSignal(CID));
-    expect(roundCounter.get(CID)).toBe(1);
+    expect(roundCounter.get(tmpDir, CID)).toBe(1);
   });
 
   it('Fix 4 — operational signals do NOT bump counter (appendSignal)', () => {
     // task_timeout is classified as 'operational' by classifySignal.
     // Even when it carries a derivable consensusId it must not count.
     writer[WRITER_INTERNAL].appendSignal(makeOperationalSignal(CID));
-    expect(roundCounter.get(CID)).toBe(0);
+    expect(roundCounter.get(tmpDir, CID)).toBe(0);
   });
 
   it('Fix 4 — mixed batch: only performance signals bump (appendSignals)', () => {
@@ -526,7 +525,7 @@ describe('PerformanceWriter — Fix 4: operational signals do not bump counter',
       makePerformanceSignal(CID),
     ];
     writer[WRITER_INTERNAL].appendSignals(batch);
-    expect(roundCounter.get(CID)).toBe(2);
+    expect(roundCounter.get(tmpDir, CID)).toBe(2);
   });
 
   it('Fix 4 — unknown signal name (classifySignal returns undefined) still bumps (backwards compat)', () => {
@@ -549,6 +548,6 @@ describe('PerformanceWriter — Fix 4: operational signals do not bump counter',
     writer[WRITER_INTERNAL].appendSignal(unknownSignal);
     // classifySignal('severity_miscalibrated') returns undefined → preserved as
     // performance-equivalent → counter bumps.
-    expect(roundCounter.get(CID)).toBe(1);
+    expect(roundCounter.get(tmpDir, CID)).toBe(1);
   });
 });

--- a/tests/orchestrator/round-counter.test.ts
+++ b/tests/orchestrator/round-counter.test.ts
@@ -462,3 +462,93 @@ describe('roundCounter — concurrent bump (f5 known limitation)', () => {
     expect(count).toBeLessThanOrEqual(CONCURRENCY);
   });
 });
+
+// ── Fix 4: signal-class filter at the round-counter bump site ─────────────────
+//
+// Addresses haiku-researcher:f8 (consensus f21444f3-a6294a51): operational
+// signals that carry a derivable consensusId (e.g. task_timeout emitted during
+// a relay cross-review) must not inflate the shortfall comparison.
+
+describe('PerformanceWriter — Fix 4: operational signals do not bump counter', () => {
+  let tmpDir: string;
+  let writer: PerformanceWriter;
+  const CID = 'f4f4f4f4-deadc0de';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gossip-fix4-'));
+    fs.mkdirSync(path.join(tmpDir, '.gossip'), { recursive: true });
+    writer = new PerformanceWriter(tmpDir);
+    roundCounter.reset(CID);
+  });
+
+  afterEach(() => {
+    roundCounter.reset(CID);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const makePerformanceSignal = (consensusId: string) => ({
+    type: 'consensus' as const,
+    signal: 'unique_confirmed' as const,
+    agentId: 'test-agent',
+    taskId: `task-${consensusId}`,
+    consensusId,
+    evidence: 'test',
+    timestamp: new Date().toISOString(),
+  });
+
+  const makeOperationalSignal = (consensusId: string) => ({
+    type: 'consensus' as const,
+    signal: 'task_timeout' as const,
+    agentId: 'test-agent',
+    taskId: `task-${consensusId}`,
+    consensusId,
+    evidence: 'timeout diagnostic',
+    timestamp: new Date().toISOString(),
+  });
+
+  it('Fix 4 — performance signals bump counter normally (appendSignal)', () => {
+    writer[WRITER_INTERNAL].appendSignal(makePerformanceSignal(CID));
+    expect(roundCounter.get(CID)).toBe(1);
+  });
+
+  it('Fix 4 — operational signals do NOT bump counter (appendSignal)', () => {
+    // task_timeout is classified as 'operational' by classifySignal.
+    // Even when it carries a derivable consensusId it must not count.
+    writer[WRITER_INTERNAL].appendSignal(makeOperationalSignal(CID));
+    expect(roundCounter.get(CID)).toBe(0);
+  });
+
+  it('Fix 4 — mixed batch: only performance signals bump (appendSignals)', () => {
+    // [performance, operational, performance] → counter = 2, not 3.
+    const batch = [
+      makePerformanceSignal(CID),
+      makeOperationalSignal(CID),
+      makePerformanceSignal(CID),
+    ];
+    writer[WRITER_INTERNAL].appendSignals(batch);
+    expect(roundCounter.get(CID)).toBe(2);
+  });
+
+  it('Fix 4 — unknown signal name (classifySignal returns undefined) still bumps (backwards compat)', () => {
+    // A signal whose name is not in PERFORMANCE_SIGNAL_NAMES or
+    // OPERATIONAL_SIGNAL_NAMES causes classifySignal to return undefined.
+    // The filter treats undefined as performance-equivalent so pre-existing
+    // signals are not silently dropped from the counter.
+    const unknownSignal = {
+      type: 'consensus' as const,
+      // Bypass VALID_CONSENSUS_SIGNALS by using a known-valid signal name but
+      // simulate the classifySignal(undefined) path by using 'severity_miscalibrated'
+      // which is in VALID_CONSENSUS_SIGNALS but NOT in either classify set.
+      signal: 'severity_miscalibrated' as any,
+      agentId: 'test-agent',
+      taskId: `task-${CID}`,
+      consensusId: CID,
+      evidence: 'test',
+      timestamp: new Date().toISOString(),
+    };
+    writer[WRITER_INTERNAL].appendSignal(unknownSignal);
+    // classifySignal('severity_miscalibrated') returns undefined → preserved as
+    // performance-equivalent → counter bumps.
+    expect(roundCounter.get(CID)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

PR #3 of self-telemetry remediation, applying Fix 4 from spec `docs/specs/2026-04-27-self-telemetry-remediation.md`. Operational signals (`task_timeout`, `task_empty`, `consensus_coverage_degraded`, etc.) no longer inflate the round-counter bump expected count — only performance-class signals contribute to shortfall comparison.

Follow-up to #293 and #294.

## What changed

`packages/orchestrator/src/performance-writer.ts` — both bump sites (`appendSignal` and `appendSignals` batch loop) gate on `classifySignal(s.signal)`:

- If `classifySignal` returns `'performance'` → bump (current behavior)
- If `classifySignal` returns `'operational'` → skip
- If `classifySignal` returns `undefined` (unknown signal name) → bump as performance-equivalent (backwards-compat for signals predating the partition; matches "optional, write-forward-only, no historical backfill" semantics documented at consensus-types.ts)

`classifySignal` was already imported at line 4. No new imports.

## Findings addressed

- haiku-researcher:f8 round 1 (consensus `f21444f3-a6294a51`) — counter bump loop did not filter by signal_class

## Test plan

- [x] `npm run build` clean
- [x] 4 new tests in `tests/orchestrator/round-counter.test.ts` Fix 4 describe block (round-counter suite 17→21)
  1. Performance signal bumps counter normally
  2. Operational signal with consensusId does NOT bump
  3. Mixed batch [performance, operational, performance] → counter = 2 not 3
  4. Unknown signal name → classifySignal undefined → still bumps (backwards-compat)
- [x] Full suite: 2600 passing, 27 pre-existing failures in `worktree-sandbox-hook.test.ts` unchanged
- [ ] Consensus review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)