### PR TITLE
fix(cli): scrub GOSSIPCAT_* env vars from gossip_update execSync

### DIFF
--- a/apps/cli/src/handlers/gossip-update.ts
+++ b/apps/cli/src/handlers/gossip-update.ts
@@ -91,10 +91,20 @@ export async function handleGossipUpdate({ check_only, confirm }: UpdateOptions)
   }
 
   // Apply the update
+  // Scrub GOSSIPCAT_* vars from the spawned process env — PR #316 pattern.
+  // A postinstall hook reading GOSSIPCAT_ORCHESTRATOR_ROLE could short-circuit
+  // sandbox checks when run from an orchestrator session.
+  const scrubbedEnv: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of Object.keys(scrubbedEnv)) {
+    if (/^GOSSIPCAT_/i.test(key)) delete scrubbedEnv[key];
+  }
   try {
-    execSync(command, { stdio: 'inherit', cwd: method === 'git-clone'
-      ? resolve(__dirname, '..', '..', '..', '..')
-      : process.cwd()
+    execSync(command, {
+      stdio: 'inherit',
+      cwd: method === 'git-clone'
+        ? resolve(__dirname, '..', '..', '..', '..')
+        : process.cwd(),
+      env: scrubbedEnv,
     });
   } catch (err) {
     return {

--- a/tests/cli/gossip-update-env-scrub.test.ts
+++ b/tests/cli/gossip-update-env-scrub.test.ts
@@ -1,0 +1,80 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Verify that handleGossipUpdate scrubs GOSSIPCAT_* vars from the env passed
+ * to execSync — PR #316 pattern. A lifecycle hook reading GOSSIPCAT_ORCHESTRATOR_ROLE
+ * could bypass sandbox checks when spawned from an orchestrator session.
+ */
+
+// Mock child_process before importing the handler so jest intercepts it.
+const mockExecSync = jest.fn();
+jest.mock('child_process', () => ({
+  execSync: mockExecSync,
+}));
+
+// Minimal existsSync mock — return false so detectInstallMethod falls through
+// to 'local', which uses process.cwd() and always runs execSync.
+jest.mock('fs', () => ({
+  existsSync: jest.fn().mockReturnValue(false),
+}));
+
+// Stub version helpers so the handler can resolve versions without filesystem.
+jest.mock('../../apps/cli/src/version', () => ({
+  getGossipcatVersion: jest.fn().mockReturnValue('0.0.1'),
+}));
+
+// Stub fetch so getLatestVersion returns a higher version, triggering the update path.
+const fakeFetchResponse = { ok: true, json: async () => ({ version: '99.0.0' }) };
+const mockFetch = jest.fn<() => Promise<typeof fakeFetchResponse>>().mockResolvedValue(fakeFetchResponse);
+global.fetch = mockFetch as unknown as typeof fetch;
+
+describe('handleGossipUpdate — env scrub', () => {
+  beforeEach(() => {
+    mockExecSync.mockReset();
+    // Inject GOSSIPCAT_* pollution into process.env for the duration of each test.
+    process.env.GOSSIPCAT_ORCHESTRATOR_ROLE = 'orchestrator';
+    process.env.GOSSIPCAT_PORT = '9999';
+    process.env.GOSSIPCAT_HTTP_PORT = '8888';
+    process.env.GOSSIPCAT_HTTP_BIND = '127.0.0.1';
+    process.env.GOSSIPCAT_HTTP_TOKEN = 'secret-token';
+    process.env.SAFE_VAR = 'keep-me';
+  });
+
+  afterEach(() => {
+    delete process.env.GOSSIPCAT_ORCHESTRATOR_ROLE;
+    delete process.env.GOSSIPCAT_PORT;
+    delete process.env.GOSSIPCAT_HTTP_PORT;
+    delete process.env.GOSSIPCAT_HTTP_BIND;
+    delete process.env.GOSSIPCAT_HTTP_TOKEN;
+    delete process.env.SAFE_VAR;
+  });
+
+  it('passes env to execSync with all GOSSIPCAT_* keys removed', async () => {
+    const { handleGossipUpdate } = await import('../../apps/cli/src/handlers/gossip-update');
+    await handleGossipUpdate({ check_only: false, confirm: true });
+
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    const [, options] = mockExecSync.mock.calls[0] as [string, { env: NodeJS.ProcessEnv }];
+    const envKeys = Object.keys(options.env ?? {});
+
+    // No GOSSIPCAT_* key should survive.
+    const leaked = envKeys.filter(k => /^GOSSIPCAT_/i.test(k));
+    expect(leaked).toEqual([]);
+  });
+
+  it('preserves non-GOSSIPCAT env vars in the scrubbed env', async () => {
+    const { handleGossipUpdate } = await import('../../apps/cli/src/handlers/gossip-update');
+    await handleGossipUpdate({ check_only: false, confirm: true });
+
+    const [, options] = mockExecSync.mock.calls[0] as [string, { env: NodeJS.ProcessEnv }];
+    expect(options.env?.SAFE_VAR).toBe('keep-me');
+  });
+
+  it('does not mutate process.env — original vars still present after call', async () => {
+    const { handleGossipUpdate } = await import('../../apps/cli/src/handlers/gossip-update');
+    await handleGossipUpdate({ check_only: false, confirm: true });
+
+    expect(process.env.GOSSIPCAT_ORCHESTRATOR_ROLE).toBe('orchestrator');
+    expect(process.env.GOSSIPCAT_PORT).toBe('9999');
+  });
+});


### PR DESCRIPTION
## Summary

- Apply the PR #316 env-scrub pattern to the `gossip_update` handler's `execSync` call.
- Prevents 5 `GOSSIPCAT_*` vars (`ORCHESTRATOR_ROLE`, `PORT`, `HTTP_PORT`, `HTTP_BIND`, `HTTP_TOKEN`) from leaking into spawned `npm install` / `git pull` lifecycle hooks.
- Found by a handler audit (haiku-researcher, 2026-04-29) following the ref-allowlist work in #316.

## Risk

`GOSSIPCAT_ORCHESTRATOR_ROLE` is the orchestrator's worktree-sandbox bypass flag. A `postinstall` hook reading it from inherited env could short-circuit sandbox checks during a `gossip_update`. PR #316 fixed this for test runs of `runHook()`; production handlers were missed.

## Out of scope

- `dispatch.ts:501` and `ref-allowlist-detection.ts:24/43/59/100` also inherit `process.env`, but only invoke read-only `git rev-parse` / `git log`. No hook execution path; defense-in-depth nits, not real vulnerabilities.

## Test plan

- [x] `npx jest tests/cli/gossip-update-env-scrub.test.ts` — 3/3 pass
  - zero GOSSIPCAT_* keys survive in execSync env arg
  - non-GOSSIPCAT_ vars preserved
  - process.env not mutated after the call
- [x] `npx tsc --noEmit -p apps/cli/tsconfig.json` clean
- [ ] CI green
- [ ] Smoke: `gossip_update(check_only: true)` still emits update summary unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)