### PR TITLE
fix(round-counter): atomic flush of in-memory fallback on FS recovery

### DIFF
--- a/packages/orchestrator/src/round-counter.ts
+++ b/packages/orchestrator/src/round-counter.ts
@@ -183,8 +183,32 @@ export function bump(projectRoot: string, consensusId: string): void {
     const next = (inMemoryFallback.get(fbk) ?? 0) + 1;
     inMemoryFallback.set(fbk, next);
   } else {
-    // Persisted append supersedes any prior fallback entry for this key.
-    inMemoryFallback.delete(fbk);
+    // FS recovered — flush any in-memory bumps accumulated during the read-only
+    // period before clearing the fallback. If any backfill append fails, keep
+    // the fallback intact (atomic flush: all-or-nothing).
+    const priorCount = inMemoryFallback.get(fbk) ?? 0;
+    if (priorCount > 0) {
+      let allFlushed = true;
+      for (let i = 0; i < priorCount; i++) {
+        const backfillRecord = {
+          type: '_meta',
+          signal: 'round_counter_bumped',
+          consensusId,
+          bumpedAt: new Date().toISOString(),
+          _emission_path: 'round-counter-bump-backfill',
+        };
+        if (!appendMetaRecord(projectRoot, backfillRecord)) {
+          allFlushed = false;
+          break;
+        }
+      }
+      if (allFlushed) {
+        inMemoryFallback.delete(fbk);
+      }
+      // If !allFlushed, fbk stays at priorCount — next successful bump will retry.
+    } else {
+      inMemoryFallback.delete(fbk);
+    }
   }
 }
 

--- a/tests/orchestrator/round-counter.test.ts
+++ b/tests/orchestrator/round-counter.test.ts
@@ -213,6 +213,68 @@ describe('roundCounter — persistence (Option C)', () => {
     }
   });
 
+  it('ROFS-recovery: prior in-memory bumps are flushed to JSONL when FS recovers', () => {
+    // Skip when running as root (chmod has no effect for root).
+    if (typeof process.getuid === 'function' && process.getuid() === 0) return;
+
+    const gossipDir = path.join(tmpDir, '.gossip');
+
+    // Phase 1: filesystem is read-only — 3 bumps accumulate in-memory only.
+    fs.chmodSync(gossipDir, 0o555);
+    try {
+      roundCounter.bump(tmpDir, CID);
+      roundCounter.bump(tmpDir, CID);
+      roundCounter.bump(tmpDir, CID);
+    } finally {
+      fs.chmodSync(gossipDir, 0o755);
+    }
+    // In-memory shadow sees all 3 even though nothing was persisted.
+    expect(roundCounter.get(tmpDir, CID)).toBe(3);
+
+    // Phase 2: filesystem recovers — 4th bump should flush the 3 prior bumps.
+    roundCounter.bump(tmpDir, CID);
+    // get() must now return 4, not 1.
+    expect(roundCounter.get(tmpDir, CID)).toBe(4);
+
+    // Verify persistence: force a fresh JSONL scan (no in-memory state).
+    roundCounter.__resetForTests();
+    // The JSONL now contains 4 bump records (3 backfill + 1 live).
+    expect(roundCounter.get(tmpDir, CID)).toBe(4);
+  });
+
+  it('ROFS file-only readonly: fallback continues to accumulate across bump cycles', () => {
+    // Skip when running as root.
+    if (typeof process.getuid === 'function' && process.getuid() === 0) return;
+
+    const gossipDir = path.join(tmpDir, '.gossip');
+
+    // Phase 1: dir read-only — 2 bumps accumulate in-memory.
+    fs.chmodSync(gossipDir, 0o555);
+    try {
+      roundCounter.bump(tmpDir, CID);
+      roundCounter.bump(tmpDir, CID);
+    } finally {
+      fs.chmodSync(gossipDir, 0o755);
+    }
+    expect(roundCounter.get(tmpDir, CID)).toBe(2);
+
+    // Phase 2: dir is writable but the JSONL file itself is read-only
+    // (FS-flapping scenario). The live bump's append still fails, so the
+    // bump goes through the !ok path — fallback should increment to 3.
+    fs.mkdirSync(gossipDir, { recursive: true });
+    const jsonlFile = path.join(gossipDir, 'agent-performance.jsonl');
+    fs.writeFileSync(jsonlFile, '');
+    fs.chmodSync(jsonlFile, 0o444);
+
+    try {
+      roundCounter.bump(tmpDir, CID);
+      // appendMetaRecord returned false → !ok branch → fbk = priorCount + 1 = 3.
+      expect(roundCounter.get(tmpDir, CID)).toBe(3);
+    } finally {
+      fs.chmodSync(jsonlFile, 0o644);
+    }
+  });
+
   it('missing file is treated as empty (no throw)', () => {
     expect(roundCounter.get(tmpDir, CID)).toBe(0);
     roundCounter.bump(tmpDir, CID);


### PR DESCRIPTION
## Summary
- Closes consensus `00f3706c-bbf54640:f1` (sonnet-reviewer correct, haiku dispute incorrect — verified by orchestrator)
- Replaces `inMemoryFallback.delete(fbk)` with atomic priorCount backfill via `appendMetaRecord` calls
- Restores `get() = sum(bumps)` invariant across read-only-fs → recovery transitions

## Bug

`bump()` appends a `round_counter_bumped` record to JSONL. On ROFS the append fails and the count accumulates in `inMemoryFallback`. When the filesystem recovers, the next successful bump used to delete the fallback entry **without flushing** — silently losing every prior in-memory bump.

Repro: 3 ROFS bumps (fbk=3) → FS recovers → 4th bump appends 1 record → `delete(fbk)` → `get()` returns 1 instead of 4.

## Fix

When `ok === true` and `priorCount > 0`, loop `priorCount` additional `appendMetaRecord` calls tagged `_emission_path: 'round-counter-bump-backfill'`. If any backfill append fails, break and leave `fbk` intact so the next successful bump retries — all-or-nothing.

## Tests

Two new tests in `tests/orchestrator/round-counter.test.ts`:
- `ROFS-recovery: prior in-memory bumps are flushed to JSONL when FS recovers` — 3 ROFS + 1 recovery → `get()` returns 4 live AND after `__resetForTests()` (verifies persistence).
- `ROFS file-only readonly: fallback continues to accumulate across bump cycles` — exercises file-readonly-but-dir-writable path.

51/51 round-counter tests pass.

## Test plan
- [x] `npm test --testPathPattern='round-counter'` — 51/51
- [ ] CI green
- [ ] Reset semantics unchanged (verified by existing reset tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)