### PR TITLE
test(cli): harden gossip-update-env-scrub test (consensus 591af14b followup)

### DIFF
--- a/tests/cli/gossip-update-env-scrub.test.ts
+++ b/tests/cli/gossip-update-env-scrub.test.ts
@@ -53,7 +53,12 @@ describe('handleGossipUpdate — env scrub', () => {
     const { handleGossipUpdate } = await import('../../apps/cli/src/handlers/gossip-update');
     await handleGossipUpdate({ check_only: false, confirm: true });
 
+    // Tighten: assert env: option is present, not just call count.
     expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ env: expect.any(Object) }),
+    );
     const [, options] = mockExecSync.mock.calls[0] as [string, { env: NodeJS.ProcessEnv }];
     const envKeys = Object.keys(options.env ?? {});
 
@@ -74,7 +79,38 @@ describe('handleGossipUpdate — env scrub', () => {
     const { handleGossipUpdate } = await import('../../apps/cli/src/handlers/gossip-update');
     await handleGossipUpdate({ check_only: false, confirm: true });
 
-    expect(process.env.GOSSIPCAT_ORCHESTRATOR_ROLE).toBe('orchestrator');
-    expect(process.env.GOSSIPCAT_PORT).toBe('9999');
+    // Loop over all 5 GOSSIPCAT_* keys to ensure none are deleted from process.env.
+    const expectedKeys: Array<[string, string]> = [
+      ['GOSSIPCAT_ORCHESTRATOR_ROLE', 'orchestrator'],
+      ['GOSSIPCAT_PORT', '9999'],
+      ['GOSSIPCAT_HTTP_PORT', '8888'],
+      ['GOSSIPCAT_HTTP_BIND', '127.0.0.1'],
+      ['GOSSIPCAT_HTTP_TOKEN', 'secret-token'],
+    ];
+    for (const [key, value] of expectedKeys) {
+      expect(process.env[key]).toBe(value);
+    }
+  });
+
+  it('scrubs GOSSIPCAT_* env vars on global install path', async () => {
+    const originalGlobal = process.env.npm_config_global;
+    process.env.npm_config_global = 'true';
+    try {
+      const { handleGossipUpdate } = await import('../../apps/cli/src/handlers/gossip-update');
+      await handleGossipUpdate({ check_only: false, confirm: true });
+
+      expect(mockExecSync).toHaveBeenCalledTimes(1);
+      const [cmd, options] = mockExecSync.mock.calls[0] as [string, { env: NodeJS.ProcessEnv }];
+      // Global install uses 'npm install -g ...' command.
+      expect(cmd).toContain('-g');
+      const leaked = Object.keys(options.env ?? {}).filter(k => /^GOSSIPCAT_/i.test(k));
+      expect(leaked).toEqual([]);
+    } finally {
+      if (originalGlobal === undefined) {
+        delete process.env.npm_config_global;
+      } else {
+        process.env.npm_config_global = originalGlobal;
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

Test-only follow-up to PR #317 from consensus round `591af14b-3f674c9c`. Production code is unchanged — env-scrub implementation was confirmed correct (9 confirmed / 0 disputed across both reviewers). These tighten the test so future regressions surface loudly.

- **f6 (medium)**: tighten `toHaveBeenCalledWith` to require the `env:` option, not just call-count > 0. Catches the regression where a future handler refactor (e.g. `import * as cp from 'node:child_process'`) drops env scrubbing while jest.mock still intercepts.
- **f4 (low)**: add `'scrubs GOSSIPCAT_* env vars on global install path'` — sets `npm_config_global=true`, asserts `-g` flag and scrubbed env on that branch.
- **f5 (low)**: loop over all 5 GOSSIPCAT_* keys in the mutation-safety assertion (was 2 of 5).

## Test plan

- [x] \`npx jest tests/cli/gossip-update-env-scrub.test.ts\` — 4/4 pass (was 3/3)
- [x] \`npx tsc --noEmit -p apps/cli/tsconfig.json\` clean
- [x] No production files touched (verified via \`git diff --name-only\`)
- [ ] CI green

## Provenance

- Consensus round: \`591af14b-3f674c9c\`
- Findings: \`sonnet-reviewer:f4\`, \`sonnet-reviewer:f5\`, \`sonnet-reviewer:f6\`
- Parent PR: #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)