### PR TITLE
feat(dashboard): ref-allowlist violations UI — card + page (PR B)

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -12,6 +12,8 @@ import { TaskDetailModal } from '@/components/TaskDetailModal';
 import { TasksSection } from '@/components/TasksSection';
 import { MemoryFolders } from '@/components/MemoryFolders';
 import { FleetHealthTrend } from '@/components/FleetHealthTrend';
+import { ViolationsCard } from '@/components/ViolationsCard';
+import { ViolationsPage } from '@/components/ViolationsPage';
 import { SkillVerdictsSnapshot } from '@/components/SkillVerdictsSnapshot';
 import { RecentSignalsPeek } from '@/components/RecentSignalsPeek';
 import { DroppedFindingDrift } from '@/components/DroppedFindingDrift';
@@ -512,14 +514,17 @@ function Dashboard() {
     content = <LogsPage />;
   } else if (route === '/signals') {
     content = <SignalsPage />;
+  } else if (route === '/violations') {
+    content = <ViolationsPage />;
   } else {
     // Main dashboard — sidebar + main layout
     content = (
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[280px_1fr] lg:items-start">
-        {/* Left sidebar: System Pulse + Circuit Alerts */}
+        {/* Left sidebar: System Pulse + Circuit Alerts + Violations */}
         <aside className="space-y-4 lg:sticky lg:top-4">
           <SystemPulse overview={overview} activeTasks={activeTaskCount} />
           {agents && <CircuitAlerts agents={agents} />}
+          <ViolationsCard />
         </aside>
 
         {/* Main: Active tasks + Recent tasks + Team hero + Consensus + Memories */}

--- a/packages/dashboard-v2/src/components/ViolationsCard.tsx
+++ b/packages/dashboard-v2/src/components/ViolationsCard.tsx
@@ -46,7 +46,7 @@ export function ViolationsCard() {
             !
           </span>
           <span
-            className={`font-mono text-[11px] font-bold uppercase tracking-widest ${
+            className={`min-w-0 truncate font-mono text-[11px] font-bold uppercase tracking-widest ${
               hasViolations ? 'text-destructive' : 'text-muted-foreground'
             }`}
           >
@@ -54,13 +54,13 @@ export function ViolationsCard() {
           </span>
         </div>
         {hasViolations && (
-          <span className="rounded-full border border-destructive/20 bg-destructive/10 px-2 py-0.5 font-mono text-xs font-bold text-destructive">
+          <span className="shrink-0 rounded-full border border-destructive/20 bg-destructive/10 px-2 py-0.5 font-mono text-xs font-bold text-destructive">
             {total}
           </span>
         )}
       </div>
 
-      <div className="px-3.5 py-3">
+      <div className="min-h-[52px] px-3.5 py-3">
         {err && (
           <p className="font-mono text-[10px] text-muted-foreground">
             failed to load violation data
@@ -83,10 +83,10 @@ export function ViolationsCard() {
               {total} direct master push{total === 1 ? '' : 'es'} detected
             </p>
             {latest && (
-              <div className="mt-1 flex items-center gap-2 font-mono text-[10px] text-muted-foreground">
-                <span>Most recent:</span>
-                <span className="text-foreground">{latest.agentId}</span>
-                <span className="text-muted-foreground/50">{timeAgo(latest.detectedAt)}</span>
+              <div className="mt-1 flex min-w-0 items-center gap-2 font-mono text-[10px] text-muted-foreground">
+                <span className="shrink-0">Most recent:</span>
+                <span className="truncate text-foreground">{latest.agentId}</span>
+                <span className="shrink-0 text-muted-foreground/50">{timeAgo(latest.detectedAt)}</span>
               </div>
             )}
           </>

--- a/packages/dashboard-v2/src/components/ViolationsCard.tsx
+++ b/packages/dashboard-v2/src/components/ViolationsCard.tsx
@@ -9,9 +9,11 @@ export function ViolationsCard() {
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
     api<ViolationsResponse>('violations?pageSize=1')
-      .then(setData)
-      .catch((e) => setErr(String(e?.message ?? e)));
+      .then((res) => { if (!cancelled) setData(res); })
+      .catch((e) => { if (!cancelled) setErr(String(e?.message ?? e)); });
+    return () => { cancelled = true; };
   }, []);
 
   const total = data?.total ?? 0;

--- a/packages/dashboard-v2/src/components/ViolationsCard.tsx
+++ b/packages/dashboard-v2/src/components/ViolationsCard.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react';
+import { api } from '@/lib/api';
+import { timeAgo } from '@/lib/utils';
+import { href } from '@/lib/router';
+import type { ViolationsResponse } from '@/lib/types';
+
+export function ViolationsCard() {
+  const [data, setData] = useState<ViolationsResponse | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    api<ViolationsResponse>('violations?pageSize=1')
+      .then(setData)
+      .catch((e) => setErr(String(e?.message ?? e)));
+  }, []);
+
+  const total = data?.total ?? 0;
+  const latest = data?.items?.[0] ?? null;
+  const hasViolations = total > 0;
+
+  return (
+    <div
+      className={`rounded-lg border ${
+        hasViolations
+          ? 'border-destructive/30 bg-destructive/10'
+          : 'border-border bg-muted/20'
+      }`}
+    >
+      <div
+        className={`flex items-center justify-between border-b px-3.5 py-3 ${
+          hasViolations
+            ? 'border-destructive/20 bg-destructive/[0.06]'
+            : 'border-border/40'
+        }`}
+      >
+        <div className="flex items-center gap-2">
+          <span
+            className={`inline-flex h-4 w-4 items-center justify-center rounded-sm font-mono text-[11px] font-bold ${
+              hasViolations
+                ? 'bg-destructive/15 text-destructive'
+                : 'bg-muted text-muted-foreground'
+            }`}
+          >
+            !
+          </span>
+          <span
+            className={`font-mono text-[11px] font-bold uppercase tracking-widest ${
+              hasViolations ? 'text-destructive' : 'text-muted-foreground'
+            }`}
+          >
+            Process Violations
+          </span>
+        </div>
+        {hasViolations && (
+          <span className="rounded-full border border-destructive/20 bg-destructive/10 px-2 py-0.5 font-mono text-xs font-bold text-destructive">
+            {total}
+          </span>
+        )}
+      </div>
+
+      <div className="px-3.5 py-3">
+        {err && (
+          <p className="font-mono text-[10px] text-muted-foreground">
+            failed to load violation data
+          </p>
+        )}
+
+        {!err && !data && (
+          <p className="font-mono text-[10px] text-muted-foreground/60">Loading…</p>
+        )}
+
+        {!err && data && !hasViolations && (
+          <p className="font-mono text-[10px] text-muted-foreground/70">
+            No violations detected
+          </p>
+        )}
+
+        {!err && data && hasViolations && (
+          <>
+            <p className="font-mono text-[11px] text-foreground">
+              {total} direct master push{total === 1 ? '' : 'es'} detected
+            </p>
+            {latest && (
+              <div className="mt-1 flex items-center gap-2 font-mono text-[10px] text-muted-foreground">
+                <span>Most recent:</span>
+                <span className="text-foreground">{latest.agentId}</span>
+                <span className="text-muted-foreground/50">{timeAgo(latest.detectedAt)}</span>
+              </div>
+            )}
+          </>
+        )}
+
+        {!err && data && (
+          <div className="mt-2 text-right">
+            <a
+              href={href('/violations')}
+              className={`font-mono text-[10px] transition hover:underline ${
+                hasViolations ? 'text-destructive' : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              View all →
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard-v2/src/components/ViolationsPage.tsx
+++ b/packages/dashboard-v2/src/components/ViolationsPage.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useState } from 'react';
+import { api } from '@/lib/api';
+import { timeAgo } from '@/lib/utils';
+import { href } from '@/lib/router';
+import type { ViolationEntry, ViolationsResponse } from '@/lib/types';
+
+const PAGE_SIZE = 25;
+
+function CommitCell({ commits }: { commits: string[] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (commits.length === 0) {
+    return <span className="text-muted-foreground/50">—</span>;
+  }
+
+  const first = commits[0];
+  // Extract just the subject (after sha prefix if present)
+  const subject = first.includes(' ') ? first.slice(first.indexOf(' ') + 1) : first;
+  const overflow = commits.length - 1;
+
+  return (
+    <span className="font-inter text-[11px]">
+      <span className="text-foreground">{subject}</span>
+      {overflow > 0 && (
+        <>
+          {' '}
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="font-mono text-[10px] text-muted-foreground/70 underline hover:text-foreground"
+          >
+            {expanded ? '(collapse)' : `(+${overflow} more)`}
+          </button>
+          {expanded && (
+            <ul className="mt-1 space-y-0.5 pl-2">
+              {commits.slice(1).map((c, i) => {
+                const s = c.includes(' ') ? c.slice(c.indexOf(' ') + 1) : c;
+                return (
+                  <li key={i} className="font-mono text-[10px] text-muted-foreground/80">
+                    {s}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </>
+      )}
+    </span>
+  );
+}
+
+function ViolationRow({ row }: { row: ViolationEntry }) {
+  const preSha = row.preSha.slice(0, 8);
+  const postSha = row.postSha.slice(0, 8);
+
+  return (
+    <tr className="border-t border-border/20 align-top transition-colors hover:bg-accent/20">
+      <td className="whitespace-nowrap py-3 pl-4 pr-4 font-mono text-[10px] text-muted-foreground/80">
+        {timeAgo(row.detectedAt)}
+      </td>
+      <td className="whitespace-nowrap py-3 pr-4">
+        <a
+          href={href(`/agent/${encodeURIComponent(row.agentId)}`)}
+          className="font-mono text-[11px] text-foreground hover:text-primary hover:underline"
+        >
+          {row.agentId}
+        </a>
+      </td>
+      <td className="whitespace-nowrap py-3 pr-4 font-mono text-[10px]">
+        <span className="text-muted-foreground/70">{preSha}</span>
+        <span className="mx-1 text-muted-foreground/40">→</span>
+        <span className="text-foreground">{postSha}</span>
+      </td>
+      <td className="py-3 pr-4">
+        <CommitCell commits={row.commits} />
+      </td>
+    </tr>
+  );
+}
+
+export function ViolationsPage() {
+  const [rows, setRows] = useState<ViolationEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    api<ViolationsResponse>(`violations?page=${page}&pageSize=${PAGE_SIZE}`)
+      .then((res) => {
+        setRows(res.items ?? []);
+        setTotal(res.total ?? 0);
+      })
+      .catch((e) => setError(String(e?.message ?? e)))
+      .finally(() => setLoading(false));
+  }, [page]);
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
+          Process Violations
+          {total > 0 && (
+            <span className="ml-2 text-destructive">{total}</span>
+          )}
+        </h1>
+        <p className="mt-0.5 font-mono text-[10px] text-muted-foreground/70">
+          Direct master pushes detected by the ref-allowlist enforcer
+        </p>
+      </div>
+
+      <div className="overflow-hidden rounded-md border border-border/40 bg-card/80">
+        {error && (
+          <div className="border-b border-border/60 bg-disputed/10 px-3 py-2 font-mono text-[10px] text-disputed">
+            {error}
+          </div>
+        )}
+
+        {!error && (
+          <table className="w-full text-left">
+            <thead>
+              <tr className="border-b border-border/40 bg-muted/20 font-mono text-[10px] uppercase tracking-wider text-muted-foreground/80">
+                <th className="py-2.5 pl-4 pr-4">When</th>
+                <th className="py-2.5 pr-4">Agent</th>
+                <th className="py-2.5 pr-4">Commit Range</th>
+                <th className="py-2.5 pr-4">Commits</th>
+              </tr>
+            </thead>
+            <tbody>
+              {!loading && rows.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="px-4 py-12 text-center font-mono text-[11px] text-muted-foreground/50">
+                    No violations recorded
+                  </td>
+                </tr>
+              )}
+              {loading && (
+                <tr>
+                  <td colSpan={4} className="px-4 py-8 text-center font-mono text-[10px] text-muted-foreground/50">
+                    Loading…
+                  </td>
+                </tr>
+              )}
+              {!loading && rows.map((row) => (
+                <ViolationRow key={`${row.taskId}-${row.detectedAt}`} row={row} />
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        <div className="flex items-center justify-between border-t border-border/60 px-3 py-2">
+          <span className="font-mono text-[10px] text-muted-foreground/60">
+            {loading
+              ? 'loading…'
+              : total === 0
+                ? 'no violations'
+                : `${(page - 1) * PAGE_SIZE + 1}–${Math.min(page * PAGE_SIZE, total)} of ${total}`}
+          </span>
+          <div className={`flex items-center gap-2 font-mono text-[10px] text-muted-foreground ${totalPages <= 1 ? 'invisible' : ''}`}>
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1 || loading}
+              className="rounded-sm border border-border/40 bg-card px-2 py-0.5 transition hover:bg-accent/50 disabled:opacity-30"
+            >
+              ◂ Prev
+            </button>
+            <span className="tabular-nums">{page} / {totalPages}</span>
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page >= totalPages || loading}
+              className="rounded-sm border border-border/40 bg-card px-2 py-0.5 transition hover:bg-accent/50 disabled:opacity-30"
+            >
+              Next ▸
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard-v2/src/components/ViolationsPage.tsx
+++ b/packages/dashboard-v2/src/components/ViolationsPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { api } from '@/lib/api';
 import { timeAgo } from '@/lib/utils';
-import { href } from '@/lib/router';
 import type { ViolationEntry, ViolationsResponse } from '@/lib/types';
 
 const PAGE_SIZE = 25;
@@ -26,6 +25,7 @@ function CommitCell({ commits }: { commits: string[] }) {
           {' '}
           <button
             type="button"
+            aria-expanded={expanded}
             onClick={() => setExpanded((v) => !v)}
             className="font-mono text-[10px] text-muted-foreground/70 underline hover:text-foreground"
           >
@@ -60,7 +60,7 @@ function ViolationRow({ row }: { row: ViolationEntry }) {
       </td>
       <td className="whitespace-nowrap py-3 pr-4">
         <a
-          href={href(`/agent/${encodeURIComponent(row.agentId)}`)}
+          href={`/dashboard/agent/${encodeURIComponent(row.agentId)}`}
           className="font-mono text-[11px] text-foreground hover:text-primary hover:underline"
         >
           {row.agentId}
@@ -86,15 +86,18 @@ export function ViolationsPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
     setLoading(true);
     setError(null);
     api<ViolationsResponse>(`violations?page=${page}&pageSize=${PAGE_SIZE}`)
       .then((res) => {
+        if (cancelled) return;
         setRows(res.items ?? []);
         setTotal(res.total ?? 0);
       })
-      .catch((e) => setError(String(e?.message ?? e)))
-      .finally(() => setLoading(false));
+      .catch((e) => { if (!cancelled) setError(String(e?.message ?? e)); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
   }, [page]);
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));

--- a/packages/dashboard-v2/src/components/ViolationsPage.tsx
+++ b/packages/dashboard-v2/src/components/ViolationsPage.tsx
@@ -18,7 +18,7 @@ function CommitCell({ commits }: { commits: string[] }) {
   const overflow = commits.length - 1;
 
   return (
-    <span className="font-inter text-[11px]">
+    <span className="font-mono text-[11px]">
       <span className="text-foreground">{subject}</span>
       {overflow > 0 && (
         <>
@@ -58,7 +58,7 @@ function ViolationRow({ row }: { row: ViolationEntry }) {
       <td className="whitespace-nowrap py-3 pl-4 pr-4 font-mono text-[10px] text-muted-foreground/80">
         {timeAgo(row.detectedAt)}
       </td>
-      <td className="whitespace-nowrap py-3 pr-4">
+      <td className="max-w-[160px] truncate whitespace-nowrap py-3 pr-4">
         <a
           href={`/dashboard/agent/${encodeURIComponent(row.agentId)}`}
           className="font-mono text-[11px] text-foreground hover:text-primary hover:underline"
@@ -105,12 +105,16 @@ export function ViolationsPage() {
   return (
     <div className="space-y-4">
       <div>
-        <h1 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
-          Process Violations
+        <div className="flex items-center gap-2">
+          <h1 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
+            Process Violations
+          </h1>
           {total > 0 && (
-            <span className="ml-2 text-destructive">{total}</span>
+            <span className="rounded-full border border-destructive/30 bg-destructive/10 px-2 py-0.5 font-mono text-xs font-bold text-destructive">
+              {total}
+            </span>
           )}
-        </h1>
+        </div>
         <p className="mt-0.5 font-mono text-[10px] text-muted-foreground/70">
           Direct master pushes detected by the ref-allowlist enforcer
         </p>
@@ -118,13 +122,13 @@ export function ViolationsPage() {
 
       <div className="overflow-hidden rounded-md border border-border/40 bg-card/80">
         {error && (
-          <div className="border-b border-border/60 bg-disputed/10 px-3 py-2 font-mono text-[10px] text-disputed">
+          <div className="border-b border-border/60 bg-destructive/10 px-3 py-2 font-mono text-[10px] text-destructive">
             {error}
           </div>
         )}
 
         {!error && (
-          <table className="w-full text-left">
+          <table className="w-full table-fixed text-left">
             <thead>
               <tr className="border-b border-border/40 bg-muted/20 font-mono text-[10px] uppercase tracking-wider text-muted-foreground/80">
                 <th className="py-2.5 pl-4 pr-4">When</th>
@@ -136,14 +140,14 @@ export function ViolationsPage() {
             <tbody>
               {!loading && rows.length === 0 && (
                 <tr>
-                  <td colSpan={4} className="px-4 py-12 text-center font-mono text-[11px] text-muted-foreground/50">
+                  <td colSpan={4} className="px-4 py-6 text-center font-mono text-[11px] text-muted-foreground/50">
                     No violations recorded
                   </td>
                 </tr>
               )}
               {loading && (
                 <tr>
-                  <td colSpan={4} className="px-4 py-8 text-center font-mono text-[10px] text-muted-foreground/50">
+                  <td colSpan={4} className="px-4 py-6 text-center font-mono text-[10px] text-muted-foreground/50">
                     Loading…
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary

PR B (frontend split) of the ref-allowlist dashboard surface per [`docs/specs/2026-04-29-ref-allowlist-dashboard.md`](docs/specs/2026-04-29-ref-allowlist-dashboard.md). Adds the Overview card and the `/violations` drill-in page consuming the API shipped in PR A.

**Stacked on #324.** Will rebase onto master after #324 merges (do not `--delete-branch` on #324).

## Files

- **NEW** `packages/dashboard-v2/src/components/ViolationsCard.tsx` — Overview card. Fetches `/dashboard/api/violations?pageSize=1`. N=0 → muted "No violations detected" placeholder (always visible — signals system is armed). N>0 → `bg-destructive/10 border-destructive/30` + count + most-recent agent + timeAgo. "View all →" link via `href()` helper. Mirrors `CircuitAlerts` structure.
- **NEW** `packages/dashboard-v2/src/components/ViolationsPage.tsx` — `/violations` drill-in. Table: When | Agent | Commit Range | Commits. Agent cell links to `/agent/{id}` (TeamPage leaderboard pattern). SHA delta `preSha.slice(0,8) → postSha.slice(0,8)` monospace. Commits cell shows first subject + `(+N more)` inline-expand toggle. Prev/next pagination at `pageSize=25`.
- **EDIT** `packages/dashboard-v2/src/App.tsx` — import + place `ViolationsCard` in Overview sidebar after `CircuitAlerts`; add `/violations` route returning `<ViolationsPage />`.

## Test plan

- [x] `npx tsc --noEmit -p packages/dashboard-v2/tsconfig.json` — only the pre-existing `useElementWidth.ts:23` React 19 RefObject error (verified present on base branch before changes)
- [x] No changes outside the 3 listed files
- [ ] Visual verification post-build (per `feedback_visual_verify_after_dashboard_pr.md`) — orchestrator to crop card + page screenshots once PR is reviewable

## Upstream

- PR #316 (commit 58d52e0) — ref-allowlist detector (writes `process-violations.jsonl`, emits `boundary_escape` signal with category `process_discipline`).
- PR #324 — PR A, backend split (API endpoint + signal label fix). This PR consumes its `ViolationEntry`/`ViolationsResponse` types and the `/dashboard/api/violations` route.

## Note on consensus

Spec gates consensus before merging PR B (touches Overview layout). Consensus dispatch will follow this PR open.