### PR TITLE
feat(resolver): line-anchored staleness heuristic behind config flag

### DIFF
--- a/packages/orchestrator/src/audit-log-chain.ts
+++ b/packages/orchestrator/src/audit-log-chain.ts
@@ -37,12 +37,33 @@ export const AUDIT_LOG_FILENAME = 'finding-resolutions.jsonl';
 export interface AuditEntryInput {
   ts: string; // ISO-8601
   finding_id: string;
-  action: 'resolve' | 'unresolve' | 'path_validation_rejected' | 'skipped';
+  action:
+    | 'resolve'
+    | 'unresolve'
+    | 'path_validation_rejected'
+    | 'skipped'
+    | 'flag_for_review';
   resolved_by?: 'commit:' | 'stale_anchor' | 'manual' | string;
   before_quote?: string;
-  after_check?: 'absent' | 'moved' | 'renamed' | 'rejected_path' | 'not_source' | string;
+  after_check?:
+    | 'absent'
+    | 'moved'
+    | 'renamed'
+    | 'rejected_path'
+    | 'not_source'
+    | 'present_elsewhere_only'
+    | string;
   operator?: 'auto' | string;
   reason?: string;
+  /**
+   * Conditional invariant (spec 2026-04-28-resolver-line-anchored-staleness §Audit
+   * log entry shape): when `resolved_by === 'stale_anchor'`, both `cited_line`
+   * AND `window` MUST be present. They are typed optional only to preserve
+   * back-compat for legacy entries that predate the line-anchored heuristic;
+   * any new stale_anchor entry will populate both fields.
+   */
+  cited_line?: number;
+  window?: number;
   // Free-form payload for path_validation_rejected diagnostics, etc.
   // Anything additional is hashed verbatim.
   [k: string]: unknown;

--- a/packages/orchestrator/src/finding-resolver.ts
+++ b/packages/orchestrator/src/finding-resolver.ts
@@ -53,7 +53,34 @@ export interface ResolveOptions {
    * `.gossip/config.json` → `resolver.coldStartWindow` if available.
    */
   coldStartWindow?: string;
+  /**
+   * Enable the line-anchored staleness heuristic
+   * (spec docs/specs/2026-04-28-resolver-line-anchored-staleness.md).
+   * Default `false` — when off, behavior matches the pre-PR file-scoped
+   * "absent everywhere" → commit:<sha> path. When on, the resolver also
+   * resolves findings whose cited identifier is absent from a ±window
+   * around the cited line but still present elsewhere in the file
+   * (resolved_by: 'stale_anchor'). See §Heuristic decision matrix.
+   */
+  lineAnchored?: boolean;
 }
+
+/**
+ * Default ±window for the line-anchored staleness heuristic. Conservative
+ * initial pick per spec §Window size; field data drives tuning. Do not
+ * inline this as a magic number — the audit log records it per resolution
+ * so calibration sweeps can correlate window size with unresolve rates.
+ */
+const LINE_ANCHORED_WINDOW = 5;
+
+/**
+ * Three-state symbol-presence classification per `(file, identifier)` pair.
+ * See spec §Heuristic — three-state evaluation.
+ */
+export type SymbolPresence =
+  | { kind: 'absent_everywhere' }
+  | { kind: 'present_at_anchor' }
+  | { kind: 'present_elsewhere' };
 
 export interface ResolveResult {
   ok: true;
@@ -296,41 +323,102 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
     }
     if (symbolsToCheck.size === 0) continue;
 
-    let allClear = true;
+    // Three-state classification per (cite, symbol) pair.
+    // Spec §Heuristic — three-state evaluation. We aggregate at the
+    // finding level: every cite must classify the same way for either
+    // the existing absent_everywhere → commit:<sha> path or the new
+    // present_elsewhere → stale_anchor path to fire. Mixed states or
+    // any present_at_anchor leave the finding open.
+    let sawAbsentEverywhere = false;
+    let sawPresentElsewhere = false;
+    let sawPresentAtAnchor = false;
+    let sawCiteWithoutLine = false;
+    let readFailure = false;
     for (const fc of safeFileCites) {
       let body: string;
       try { body = fs.readFileSync(fc.absPath, 'utf8'); }
-      catch { allClear = false; break; }
+      catch { readFailure = true; break; }
       const stripped = stripJsTsComments(body);
       for (const sym of symbolsToCheck) {
-        if (containsToken(stripped, sym)) {
-          allClear = false;
-          break;
+        const presence = classifyPresence(
+          body,
+          stripped,
+          sym,
+          fc.line,
+          LINE_ANCHORED_WINDOW,
+        );
+        if (presence.kind === 'absent_everywhere') {
+          sawAbsentEverywhere = true;
+        } else if (presence.kind === 'present_at_anchor') {
+          sawPresentAtAnchor = true;
+        } else {
+          // present_elsewhere — but if this cite has no line, classifyPresence
+          // returns present_elsewhere (no anchor to test); track for the
+          // "fall back to file-scoped, leave open" rule per spec matrix.
+          sawPresentElsewhere = true;
+          if (fc.line === undefined) sawCiteWithoutLine = true;
         }
       }
-      if (!allClear) break;
     }
-    if (!allClear) continue;
+    if (readFailure) continue;
+
+    // Aggregate per spec §Heuristic decision matrix.
+    const allAbsentEverywhere =
+      sawAbsentEverywhere && !sawPresentElsewhere && !sawPresentAtAnchor;
+    const allPresentElsewhere =
+      sawPresentElsewhere &&
+      !sawAbsentEverywhere &&
+      !sawPresentAtAnchor &&
+      !sawCiteWithoutLine;
+
+    if (!allAbsentEverywhere && !(opts.lineAnchored && allPresentElsewhere)) {
+      // Mixed state, any present_at_anchor, any cite without line, or
+      // line-anchored heuristic disabled → leave open.
+      continue;
+    }
 
     // emit resolution
     const findingId = String(entry.taskId ?? entry.findingId ?? '');
     const beforeQuote = Array.from(symbolsToCheck).slice(0, 3).join(', ');
-    const resolvedBy = headSha ? `commit:${headSha}` : 'manual';
+    const useStaleAnchor = !allAbsentEverywhere && allPresentElsewhere;
+    const resolvedBy = useStaleAnchor
+      ? 'stale_anchor'
+      : (headSha ? `commit:${headSha}` : 'manual');
     try {
       // mutate row in memory; we'll rewrite the file at the end
       entry.status = 'resolved';
       entry.resolvedAt = new Date().toISOString();
       entry.resolvedBy = resolvedBy;
       row.raw = JSON.stringify(entry);
-      appendChainedEntry(projectRoot, {
-        ts: entry.resolvedAt,
-        finding_id: findingId,
-        action: 'resolve',
-        resolved_by: resolvedBy,
-        before_quote: beforeQuote,
-        after_check: 'absent',
-        operator: 'auto',
-      });
+      if (useStaleAnchor) {
+        // Single-line semantics: the audit entry records the cited_line
+        // and window from the FIRST cite. Multi-cite findings with all
+        // cites passing the strict-AND aggregate share the same window
+        // size; the first cite's line is recorded as the anchor for
+        // post-hoc audit. This is documented in spec §Audit log entry shape.
+        const firstCite = safeFileCites[0];
+        appendChainedEntry(projectRoot, {
+          ts: entry.resolvedAt,
+          finding_id: findingId,
+          action: 'resolve',
+          resolved_by: 'stale_anchor',
+          before_quote: beforeQuote,
+          after_check: 'present_elsewhere_only',
+          operator: 'auto',
+          cited_line: firstCite.line as number,
+          window: LINE_ANCHORED_WINDOW,
+        });
+      } else {
+        appendChainedEntry(projectRoot, {
+          ts: entry.resolvedAt,
+          finding_id: findingId,
+          action: 'resolve',
+          resolved_by: resolvedBy,
+          before_quote: beforeQuote,
+          after_check: 'absent',
+          operator: 'auto',
+        });
+      }
       resolvedCount++;
       resolvedFindingIds.push(findingId);
     } catch (err) {
@@ -653,6 +741,61 @@ export function containsToken(haystack: string, token: string): boolean {
   // word boundary, which caused false token matches on dotted-access forms.
   const re = new RegExp(`(^|[^A-Za-z0-9_$.])${escaped}(?![A-Za-z0-9_$])`);
   return re.test(haystack);
+}
+
+/**
+ * Classify presence of `symbol` against (raw `body`, comment-`stripped` body,
+ * `citedLine`, `window`). Returns one of three states per spec §Heuristic.
+ *
+ * Caller contract (spec §Implementation):
+ *  - Caller pre-computes `stripped = stripJsTsComments(body)` once before
+ *    calling. The helper itself is pure: no fs access, no
+ *    comment-stripping side-effects, no surprises.
+ *  - Whole-file presence is checked against `stripped` (so identifiers
+ *    inside comments don't masquerade as real callsites).
+ *  - Anchor-window presence is checked against the RAW `body` (so the
+ *    window line numbers match the citation's frame of reference —
+ *    comment-stripping compresses line numbers and would point at the
+ *    wrong source lines).
+ *
+ * Window semantics:
+ *  - `citedLine` is 1-indexed (editor convention); `body.split('\n')[i]`
+ *    is the (i+1)-th line, so the window's 0-indexed bounds are
+ *    `lo = (citedLine - 1) - window` and `hi = (citedLine - 1) + window`.
+ *  - The slice end is INCLUSIVE: `lines.slice(lo, hi + 1)` (Array.slice's
+ *    end argument is exclusive, so we add 1 to make `hi` inclusive).
+ *  - When `citedLine === undefined`, no anchor window can be computed.
+ *    The helper returns `absent_everywhere` if the symbol is missing
+ *    file-scope, otherwise `present_elsewhere` — the resolver caller
+ *    treats `present_elsewhere` + `cite-without-line` as "leave open"
+ *    per spec decision matrix.
+ */
+export function classifyPresence(
+  body: string,
+  stripped: string,
+  symbol: string,
+  citedLine: number | undefined,
+  window: number,
+): SymbolPresence {
+  const inFile = containsToken(stripped, symbol);
+  if (!inFile) return { kind: 'absent_everywhere' };
+  if (citedLine === undefined) {
+    // No anchor — symbol is somewhere in the file. Treated as
+    // present_elsewhere; the caller will keep this finding open.
+    return { kind: 'present_elsewhere' };
+  }
+  const lines = body.split('\n');
+  if (lines.length === 0) return { kind: 'present_elsewhere' };
+  const lo = Math.max(0, (citedLine - 1) - window);
+  const hi = Math.min(lines.length - 1, (citedLine - 1) + window);
+  // Inclusive end-index: Array.slice's end argument is exclusive, so use
+  // hi + 1. Spec §Implementation explicitly mandates this off-by-one
+  // resolution after consensus round 2 finding f4.
+  const windowText = lines.slice(lo, hi + 1).join('\n');
+  const inWindow = containsToken(windowText, symbol);
+  return inWindow
+    ? { kind: 'present_at_anchor' }
+    : { kind: 'present_elsewhere' };
 }
 
 // ─── consensus report backfill ────────────────────────────────────────────

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -144,6 +144,7 @@ export {
   inferLeadIdentifier,
   stripJsTsComments,
   containsToken,
+  classifyPresence,
   FINDING_RESOLVER_INTERNALS,
 } from './finding-resolver';
-export type { ResolveOptions, ResolveResult, ResolveSkipped } from './finding-resolver';
+export type { ResolveOptions, ResolveResult, ResolveSkipped, SymbolPresence } from './finding-resolver';

--- a/tests/orchestrator/finding-resolver-line-anchored.test.ts
+++ b/tests/orchestrator/finding-resolver-line-anchored.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for the line-anchored staleness heuristic.
+ * Spec: docs/specs/2026-04-28-resolver-line-anchored-staleness.md (v3,
+ * post 2-round consensus). Cases 1–8 per §Tests.
+ *
+ * Premise: the resolver classifies each (cite, symbol) pair as one of
+ *   - absent_everywhere   → existing commit:<sha> path
+ *   - present_at_anchor   → leave open
+ *   - present_elsewhere   → new stale_anchor path (when flag is on)
+ * with strict-AND aggregation across all cites.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { execFileSync } from 'child_process';
+
+import {
+  resolveFindings,
+  classifyPresence,
+} from '@gossip/orchestrator';
+
+function makeTempProject(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'finding-resolver-line-anchored-'));
+  fs.mkdirSync(path.join(root, '.gossip'));
+  return root;
+}
+
+function initGit(root: string): void {
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: root });
+  execFileSync('git', ['config', 'user.email', 't@t'], { cwd: root });
+  execFileSync('git', ['config', 'user.name', 't'], { cwd: root });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: root });
+}
+
+function commit(root: string, msg: string): string {
+  execFileSync('git', ['add', '-A'], { cwd: root });
+  execFileSync('git', ['commit', '-q', '-m', msg, '--no-gpg-sign'], { cwd: root });
+  return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+}
+
+function writeFinding(root: string, entry: any): void {
+  const p = path.join(root, '.gossip', 'implementation-findings.jsonl');
+  const prev = fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : '';
+  fs.writeFileSync(p, prev + JSON.stringify(entry) + '\n');
+}
+
+function readFindings(root: string): any[] {
+  const p = path.join(root, '.gossip', 'implementation-findings.jsonl');
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8').split('\n').filter(Boolean).map(l => JSON.parse(l));
+}
+
+function readAuditEntries(root: string): any[] {
+  const p = path.join(root, '.gossip', 'finding-resolutions.jsonl');
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8').split('\n').filter(Boolean).map(l => JSON.parse(l));
+}
+
+/**
+ * Build a file with `symbol` placed at specific 1-indexed lines, padded
+ * with neutral filler. Total line count = `totalLines`. Allows constructing
+ * synthetic identifier-reuse fixtures with deterministic anchor windows.
+ */
+function buildFileWithSymbolAt(
+  totalLines: number,
+  symbol: string,
+  atLines: number[],
+): string {
+  const lines: string[] = [];
+  const set = new Set(atLines);
+  for (let i = 1; i <= totalLines; i++) {
+    if (set.has(i)) {
+      // Ensure the symbol is the only identifier on the line (no comments,
+      // no string literals — stripJsTsComments would no-op anyway).
+      lines.push(`const _l${i} = ${symbol}(0);`);
+    } else {
+      lines.push(`const _filler${i} = ${i};`);
+    }
+  }
+  return lines.join('\n') + '\n';
+}
+
+// ─── classifyPresence pure helper sanity ────────────────────────────────
+
+describe('classifyPresence — pure helper', () => {
+  test('absent_everywhere when symbol missing from file', () => {
+    const body = 'const a = 1;\nconst b = 2;\n';
+    expect(classifyPresence(body, body, 'Math.min', 5, 5)).toEqual({
+      kind: 'absent_everywhere',
+    });
+  });
+
+  test('present_at_anchor when symbol within window', () => {
+    const body = buildFileWithSymbolAt(20, 'Math.min', [10]);
+    // citedLine=12, window=5 → window covers lines 7..17, line 10 is in.
+    expect(classifyPresence(body, body, 'Math.min', 12, 5)).toEqual({
+      kind: 'present_at_anchor',
+    });
+  });
+
+  test('present_elsewhere when symbol outside window', () => {
+    const body = buildFileWithSymbolAt(40, 'Math.min', [30]);
+    // citedLine=10, window=5 → window covers 5..15; line 30 is far out.
+    expect(classifyPresence(body, body, 'Math.min', 10, 5)).toEqual({
+      kind: 'present_elsewhere',
+    });
+  });
+
+  test('present_elsewhere when citedLine is undefined (no anchor) and symbol present', () => {
+    const body = 'const x = Math.min(1, 2);\n';
+    expect(classifyPresence(body, body, 'Math.min', undefined, 5)).toEqual({
+      kind: 'present_elsewhere',
+    });
+  });
+
+  test('inclusive end-index: line at hi is in the window', () => {
+    // citedLine=10, window=5 → window covers 5..15 INCLUSIVE.
+    const body = buildFileWithSymbolAt(30, 'Math.min', [15]);
+    expect(classifyPresence(body, body, 'Math.min', 10, 5)).toEqual({
+      kind: 'present_at_anchor',
+    });
+  });
+});
+
+// ─── resolveFindings integration ────────────────────────────────────────
+
+describe('finding-resolver — line-anchored staleness (resolveFindings)', () => {
+  function setupRepoWithFixture(
+    relPath: string,
+    initialContent: string,
+    fixedContent: string,
+  ): { root: string; headSha: string } {
+    const root = makeTempProject();
+    initGit(root);
+    const abs = path.join(root, relPath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, initialContent);
+    commit(root, 'init');
+    fs.writeFileSync(abs, fixedContent);
+    // Touch a sibling file so the "fixed" commit has at least one diff
+    // even when initialContent === fixedContent (cases 2 + 5 — anchor
+    // still true / cite without line — both intentionally leave the
+    // cited file unchanged but still need a non-empty HEAD commit so
+    // resolveFindings sees a watermark).
+    fs.writeFileSync(path.join(root, '.gossip', '_marker'), Date.now().toString());
+    const headSha = commit(root, 'refactor');
+    return { root, headSha };
+  }
+
+  // ── Case 1: identifier-reuse refactor → stale_anchor ───────────────────
+  test('case 1: identifier-reuse refactor resolves as stale_anchor when flag on', async () => {
+    // Initial: Math.min at :120 (cited line). Fixed: Math.min still at
+    // :119 + :126 (unrelated callsites) but :120 is gone — outside ±5
+    // is :126; :119 is INSIDE the window. Need it strictly outside.
+    // Use lines :110 + :130 to be unambiguously outside ±5 of :120.
+    const initial = buildFileWithSymbolAt(200, 'Math.min', [110, 120, 130]);
+    const fixed = buildFileWithSymbolAt(200, 'Math.min', [110, 130]);
+    const { root } = setupRepoWithFixture('src/foo.ts', initial, fixed);
+
+    writeFinding(root, {
+      taskId: 'case1:f1',
+      finding: 'Stack overflow with `Math.min` <cite tag="file">src/foo.ts:120</cite>',
+      tag: 'finding',
+      type: 'finding',
+      status: 'open',
+    });
+
+    const result = await resolveFindings(root, { full: true, lineAnchored: true });
+    if (!result.ok) throw new Error('lock contended');
+    expect(result.resolved).toBe(1);
+    const findings = readFindings(root);
+    expect(findings[0].status).toBe('resolved');
+    expect(findings[0].resolvedBy).toBe('stale_anchor');
+  });
+
+  // ── Case 2: anchor-still-true → leave open ─────────────────────────────
+  test('case 2: anchor still has the cited symbol → leave open', async () => {
+    const initial = buildFileWithSymbolAt(200, 'Math.min', [120]);
+    const fixed = buildFileWithSymbolAt(200, 'Math.min', [120]);
+    const { root } = setupRepoWithFixture('src/foo.ts', initial, fixed);
+
+    writeFinding(root, {
+      taskId: 'case2:f1',
+      finding: '`Math.min` issue <cite tag="file">src/foo.ts:120</cite>',
+      tag: 'finding',
+      type: 'finding',
+      status: 'open',
+    });
+
+    const result = await resolveFindings(root, { full: true, lineAnchored: true });
+    if (!result.ok) throw new Error('lock contended');
+    expect(result.resolved).toBe(0);
+    expect(readFindings(root)[0].status).toBe('open');
+  });
+
+  // ── Case 3: edge of window (within ±5) → leave open ────────────────────
+  test('case 3: identifier within window (±5) → leave open', async () => {
+    // Cite at :120. Identifier present only at :115 (within ±5). Must
+    // classify as present_at_anchor → leave open.
+    const initial = buildFileWithSymbolAt(200, 'Math.min', [115, 120]);
+    const fixed = buildFileWithSymbolAt(200, 'Math.min', [115]);
+    const { root } = setupRepoWithFixture('src/foo.ts', initial, fixed);
+
+    writeFinding(root, {
+      taskId: 'case3:f1',
+      finding: '`Math.min` <cite tag="file">src/foo.ts:120</cite>',
+      tag: 'finding',
+      type: 'finding',
+      status: 'open',
+    });
+
+    const result = await resolveFindings(root, { full: true, lineAnchored: true });
+    if (!result.ok) throw new Error('lock contended');
+    expect(result.resolved).toBe(0);
+    expect(readFindings(root)[0].status).toBe('open');
+  });
+
+  // ── Case 4: outside window → stale_anchor ──────────────────────────────
+  test('case 4: identifier only at :200 (cite :120) → stale_anchor', async () => {
+    const initial = buildFileWithSymbolAt(250, 'Math.min', [120, 200]);
+    const fixed = buildFileWithSymbolAt(250, 'Math.min', [200]);
+    const { root } = setupRepoWithFixture('src/foo.ts', initial, fixed);
+
+    writeFinding(root, {
+      taskId: 'case4:f1',
+      finding: '`Math.min` <cite tag="file">src/foo.ts:120</cite>',
+      tag: 'finding',
+      type: 'finding',
+      status: 'open',
+    });
+
+    const result = await resolveFindings(root, { full: true, lineAnchored: true });
+    if (!result.ok) throw new Error('lock contended');
+    expect(result.resolved).toBe(1);
+    expect(readFindings(root)[0].resolvedBy).toBe('stale_anchor');
+  });
+
+  // ── Case 5: cite without line → leave open (preserve fallback) ─────────
+  test('case 5: cite without line and symbol present → leave open', async () => {
+    // <cite tag="file">foo.ts</cite> (no :line); identifier exists in file.
+    const initial = `const a = Math.min(1, 2);\n`;
+    const fixed = `const a = Math.min(1, 2);\n`;
+    const { root } = setupRepoWithFixture('src/foo.ts', initial, fixed);
+
+    writeFinding(root, {
+      taskId: 'case5:f1',
+      finding: '`Math.min` somewhere <cite tag="file">src/foo.ts</cite>',
+      tag: 'finding',
+      type: 'finding',
+      status: 'open',
+    });
+
+    const result = await resolveFindings(root, { full: true, lineAnchored: true });
+    if (!result.ok) throw new Error('lock contended');
+    expect(result.resolved).toBe(0);
+    expect(readFindings(root)[0].status).toBe('open');
+  });
+
+  // ── Case 6: multi-cite AND, mixed-state → leave open ───────────────────
+  test('case 6: multi-cite mixed (one stale_anchor + one still-true) → leave open', async () => {
+    const fileA_initial = buildFileWithSymbolAt(200, 'Math.min', [110, 120, 130]);
+    const fileA_fixed = buildFileWithSymbolAt(200, 'Math.min', [110, 130]); // anchor :120 stale
+    const fileB_initial = buildFileWithSymbolAt(200, 'Math.min', [50]);
+    const fileB_fixed = buildFileWithSymbolAt(200, 'Math.min', [50]); // anchor :50 still true
+    const root = makeTempProject();
+    initGit(root);
+    fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'src/a.ts'), fileA_initial);
+    fs.writeFileSync(path.join(root, 'src/b.ts'), fileB_initial);
+    commit(root, 'init');
+    fs.writeFileSync(path.join(root, 'src/a.ts'), fileA_fixed);
+    fs.writeFileSync(path.join(root, 'src/b.ts'), fileB_fixed);
+    commit(root, 'partial fix');
+
+    writeFinding(root, {
+      taskId: 'case6:f1',
+      finding: '`Math.min` at <cite tag="file">src/a.ts:120</cite> and <cite tag="file">src/b.ts:50</cite>',
+      tag: 'finding',
+      type: 'finding',
+      status: 'open',
+    });
+
+    const result = await resolveFindings(root, { full: true, lineAnchored: true });
+    if (!result.ok) throw new Error('lock contended');
+    expect(result.resolved).toBe(0);
+    expect(readFindings(root)[0].status).toBe('open');
+  });
+
+  // ── Case 7: audit-log shape verification ───────────────────────────────
+  test('case 7: stale_anchor audit entry has present_elsewhere_only + cited_line + window', async () => {
+    const initial = buildFileWithSymbolAt(200, 'Math.min', [110, 120, 130]);
+    const fixed = buildFileWithSymbolAt(200, 'Math.min', [110, 130]);
+    const { root } = setupRepoWithFixture('src/foo.ts', initial, fixed);
+
+    writeFinding(root, {
+      taskId: 'case7:f1',
+      finding: '`Math.min` <cite tag="file">src/foo.ts:120</cite>',
+      tag: 'finding',
+      type: 'finding',
+      status: 'open',
+    });
+
+    await resolveFindings(root, { full: true, lineAnchored: true });
+    const audit = readAuditEntries(root);
+    const resolveEntry = audit.find(e => e.action === 'resolve' && e.finding_id === 'case7:f1');
+    expect(resolveEntry).toBeDefined();
+    expect(resolveEntry.resolved_by).toBe('stale_anchor');
+    expect(resolveEntry.after_check).toBe('present_elsewhere_only');
+    expect(resolveEntry.cited_line).toBe(120);
+    expect(resolveEntry.window).toBe(5);
+    expect(resolveEntry.operator).toBe('auto');
+  });
+
+  // ── Case 8: config flag default off → no stale_anchor ─────────────────
+  test('case 8: lineAnchored flag default off → identifier-reuse refactor stays open', async () => {
+    const initial = buildFileWithSymbolAt(200, 'Math.min', [110, 120, 130]);
+    const fixed = buildFileWithSymbolAt(200, 'Math.min', [110, 130]);
+    const { root } = setupRepoWithFixture('src/foo.ts', initial, fixed);
+
+    writeFinding(root, {
+      taskId: 'case8:f1',
+      finding: '`Math.min` <cite tag="file">src/foo.ts:120</cite>',
+      tag: 'finding',
+      type: 'finding',
+      status: 'open',
+    });
+
+    // No lineAnchored: behavior must match pre-PR — leave open since
+    // Math.min still appears in the file.
+    const result = await resolveFindings(root, { full: true });
+    if (!result.ok) throw new Error('lock contended');
+    expect(result.resolved).toBe(0);
+    const findings = readFindings(root);
+    expect(findings[0].status).toBe('open');
+    // No stale_anchor audit entries either.
+    const audit = readAuditEntries(root);
+    expect(audit.find(e => e.resolved_by === 'stale_anchor')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Closes `project_open_findings_auto_resolve.md` calibration gap (followup #3 from session 2026-04-28)
- Three-state classifier (absent_everywhere / present_at_anchor / present_elsewhere) with stale_anchor resolution for identifier-reuse refactors
- Behind `lineAnchored: false` default config flag for safe rollout

## Background

Auto-resolver was missing identifier-reuse refactors: when `Math.min(...arr)` was replaced by `arr.reduce(...)` in PR #232, the finding cited line `:120` but `Math.min` was still grep-present at unrelated callsites in the same file. File-scoped check returned hit → finding stayed open. Three such findings sat as stale carry-overs in the dashboard for 16 days before manual sweep this session.

Spec at `docs/specs/2026-04-28-resolver-line-anchored-staleness.md` (v3, drafted through 2 consensus rounds: `d3e88382-1a144171` then `cd6694c8-3d754757`).

## Behavior

| Config | Behavior |
|--------|----------|
| `lineAnchored: false` (default) | Resolver behaves exactly as before this PR. Only commit:<sha> resolutions on absent_everywhere fire. |
| `lineAnchored: true` | New stale_anchor path fires when ALL cites are present_elsewhere with no anchor-true and no cite-without-line. |

Mixed states (absent_everywhere + present_elsewhere, or any cite-without-line in the AND-set) leave the finding open per the strict-AND decision matrix.

## Implementation

- `audit-log-chain.ts`: AuditEntryInput extended with `'flag_for_review'` action, `'present_elsewhere_only'` after_check, optional `cited_line` and `window` fields. Conditional invariant documented in JSDoc.
- `finding-resolver.ts`: `SymbolPresence` discriminated union, pure `classifyPresence` helper (caller pre-computes `stripped`), three-state aggregator. Anchor-window slice uses inclusive-end (`lines.slice(lo, hi + 1)`).
- `index.ts`: exports for `classifyPresence` + `SymbolPresence`.

`flag_for_review` action literal lands but no emission site yet — future pivot if the >5% stale_anchor unresolve gate fires per spec §Risks.

## Tests

13 new tests in `tests/orchestrator/finding-resolver-line-anchored.test.ts`:
- 5 `classifyPresence` pure-helper sanity tests
- 8 spec cases: identifier-reuse → stale_anchor; anchor-still-true → leave open; edge of window → leave open; outside window → stale_anchor; cite-without-line → leave open; multi-cite mixed-state → leave open; audit-log shape verification; flag default off.

Total: 58 existing + 13 new = 71/71 finding-resolver tests pass. `tsc --noEmit` clean.

## Test plan
- [x] `npm test --testPathPattern='finding-resolver'` — 71/71
- [x] `npx tsc --noEmit -p packages/orchestrator` — clean
- [ ] CI green
- [ ] Manual: enable `lineAnchored: true` in a test project for 30d; monitor manual `unresolve` rate on `stale_anchor` entries (per spec §Risks 5% gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)