### PR TITLE
fix(orchestrator): PR #328 follow-up — register transport_failure + Option B warning + test coverage

### DIFF
--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -160,3 +160,5 @@ export {
   FINDING_RESOLVER_INTERNALS,
 } from './finding-resolver';
 export type { ResolveOptions, ResolveResult, ResolveSkipped, SymbolPresence } from './finding-resolver';
+export { TaskStreamEventType } from './task-stream';
+export type { TaskStreamEvent } from './task-stream';

--- a/packages/orchestrator/src/performance-writer.ts
+++ b/packages/orchestrator/src/performance-writer.ts
@@ -51,6 +51,11 @@ const VALID_CONSENSUS_SIGNALS = new Set([
   // Sandbox policy violation — recorded for observability, zero weight in scoring.
   // Consensus round bb03845d-64264402 (7/7 confirmed).
   'boundary_escape',
+  // Transport-layer failure (relay-worker resolutionRoots gap, missing/deleted
+  // worktree, cwd misrouting). Excluded from accuracy/uniqueness arithmetic
+  // per performance-reader.ts:950 + L75. Pre-PR #329: rejected by validateSignal
+  // and silently dropped, masking the fail-closed signal emit added in PR #328.
+  'transport_failure',
 ]);
 
 const VALID_IMPL_SIGNALS = new Set([

--- a/packages/tools/src/tool-server.ts
+++ b/packages/tools/src/tool-server.ts
@@ -136,7 +136,19 @@ export class ToolServer {
 
   assignRoot(agentId: string, root: string): void {
     const abs = resolve(root);
-    this.agentRoots.set(agentId, canonicalizeForBoundary(abs));
+    const canonical = canonicalizeForBoundary(abs);
+    const existing = this.agentRoots.get(agentId);
+    if (existing && existing !== canonical) {
+      // Option B (spec §"Concurrent rounds"): two parallel rounds dispatched
+      // the same agentId with different roots. Last-write-wins corrupts the
+      // earlier task's cwd. Warn so operators can correlate; Option A re-key
+      // by (agentId, taskId) is deferred until production observes this.
+      process.stderr.write(
+        `[gossipcat] assignRoot collision: agent=${agentId} replacing root ` +
+        `${existing} → ${canonical} (Option B last-write-wins)\n`,
+      );
+    }
+    this.agentRoots.set(agentId, canonical);
     this.writeAgents.add(agentId);
   }
 

--- a/tests/orchestrator/dispatch-pipeline-resolution-roots.test.ts
+++ b/tests/orchestrator/dispatch-pipeline-resolution-roots.test.ts
@@ -19,7 +19,8 @@
  *     undefined / empty array.
  */
 import { DispatchPipeline, WorkerAgent } from '@gossip/orchestrator';
-import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { TaskStreamEventType } from '@gossip/orchestrator';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -49,7 +50,7 @@ function fakeWorkerAgent(impl: {
 }): any {
   const wa: any = Object.create(WorkerAgent.prototype);
   wa.executeTask = impl.executeTask ?? (async function* () {
-    yield { type: 'final_result', payload: { result: 'ok', inputTokens: 0, outputTokens: 0 }, timestamp: Date.now() };
+    yield { type: TaskStreamEventType.FINAL_RESULT, payload: { result: 'ok', inputTokens: 0, outputTokens: 0 }, timestamp: Date.now() };
   });
   wa.subscribeToBatch = jest.fn().mockResolvedValue(undefined);
   wa.unsubscribeFromBatch = jest.fn().mockResolvedValue(undefined);
@@ -60,7 +61,7 @@ function plainRelayWorker(opts?: { result?: string }) {
   return {
     executeTask: jest.fn().mockImplementation(async function* () {
       yield {
-        type: 'final_result',
+        type: TaskStreamEventType.FINAL_RESULT,
         payload: { result: opts?.result ?? 'done', inputTokens: 0, outputTokens: 0 },
         timestamp: Date.now(),
       };
@@ -115,7 +116,7 @@ describe('DispatchPipeline — resolutionRoots → relay tool-call scoping (Path
     const wa = fakeWorkerAgent({
       executeTask: async function* () {
         executeTaskCalledAt = Date.now();
-        yield { type: 'final_result', payload: { result: 'ok', inputTokens: 0, outputTokens: 0 }, timestamp: Date.now() };
+        yield { type: TaskStreamEventType.FINAL_RESULT, payload: { result: 'ok', inputTokens: 0, outputTokens: 0 }, timestamp: Date.now() };
       },
     });
     workers.set('relay-1', wa);
@@ -149,6 +150,19 @@ describe('DispatchPipeline — resolutionRoots → relay tool-call scoping (Path
     const { finalResultPromise } = pipeline.dispatch('relay-1', 'review', { resolutionRoots: [ghost] });
     await expect(finalResultPromise).rejects.toThrow(/does not exist or is not a directory/);
     expect(ts._calls.filter(c => c.type === 'assignRoot')).toHaveLength(0);
+
+    // Invariant #3 (fail-closed): assert transport_failure signal emitted.
+    // Read the JSONL written by emitConsensusSignals → PerformanceWriter.
+    const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+    expect(existsSync(perfPath)).toBe(true);
+    const lines = readFileSync(perfPath, 'utf8').trim().split('\n').filter(Boolean);
+    const signals = lines.map(l => JSON.parse(l));
+    const tf = signals.filter(s => s.signal === 'transport_failure');
+    expect(tf).toHaveLength(1);
+    expect(tf[0].agentId).toBe('relay-1');
+    expect(typeof tf[0].taskId).toBe('string');
+    expect(tf[0].taskId.length).toBeGreaterThan(0);
+    expect(tf[0].evidence).toMatch(/does not exist or is not a directory/);
   });
 
   // ── Test 5 — multiple roots: only [0] used ─────────────────────────────
@@ -177,7 +191,7 @@ describe('DispatchPipeline — resolutionRoots → relay tool-call scoping (Path
       workers.set('shared', fakeWorkerAgent({
         executeTask: async function* () {
           await new Promise(r => setTimeout(r, 5));
-          yield { type: 'final_result', payload: { result: 'ok', inputTokens: 0, outputTokens: 0 }, timestamp: Date.now() };
+          yield { type: TaskStreamEventType.FINAL_RESULT, payload: { result: 'ok', inputTokens: 0, outputTokens: 0 }, timestamp: Date.now() };
         },
       }));
       const r1 = pipeline.dispatch('shared', 'A', { resolutionRoots: [worktree] });
@@ -208,13 +222,58 @@ describe('DispatchPipeline — resolutionRoots → relay tool-call scoping (Path
     const { workers, pipeline } = buildPipeline(ts);
     workers.set('relay-1', fakeWorkerAgent({
       executeTask: async function* () {
-        yield { type: 'error', payload: { error: 'boom' }, timestamp: Date.now() };
+        yield { type: TaskStreamEventType.ERROR, payload: { error: 'boom' }, timestamp: Date.now() };
       },
     }));
     const { finalResultPromise } = pipeline.dispatch('relay-1', 'review', { resolutionRoots: [worktree] });
     await finalResultPromise.catch(() => {});
     const releases = ts._calls.filter(c => c.type === 'releaseAgent' && c.agentId === 'relay-1');
     expect(releases.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── Test 8c — releaseAgent on user-cancellation ───────────────────────
+  it('Test 8c — releaseAgent called when cancelRunningTasks() fires mid-flight', async () => {
+    const ts = mkToolServer();
+    const { workers, pipeline } = buildPipeline(ts);
+    let resolveExecute: () => void = () => {};
+    workers.set('relay-1', fakeWorkerAgent({
+      executeTask: async function* () {
+        await new Promise<void>(r => { resolveExecute = r; });
+        yield { type: TaskStreamEventType.FINAL_RESULT, payload: { result: 'ok', inputTokens: 0, outputTokens: 0 }, timestamp: Date.now() };
+      },
+    }));
+    const { finalResultPromise } = pipeline.dispatch('relay-1', 'review', { resolutionRoots: [worktree] });
+    // Yield to runTask so assignRoot fires + entry is registered.
+    await new Promise(r => setImmediate(r));
+    expect(ts._calls.filter(c => c.type === 'assignRoot')).toHaveLength(1);
+    const cancelled = pipeline.cancelRunningTasks();
+    expect(cancelled).toBeGreaterThanOrEqual(1);
+    const releases = ts._calls.filter(c => c.type === 'releaseAgent' && c.agentId === 'relay-1');
+    expect(releases).toHaveLength(1);
+    resolveExecute();
+    await finalResultPromise.catch(() => {});
+  });
+
+  // ── Test 8d — releaseAgent on collect-timeout sweep ────────────────────
+  it('Test 8d — releaseAgent called when collect() times out a stale entry', async () => {
+    const ts = mkToolServer();
+    const { workers, pipeline } = buildPipeline(ts);
+    let resolveExecute: () => void = () => {};
+    workers.set('relay-1', fakeWorkerAgent({
+      executeTask: async function* () {
+        await new Promise<void>(r => { resolveExecute = r; });
+        yield { type: TaskStreamEventType.FINAL_RESULT, payload: { result: 'ok', inputTokens: 0, outputTokens: 0 }, timestamp: Date.now() };
+      },
+    }));
+    const { finalResultPromise } = pipeline.dispatch('relay-1', 'review', { resolutionRoots: [worktree] });
+    await new Promise(r => setImmediate(r));
+    expect(ts._calls.filter(c => c.type === 'assignRoot')).toHaveLength(1);
+    // Short timeout forces the sweep at dispatch-pipeline.ts:877-884 to fire.
+    await pipeline.collect(undefined, 50).catch(() => {});
+    const releases = ts._calls.filter(c => c.type === 'releaseAgent' && c.agentId === 'relay-1');
+    expect(releases.length).toBeGreaterThanOrEqual(1);
+    resolveExecute();
+    await finalResultPromise.catch(() => {});
   });
 
   // ── Test 9 — empty/undefined arrays do not crash the pipeline ──────────
@@ -235,7 +294,7 @@ describe('DispatchPipeline — resolutionRoots → relay tool-call scoping (Path
     const wa = fakeWorkerAgent({
       executeTask: async function* () {
         await new Promise<void>(r => { resolveExecute = r; });
-        yield { type: 'final_result', payload: { result: 'ok', inputTokens: 0, outputTokens: 0 }, timestamp: Date.now() };
+        yield { type: TaskStreamEventType.FINAL_RESULT, payload: { result: 'ok', inputTokens: 0, outputTokens: 0 }, timestamp: Date.now() };
       },
     });
     workers.set('relay-1', wa);

--- a/tests/tools/tool-server-scope.test.ts
+++ b/tests/tools/tool-server-scope.test.ts
@@ -439,4 +439,50 @@ describe('ToolServer scope enforcement', () => {
       expect(fs.existsSync(join(projectRoot, scopeDir, 'file.txt'))).toBe(true);
     });
   });
+
+  describe('assignRoot Option B collision warning', () => {
+    let stderrCalls: string[];
+    let originalWrite: typeof process.stderr.write;
+
+    beforeEach(() => {
+      stderrCalls = [];
+      originalWrite = process.stderr.write.bind(process.stderr);
+      (process.stderr as { write: (chunk: unknown) => boolean }).write = (chunk: unknown) => {
+        stderrCalls.push(String(chunk));
+        return true;
+      };
+    });
+
+    afterEach(() => {
+      (process.stderr as { write: typeof process.stderr.write }).write = originalWrite;
+    });
+
+    it('warns when same agentId is re-assigned to a different root', () => {
+      const wt1 = fs.mkdtempSync(path.join(os.tmpdir(), 'wt1-'));
+      const wt2 = fs.mkdtempSync(path.join(os.tmpdir(), 'wt2-'));
+      try {
+        server.assignRoot('shared-agent', wt1);
+        expect(stderrCalls.find((c: string) => c.includes('assignRoot collision'))).toBeUndefined();
+        server.assignRoot('shared-agent', wt2);
+        const collision = stderrCalls.find((c: string) => c.includes('assignRoot collision'));
+        expect(collision).toBeDefined();
+        expect(collision!).toContain('shared-agent');
+        expect(collision!).toContain('Option B');
+      } finally {
+        fs.rmSync(wt1, { recursive: true, force: true });
+        fs.rmSync(wt2, { recursive: true, force: true });
+      }
+    });
+
+    it('does NOT warn when re-assigning the same root (idempotent assignRoot)', () => {
+      const wt = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-idem-'));
+      try {
+        server.assignRoot('idem-agent', wt);
+        server.assignRoot('idem-agent', wt);
+        expect(stderrCalls.find((c: string) => c.includes('assignRoot collision'))).toBeUndefined();
+      } finally {
+        fs.rmSync(wt, { recursive: true, force: true });
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Pre-merge consensus `84870901-0136416f` on PR #328 flagged 4 non-blocking items. While implementing them, surfaced a **real latent bug**: PR #328's fail-closed `transport_failure` signal was being silently dropped because the signal name was never registered in `validateSignal`'s allowlist (warned about in spec consensus `0df2a87c-9c8049e4:f7`, missed during PR #328 implementation).

## Changes

### Real bug fix — register `transport_failure` in `VALID_CONSENSUS_SIGNALS`
`packages/orchestrator/src/performance-writer.ts:64-69` — added `transport_failure` to the allowlist. Previously the row was rejected by `validateSignal`, the `try/catch` in `emitConsensusSignals` swallowed the error, and the fail-closed branch (`dispatch-pipeline.ts:481`) was structurally inert. New Test 4 below now verifies the row actually lands in `.gossip/agent-performance.jsonl`.

### Option B collision warning — `tool-server.ts:assignRoot`
Spec §"Concurrent rounds" Option B promised a warning when the same `agentId` is re-pinned to a different root (last-write-wins corruption risk). The comment at `dispatch-pipeline.ts:494-498` described it but the implementation never delivered. `assignRoot` now writes `[gossipcat] assignRoot collision: ...` to stderr on divergence; idempotent re-assignment stays silent.

### Test coverage gaps closed
- **Test 4** (`84870901:f9`) — assert `transport_failure` signal is actually emitted when dispatch fails closed (read JSONL, find one matching row with correct `agentId`/`taskId`/`evidence`).
- **Test 8c** (`84870901:f10`) — assert `releaseAgent` fires when `cancelRunningTasks()` is called mid-flight on a task with `resolutionRootAssigned=true`.
- **Test 8d** (`84870901:f10`) — assert `releaseAgent` fires when `collect()` times out a stale entry with `resolutionRootAssigned=true`.
- **Two new `tool-server-scope` tests** — verify the Option B warning fires on collision, stays silent on idempotent re-assign.

### Test stub enum migration (`84870901:f14`)
Replaced raw `'final_result'` / `'error'` strings in `fakeWorkerAgent` / `plainRelayWorker` with `TaskStreamEventType.FINAL_RESULT` / `.ERROR`. Production switch uses the enum, so a future rename would silently false-green tests. Required exporting `TaskStreamEventType` from the orchestrator barrel.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test --ci` — 209 suites / 2869 passing / 29 skipped (incl. 14/14 new dispatch-pipeline tests + 40/40 tool-server-scope incl. 2 new)
- [x] `npm run build:mcp` — MCP bundle rebuilt
- [x] Spec invariants from `docs/specs/2026-04-29-relay-worker-resolution-roots.md` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)