### PR TITLE
fix(dashboard): 10 route-audit fixes (signals, headers, thresholds, dedup)

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -174,8 +174,7 @@ function TeamPage({ agents, tasks }: { agents: AgentData[]; tasks: import('@/lib
               const s = agent.scores;
               const lt = lastTaskByAgent.get(agent.id);
               const weightColor = s.dispatchWeight >= 1.2 ? 'text-confirmed' : s.dispatchWeight >= 0.8 ? 'text-foreground' : 'text-disputed';
-              const rankDisplay = sortDir === 'desc' && (sortKey === 'weight' || sortKey === 'accuracy' || sortKey === 'impact')
-                ? i + 1 : null;
+              const rankDisplay = i + 1;
 
               return (
                 <tr
@@ -188,7 +187,7 @@ function TeamPage({ agents, tasks }: { agents: AgentData[]; tasks: import('@/lib
                       rankDisplay === 1 ? 'font-bold text-primary' :
                       rankDisplay === 2 || rankDisplay === 3 ? 'font-semibold text-foreground/80' :
                       'text-muted-foreground/40'
-                    }`}>{rankDisplay ?? '·'}</span>
+                    }`}>{rankDisplay}</span>
                   </td>
 
                   {/* Agent */}
@@ -442,7 +441,7 @@ function FindingsPage({
     <>
       <div className="mb-6">
         <h1 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
-          Debates <span className="ml-2 text-foreground">{visibleRuns.length}</span>
+          Debates <span className="ml-2 text-primary">{visibleRuns.length}</span>
           {!showRetracted && retractedCount > 0 && (
             <span className="ml-2 font-normal normal-case tracking-normal text-muted-foreground/60">
               / {consensus.totalRuns ?? consensus.runs.length} total

--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -234,30 +234,6 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
               {agent.preset && (
                 <span className="rounded-sm bg-muted px-2 py-0.5 font-mono text-[10px] text-muted-foreground">{agent.preset}</span>
               )}
-              {(() => {
-                const kind = getBenchBadgeKind(s);
-                if (kind === 'benched') return (
-                  <span className="rounded-sm bg-destructive/10 px-2 py-0.5 font-mono text-[10px] font-bold text-destructive">
-                    BENCHED
-                  </span>
-                );
-                if (kind === 'struggling') return (
-                  <span className="rounded-sm bg-unverified/10 px-2 py-0.5 font-mono text-[10px] font-bold text-unverified">
-                    STRUGGLING ({s.consecutiveFailures} FAILS)
-                  </span>
-                );
-                if (kind === 'kept-for-coverage') return (
-                  <span className="rounded-sm border border-unverified/40 px-2 py-0.5 font-mono text-[10px] font-bold text-unverified">
-                    KEPT FOR COVERAGE
-                  </span>
-                );
-                if (s.consecutiveFailures > 0) return (
-                  <span className="rounded-sm bg-unverified/10 px-2 py-0.5 font-mono text-[10px] font-bold text-unverified">
-                    {s.consecutiveFailures} CONSECUTIVE FAILS
-                  </span>
-                );
-                return null;
-              })()}
               <span className="font-mono text-[10px] text-muted-foreground/60">
                 {s.signals} signals{agent.lastTask ? ` · ${timeAgo(agent.lastTask.timestamp)}` : ''}
               </span>

--- a/packages/dashboard-v2/src/components/CategoryCompetency.tsx
+++ b/packages/dashboard-v2/src/components/CategoryCompetency.tsx
@@ -45,7 +45,7 @@ export function CategoryCompetency({ categoryAccuracy, categoryCorrect, category
   return (
     <div className="space-y-2">
       {rows.map((row) => {
-        const fill = row.acc >= 0.9 ? 'bg-confirmed' : row.acc >= 0.7 ? 'bg-unverified' : 'bg-disputed';
+        const fill = row.acc >= 0.7 ? 'bg-confirmed' : row.acc >= 0.4 ? 'bg-unverified' : 'bg-disputed';
         const title = row.n > 0
           ? `${row.c} correct / ${row.h} hallucinated / ${row.n} total`
           : undefined;

--- a/packages/dashboard-v2/src/components/DroppedFindingDrift.tsx
+++ b/packages/dashboard-v2/src/components/DroppedFindingDrift.tsx
@@ -25,7 +25,7 @@ export function DroppedFindingDrift({ overview }: { overview: OverviewData | nul
   return (
     <section className="rounded-lg border border-border bg-card p-4">
       <header className="mb-3 flex items-baseline justify-between">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Dropped Finding Types</h3>
+        <h3 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">Dropped Finding Types</h3>
         <span className="text-xs text-muted-foreground">last 20 rounds</span>
       </header>
       {total === 0 ? (

--- a/packages/dashboard-v2/src/components/FleetHealthTrend.tsx
+++ b/packages/dashboard-v2/src/components/FleetHealthTrend.tsx
@@ -26,14 +26,14 @@ function groupByAgent(points: FleetTrendPoint[]): AgentSeries[] {
   return series;
 }
 
-function Sparkline({ values }: { values: number[] }) {
+function Sparkline({ values, className }: { values: number[]; className?: string }) {
   const W = 120;
   const H = 20;
   if (values.length === 0) return <svg width={W} height={H} />;
   if (values.length === 1) {
     const y = H - values[0] * H;
     return (
-      <svg width={W} height={H}>
+      <svg width={W} height={H} className={className}>
         <circle cx={W / 2} cy={y} r={2} fill="currentColor" />
       </svg>
     );
@@ -41,7 +41,7 @@ function Sparkline({ values }: { values: number[] }) {
   const step = W / (values.length - 1);
   const pts = values.map((v, i) => `${(i * step).toFixed(1)},${(H - v * H).toFixed(1)}`).join(' ');
   return (
-    <svg width={W} height={H} className="text-primary">
+    <svg width={W} height={H} className={className}>
       <polyline points={pts} fill="none" stroke="currentColor" strokeWidth={1.5} />
     </svg>
   );
@@ -78,7 +78,7 @@ export function FleetHealthTrend() {
             <li key={s.agentId} className={`flex items-center justify-between gap-3 text-xs${isDormant ? ' opacity-40' : ''}`}>
               <span className="truncate font-mono text-foreground">{s.agentId}</span>
               <div className="flex items-center gap-2">
-                <Sparkline values={s.points.map((p) => p.accuracy)} />
+                <Sparkline values={s.points.map((p) => p.accuracy)} className={s.latest >= 0.7 ? 'text-confirmed' : s.latest >= 0.4 ? 'text-unverified' : 'text-disputed'} />
                 <span className="w-10 text-right tabular-nums text-muted-foreground">
                   {Math.round(s.latest * 100)}%
                 </span>

--- a/packages/dashboard-v2/src/components/LogsPage.tsx
+++ b/packages/dashboard-v2/src/components/LogsPage.tsx
@@ -213,7 +213,7 @@ export function LogsPage() {
             </div>
           ))}
           {filteredEntries.length === 0 && (
-            <div className="py-8 text-center text-sm text-muted-foreground">
+            <div className="py-8 text-center font-mono text-xs text-muted-foreground">
               {entries.length === 0 ? 'Loading...' : 'No matching log entries.'}
             </div>
           )}

--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -35,6 +35,42 @@ const SIGNAL_TYPES = [
   'format_compliance',
 ];
 
+const SIGNAL_LABELS: Record<string, string> = {
+  agreement: 'Agreement',
+  consensus_verified: 'Consensus verified',
+  unique_confirmed: 'Unique (confirmed)',
+  unique_unconfirmed: 'Unique (unconfirmed)',
+  disagreement: 'Disagreement',
+  hallucination_caught: 'Hallucination',
+  new_finding: 'New finding',
+  unverified: 'Unverified',
+  impl_test_pass: 'Test pass',
+  impl_test_fail: 'Test fail',
+  impl_typecheck_pass: 'Typecheck pass',
+  impl_typecheck_fail: 'Typecheck fail',
+  impl_peer_approved: 'Peer approved',
+  impl_peer_rejected: 'Peer rejected',
+  boundary_escape: 'Boundary escape',
+};
+
+const SIGNAL_CLS: Record<string, string> = {
+  agreement: 'text-confirmed',
+  consensus_verified: 'text-confirmed',
+  impl_test_pass: 'text-confirmed',
+  impl_typecheck_pass: 'text-confirmed',
+  impl_peer_approved: 'text-confirmed',
+  disagreement: 'text-disputed',
+  hallucination_caught: 'text-disputed',
+  impl_test_fail: 'text-disputed',
+  impl_typecheck_fail: 'text-disputed',
+  impl_peer_rejected: 'text-disputed',
+  boundary_escape: 'text-disputed',
+  unique_confirmed: 'text-unique',
+  new_finding: 'text-unique',
+  unique_unconfirmed: 'text-unique/70',
+  unverified: 'text-unverified',
+};
+
 // Global severity palette — matches FindingsMetrics SEVERITY_CLS so a
 // "high" chip reads the same orange everywhere on the dashboard.
 const SEVERITY_BADGE: Record<string, string> = {
@@ -163,7 +199,7 @@ export function SignalsPage() {
     <div className="space-y-4">
       <div className="flex items-baseline justify-between">
         <div>
-          <h1 className="font-mono text-sm font-bold uppercase tracking-widest text-primary">Signals</h1>
+          <h1 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">Signals</h1>
           <p className="mt-0.5 font-mono text-[10px] text-muted-foreground/70">
             {headerLabel} — showing {rows.length} of {total}
           </p>
@@ -216,7 +252,7 @@ export function SignalsPage() {
                     >
                       <td className="whitespace-nowrap px-2 py-1 text-muted-foreground/80" title={r.timestamp}>{timeAgo(r.timestamp)}</td>
                       <td className="whitespace-nowrap px-2 py-1 text-foreground">{r.agentId}</td>
-                      <td className="whitespace-nowrap px-2 py-1 text-foreground">{r.signal}</td>
+                      <td className={`whitespace-nowrap px-2 py-1 ${SIGNAL_CLS[r.signal] ?? 'text-foreground'}`}>{SIGNAL_LABELS[r.signal] ?? r.signal}</td>
                       <td className="whitespace-nowrap px-2 py-1 text-muted-foreground/80">{r.counterpartId ?? '—'}</td>
                       <td className="whitespace-nowrap px-2 py-1">
                         {r.severity ? (

--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -71,7 +71,7 @@ export function SystemPulse({ overview, activeTasks }: SystemPulseProps) {
         <div className="flex flex-col items-center justify-center gap-2 py-4 px-3">
           <div className="flex items-center gap-3">
             <div className="flex flex-col items-center gap-0.5">
-              <span className={`font-mono text-2xl font-bold leading-none ${overview.agentsOnline > 0 ? 'text-orange-400' : 'text-foreground'}`}>{overview.agentsOnline}</span>
+              <span className={`font-mono text-2xl font-bold leading-none ${overview.agentsOnline > 0 ? 'text-primary' : 'text-foreground'}`}>{overview.agentsOnline}</span>
               <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Dispatched</span>
             </div>
             <span className="text-border font-mono text-lg leading-none">·</span>


### PR DESCRIPTION
## Summary

Bundled output of sonnet-designer's 7-route comprehensive audit, follow-up to PRs #320 and #321. ~50 insertions / 38 deletions across 8 files. Pure frontend.

### HIGH — data trust + glanceability
- **SignalsPage h1** — \`text-sm text-primary\` → \`text-[11px] text-foreground\`. Stops the heading from shouting; matches Team/Tasks/Debates.
- **SignalsPage signal column** — was rendering raw snake_case (\`hallucination_caught\`, \`impl_typecheck_fail\`, …). Added \`SIGNAL_LABELS\` + \`SIGNAL_CLS\` maps (text-prefixed for table-cell coloring; SignalTimeline's bg-prefixed exports don't fit) so each row gets a human label in the right semantic color.
- **DroppedFindingDrift h3** — switched from \`text-sm font-semibold\` to the canonical \`font-mono text-[11px] tracking-widest text-foreground\` every other section header uses.

### MEDIUM — palette consistency
- **CategoryCompetency** — thresholds 0.9/0.7 → 0.7/0.4. A 72% accuracy now reads green in both the metrics bar and the category bars on the Agent page (was green above, amber below).
- **FleetHealthTrend** — sparklines no longer all amber. Per-row class by \`s.latest\`: \`text-confirmed\` ≥ 0.7, \`text-unverified\` ≥ 0.4, \`text-disputed\` < 0.4.
- **AgentPage** — removed the duplicate inline bench badge in the header card (-23 lines). Full alert panel above already expresses the state; inline badge is preserved for compact contexts (Team table, CircuitAlerts).

### LOW — polish
- LogsPage empty/loading text now \`font-mono text-xs\`.
- **Self-revision**: SystemPulse \"Dispatched\" color reverted from PR #321's \`text-orange-400\` to \`text-primary\` — orange is high-severity, dispatched agents are a healthy state.
- App.tsx debates count: \`text-foreground\` → \`text-primary\`, matching other page counts.
- App.tsx team rank column: simplified to always render \`i + 1\`.

## Test plan

- [x] \`npm run build:dashboard\` — clean (73 modules, 658ms)
- [x] \`npx tsc --noEmit -p packages/dashboard-v2/tsconfig.json\` — only pre-existing useElementWidth.ts error
- [x] Premise verification: 10/10 cited file:line claims confirmed before edit
- [x] No backend changes
- [ ] CI green
- [ ] Smoke: SignalsPage shows labeled colored signal column; CategoryCompetency / metrics bars agree on green/amber for 72% accuracy; FleetHealthTrend sparklines vary in color by health tier

## Provenance

- Audit dispatch: sonnet-designer task \`a9c4602c3de98f026\` (7-route comprehensive)
- Implementer: sonnet-implementer task \`3ef4a063\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)