### PR TITLE
fix(skill-graduation): detach effectiveness runner + path-traversal hardening

### DIFF
--- a/apps/cli/src/handlers/check-effectiveness-runner.ts
+++ b/apps/cli/src/handlers/check-effectiveness-runner.ts
@@ -15,6 +15,16 @@ export interface RunnerOptions {
   projectRoot: string;
 }
 
+// Defense-in-depth: directory and skill-file names must be safe identifiers.
+// readdirSync entries are filesystem-controlled; reject anything that could
+// escape via `..`, `/`, or shell metacharacters before passing to join() or
+// downstream tools (consensus 059e4ec4, gemini:f1 + sonnet:f3).
+//
+// Allows dots so model-version-style agent IDs work (gemini-1.5-pro,
+// claude-3.5-sonnet — consensus 1a93ddd0:gemini:f1) but the negative
+// lookahead `(?!.*\.\.)` rejects any `..` substring to keep traversal closed.
+const SAFE_NAME = /^(?!.*\.\.)[a-zA-Z0-9._-]+$/;
+
 /**
  * Walk .gossip/agents/<agentId>/skills/*.md and call checkEffectiveness
  * on each (agentId, category) pair. Errors per skill are swallowed so one
@@ -26,6 +36,9 @@ export async function runCheckEffectivenessForAllSkills(opts: RunnerOptions): Pr
 
   const agentDirs = readdirSync(baseDir);
   for (const agentId of agentDirs) {
+    // Skip synthetic/system dirs (e.g. `_project`) — they are not agents.
+    if (agentId.startsWith('_')) continue;
+    if (!SAFE_NAME.test(agentId)) continue;
     const skillsDir = join(baseDir, agentId, 'skills');
     if (!existsSync(skillsDir)) continue;
 
@@ -36,6 +49,7 @@ export async function runCheckEffectivenessForAllSkills(opts: RunnerOptions): Pr
     const files = readdirSync(skillsDir).filter(f => f.endsWith('.md'));
     for (const file of files) {
       const category = file.replace(/\.md$/, '');
+      if (!SAFE_NAME.test(category)) continue;
       try {
         const verdict = await opts.skillEngine.checkEffectiveness(agentId, category, { role });
         if (verdict.shouldUpdate) {

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -1131,19 +1131,31 @@ export async function handleCollect(
     }
   } catch { /* best-effort */ }
 
-  // Run checkEffectiveness on all skill files — must happen AFTER signals are written above
-  // so per-category counters reflect the current consensus round.
+  // Run checkEffectiveness on all skill files — fire-and-forget via setImmediate.
+  // Per consensus c0663a37: awaiting here meant the runner rode the MCP response
+  // window and was killed by SIGTERM (12-min relay disconnect cycle) before any
+  // skill could graduate. Counters are already written by emitConsensusSignals
+  // above, so the detached runner sees fresh state. Runner has its own internal
+  // try/catch + rate-limited logging.
   if (ctx.skillEngine) {
-    try {
-      const { runCheckEffectivenessForAllSkills } = await import('./check-effectiveness-runner');
-      await runCheckEffectivenessForAllSkills({
-        skillEngine: ctx.skillEngine,
-        registryGet: (id: string) => ctx.mainAgent.getAgentConfig(id),
-        projectRoot: process.cwd(),
-      });
-    } catch (e) {
-      process.stderr.write(`[gossipcat] checkEffectiveness post-collect run failed: ${(e as Error).message}\n`);
-    }
+    // Snapshot all closure inputs in the outer scope so the detached callback
+    // is robust to ctx mutation (consensus 480ec3e2, sonnet:f8 + gemini:f2).
+    const skillEngine = ctx.skillEngine;
+    const mainAgent = ctx.mainAgent;
+    const registryGet = (id: string) => mainAgent.getAgentConfig(id);
+    const projectRoot = process.cwd();
+    setImmediate(async () => {
+      try {
+        const { runCheckEffectivenessForAllSkills } = await import('./check-effectiveness-runner');
+        await runCheckEffectivenessForAllSkills({
+          skillEngine,
+          registryGet,
+          projectRoot,
+        });
+      } catch (e) {
+        process.stderr.write(`[gossipcat] checkEffectiveness post-collect run failed: ${(e as Error).message}\n`);
+      }
+    });
   }
 
   // Session save reminder — only every 10th task completion to avoid nagging


### PR DESCRIPTION
## Summary

After PR #306 shipped the one-sample Wilson math, **0 of 4 mathematically-eligible skills graduated at runtime**. Diagnosis (consensus c0663a37) found the root cause: `runCheckEffectivenessForAllSkills` was awaited at the tail of `gossip_collect`, and the relay process was being SIGTERM'd within milliseconds of synthesis (12-min disconnect cycle, see `project_relay_disconnect_cycle.md`) — runner never reached on 9/9 rounds in the diagnosis session.

This PR detaches the runner via `setImmediate` so it survives the MCP response-window kill, plus adds path-traversal hardening to the runner since both files were touched.

## Changes

- **`collect.ts:1134-1158`** — `setImmediate(async () => { ... })` fire-and-forget detach. Closure captures `skillEngine`, `mainAgent`, `registryGet`, `projectRoot` in the outer scope for stability across the event-loop boundary.
- **`check-effectiveness-runner.ts`** — `SAFE_NAME` regex `/^(?!.*\.\.)[a-zA-Z0-9._-]+$/` validates `agentId` and skill `category` before path construction. Allows dotted model IDs (`gemini-1.5-pro`, `claude-3.5-sonnet`); rejects `..` substring via negative lookahead. Plus `if (agentId.startsWith('_')) continue;` to skip synthetic dirs (`_project`).

## Validation

- 4 consensus rounds across 2 sessions reviewed the diff (c0663a37 diagnosis, 480ec3e2 + 059e4ec4 + 1a93ddd0 review). All blocking findings resolved; 1 hallucination caught (gemini's "state-overwrite race" — append-only JSONL doesn't overwrite).
- Direct invocation of `checkEffectiveness('gemini-reviewer', 'citation-grounding', { role: 'reviewer' })` graduates the skill from `pending` → `passed` (verdict object dump in commit body).
- `tsc --noEmit` clean
- Targeted tests pass: `tests/cli/collect*` (49) + `tests/orchestrator/skill-engine*` (59)

## Test plan

- [ ] CI green
- [ ] After release: `npm install -g gossipcat@<new>`, `/mcp` reconnect, trigger any consensus round, observe `[gossipcat] checkEffectiveness gemini-reviewer/input-validation: passed` in `.gossip/mcp.log`
- [ ] Skill file `gemini-reviewer/input-validation.md` mtime changes post-round

🤖 Generated with [Claude Code](https://claude.com/claude-code)