### PR TITLE
test(dashboard): migrate insight-filter cases out of excluded suite

### DIFF
--- a/tests/relay/dashboard-edge-cases.test.ts
+++ b/tests/relay/dashboard-edge-cases.test.ts
@@ -2,7 +2,6 @@ import { overviewHandler } from '@gossip/relay/dashboard/api-overview';
 import { agentsHandler } from '@gossip/relay/dashboard/api-agents';
 import { skillsGetHandler, skillsBindHandler } from '@gossip/relay/dashboard/api-skills';
 import { memoryHandler } from '@gossip/relay/dashboard/api-memory';
-import { openFindingsHandler } from '@gossip/relay/dashboard/api-open-findings';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -138,30 +137,7 @@ describe('Dashboard API: Edge Cases', () => {
     });
   });
 
-  // Spec: docs/specs/2026-04-28-write-time-insight-filter.md (consensus 7438ce05-25ff407f)
-  describe('api-open-findings: insight filter', () => {
-    it('excludes type:insight rows from count and list, includes type:finding rows', async () => {
-      const insightEntry = JSON.stringify({ taskId: 'task-insight-1', finding: 'Informational insight note', status: 'open', type: 'insight', timestamp: new Date().toISOString() });
-      const findingEntry = JSON.stringify({ taskId: 'task-finding-1', finding: 'Actionable security finding', status: 'open', type: 'finding', timestamp: new Date().toISOString() });
-      writeFileSync(join(projectRoot, '.gossip', 'implementation-findings.jsonl'), [insightEntry, findingEntry].join('\n') + '\n');
-
-      const result = await openFindingsHandler(projectRoot);
-
-      expect(result.totals.open).toBe(1);
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].finding_id).toBe('task-finding-1');
-      expect(result.rows.some(r => r.finding_id === 'task-insight-1')).toBe(false);
-    });
-
-    it('does NOT exclude type:null legacy rows (cheap variant — null stays visible)', async () => {
-      const legacyEntry = JSON.stringify({ taskId: 'task-legacy-1', finding: 'Legacy finding with null type', status: 'open', type: null, timestamp: new Date().toISOString() });
-      writeFileSync(join(projectRoot, '.gossip', 'implementation-findings.jsonl'), legacyEntry + '\n');
-
-      const result = await openFindingsHandler(projectRoot);
-
-      expect(result.totals.open).toBe(1);
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].finding_id).toBe('task-legacy-1');
-    });
-  });
+  // Note: api-open-findings insight-filter assertions live in
+  // tests/relay/dashboard-open-findings-insight-filter.test.ts so they run in CI
+  // without being gated by the pre-existing totalSignals failures in this suite.
 });

--- a/tests/relay/dashboard-open-findings-insight-filter.test.ts
+++ b/tests/relay/dashboard-open-findings-insight-filter.test.ts
@@ -1,0 +1,46 @@
+// Spec: docs/specs/2026-04-28-write-time-insight-filter.md (consensus 7438ce05-25ff407f)
+//
+// Extracted from tests/relay/dashboard-edge-cases.test.ts so these assertions run
+// in CI. The parent suite is gated by RUN_KNOWN_BROKEN=1 due to 3 pre-existing
+// totalSignals failures unrelated to the insight filter.
+import { openFindingsHandler } from '@gossip/relay/dashboard/api-open-findings';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('Dashboard API: api-open-findings insight filter', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'gossip-dash-insight-'));
+    mkdirSync(join(projectRoot, '.gossip'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('excludes type:insight rows from count and list, includes type:finding rows', async () => {
+    const insightEntry = JSON.stringify({ taskId: 'task-insight-1', finding: 'Informational insight note', status: 'open', type: 'insight', timestamp: new Date().toISOString() });
+    const findingEntry = JSON.stringify({ taskId: 'task-finding-1', finding: 'Actionable security finding', status: 'open', type: 'finding', timestamp: new Date().toISOString() });
+    writeFileSync(join(projectRoot, '.gossip', 'implementation-findings.jsonl'), [insightEntry, findingEntry].join('\n') + '\n');
+
+    const result = await openFindingsHandler(projectRoot);
+
+    expect(result.totals.open).toBe(1);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].finding_id).toBe('task-finding-1');
+    expect(result.rows.some(r => r.finding_id === 'task-insight-1')).toBe(false);
+  });
+
+  it('does NOT exclude type:null legacy rows (cheap variant — null stays visible)', async () => {
+    const legacyEntry = JSON.stringify({ taskId: 'task-legacy-1', finding: 'Legacy finding with null type', status: 'open', type: null, timestamp: new Date().toISOString() });
+    writeFileSync(join(projectRoot, '.gossip', 'implementation-findings.jsonl'), legacyEntry + '\n');
+
+    const result = await openFindingsHandler(projectRoot);
+
+    expect(result.totals.open).toBe(1);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].finding_id).toBe('task-legacy-1');
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts the 2 `api-open-findings` insight-filter tests from `tests/relay/dashboard-edge-cases.test.ts` (which is in `KNOWN_BROKEN_SUITES` due to 3 pre-existing `totalSignals` failures) into a new file `tests/relay/dashboard-open-findings-insight-filter.test.ts`.
- New file runs in default CI; insight-filter coverage is no longer gated behind `RUN_KNOWN_BROKEN=1`.
- The parent edge-cases suite stays in `KNOWN_BROKEN_SUITES`; its 3 pre-existing failures are unchanged and tracked as separate tech debt.

Resolves the "insight-filter tests inert" item from session 2026-04-28's `next-session.md`.

## Test plan
- [x] `npx jest tests/relay/dashboard-open-findings-insight-filter.test.ts` → 2/2 pass
- [x] `RUN_KNOWN_BROKEN=1 npx jest tests/relay/dashboard-edge-cases.test.ts` → 8 pass / 3 pre-existing fail (no new failures introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)