### PR TITLE
fix(resolver): handle in-project absolute paths and skip auto-memory citations

### DIFF
--- a/packages/orchestrator/src/audit-log-chain.ts
+++ b/packages/orchestrator/src/audit-log-chain.ts
@@ -37,10 +37,10 @@ export const AUDIT_LOG_FILENAME = 'finding-resolutions.jsonl';
 export interface AuditEntryInput {
   ts: string; // ISO-8601
   finding_id: string;
-  action: 'resolve' | 'unresolve' | 'path_validation_rejected';
+  action: 'resolve' | 'unresolve' | 'path_validation_rejected' | 'skipped';
   resolved_by?: 'commit:' | 'stale_anchor' | 'manual' | string;
   before_quote?: string;
-  after_check?: 'absent' | 'moved' | 'renamed' | 'rejected_path' | string;
+  after_check?: 'absent' | 'moved' | 'renamed' | 'rejected_path' | 'not_source' | string;
   operator?: 'auto' | string;
   reason?: string;
   // Free-form payload for path_validation_rejected diagnostics, etc.

--- a/packages/orchestrator/src/finding-resolver.ts
+++ b/packages/orchestrator/src/finding-resolver.ts
@@ -25,6 +25,7 @@
 // and Phase 3 (post-commit hook) are out of scope — see spec §Rollout.
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
 
@@ -191,6 +192,31 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
     const cites = parseCites(findingText);
     if (cites.fileCites.length === 0) continue; // no anchor, nothing to check
 
+    // Bucket B — skip findings citing auto-memory paths (not source code).
+    // These are ~/.claude/projects/<encoded-cwd>/memory/ files. They are
+    // not candidates for git-touched-set + symbol-presence resolution.
+    // Emit a 'skipped'/'not_source' audit entry instead of a rejection.
+    let skipAsMemory = false;
+    for (const fc of cites.fileCites) {
+      if (isAutoMemoryPath(projectRoot, fc.path)) {
+        skipAsMemory = true;
+        break;
+      }
+    }
+    if (skipAsMemory) {
+      try {
+        appendChainedEntry(projectRoot, {
+          ts: new Date().toISOString(),
+          finding_id: String(entry.taskId ?? entry.findingId ?? ''),
+          action: 'skipped',
+          after_check: 'not_source',
+          operator: 'auto',
+          reason: 'finding cites auto-memory path, not source code',
+        });
+      } catch { /* best-effort */ }
+      continue;
+    }
+
     // path validation — reject and audit-log any adversarial citation
     const safeFileCites: Array<{ path: string; line?: number; absPath: string }> = [];
     let rejected = false;
@@ -353,6 +379,26 @@ const PATH_REJECT_REASONS = {
   ESCAPE: 'realpath escapes project root',
 } as const;
 
+/**
+ * Detect whether a cited path refers to Claude Code's auto-generated
+ * project-memory directory. These files live at:
+ *   ~/.claude/projects/<encoded-cwd>/memory/<file>
+ * where <encoded-cwd> is the project root with '/' replaced by '-' and
+ * a leading '-' prepended (e.g. /Users/foo/bar → -Users-foo-bar).
+ *
+ * Memory citations are not source code — findings citing them are not
+ * candidates for git-touched-set + symbol-presence resolution. They
+ * should be skipped (not rejected) with a 'skipped'/'not_source' audit
+ * entry so they don't pollute path-rejection counts.
+ */
+export function isAutoMemoryPath(projectRoot: string, citedPath: string): boolean {
+  if (!citedPath || !path.isAbsolute(citedPath)) return false;
+  const encoded = projectRoot.replace(/\//g, '-');
+  // Claude Code encodes leading '/' as leading '-', so encoded starts with '-'
+  const memoryDir = path.join(os.homedir(), '.claude', 'projects', encoded, 'memory') + path.sep;
+  return citedPath.startsWith(memoryDir) || citedPath === memoryDir.slice(0, -1);
+}
+
 export function validatePath(
   projectRoot: string,
   citedPath: string,
@@ -360,13 +406,26 @@ export function validatePath(
   if (!citedPath || typeof citedPath !== 'string') {
     return { ok: false, reason: 'empty or non-string path' };
   }
+  // Order matters: NUL → traversal → tilde → URL → abs-into-root check → realpath/escape
   if (citedPath.includes('\0')) return { ok: false, reason: PATH_REJECT_REASONS.NUL };
   if (citedPath.includes('..')) return { ok: false, reason: PATH_REJECT_REASONS.TRAVERSAL };
-  if (citedPath.startsWith('/')) return { ok: false, reason: PATH_REJECT_REASONS.ABSOLUTE };
   if (citedPath.startsWith('~')) return { ok: false, reason: PATH_REJECT_REASONS.TILDE };
   if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(citedPath)) return { ok: false, reason: PATH_REJECT_REASONS.URL };
 
-  const resolved = path.resolve(projectRoot, citedPath);
+  // Bucket A — absolute path handling: instead of flat-rejecting every
+  // leading-'/' path, check whether the absolute citation resolves INTO
+  // the project root. If so, accept and let the realpath/escape check
+  // downstream be the real boundary.
+  if (citedPath.startsWith('/')) {
+    const absRel = path.relative(projectRoot, citedPath);
+    if (absRel.startsWith('..') || path.isAbsolute(absRel)) {
+      // absolute path escapes the project root — reject as ESCAPE, not ABSOLUTE
+      return { ok: false, reason: PATH_REJECT_REASONS.ESCAPE };
+    }
+    // falls through to realpath check below with citedPath as the resolved form
+  }
+
+  const resolved = citedPath.startsWith('/') ? citedPath : path.resolve(projectRoot, citedPath);
   const rel = path.relative(projectRoot, resolved);
   if (rel.startsWith('..') || path.isAbsolute(rel)) {
     return { ok: false, reason: PATH_REJECT_REASONS.ESCAPE };

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -140,6 +140,7 @@ export {
   resolveFindings,
   parseCites,
   validatePath,
+  isAutoMemoryPath,
   inferLeadIdentifier,
   stripJsTsComments,
   containsToken,

--- a/tests/orchestrator/finding-resolver.test.ts
+++ b/tests/orchestrator/finding-resolver.test.ts
@@ -19,6 +19,7 @@ import {
   resolveFindings,
   parseCites,
   validatePath,
+  isAutoMemoryPath,
   inferLeadIdentifier,
   stripJsTsComments,
   containsToken,
@@ -152,6 +153,63 @@ describe('finding-resolver — path validation (test #3)', () => {
     fs.symlinkSync(path.join(outside, 'secret.txt'), path.join(root, 'leak.txt'));
     const r = validatePath(root, 'leak.txt');
     expect(r.ok).toBe(false);
+  });
+
+  // Bucket A — absolute path inside projectRoot should be accepted
+  test('accepts absolute path that resolves inside projectRoot', () => {
+    const root = makeTempProject();
+    fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'src', 'foo.ts'), 'export const x = 1;\n');
+    const absPath = path.join(root, 'src', 'foo.ts');
+    const r = validatePath(root, absPath);
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error();
+    // absPath should be the realpathed form of the file
+    expect(r.absPath).toBeTruthy();
+    expect(r.absPath).toContain('foo.ts');
+  });
+
+  // Bucket A — absolute path OUTSIDE projectRoot should reject with ESCAPE, not ABSOLUTE
+  test('rejects absolute path outside projectRoot with reason ESCAPE', () => {
+    const root = makeTempProject();
+    const r = validatePath(root, '/etc/passwd');
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error();
+    expect(r.reason).toContain('escapes project root');
+  });
+});
+
+describe('isAutoMemoryPath', () => {
+  test('matches ~/.claude/projects/<encoded>/memory/foo.md', () => {
+    // Construct the encoded project root path as Claude Code does it
+    const projectRoot = '/Users/test/myproject';
+    const encoded = projectRoot.replace(/\//g, '-'); // -Users-test-myproject
+    const memPath = path.join(os.homedir(), '.claude', 'projects', encoded, 'memory', 'MEMORY.md');
+    expect(isAutoMemoryPath(projectRoot, memPath)).toBe(true);
+  });
+
+  test('matches nested memory file', () => {
+    const projectRoot = '/Users/test/myproject';
+    const encoded = projectRoot.replace(/\//g, '-');
+    const memPath = path.join(os.homedir(), '.claude', 'projects', encoded, 'memory', 'project_foo.md');
+    expect(isAutoMemoryPath(projectRoot, memPath)).toBe(true);
+  });
+
+  test('does not match a non-memory path', () => {
+    const projectRoot = '/Users/test/myproject';
+    expect(isAutoMemoryPath(projectRoot, '/Users/test/myproject/src/foo.ts')).toBe(false);
+  });
+
+  test('does not match a different project encoded path', () => {
+    const projectRoot = '/Users/test/myproject';
+    const otherEncoded = '-Users-other-project';
+    const memPath = path.join(os.homedir(), '.claude', 'projects', otherEncoded, 'memory', 'foo.md');
+    expect(isAutoMemoryPath(projectRoot, memPath)).toBe(false);
+  });
+
+  test('does not match a relative path', () => {
+    const projectRoot = '/Users/test/myproject';
+    expect(isAutoMemoryPath(projectRoot, 'memory/foo.md')).toBe(false);
   });
 });
 
@@ -454,5 +512,55 @@ describe('finding-resolver — resolveFindings', () => {
     const result = await resolveFindings(root);
     if (!result.ok) throw new Error();
     expect(result.resolved).toBe(1);
+  });
+
+  // Bucket A integration: finding citing absolute in-project path resolves cleanly
+  test('Bucket A: finding with absolute in-project citation resolves when symbol is absent', async () => {
+    const { root } = setupGitFixture();
+    // cite the file using an absolute path — same file as src/foo.ts but absolute
+    const absFilePath = path.join(root, 'src', 'foo.ts');
+    writeFinding(root, {
+      taskId: 'abs-path-test:f1',
+      finding: `Bad \`Math.min\` spread <cite tag="file">${absFilePath}:1</cite>`,
+      tag: 'finding',
+      type: 'finding',
+      status: 'open',
+    });
+    const result = await resolveFindings(root, { full: true });
+    if (!result.ok) throw new Error();
+    // should resolve (not reject) because Math.min is gone from src/foo.ts
+    expect(result.resolved).toBe(1);
+    expect(result.pathRejections).toBe(0);
+    const findings = readFindings(root);
+    expect(findings[0].status).toBe('resolved');
+  });
+
+  // Bucket B integration: finding citing auto-memory path produces 'skipped' audit entry
+  test('Bucket B: finding citing auto-memory path produces skipped/not_source audit entry', async () => {
+    const { root } = setupGitFixture();
+    // Simulate an auto-memory path for this project root
+    const encoded = root.replace(/\//g, '-');
+    const memPath = path.join(os.homedir(), '.claude', 'projects', encoded, 'memory', 'MEMORY.md');
+    writeFinding(root, {
+      taskId: 'memory-cite-test:f1',
+      finding: `Note: see \`Math.min\` docs at <cite tag="file">${memPath}:1</cite>`,
+      tag: 'finding',
+      type: 'finding',
+      status: 'open',
+    });
+    const result = await resolveFindings(root, { full: true });
+    if (!result.ok) throw new Error();
+    // should NOT count as a pathRejection
+    expect(result.pathRejections).toBe(0);
+    // should NOT resolve (it's skipped, not resolved)
+    expect(result.resolved).toBe(0);
+    // audit log should contain a 'skipped'/'not_source' entry
+    const auditPath = path.join(root, '.gossip', 'finding-resolutions.jsonl');
+    expect(fs.existsSync(auditPath)).toBe(true);
+    const lines = fs.readFileSync(auditPath, 'utf-8').split('\n').filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const entry = JSON.parse(lines[lines.length - 1]);
+    expect(entry.action).toBe('skipped');
+    expect(entry.after_check).toBe('not_source');
   });
 });


### PR DESCRIPTION
## Summary

`gossip_resolve_findings` `validatePath` flat-rejected every leading-`/` path before the in-root check could run, leaving 10/521 open findings (~2%) permanently unresolvable and producing audit-log noise that forced manual operator interventions.

Two fixes:

- **Bucket A — absolute paths inside `projectRoot`:** the flat `ABSOLUTE` early-return is removed. Absolute paths now go through `path.relative(projectRoot, citedPath)`; if the relative form starts with `..` or is itself absolute, reject as `ESCAPE` (semantically correct). Otherwise the path falls through to the realpath/symlink check which is the real boundary.
- **Bucket B — auto-memory citations:** new `isAutoMemoryPath` helper encodes Claude Code's `projectRoot.replace(/\//g, '-')` transform to detect `~/.claude/projects/<encoded-cwd>/memory/` paths. Findings citing these are skipped at finding-level with a new audit entry shape `{action:"skipped", after_check:"not_source"}` so memory citations don't inflate `pathRejections` counters.

Order preserved: NUL → traversal → tilde → URL → abs-into-root → realpath/escape. `/project/../etc/passwd` is still caught by the traversal check before reaching the new abs-path branch.

## Files changed

- `packages/orchestrator/src/finding-resolver.ts` (+47): new `isAutoMemoryPath`, revised `validatePath`, Bucket B skip in `runUnderLock`
- `packages/orchestrator/src/audit-log-chain.ts` (+2): extend action / after_check unions
- `packages/orchestrator/src/index.ts` (+1): export `isAutoMemoryPath`
- `tests/orchestrator/finding-resolver.test.ts` (+70): 5 `isAutoMemoryPath` units, 2 `validatePath` units, 2 integration tests

## Test plan

- [x] `npm run build` — clean
- [x] `npx jest tests/orchestrator/finding-resolver.test.ts` — 40/40 pass including new Bucket A and Bucket B integration tests
- [ ] Post-merge: re-run `gossip_resolve_findings` against the 10 known-rejected findings to confirm Bucket A resolves and Bucket B skips

## Refs

- Spec: `docs/specs/2026-04-27-open-findings-auto-resolve.md` (rev2)
- Origin memory: `project_resolver_absolute_path_handling.md`
- Builds on PR #299 (Phase 1 auto-resolver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)