### PR TITLE
feat(eval): curated eval-suite PR A — harness + 5 seed cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ apps/cli/src/**/*.d.ts
 settings.local.json
 gossipcat-*.tgz
 .mcpregistry_*
+eval/.runs/
+eval/cases-private/

--- a/apps/cli/src/commands/eval.ts
+++ b/apps/cli/src/commands/eval.ts
@@ -1,0 +1,21 @@
+/**
+ * apps/cli/src/commands/eval.ts — thin shim for `gossipcat eval`.
+ *
+ * The actual handler lives in `eval/cli-handler.ts` at the repo root, so the
+ * harness/match/score modules can sit under `eval/` without violating the
+ * CLI tsconfig's `rootDir: src` constraint. We dynamic-import via a path
+ * resolved at runtime — this keeps tsc happy and ts-node/JIT-runtime works
+ * because the eval/ directory is reachable from the project working dir.
+ */
+
+import { resolve } from 'path';
+
+export async function runEvalCommand(argv: string[]): Promise<void> {
+  // Resolve the handler from the project working dir so this shim works
+  // whether the CLI is launched via `npm start`, `npx ts-node`, or a packed
+  // binary that ships with eval/ on disk.
+  const handlerPath = resolve(process.cwd(), 'eval', 'cli-handler');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const mod = require(handlerPath) as { runEvalCommand: (argv: string[]) => Promise<void> };
+  await mod.runEvalCommand(argv);
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -48,6 +48,12 @@ async function main(): Promise<void> {
       return;
     }
 
+    case 'eval': {
+      const { runEvalCommand } = await import('./commands/eval');
+      await runEvalCommand(process.argv.slice(3));
+      return;
+    }
+
     case 'help':
     case '--help':
     case '-h':
@@ -176,6 +182,7 @@ function printHelp(): void {
     gossipcat tasks            Show recent task history
     gossipcat tasks <id>       Show detail for a specific task
     gossipcat tasks --agent <id>  Filter tasks by agent
+    gossipcat eval             Run the curated eval suite (eval/cases/*.yaml)
     gossipcat sync             Sync task history to Supabase
     gossipcat sync --setup     Configure Supabase connection
     gossipcat sync --status    Show sync status

--- a/eval/README.md
+++ b/eval/README.md
@@ -1,0 +1,146 @@
+# Curated Eval Suite
+
+Fixed-corpus benchmark for agent review accuracy. Each case freezes a
+"the bug was here, the fix landed in commit X" pair, replays it against a
+configurable agent set, and scores findings against a known ground truth.
+
+Spec: `docs/specs/2026-04-29-curated-eval-suite.md` (gitignored — see your
+local checkout).
+
+## Quick start
+
+```bash
+# Run the full suite against all native:true reviewers in .gossip/config.json
+gossipcat eval
+
+# Subset of cases / agents
+gossipcat eval --cases eval/cases/2026-04-29-pr325-aria-expanded.yaml --agents sonnet-reviewer
+
+# Paired before/after via McNemar (after a skill change, etc.)
+gossipcat eval --against eval/.runs/2026-04-29T12-00-00-000Z
+```
+
+Output: a Markdown leaderboard on stdout plus per-run artefacts under
+`eval/.runs/<runId>/` (gitignored).
+
+## Case format
+
+```yaml
+id: pr325-abortcontroller            # short, kebab-case, unique
+title: Human-readable case title
+parent_sha: a3f36b7                  # commit BEFORE the fix
+fix_sha: 0424bf8                     # commit that resolved it (optional)
+fix_pr: 325                          # PR number (optional)
+scope:
+  files:
+    - packages/dashboard-v2/src/components/ViolationsCard.tsx
+ground_truth:
+  - id: gt1                          # stable per-case identifier
+    severity: medium                 # critical | high | medium | low
+    file: packages/.../ViolationsCard.tsx
+    line_range: [11, 15]             # inclusive [start, end]
+    summary: useEffect fetch lacks cleanup; setState fires on unmount
+    category: concurrency            # match the agent finding-tag categories
+prompt: |
+  The natural-language task the agent receives. NO ground-truth
+  hints. NO answer leakage.
+notes: |
+  Free-form notes for case authors. Never sent to the agent.
+```
+
+A negative case sets `ground_truth: []`. The expectation is that consensus
+emits zero findings — any non-empty output drops precision to 0.
+
+## Scoring rubric
+
+For each agent finding `f` against the case ground-truth list:
+
+```
+match(f, gt):
+  if f.file != gt.file: 0
+  if f.line outside gt.line_range ± 5: 0.5     # near miss
+  if token_similarity(f.summary, gt.summary) > 0.6: 1.0
+  if f.category == gt.category: 0.7
+  else: 0.3
+```
+
+`token_similarity` is Jaccard on lowercased word-tokens after stopword strip.
+Severity weights: `critical=4, high=2, medium=1, low=0.5`. A missed `critical`
+ground truth costs 4× a missed `low`; same multiplier on the fabrication side.
+
+Per-agent metrics are micro-averaged across cases:
+
+```
+Precision = Σ(match · w_finding) / Σ(w_finding)
+Recall    = Σ(matched_gt_w)       / Σ(gt_w)
+F1        = 2 · P · R / (P + R)
+```
+
+A case is considered "passed" by an agent when `F1 ≥ 0.5` — that's the
+threshold McNemar pairing uses.
+
+## Anti-contamination
+
+The suite lives under `eval/cases/` and is checked into the repo. Mitigations:
+
+1. **No ground truth in the dispatch prompt.** `prepareDispatchCase()` in
+   `eval/harness.ts` is the single chokepoint: it builds the
+   `DispatchableCase` from the loaded yaml, dropping the `ground_truth`
+   block before any string ever reaches the agent. The
+   `tests/eval/contamination.test.ts` test asserts that no ground-truth
+   sentinel string appears in the prompt sent to the dispatcher.
+2. **Hold-out cases.** Operators may drop additional cases in
+   `eval/cases-private/` (gitignored). These are the real gate; the
+   visible suite is the dev-loop signal.
+3. **Suite rotation.** Add ≥10 new cases per quarter, retire equal number
+   (PR C concern, not PR A).
+
+## McNemar paired before/after
+
+When testing a skill change, run the suite twice:
+
+```bash
+gossipcat eval                                     # writes runId R0
+# ... develop or bind a new skill ...
+gossipcat eval --against eval/.runs/R0             # writes R1, paired vs R0
+```
+
+Output 2x2:
+
+|                  | After: pass | After: fail |
+|------------------|-------------|-------------|
+| **Before: pass** | a (no change) | b (regression) |
+| **Before: fail** | c (improved)  | d (still failing) |
+
+`χ² = (b - c)² / (b + c)`. We do **not** compute p-values; operator interprets
+with df=1, or pipes χ² downstream. With N≈30 cases, `|b - c| ≥ 7` is roughly
+p<0.05 — anything below that lacks the statistical power to declare a real
+movement, only suggestive signal.
+
+## Adding a case
+
+1. Find a real PR in this repo where consensus / cross-review caught a
+   real bug, and a fix commit landed. The PR description must cite the
+   bug specifically.
+2. Identify `parent_sha` (commit before the fix) and `fix_sha`. Confirm
+   the bug is reproducible at `parent_sha` via local checkout.
+3. Write `ground_truth[]` from the fix commit's actual changes — file,
+   inclusive line range, one-sentence summary, category, severity.
+4. Pick a `prompt` that mirrors what a reviewer would naturally be asked
+   for that surface. Do NOT hint at the bug.
+5. Add `notes:` describing what the failure mode looks like and why this
+   case is in the suite.
+
+For negative cases, set `ground_truth: []` and document the failure mode
+the case is meant to catch in `notes:`.
+
+## Files
+
+| File              | Purpose                                                           |
+|-------------------|-------------------------------------------------------------------|
+| `harness.ts`      | `loadCases`, `runCase`, `runSuite`. Anti-contamination chokepoint. |
+| `match.ts`        | `match()` rubric + `tokenSimilarity` (Jaccard, stopword strip).    |
+| `score.ts`        | Precision / Recall / F1 with severity weights.                     |
+| `report.ts`       | `formatLeaderboard`, `formatMcNemar`.                              |
+| `cases/*.yaml`    | The visible suite.                                                 |
+| `.runs/<runId>/`  | Per-case JSON + leaderboard.md + mcnemar.md (gitignored).          |

--- a/eval/README.md
+++ b/eval/README.md
@@ -117,6 +117,19 @@ with df=1, or pipes χ² downstream. With N≈30 cases, `|b - c| ≥ 7` is rough
 p<0.05 — anything below that lacks the statistical power to declare a real
 movement, only suggestive signal.
 
+> **Divergence note — McNemar pairing pass-proxy.** When `--against
+> <baselineDir>` is used, baseline `pass/fail` outcomes are reconstructed from
+> per-case JSON using a coarse proxy: any non-empty `byAgent` finding list
+> counts as a pass. The "current" run uses the strict `F1 ≥ 0.5` threshold
+> documented above. The two halves of the 2×2 are therefore not measured on
+> the same scale; pairing is suggestive, not statistically clean. The CLI
+> emits a stderr warning when this proxy is in effect.
+>
+> For strict same-threshold pairing, rerun `runSuite()` over the archived
+> cases against the baseline run and compare per-case `F1 ≥ 0.5` directly
+> instead of going through `--against`. The `eval/.runs/<runId>/<caseId>.json`
+> files preserve `groundTruth` so this rerun is fully offline.
+
 ## Adding a case
 
 1. Find a real PR in this repo where consensus / cross-review caught a

--- a/eval/cases/2026-04-29-gemini-files-missing.yaml
+++ b/eval/cases/2026-04-29-gemini-files-missing.yaml
@@ -1,0 +1,17 @@
+id: gemini-files-missing
+title: NEGATIVE — agent should not fabricate "files missing" findings
+parent_sha: a3f36b7
+scope:
+  files:
+    - packages/dashboard-v2/src/components/ViolationsCard.tsx
+    - packages/dashboard-v2/src/components/ViolationsPage.tsx
+ground_truth: []
+prompt: |
+  Review the listed files. Report only findings you can anchor with a real
+  file:line citation that exists in the supplied scope.
+notes: |
+  NEGATIVE case. The known failure mode here is gemini-reviewer under broken
+  resolutionRoots claiming "files missing" or "scope unreachable" when in
+  fact the files exist and are well-formed. A consensus run on this case
+  should produce zero findings — any non-empty output drops precision to 0
+  (fabrication penalty, weighted by severity).

--- a/eval/cases/2026-04-29-gemini-files-missing.yaml
+++ b/eval/cases/2026-04-29-gemini-files-missing.yaml
@@ -9,9 +9,3 @@ ground_truth: []
 prompt: |
   Review the listed files. Report only findings you can anchor with a real
   file:line citation that exists in the supplied scope.
-notes: |
-  NEGATIVE case. The known failure mode here is gemini-reviewer under broken
-  resolutionRoots claiming "files missing" or "scope unreachable" when in
-  fact the files exist and are well-formed. A consensus run on this case
-  should produce zero findings — any non-empty output drops precision to 0
-  (fabrication penalty, weighted by severity).

--- a/eval/cases/2026-04-29-pr325-abortcontroller.yaml
+++ b/eval/cases/2026-04-29-pr325-abortcontroller.yaml
@@ -23,7 +23,3 @@ ground_truth:
 prompt: |
   Review the listed React components for fetch lifecycle bugs — in particular,
   setState-after-unmount and stale-response races on dependency change.
-notes: |
-  Both findings landed together in fix commit 0424bf8 (PR #325). Positive case:
-  consensus should recall both. Recall>=0.5 is the bar; precision drops with
-  fabricated extras.

--- a/eval/cases/2026-04-29-pr325-abortcontroller.yaml
+++ b/eval/cases/2026-04-29-pr325-abortcontroller.yaml
@@ -1,0 +1,29 @@
+id: pr325-abortcontroller
+title: Missing AbortController on fetch in dashboard ViolationsCard / ViolationsPage
+parent_sha: a3f36b7
+fix_sha: 0424bf8
+fix_pr: 325
+scope:
+  files:
+    - packages/dashboard-v2/src/components/ViolationsCard.tsx
+    - packages/dashboard-v2/src/components/ViolationsPage.tsx
+ground_truth:
+  - id: gt1
+    severity: medium
+    file: packages/dashboard-v2/src/components/ViolationsCard.tsx
+    line_range: [11, 15]
+    summary: useEffect fetch lacks cleanup; setState fires on unmount race
+    category: concurrency
+  - id: gt2
+    severity: medium
+    file: packages/dashboard-v2/src/components/ViolationsPage.tsx
+    line_range: [88, 98]
+    summary: useEffect fetch on [page] dependency lacks AbortController; Prev/Next race condition leaves stale page rendered
+    category: concurrency
+prompt: |
+  Review the listed React components for fetch lifecycle bugs — in particular,
+  setState-after-unmount and stale-response races on dependency change.
+notes: |
+  Both findings landed together in fix commit 0424bf8 (PR #325). Positive case:
+  consensus should recall both. Recall>=0.5 is the bar; precision drops with
+  fabricated extras.

--- a/eval/cases/2026-04-29-pr325-aria-expanded.yaml
+++ b/eval/cases/2026-04-29-pr325-aria-expanded.yaml
@@ -1,0 +1,22 @@
+id: pr325-aria-expanded
+title: Disclosure button missing aria-expanded — a11y regression in ViolationsPage
+parent_sha: a3f36b7
+fix_sha: 0424bf8
+fix_pr: 325
+scope:
+  files:
+    - packages/dashboard-v2/src/components/ViolationsPage.tsx
+ground_truth:
+  - id: gt1
+    severity: low
+    file: packages/dashboard-v2/src/components/ViolationsPage.tsx
+    line_range: [27, 33]
+    summary: Toggle button lacks aria-expanded reflecting open/closed state; screen readers can't announce disclosure status
+    category: accessibility
+prompt: |
+  Review this component for accessibility issues, focusing on ARIA attribute
+  coverage on interactive elements.
+notes: |
+  Positive a11y case. low-severity by design — fabricating a "critical a11y"
+  finding would cost 4× a low truth miss, so this case stress-tests severity
+  weighting on the fabrication side too.

--- a/eval/cases/2026-04-29-pr325-aria-expanded.yaml
+++ b/eval/cases/2026-04-29-pr325-aria-expanded.yaml
@@ -16,7 +16,3 @@ ground_truth:
 prompt: |
   Review this component for accessibility issues, focusing on ARIA attribute
   coverage on interactive elements.
-notes: |
-  Positive a11y case. low-severity by design — fabricating a "critical a11y"
-  finding would cost 4× a low truth miss, so this case stress-tests severity
-  weighting on the fabrication side too.

--- a/eval/cases/2026-04-29-pr325-color-token-split.yaml
+++ b/eval/cases/2026-04-29-pr325-color-token-split.yaml
@@ -1,0 +1,22 @@
+id: pr325-color-token-split
+title: Color token used for both severity and status — semantic ambiguity in ViolationsPage
+parent_sha: 0424bf8
+fix_sha: d9c6f4a
+fix_pr: 325
+scope:
+  files:
+    - packages/dashboard-v2/src/components/ViolationsPage.tsx
+ground_truth:
+  - id: gt1
+    severity: critical
+    file: packages/dashboard-v2/src/components/ViolationsPage.tsx
+    line_range: [121, 121]
+    summary: Single color token mapped to both severity and status states; renders identical hue for unrelated meanings
+    category: type_safety
+prompt: |
+  Review this component for semantic / typing issues with color or status
+  mapping. Look for one token serving two different conceptual axes.
+notes: |
+  Positive semantic case. The mapped token lacked a discriminator between
+  severity-axis and status-axis renderings; fix split it into two tokens.
+  type_safety category captures "single value smuggled across two domains."

--- a/eval/cases/2026-04-29-pr325-color-token-split.yaml
+++ b/eval/cases/2026-04-29-pr325-color-token-split.yaml
@@ -16,7 +16,3 @@ ground_truth:
 prompt: |
   Review this component for semantic / typing issues with color or status
   mapping. Look for one token serving two different conceptual axes.
-notes: |
-  Positive semantic case. The mapped token lacked a discriminator between
-  severity-axis and status-axis renderings; fix split it into two tokens.
-  type_safety category captures "single value smuggled across two domains."

--- a/eval/cases/2026-04-29-pr325-sidebar-overflow.yaml
+++ b/eval/cases/2026-04-29-pr325-sidebar-overflow.yaml
@@ -16,7 +16,3 @@ ground_truth:
 prompt: |
   Review this dashboard component for layout bugs at narrow viewports.
   Focus on width constraints, overflow, and grid-cell sizing.
-notes: |
-  Positive design case. The fix landed post-rebase as d9c6f4a (the original
-  pre-rebase SHA was 037f302). Consensus should catch the missing min-width:0 /
-  overflow handling. visual-category findings are the expected anchor.

--- a/eval/cases/2026-04-29-pr325-sidebar-overflow.yaml
+++ b/eval/cases/2026-04-29-pr325-sidebar-overflow.yaml
@@ -1,0 +1,22 @@
+id: pr325-sidebar-overflow
+title: ViolationsCard sidebar widget overflows its grid cell at narrow widths
+parent_sha: 0424bf8
+fix_sha: d9c6f4a
+fix_pr: 325
+scope:
+  files:
+    - packages/dashboard-v2/src/components/ViolationsCard.tsx
+ground_truth:
+  - id: gt1
+    severity: critical
+    file: packages/dashboard-v2/src/components/ViolationsCard.tsx
+    line_range: [86, 90]
+    summary: Sidebar tile width unconstrained — content overflows grid cell at <=1280px viewports
+    category: visual
+prompt: |
+  Review this dashboard component for layout bugs at narrow viewports.
+  Focus on width constraints, overflow, and grid-cell sizing.
+notes: |
+  Positive design case. The fix landed post-rebase as d9c6f4a (the original
+  pre-rebase SHA was 037f302). Consensus should catch the missing min-width:0 /
+  overflow handling. visual-category findings are the expected anchor.

--- a/eval/cli-handler.ts
+++ b/eval/cli-handler.ts
@@ -1,0 +1,126 @@
+/**
+ * eval/cli-handler.ts — `gossipcat eval` implementation.
+ *
+ * Lives at repo root rather than apps/cli/src because the harness/match/score
+ * modules also live under eval/ and the CLI tsconfig's rootDir would forbid
+ * cross-tree imports. The CLI shim at apps/cli/src/commands/eval.ts dynamic-
+ * loads this module at runtime.
+ *
+ * Flags:
+ *   --cases <glob>           Repeatable. Defaults to eval/cases/*.yaml + eval/cases-private/*.yaml
+ *   --agents <id,id,...>     Comma-separated. Defaults to all native:true agents in .gossip/config.json.
+ *   --out <path>             Output dir. Defaults to eval/.runs/.
+ *   --against <runDir>       Compute McNemar paired against the named baseline run dir.
+ */
+
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+
+import { loadCases, runSuite } from './harness';
+import { formatLeaderboard, formatMcNemar, PairedOutcome } from './report';
+import { findConfigPath, loadConfig } from '../apps/cli/src/config';
+
+interface EvalArgs {
+  cases?: string[];
+  agents?: string[];
+  out?: string;
+  against?: string;
+}
+
+function parseArgs(argv: string[]): EvalArgs {
+  const out: EvalArgs = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--cases' && i + 1 < argv.length) {
+      out.cases = (out.cases || []).concat(argv[++i]);
+    } else if (a === '--agents' && i + 1 < argv.length) {
+      out.agents = argv[++i].split(',').map(s => s.trim()).filter(Boolean);
+    } else if (a === '--out' && i + 1 < argv.length) {
+      out.out = argv[++i];
+    } else if (a === '--against' && i + 1 < argv.length) {
+      out.against = argv[++i];
+    }
+  }
+  return out;
+}
+
+function defaultAgents(): string[] {
+  const cfgPath = findConfigPath();
+  if (!cfgPath) return [];
+  try {
+    const cfg = loadConfig(cfgPath);
+    if (!cfg.agents) return [];
+    return Object.entries(cfg.agents)
+      .filter(([_id, a]) => a.native === true)
+      .map(([id]) => id);
+  } catch {
+    return [];
+  }
+}
+
+export async function runEvalCommand(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+  const root = process.cwd();
+  const casePatterns = args.cases && args.cases.length > 0
+    ? args.cases
+    : ['eval/cases/*.yaml', 'eval/cases-private/*.yaml'];
+  const agents = args.agents && args.agents.length > 0 ? args.agents : defaultAgents();
+
+  const cases = casePatterns.flatMap(p => loadCases(p, root));
+  if (cases.length === 0) {
+    process.stdout.write('# Eval Suite\n\n_No cases found._\n');
+    return;
+  }
+
+  const outDir = args.out ? resolve(args.out) : join(root, 'eval', '.runs');
+  const { scores } = await runSuite(cases, agents, { outDir, worktreeRoot: root });
+
+  const leaderboard = formatLeaderboard(scores);
+  process.stdout.write(leaderboard);
+
+  const summaryPath = join(outDir, scores.runId, 'leaderboard.md');
+  writeFileSync(summaryPath, leaderboard);
+
+  if (args.against) {
+    const baselineDir = resolve(args.against);
+    const after: PairedOutcome[] = scores.perCase.map(sc => ({
+      caseId: sc.caseId,
+      pass: sc.f1 >= 0.5,
+    }));
+    const before = loadBaselineOutcomes(baselineDir);
+    if (before.length === 0) {
+      process.stdout.write(`\n_No baseline outcomes found at ${baselineDir}._\n`);
+      return;
+    }
+    const mc = formatMcNemar(before, after);
+    process.stdout.write('\n' + mc);
+    writeFileSync(join(outDir, scores.runId, 'mcnemar.md'), mc);
+  }
+}
+
+function loadBaselineOutcomes(baselineDir: string): PairedOutcome[] {
+  if (!existsSync(baselineDir)) return [];
+  const files = readdirSync(baselineDir).filter(f => f.endsWith('.json'));
+  const outcomes: PairedOutcome[] = [];
+  for (const f of files) {
+    try {
+      const raw = JSON.parse(readFileSync(join(baselineDir, f), 'utf-8')) as {
+        caseId?: unknown;
+        byAgent?: Record<string, unknown[]>;
+      };
+      // Coarse pass proxy: any non-empty per-agent finding list ⇒ pass.
+      // Operators wanting sharper pairing should rerun runSuite() over the
+      // archived cases and use the per-case F1 directly.
+      const byAgent = raw.byAgent || {};
+      let any = false;
+      for (const aid of Object.keys(byAgent)) {
+        const list = byAgent[aid];
+        if (Array.isArray(list) && list.length > 0) { any = true; break; }
+      }
+      outcomes.push({ caseId: String(raw.caseId), pass: any });
+    } catch {
+      // skip unreadable
+    }
+  }
+  return outcomes;
+}

--- a/eval/cli-handler.ts
+++ b/eval/cli-handler.ts
@@ -92,6 +92,11 @@ export async function runEvalCommand(argv: string[]): Promise<void> {
       process.stdout.write(`\n_No baseline outcomes found at ${baselineDir}._\n`);
       return;
     }
+    process.stderr.write(
+      "⚠ Baseline outcomes loaded with coarse 'any findings = pass' proxy. " +
+      'For strict F1>=0.5 pairing, manually rerun runSuite() over the archived ' +
+      'cases. See README §McNemar.\n',
+    );
     const mc = formatMcNemar(before, after);
     process.stdout.write('\n' + mc);
     writeFileSync(join(outDir, scores.runId, 'mcnemar.md'), mc);

--- a/eval/harness.ts
+++ b/eval/harness.ts
@@ -1,0 +1,551 @@
+/**
+ * eval/harness.ts — load cases, dispatch consensus at parent_sha, score.
+ *
+ * Anti-contamination contract (spec § "Anti-contamination"):
+ *   1. The dispatched prompt MUST be the case `prompt` field plus the file
+ *      list — NEVER the `ground_truth` block. We strip ground_truth from the
+ *      object passed to the dispatch layer in `prepareDispatchCase`.
+ *   2. Run results are written to eval/.runs/<runId>/<caseId>.json.
+ *
+ * Checkout strategy:
+ *   - Each case freezes a `parent_sha` (state before the bug was caught).
+ *   - The harness checks out parent_sha in a worktree-scoped manner, runs
+ *     consensus, restores HEAD on completion. To stay safe in concurrent
+ *     environments we operate against an explicit worktree path provided by
+ *     the caller; if absent, we run against process.cwd() and best-effort
+ *     restore.
+ *
+ * MVP note (PR A): This harness wires dispatch via the MainAgent API. If the
+ * caller's environment can't reach a relay/orchestrator (no API key, sandbox,
+ * etc.) we still emit a structured run file with empty `byAgent` so the
+ * scoring + reporting paths are exercised end-to-end. That's the "score may
+ * be 0/0 but proves wiring" path called out in the spec § "Phasing".
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import { dirname, isAbsolute, join, relative, resolve } from 'path';
+import { execFileSync } from 'child_process';
+
+import { FindingShape, GroundTruthShape } from './match';
+import { CaseRun, scoreSuite, SuiteScores } from './score';
+
+export interface EvalCase {
+  id: string;
+  title: string;
+  parent_sha: string;
+  fix_sha?: string;
+  fix_pr?: number;
+  scope: { files: string[] };
+  ground_truth: GroundTruthShape[];
+  prompt: string;
+  notes?: string;
+  /** Original yaml path on disk — for traceability in run files. */
+  sourcePath: string;
+}
+
+/** What we hand to the dispatch layer — `ground_truth` is GONE. */
+export interface DispatchableCase {
+  id: string;
+  title: string;
+  parent_sha: string;
+  scope: { files: string[] };
+  prompt: string;
+  notes?: string;
+}
+
+export interface RunOptions {
+  /** Working tree to operate on. Defaults to process.cwd(). */
+  worktreeRoot?: string;
+  /** Output directory for run JSON. Defaults to <worktreeRoot>/eval/.runs. */
+  outDir?: string;
+  /** Agent IDs to dispatch. Empty array → no dispatch, harness still scores. */
+  agents?: string[];
+  /**
+   * Optional injection point — caller can supply a custom dispatcher (e.g. for
+   * tests, or to wire into an already-running MainAgent). Receives the
+   * sanitized DispatchableCase plus agent IDs and returns a per-agent finding
+   * map. If omitted, the harness runs the default MainAgent dispatch path.
+   */
+  dispatcher?: (sanitized: DispatchableCase, agents: string[]) => Promise<Record<string, FindingShape[]>>;
+  /**
+   * Skip git checkout entirely. Useful in tests where we just want to validate
+   * the prompt/sanitization path. Default: false.
+   */
+  skipCheckout?: boolean;
+}
+
+/** Load a single yaml case file. Tailored to the `eval/cases/*.yaml` schema. */
+export function loadCase(yamlPath: string): EvalCase {
+  const raw = readFileSync(yamlPath, 'utf-8');
+  return parseCaseYaml(raw, yamlPath);
+}
+
+/** Load all cases matching a glob-ish filter. Supports `eval/cases/*.yaml` shape. */
+export function loadCases(globPath: string, baseDir?: string): EvalCase[] {
+  const base = baseDir || process.cwd();
+  const out: EvalCase[] = [];
+
+  // Minimal glob: we only honor a trailing `*.yaml` pattern. Anything else is
+  // treated as a literal file path. The full-glob job belongs to the CLI layer
+  // where the shell already expanded paths.
+  if (globPath.endsWith('*.yaml') || globPath.endsWith('*.yml')) {
+    const dir = isAbsolute(globPath) ? dirname(globPath) : resolve(base, dirname(globPath));
+    if (!existsSync(dir)) return out;
+    const ext = globPath.endsWith('.yml') ? '.yml' : '.yaml';
+    for (const name of readdirSync(dir)) {
+      if (!name.endsWith(ext)) continue;
+      out.push(loadCase(join(dir, name)));
+    }
+    return out;
+  }
+
+  const p = isAbsolute(globPath) ? globPath : resolve(base, globPath);
+  if (existsSync(p)) out.push(loadCase(p));
+  return out;
+}
+
+/** Strip ground_truth from an EvalCase. The single anti-contamination chokepoint. */
+export function prepareDispatchCase(c: EvalCase): DispatchableCase {
+  return {
+    id: c.id,
+    title: c.title,
+    parent_sha: c.parent_sha,
+    scope: { files: [...c.scope.files] },
+    prompt: c.prompt,
+    ...(c.notes ? { notes: c.notes } : {}),
+  };
+}
+
+/** Build the natural-language prompt that goes to each reviewer agent. */
+export function buildDispatchPrompt(d: DispatchableCase): string {
+  const fileList = d.scope.files.map(f => `- ${f}`).join('\n');
+  return `Eval case: ${d.title}\n\n${d.prompt}\n\nScope (review only these files):\n${fileList}\n`;
+}
+
+export interface RunCaseResult {
+  caseId: string;
+  runId: string;
+  parent_sha: string;
+  agents: string[];
+  byAgent: Record<string, FindingShape[]>;
+  outPath: string;
+  /** Set when something went wrong but we still emitted a placeholder run file. */
+  warning?: string;
+}
+
+function gitOk(args: string[], cwd: string): { ok: boolean; out: string; err?: string } {
+  try {
+    const out = execFileSync('git', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] }).toString();
+    return { ok: true, out };
+  } catch (e) {
+    const err = e instanceof Error ? e.message : String(e);
+    return { ok: false, out: '', err };
+  }
+}
+
+export async function runCase(
+  c: EvalCase,
+  agents: string[],
+  opts: RunOptions = {},
+): Promise<RunCaseResult> {
+  const root = opts.worktreeRoot ? resolve(opts.worktreeRoot) : process.cwd();
+  const outDir = opts.outDir ? resolve(opts.outDir) : join(root, 'eval', '.runs');
+  const runId = process.env.GOSSIP_EVAL_RUN_ID || new Date().toISOString().replace(/[:.]/g, '-');
+  const runDir = join(outDir, runId);
+  if (!existsSync(runDir)) mkdirSync(runDir, { recursive: true });
+  const outPath = join(runDir, `${c.id}.json`);
+
+  const sanitized = prepareDispatchCase(c);
+
+  let restoreRef: string | undefined;
+  let warning: string | undefined;
+  if (!opts.skipCheckout) {
+    const head = gitOk(['rev-parse', '--abbrev-ref', 'HEAD'], root);
+    if (head.ok) restoreRef = head.out.trim() === 'HEAD'
+      ? gitOk(['rev-parse', 'HEAD'], root).out.trim()
+      : head.out.trim();
+    const co = gitOk(['checkout', c.parent_sha], root);
+    if (!co.ok) {
+      warning = `git checkout ${c.parent_sha} failed: ${co.err}`;
+    }
+  }
+
+  let byAgent: Record<string, FindingShape[]> = {};
+  try {
+    if (agents.length > 0) {
+      const dispatcher = opts.dispatcher || defaultDispatcher;
+      byAgent = await dispatcher(sanitized, agents);
+    }
+  } catch (e) {
+    warning = (warning ? warning + '; ' : '') + `dispatcher threw: ${e instanceof Error ? e.message : String(e)}`;
+    byAgent = {};
+  } finally {
+    if (!opts.skipCheckout && restoreRef) {
+      gitOk(['checkout', restoreRef], root);
+    }
+  }
+
+  const result: RunCaseResult = {
+    caseId: c.id,
+    runId,
+    parent_sha: c.parent_sha,
+    agents,
+    byAgent,
+    outPath,
+    ...(warning ? { warning } : {}),
+  };
+
+  // Run file includes ground_truth so scoring is reproducible offline. The
+  // anti-contamination contract is about what reaches the *agent*, not what
+  // gets written to disk after the run is complete.
+  writeFileSync(outPath, JSON.stringify({
+    runId,
+    caseId: c.id,
+    parent_sha: c.parent_sha,
+    sourcePath: relative(root, c.sourcePath),
+    agents,
+    byAgent,
+    groundTruth: c.ground_truth,
+    warning,
+    timestamp: new Date().toISOString(),
+  }, null, 2));
+
+  return result;
+}
+
+/** Run multiple cases sequentially and emit a SuiteScores. */
+export async function runSuite(
+  cases: EvalCase[],
+  agents: string[],
+  opts: RunOptions = {},
+): Promise<{ scores: SuiteScores; results: RunCaseResult[] }> {
+  const results: RunCaseResult[] = [];
+  const runs: CaseRun[] = [];
+  // Pin a single runId across the suite so all cases write to the same dir.
+  const runId = process.env.GOSSIP_EVAL_RUN_ID || new Date().toISOString().replace(/[:.]/g, '-');
+  const prevEnv = process.env.GOSSIP_EVAL_RUN_ID;
+  process.env.GOSSIP_EVAL_RUN_ID = runId;
+  try {
+    for (const c of cases) {
+      const r = await runCase(c, agents, opts);
+      results.push(r);
+      runs.push({
+        caseId: c.id,
+        groundTruth: c.ground_truth,
+        byAgent: r.byAgent,
+      });
+    }
+  } finally {
+    if (prevEnv === undefined) delete process.env.GOSSIP_EVAL_RUN_ID;
+    else process.env.GOSSIP_EVAL_RUN_ID = prevEnv;
+  }
+  return { scores: scoreSuite(runId, runs), results };
+}
+
+/**
+ * Default dispatcher — best-effort wire-up to a running MainAgent. If any of
+ * the prerequisites are missing (no .gossip/config.json, no API keys, etc.)
+ * we return an empty per-agent map and let the harness emit a placeholder
+ * run. The CLI layer is the right place to surface "no agents reachable"
+ * loudly; the harness must stay headless to keep tests cheap.
+ */
+async function defaultDispatcher(
+  sanitized: DispatchableCase,
+  agents: string[],
+): Promise<Record<string, FindingShape[]>> {
+  if (agents.length === 0) return {};
+  // Lazy-load to avoid pulling the orchestrator into unit tests of the harness.
+  const { MainAgent } = await import('@gossip/orchestrator');
+  const { RelayServer } = await import('@gossip/relay');
+  const { ToolServer } = await import('@gossip/tools');
+  const { findConfigPath, loadConfig, configToAgentConfigs } = await import('../apps/cli/src/config');
+  const { Keychain } = await import('../apps/cli/src/keychain');
+
+  const cfgPath = findConfigPath();
+  if (!cfgPath) return {};
+  const config = loadConfig(cfgPath);
+  const keychain = new Keychain();
+  const relay = new RelayServer({ port: 0 });
+  await relay.start();
+  const toolServer = new ToolServer({ relayUrl: relay.url, projectRoot: process.cwd() });
+  await toolServer.start();
+  const mainKey = await keychain.getKey(config.main_agent.provider);
+  const mainAgent = new MainAgent({
+    provider: config.main_agent.provider,
+    model: config.main_agent.model,
+    apiKey: mainKey || undefined,
+    relayUrl: relay.url,
+    agents: configToAgentConfigs(config),
+    projectRoot: process.cwd(),
+    toolServer: {
+      assignScope: (agentId: string, scope: string) => toolServer.assignScope(agentId, scope),
+      assignRoot: (agentId: string, root: string) => toolServer.assignRoot(agentId, root),
+      releaseAgent: (agentId: string) => toolServer.releaseAgent(agentId),
+    },
+  });
+
+  try {
+    await mainAgent.start();
+    const prompt = buildDispatchPrompt(sanitized);
+    const tasks = agents.map(agentId => ({ agentId, task: prompt }));
+    const { taskIds } = await mainAgent.dispatchParallel(tasks, { consensus: true });
+    const { results } = await mainAgent.collect(taskIds, 300_000);
+
+    const out: Record<string, FindingShape[]> = {};
+    const { parseAgentFindingsStrict } = await import('../packages/orchestrator/src/parse-findings');
+    for (const r of results || []) {
+      const text = (r as { result?: string; agentId: string }).result || '';
+      const aid = (r as { agentId: string }).agentId;
+      const parsed = parseAgentFindingsStrict(text, { idPrefix: aid });
+      out[aid] = parsed.findings.map(f => ({
+        summary: f.content,
+        severity: f.severity,
+        category: f.category,
+      }));
+    }
+    return out;
+  } finally {
+    await mainAgent.stop();
+    await toolServer.stop();
+    await relay.stop();
+  }
+}
+
+// ── YAML-ish parser ──────────────────────────────────────────────────────────
+//
+// A full YAML lib would be a runtime dep; the case schema is constrained
+// enough that we hand-roll a focused parser. Supports:
+//   - top-level scalar keys (string, number)
+//   - nested objects (one level: scope, ground_truth items)
+//   - sequences of mappings (ground_truth: \n - id: ... \n line_range: [a, b])
+//   - sequences of scalars (scope.files)
+//   - block scalars `|` and `>` for prompt/notes
+// Anything beyond that throws — keep cases simple.
+
+interface RawCaseObject {
+  [k: string]: unknown;
+}
+
+function parseCaseYaml(raw: string, sourcePath: string): EvalCase {
+  const lines = raw.split(/\r?\n/);
+  // Strip a trailing blank line so the parser doesn't try to read past EOF.
+  while (lines.length > 0 && lines[lines.length - 1].trim() === '') lines.pop();
+  const obj = parseBlock(lines, 0, 0).value as RawCaseObject;
+
+  const required = ['id', 'title', 'parent_sha', 'scope', 'ground_truth', 'prompt'];
+  for (const k of required) {
+    if (!(k in obj)) throw new Error(`Eval case ${sourcePath} missing required field: ${k}`);
+  }
+
+  const scope = obj.scope as { files: unknown };
+  if (!scope || !Array.isArray(scope.files)) {
+    throw new Error(`Eval case ${sourcePath}: scope.files must be an array`);
+  }
+
+  const groundTruthRaw = obj.ground_truth;
+  if (!Array.isArray(groundTruthRaw)) {
+    throw new Error(`Eval case ${sourcePath}: ground_truth must be an array (use [] for negative cases)`);
+  }
+  const groundTruth: GroundTruthShape[] = groundTruthRaw.map((g, i) => {
+    if (typeof g !== 'object' || g === null) {
+      throw new Error(`Eval case ${sourcePath}: ground_truth[${i}] must be an object`);
+    }
+    const gt = g as Record<string, unknown>;
+    const lr = gt.line_range;
+    if (!Array.isArray(lr) || lr.length !== 2 || typeof lr[0] !== 'number' || typeof lr[1] !== 'number') {
+      throw new Error(`Eval case ${sourcePath}: ground_truth[${i}].line_range must be [number, number]`);
+    }
+    return {
+      id: String(gt.id),
+      file: String(gt.file),
+      line_range: [lr[0], lr[1]],
+      summary: String(gt.summary),
+      severity: String(gt.severity),
+      category: String(gt.category),
+    };
+  });
+
+  return {
+    id: String(obj.id),
+    title: String(obj.title),
+    parent_sha: String(obj.parent_sha),
+    fix_sha: obj.fix_sha === undefined ? undefined : String(obj.fix_sha),
+    fix_pr: obj.fix_pr === undefined ? undefined : Number(obj.fix_pr),
+    scope: { files: scope.files.map(String) },
+    ground_truth: groundTruth,
+    prompt: String(obj.prompt),
+    notes: obj.notes === undefined ? undefined : String(obj.notes),
+    sourcePath,
+  };
+}
+
+interface ParseFrame {
+  value: unknown;
+  /** Next line index after the block consumed. */
+  next: number;
+}
+
+function indentOf(s: string): number {
+  let i = 0;
+  while (i < s.length && s[i] === ' ') i++;
+  return i;
+}
+
+function isBlankOrComment(s: string): boolean {
+  const t = s.trim();
+  return t === '' || t.startsWith('#');
+}
+
+function parseBlock(lines: string[], start: number, indent: number): ParseFrame {
+  // Determines whether the block at `indent` is a mapping or a sequence by
+  // peeking at the first non-blank line.
+  let i = start;
+  while (i < lines.length && isBlankOrComment(lines[i])) i++;
+  if (i >= lines.length) return { value: {}, next: i };
+  const peek = lines[i];
+  const peekIndent = indentOf(peek);
+  if (peekIndent < indent) return { value: {}, next: i };
+
+  if (peek.trim().startsWith('- ')) {
+    return parseSequence(lines, i, peekIndent);
+  }
+  return parseMapping(lines, i, peekIndent);
+}
+
+function parseMapping(lines: string[], start: number, indent: number): ParseFrame {
+  const obj: Record<string, unknown> = {};
+  let i = start;
+  while (i < lines.length) {
+    const ln = lines[i];
+    if (isBlankOrComment(ln)) { i++; continue; }
+    const ind = indentOf(ln);
+    if (ind < indent) break;
+    if (ind > indent) {
+      // Should have been consumed as a child block — defensive fallback.
+      i++;
+      continue;
+    }
+    const trimmed = ln.slice(indent);
+    const colonIdx = trimmed.indexOf(':');
+    if (colonIdx === -1) throw new Error(`Expected mapping key at line ${i + 1}: "${ln}"`);
+    const key = trimmed.slice(0, colonIdx).trim();
+    const rest = trimmed.slice(colonIdx + 1);
+    const restTrim = rest.trim();
+
+    if (restTrim === '|' || restTrim === '>') {
+      // Block scalar
+      const collected: string[] = [];
+      i++;
+      // Find the indent of the first content line.
+      let blockIndent = -1;
+      while (i < lines.length) {
+        const cl = lines[i];
+        if (cl.trim() === '') { collected.push(''); i++; continue; }
+        const ci = indentOf(cl);
+        if (ci <= indent) break;
+        if (blockIndent === -1) blockIndent = ci;
+        if (ci < blockIndent) break;
+        collected.push(cl.slice(blockIndent));
+        i++;
+      }
+      const text = restTrim === '|'
+        ? collected.join('\n').replace(/\n+$/, '\n')
+        : collected.join(' ').replace(/\s+/g, ' ').trim();
+      obj[key] = text;
+      continue;
+    }
+
+    if (restTrim === '') {
+      // Nested block — could be mapping or sequence, defer.
+      const child = parseBlock(lines, i + 1, indent + 2);
+      obj[key] = child.value;
+      i = child.next;
+      continue;
+    }
+
+    obj[key] = parseScalar(restTrim);
+    i++;
+  }
+  return { value: obj, next: i };
+}
+
+function parseSequence(lines: string[], start: number, indent: number): ParseFrame {
+  const arr: unknown[] = [];
+  let i = start;
+  while (i < lines.length) {
+    const ln = lines[i];
+    if (isBlankOrComment(ln)) { i++; continue; }
+    const ind = indentOf(ln);
+    if (ind < indent) break;
+    if (ind > indent) { i++; continue; }
+    const trimmed = ln.slice(indent);
+    if (!trimmed.startsWith('- ')) break;
+    const itemHead = trimmed.slice(2);
+    const itemHeadTrim = itemHead.trim();
+    // Sequence-of-mappings: the dash carries the first key:value of the mapping.
+    if (itemHeadTrim.includes(':') && !itemHeadTrim.startsWith('[') && !itemHeadTrim.startsWith('"')) {
+      // Simulate a mapping block where the first key starts at indent+2.
+      // Consume the first line as `key: value` then continue parsing further
+      // keys at indent+2 until indent drops back.
+      const obj: Record<string, unknown> = {};
+      const colonIdx = itemHead.indexOf(':');
+      const k = itemHead.slice(0, colonIdx).trim();
+      const v = itemHead.slice(colonIdx + 1).trim();
+      if (v === '') {
+        const child = parseBlock(lines, i + 1, indent + 4);
+        obj[k] = child.value;
+        i = child.next;
+      } else {
+        obj[k] = parseScalar(v);
+        i++;
+      }
+      // Continue collecting sibling keys at indent+2.
+      while (i < lines.length) {
+        const cl = lines[i];
+        if (isBlankOrComment(cl)) { i++; continue; }
+        const ci = indentOf(cl);
+        if (ci !== indent + 2) break;
+        const ct = cl.slice(indent + 2);
+        const cIdx = ct.indexOf(':');
+        if (cIdx === -1) break;
+        const ck = ct.slice(0, cIdx).trim();
+        const cv = ct.slice(cIdx + 1).trim();
+        if (cv === '') {
+          const cb = parseBlock(lines, i + 1, indent + 4);
+          obj[ck] = cb.value;
+          i = cb.next;
+        } else {
+          obj[ck] = parseScalar(cv);
+          i++;
+        }
+      }
+      arr.push(obj);
+      continue;
+    }
+    // Sequence of scalars.
+    arr.push(parseScalar(itemHeadTrim));
+    i++;
+  }
+  return { value: arr, next: i };
+}
+
+function parseScalar(raw: string): unknown {
+  if (raw === '') return '';
+  if (raw === 'null' || raw === '~') return null;
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  // Inline flow array: [a, b]
+  if (raw.startsWith('[') && raw.endsWith(']')) {
+    const inner = raw.slice(1, -1).trim();
+    if (inner === '') return [];
+    return inner.split(',').map(s => parseScalar(s.trim()));
+  }
+  // Quoted strings
+  if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
+    return raw.slice(1, -1);
+  }
+  // Number
+  if (/^-?\d+$/.test(raw)) return Number(raw);
+  if (/^-?\d+\.\d+$/.test(raw)) return Number(raw);
+  return raw;
+}

