### PR TITLE
feat(dashboard): empathy pass PR-D — Glossary trigger fix + a11y + 8-item tooltip pass

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -144,15 +144,15 @@ function TeamPage({ agents, tasks }: { agents: AgentData[]; tasks: import('@/lib
               </th>
               <th className="py-2.5 pr-4 text-left align-top">
                 <div className="flex items-center gap-2 text-[10px]">
-                  <button onClick={() => toggleSort('accuracy')} className="flex items-center gap-1 hover:text-foreground">
+                  <button onClick={() => toggleSort('accuracy')} className="flex items-center gap-1 hover:text-foreground" data-tooltip="Accuracy — fraction of findings confirmed by cross-review (with hallucination penalty)">
                     <span className="inline-block h-1.5 w-1.5 rounded-full bg-confirmed" />Acc{arrow('accuracy')}
                   </button>
                   <span className="text-muted-foreground/30">·</span>
-                  <button onClick={() => toggleSort('uniqueness')} className="flex items-center gap-1 hover:text-foreground">
+                  <button onClick={() => toggleSort('uniqueness')} className="flex items-center gap-1 hover:text-foreground" data-tooltip="Uniqueness — findings this agent surfaced that no peer found">
                     <span className="inline-block h-1.5 w-1.5 rounded-full bg-unique" />Unq{arrow('uniqueness')}
                   </button>
                   <span className="text-muted-foreground/30">·</span>
-                  <button onClick={() => toggleSort('impact')} className="flex items-center gap-1 hover:text-foreground">
+                  <button onClick={() => toggleSort('impact')} className="flex items-center gap-1 hover:text-foreground" data-tooltip="Impact — severity-weighted finding score">
                     <span className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--color-impact)]" />Imp{arrow('impact')}
                   </button>
                 </div>

--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -86,7 +86,7 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
 
   const metricBars = [
     { label: 'accuracy', value: s.accuracy, fill: s.accuracy >= 0.7 ? 'bg-confirmed' : s.accuracy >= 0.4 ? 'bg-unverified' : 'bg-disputed' },
-    { label: 'reliability', value: s.reliability, fill: 'bg-chart' },
+    { label: 'reliability', value: s.reliability, fill: 'bg-chart', tooltip: 'Task completion rate — fraction of dispatched tasks that finished without pipeline error or timeout' },
     { label: 'unique', value: s.uniqueness, fill: 'bg-unique' },
     { label: 'impact', value: s.impactScore, fill: 'bg-[var(--color-impact)]' },
   ];
@@ -265,7 +265,7 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
           <div className="rounded-lg border border-border/40 bg-card/80 p-4 shadow-[inset_0_1px_3px_rgba(0,0,0,0.35)]">
             <div className="space-y-2.5">
               {metricBars.map(m => (
-                <div key={m.label} className="grid grid-cols-[72px_1fr_44px] items-center gap-3">
+                <div key={m.label} className="grid grid-cols-[72px_1fr_44px] items-center gap-3" {...(m.tooltip ? { 'data-tooltip': m.tooltip } : {})}>
                   <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">{m.label}</span>
                   <div className="h-1.5 overflow-hidden rounded-full bg-background/80">
                     <div className={`h-full rounded-full transition-all ${m.fill}`} style={{ width: `${Math.max(0, Math.min(100, m.value * 100))}%` }} />

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -35,13 +35,13 @@ const TAG_MAP: Record<string, { label: string; filter: FilterType; cls: string }
   new_finding: { label: 'NEW', filter: 'unique', cls: 'text-unique bg-unique/10' },
 };
 
-const FILTER_CHIPS: { key: FilterType; label: string; cls: string; activeCls: string }[] = [
+const FILTER_CHIPS: { key: FilterType; label: string; cls: string; activeCls: string; tooltip?: string }[] = [
   { key: 'all', label: 'All', cls: 'text-muted-foreground border-border/40 hover:border-border/60', activeCls: 'text-foreground bg-muted border-border' },
   { key: 'confirmed', label: 'Confirmed', cls: 'text-confirmed/50 border-confirmed/20 hover:border-confirmed/40', activeCls: 'text-confirmed bg-confirmed/10 border-confirmed/40' },
   { key: 'unique', label: 'Unique', cls: 'text-unique/50 border-unique/20 hover:border-unique/40', activeCls: 'text-unique bg-unique/10 border-unique/40' },
   { key: 'disputed', label: 'Disputed', cls: 'text-disputed/50 border-disputed/20 hover:border-disputed/40', activeCls: 'text-disputed bg-disputed/10 border-disputed/40' },
   { key: 'unverified', label: 'Unverified', cls: 'text-unverified/50 border-unverified/20 hover:border-unverified/40', activeCls: 'text-unverified bg-unverified/10 border-unverified/40' },
-  { key: 'insight', label: 'Insight', cls: 'text-zinc-500 border-zinc-500/20 hover:border-zinc-500/40', activeCls: 'text-zinc-400 bg-zinc-500/10 border-zinc-500/40' },
+  { key: 'insight', label: 'Insight', cls: 'text-zinc-500 border-zinc-500/20 hover:border-zinc-500/40', activeCls: 'text-zinc-400 bg-zinc-500/10 border-zinc-500/40', tooltip: 'Observations without a specific file:line anchor. Not scored — cannot be confirmed or disputed by peers.' },
 ];
 
 const SEV_FILTER_CHIPS: { key: 'all' | 'critical' | 'high' | 'medium' | 'low'; label: string; cls: string; activeCls: string }[] = [
@@ -574,7 +574,8 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
                       <span className="font-mono text-[10px] text-muted-foreground/50">Type:</span>
                       {FILTER_CHIPS.map(tab => (
                         <button key={tab.key} onClick={() => setFilter(tab.key)}
-                          className={`rounded-md border px-3 py-1.5 font-mono text-[10px] font-medium transition ${filter === tab.key ? tab.activeCls : tab.cls}`}>
+                          className={`rounded-md border px-3 py-1.5 font-mono text-[10px] font-medium transition ${filter === tab.key ? tab.activeCls : tab.cls}`}
+                          {...(tab.tooltip ? { 'data-tooltip': tab.tooltip } : {})}>
                           {tab.label}
                         </button>
                       ))}
@@ -802,6 +803,7 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
                           key={chip.key}
                           onClick={() => setFilter(chip.key)}
                           className={`rounded-sm px-2 py-0.5 font-mono text-[10px] font-semibold transition ${filter === chip.key ? chip.activeCls : chip.cls} hover:opacity-80`}
+                          {...(chip.tooltip ? { 'data-tooltip': chip.tooltip } : {})}
                         >
                           {chip.label}
                         </button>

--- a/packages/dashboard-v2/src/components/GlossaryModal.tsx
+++ b/packages/dashboard-v2/src/components/GlossaryModal.tsx
@@ -67,6 +67,12 @@ const TERMS: GlossaryTerm[] = [
     seeAlso: 'Accuracy (Adjusted), Consensus Round',
   },
   {
+    term: 'Reliability',
+    definition:
+      'Task completion rate — the fraction of dispatched tasks that finished without a pipeline error or timeout. Distinct from accuracy, which measures finding correctness.',
+    seeAlso: 'Accuracy (Adjusted)',
+  },
+  {
     term: 'Impact',
     definition:
       'A severity-weighted score for an agent\'s findings. Critical and high findings contribute more than medium or low ones. Impact reflects not just how many findings an agent produces, but how serious those findings tend to be.',
@@ -156,7 +162,7 @@ export function GlossaryModal({ open, onClose }: GlossaryModalProps) {
             aria-label="Close glossary"
             className="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-border/40 bg-card font-mono text-xs text-muted-foreground transition hover:bg-muted hover:text-foreground"
           >
-            x
+            &times;
           </button>
         </div>
 

--- a/packages/dashboard-v2/src/components/SignalFilterRail.tsx
+++ b/packages/dashboard-v2/src/components/SignalFilterRail.tsx
@@ -123,7 +123,7 @@ export function SignalFilterRail({ filters, onChange, agents, signalTypes }: Pro
       </div>
 
       <div>
-        <label className={LABEL_CLS}>Source</label>
+        <label className={LABEL_CLS} data-tooltip="manual = operator-recorded · impl = implementer pipeline · meta = orchestrator self-telemetry · auto-provisional = unvalidated">Source</label>
         <select className={INPUT_CLS} value={filters.source ?? ''} onChange={set('source')}>
           <option value="">any</option>
           {SOURCES.map((s) => (

--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -228,9 +228,9 @@ export function SignalsPage() {
                   <th className="px-2 py-1.5 font-semibold uppercase tracking-widest">Time</th>
                   <th className="px-2 py-1.5 font-semibold uppercase tracking-widest">Agent</th>
                   <th className="px-2 py-1.5 font-semibold uppercase tracking-widest">Signal</th>
-                  <th className="px-2 py-1.5 font-semibold uppercase tracking-widest">Counterpart</th>
-                  <th className="px-2 py-1.5 font-semibold uppercase tracking-widest">Sev</th>
-                  <th className="px-2 py-1.5 font-semibold uppercase tracking-widest">Finding</th>
+                  <th className="px-2 py-1.5 font-semibold uppercase tracking-widest" data-tooltip="The other agent in this signal — e.g. the peer who agreed or disputed">Counterpart</th>
+                  <th className="px-2 py-1.5 font-semibold uppercase tracking-widest" data-tooltip="Severity of the associated finding (critical / high / medium / low)">Sev</th>
+                  <th className="px-2 py-1.5 font-semibold uppercase tracking-widest" data-tooltip="Finding ID — click row to open finding detail">Finding</th>
                   <th className="px-2 py-1.5 font-semibold uppercase tracking-widest">Consensus</th>
                   <th className="px-2 py-1.5 font-semibold uppercase tracking-widest">Evidence</th>
                 </tr>

--- a/packages/dashboard-v2/src/components/SkillCard.tsx
+++ b/packages/dashboard-v2/src/components/SkillCard.tsx
@@ -5,6 +5,16 @@ interface Props {
   slot: SkillSlot;
 }
 
+const STATUS_TOOLTIP: Record<SkillStatus, string> = {
+  silent_skill: 'No signals recorded after bind — skill may not be injecting correctly',
+  insufficient_evidence: 'Fewer than 120 post-bind signals — verdict pending more data',
+  inconclusive: 'Mixed signals — needs further evaluation',
+  passed: 'Skill verified effective',
+  failed: 'Skill verified ineffective',
+  pending: 'Awaiting evidence',
+  flagged_for_manual_review: 'Manual review required',
+};
+
 const STATUS_CLS: Record<SkillStatus, string> = {
   pending: 'border-border/50 bg-muted/30 text-muted-foreground',
   passed: 'border-confirmed/40 bg-confirmed/10 text-confirmed',
@@ -56,7 +66,7 @@ export function SkillCard({ slot }: Props) {
           </div>
         </div>
         {status && (
-          <span className={`shrink-0 rounded-sm border px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase ${statusCls}`}>
+          <span className={`shrink-0 rounded-sm border px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase ${statusCls}`} title={STATUS_TOOLTIP[status]}>
             {status.replace(/_/g, ' ')}
           </span>
         )}

--- a/packages/dashboard-v2/src/components/TopBar.tsx
+++ b/packages/dashboard-v2/src/components/TopBar.tsx
@@ -54,9 +54,9 @@ export function TopBar() {
         <button
           onClick={() => setGlossaryOpen(true)}
           aria-label="Open glossary"
-          className="flex h-7 w-7 items-center justify-center rounded-full border border-border/60 bg-card font-mono text-xs font-semibold text-muted-foreground transition hover:border-border hover:text-foreground"
+          className="flex items-center justify-center rounded-md border border-border/60 bg-card px-2.5 py-1 font-mono text-xs font-semibold text-muted-foreground transition hover:border-border hover:text-foreground"
         >
-          ?
+          Glossary
         </button>
         <div className="flex items-center gap-2 rounded-md border border-border bg-card px-3.5 py-1.5 font-mono text-xs text-muted-foreground">
           <span className={`inline-block h-1.5 w-1.5 rounded-full ${online ? 'bg-confirmed shadow-[0_0_6px_rgba(52,211,153,0.5)]' : 'bg-destructive'}`} />

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -204,6 +204,10 @@ html::after {
 [data-tooltip]:hover::before {
   opacity: 1;
 }
+[data-tooltip]:focus-within::after,
+[data-tooltip]:focus-within::before {
+  opacity: 1;
+}
 [data-tooltip-pos="bottom"]::after {
   bottom: auto;
   top: 100%;


### PR DESCRIPTION
## Summary

PR-D — final piece of the dashboard empathy pass. Resolves operator pushback on the unclear "?" icon affordance and closes the remaining tooltip gaps from the original 36-item punch list.

Implements **Option B refined** as decided by consensus round f0e542ba-782f4fef (3 agents, 2 rounds; 21 confirmed, 1 disputed which the dispute author resolved themselves in cross-review). Decisive argument: the modal and inline tooltips serve genuinely different affordances — modal is read-ahead reference, tooltip is mid-task lookup. Two registers, not in conflict.

### Group 1 — Glossary trigger fix (HIGH)

- `packages/dashboard-v2/src/components/TopBar.tsx:54-60` — replaced `?` glyph with text label "Glossary"; classes changed from `h-7 w-7 rounded-full` to `rounded-md px-2.5 py-1` (matching tab pill shape). aria-label / onClick / surrounding markup unchanged.

### Group 2 — A11y (HIGH + MEDIUM)

- `packages/dashboard-v2/src/components/GlossaryModal.tsx:165` — close button glyph `x` → `&times;`.
- `packages/dashboard-v2/src/components/GlossaryModal.tsx:69-74` — added Reliability entry to TERMS (insertion between Uniqueness and Impact, definition-paired with Accuracy).
- `packages/dashboard-v2/src/globals.css:207-210` — added sibling `:focus-within` rule alongside existing `:hover` so keyboard tab-through surfaces tooltips. Existing `:hover` rule unchanged.

### Group 3 — 8-item tooltip pass (MEDIUM/LOW)

| Element | File:line | Tooltip |
|---|---|---|
| Sev `<th>` | `SignalsPage.tsx:232` | "Severity of the associated finding (critical / high / medium / low)" |
| Counterpart `<th>` | `SignalsPage.tsx:231` | "The other agent in this signal — e.g. the peer who agreed or disputed" |
| Finding `<th>` | `SignalsPage.tsx:233` | "Finding ID — click row to open finding detail" |
| Reliability bar | `AgentPage.tsx:89` (+ Glossary entry) | "Task completion rate — fraction of dispatched tasks that finished without pipeline error or timeout" |
| Insight chip | `FindingsMetrics.tsx:44` | "Observations without a specific file:line anchor. Not scored — cannot be confirmed or disputed by peers." |
| Source label | `SignalFilterRail.tsx:126` | "manual = operator-recorded · impl = implementer pipeline · meta = orchestrator self-telemetry · auto-provisional = unvalidated" |
| Skill verdict badges | `SkillCard.tsx:8-16, 58-60` | STATUS_TOOLTIP map with 7 entries applied via `title=` |
| Acc/Unq/Imp sort buttons | `App.tsx:148-156` | per-button data-tooltip; Halluc at line 166 untouched |

### Decisions referenced

From the consensus log on the empathy-pass memory and consensus f0e542ba-782f4fef:

- Keep GlossaryModal — read-ahead reference is a use case hover tooltips can't replicate.
- Two registers: `data-tooltip` for short single-sentence terms, modal for multi-sentence cross-referenced entries.
- Iron law: no operator-facing element removed/replaced/reordered. All changes additive (text relabel of one button, new entries to TERMS/STATUS_TOOLTIP, new tooltip attributes).

### Verification

- ✅ Vite build clean (76 modules, 675ms)
- ✅ `:hover` rule preserved unchanged at `globals.css:204-206`
- ✅ Modal close button keeps aria-label, ref, onClick — only visual glyph changed
- ✅ TopBar TABS array, /debates URL, route name unchanged
- ✅ Halluc tooltip at `App.tsx:166` not touched

### Empathy pass series complete

- #330 PR-A — copy quick-wins ✅ MERGED
- #331 PR-B — in-app glossary modal + TopBar "?" icon ✅ MERGED
- #332 PR-C — naming alignment + stale-banner fallback ✅ MERGED
- #333 PR-D — Glossary trigger fix + a11y + 8-item tooltip pass ← this PR