### PR TITLE
chore(audit): post-merge hardening from consensus da98479b-b8b746a9

### DIFF
--- a/apps/cli/src/handlers/check-effectiveness-runner.ts
+++ b/apps/cli/src/handlers/check-effectiveness-runner.ts
@@ -6,7 +6,7 @@
  * per-category accuracy counters reflect the current consensus round.
  */
 import { existsSync, readdirSync, realpathSync } from 'fs';
-import { join, resolve } from 'path';
+import { join } from 'path';
 import type { SkillEngine } from '@gossip/orchestrator';
 
 export interface RunnerOptions {
@@ -49,7 +49,11 @@ export async function runCheckEffectivenessForAllSkills(opts: RunnerOptions): Pr
     try {
       canonicalSkillsDir = realpathSync(skillsDir);
     } catch { continue; }
-    if (!canonicalSkillsDir.startsWith(resolve(canonicalBaseDir) + '/')) continue;
+    // canonicalBaseDir is already absolute from realpathSync; trailing '/' prevents prefix collisions like '/agents-evil/'
+    if (!canonicalSkillsDir.startsWith(canonicalBaseDir + '/')) {
+      process.stderr.write(`[gossipcat] checkEffectiveness: skipping ${agentId} — skillsDir resolved outside agents tree (canonical=${canonicalSkillsDir})\n`);
+      continue;
+    }
 
     const role = opts.registryGet(agentId)?.role;
     // Implementers never get per-category accuracy checks

--- a/packages/orchestrator/src/finding-resolver.ts
+++ b/packages/orchestrator/src/finding-resolver.ts
@@ -371,6 +371,11 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
       !sawPresentAtAnchor &&
       !sawCiteWithoutLine;
 
+    // Resolution gate: absent_everywhere findings ALWAYS resolve via the
+    // commit:<sha> fastpath (flag-independent). The lineAnchored flag gates
+    // only the new stale_anchor path for present_elsewhere findings. Mixed
+    // states leave open per the decision matrix in
+    // docs/specs/2026-04-28-resolver-line-anchored-staleness.md.
     if (!allAbsentEverywhere && !(opts.lineAnchored && allPresentElsewhere)) {
       // Mixed state, any present_at_anchor, any cite without line, or
       // line-anchored heuristic disabled → leave open.
@@ -397,6 +402,12 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
         // size; the first cite's line is recorded as the anchor for
         // post-hoc audit. This is documented in spec §Audit log entry shape.
         const firstCite = safeFileCites[0];
+        // Invariant: stale_anchor path requires a cited line. allPresentElsewhere
+        // implies !sawCiteWithoutLine, so firstCite.line must be defined here.
+        if (firstCite.line === undefined) {
+          throw new Error('finding-resolver invariant: stale_anchor path reached with undefined cited line');
+        }
+        const citedLine = firstCite.line;
         appendChainedEntry(projectRoot, {
           ts: entry.resolvedAt,
           finding_id: findingId,
@@ -405,7 +416,7 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
           before_quote: beforeQuote,
           after_check: 'present_elsewhere_only',
           operator: 'auto',
-          cited_line: firstCite.line as number,
+          cited_line: citedLine,
           window: LINE_ANCHORED_WINDOW,
         });
       } else {


### PR DESCRIPTION
## Summary
Three small clarity/observability fixes from the post-merge audit (consensus `da98479b-b8b746a9`) on PRs #308 and #310. No behavior changes; existing 147/147 tests still pass.

## Findings addressed

| PR | Severity | Finding | Fix |
|----|----------|---------|-----|
| #308 f6 | MED | Silent skip on exact-match symlink (no stderr trace) | Log to stderr before continue |
| #308 f5 | LOW | `resolve(canonicalBaseDir)` is a no-op | Remove the call + unused import; add comment |
| #310 f9 | HIGH | `firstCite.line as number` cast invariant implicit across 4 flag conditions | Explicit runtime throw + named `citedLine` const |
| #310 f10 | MED | `lineAnchored` conditional preserves pre-PR behavior but requires non-local reasoning | Add comment block above the gate |

## Diff
- `apps/cli/src/handlers/check-effectiveness-runner.ts` — 8 lines (+stderr log, -resolve() no-op, -unused import, +comment)
- `packages/orchestrator/src/finding-resolver.ts` — 13 lines (+comment block, +invariant throw, +named const, -as number cast)

## Test plan
- [x] `npm test --testPathPattern='finding-resolver|check-effectiveness'` — 147/147
- [x] `npx tsc --noEmit -p packages/orchestrator` and `apps/cli` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)