### PR TITLE
feat(dashboard): empathy pass PR-C — naming alignment + stale banner fallback

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -445,7 +445,7 @@ function FindingsPage({
     <>
       <div className="mb-6">
         <h1 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
-          Debates <span className="ml-2 text-primary">{visibleRuns.length}</span>
+          Consensus Rounds <span className="ml-2 text-primary">{visibleRuns.length}</span>
           {!showRetracted && retractedCount > 0 && (
             <span className="ml-2 font-normal normal-case tracking-normal text-muted-foreground/60">
               / {consensus.totalRuns ?? consensus.runs.length} total

--- a/packages/dashboard-v2/src/components/ActiveTasksBanner.tsx
+++ b/packages/dashboard-v2/src/components/ActiveTasksBanner.tsx
@@ -52,7 +52,16 @@ export function ActiveTasksBanner({ onCountChange }: { onCountChange?: (n: numbe
   const live = tasks.filter(t => now - new Date(t.startedAt).getTime() < STALE_MS);
   const staleCount = tasks.length - live.length;
 
-  if (live.length === 0) return null;
+  if (live.length === 0) {
+    if (staleCount === 0) return null;
+    return (
+      <div className="rounded-lg border border-border bg-card/60 px-4 py-2.5">
+        <span className="font-mono text-xs text-muted-foreground">
+          {staleCount} stale task{staleCount === 1 ? '' : 's'} — likely orphaned (&gt;2h since last update)
+        </span>
+      </div>
+    );
+  }
 
   return (
     <div className="rounded-lg border border-border bg-card/60 px-4 py-2.5">

--- a/packages/dashboard-v2/src/components/TopBar.tsx
+++ b/packages/dashboard-v2/src/components/TopBar.tsx
@@ -6,7 +6,7 @@ import { GlossaryModal } from './GlossaryModal';
 const TABS = [
   { to: '/', label: 'Dashboard', match: (r: string) => r === '/' },
   { to: '/team', label: 'Team', match: (r: string) => r === '/team' || r.startsWith('/agent/') },
-  { to: '/debates', label: 'Debates', match: (r: string) => r === '/debates' },
+  { to: '/debates', label: 'Consensus Rounds', match: (r: string) => r === '/debates' },
   { to: '/tasks', label: 'Tasks', match: (r: string) => r === '/tasks' },
   { to: '/signals', label: 'Signals', match: (r: string) => r === '/signals' },
   { to: '/logs', label: 'Logs', match: (r: string) => r === '/logs' },


### PR DESCRIPTION
## Summary

PR-C — final piece of the dashboard empathy pass. Two small changes bundled:

1. Rename "Debates" → "Consensus Rounds" in user-visible labels. URL `/debates` and route name unchanged.
2. ActiveTasksBanner: render a muted stale-only banner when no live tasks remain but stale ones exist (instead of disappearing silently).

Completes the empathy-pass quick-win sequence after #330 (PR-A copy/tooltips) and #331 (PR-B glossary modal).

### Changes

#### Naming alignment

- `packages/dashboard-v2/src/components/TopBar.tsx:8` — TABS entry: `label: 'Debates'` → `label: 'Consensus Rounds'`. `to: '/debates'` and `match` predicate identical and untouched.
- `packages/dashboard-v2/src/App.tsx:447` — FindingsPage `<h1>` text: "Debates" → "Consensus Rounds". The PR-A sub-header below ("Multi-agent review rounds — findings confirmed when ≥2 agents agree.") preserved as-is.

URL paths, route names, and route handlers continue to use "debates" so existing log greps and bookmarks keep working.

#### Stale-only banner

- `packages/dashboard-v2/src/components/ActiveTasksBanner.tsx:55-64` — replaced single `if (live.length === 0) return null` with a two-branch guard. When no live tasks remain but `staleCount > 0`, render a minimal banner with the same outer container styling (`rounded-lg border border-border bg-card/60 px-4 py-2.5`) and a muted single-line message: `{n} stale task{s} — likely orphaned (>2h since last update)`. The both-zero case still returns null.

Muted styling, not warning red — a stale task is absent activity, not a failure.

### Decisions referenced

From the operator-locked decision log on the empathy-pass memory (\`/Users/goku/.claude/projects/-Users-goku-Desktop-gossip/memory/project_dashboard_empathy_pass.md\`):

- **Q1**: "Consensus Rounds" is the canonical user-facing label.
- **Q5**: stale-banner disappearance is a gap; render minimal banner when live empty but stale present.

### Verification

- ✅ Vite build clean (76 modules, 661ms)
- ✅ URL `/debates` still resolves (TABS `to` field unchanged)
- ✅ PR-A sub-header below FindingsPage h1 untouched
- ✅ PR-B glossary modal + "?" button preserved (no TopBar regression)

### Empathy-pass series complete

- #330 PR-A — 5 quick-win copy changes (sub-headers, tooltips, Category Competency note, Dropped Finding Types rename) ✅ MERGED
- #331 PR-B — in-app glossary modal + TopBar "?" icon ✅ MERGED
- #332 PR-C — naming alignment + stale-banner fallback ← this PR

Resolves the 6 HIGH-severity items from the original 36-item punch list.