### PR TITLE
feat(cli): ref-allowlist Phase 1 — detect direct master push by write-mode agents

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -424,7 +424,16 @@ export async function handleDispatchSingle(
       emitConsensusSignals(process.cwd(), premiseResult.signals);
     }
 
-    ctx.nativeTaskMap.set(taskId, { agentId: agent_id, task, startedAt: Date.now(), timeoutMs, planId: plan_id, step, writeMode: write_mode, relayToken });
+    // Ref-allowlist Phase 1: snapshot origin/master before agent runs so the
+    // relay path can detect a direct push to master (no PR-merge entry).
+    // Runs for ALL write-mode dispatches; null on git failure (offline/no remote).
+    let preDispatchSha: string | null = null;
+    if (write_mode) {
+      const { capturePreDispatchSha } = require('./ref-allowlist-detection');
+      preDispatchSha = capturePreDispatchSha();
+    }
+
+    ctx.nativeTaskMap.set(taskId, { agentId: agent_id, task, startedAt: Date.now(), timeoutMs, planId: plan_id, step, writeMode: write_mode, relayToken, preDispatchSha });
     spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
     persistNativeTaskMap();
     process.stderr.write(`[gossipcat] → dispatch → ${agent_id} (${nativeConfig.model}) [${taskId}]\n`);

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -550,6 +550,15 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
   // Release scope if this native task held one
   try { ctx.mainAgent.scopeTracker.release(task_id); } catch { /* best-effort — no scope registered is fine */ }
 
+  // Ref-allowlist Phase 1: detect direct master push (no PR-merge entry).
+  // Runs for every write-mode task that had a preDispatchSha captured at dispatch.
+  if (taskInfo.writeMode && taskInfo.preDispatchSha) {
+    try {
+      const { checkRefAllowlistViolation } = require('./ref-allowlist-detection');
+      checkRefAllowlistViolation(task_id, taskInfo.agentId, taskInfo.preDispatchSha);
+    } catch { /* best-effort — violation detection must not block relay completion */ }
+  }
+
   // Bug f13: prune orphaned worktrees on native error — mirrors dispatch-pipeline.ts:473-475.
   // Native worktrees use Claude Code's Agent(isolation:"worktree") so there's no
   // worktreePath in NativeTaskInfo. pruneOrphans() iterates all gossip-wt-* worktrees