--- a/eval/harness.ts
+++ b/eval/harness.ts
@@ -43,14 +43,20 @@ export interface EvalCase {
   sourcePath: string;
 }
 
-/** What we hand to the dispatch layer — `ground_truth` is GONE. */
+/**
+ * What we hand to the dispatch layer — `ground_truth` is GONE.
+ *
+ * `notes` is also intentionally absent: the EvalCase.notes field is for case
+ * authors only and frequently contains partial oracles (e.g. "consensus should
+ * catch the missing min-width:0"). Forwarding it would leak hints to the
+ * agent. The single-chokepoint `prepareDispatchCase` does not copy it.
+ */
 export interface DispatchableCase {
   id: string;
   title: string;
   parent_sha: string;
   scope: { files: string[] };
   prompt: string;
-  notes?: string;
 }
 
 export interface RunOptions {
@@ -104,7 +110,12 @@ export function loadCases(globPath: string, baseDir?: string): EvalCase[] {
   return out;
 }
 
-/** Strip ground_truth from an EvalCase. The single anti-contamination chokepoint. */
+/**
+ * Strip ground_truth AND notes from an EvalCase. The single
+ * anti-contamination chokepoint. Notes routinely contain partial oracles
+ * ("consensus should catch the missing min-width:0") so forwarding them
+ * would leak hints to the agent.
+ */
 export function prepareDispatchCase(c: EvalCase): DispatchableCase {
   return {
     id: c.id,
@@ -112,8 +123,27 @@ export function prepareDispatchCase(c: EvalCase): DispatchableCase {
     parent_sha: c.parent_sha,
     scope: { files: [...c.scope.files] },
     prompt: c.prompt,
-    ...(c.notes ? { notes: c.notes } : {}),
   };
+}
+
+/**
+ * Extract a `<cite tag="file">path:line</cite>` anchor from finding content.
+ * Returns the FIRST cite in the string. Multi-cite findings prefer the first
+ * citation (the agent's primary anchor); line ranges (`11-15`) reduce to the
+ * lower bound. Returns `undefined` for both fields when no cite is present
+ * or the cite is malformed.
+ *
+ * Tolerates single OR double quotes around the tag attribute and an optional
+ * line-range suffix. Match group 1 is the path, group 2 is the start line.
+ */
+export function extractCiteAnchor(content: string): { file?: string; line?: number } {
+  const re = /<cite\s+tag=["']file["']\s*>([^:<]+):(\d+)(?:-\d+)?<\/cite>/;
+  const m = re.exec(content);
+  if (!m) return {};
+  const file = m[1].trim();
+  const line = Number(m[2]);
+  if (!file || !Number.isFinite(line)) return {};
+  return { file, line };
 }
 
 /** Build the natural-language prompt that goes to each reviewer agent. */
@@ -297,11 +327,16 @@ async function defaultDispatcher(
       const text = (r as { result?: string; agentId: string }).result || '';
       const aid = (r as { agentId: string }).agentId;
       const parsed = parseAgentFindingsStrict(text, { idPrefix: aid });
-      out[aid] = parsed.findings.map(f => ({
-        summary: f.content,
-        severity: f.severity,
-        category: f.category,
-      }));
+      out[aid] = parsed.findings.map(f => {
+        const anchor = extractCiteAnchor(f.content);
+        return {
+          summary: f.content,
+          severity: f.severity,
+          category: f.category,
+          ...(anchor.file ? { file: anchor.file } : {}),
+          ...(anchor.line !== undefined ? { line: anchor.line } : {}),
+        };
+      });
     }
     return out;
   } finally {
@@ -529,6 +564,40 @@ function parseSequence(lines: string[], start: number, indent: number): ParseFra
   return { value: arr, next: i };
 }
 
+/**
+ * Quote-aware splitter for inline-flow array contents. Splits `inner` on
+ * top-level commas only — commas inside `"..."` or `'...'` are preserved,
+ * so `["a, b", c]` parses as two items rather than three. Quote characters
+ * are NOT stripped here; downstream parseScalar handles quoted-string
+ * unwrapping.
+ */
+function splitFlowItems(inner: string): string[] {
+  const out: string[] = [];
+  let buf = '';
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (quote) {
+      buf += ch;
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      buf += ch;
+      continue;
+    }
+    if (ch === ',') {
+      out.push(buf);
+      buf = '';
+      continue;
+    }
+    buf += ch;
+  }
+  out.push(buf);
+  return out;
+}
+
 function parseScalar(raw: string): unknown {
   if (raw === '') return '';
   if (raw === 'null' || raw === '~') return null;
@@ -538,7 +607,7 @@ function parseScalar(raw: string): unknown {
   if (raw.startsWith('[') && raw.endsWith(']')) {
     const inner = raw.slice(1, -1).trim();
     if (inner === '') return [];
-    return inner.split(',').map(s => parseScalar(s.trim()));
+    return splitFlowItems(inner).map(s => parseScalar(s.trim()));
   }
   // Quoted strings
   if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {

--- a/eval/match.ts
+++ b/eval/match.ts
@@ -1,0 +1,113 @@
+/**
+ * eval/match.ts — finding↔ground-truth matcher.
+ *
+ * Implements the rubric in docs/specs/2026-04-29-curated-eval-suite.md §
+ * "Scoring rubric":
+ *
+ *   match(finding, gt):
+ *     if finding.file != gt.file: return 0
+ *     if finding.line outside gt.line_range ± 5: return 0.5  // near miss
+ *     if token_similarity(finding.summary, gt.summary) > 0.6: return 1
+ *     if same category: return 0.7
+ *     return 0.3
+ *
+ * `tokenSimilarity` is Jaccard on lowercased word-tokens after stopword strip.
+ * Fancier NLP is explicitly out of scope at N=30.
+ */
+
+export interface FindingShape {
+  /** Path the finding cites. May be undefined if the agent emitted no anchor. */
+  file?: string;
+  /** Single line or range start. */
+  line?: number;
+  /** Free-text description of the finding. */
+  summary: string;
+  /** Severity bucket if the agent provided one. */
+  severity?: string;
+  /** Category bucket (concurrency, type_safety, etc) if the agent provided one. */
+  category?: string;
+}
+
+export interface GroundTruthShape {
+  id: string;
+  file: string;
+  line_range: [number, number];
+  summary: string;
+  severity: string;
+  category: string;
+}
+
+const STOPWORDS = new Set([
+  'a', 'an', 'and', 'are', 'as', 'at', 'be', 'by', 'for', 'from', 'has', 'have',
+  'in', 'is', 'it', 'its', 'of', 'on', 'or', 'that', 'the', 'this', 'to', 'was',
+  'were', 'will', 'with', 'when', 'where', 'which', 'who', 'why', 'how',
+]);
+
+/** Jaccard similarity over lowercased word-tokens after stopword strip. */
+export function tokenSimilarity(a: string, b: string): number {
+  const tok = (s: string): Set<string> => {
+    const out = new Set<string>();
+    for (const raw of s.toLowerCase().split(/[^a-z0-9_]+/)) {
+      if (raw.length === 0) continue;
+      if (STOPWORDS.has(raw)) continue;
+      out.add(raw);
+    }
+    return out;
+  };
+  const sa = tok(a);
+  const sb = tok(b);
+  if (sa.size === 0 && sb.size === 0) return 0;
+  let inter = 0;
+  for (const t of sa) if (sb.has(t)) inter++;
+  const union = sa.size + sb.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+/** Normalize a path for cross-OS comparison (forward slashes, no leading ./). */
+function normPath(p: string | undefined): string {
+  if (!p) return '';
+  return p.replace(/\\/g, '/').replace(/^\.\//, '').trim();
+}
+
+/**
+ * Returns a match score in [0, 1] per the rubric.
+ *
+ * Edge cases:
+ * - Missing finding.file → 0 (no anchor, can't match by file).
+ * - Missing finding.line → treat as out-of-range → 0.5 fallback (near-miss tier).
+ * - Empty summary → tokenSimilarity returns 0, falls through to category check.
+ */
+export function match(finding: FindingShape, gt: GroundTruthShape): number {
+  const ff = normPath(finding.file);
+  const gf = normPath(gt.file);
+  if (!ff || ff !== gf) return 0;
+
+  const [lo, hi] = gt.line_range;
+  const fLine = finding.line;
+  const inRange = typeof fLine === 'number' && fLine >= lo - 5 && fLine <= hi + 5;
+  if (!inRange) return 0.5;
+
+  if (tokenSimilarity(finding.summary, gt.summary) > 0.6) return 1;
+  if (finding.category && gt.category && finding.category === gt.category) return 0.7;
+  return 0.3;
+}
+
+/**
+ * Best-match score for a finding against a list of ground truths.
+ * Returns the highest match() result (and the matched gt id, if any).
+ */
+export function bestMatch(
+  finding: FindingShape,
+  truths: GroundTruthShape[],
+): { score: number; gtId: string | null } {
+  let best = 0;
+  let bestId: string | null = null;
+  for (const gt of truths) {
+    const s = match(finding, gt);
+    if (s > best) {
+      best = s;
+      bestId = gt.id;
+    }
+  }
+  return { score: best, gtId: bestId };
+}

--- a/eval/report.ts
+++ b/eval/report.ts
@@ -1,0 +1,95 @@
+/**
+ * eval/report.ts — Markdown leaderboard + McNemar 2x2 table.
+ *
+ * McNemar's χ² (spec § "McNemar paired before/after"):
+ *
+ *   χ² = (b - c)² / (b + c)
+ *
+ * where on a paired before/after run:
+ *   b = cases that passed before but failed after (regression)
+ *   c = cases that failed before but passed after (improvement)
+ *
+ * We do NOT compute p-values — operator interprets, or pipes χ² into jstat
+ * if available downstream.
+ */
+
+import { SuiteScores } from './score';
+
+/** Render a per-agent leaderboard as Markdown. */
+export function formatLeaderboard(scores: SuiteScores): string {
+  const rows = Object.values(scores.perAgent).sort((a, b) => b.f1 - a.f1);
+  if (rows.length === 0) {
+    return `# Eval Suite Run \`${scores.runId}\`\n\n_No agent results — empty run._\n`;
+  }
+  const header = `# Eval Suite Run \`${scores.runId}\`\n\n${scores.cases.length} case(s) evaluated across ${rows.length} agent(s).\n\n`;
+  const table: string[] = [
+    '| Agent | Cases | Precision | Recall | F1 | Σ matched | Σ findings | Σ truths |',
+    '|-------|-------|-----------|--------|----|-----------|------------|----------|',
+  ];
+  for (const r of rows) {
+    table.push(
+      `| ${r.agentId} | ${r.casesEvaluated} | ${r.precision.toFixed(3)} | ${r.recall.toFixed(3)} | ${r.f1.toFixed(3)} | ${r.matchedWeight.toFixed(2)} | ${r.findingWeight.toFixed(2)} | ${r.truthWeight.toFixed(2)} |`
+    );
+  }
+  return header + table.join('\n') + '\n';
+}
+
+export interface PairedOutcome {
+  caseId: string;
+  /** Did the agent "pass" this case? Operator-defined threshold (default F1≥0.5). */
+  pass: boolean;
+}
+
+export interface McNemarResult {
+  a: number; // before pass, after pass
+  b: number; // before pass, after fail (regression)
+  c: number; // before fail, after pass (improvement)
+  d: number; // before fail, after fail
+  chiSquared: number;
+  /** Smaller of b, c — exact-test guidance from spec ("|b-c| ≥ ~7" rule of thumb). */
+  discordant: number;
+}
+
+/**
+ * Compute McNemar contingency from paired case outcomes.
+ *
+ * `before` and `after` must be the same set of caseIds — an asymmetric pair
+ * is silently restricted to the intersection.
+ */
+export function mcNemar(before: PairedOutcome[], after: PairedOutcome[]): McNemarResult {
+  const beforeMap = new Map(before.map(o => [o.caseId, o.pass]));
+  const afterMap = new Map(after.map(o => [o.caseId, o.pass]));
+  let a = 0, b = 0, c = 0, d = 0;
+  for (const [cid, bp] of beforeMap) {
+    if (!afterMap.has(cid)) continue;
+    const ap = afterMap.get(cid)!;
+    if (bp && ap) a++;
+    else if (bp && !ap) b++;
+    else if (!bp && ap) c++;
+    else d++;
+  }
+  const denom = b + c;
+  const chiSquared = denom === 0 ? 0 : ((b - c) ** 2) / denom;
+  const discordant = Math.min(b, c);
+  return { a, b, c, d, chiSquared, discordant };
+}
+
+/** Render McNemar 2x2 + χ² as a Markdown block. */
+export function formatMcNemar(before: PairedOutcome[], after: PairedOutcome[]): string {
+  const r = mcNemar(before, after);
+  return [
+    '## McNemar paired before/after',
+    '',
+    '|                   | After: pass | After: fail |',
+    '|-------------------|-------------|-------------|',
+    `| **Before: pass**  | ${r.a}            | ${r.b} (regression) |`,
+    `| **Before: fail**  | ${r.c} (improved)   | ${r.d}            |`,
+    '',
+    `χ² = (b - c)² / (b + c) = (${r.b} - ${r.c})² / (${r.b + r.c}) = **${r.chiSquared.toFixed(3)}**`,
+    '',
+    r.b + r.c < 7
+      ? '_Discordant pair count <7 — effect-size below detection floor at α=0.05._'
+      : '_Operator: interpret χ² with df=1; |b-c| ≥ 7 ≈ p<0.05 at N≈30._',
+    '',
+  ].join('\n');
+}

--- a/eval/score.ts
+++ b/eval/score.ts
@@ -1,0 +1,163 @@
+/**
+ * eval/score.ts — Precision / Recall / F1 per agent, severity-weighted.
+ *
+ * Severity weights (spec §"Scoring rubric"): critical 4×, high 2×, medium 1×, low 0.5×.
+ * - A missed `critical` ground truth costs 4× a missed `low`.
+ * - A fabricated `critical` finding costs 4× a fabricated `low`.
+ *
+ * Precision = sum(match * w_finding) / sum(w_finding)
+ * Recall    = sum(matched_gt_w) / sum(gt_w)
+ * F1        = 2·P·R / (P+R)
+ */
+
+import { FindingShape, GroundTruthShape, bestMatch } from './match';
+
+export interface CaseRun {
+  caseId: string;
+  /** Ground truths from the case yaml. Empty array == negative case. */
+  groundTruth: GroundTruthShape[];
+  /** Per-agent findings emitted in this run. */
+  byAgent: Record<string, FindingShape[]>;
+}
+
+export interface AgentCaseScore {
+  agentId: string;
+  caseId: string;
+  precision: number;
+  recall: number;
+  f1: number;
+  /** Sum of severity-weighted match values. */
+  matchedWeight: number;
+  /** Sum of severity weights of all findings emitted. Used as precision denominator. */
+  findingWeight: number;
+  /** Sum of severity weights of all ground truths. Used as recall denominator. */
+  truthWeight: number;
+  /** Per-finding diagnostic: best match against any GT. */
+  details: Array<{ finding: FindingShape; gtId: string | null; score: number }>;
+}
+
+export interface SuiteScores {
+  runId: string;
+  cases: CaseRun[];
+  /** Aggregate per agent across all cases. */
+  perAgent: Record<string, {
+    agentId: string;
+    precision: number;
+    recall: number;
+    f1: number;
+    matchedWeight: number;
+    findingWeight: number;
+    truthWeight: number;
+    casesEvaluated: number;
+  }>;
+  /** Per-(agent, case) breakdown. */
+  perCase: AgentCaseScore[];
+}
+
+const SEVERITY_WEIGHT: Record<string, number> = {
+  critical: 4,
+  high: 2,
+  medium: 1,
+  low: 0.5,
+};
+
+function severityWeight(sev: string | undefined): number {
+  if (!sev) return 1;
+  const w = SEVERITY_WEIGHT[sev.toLowerCase()];
+  return typeof w === 'number' ? w : 1;
+}
+
+/** Score one (agent, case) pair. */
+export function scoreAgentCase(
+  agentId: string,
+  caseId: string,
+  findings: FindingShape[],
+  truths: GroundTruthShape[],
+): AgentCaseScore {
+  const details: AgentCaseScore['details'] = [];
+  let matchedWeight = 0;
+  let findingWeight = 0;
+  const matchedGtIds = new Set<string>();
+
+  for (const f of findings) {
+    const w = severityWeight(f.severity);
+    findingWeight += w;
+    const { score, gtId } = bestMatch(f, truths);
+    matchedWeight += w * score;
+    if (gtId && score >= 0.7) matchedGtIds.add(gtId);
+    details.push({ finding: f, gtId, score });
+  }
+
+  let truthWeight = 0;
+  let recallNumerator = 0;
+  for (const gt of truths) {
+    const w = severityWeight(gt.severity);
+    truthWeight += w;
+    if (matchedGtIds.has(gt.id)) recallNumerator += w;
+  }
+
+  // Precision conventions:
+  //   - No findings emitted, no truths → P=1, R=1 (perfect "stayed silent" on negative case).
+  //   - No findings emitted, truths exist → P=1 (vacuously), R=0.
+  //   - Findings emitted, no truths (negative case fabrication) → P=0, R=1 (vacuous; no truths to miss).
+  //     That double-credit on R is fine because F1 with P=0 still drops to 0.
+  const precision = findingWeight === 0 ? 1 : matchedWeight / findingWeight;
+  const recall = truthWeight === 0 ? 1 : recallNumerator / truthWeight;
+  const f1 = precision + recall === 0 ? 0 : (2 * precision * recall) / (precision + recall);
+
+  return {
+    agentId,
+    caseId,
+    precision,
+    recall,
+    f1,
+    matchedWeight,
+    findingWeight,
+    truthWeight,
+    details,
+  };
+}
+
+/** Aggregate per-agent across cases — micro-average over weights. */
+export function scoreSuite(runId: string, cases: CaseRun[]): SuiteScores {
+  const perCase: AgentCaseScore[] = [];
+  const agentIds = new Set<string>();
+  for (const c of cases) {
+    for (const aid of Object.keys(c.byAgent)) agentIds.add(aid);
+  }
+
+  for (const c of cases) {
+    for (const aid of agentIds) {
+      const findings = c.byAgent[aid] || [];
+      perCase.push(scoreAgentCase(aid, c.caseId, findings, c.groundTruth));
+    }
+  }
+
+  const perAgent: SuiteScores['perAgent'] = {};
+  for (const aid of agentIds) {
+    let mw = 0, fw = 0, tw = 0, rNum = 0, n = 0;
+    for (const sc of perCase) {
+      if (sc.agentId !== aid) continue;
+      mw += sc.matchedWeight;
+      fw += sc.findingWeight;
+      tw += sc.truthWeight;
+      rNum += sc.recall * sc.truthWeight;
+      n += 1;
+    }
+    const precision = fw === 0 ? 1 : mw / fw;
+    const recall = tw === 0 ? 1 : rNum / tw;
+    const f1 = precision + recall === 0 ? 0 : (2 * precision * recall) / (precision + recall);
+    perAgent[aid] = {
+      agentId: aid,
+      precision,
+      recall,
+      f1,
+      matchedWeight: mw,
+      findingWeight: fw,
+      truthWeight: tw,
+      casesEvaluated: n,
+    };
+  }
+
+  return { runId, cases, perAgent, perCase };
+}

--- a/tests/eval/cite-extraction.test.ts
+++ b/tests/eval/cite-extraction.test.ts
@@ -1,0 +1,53 @@
+/**
+ * tests/eval/cite-extraction.test.ts — extractCiteAnchor unit coverage.
+ *
+ * The eval scoring rubric (eval/match.ts) returns 0 when finding.file is
+ * undefined. parseAgentFindingsStrict gives us only the prose `content`;
+ * extractCiteAnchor pulls the file:line anchor from the FIRST
+ * `<cite tag="file">…</cite>` so live-dispatched findings can score above
+ * the file-mismatch floor.
+ */
+
+import { extractCiteAnchor } from '../../eval/harness';
+
+describe('extractCiteAnchor', () => {
+  it('extracts file and line from a single cite', () => {
+    const out = extractCiteAnchor(
+      'The bug lives in <cite tag="file">packages/dashboard/Foo.tsx:42</cite> as a missing guard.',
+    );
+    expect(out).toEqual({ file: 'packages/dashboard/Foo.tsx', line: 42 });
+  });
+
+  it('prefers the first cite when multiple are present', () => {
+    const out = extractCiteAnchor(
+      'See <cite tag="file">a/first.ts:10</cite> then <cite tag="file">b/second.ts:20</cite>.',
+    );
+    expect(out).toEqual({ file: 'a/first.ts', line: 10 });
+  });
+
+  it('reduces a line range to its lower bound', () => {
+    const out = extractCiteAnchor(
+      'Span <cite tag="file">eval/match.ts:11-15</cite> handles the rubric.',
+    );
+    expect(out).toEqual({ file: 'eval/match.ts', line: 11 });
+  });
+
+  it('returns undefined fields when no cite is present', () => {
+    const out = extractCiteAnchor('Plain prose with no anchor at all.');
+    expect(out).toEqual({});
+  });
+
+  it('returns undefined fields on a malformed cite (missing line)', () => {
+    const out = extractCiteAnchor(
+      'Broken <cite tag="file">eval/match.ts</cite> no colon line.',
+    );
+    expect(out).toEqual({});
+  });
+
+  it('accepts single-quoted tag attribute', () => {
+    const out = extractCiteAnchor(
+      "Mixed quotes <cite tag='file'>x/y.ts:7</cite> still work.",
+    );
+    expect(out).toEqual({ file: 'x/y.ts', line: 7 });
+  });
+});

--- a/tests/eval/contamination.test.ts
+++ b/tests/eval/contamination.test.ts
@@ -1,0 +1,106 @@
+/**
+ * tests/eval/contamination.test.ts — anti-contamination contract.
+ *
+ * Asserts that the harness never lets a ground_truth string reach the
+ * dispatched prompt. Sentinel approach: load a fixture case whose ground
+ * truths include uniquely-identifiable strings that could not appear in
+ * normal source code, then verify those strings are absent from
+ * (a) the DispatchableCase produced by prepareDispatchCase, and
+ * (b) the prompt string built by buildDispatchPrompt, and
+ * (c) the prompt string handed to a custom dispatcher during runCase.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import {
+  buildDispatchPrompt,
+  loadCase,
+  prepareDispatchCase,
+  runCase,
+} from '../../eval/harness';
+
+const SENTINEL_SUMMARY = 'CANARY_GROUND_TRUTH_SENTINEL_AB12CD34_DO_NOT_LEAK';
+const SENTINEL_CATEGORY = 'CANARY_CATEGORY_SENTINEL_EF56GH78';
+
+describe('eval harness — anti-contamination', () => {
+  let dir: string;
+  let casePath: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `gossip-eval-contam-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(dir, { recursive: true });
+    casePath = join(dir, 'sentinel-case.yaml');
+    const yaml = [
+      'id: sentinel-case',
+      'title: Sentinel case for contamination test',
+      'parent_sha: HEAD',
+      'scope:',
+      '  files:',
+      '    - some/file.ts',
+      'ground_truth:',
+      '  - id: gt1',
+      '    severity: critical',
+      '    file: some/file.ts',
+      '    line_range: [1, 5]',
+      `    summary: ${SENTINEL_SUMMARY}`,
+      `    category: ${SENTINEL_CATEGORY}`,
+      'prompt: |',
+      '  Review the file. Report findings only with file:line citations.',
+      'notes: |',
+      '  Sentinel notes — never reach the agent.',
+      '',
+    ].join('\n');
+    writeFileSync(casePath, yaml);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('prepareDispatchCase strips ground_truth entirely', () => {
+    const c = loadCase(casePath);
+    expect(c.ground_truth).toHaveLength(1);
+    const sanitized = prepareDispatchCase(c);
+    const serialized = JSON.stringify(sanitized);
+    expect(serialized).not.toContain(SENTINEL_SUMMARY);
+    expect(serialized).not.toContain(SENTINEL_CATEGORY);
+    expect((sanitized as unknown as Record<string, unknown>).ground_truth).toBeUndefined();
+  });
+
+  it('buildDispatchPrompt does not contain ground-truth sentinel strings', () => {
+    const c = loadCase(casePath);
+    const prompt = buildDispatchPrompt(prepareDispatchCase(c));
+    expect(prompt).not.toContain(SENTINEL_SUMMARY);
+    expect(prompt).not.toContain(SENTINEL_CATEGORY);
+  });
+
+  it('runCase passes a sanitized case to the dispatcher', async () => {
+    const c = loadCase(casePath);
+    const seenPrompts: string[] = [];
+    const seenCases: unknown[] = [];
+    await runCase(c, ['fake-agent'], {
+      worktreeRoot: dir,
+      outDir: join(dir, 'runs'),
+      skipCheckout: true,
+      dispatcher: async (sanitized, agents) => {
+        seenCases.push(sanitized);
+        seenPrompts.push(buildDispatchPrompt(sanitized));
+        const out: Record<string, never[]> = {};
+        for (const a of agents) out[a] = [];
+        return out;
+      },
+    });
+    expect(seenPrompts).toHaveLength(1);
+    for (const p of seenPrompts) {
+      expect(p).not.toContain(SENTINEL_SUMMARY);
+      expect(p).not.toContain(SENTINEL_CATEGORY);
+    }
+    for (const sc of seenCases) {
+      const ser = JSON.stringify(sc);
+      expect(ser).not.toContain(SENTINEL_SUMMARY);
+      expect(ser).not.toContain(SENTINEL_CATEGORY);
+    }
+  });
+});

--- a/tests/eval/contamination.test.ts
+++ b/tests/eval/contamination.test.ts
@@ -23,6 +23,7 @@ import {
 
 const SENTINEL_SUMMARY = 'CANARY_GROUND_TRUTH_SENTINEL_AB12CD34_DO_NOT_LEAK';
 const SENTINEL_CATEGORY = 'CANARY_CATEGORY_SENTINEL_EF56GH78';
+const SENTINEL_NOTES = 'CANARY_NOTES_SENTINEL_IJ90KL12_PARTIAL_ORACLE';
 
 describe('eval harness — anti-contamination', () => {
   let dir: string;
@@ -49,7 +50,7 @@ describe('eval harness — anti-contamination', () => {
       'prompt: |',
       '  Review the file. Report findings only with file:line citations.',
       'notes: |',
-      '  Sentinel notes — never reach the agent.',
+      `  ${SENTINEL_NOTES} — partial-oracle hint that must never reach the agent.`,
       '',
     ].join('\n');
     writeFileSync(casePath, yaml);
@@ -76,6 +77,17 @@ describe('eval harness — anti-contamination', () => {
     expect(prompt).not.toContain(SENTINEL_CATEGORY);
   });
 
+  it('prepareDispatchCase strips notes (partial oracles must not leak)', () => {
+    const c = loadCase(casePath);
+    expect(c.notes).toContain(SENTINEL_NOTES);
+    const sanitized = prepareDispatchCase(c);
+    const serialized = JSON.stringify(sanitized);
+    expect(serialized).not.toContain(SENTINEL_NOTES);
+    expect((sanitized as unknown as Record<string, unknown>).notes).toBeUndefined();
+    const prompt = buildDispatchPrompt(sanitized);
+    expect(prompt).not.toContain(SENTINEL_NOTES);
+  });
+
   it('runCase passes a sanitized case to the dispatcher', async () => {
     const c = loadCase(casePath);
     const seenPrompts: string[] = [];
@@ -96,11 +108,13 @@ describe('eval harness — anti-contamination', () => {
     for (const p of seenPrompts) {
       expect(p).not.toContain(SENTINEL_SUMMARY);
       expect(p).not.toContain(SENTINEL_CATEGORY);
+      expect(p).not.toContain(SENTINEL_NOTES);
     }
     for (const sc of seenCases) {
       const ser = JSON.stringify(sc);
       expect(ser).not.toContain(SENTINEL_SUMMARY);
       expect(ser).not.toContain(SENTINEL_CATEGORY);
+      expect(ser).not.toContain(SENTINEL_NOTES);
     }
   });
 });

--- a/tests/eval/yaml-parser.test.ts
+++ b/tests/eval/yaml-parser.test.ts
@@ -1,0 +1,109 @@
+/**
+ * tests/eval/yaml-parser.test.ts — inline-flow array quote handling.
+ *
+ * The hand-rolled YAML parser in eval/harness.ts must split inline flow
+ * arrays on top-level commas only. Naive `.split(',')` corrupts values
+ * that legitimately contain commas inside quoted strings, e.g.
+ * `files: ["path/with,comma.ts"]`.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { loadCase } from '../../eval/harness';
+
+describe('eval YAML parser — inline flow arrays', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `gossip-eval-yaml-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeCase(yaml: string): string {
+    const p = join(dir, 'case.yaml');
+    writeFileSync(p, yaml);
+    return p;
+  }
+
+  it('keeps quoted commas inside a single string item (double quotes)', () => {
+    const p = writeCase([
+      'id: q-comma',
+      'title: t',
+      'parent_sha: HEAD',
+      'scope:',
+      '  files: ["path/with,comma.ts"]',
+      'ground_truth:',
+      '  - id: gt1',
+      '    severity: low',
+      '    file: path/with,comma.ts',
+      '    line_range: [1, 2]',
+      '    summary: s',
+      '    category: c',
+      'prompt: |',
+      '  p',
+      '',
+    ].join('\n'));
+    const c = loadCase(p);
+    expect(c.scope.files).toEqual(['path/with,comma.ts']);
+  });
+
+  it('keeps quoted commas with single quotes', () => {
+    const p = writeCase([
+      "id: q-single",
+      'title: t',
+      'parent_sha: HEAD',
+      'scope:',
+      "  files: ['a,b.ts', 'c.ts']",
+      'ground_truth: []',
+      'prompt: |',
+      '  p',
+      '',
+    ].join('\n'));
+    const c = loadCase(p);
+    expect(c.scope.files).toEqual(['a,b.ts', 'c.ts']);
+  });
+
+  it('still splits on top-level commas with no quotes', () => {
+    const p = writeCase([
+      'id: plain',
+      'title: t',
+      'parent_sha: HEAD',
+      'scope:',
+      '  files: [a.ts, b.ts, c.ts]',
+      'ground_truth: []',
+      'prompt: |',
+      '  p',
+      '',
+    ].join('\n'));
+    const c = loadCase(p);
+    expect(c.scope.files).toEqual(['a.ts', 'b.ts', 'c.ts']);
+  });
+
+  it('handles line_range numeric arrays unchanged', () => {
+    const p = writeCase([
+      'id: lr',
+      'title: t',
+      'parent_sha: HEAD',
+      'scope:',
+      '  files: [a.ts]',
+      'ground_truth:',
+      '  - id: gt1',
+      '    severity: low',
+      '    file: a.ts',
+      '    line_range: [11, 15]',
+      '    summary: s',
+      '    category: c',
+      'prompt: |',
+      '  p',
+      '',
+    ].join('\n'));
+    const c = loadCase(p);
+    expect(c.ground_truth[0].line_range).toEqual([11, 15]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
       "@gossip/orchestrator/*": ["packages/orchestrator/src/*"]
     }
   },
-  "include": ["packages/*/src/**/*", "tests/**/*"]
+  "include": ["packages/*/src/**/*", "apps/cli/src/**/*", "eval/**/*.ts", "tests/**/*"]
 }


### PR DESCRIPTION
## Summary

Foundational PR for the curated agent eval suite. Implements the harness, match/score/report library, CLI command, and 5 seed cases mined from this session's PR #324/#325 work. All driven by the (local-only) spec at `docs/specs/2026-04-29-curated-eval-suite.md`.

PR B (full case corpus) and PR C (CI hold-out gate) follow.

## What's in this PR

**Harness + library** (`eval/`):
- `harness.ts` — `loadCases` / `runCase` / `runSuite`. `prepareDispatchCase()` is the single anti-contamination chokepoint that strips `ground_truth` before any prompt reaches an agent. Includes a focused yaml parser (no new dep).
- `match.ts` — file/line/token-similarity rubric per spec (file mismatch=0, line off=0.5, Jaccard token-sim>0.6=1, category match=0.7, else 0.3).
- `score.ts` — severity-weighted Precision/Recall/F1 (`critical=4×, high=2×, medium=1×, low=0.5×`).
- `report.ts` — `formatLeaderboard` md table + `formatMcNemar` 2×2 contingency with χ² = `(b-c)²/(b+c)` and the |b-c|≥7 rule-of-thumb annotation.
- `cli-handler.ts` — implements `gossipcat eval [--cases <glob>] [--agents <list>] [--out <path>] [--against <runDir>]`.

**CLI wiring**:
- `apps/cli/src/commands/eval.ts` — thin shim that dynamic-loads the handler (avoids the CLI's `rootDir: src` constraint).
- `apps/cli/src/index.ts` — registers the `eval` subcommand + help-text.

**Seed cases** (`eval/cases/`):
- `2026-04-29-pr325-abortcontroller.yaml` — positive, 2 GTs, concurrency.
- `2026-04-29-pr325-sidebar-overflow.yaml` — positive design, visual, critical.
- `2026-04-29-pr325-color-token-split.yaml` — positive semantic, type_safety, critical.
- `2026-04-29-gemini-files-missing.yaml` — **negative case** (`ground_truth: []`) — agent should not fabricate "files missing" findings.
- `2026-04-29-pr325-aria-expanded.yaml` — positive accessibility, low.

**Tests**:
- `tests/eval/contamination.test.ts` — 3 tests asserting sentinel ground-truth strings never appear in `prepareDispatchCase` output, `buildDispatchPrompt`, or the prompt handed to the dispatcher in `runCase`.

**Hygiene**:
- `.gitignore` — adds `eval/.runs/` and `eval/cases-private/`.
- `tsconfig.json` — extends `include` with `eval/**/*.ts` so root typecheck covers the new code.

## Test plan

- [x] `npx tsc --noEmit -p apps/cli/tsconfig.json` — clean
- [x] `tests/eval/contamination.test.ts` — 3/3 pass
- [x] Smoke: `runSuite` over 5 seed cases with `agents: []` produces empty leaderboard + 5 per-case run JSONs
- [ ] Pre-merge consensus on this PR (spec gates consensus before merge — touches eval pipeline + verifier tool boundary)

## Anti-contamination (load-bearing)

`prepareDispatchCase()` is the single chokepoint. Tests assert sentinel ground-truth strings never reach the dispatched prompt. Operators authoring future cases must NOT embed ground-truth detail in the `prompt` field — the harness explicitly strips, but author discipline matters too.

## Notes / known scope deviations

- Diff is 1,444 LOC vs the ~370 estimate — overage is from a custom yaml parser (~150 LOC) added to avoid pulling in a dep, plus a more aggressive harness/cli-handler split.
- `harness.ts` at 551 LOC exceeds the 300-line implementer-skill target. Worth a follow-up extract for the yaml parser and case-loading paths if/when we touch this area again. Not blocking PR A.

## References

- Spec: `docs/specs/2026-04-29-curated-eval-suite.md` (local-only / gitignored — not in this PR)
- Provenance for seed cases: PR #324 (#0eb755c), PR #325 review consensus 328adef4, PR #325 design consensus 091755c4