### PR TITLE
feat(dashboard): ref-allowlist violations API + signal label (PR A)

### DIFF
--- a/packages/dashboard-v2/src/components/SignalTimeline.tsx
+++ b/packages/dashboard-v2/src/components/SignalTimeline.tsx
@@ -23,6 +23,7 @@ const SIGNAL_COLORS: Record<string, string> = {
   // Amber/orange — fabricated citations are write-time warnings, not consensus
   // errors; keep visually distinct from the red disputed bucket.
   citation_fabricated: 'bg-amber-500',
+  boundary_escape: 'bg-destructive',
 };
 
 const SIGNAL_LABELS: Record<string, string> = {
@@ -35,6 +36,7 @@ const SIGNAL_LABELS: Record<string, string> = {
   new_finding: 'New finding',
   unverified: 'Unverified',
   citation_fabricated: 'Fabricated citation',
+  boundary_escape: 'Process violation',
 };
 
 // Pill sizing budget. MIN_PILL_WIDTH gives a slight breathing margin above the

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -289,6 +289,22 @@ export interface FindingDetail {
   retracted?: { reason: string; at: string };
 }
 
+export interface ViolationEntry {
+  taskId: string;
+  agentId: string;
+  preSha: string;
+  postSha: string;
+  detectedAt: string;   // ISO-8601
+  commits: string[];    // "sha subject" strings
+}
+
+export interface ViolationsResponse {
+  items: ViolationEntry[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
 export type DashboardEvent =
   | { type: 'task_dispatched'; taskId: string; agentId: string }
   | { type: 'task_completed'; taskId: string; agentId: string }

--- a/packages/relay/src/dashboard/api-violations.ts
+++ b/packages/relay/src/dashboard/api-violations.ts
@@ -1,0 +1,55 @@
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+export interface ViolationEntry {
+  taskId: string;
+  agentId: string;
+  preSha: string;
+  postSha: string;
+  detectedAt: string;   // ISO-8601
+  commits: string[];    // "sha subject" strings
+}
+
+export interface ViolationsResponse {
+  items: ViolationEntry[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+const FILE = '.gossip/process-violations.jsonl';
+
+export function violationsHandler(
+  projectRoot: string,
+  query?: URLSearchParams,
+): ViolationsResponse {
+  const page = Math.max(1, parseInt(query?.get('page') ?? '1', 10));
+  const pageSize = Math.min(100, Math.max(1, parseInt(query?.get('pageSize') ?? '25', 10)));
+  const agentFilter = query?.get('agentId') ?? null;
+
+  const filePath = join(projectRoot, FILE);
+  if (!existsSync(filePath)) {
+    return { items: [], total: 0, page, pageSize };
+  }
+
+  const raw = readFileSync(filePath, 'utf-8');
+  const lines = raw.trim().split('\n').filter(Boolean);
+
+  const entries: ViolationEntry[] = [];
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line) as ViolationEntry;
+      if (!agentFilter || entry.agentId === agentFilter) {
+        entries.push(entry);
+      }
+    } catch { continue; }
+  }
+
+  entries.sort((a, b) =>
+    new Date(b.detectedAt).getTime() - new Date(a.detectedAt).getTime()
+  );
+
+  const total = entries.length;
+  const start = (page - 1) * pageSize;
+  return { items: entries.slice(start, start + pageSize), total, page, pageSize };
+}

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -15,6 +15,7 @@ import { learningsHandler } from './api-learnings';
 import { tasksHandler } from './api-tasks';
 import { activeTasksHandler } from './api-active-tasks';
 import { logsHandler } from './api-logs';
+import { violationsHandler } from './api-violations';
 import { readFileSync, existsSync, realpathSync } from 'fs';
 import { join, resolve } from 'path';
 import { createHash, timingSafeEqual } from 'crypto';
@@ -334,6 +335,12 @@ export class DashboardRouter {
 
       if (url === '/dashboard/api/logs' && req.method === 'GET') {
         const data = logsHandler(this.projectRoot, query ?? undefined);
+        this.json(res, 200, data);
+        return true;
+      }
+
+      if (url === '/dashboard/api/violations' && req.method === 'GET') {
+        const data = violationsHandler(this.projectRoot, query ?? undefined);
         this.json(res, 200, data);
         return true;
       }

--- a/tests/relay/api-violations.test.ts
+++ b/tests/relay/api-violations.test.ts
@@ -1,0 +1,110 @@
+import { violationsHandler, ViolationEntry } from '../../packages/relay/src/dashboard/api-violations';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+function setupRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'gossip-test-violations-'));
+  mkdirSync(join(root, '.gossip'), { recursive: true });
+  return root;
+}
+
+function makeEntry(overrides: Partial<ViolationEntry> = {}): ViolationEntry {
+  return {
+    taskId: 'task-abc',
+    agentId: 'sonnet-implementer',
+    preSha: 'aaa1111',
+    postSha: 'bbb2222',
+    detectedAt: new Date().toISOString(),
+    commits: ['bbb2222 feat: direct push'],
+    ...overrides,
+  };
+}
+
+describe('violationsHandler', () => {
+  it('returns empty response when file does not exist', () => {
+    const root = setupRoot();
+    const result = violationsHandler(root);
+    expect(result).toEqual({ items: [], total: 0, page: 1, pageSize: 25 });
+  });
+
+  it('returns empty response when file is empty', () => {
+    const root = setupRoot();
+    writeFileSync(join(root, '.gossip', 'process-violations.jsonl'), '');
+    const result = violationsHandler(root);
+    expect(result).toEqual({ items: [], total: 0, page: 1, pageSize: 25 });
+  });
+
+  it('returns one entry when file has one valid line', () => {
+    const root = setupRoot();
+    const entry = makeEntry({ taskId: 'task-1' });
+    writeFileSync(join(root, '.gossip', 'process-violations.jsonl'), JSON.stringify(entry) + '\n');
+    const result = violationsHandler(root);
+    expect(result.total).toBe(1);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].taskId).toBe('task-1');
+    expect(result.page).toBe(1);
+    expect(result.pageSize).toBe(25);
+  });
+
+  it('filters by agentId when query param is set', () => {
+    const root = setupRoot();
+    const e1 = makeEntry({ taskId: 'task-1', agentId: 'agent-a' });
+    const e2 = makeEntry({ taskId: 'task-2', agentId: 'agent-b' });
+    writeFileSync(
+      join(root, '.gossip', 'process-violations.jsonl'),
+      JSON.stringify(e1) + '\n' + JSON.stringify(e2) + '\n',
+    );
+    const query = new URLSearchParams({ agentId: 'agent-a' });
+    const result = violationsHandler(root, query);
+    expect(result.total).toBe(1);
+    expect(result.items[0].agentId).toBe('agent-a');
+  });
+
+  it('paginates correctly', () => {
+    const root = setupRoot();
+    const lines = Array.from({ length: 5 }, (_, i) =>
+      JSON.stringify(makeEntry({ taskId: `task-${i}`, detectedAt: new Date(Date.now() - i * 1000).toISOString() }))
+    ).join('\n') + '\n';
+    writeFileSync(join(root, '.gossip', 'process-violations.jsonl'), lines);
+
+    const query = new URLSearchParams({ page: '2', pageSize: '2' });
+    const result = violationsHandler(root, query);
+    expect(result.total).toBe(5);
+    expect(result.items).toHaveLength(2);
+    expect(result.page).toBe(2);
+    expect(result.pageSize).toBe(2);
+  });
+
+  it('skips malformed lines without throwing', () => {
+    const root = setupRoot();
+    const e1 = makeEntry({ taskId: 'task-ok' });
+    writeFileSync(
+      join(root, '.gossip', 'process-violations.jsonl'),
+      'not-json\n' + JSON.stringify(e1) + '\n',
+    );
+    const result = violationsHandler(root);
+    expect(result.total).toBe(1);
+    expect(result.items[0].taskId).toBe('task-ok');
+  });
+
+  it('sorts entries newest-first by detectedAt', () => {
+    const root = setupRoot();
+    const older = makeEntry({ taskId: 'old', detectedAt: '2026-04-28T10:00:00.000Z' });
+    const newer = makeEntry({ taskId: 'new', detectedAt: '2026-04-29T10:00:00.000Z' });
+    writeFileSync(
+      join(root, '.gossip', 'process-violations.jsonl'),
+      JSON.stringify(older) + '\n' + JSON.stringify(newer) + '\n',
+    );
+    const result = violationsHandler(root);
+    expect(result.items[0].taskId).toBe('new');
+    expect(result.items[1].taskId).toBe('old');
+  });
+
+  it('clamps pageSize to max 100', () => {
+    const root = setupRoot();
+    const query = new URLSearchParams({ pageSize: '999' });
+    const result = violationsHandler(root, query);
+    expect(result.pageSize).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary

PR A (backend split) of the ref-allowlist dashboard surface per [`docs/specs/2026-04-29-ref-allowlist-dashboard.md`](docs/specs/2026-04-29-ref-allowlist-dashboard.md). Surfaces the `process-violations.jsonl` data stream and the `boundary_escape` signal class to the dashboard, so the detector shipped in PR #316 has visible operator output.

PR B (UI surface — `ViolationsCard`, `ViolationsPage`, `App.tsx` wiring) follows in a separate PR. Consensus is gated before PR B per the spec.

## Files

- **NEW** `packages/relay/src/dashboard/api-violations.ts` — `violationsHandler` reads `.gossip/process-violations.jsonl`, `agentId` filter, newest-first sort, pagination. Mirrors `api-overview.ts` pattern. `ViolationEntry` / `ViolationsResponse` interfaces defined inline + exported (no relay-side `types.ts` exists; deviation from spec skeleton noted to avoid one-off file for 2 types).
- **EDIT** `packages/relay/src/dashboard/routes.ts` — register `GET /dashboard/api/violations` in `handleApi`.
- **EDIT** `packages/dashboard-v2/src/lib/types.ts` — `ViolationEntry` + `ViolationsResponse` interfaces verbatim from spec API Contract.
- **EDIT** `packages/dashboard-v2/src/components/SignalTimeline.tsx` — `boundary_escape` entry in `SIGNAL_COLORS` (`bg-destructive`) and `SIGNAL_LABELS` (`Process violation`).
- **NEW** `tests/relay/api-violations.test.ts` — 8 unit tests: absent file, zero-byte file, one entry, agentId filter, pagination, malformed-line skip, sort order, pageSize clamp.

## Test plan

- [x] `npx tsc --noEmit -p packages/relay/tsconfig.json` — 0 errors
- [x] `npx jest tests/relay/api-violations.test.ts` — 8/8 pass
- [x] `npx jest tests/relay/` — 165/165 pass, 20 suites, no regressions
- [ ] Pre-existing dashboard-v2 typecheck error in `useElementWidth.ts:23` (React `RefObject<T | null>`) is unrelated to this change

## Upstream

Detector was shipped in #316 (commit 58d52e0); validated armed-but-zero-violations 2026-04-29 — see `project_ref_allowlist_detection_validation.md`.