### PR TITLE
fix(dashboard): 10 design-QA fixes (data-trust + palette + polish)

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -377,8 +377,7 @@ function TasksPage({ tasks }: { tasks: import('@/lib/types').TasksData }) {
           placeholder="Search tasks by description, agent, id, status..."
           className="w-full max-w-md rounded-md border border-border/40 bg-card/80 px-3 py-1.5 font-mono text-xs text-foreground placeholder:text-muted-foreground/50 focus:border-primary/40 focus:outline-none"
         />
-        {totalPages > 1 && (
-          <div className="flex shrink-0 items-center gap-2 font-mono text-[11px] text-muted-foreground">
+        <div className={`flex shrink-0 items-center gap-2 font-mono text-[11px] text-muted-foreground ${totalPages <= 1 ? 'invisible' : ''}`}>
             <button
               onClick={() => setPage((p) => Math.max(0, p - 1))}
               disabled={clampedPage === 0}
@@ -391,7 +390,6 @@ function TasksPage({ tasks }: { tasks: import('@/lib/types').TasksData }) {
               className="rounded-sm border border-border/40 bg-card px-2 py-0.5 transition hover:bg-accent/50 disabled:opacity-30"
             >Next ▸</button>
           </div>
-        )}
       </div>
 
       <div className="overflow-hidden rounded-md border border-border/40 bg-card/80">
@@ -528,6 +526,7 @@ function Dashboard() {
         {/* Main: Active tasks + Recent tasks + Team hero + Consensus + Memories */}
         <main className="min-w-0 space-y-6">
           <ActiveTasksBanner onCountChange={setActiveTaskCount} />
+          <FindingsMetrics consensus={consensus} reports={consensusReports} />
           {tasks && <TasksSection tasks={tasks} limit={5} />}
           {agents && <TeamHero agents={agents} />}
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -538,7 +537,6 @@ function Dashboard() {
             <RecentSignalsPeek />
             <DroppedFindingDrift overview={overview} />
           </div>
-          <FindingsMetrics consensus={consensus} reports={consensusReports} />
           {(gossipMemories || nativeMemories) && (
             <MemoryFolders
               memories={[...(gossipMemories ?? []), ...(nativeMemories ?? [])]}

--- a/packages/dashboard-v2/src/components/AgentCardBig.tsx
+++ b/packages/dashboard-v2/src/components/AgentCardBig.tsx
@@ -40,7 +40,7 @@ export function AgentCardBig({ agent }: AgentCardBigProps) {
   return (
     <a
       href={`/dashboard/agent/${encodeURIComponent(agent.id)}`}
-      className="group relative block rounded-xl border border-border bg-card p-3 transition-all hover:-translate-y-0.5 hover:border-primary/30 hover:bg-card/90"
+      className="group relative block rounded-lg border border-border bg-card p-3 transition-all hover:-translate-y-0.5 hover:border-primary/30 hover:bg-card/90"
     >
       {/* Flatten pass: the card used to layer gradient + inset highlight line
           + outer shadow + hover ring + per-agent avatar halo blur, which felt
@@ -83,7 +83,7 @@ export function AgentCardBig({ agent }: AgentCardBigProps) {
               );
               if (kind === 'kept-for-coverage') return (
                 <span
-                  className="shrink-0 rounded-sm border border-unverified/40 px-1 py-0.5 font-mono text-[8px] font-bold text-unverified"
+                  className="shrink-0 rounded-sm border border-unverified/40 bg-unverified/10 px-1 py-0.5 font-mono text-[8px] font-bold text-unverified"
                   data-tooltip={`Would bench (${s.bench.reason ?? 'rule'}), but kept as sole provider of a category.`}
                 >
                   KEPT FOR COVERAGE

--- a/packages/dashboard-v2/src/components/CircuitAlerts.tsx
+++ b/packages/dashboard-v2/src/components/CircuitAlerts.tsx
@@ -23,7 +23,7 @@ function describe(agent: AgentData): Reason {
     return { label: 'benched', cls: 'bg-destructive/15 text-destructive' };
   }
   if (s.bench?.state === 'kept-for-coverage') {
-    return { label: 'kept for coverage', cls: 'border border-unverified/40 text-unverified' };
+    return { label: 'kept for coverage', cls: 'border border-unverified/40 bg-unverified/10 text-unverified' };
   }
   if (s.circuitOpen) {
     return { label: `struggling (${s.consecutiveFailures} fails)`, cls: 'bg-unverified/15 text-unverified' };

--- a/packages/dashboard-v2/src/components/DroppedFindingDrift.tsx
+++ b/packages/dashboard-v2/src/components/DroppedFindingDrift.tsx
@@ -3,11 +3,11 @@ import type { OverviewData } from '@/lib/types';
 // Deterministic color picker from a palette — no hash randomness to keep
 // the same type the same color across renders.
 const PALETTE = [
-  'bg-disputed',
-  'bg-unverified',
+  'bg-primary/70',
+  'bg-cyan-500/60',
   'bg-unique',
   'bg-muted-foreground/60',
-  'bg-primary/70',
+  'bg-primary/50',
   'bg-confirmed/70',
 ];
 

--- a/packages/dashboard-v2/src/components/FleetHealthTrend.tsx
+++ b/packages/dashboard-v2/src/components/FleetHealthTrend.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { api } from '@/lib/api';
 import type { FleetTrendPoint, FleetTrendResponse } from '@/lib/types';
+import { EmptyState } from './EmptyState';
 
 interface AgentSeries {
   agentId: string;
@@ -61,10 +62,11 @@ export function FleetHealthTrend() {
   return (
     <section className="rounded-lg border border-border bg-card p-4">
       <header className="mb-3 flex items-baseline justify-between">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Fleet Health Trend</h3>
+        <h3 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">Fleet Health Trend</h3>
         <span className="text-xs text-muted-foreground">last 30d</span>
       </header>
-      {err && <p className="text-xs text-muted-foreground">unavailable</p>}
+      {!data && !err && <EmptyState title="Loading…" compact />}
+      {err && <p className="text-xs text-muted-foreground">failed to load trend data</p>}
       {!err && data && series.length === 0 && (
         <p className="text-xs text-muted-foreground">no recent consensus signals</p>
       )}

--- a/packages/dashboard-v2/src/components/RecentSignalsPeek.tsx
+++ b/packages/dashboard-v2/src/components/RecentSignalsPeek.tsx
@@ -38,11 +38,11 @@ export function RecentSignalsPeek() {
   return (
     <section className="rounded-lg border border-border bg-card p-4">
       <header className="mb-3 flex items-baseline justify-between">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Recent Signals</h3>
+        <h3 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">Recent Signals</h3>
         <button
           type="button"
           onClick={() => navigate('/signals')}
-          className="text-xs text-primary hover:underline"
+          className="font-mono text-[10px] text-muted-foreground hover:underline"
         >
           all signals →
         </button>
@@ -60,7 +60,7 @@ export function RecentSignalsPeek() {
                 {LABELS[s.signal] ?? s.signal}
               </span>
               <span className="w-24 shrink-0 truncate font-mono text-muted-foreground">{s.agentId}</span>
-              <span className="flex-1 truncate text-muted-foreground">{truncate(s.evidence ?? '', 80)}</span>
+              <span className="flex-1 truncate font-mono text-muted-foreground">{truncate(s.evidence ?? '', 80)}</span>
             </li>
           ))}
         </ul>

--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -45,7 +45,7 @@ export function SystemPulse({ overview, activeTasks }: SystemPulseProps) {
   const totalAgents = overview.relayCount + overview.nativeCount;
   const successRate = overview.tasksCompleted + overview.tasksFailed > 0
     ? Math.round((overview.tasksCompleted / (overview.tasksCompleted + overview.tasksFailed)) * 100)
-    : 100;
+    : null;
   const confirmRate = overview.totalFindings > 0
     ? Math.round((overview.confirmedFindings / overview.totalFindings) * 100)
     : 0;
@@ -103,7 +103,7 @@ export function SystemPulse({ overview, activeTasks }: SystemPulseProps) {
         </div>
         <div className="flex items-center justify-between py-1 font-mono text-[11px]">
           <span className="text-muted-foreground">actionable</span>
-          <span className="font-semibold text-unverified tabular-nums">{overview.actionableFindings}</span>
+          <span className={`font-semibold tabular-nums ${overview.actionableFindings > 0 ? 'text-orange-400' : 'text-foreground'}`}>{overview.actionableFindings}</span>
         </div>
         {overview.tasksFailed > 0 && (
           <div className="flex items-center justify-between py-1 font-mono text-[11px]">
@@ -117,8 +117,8 @@ export function SystemPulse({ overview, activeTasks }: SystemPulseProps) {
         </div>
         <div className="flex items-center justify-between py-1 font-mono text-[11px]">
           <span className="text-muted-foreground">success rate</span>
-          <span className={`font-semibold tabular-nums ${successRate >= 95 ? 'text-confirmed' : successRate >= 80 ? 'text-unverified' : 'text-destructive'}`}>
-            {successRate}%
+          <span className={`font-semibold tabular-nums ${successRate === null ? 'text-muted-foreground' : successRate >= 95 ? 'text-confirmed' : successRate >= 80 ? 'text-unverified' : 'text-destructive'}`}>
+            {successRate === null ? '—' : `${successRate}%`}
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Summary

10 atomic UX/design fixes from sonnet-designer's QA audit. Single PR, no production-data behavior changes — all visual/copy/semantic-color and one Overview reorder.

### HIGH — data trust + palette correctness
- **SystemPulse**: \`successRate\` no longer defaults to "100%" green when zero tasks have run. Renders em-dash in muted color until real data exists. **This was a real data-trust bug**: a fresh install advertised "100% success" in green next to "0 tasks completed."
- **SystemPulse**: \`actionableFindings\` count moved off \`text-unverified\` (which globally means "pending review") to \`text-orange-400\` for non-zero (matches global "high severity" semantic) and \`text-foreground\` for zero.
- **FleetHealthTrend + RecentSignalsPeek**: section headers now follow the \`font-mono text-[11px] tracking-widest\` convention every other section header uses.

### MEDIUM — consistency + states
- **CircuitAlerts + AgentCardBig**: "kept for coverage" badge now has \`bg-unverified/10\` fill matching its filled siblings (was outline-only, lower contrast).
- **App.tsx Overview**: FindingsMetrics moved from below ~700px of tasks + team content to immediately after ActiveTasksBanner. Eye-path now goes tasks → findings → team → trends.
- **FleetHealthTrend**: added \`!data && !err\` loading guard with EmptyState. Error copy ("failed to load trend data") differentiated from empty copy ("no recent consensus signals") — operators can now tell which state they're seeing.
- **DroppedFindingDrift**: PALETTE swapped \`bg-disputed\` → \`bg-primary/70\` and \`bg-unverified\` → \`bg-cyan-500/60\` (the two review-state colors could collide with chart segment hashing).

### LOW — polish
- AgentCardBig: \`rounded-xl\` → \`rounded-lg\` (every other card uses lg).
- RecentSignalsPeek: evidence span gets \`font-mono\` (was sans-serif on a mono row).
- App.tsx pagination: container now always rendered with \`invisible\` when totalPages <= 1, preventing search-driven layout shift.

## Note on premise deviation

The QA spec said RecentSignalsPeek's "all signals →" link was \`text-muted-foreground\`. In source it was actually \`text-primary hover:underline\`. The implementer applied the design target regardless (\`font-mono text-[10px] text-muted-foreground\`) — intentionally muting the link color. **This is a small but visible color change.** If you want the primary accent back on that link specifically, we can revert that one substring.

## Test plan

- [x] \`git diff --stat\` — 7 files, 19/19 swaps
- [x] No new tests added (visual changes only; dashboard-v2 has no test suite — Vite package)
- [x] Pre-existing useElementWidth.ts TS error confirmed unrelated to this diff (verified via stash)
- [ ] CI green
- [ ] Smoke: dashboard renders, Overview eye-path reads tasks→findings→team→trends, fresh-install state shows em-dash not "100%"

## Provenance

- QA round: sonnet-designer task \`c60b82bb\`
- Implementer: sonnet-implementer task \`fff1e61d\`
- Punch list memory line: 10 items, ~21 LOC budget, came in at 19 swaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)