### PR TITLE
fix(dashboard): tri-stat agents widget + mute dormant fleet rows

### DIFF
--- a/packages/dashboard-v2/src/components/FleetHealthTrend.tsx
+++ b/packages/dashboard-v2/src/components/FleetHealthTrend.tsx
@@ -72,8 +72,10 @@ export function FleetHealthTrend() {
       )}
       {!err && series.length > 0 && (
         <ul className="space-y-1.5">
-          {series.map((s) => (
-            <li key={s.agentId} className="flex items-center justify-between gap-3 text-xs">
+          {series.map((s) => {
+            const isDormant = s.latest === 0;
+            return (
+            <li key={s.agentId} className={`flex items-center justify-between gap-3 text-xs${isDormant ? ' opacity-40' : ''}`}>
               <span className="truncate font-mono text-foreground">{s.agentId}</span>
               <div className="flex items-center gap-2">
                 <Sparkline values={s.points.map((p) => p.accuracy)} />
@@ -82,7 +84,8 @@ export function FleetHealthTrend() {
                 </span>
               </div>
             </li>
-          ))}
+            );
+          })}
         </ul>
       )}
     </section>

--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -67,12 +67,25 @@ export function SystemPulse({ overview, activeTasks }: SystemPulseProps) {
       <div className="relative grid grid-cols-2 border-b border-border">
         <span className="pointer-events-none absolute left-0 right-0 top-1/2 h-px bg-border" />
         <span className="pointer-events-none absolute bottom-0 left-1/2 top-0 w-px bg-border" />
-        <BigStat
-          value={overview.agentsOnline}
-          unit={`/${totalAgents}`}
-          label="Agents Online"
-          valueClass="text-confirmed"
-        />
+        {/* Three-chip agent stat row */}
+        <div className="flex flex-col items-center justify-center gap-2 py-4 px-3">
+          <div className="flex items-center gap-3">
+            <div className="flex flex-col items-center gap-0.5">
+              <span className={`font-mono text-2xl font-bold leading-none ${overview.agentsOnline > 0 ? 'text-orange-400' : 'text-foreground'}`}>{overview.agentsOnline}</span>
+              <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Dispatched</span>
+            </div>
+            <span className="text-border font-mono text-lg leading-none">·</span>
+            <div className="flex flex-col items-center gap-0.5">
+              <span className={`font-mono text-2xl font-bold leading-none ${overview.relayConnected > 0 ? 'text-confirmed' : 'text-muted-foreground'}`}>{overview.relayConnected}</span>
+              <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Connected</span>
+            </div>
+            <span className="text-border font-mono text-lg leading-none">·</span>
+            <div className="flex flex-col items-center gap-0.5">
+              <span className="font-mono text-2xl font-bold leading-none text-muted-foreground">{totalAgents}</span>
+              <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Registered</span>
+            </div>
+          </div>
+        </div>
         <BigStat
           value={activeTasks}
           label="Active Tasks"


### PR DESCRIPTION
## Summary

Two design follow-ups from sonnet-designer's post-PR-#320 triage. Pure frontend, no backend changes.

### Issue 1 (HIGH) — \"AGENTS ONLINE\" mislabel

Previous widget: \`agentsOnline / totalAgents\` as one BigStat labeled \"AGENTS ONLINE\". But \`agentsOnline\` counts in-flight tasks (last 30 min); denominator counts all registered. At rest = always **0/N**, made the system look offline when it was healthy and idle.

Replaced with a three-chip flex row:
- **DISPATCHED** — in-flight task count, \`text-orange-400\` when > 0
- **CONNECTED** — live WS connections (\`relayConnected\` already in \`OverviewData\` since \`types.ts:4\`, just never rendered), \`text-confirmed\` when > 0
- **REGISTERED** — static total, \`text-muted-foreground\`

Operator now sees three orthogonal axes: who is *working*, who is *reachable*, who is *configured*. No backend change.

### Issue 5 (LOW) — Mute dormant fleet rows

Agents with no signal activity (\`native-claude\`, \`openclaw-agent\`, \`gemini-implementer\`, \`test-agent-smoke\`) rendered flat-zero sparklines at full opacity, adding noise. Already sorted to bottom; now also rendered at \`opacity-40\` when \`s.latest === 0\`. Kept visible as canary signal, visually de-emphasized.

## Diff

- \`SystemPulse.tsx\`: +14 / -7
- \`FleetHealthTrend.tsx\`: +3

## Test plan

- [x] \`npm run build:dashboard\` — clean (617ms, 73 modules)
- [x] \`npx tsc --noEmit -p packages/dashboard-v2/tsconfig.json\` — zero new errors (pre-existing \`useElementWidth.ts\` unrelated)
- [x] No backend touched — \`relayConnected\` was already in the API payload
- [ ] CI green
- [ ] Smoke: dashboard shows DISPATCHED/CONNECTED/REGISTERED tri-row at idle, dormant agents visibly muted in Fleet Health Trend

## Provenance

- Triage: sonnet-designer task \`a4cdee06\` (5-issue post-screenshot audit)
- Implementer: sonnet-implementer task \`3aca51a1\`
- Issues 2 (success-rate threshold), 3 (verified shipped), 4 (FindingsMetrics density) — out of scope for this PR per designer's verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)