### PR TITLE
fix(self-telemetry): #298 follow-ups F11 / F9 / F3

### DIFF
--- a/packages/orchestrator/src/round-counter.ts
+++ b/packages/orchestrator/src/round-counter.ts
@@ -29,20 +29,13 @@
 //
 // Backwards compatibility:
 //   - The legacy `<projectRoot>/.gossip/round-counters.json` file is no longer
-//     read or written. `writeCountersAtomic` is retained as an unused export
-//     for any third-party importers but is not exercised by this module.
+//     read or written. The file may still exist on disk from prior versions;
+//     it is silently ignored.
 
 import * as fs from 'fs';
 import * as path from 'path';
 
-const SCHEMA_VERSION = 1;
-const COUNTERS_FILENAME = 'round-counters.json';
 const JSONL_FILENAME = 'agent-performance.jsonl';
-
-interface CountersFile {
-  _version: number;
-  counts: Record<string, number>;
-}
 
 /**
  * In-memory fallback used when the filesystem rejects writes (read-only fs,
@@ -68,10 +61,6 @@ const scanCache = new Map<string, ScanCache>();
 
 function jsonlPath(projectRoot: string): string {
   return path.join(projectRoot, '.gossip', JSONL_FILENAME);
-}
-
-function counterFilePath(projectRoot: string): string {
-  return path.join(projectRoot, '.gossip', COUNTERS_FILENAME);
 }
 
 /**
@@ -154,6 +143,12 @@ function readCountsCached(projectRoot: string): Map<string, number> {
     return new Map();
   }
   const cached = scanCache.get(filePath);
+  // Rotation invariant: rotateJsonlIfNeeded (performance-writer.ts) renames the
+  // JSONL away once it crosses the size threshold (~5MB) and creates a fresh
+  // empty file. Cache key is filePath only, but invalidation is safe because
+  // the new file's size (0B) and mtime differ from any cached entry from the
+  // pre-rotation file (~5MB), forcing a fresh scan that correctly returns 0
+  // bumps for the new stream.
   if (cached && cached.mtimeMs === st.mtimeMs && cached.size === st.size) {
     return cached.counts;
   }
@@ -161,46 +156,6 @@ function readCountsCached(projectRoot: string): Map<string, number> {
   scanCache.set(filePath, { mtimeMs: st.mtimeMs, size: st.size, counts });
   return counts;
 }
-
-/**
- * Write counters atomically to the legacy `round-counters.json` file. RETAINED
- * as a public-but-unused helper for third-party importers; this module no
- * longer calls it. Counter state is derived from the JSONL stream instead
- * (Option C, spec 2026-04-27-self-telemetry-crash-consistency).
- *
- * @deprecated Use the JSONL-derived counter via `bump`/`get`/`reset`. Kept
- * exported for back-compat with any external callers.
- */
-function writeCountersAtomic(projectRoot: string, m: Map<string, number>): boolean {
-  const target = counterFilePath(projectRoot);
-  const dir = path.dirname(target);
-  try {
-    fs.mkdirSync(dir, { recursive: true });
-  } catch { /* best-effort */ }
-  const payload: CountersFile = {
-    _version: SCHEMA_VERSION,
-    counts: Object.fromEntries(m),
-  };
-  const tmp = `${target}.${process.pid}.${Date.now()}.${tmpCounter++}.tmp`;
-  try {
-    fs.writeFileSync(tmp, JSON.stringify(payload));
-  } catch {
-    return false;
-  }
-  try {
-    fs.renameSync(tmp, target);
-    return true;
-  } catch {
-    try { fs.unlinkSync(tmp); } catch { /* best-effort */ }
-    return false;
-  }
-}
-// `writeCountersAtomic` is intentionally unused by this module under Option C.
-// The `void` reference below silences the "declared but never read" linter
-// warning while keeping the function in the module for back-compat.
-void writeCountersAtomic;
-
-let tmpCounter = 0;
 
 /**
  * Increment the signal count for `consensusId` by 1.

--- a/tests/orchestrator/round-counter.test.ts
+++ b/tests/orchestrator/round-counter.test.ts
@@ -175,6 +175,31 @@ describe('roundCounter — persistence (Option C)', () => {
     expect(roundCounter.get(tmpDir, CID)).toBe(3);
   });
 
+  it('F3 — interleaved reset and bump: final count == bumps after the latest reset record', () => {
+    // The append-only JSONL guarantees record ordering matches the order of
+    // appendFileSync calls. A reset is just a `_meta`/`round_counter_reset`
+    // line; bumps after it are counted, bumps before it are masked. This test
+    // confirms the get() semantics are deterministic regardless of the
+    // bump/reset interleave: we drive an explicit interleave (5 bumps → reset
+    // → 2 bumps → reset → 3 bumps) and assert get() == 3.
+    for (let i = 0; i < 5; i++) roundCounter.bump(tmpDir, CID);
+    roundCounter.reset(tmpDir, CID);
+    for (let i = 0; i < 2; i++) roundCounter.bump(tmpDir, CID);
+    roundCounter.reset(tmpDir, CID);
+    for (let i = 0; i < 3; i++) roundCounter.bump(tmpDir, CID);
+    roundCounter.__resetForTests();
+    expect(roundCounter.get(tmpDir, CID)).toBe(3);
+
+    // Confirm the JSONL contains the exact sequence we expect: 5 bumps,
+    // 1 reset, 2 bumps, 1 reset, 3 bumps. Total 12 lines.
+    const file = path.join(tmpDir, '.gossip', 'agent-performance.jsonl');
+    const lines = fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);
+    const bumps = lines.filter(l => l.includes('round_counter_bumped'));
+    const resets = lines.filter(l => l.includes('round_counter_reset'));
+    expect(bumps).toHaveLength(10);
+    expect(resets).toHaveLength(2);
+  });
+
   it('read-only filesystem: bump does not throw and stays in-memory', () => {
     const dir = path.join(tmpDir, '.gossip');
     fs.chmodSync(dir, 0o555);


### PR DESCRIPTION
## Summary

Closes the three deferred findings from consensus `441075a5-aa324609` (PR #298 Option C round-counter merge).

- **F11** (low/suggestion) — Dead code cleanup in `round-counter.ts`. Under Option C the legacy `round-counters.json` file is no longer read or written. Removed the unused chain that supported it: `SCHEMA_VERSION`, `COUNTERS_FILENAME`, `CountersFile`, `counterFilePath`, `writeCountersAtomic`, `tmpCounter`, and the `void writeCountersAtomic` linter-silencer. The "retained for third-party importers" claim in the leading comment was misleading — `writeCountersAtomic` was never exported.
- **F9** (medium) — Documents the scan-cache rotation invariant inline at `readCountsCached`. The cache keyed by `filePath` is safe across `rotateJsonlIfNeeded` because the new empty file (0B) and its mtime always differ from any cached entry from the pre-rotation file (~5MB at threshold), forcing a fresh scan.
- **F3** (low) — Adds explicit interleaved `reset`/`bump` coverage: 5 bumps → reset → 2 bumps → reset → 3 bumps. Asserts both `get() === 3` and the underlying JSONL line counts (10 bumps, 2 resets).

## Files

- `packages/orchestrator/src/round-counter.ts`: −36 LOC dead code, +6 LOC F9 comment
- `tests/orchestrator/round-counter.test.ts`: +27 LOC F3 test

## Test plan

- [x] `npm run build` — clean
- [x] `npx jest tests/orchestrator/round-counter.test.ts` — 49/49 pass (was 48)

## Refs

- PR #298 (merge commit 18fea09) — Phase A.2 Option C
- Consensus `441075a5-aa324609` — origin findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)