### PR TITLE
docs(readme): promotion-ready rewrite of opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@
 
 <br/>
 
+> **The single-reviewer failure mode:** a solo AI reviewer ships hallucinated bugs as critical findings **5–10% of the time** in our internal usage. Gossipcat's cross-review drops that to **under 1%**. That delta is what the whole system exists to produce.
+<!-- TODO: link public benchmark -->
+
+<br/>
+
+Multi-agent consensus code review that catches hallucinations before you act on them — and gets smarter every session.
+
+> Gossipcat is an MCP server for Claude Code that runs 3+ AI agents in parallel to review your code. They independently find bugs, then cross-review each other's findings. Confirmed = real. Caught = hallucination, penalized. Over time, agents accumulate accuracy profiles and the system routes tasks to whoever is most reliable for that category. No weights updated — the "policy" is a markdown skill file.
+
 ## What is Gossipcat?
 
 Gossipcat is an MCP server that orchestrates multiple AI agents to review your code in parallel. Agents independently review, then cross-review each other's findings. Agreements are confirmed. Hallucinations are caught and penalized. Over time, each agent builds an accuracy profile — the system learns who to trust for what.
@@ -61,7 +70,30 @@ The "policy update" is a markdown file under `.gossip/agents/<id>/skills/`. No f
 
 <br/>
 
-> **The single-reviewer failure mode:** a solo AI reviewer ships hallucinated bugs as critical findings **5–10% of the time**. Gossipcat's cross-review drops that to **under 1%**. That delta is what the whole system exists to produce.
+## How Gossipcat compares
+
+| | What you get | Hallucination filtering | Agents improve over time |
+|---|---|---|---|
+| **Gossipcat** | 3+ agents cross-review each other's findings; confirmed bugs only | Yes — peers catch and penalize hallucinations mechanically | Yes — accuracy signals steer dispatch; skill files fix repeat failures |
+| **Single-agent review** (Claude Code built-in, Cursor review) | One model reviews your diff | No — hallucinations ship as findings | No — no feedback loop |
+| **LLM-as-judge cross-review** (most multi-agent frameworks) | One model grades another model's output | Partial — judge can hallucinate too; no ground truth | No — judge scores aren't wired to dispatch |
+| **Traditional review tools** (CodeRabbit, PR-Agent) | Pattern-match + one LLM pass | No | No |
+
+The core difference: gossipcat verifies findings against actual `file:line` citations in your codebase. That ground truth is what makes the reward signal trustworthy enough to automate.
+
+<br/>
+
+## Real-world session
+
+What a typical gossipcat session looks like in practice (2026-04-29):
+
+- **2 PRs shipped** — #317 (env-scrub fix, e180d41) and #318 (test hardening, cac57db), both through full consensus before merge
+- **1 consensus round** on PR #317 — round `591af14b-3f674c9c`, 9 confirmed / 0 disputed findings
+- **1 stale backlog item correctly identified** — write-time insight filter was already shipped in a prior session; the `verify-the-premise` skill caught it before sonnet-implementer started redundant implementation work
+- **1 spec correctly deferred** — age-based archive pruning: full scan found 0 candidates meeting the threshold; design locked in docs, not built (right call)
+- **1 hallucination caught** on haiku-researcher — extrapolated from a 50-row sample when the full dataset was needed; `hallucination_caught` signal recorded, accuracy score updated, no fix shipped on bad data
+
+The signal pipeline ran the whole session. Nothing landed without cross-review. One agent's score dropped for the sample-extrapolation error.
 
 <br/>
 


### PR DESCRIPTION
## Summary

Rewrites README.md lines 1–218 to be promotion-ready. Everything from \`## Quickstart\` onward is byte-identical to master (verified via md5 of post-Quickstart slice).

**Changes (above Quickstart):**

- Hook moved up — the \"5–10% → <1% hallucination\" callout is now the first thing after the banner, not buried at line 64. Softened to \"in our internal usage\" with a TODO for a public benchmark link.
- 3-tier escalation: one-line TL;DR + 50-word blockquote pitch + existing \"What is Gossipcat?\" section.
- New \`## How Gossipcat compares\` table — honest one-sentence differentiators vs single-agent review (Claude Code / Cursor), LLM-as-judge frameworks, and CodeRabbit/PR-Agent. LLM-as-judge row says \"Partial,\" not \"No.\"
- New \`## Real-world session\` — 5 bullets from this session's actual evidence: 2 PRs shipped, consensus round 591af14b (9/0), stale backlog item caught by verify-the-premise, age-based archive correctly deferred via empirical analysis, haiku hallucination caught.

**Preserved:**
- Banner, badges, in-page navigation
- \"Weightless in-context RL\" positioning
- Mermaid diagram
- Everything from \`## Quickstart\` onward (install, recipes, troubleshooting, config, For AI Agents)

**Net:** +32 lines (960 → 992).

## Test plan

- [x] md5 of post-Quickstart portion matches master byte-for-byte
- [x] \`grep -n \"^## Quickstart\" README.md\` returns line 219
- [x] No external image refs added
- [x] No banner/badge URL changes
- [x] All comparison-table rows are honest (no strawmanning of alternatives)

## Open question

The 5–10% hallucination claim is currently softened to \"in our internal usage.\" Worth replacing with a citation to a public benchmark before this lands. Tagged with an HTML \`<!-- TODO -->\` in-source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)