### PR TITLE
feat(orchestrator): transport_failure signal class — relay-worker resolutionRoots gap mitigation

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -762,9 +762,17 @@ export async function handleCollect(
     try {
       const { writeFileSync: wfr, mkdirSync: mdr } = require('fs');
       const { join: jr } = require('path');
+      const { randomBytes: rb } = require('crypto');
       const reportsDir = jr(process.cwd(), '.gossip', 'consensus-reports');
       mdr(reportsDir, { recursive: true });
-      const reportId = consensusReport.signals?.[0]?.consensusId || Date.now().toString();
+      // Fallback consensus_id MUST match the canonical 8-8 hex regex
+      // (`/^[0-9a-f]{8}-[0-9a-f]{8}$/`) so downstream resolvers — most
+      // importantly `extractConsensusId` in transport-failure-detector.ts —
+      // can derive the round id from a `finding_id` later. Date.now() returned
+      // a 13-char decimal which silently broke the lookup.
+      const reportId =
+        consensusReport.signals?.[0]?.consensusId ||
+        `${rb(4).toString('hex')}-${rb(4).toString('hex')}`;
       const reportPath = jr(reportsDir, `${reportId}.json`);
       const topic = allResults?.find((r: any) => r.task)?.task?.slice(0, 500) || '';
       wfr(reportPath, JSON.stringify({
@@ -793,7 +801,18 @@ export async function handleCollect(
         // round-trip through the JSON payload or the feature is invisible.
         ...(consensusReport.authorDiagnostics ? { authorDiagnostics: consensusReport.authorDiagnostics } : {}),
       }, null, 2));
-    } catch { /* best-effort */ }
+    } catch (e) {
+      // Best-effort still applies (we don't throw to the caller), but the
+      // failure must be visible — a silent swallow here means the
+      // transport-failure detector loses its `resolutionRoots` lookup table
+      // and every subsequent `gossip_signals` call against this round
+      // mis-classifies. Surface to stderr so operators can correlate.
+      const reportIdForLog =
+        consensusReport.signals?.[0]?.consensusId || '<unknown>';
+      process.stderr.write(
+        `[gossipcat] consensus-report write failed for ${reportIdForLog}: ${(e as Error).message ?? e}\n`,
+      );
+    }
   }
 
   // Auto-persist confirmed findings to implementation-findings.jsonl

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -322,6 +322,11 @@ export async function handleCollect(
   // Step 5: Run consensus on merged results (relay + native together)
   let consensusReport: any = undefined;
   let provisionalSignalCount = 0;
+  // Hoisted out of the consensus block so the dashboard-persistence path
+  // (later in this function) can record `resolutionRoots` on the consensus
+  // report — the transport-failure detector reads it back when classifying
+  // signals. Path 2, spec docs/specs/2026-04-29-relay-worker-resolution-roots.md.
+  let outerEffectiveRoots: readonly string[] = resolutionRoots ?? [];
   const CONSENSUS_TIMEOUT_MS = 1_800_000; // 30 min — native subagents (sonnet/opus) frequently take 2-5 min per cross-review, plus orchestrator dispatch overhead. 15 min was too tight in practice.
   // MIN_AGENTS_FOR_CONSENSUS = 2 (see @gossip/orchestrator/types)
   if (consensus && allResults.filter((r: any) => r.status === 'completed').length >= 2) {
@@ -387,6 +392,7 @@ export async function handleCollect(
       } catch (err) {
         process.stderr.write(`[consensus] auto-discovery failed: ${(err as Error).message}\n`);
       }
+      outerEffectiveRoots = effectiveRoots;
 
       // Hoisted so verifierToolRunner callback can close over it when building the engine config.
       // Constructed AFTER effectiveRoots so fileSearch can prioritize matches under a
@@ -767,6 +773,13 @@ export async function handleCollect(
         topic,
         agentCount: consensusReport.agentCount,
         rounds: consensusReport.rounds,
+        // Persist resolutionRoots so the transport-failure detector
+        // (Path 2, spec docs/specs/2026-04-29-relay-worker-resolution-roots.md)
+        // can look up "did this round dispatch with resolutionRoots?" from a
+        // bare `consensus_id` derived from a `finding_id`. Empty array when
+        // none was passed — preserving the explicit "no roots" signal in the
+        // record.
+        resolutionRoots: outerEffectiveRoots.length > 0 ? [...outerEffectiveRoots] : [],
         confirmed: consensusReport.confirmed || [],
         disputed: consensusReport.disputed || [],
         unverified: consensusReport.unverified || [],

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2671,6 +2671,34 @@ server.tool(
         };
       });
 
+      // Transport-failure rewrite (Path 2, spec
+      // docs/specs/2026-04-29-relay-worker-resolution-roots.md). Runs BEFORE
+      // category enforcement / dedup so the persisted signal class reflects
+      // the rewrite, and BEFORE the auto-skill-gap suggestion path so a relay
+      // cwd outage doesn't trigger spurious skill development. Native agents
+      // and rounds without resolutionRoots are exempt — the detector returns
+      // the input unchanged when preconditions don't hold.
+      try {
+        const { maybeRewriteHallucinationToTransportFailure } = await import('@gossip/orchestrator');
+        const isNativeAgent = (agentId: string): boolean =>
+          ctx.nativeAgentConfigs.has(agentId);
+        for (let i = 0; i < formatted.length; i++) {
+          const s = formatted[i];
+          if (s.type !== 'consensus') continue;
+          if (s.signal !== 'hallucination_caught') continue;
+          const rewritten = maybeRewriteHallucinationToTransportFailure(
+            process.cwd(),
+            s,
+            isNativeAgent,
+          );
+          if (rewritten !== s) {
+            formatted[i] = rewritten;
+          }
+        }
+      } catch (err) {
+        process.stderr.write(`[gossip_signals] transport-failure detector failed: ${(err as Error).message}\n`);
+      }
+
       // Category enforcement for hallucination_caught: if both inferCategory
       // and extractCategories fail, we PERSIST the signal with category:undefined
       // (matching consensus-engine.ts:983-999). Per-category skill-gap routing

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2680,8 +2680,28 @@ server.tool(
       // the input unchanged when preconditions don't hold.
       try {
         const { maybeRewriteHallucinationToTransportFailure } = await import('@gossip/orchestrator');
-        const isNativeAgent = (agentId: string): boolean =>
-          ctx.nativeAgentConfigs.has(agentId);
+        const { existsSync: nativeExists } = require('fs');
+        const { join: nativeJoin } = require('path');
+        // Cache `.claude/agents/<id>.md` lookups for the duration of this batch
+        // — fs probes are cheap but agents may repeat across signals and the
+        // cache makes the fallback negligible vs the in-memory map check.
+        const nativeFileCache = new Map<string, boolean>();
+        const isNativeAgent = (agentId: string): boolean => {
+          if (ctx.nativeAgentConfigs.has(agentId)) return true;
+          // Fallback: an agent registered in `.claude/agents/<id>.md` after
+          // gossip_setup but before MCP restart is missing from the in-memory
+          // `nativeAgentConfigs` snapshot. Probe disk so newly added native
+          // subagents aren't misclassified as relay agents (which would
+          // silently exonerate real hallucinations as transport failures).
+          const cached = nativeFileCache.get(agentId);
+          if (cached !== undefined) return cached;
+          let onDisk = false;
+          try {
+            onDisk = nativeExists(nativeJoin(process.cwd(), '.claude', 'agents', `${agentId}.md`));
+          } catch { onDisk = false; }
+          nativeFileCache.set(agentId, onDisk);
+          return onDisk;
+        };
         for (let i = 0; i < formatted.length; i++) {
           const s = formatted[i];
           if (s.type !== 'consensus') continue;

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -157,7 +157,19 @@ export interface ConsensusSignal {
     | 'boundary_escape'
     | 'task_timeout'
     | 'task_empty'
-    | 'consensus_coverage_degraded';
+    | 'consensus_coverage_degraded'
+    /**
+     * Relay-worker `resolutionRoots` plumbing gap (spec
+     * docs/specs/2026-04-29-relay-worker-resolution-roots.md, Path 2). When a
+     * relay-routed agent records `hallucination_caught` whose finding text
+     * matches the "files not present / empty diff / cannot read" pattern AND
+     * the consensus round was dispatched with `resolutionRoots`, the signal is
+     * rewritten from `hallucination_caught` to `transport_failure` BEFORE
+     * persisting to `agent-performance.jsonl`. `transport_failure` is excluded
+     * from accuracy / uniqueness / circuit-breaker arithmetic — it tracks
+     * separately as `AgentScore.transport_failure_count`.
+     */
+    | 'transport_failure';
   agentId: string;
   counterpartId?: string;
   skill?: string;
@@ -307,6 +319,7 @@ const OPERATIONAL_SIGNAL_NAMES: ReadonlySet<string> = new Set([
   'finding_dropped_format',
   'consensus_round_retracted',
   'unverified',
+  'transport_failure',
 ]);
 
 export function classifySignal(signalName: string): SignalClass | undefined {

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -102,6 +102,18 @@ export {
   emitScoringAdjustmentSignals,
   emitPipelineSignals,
 } from './signal-helpers';
+export {
+  shouldRewriteToTransportFailure,
+  appendTransportRewrite,
+  lookupRoundResolutionRoots,
+  extractConsensusId,
+  maybeRewriteHallucinationToTransportFailure,
+  TRANSPORT_FAILURE_PATTERN,
+} from './transport-failure-detector';
+export type {
+  TransportFailureContext,
+  TransportRewriteAudit,
+} from './transport-failure-detector';
 export { COMPLETION_SIGNAL_ALLOWLIST, EMISSION_PATHS } from './completion-signals.allowlist';
 export type { EmissionPath } from './completion-signals.allowlist';
 export { PipelineDriftDetector } from './pipeline-drift-detector';

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -49,6 +49,16 @@ export interface AgentScore {
   categoryCorrect: Record<string, number>;
   categoryHallucinated: Record<string, number>;
   categoryAccuracy: Record<string, number>;
+  /**
+   * Count of `transport_failure` rows (rewritten from `hallucination_caught`
+   * by the relay-worker resolutionRoots-gap detector — see
+   * docs/specs/2026-04-29-relay-worker-resolution-roots.md Path 2). These
+   * rows are EXCLUDED from accuracy / uniqueness / circuit-breaker arithmetic;
+   * the count is surfaced here so dashboards can show "ops issue" counters
+   * without polluting the scoring track. Field is always populated (defaults
+   * to 0) so dashboard renderers never see `undefined`.
+   */
+  transport_failure_count: number;
 }
 
 export interface CategoryCounters {
@@ -84,6 +94,12 @@ const KNOWN_SIGNALS: Record<ConsensusSignal['signal'], true> = {
   task_timeout: true,
   task_empty: true,
   consensus_coverage_degraded: true,
+  // Operational rewrite from hallucination_caught when the relay worker ran
+  // without the dispatched resolutionRoots (Path 2, spec
+  // docs/specs/2026-04-29-relay-worker-resolution-roots.md). Listed here so the
+  // scoring switch's exhaustiveness check holds; it's a no-op for accuracy /
+  // uniqueness / circuit breaker — only `transport_failure_count` is bumped.
+  transport_failure: true,
 };
 
 const SEVERITY_MULTIPLIER: Record<string, number> = {
@@ -616,6 +632,7 @@ export class PerformanceReader {
       categoryStrengths: Record<string, number>;
       categoryCorrect: Record<string, number>;
       categoryHallucinated: Record<string, number>;
+      transportFailures: number;
     }>();
 
     const ensure = (id: string) => {
@@ -628,6 +645,7 @@ export class PerformanceReader {
         unverifiedsEmitted: 0, unverifiedsReceived: 0,
         totalSignals: 0, lastSignalMs: 0, categoryStrengths: {},
         categoryCorrect: {}, categoryHallucinated: {},
+        transportFailures: 0,
       });
       return acc.get(id)!;
     };
@@ -900,6 +918,15 @@ export class PerformanceReader {
           // Transport/provider failure — contributes nothing to any scoring accumulator.
           // Does not affect accuracy, uniqueness, reliability, or circuit breaker.
           break;
+        case 'transport_failure':
+          // Rewritten from `hallucination_caught` by the relay-worker
+          // resolutionRoots-gap detector (Path 2, spec
+          // docs/specs/2026-04-29-relay-worker-resolution-roots.md). Counted
+          // separately for ops dashboards; deliberately excluded from accuracy
+          // / uniqueness / circuit-breaker arithmetic so a relay-side cwd bug
+          // can't poison agent rankings.
+          a.transportFailures++;
+          break;
         case 'boundary_escape':
           // Sandbox policy violation — recorded for observability, zero weight.
           // Kept out of NEGATIVE_SIGNALS so scope events don't feed the circuit breaker.
@@ -916,6 +943,11 @@ export class PerformanceReader {
     const signalsByAgent = new Map<string, (ConsensusSignal | ImplSignal)[]>();
     for (const signal of consensusSignals) {
       if (!KNOWN_SIGNALS[signal.signal]) continue;
+      // Exclude transport_failure from the streak entirely — it is neither a
+      // negative signal (would feed circuit-breaker) nor a positive signal
+      // (would reset a real failure streak). Treat it as if absent so a relay
+      // cwd outage neither benches nor rehabilitates the agent.
+      if (signal.signal === 'transport_failure') continue;
       const list = signalsByAgent.get(signal.agentId) || [];
       list.push(signal);
       signalsByAgent.set(signal.agentId, list);
@@ -1035,6 +1067,7 @@ export class PerformanceReader {
         categoryCorrect: { ...a.categoryCorrect },
         categoryHallucinated: { ...a.categoryHallucinated },
         categoryAccuracy,
+        transport_failure_count: a.transportFailures,
       });
     }
 
@@ -1051,6 +1084,7 @@ export class PerformanceReader {
           consecutiveFailures: consec,
           circuitOpen: consec >= CIRCUIT_BREAKER_THRESHOLD,
           categoryStrengths: {}, categoryCorrect: {}, categoryHallucinated: {}, categoryAccuracy: {},
+          transport_failure_count: 0,
         });
       }
     }

--- a/packages/orchestrator/src/transport-failure-detector.ts
+++ b/packages/orchestrator/src/transport-failure-detector.ts
@@ -46,6 +46,18 @@ export const TRANSPORT_FAILURE_PATTERN =
   /files? (?:are )?(?:not present|missing)|empty diff|empty workspace|cannot be (?:read|located)|not (?:found|present) (?:on|in)(?: the)? (?:disk|filesystem|worktree)/i;
 
 /**
+ * Cite-anchor pattern. A real grounded hallucination almost always carries a
+ * `<cite tag="file">path:line</cite>` anchor — the model claims to have read
+ * the file. A relay-cwd transport failure CANNOT produce one because the
+ * worker never actually loaded the file. Co-presence of a cite anchor
+ * therefore vetoes the rewrite: prefer false-negative (preserve as
+ * hallucination) over false-positive (silently exonerate a real
+ * hallucination). See PR #327 sonnet review CRITICAL #1.
+ */
+export const CITE_ANCHOR_PATTERN =
+  /<cite\s+tag=["']file["']\s*>[^<]+<\/cite>/i;
+
+/**
  * Caller context required to evaluate the rewrite preconditions. The detector
  * is a pure function over this struct so unit tests can exercise every code
  * path without touching the filesystem or `.gossip/config.json`.
@@ -79,7 +91,12 @@ export function shouldRewriteToTransportFailure(
   if (ctx.isNativeAgent) return false;
   if (!ctx.hadResolutionRoots) return false;
   if (!ctx.findingText) return false;
-  return TRANSPORT_FAILURE_PATTERN.test(ctx.findingText);
+  if (!TRANSPORT_FAILURE_PATTERN.test(ctx.findingText)) return false;
+  // Co-presence veto: if the finding carries a `<cite tag="file">…</cite>`
+  // anchor, the agent at least *claims* to have read code. A relay transport
+  // failure cannot synthesize a cite. Preserve as hallucination_caught.
+  if (CITE_ANCHOR_PATTERN.test(ctx.findingText)) return false;
+  return true;
 }
 
 /**
@@ -185,10 +202,14 @@ export function maybeRewriteHallucinationToTransportFailure(
     extractConsensusId(signal.findingId) ?? signal.consensusId ?? undefined;
   if (!consensusId) return signal;
   const roots = lookupRoundResolutionRoots(projectRoot, consensusId);
+  // Coalesce both fields: callers can place transport text in either `finding`
+  // or `evidence`. Concatenating preserves cite anchors that may live in only
+  // one of the two and matches the pattern across either source.
+  const findingText = `${signal.evidence ?? ''} ${(signal as { finding?: string }).finding ?? ''}`.trim();
   const ctx: TransportFailureContext = {
     isNativeAgent: isNativeAgent(signal.agentId),
     hadResolutionRoots: roots.length > 0,
-    findingText: signal.evidence ?? '',
+    findingText,
   };
   if (!shouldRewriteToTransportFailure(signal.signal, ctx)) return signal;
   appendTransportRewrite(projectRoot, {

--- a/packages/orchestrator/src/transport-failure-detector.ts
+++ b/packages/orchestrator/src/transport-failure-detector.ts
@@ -1,0 +1,207 @@
+/**
+ * transport-failure-detector.ts — Path 2 mitigation for the relay-worker
+ * `resolutionRoots` plumbing gap.
+ *
+ * Spec: docs/specs/2026-04-29-relay-worker-resolution-roots.md.
+ *
+ * When a consensus round dispatches a relay-routed agent (gemini-reviewer,
+ * gemini-tester, openclaw-agent, …) with `resolutionRoots: [...]`, the relay
+ * worker process currently runs against `process.cwd() === projectRoot` —
+ * NOT the dispatched worktree. The agent then emits findings of the shape
+ * "files are not present in the provided worktree / empty diff / cannot be
+ * read", and a downstream cross-reviewer correctly flags those as
+ * `hallucination_caught`. The score hit lands on the model even though the
+ * actual cause was a transport-layer omission (consensus 328adef4-087942f7,
+ * 2026-04-29).
+ *
+ * This module intercepts `gossip_signals(action: "record")` BEFORE the
+ * persistence path and rewrites qualifying `hallucination_caught` signals to
+ * `transport_failure`. The rewrite has THREE preconditions and ALL must hold:
+ *
+ *   1. `signal.signal === 'hallucination_caught'`
+ *   2. The agent is NOT a native subagent. Native agents run in-process with
+ *      the orchestrator's cwd, so a "files not present" finding from a native
+ *      agent is a real hallucination, not a transport failure.
+ *   3. The consensus round was dispatched with `resolutionRoots`. Without
+ *      `resolutionRoots`, there is no relay-side cwd divergence to blame —
+ *      a "files not present" finding is just a finding.
+ *   4. The finding text matches the transport-failure pattern.
+ *
+ * On match, every rewrite is appended to `.gossip/transport-rewrites.jsonl`
+ * so operators can verify the heuristic is not over-triggering. The original
+ * `signal: "hallucination_caught"` is preserved in the audit row, making the
+ * rewrite reversible: a future `gossip_signals(action: "retract", ...)` can
+ * walk the audit log and undo bad reclassifications without losing the
+ * original signal class.
+ */
+
+import { appendFileSync, mkdirSync, readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import type { ConsensusSignal } from './consensus-types';
+
+/** Pattern from spec §"Path 2" tightened with a few additional phrasings the
+ * model uses interchangeably. Case-insensitive. Order: longest alternative
+ * first to avoid silently skipping subset matches in JS regex `|`. */
+export const TRANSPORT_FAILURE_PATTERN =
+  /files? (?:are )?(?:not present|missing)|empty diff|empty workspace|cannot be (?:read|located)|not (?:found|present) (?:on|in)(?: the)? (?:disk|filesystem|worktree)/i;
+
+/**
+ * Caller context required to evaluate the rewrite preconditions. The detector
+ * is a pure function over this struct so unit tests can exercise every code
+ * path without touching the filesystem or `.gossip/config.json`.
+ */
+export interface TransportFailureContext {
+  /** True when the agent is a native Claude Code subagent (runs in-process,
+   * sees the orchestrator's cwd). */
+  isNativeAgent: boolean;
+  /** True when the consensus round was dispatched with a non-empty
+   * `resolutionRoots`. Looked up by the caller via `consensus_id` against the
+   * persisted consensus report. */
+  hadResolutionRoots: boolean;
+  /** Finding text — usually the `finding` field, falling back to
+   * `evidence` when callers consolidate the two before recording. */
+  findingText: string;
+}
+
+/**
+ * Pure detector. Returns `true` when ALL preconditions hold and the caller
+ * SHOULD rewrite `signal: "hallucination_caught"` to
+ * `signal: "transport_failure"` before persistence.
+ *
+ * Native agents and rounds without `resolutionRoots` are explicitly EXEMPT —
+ * see module docstring.
+ */
+export function shouldRewriteToTransportFailure(
+  signalName: string,
+  ctx: TransportFailureContext,
+): boolean {
+  if (signalName !== 'hallucination_caught') return false;
+  if (ctx.isNativeAgent) return false;
+  if (!ctx.hadResolutionRoots) return false;
+  if (!ctx.findingText) return false;
+  return TRANSPORT_FAILURE_PATTERN.test(ctx.findingText);
+}
+
+/**
+ * Audit-log row appended to `.gossip/transport-rewrites.jsonl` on every
+ * rewrite. Schema is intentionally narrow — operators reading the file should
+ * be able to map a row 1:1 to a (consensus_id, finding_id, agent_id) tuple
+ * and reconstruct the original signal class. Excerpt is hard-capped at 200
+ * chars to keep rotation predictable.
+ */
+export interface TransportRewriteAudit {
+  ts: string;
+  consensus_id: string | undefined;
+  finding_id: string | undefined;
+  agent_id: string;
+  original_signal: 'hallucination_caught';
+  rewritten_to: 'transport_failure';
+  finding_excerpt: string;
+}
+
+/**
+ * Append a rewrite audit row to `.gossip/transport-rewrites.jsonl`. Best
+ * effort — failures are swallowed and surfaced via stderr so the record path
+ * never throws to the MCP caller. Mirrors the established pattern in
+ * signal-helpers.ts (every helper wraps appendSignal in try/catch).
+ */
+export function appendTransportRewrite(
+  projectRoot: string,
+  audit: TransportRewriteAudit,
+): void {
+  try {
+    const filePath = join(projectRoot, '.gossip', 'transport-rewrites.jsonl');
+    mkdirSync(dirname(filePath), { recursive: true });
+    appendFileSync(filePath, JSON.stringify(audit) + '\n', 'utf-8');
+  } catch (err) {
+    process.stderr.write(
+      `[gossipcat] appendTransportRewrite failed: ${(err as Error).message}\n`,
+    );
+  }
+}
+
+/**
+ * Lookup helper: read the persisted consensus report at
+ * `.gossip/consensus-reports/<consensus_id>.json` and return its
+ * `resolutionRoots` array (empty if absent). Used by the
+ * `gossip_signals(action: "record")` handler to evaluate
+ * `hadResolutionRoots`.
+ *
+ * The handler can derive `consensus_id` from `finding_id` shapes
+ * `<consensus_id>:fN` (bulk) and `<consensus_id>:<agent>:fN` (manual) — the
+ * 17-character prefix `xxxxxxxx-xxxxxxxx`.
+ */
+export function lookupRoundResolutionRoots(
+  projectRoot: string,
+  consensusId: string,
+): readonly string[] {
+  try {
+    const reportPath = join(
+      projectRoot,
+      '.gossip',
+      'consensus-reports',
+      `${consensusId}.json`,
+    );
+    if (!existsSync(reportPath)) return [];
+    const raw = readFileSync(reportPath, 'utf-8');
+    const parsed = JSON.parse(raw) as { resolutionRoots?: readonly string[] };
+    return Array.isArray(parsed.resolutionRoots) ? parsed.resolutionRoots : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Extract the 17-character `<consensus_id>` prefix from a `finding_id`. Both
+ * canonical shapes are accepted:
+ *   - `<consensus_id>:fN`              → bulk_from_consensus
+ *   - `<consensus_id>:<agent>:fN`      → manual record
+ *
+ * Returns `undefined` when the input is malformed.
+ */
+export function extractConsensusId(findingId: string | undefined): string | undefined {
+  if (!findingId) return undefined;
+  const match = findingId.match(/^([0-9a-f]{8}-[0-9a-f]{8})(?::|$)/);
+  return match ? match[1] : undefined;
+}
+
+/**
+ * Caller-facing convenience: given a manually recorded consensus signal and a
+ * resolver that knows whether the signal's agent is native, decide whether to
+ * rewrite, append the audit row, and return the (possibly rewritten) signal.
+ *
+ * The native-agent check is injected as a callback so the orchestrator
+ * package stays free of `apps/cli/.../mcp-context.ts` (which holds
+ * `nativeAgentConfigs`). Callers in `apps/cli` thread the live
+ * `nativeAgentConfigs` map through the closure.
+ */
+export function maybeRewriteHallucinationToTransportFailure(
+  projectRoot: string,
+  signal: ConsensusSignal,
+  isNativeAgent: (agentId: string) => boolean,
+): ConsensusSignal {
+  if (signal.signal !== 'hallucination_caught') return signal;
+  const consensusId =
+    extractConsensusId(signal.findingId) ?? signal.consensusId ?? undefined;
+  if (!consensusId) return signal;
+  const roots = lookupRoundResolutionRoots(projectRoot, consensusId);
+  const ctx: TransportFailureContext = {
+    isNativeAgent: isNativeAgent(signal.agentId),
+    hadResolutionRoots: roots.length > 0,
+    findingText: signal.evidence ?? '',
+  };
+  if (!shouldRewriteToTransportFailure(signal.signal, ctx)) return signal;
+  appendTransportRewrite(projectRoot, {
+    ts: new Date().toISOString(),
+    consensus_id: consensusId,
+    finding_id: signal.findingId,
+    agent_id: signal.agentId,
+    original_signal: 'hallucination_caught',
+    rewritten_to: 'transport_failure',
+    finding_excerpt: (signal.evidence ?? '').slice(0, 200),
+  });
+  return {
+    ...signal,
+    signal: 'transport_failure',
+  };
+}

--- a/packages/relay/src/dashboard/api-agents.ts
+++ b/packages/relay/src/dashboard/api-agents.ts
@@ -173,6 +173,7 @@ const DEFAULT_SCORE: AgentScore = {
   weightedHallucinations: 0,
   consecutiveFailures: 0, circuitOpen: false, categoryStrengths: {},
   categoryCorrect: {}, categoryHallucinated: {}, categoryAccuracy: {},
+  transport_failure_count: 0,
 };
 
 interface TaskGraphEntry {

--- a/packages/relay/src/dashboard/api-agents.ts
+++ b/packages/relay/src/dashboard/api-agents.ts
@@ -159,6 +159,13 @@ export interface AgentResponse {
     uniqueFindings: number;
     unverifiedsEmitted: number;
     unverifiedsReceived: number;
+    /** Count of `transport_failure` signals attributed to this agent.
+     * Excluded from accuracy / uniqueness / circuit-breaker arithmetic
+     * (Path 2 mitigation, spec
+     * docs/specs/2026-04-29-relay-worker-resolution-roots.md). Surfaced for
+     * dashboard observability so operators can spot agents whose hallucination
+     * counts were inflated by relay-cwd transport failures. */
+    transportFailureCount: number;
     bench: {
       state: 'benched' | 'kept-for-coverage' | 'none';
       reason?: 'chronic-low-accuracy' | 'burst-hallucination';
@@ -327,6 +334,7 @@ export async function agentsHandler(
         uniqueFindings: score.uniqueFindings ?? 0,
         unverifiedsEmitted: score.unverifiedsEmitted ?? 0,
         unverifiedsReceived: score.unverifiedsReceived ?? 0,
+        transportFailureCount: score.transport_failure_count ?? 0,
         consecutiveFailures: score.consecutiveFailures ?? 0,
         circuitOpen: score.circuitOpen ?? false,
         bench,

--- a/tests/orchestrator/collect-check-effectiveness.test.ts
+++ b/tests/orchestrator/collect-check-effectiveness.test.ts
@@ -49,6 +49,7 @@ function makeStubPerfReader(
     categoryAccuracy: {},
     categoryCorrect,
     categoryHallucinated,
+    transport_failure_count: 0,
   };
   jest.spyOn(reader, 'getScores').mockReturnValue(new Map([[agentId, score]]));
   jest.spyOn(reader, 'getCountersSince').mockImplementation((_a, cat) => ({

--- a/tests/orchestrator/dispatch-differentiator.test.ts
+++ b/tests/orchestrator/dispatch-differentiator.test.ts
@@ -10,6 +10,7 @@ function makeProfile(id: string, strengths: Record<string, number>): AgentScore 
     uniqueFindings: 3, hallucinations: 0, weightedHallucinations: 0,
     consecutiveFailures: 0, circuitOpen: false,
     categoryCorrect: {}, categoryHallucinated: {}, categoryAccuracy: {},
+    transport_failure_count: 0,
   };
 }
 

--- a/tests/orchestrator/is-benched.test.ts
+++ b/tests/orchestrator/is-benched.test.ts
@@ -31,6 +31,7 @@ function makeScore(partial: Partial<AgentScore> & { agentId: string }): AgentSco
     categoryCorrect: {},
     categoryHallucinated: {},
     categoryAccuracy: {},
+    transport_failure_count: 0,
     ...partial,
   };
 }

--- a/tests/orchestrator/performance-reader-transport-failure.test.ts
+++ b/tests/orchestrator/performance-reader-transport-failure.test.ts
@@ -1,0 +1,163 @@
+/**
+ * performance-reader transport_failure exclusion tests — Path 2 mitigation
+ * for the relay-worker resolutionRoots plumbing gap. Spec:
+ * docs/specs/2026-04-29-relay-worker-resolution-roots.md.
+ *
+ * Verifies:
+ *   - `transport_failure` rows are excluded from accuracy / uniqueness
+ *     arithmetic — a relay cwd outage cannot poison agent rankings.
+ *   - `transport_failure_count` is populated on AgentScore so dashboards can
+ *     surface the ops issue separately from the scoring track.
+ *   - `transport_failure` is NOT a negative signal: it never feeds the
+ *     circuit breaker.
+ */
+
+import { PerformanceReader } from '../../packages/orchestrator/src/performance-reader';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const TEST_DIR = join(__dirname, '..', '..', '.test-perf-reader-transport-failure');
+
+function writeSignals(signals: any[]): void {
+  mkdirSync(join(TEST_DIR, '.gossip'), { recursive: true });
+  const data = signals.map(s => JSON.stringify(s)).join('\n') + '\n';
+  writeFileSync(join(TEST_DIR, '.gossip', 'agent-performance.jsonl'), data);
+}
+
+beforeEach(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterAll(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+});
+
+const now = new Date().toISOString();
+
+function makeBaseAgreement(taskId: string, agentId = 'gemini-reviewer'): any {
+  return {
+    type: 'consensus',
+    signal: 'agreement',
+    taskId,
+    agentId,
+    counterpartId: 'sonnet-reviewer',
+    category: 'trust_boundaries',
+    severity: 'medium',
+    evidence: 'confirmed peer finding',
+    timestamp: now,
+  };
+}
+
+describe('PerformanceReader — transport_failure exclusion', () => {
+  it('excludes transport_failure from accuracy arithmetic', () => {
+    // Three agreements (positive) + one transport_failure. Without the
+    // exclusion, the transport_failure should not contribute. We verify by
+    // comparing to a baseline run with NO transport_failure row.
+    writeSignals([
+      makeBaseAgreement('t-1'),
+      makeBaseAgreement('t-2'),
+      makeBaseAgreement('t-3'),
+      {
+        type: 'consensus',
+        signal: 'transport_failure',
+        taskId: 't-4',
+        agentId: 'gemini-reviewer',
+        consensusId: '328adef4-087942f7',
+        findingId: '328adef4-087942f7:gemini-reviewer:f1',
+        category: 'trust_boundaries',
+        evidence: 'Files are not present in the provided worktree',
+        timestamp: now,
+      },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getScores().get('gemini-reviewer');
+    expect(score).toBeDefined();
+    // Hallucination count must be zero — the transport_failure row must NOT
+    // be counted as a hallucination.
+    expect(score!.hallucinations).toBe(0);
+    expect(score!.weightedHallucinations).toBe(0);
+    // Accuracy should reflect 3 agreements / 3 total = 1.0 (or whatever the
+    // baseline produces). The key invariant is: transport_failure didn't
+    // pull accuracy down.
+    expect(score!.accuracy).toBeGreaterThan(0.5);
+  });
+
+  it('populates transport_failure_count on AgentScore', () => {
+    writeSignals([
+      makeBaseAgreement('t-1'),
+      {
+        type: 'consensus',
+        signal: 'transport_failure',
+        taskId: 't-2',
+        agentId: 'gemini-reviewer',
+        consensusId: '328adef4-087942f7',
+        findingId: '328adef4-087942f7:gemini-reviewer:f1',
+        evidence: 'Files are not present',
+        timestamp: now,
+      },
+      {
+        type: 'consensus',
+        signal: 'transport_failure',
+        taskId: 't-3',
+        agentId: 'gemini-reviewer',
+        consensusId: '328adef4-087942f7',
+        findingId: '328adef4-087942f7:gemini-reviewer:f2',
+        evidence: 'empty diff',
+        timestamp: now,
+      },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getScores().get('gemini-reviewer');
+    expect(score).toBeDefined();
+    expect(score!.transport_failure_count).toBe(2);
+  });
+
+  it('does not feed circuit breaker — transport_failure breaks no streak and starts no streak', () => {
+    // Two trailing hallucinations would bump consecutiveFailures to 2 (just
+    // under the threshold). Insert a transport_failure as the most recent
+    // signal — it should NOT count as a failure (streak stays 2) and should
+    // NOT count as a positive (does not reset the streak to 0). The streak
+    // is computed from the next-most-recent eligible signal: hallucination.
+    const t0 = new Date(Date.now() - 3000).toISOString();
+    const t1 = new Date(Date.now() - 2000).toISOString();
+    const t2 = new Date(Date.now() - 1000).toISOString();
+    writeSignals([
+      {
+        type: 'consensus', signal: 'hallucination_caught',
+        taskId: 'h-1', agentId: 'gemini-reviewer',
+        category: 'trust_boundaries', evidence: 'real hallucination',
+        timestamp: t0,
+      },
+      {
+        type: 'consensus', signal: 'hallucination_caught',
+        taskId: 'h-2', agentId: 'gemini-reviewer',
+        category: 'trust_boundaries', evidence: 'real hallucination',
+        timestamp: t1,
+      },
+      {
+        type: 'consensus', signal: 'transport_failure',
+        taskId: 'h-3', agentId: 'gemini-reviewer',
+        consensusId: '328adef4-087942f7',
+        findingId: '328adef4-087942f7:gemini-reviewer:f1',
+        evidence: 'Files are not present',
+        timestamp: t2,
+      },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getScores().get('gemini-reviewer');
+    expect(score).toBeDefined();
+    // Two hallucinations are streak-eligible; transport_failure is invisible
+    // to the streak logic so the count is exactly 2.
+    expect(score!.consecutiveFailures).toBe(2);
+    expect(score!.circuitOpen).toBe(false);
+  });
+
+  it('defaults transport_failure_count to 0 when absent', () => {
+    writeSignals([makeBaseAgreement('t-1')]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getScores().get('gemini-reviewer');
+    expect(score).toBeDefined();
+    expect(score!.transport_failure_count).toBe(0);
+  });
+});

--- a/tests/orchestrator/skill-engine-baseline-snapshot.test.ts
+++ b/tests/orchestrator/skill-engine-baseline-snapshot.test.ts
@@ -94,6 +94,7 @@ function makeStubPerfReader(
           categoryAccuracy: {},
           categoryCorrect,
           categoryHallucinated,
+          transport_failure_count: 0,
         },
       ],
     ]),

--- a/tests/orchestrator/skill-engine-check-effectiveness.test.ts
+++ b/tests/orchestrator/skill-engine-check-effectiveness.test.ts
@@ -41,6 +41,7 @@ function makeStubPerfReader(
     categoryAccuracy: {},
     categoryCorrect,
     categoryHallucinated,
+    transport_failure_count: 0,
   };
   jest.spyOn(reader, 'getScores').mockReturnValue(new Map([[agentId, score]]));
   // v2: checkEffectiveness uses getCountersSince(agentId, cat, anchorMs) to get

--- a/tests/orchestrator/transport-failure-detector.test.ts
+++ b/tests/orchestrator/transport-failure-detector.test.ts
@@ -152,6 +152,36 @@ describe('shouldRewriteToTransportFailure', () => {
       }),
     ).toBe(false);
   });
+
+  // PR #327 sonnet review CRITICAL #1 — cite-anchor co-presence veto.
+  it('cite-anchor co-presence vetoes the rewrite (preserve as hallucination)', () => {
+    expect(
+      shouldRewriteToTransportFailure('hallucination_caught', {
+        ...baseCtx,
+        findingText:
+          'feature flag file is missing — see <cite tag="file">config/flags.ts:12</cite>',
+      }),
+    ).toBe(false);
+  });
+
+  it('matching text WITHOUT a cite anchor still rewrites', () => {
+    expect(
+      shouldRewriteToTransportFailure('hallucination_caught', {
+        ...baseCtx,
+        findingText: 'files are not present in the worktree',
+      }),
+    ).toBe(true);
+  });
+
+  it('cite anchor with single quotes is also detected', () => {
+    expect(
+      shouldRewriteToTransportFailure('hallucination_caught', {
+        ...baseCtx,
+        findingText:
+          "files are missing — <cite tag='file'>src/x.ts:1</cite>",
+      }),
+    ).toBe(false);
+  });
 });
 
 describe('extractConsensusId', () => {
@@ -283,6 +313,39 @@ describe('maybeRewriteHallucinationToTransportFailure — end-to-end', () => {
     } as Partial<ConsensusSignal>);
     const out = maybeRewriteHallucinationToTransportFailure(TEST_DIR, sig, isNative);
     expect(out).toBe(sig);
+  });
+
+  // PR #327 sonnet review HIGH #3 — coalesce evidence + finding fields.
+  it('coalesces signal.finding into the pattern check when evidence is unrelated', () => {
+    writeReport('328adef4-087942f7', {
+      id: '328adef4-087942f7',
+      resolutionRoots: ['/some/worktree'],
+    });
+    const sig = makeHallucinationSignal({
+      agentId: RELAY_AGENT,
+      evidence: 'unrelated noise',
+      // ConsensusSignal nominally has no `finding`, but recordSignals callers
+      // pass through a divergent `finding` field; the detector must coalesce.
+      finding: 'files are not present in the provided worktree',
+    } as Partial<ConsensusSignal> & { finding?: string });
+    const out = maybeRewriteHallucinationToTransportFailure(TEST_DIR, sig, isNative);
+    expect(out.signal).toBe('transport_failure');
+  });
+
+  // PR #327 sonnet review CRITICAL #1 — cite-anchor veto end-to-end.
+  it('preserves hallucination_caught when finding carries a cite anchor', () => {
+    writeReport('328adef4-087942f7', {
+      id: '328adef4-087942f7',
+      resolutionRoots: ['/some/worktree'],
+    });
+    const sig = makeHallucinationSignal({
+      agentId: RELAY_AGENT,
+      evidence:
+        'feature flag file is missing — see <cite tag="file">config/flags.ts:12</cite>',
+    });
+    const out = maybeRewriteHallucinationToTransportFailure(TEST_DIR, sig, isNative);
+    expect(out.signal).toBe('hallucination_caught');
+    expect(readAuditLog()).toHaveLength(0);
   });
 
   it('returns input unchanged when consensus_id cannot be derived', () => {

--- a/tests/orchestrator/transport-failure-detector.test.ts
+++ b/tests/orchestrator/transport-failure-detector.test.ts
@@ -1,0 +1,298 @@
+/**
+ * transport-failure-detector tests — Path 2 mitigation for the relay-worker
+ * resolutionRoots plumbing gap. Spec:
+ * docs/specs/2026-04-29-relay-worker-resolution-roots.md.
+ *
+ * Covers the five canonical cases from the dispatch task:
+ *   (a) hallucination_caught against native agent → NOT rewritten
+ *   (b) hallucination_caught against relay agent + resolutionRoots
+ *       + matching pattern → rewritten
+ *   (c) hallucination_caught against relay agent + resolutionRoots
+ *       BUT non-matching text → NOT rewritten
+ *   (d) hallucination_caught against relay agent WITHOUT resolutionRoots
+ *       → NOT rewritten
+ *   (e) audit log preserves original signal so retraction is reversible
+ */
+
+import {
+  shouldRewriteToTransportFailure,
+  maybeRewriteHallucinationToTransportFailure,
+  appendTransportRewrite,
+  lookupRoundResolutionRoots,
+  extractConsensusId,
+  TRANSPORT_FAILURE_PATTERN,
+} from '../../packages/orchestrator/src/transport-failure-detector';
+import type { ConsensusSignal } from '../../packages/orchestrator/src/consensus-types';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const TEST_DIR = join(__dirname, '..', '..', '.test-transport-failure-detector');
+
+beforeEach(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterAll(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+});
+
+function writeReport(consensusId: string, body: Record<string, unknown>): void {
+  const dir = join(TEST_DIR, '.gossip', 'consensus-reports');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${consensusId}.json`), JSON.stringify(body));
+}
+
+function readAuditLog(): Array<Record<string, unknown>> {
+  const path = join(TEST_DIR, '.gossip', 'transport-rewrites.jsonl');
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf-8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as Record<string, unknown>);
+}
+
+function makeHallucinationSignal(overrides: Partial<ConsensusSignal> = {}): ConsensusSignal {
+  return {
+    type: 'consensus',
+    signal: 'hallucination_caught',
+    taskId: 't-1',
+    consensusId: '328adef4-087942f7',
+    findingId: '328adef4-087942f7:gemini-reviewer:f1',
+    agentId: 'gemini-reviewer',
+    evidence: 'Files are not present in the provided worktree',
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  } as ConsensusSignal;
+}
+
+describe('TRANSPORT_FAILURE_PATTERN', () => {
+  it('matches the canonical relay-worker error phrasings', () => {
+    const cases = [
+      'Files are not present in the provided worktree',
+      'The core feature files are missing',
+      'git diff reports empty diff for the specified commit',
+      'empty workspace at the cited path',
+      'cannot be read from disk',
+      'cannot be located on disk',
+      'not found on disk',
+      'not present in the worktree',
+      'not present on the filesystem',
+    ];
+    for (const text of cases) {
+      expect(TRANSPORT_FAILURE_PATTERN.test(text)).toBe(true);
+    }
+  });
+
+  it('does not match unrelated hallucination text', () => {
+    const cases = [
+      'XSS vulnerability in template renderer',
+      'unbounded loop on user input',
+      'race condition between A and B',
+      'function returns wrong type at line 42',
+    ];
+    for (const text of cases) {
+      expect(TRANSPORT_FAILURE_PATTERN.test(text)).toBe(false);
+    }
+  });
+});
+
+describe('shouldRewriteToTransportFailure', () => {
+  const baseCtx = {
+    isNativeAgent: false,
+    hadResolutionRoots: true,
+    findingText: 'Files are not present in the provided worktree',
+  };
+
+  it('case (a): native agent → does NOT rewrite', () => {
+    expect(
+      shouldRewriteToTransportFailure('hallucination_caught', {
+        ...baseCtx,
+        isNativeAgent: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('case (b): relay agent + resolutionRoots + matching text → rewrites', () => {
+    expect(
+      shouldRewriteToTransportFailure('hallucination_caught', baseCtx),
+    ).toBe(true);
+  });
+
+  it('case (c): relay agent + resolutionRoots + non-matching text → does NOT rewrite', () => {
+    expect(
+      shouldRewriteToTransportFailure('hallucination_caught', {
+        ...baseCtx,
+        findingText: 'XSS vulnerability in renderUserBio',
+      }),
+    ).toBe(false);
+  });
+
+  it('case (d): relay agent + matching text + NO resolutionRoots → does NOT rewrite', () => {
+    expect(
+      shouldRewriteToTransportFailure('hallucination_caught', {
+        ...baseCtx,
+        hadResolutionRoots: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('only fires for hallucination_caught — agreement / unique_confirmed pass through', () => {
+    for (const sig of ['agreement', 'unique_confirmed', 'disagreement', 'task_empty']) {
+      expect(shouldRewriteToTransportFailure(sig, baseCtx)).toBe(false);
+    }
+  });
+
+  it('returns false on empty findingText', () => {
+    expect(
+      shouldRewriteToTransportFailure('hallucination_caught', {
+        ...baseCtx,
+        findingText: '',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('extractConsensusId', () => {
+  it('parses the bulk shape <consensus_id>:fN', () => {
+    expect(extractConsensusId('328adef4-087942f7:f1')).toBe('328adef4-087942f7');
+  });
+
+  it('parses the manual shape <consensus_id>:<agent>:fN', () => {
+    expect(extractConsensusId('328adef4-087942f7:gemini-reviewer:f1')).toBe(
+      '328adef4-087942f7',
+    );
+  });
+
+  it('returns undefined on missing input', () => {
+    expect(extractConsensusId(undefined)).toBeUndefined();
+    expect(extractConsensusId('')).toBeUndefined();
+  });
+
+  it('returns undefined on malformed prefix', () => {
+    expect(extractConsensusId('not-a-consensus-id:f1')).toBeUndefined();
+    expect(extractConsensusId('xxxxxxxx-xxxxxxxx:f1')).toBeUndefined();
+  });
+});
+
+describe('lookupRoundResolutionRoots', () => {
+  it('returns empty array when the report does not exist', () => {
+    expect(lookupRoundResolutionRoots(TEST_DIR, 'aaaaaaaa-bbbbbbbb')).toEqual([]);
+  });
+
+  it('returns the roots array when the report has one', () => {
+    writeReport('aaaaaaaa-bbbbbbbb', {
+      id: 'aaaaaaaa-bbbbbbbb',
+      resolutionRoots: ['/abs/path/to/worktree'],
+    });
+    expect(lookupRoundResolutionRoots(TEST_DIR, 'aaaaaaaa-bbbbbbbb')).toEqual([
+      '/abs/path/to/worktree',
+    ]);
+  });
+
+  it('returns empty array when resolutionRoots is missing or non-array', () => {
+    writeReport('cccccccc-dddddddd', { id: 'cccccccc-dddddddd' });
+    expect(lookupRoundResolutionRoots(TEST_DIR, 'cccccccc-dddddddd')).toEqual([]);
+  });
+});
+
+describe('appendTransportRewrite — case (e) audit preserves original signal', () => {
+  it('appends a row containing original_signal so retraction can replay it', () => {
+    appendTransportRewrite(TEST_DIR, {
+      ts: '2026-04-29T12:00:00.000Z',
+      consensus_id: '328adef4-087942f7',
+      finding_id: '328adef4-087942f7:gemini-reviewer:f1',
+      agent_id: 'gemini-reviewer',
+      original_signal: 'hallucination_caught',
+      rewritten_to: 'transport_failure',
+      finding_excerpt: 'Files are not present in the provided worktree',
+    });
+    const rows = readAuditLog();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      original_signal: 'hallucination_caught',
+      rewritten_to: 'transport_failure',
+      consensus_id: '328adef4-087942f7',
+      finding_id: '328adef4-087942f7:gemini-reviewer:f1',
+      agent_id: 'gemini-reviewer',
+    });
+  });
+});
+
+describe('maybeRewriteHallucinationToTransportFailure — end-to-end', () => {
+  const RELAY_AGENT = 'gemini-reviewer';
+  const NATIVE_AGENT = 'sonnet-reviewer';
+  const isNative = (id: string): boolean => id === NATIVE_AGENT;
+
+  it('case (b): rewrites when ALL preconditions hold', () => {
+    writeReport('328adef4-087942f7', {
+      id: '328adef4-087942f7',
+      resolutionRoots: ['/some/worktree'],
+    });
+    const sig = makeHallucinationSignal({ agentId: RELAY_AGENT });
+    const out = maybeRewriteHallucinationToTransportFailure(TEST_DIR, sig, isNative);
+    expect(out.signal).toBe('transport_failure');
+    expect(out.agentId).toBe(RELAY_AGENT);
+    // Audit log written
+    const rows = readAuditLog();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].original_signal).toBe('hallucination_caught');
+  });
+
+  it('case (a): does NOT rewrite for native agent', () => {
+    writeReport('328adef4-087942f7', {
+      id: '328adef4-087942f7',
+      resolutionRoots: ['/some/worktree'],
+    });
+    const sig = makeHallucinationSignal({ agentId: NATIVE_AGENT });
+    const out = maybeRewriteHallucinationToTransportFailure(TEST_DIR, sig, isNative);
+    expect(out.signal).toBe('hallucination_caught');
+    expect(readAuditLog()).toHaveLength(0);
+  });
+
+  it('case (c): does NOT rewrite when text does not match the pattern', () => {
+    writeReport('328adef4-087942f7', {
+      id: '328adef4-087942f7',
+      resolutionRoots: ['/some/worktree'],
+    });
+    const sig = makeHallucinationSignal({
+      agentId: RELAY_AGENT,
+      evidence: 'XSS vulnerability in renderUserBio at handlers/user.ts:42',
+    });
+    const out = maybeRewriteHallucinationToTransportFailure(TEST_DIR, sig, isNative);
+    expect(out.signal).toBe('hallucination_caught');
+    expect(readAuditLog()).toHaveLength(0);
+  });
+
+  it('case (d): does NOT rewrite when consensus round had no resolutionRoots', () => {
+    writeReport('328adef4-087942f7', {
+      id: '328adef4-087942f7',
+      resolutionRoots: [],
+    });
+    const sig = makeHallucinationSignal({ agentId: RELAY_AGENT });
+    const out = maybeRewriteHallucinationToTransportFailure(TEST_DIR, sig, isNative);
+    expect(out.signal).toBe('hallucination_caught');
+    expect(readAuditLog()).toHaveLength(0);
+  });
+
+  it('returns input unchanged for non-hallucination signals', () => {
+    const sig = makeHallucinationSignal({
+      signal: 'agreement',
+      agentId: RELAY_AGENT,
+    } as Partial<ConsensusSignal>);
+    const out = maybeRewriteHallucinationToTransportFailure(TEST_DIR, sig, isNative);
+    expect(out).toBe(sig);
+  });
+
+  it('returns input unchanged when consensus_id cannot be derived', () => {
+    const sig = makeHallucinationSignal({
+      agentId: RELAY_AGENT,
+      findingId: undefined,
+      consensusId: undefined,
+    });
+    const out = maybeRewriteHallucinationToTransportFailure(TEST_DIR, sig, isNative);
+    expect(out.signal).toBe('hallucination_caught');
+    expect(readAuditLog()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Path 2 of [`docs/specs/2026-04-29-relay-worker-resolution-roots.md`](docs/specs/2026-04-29-relay-worker-resolution-roots.md) (spec is local-only/gitignored). Server-side `transport_failure` signal-class detector — when a relay agent records a `hallucination_caught` whose finding text matches the "files missing / empty diff / cannot read" pattern AND the consensus round had `resolutionRoots` supplied, the signal is rewritten to `transport_failure` before persisting to `.gossip/agent-performance.jsonl`. Score impact lands on transport infrastructure, not the model.

**Empirical motivation:** consensus `328adef4-087942f7` (PR #325 review). gemini-reviewer hallucinated 3 critical findings ("files missing") because the relay-worker (ToolServer singleton) ran with `cwd=projectRoot` instead of the PR-branch worktree. Dispatch weight dropped to 0.30 (circuit-breaker risk) before manual retraction restored it to 1.46 — but only after operator intervention. This detector closes that loop.

Path 1 (the real fix — plumb `resolutionRoots` through `ToolServer.assignRoots()`) is scoped at ~50-60 LOC across 5 files per haiku-researcher's research; ships in a separate PR.

## What changes

**NEW**
- `packages/orchestrator/src/transport-failure-detector.ts` (207 LOC) — pure `shouldRewriteToTransportFailure()` detector, `appendTransportRewrite()` audit-log writer to `.gossip/transport-rewrites.jsonl`, `lookupRoundResolutionRoots()` consensus-report reader, `maybeRewriteHallucinationToTransportFailure()` end-to-end helper. Native-agent check injected as a callback so orchestrator package stays independent of `apps/cli/src/mcp-context.ts`.

**MODIFIED**
- `packages/orchestrator/src/consensus-types.ts` — added `'transport_failure'` to `ConsensusSignal['signal']` union and `OPERATIONAL_SIGNAL_NAMES`.
- `packages/orchestrator/src/performance-reader.ts` — `KNOWN_SIGNALS.transport_failure: true`, `transportFailures` accumulator, scoring case (counter-only, zero weight), circuit-breaker exclusion (no streak break/start), `AgentScore.transport_failure_count` populated on emit.
- `packages/orchestrator/src/index.ts` — re-exports detector API.
- `apps/cli/src/handlers/collect.ts` — hoisted `outerEffectiveRoots` so the persisted consensus-report JSON now records `resolutionRoots: []` for the detector to look up.
- `apps/cli/src/mcp-server-sdk.ts` — wires the rewrite into `gossip_signals(action: "record")` BEFORE category enforcement, dedup, and skill-gap path.
- `packages/relay/src/dashboard/api-agents.ts` + 5 test fixtures — added `transport_failure_count: 0` to AgentScore literals.

**TESTS**
- `tests/orchestrator/transport-failure-detector.test.ts` — 22 tests covering canonical cases (a)–(e), pattern matrix, consensus_id extraction from finding_id, lookup logic, audit log preservation for retraction reversibility.
- `tests/orchestrator/performance-reader-transport-failure.test.ts` — 4 tests covering accuracy exclusion, counter population, circuit-breaker invisibility, default zero.

## Test plan

- [x] `npx tsc --noEmit -p packages/orchestrator/tsconfig.json` — clean.
- [x] `npx jest tests/orchestrator/` — 124 suites, 1790 tests pass (20 skipped). 26 new tests added; 0 regressions.
- [x] `npx jest tests/relay/` and `npx jest tests/cli/` — all green.
- [x] Smoke: synthetic transport_failure-eligible signal → rewrite + audit-log write end-to-end confirmed.
- [ ] CLI typecheck via primary-worktree's stale `dist/index.d.ts` may surface a transient missing-export; resolves on `npm run build:all` post-merge.

## Out of scope (follow-ups)

- Path 1 — plumb `resolutionRoots` through `ToolServer.assignRoots()` per haiku-researcher's research. ~50-60 LOC; touch points in `dispatch-pipeline.ts` + `consensus-engine.ts:347` + `relay-tasks.ts` + new assignment hook + `tool-server.ts` wrapper.
- Dashboard surface for `transport_failure_count` on agent cards — separate PR.
- Backfill of historic relay-agent score adjustments — manual retraction is sufficient (already done for consensus 328adef4 in this session).