### PR TITLE
feat(dashboard): empathy pass PR-A — 5 quick-win copy changes

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -96,6 +96,7 @@ function TeamPage({ agents, tasks }: { agents: AgentData[]; tasks: import('@/lib
         <h1 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
           Team <span className="ml-2 text-primary">{agents.length}</span>
         </h1>
+        <p className="mt-0.5 font-mono text-[10px] text-muted-foreground/60">Per-agent accuracy, signal counts, and dispatch weights.</p>
         <div className="mt-2 grid grid-cols-2 gap-px overflow-hidden rounded-md border border-border/40 bg-border/30 sm:grid-cols-4">
           {[
             { label: 'Healthy', value: healthy, color: 'text-confirmed' },
@@ -256,8 +257,8 @@ function TeamPage({ agents, tasks }: { agents: AgentData[]; tasks: import('@/lib
                             fillClass={s.accuracy >= 0.7 ? 'bg-confirmed' : s.accuracy >= 0.4 ? 'bg-unverified' : 'bg-disputed'}
                             tooltip="Adjusted accuracy = raw signal ratio × 1/(1 + weighted hallucinations × 0.3). The penalty is recoverable via skill-gated multiplier in the same category."
                           />
-                          <MiniBar label="U" value={s.uniqueness} fillClass="bg-unique" />
-                          <MiniBar label="I" value={s.impactScore} fillClass="bg-[var(--color-impact)]" />
+                          <MiniBar label="U" value={s.uniqueness} fillClass="bg-unique" tooltip="Uniqueness — findings this agent surfaced that no other agent found" />
+                          <MiniBar label="I" value={s.impactScore} fillClass="bg-[var(--color-impact)]" tooltip="Impact — severity-weighted finding score; critical and high findings count more" />
                           {rawRatio !== null ? (
                             <MiniBar
                               label="R"
@@ -362,6 +363,7 @@ function TasksPage({ tasks }: { tasks: import('@/lib/types').TasksData }) {
         <h1 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
           Tasks <span className="ml-2 text-primary">{tasks.total}</span>
         </h1>
+        <p className="mt-0.5 font-mono text-[10px] text-muted-foreground/60">Live dispatched tasks and their relay status.</p>
         <div className="mt-2 flex gap-4 font-mono text-[11px] text-muted-foreground">
           <span><span className="text-confirmed">{completed}</span> completed</span>
           {failed > 0 && <span><span className="text-destructive">{failed}</span> failed</span>}
@@ -450,6 +452,7 @@ function FindingsPage({
             </span>
           )}
         </h1>
+        <p className="mt-0.5 font-mono text-[10px] text-muted-foreground/60">Multi-agent review rounds — findings confirmed when ≥2 agents agree.</p>
         <div className="mt-2 flex gap-4 font-mono text-[11px] text-muted-foreground">
           <span><span className="text-confirmed">{confirmedTotal}</span> confirmed</span>
           <span><span className="text-disputed">{disputedTotal}</span> disputed</span>

--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -293,9 +293,10 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
             legacy CategoryStrengths (severity-weighted sort + sparse rows) is
             retained for reference but we lead with the ratio view here. */}
         <div>
-          <h2 className="mb-3 font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
+          <h2 className="mb-1 font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
             Category Competency
           </h2>
+          <p className="mb-3 mt-0.5 font-mono text-[10px] text-muted-foreground/60">Raw per-category ratio — unweighted. Overall accuracy in Metrics applies a hallucination penalty.</p>
           <CategoryCompetency
             categoryAccuracy={s.categoryAccuracy}
             categoryCorrect={s.categoryCorrect}

--- a/packages/dashboard-v2/src/components/DroppedFindingDrift.tsx
+++ b/packages/dashboard-v2/src/components/DroppedFindingDrift.tsx
@@ -25,7 +25,7 @@ export function DroppedFindingDrift({ overview }: { overview: OverviewData | nul
   return (
     <section className="rounded-lg border border-border bg-card p-4">
       <header className="mb-3 flex items-baseline justify-between">
-        <h3 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">Dropped Finding Types</h3>
+        <h3 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">Invalid Output Types<span className="text-muted-foreground/50 font-normal normal-case ml-2">agent_finding tags rejected by the parser</span></h3>
         <span className="text-xs text-muted-foreground">last 20 rounds</span>
       </header>
       {total === 0 ? (

--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -200,6 +200,7 @@ export function SignalsPage() {
       <div className="flex items-baseline justify-between">
         <div>
           <h1 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">Signals</h1>
+          <p className="mt-0.5 font-mono text-[10px] text-muted-foreground/60">Scored events emitted by agents during consensus review.</p>
           <p className="mt-0.5 font-mono text-[10px] text-muted-foreground/70">
             {headerLabel} — showing {rows.length} of {total}
           </p>

--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -70,15 +70,15 @@ export function SystemPulse({ overview, activeTasks }: SystemPulseProps) {
         {/* Three-row agent stat (stacked to fit narrow cell) */}
         <div className="flex flex-col items-stretch justify-center gap-1.5 px-4 py-3">
           <div className="flex items-baseline justify-between gap-2">
-            <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Dispatched</span>
+            <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Agents currently executing a task">Dispatched</span>
             <span className={`font-mono text-base font-bold leading-none ${overview.agentsOnline > 0 ? 'text-primary' : 'text-foreground'}`}>{overview.agentsOnline}</span>
           </div>
           <div className="flex items-baseline justify-between gap-2">
-            <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Connected</span>
+            <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Relay agents with an active WebSocket connection">Connected</span>
             <span className={`font-mono text-base font-bold leading-none ${overview.relayConnected > 0 ? 'text-confirmed' : 'text-muted-foreground'}`}>{overview.relayConnected}</span>
           </div>
           <div className="flex items-baseline justify-between gap-2">
-            <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Registered</span>
+            <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Total agents in gossipcat config">Registered</span>
             <span className="font-mono text-base font-bold leading-none text-muted-foreground">{totalAgents}</span>
           </div>
         </div>


### PR DESCRIPTION
## Summary

PR-A of the dashboard empathy pass — pure additive copy changes that explain dense terms to new users without regressing the operator's view. From the 36-item punch list (sonnet-designer empathy audit, consensus 28623e86), these are the 5 single-PR-sized quick wins.

All changes are additive — no removed, replaced, or reordered elements. Only new tooltips, sub-headers, and clarified labels.

### Changes

- **QW1 — Page sub-headers (4 pages)** — adds explanatory `<p>` below each page `<h1>`:
  - `packages/dashboard-v2/src/components/SignalsPage.tsx:201` — "Scored events emitted by agents during consensus review."
  - `packages/dashboard-v2/src/App.tsx:99` (Team) — "Per-agent accuracy, signal counts, and dispatch weights."
  - `packages/dashboard-v2/src/App.tsx:366` (Tasks) — "Live dispatched tasks and their relay status."
  - `packages/dashboard-v2/src/App.tsx:455` (Debates) — "Multi-agent review rounds — findings confirmed when ≥2 agents agree."

- **QW2 — Category Competency note** (`packages/dashboard-v2/src/components/AgentPage.tsx:299`) — explanatory note resolving the credibility-damaging "37% overall vs 95%+ category" contradiction: "Raw per-category ratio — unweighted. Overall accuracy in Metrics applies a hallucination penalty."

- **QW3 — SystemPulse three-count tooltips** (`packages/dashboard-v2/src/components/SystemPulse.tsx:73,77,81`) — `data-tooltip` on Dispatched / Connected / Registered, distinguishing the three agent states a new user reads as an error.

- **QW4 — MiniBar U + I tooltips** (`packages/dashboard-v2/src/App.tsx:260-261`) — `tooltip` prop added to Uniqueness and Impact mini-bars (matching existing pattern on Accuracy).

- **QW5 — Dropped Finding Types header** (`packages/dashboard-v2/src/components/DroppedFindingDrift.tsx:28`) — relabeled "Dropped Finding Types" → "Invalid Output Types" with sub-label "agent_finding tags rejected by the parser". "Dropped" reads as data loss; the new label is accurate and non-alarming.

### Verification

- ✅ Vite build clean (75 modules)
- ⚠️ Pre-existing `tsc -b` error at `useElementWidth.ts:23` reproduces on `origin/master` (last touched in 5ed7a95, unrelated to this PR)
- ✅ All tooltips use the existing CSS-only system at `globals.css:161-233`
- ✅ Sub-headers match existing `font-mono text-[10px] text-muted-foreground/60` typography

### Context

Empathy-pass memory: \`/Users/goku/.claude/projects/-Users-goku-Desktop-gossip/memory/project_dashboard_empathy_pass.md\`. Operator-locked decisions for this pass: "Consensus Rounds" canonical (Q1), in-app glossary modal (Q2 — coming in PR-B), \`data-tooltip\` system confirmed real (Q3), target = developer who installed (Q4), stale banner is a gap (Q5 — coming in PR-C).

PR-B (glossary modal + TopBar "?" icon) and PR-C (naming alignment + stale-banner fallback) follow this PR.