--- a/apps/cli/src/handlers/ref-allowlist-detection.ts
+++ b/apps/cli/src/handlers/ref-allowlist-detection.ts
@@ -1,0 +1,148 @@
+/**
+ * Ref-allowlist enforcement — Phase 1 (detection-only).
+ *
+ * Spec: docs/specs/2026-04-29-ref-allowlist-enforcement.md §"Phase 1 Minimum Viable"
+ *
+ * Captures origin/master SHA at dispatch time. On relay completion, checks
+ * whether origin/master moved without a corresponding PR-merge commit.
+ * On violation: appends to .gossip/process-violations.jsonl, records a
+ * boundary_escape signal with category process_discipline, and prints a
+ * prominent stderr message. No auto-revert — operator must confirm.
+ */
+import { appendFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { execFileSync } from 'child_process';
+
+const PROCESS_VIOLATIONS_FILE = '.gossip/process-violations.jsonl';
+
+/**
+ * Capture origin/master SHA before dispatching a task.
+ * Returns null on git failure (offline, no remote, no repo) — never blocks dispatch.
+ */
+export function capturePreDispatchSha(): string | null {
+  try {
+    const sha = execFileSync('git', ['rev-parse', 'origin/master'], {
+      cwd: process.cwd(),
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+    return sha || null;
+  } catch {
+    process.stderr.write('[gossipcat] ref-allowlist: could not read origin/master SHA (offline or no remote) — skipping pre-dispatch snapshot\n');
+    return null;
+  }
+}
+
+/**
+ * Get commits between two SHAs that look like PR merges
+ * (git log --merges --grep="(#[0-9]").
+ */
+function getPrMergeCommits(preSha: string, postSha: string): string[] {
+  try {
+    const out = execFileSync(
+      'git',
+      ['log', `${preSha}..${postSha}`, '--merges', `--grep=(#[0-9]`, '--format=%H %s'],
+      { cwd: process.cwd(), stdio: ['ignore', 'pipe', 'ignore'] },
+    ).toString().trim();
+    return out ? out.split('\n').filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get all commits between two SHAs (for violation audit trail).
+ */
+function getCommitRange(preSha: string, postSha: string): string[] {
+  try {
+    const out = execFileSync(
+      'git',
+      ['log', `${preSha}..${postSha}`, '--format=%H %s'],
+      { cwd: process.cwd(), stdio: ['ignore', 'pipe', 'ignore'] },
+    ).toString().trim();
+    return out ? out.split('\n').filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+function appendViolationRecord(record: {
+  taskId: string;
+  agentId: string;
+  preSha: string;
+  postSha: string;
+  detectedAt: string;
+  commits: string[];
+}): void {
+  try {
+    const projectRoot = process.cwd();
+    mkdirSync(join(projectRoot, '.gossip'), { recursive: true });
+    const logPath = join(projectRoot, PROCESS_VIOLATIONS_FILE);
+    appendFileSync(logPath, JSON.stringify(record) + '\n', 'utf8');
+  } catch (err) {
+    process.stderr.write(`[gossipcat] ref-allowlist: failed to append violation record: ${(err as Error).message}\n`);
+  }
+}
+
+/**
+ * Check whether origin/master moved during a task without a PR-merge entry.
+ * Emits boundary_escape signal + appends to process-violations.jsonl on violation.
+ * Call this at relay-completion time for any task that had a preDispatchSha captured.
+ */
+export function checkRefAllowlistViolation(
+  taskId: string,
+  agentId: string,
+  preSha: string,
+): void {
+  let postSha: string;
+  try {
+    postSha = execFileSync('git', ['rev-parse', 'origin/master'], {
+      cwd: process.cwd(),
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+  } catch {
+    // Can't read post-SHA — skip detection, don't false-positive
+    return;
+  }
+
+  if (!postSha || postSha === preSha) return; // No change — clean
+
+  // SHA changed — check for PR-merge commits in the delta
+  const mergeCommits = getPrMergeCommits(preSha, postSha);
+  if (mergeCommits.length > 0) return; // Legitimate PR merge — no violation
+
+  // Violation: origin/master moved with no PR-merge entry
+  const allCommits = getCommitRange(preSha, postSha);
+  const detectedAt = new Date().toISOString();
+
+  appendViolationRecord({ taskId, agentId, preSha, postSha, detectedAt, commits: allCommits });
+
+  // Record boundary_escape signal with category process_discipline
+  try {
+    const { emitConsensusSignals } = require('@gossip/orchestrator');
+    emitConsensusSignals(process.cwd(), [
+      {
+        type: 'consensus' as const,
+        signal: 'boundary_escape' as const,
+        agentId,
+        taskId,
+        findingId: `proc:${taskId}:master_push`,
+        category: 'process_discipline',
+        severity: 'high',
+        evidence: `origin/master moved from ${preSha} to ${postSha} during task ${taskId} without a PR-merge entry — direct push detected. Commits: ${allCommits.slice(0, 5).join('; ')}`,
+        timestamp: detectedAt,
+      },
+    ]);
+  } catch (err) {
+    process.stderr.write(`[gossipcat] ref-allowlist: failed to emit boundary_escape signal: ${(err as Error).message}\n`);
+  }
+
+  process.stderr.write(
+    `\nREF-ALLOWLIST VIOLATION: ${taskId} agent=${agentId} origin/master moved ${preSha.slice(0, 8)}→${postSha.slice(0, 8)} with no PR merge.\n` +
+      `Operator confirmation required for revert or retroactive PR.\n` +
+      `Full audit trail at .gossip/process-violations.jsonl\n\n`,
+  );
+}

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -63,6 +63,13 @@ export interface NativeTaskInfo {
    * Threaded to TaskGraph.recordCompleted/recordFailed for compliance auditing.
    */
   memoryQueryCalled?: boolean;
+  /**
+   * origin/master SHA captured just before the agent was dispatched.
+   * Used by the ref-allowlist detection layer (Phase 1) to detect direct
+   * pushes to master without a PR-merge entry.
+   * Null when git is unavailable (offline / no remote).
+   */
+  preDispatchSha?: string | null;
 }
 
 export interface NativeResultInfo {

--- a/tests/cli/ref-allowlist-detection.test.ts
+++ b/tests/cli/ref-allowlist-detection.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for ref-allowlist Phase 1 detection layer.
+ * Spec: docs/specs/2026-04-29-ref-allowlist-enforcement.md §"Phase 1 Minimum Viable"
+ *
+ * Verifies:
+ *   (a) SHA unchanged → no signal, no JSONL append
+ *   (b) SHA changed + merge entry → no signal (legitimate PR merge)
+ *   (c) SHA changed + no merge entry → violation: JSONL appended + signal emitted + stderr message
+ *   (d) Multiple commits + one PR merge → no signal (batched merges)
+ *   (e) preDispatchSha null → no detection, no false positive
+ */
+
+import * as fs from 'fs';
+import * as childProcess from 'child_process';
+
+// ── mocks ────────────────────────────────────────────────────────────────────
+
+// Mock @gossip/orchestrator so emitConsensusSignals can be spied on
+jest.mock('@gossip/orchestrator', () => ({
+  emitConsensusSignals: jest.fn(),
+}));
+
+// Mock child_process.execFileSync to control git output
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  execFileSync: jest.fn(),
+}));
+
+// Mock fs.appendFileSync so tests don't write real files
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  appendFileSync: jest.fn(),
+  mkdirSync: jest.fn(),
+}));
+
+// ── imports after mocks ──────────────────────────────────────────────────────
+
+import { capturePreDispatchSha, checkRefAllowlistViolation } from '../../apps/cli/src/handlers/ref-allowlist-detection';
+import { emitConsensusSignals } from '@gossip/orchestrator';
+
+const mockExecFileSync = childProcess.execFileSync as jest.Mock;
+const mockEmitSignals = emitConsensusSignals as jest.Mock;
+const mockAppendFileSync = fs.appendFileSync as jest.Mock;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const PRE_SHA = 'aaaa1111bbbb2222cccc3333dddd4444eeee5555';
+const POST_SHA = 'ffff6666gggg7777hhhh8888iiii9999jjjj0000';
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe('capturePreDispatchSha', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the trimmed SHA on success', () => {
+    mockExecFileSync.mockReturnValue(Buffer.from(PRE_SHA + '\n'));
+    const sha = capturePreDispatchSha();
+    expect(sha).toBe(PRE_SHA);
+  });
+
+  it('returns null on git failure (offline/no remote)', () => {
+    mockExecFileSync.mockImplementation(() => { throw new Error('not a git repository'); });
+    const sha = capturePreDispatchSha();
+    expect(sha).toBeNull();
+  });
+});
+
+describe('checkRefAllowlistViolation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('(a) SHA unchanged → no signal, no JSONL append', () => {
+    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === 'rev-parse') return Buffer.from(PRE_SHA + '\n');
+      return Buffer.from('');
+    });
+
+    checkRefAllowlistViolation('task-abc', 'sonnet-implementer', PRE_SHA);
+
+    expect(mockEmitSignals).not.toHaveBeenCalled();
+    expect(mockAppendFileSync).not.toHaveBeenCalled();
+  });
+
+  it('(b) SHA changed + PR merge entry → no signal (legitimate merge)', () => {
+    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === 'rev-parse') return Buffer.from(POST_SHA + '\n');
+      if (args[0] === 'log' && args.includes('--merges')) {
+        return Buffer.from(`${POST_SHA} Merge pull request (#42) from feature/foo\n`);
+      }
+      return Buffer.from('');
+    });
+
+    checkRefAllowlistViolation('task-abc', 'sonnet-implementer', PRE_SHA);
+
+    expect(mockEmitSignals).not.toHaveBeenCalled();
+    expect(mockAppendFileSync).not.toHaveBeenCalled();
+  });
+
+  it('(c) SHA changed + no merge entry → violation: JSONL + signal + stderr', () => {
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === 'rev-parse') return Buffer.from(POST_SHA + '\n');
+      if (args[0] === 'log' && args.includes('--merges')) return Buffer.from('');
+      if (args[0] === 'log') return Buffer.from(`${POST_SHA} feat: sneak push to master\n`);
+      return Buffer.from('');
+    });
+
+    checkRefAllowlistViolation('task-xyz', 'sonnet-implementer', PRE_SHA);
+
+    // Signal emitted with boundary_escape + process_discipline
+    expect(mockEmitSignals).toHaveBeenCalledTimes(1);
+    const [, signals] = mockEmitSignals.mock.calls[0];
+    expect(signals).toHaveLength(1);
+    expect(signals[0].signal).toBe('boundary_escape');
+    expect(signals[0].category).toBe('process_discipline');
+    expect(signals[0].findingId).toBe('proc:task-xyz:master_push');
+    expect(signals[0].severity).toBe('high');
+    expect(signals[0].agentId).toBe('sonnet-implementer');
+
+    // JSONL appended
+    expect(mockAppendFileSync).toHaveBeenCalledTimes(1);
+    const appendCall = mockAppendFileSync.mock.calls[0];
+    const written = JSON.parse(appendCall[1].replace(/\n$/, ''));
+    expect(written.taskId).toBe('task-xyz');
+    expect(written.agentId).toBe('sonnet-implementer');
+    expect(written.preSha).toBe(PRE_SHA);
+    expect(written.postSha).toBe(POST_SHA);
+    expect(written.detectedAt).toBeTruthy();
+    expect(Array.isArray(written.commits)).toBe(true);
+
+    // Stderr message
+    const stderrCalls = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+    expect(stderrCalls).toContain('REF-ALLOWLIST VIOLATION');
+    expect(stderrCalls).toContain('task-xyz');
+    expect(stderrCalls).toContain('sonnet-implementer');
+
+    stderrSpy.mockRestore();
+  });
+
+  it('(d) Multiple commits + one PR merge → no signal (batched merges)', () => {
+    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === 'rev-parse') return Buffer.from(POST_SHA + '\n');
+      if (args[0] === 'log' && args.includes('--merges')) {
+        // One merge commit among several
+        return Buffer.from(`${POST_SHA} Merge pull request (#99) from feature/bar\n`);
+      }
+      if (args[0] === 'log') {
+        return Buffer.from(
+          `aaa Merge pull request (#99) from feature/bar\nbbb feat: step 1\nccc feat: step 2\n`,
+        );
+      }
+      return Buffer.from('');
+    });
+
+    checkRefAllowlistViolation('task-batch', 'sonnet-implementer', PRE_SHA);
+
+    expect(mockEmitSignals).not.toHaveBeenCalled();
+    expect(mockAppendFileSync).not.toHaveBeenCalled();
+  });
+
+  it('(e) preDispatchSha null → no detection, no false positive', () => {
+    // Should not be called if null — guard is in caller (dispatch/relay).
+    // But also verify that passing a null-like value short-circuits cleanly.
+    // The real guard lives in handleNativeRelay: `if (taskInfo.preDispatchSha)`.
+    // This test verifies checkRefAllowlistViolation handles a post-SHA read
+    // failure gracefully (no throw, no signal).
+    mockExecFileSync.mockImplementation(() => { throw new Error('git: command not found'); });
+
+    // Should not throw
+    expect(() => checkRefAllowlistViolation('task-null', 'sonnet-implementer', PRE_SHA)).not.toThrow();
+
+    expect(mockEmitSignals).not.toHaveBeenCalled();
+    expect(mockAppendFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/tests/cli/worktree-sandbox-hook.test.ts
+++ b/tests/cli/worktree-sandbox-hook.test.ts
@@ -25,7 +25,13 @@ function runHook(
   env?: Record<string, string>,
 ): { stdout: string; status: number | null; stderr: string } {
   const input = JSON.stringify(payload);
-  const spawnEnv = env ? { ...process.env, ...env } : undefined;
+  // Scrub GOSSIPCAT_ORCHESTRATOR_ROLE from inherited env unless the test
+  // explicitly sets it — orchestrator-session shells set this var to bypass
+  // the worktree sandbox, which short-circuits the hook and breaks the
+  // tests' JSON-parse assertions when run locally.
+  const baseEnv = { ...process.env };
+  delete baseEnv.GOSSIPCAT_ORCHESTRATOR_ROLE;
+  const spawnEnv = env ? { ...baseEnv, ...env } : baseEnv;
   const res = spawnSync('bash', [HOOK_PATH], { input, encoding: 'utf-8', env: spawnEnv });
   return { stdout: res.stdout, status: res.status, stderr: res.stderr };
 }


### PR DESCRIPTION
## Summary
Phase 1 of the ref-allowlist enforcement spec — **detection-only**. Catches the 2026-04-28 master-push incident pattern post-hoc and records it as a `boundary_escape` signal (category `process_discipline`) for the agent-scoring pipeline.

We can't install a pre-push hook because Claude Code creates worktrees out-of-process via `Agent({isolation: "worktree"})` — we have no provisioning callback to hook. Detection-only is the honest minimum that's actually shippable today.

## What it does
- For every write-mode dispatch (sequential/scoped/worktree), the orchestrator captures `git rev-parse origin/master` before handing control to the agent.
- On task completion, captures post-SHA and walks `git log <pre>..<post> --merges --grep="(#[0-9]"`. If new commits appeared with no PR-merge entry, that's a direct push.
- On violation: appends to `.gossip/process-violations.jsonl`, emits a `boundary_escape` signal with `category: process_discipline` and `finding_id: proc:<taskId>:master_push` (severity `high`), prints a stderr message identifying the offending SHA range. **No auto-revert; operator confirmation required.**

## Files
| File | Change |
|------|--------|
| `apps/cli/src/handlers/ref-allowlist-detection.ts` | New, ~120 LOC — `capturePreDispatchSha`, `checkRefAllowlistViolation` |
| `apps/cli/src/handlers/dispatch.ts` | +11/-1 — pre-SHA capture wired into write-mode path |
| `apps/cli/src/handlers/native-tasks.ts` | +9 — relay-completion violation check |
| `apps/cli/src/mcp-context.ts` | +7 — `preDispatchSha?: string \| null` on `NativeTaskInfo` |
| `tests/cli/ref-allowlist-detection.test.ts` | New, 7 tests, all pass |
| `tests/cli/worktree-sandbox-hook.test.ts` | +5/-1 — scrub `GOSSIPCAT_ORCHESTRATOR_ROLE` from `runHook()` env (local-dev fix; CI was unaffected) |

## Threat model
Single-maintainer agent process discipline. Detection-only — preventive enforcement is Phase 2 and depends on Claude Code exposing a worktree-provisioning callback we can hook into.

Reuses the existing `boundary_escape` signal (consensus-types.ts:157); no new signal type added.

## Test plan
- [x] `npm test -- tests/cli/ref-allowlist-detection.test.ts` → 7/7 pass
- [x] `npm test -- tests/cli/` → 642/642 pass after env-scrub fix (was 28 failing locally due to inherited orchestrator env var; CI was already green)
- [x] `npx tsc --noEmit -p apps/cli/tsconfig.json` → clean
- [x] `npm run build:mcp` → bundle clean (2.0MB)
- [ ] CI

## Out of scope (Phase 2)
- Pre-push hook installation (blocked on Claude Code harness API)
- Auto-revert / retroactive PR creation
- Detection on `origin/main`, `origin/release/*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)