### PR TITLE
feat(dashboard): visual pass PR-E — actionableFindings as BigStat

### DIFF
--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -19,11 +19,12 @@ interface BigStatProps {
   label: string;
   valueClass: string;
   pulse?: boolean;
+  tooltip?: string;
 }
 
-function BigStat({ value, unit, label, valueClass, pulse }: BigStatProps) {
+function BigStat({ value, unit, label, valueClass, pulse, tooltip }: BigStatProps) {
   return (
-    <div className="flex flex-col items-center py-4 px-3 text-center">
+    <div className="flex flex-col items-center py-4 px-3 text-center" data-tooltip={tooltip}>
       <div className="flex items-baseline gap-1">
         {pulse && (
           <span className="relative mr-1 inline-flex h-2 w-2">
@@ -98,6 +99,14 @@ export function SystemPulse({ overview, activeTasks }: SystemPulseProps) {
           label="Confirmed"
           valueClass="text-confirmed"
         />
+        <div className="col-span-2 border-t border-border">
+          <BigStat
+            value={overview.actionableFindings}
+            label="Actionable"
+            valueClass={overview.actionableFindings > 0 ? 'text-orange-400' : 'text-confirmed'}
+            tooltip="Findings still open and need operator review (disagreements + hallucinations + new findings)"
+          />
+        </div>
       </div>
 
       {/* Secondary stats */}


### PR DESCRIPTION
## Summary

Surfaces the `actionableFindings` count as a BigStat in `SystemPulse` so it stops getting buried in the secondary stats list. First piece of the visual / IA pass that follows the labelling pass series (#330–#333).

Per audit Diagnosis 2: `SystemPulse.tsx:113-115` rendered `actionableFindings` (currently 808) at `text-[11px]` next to "avg duration", while less-actionable Consensus count + Confirmed% got `text-2xl` BigStat treatment. The loudest number ≠ the most actionable number.

### Change

- `packages/dashboard-v2/src/components/SystemPulse.tsx` — added a 5th `<BigStat>` cell for `actionableFindings`, slotted in a `col-span-2 border-t border-border` row beneath the existing 2×2 grid (Active Tasks / Consensus / Confirmed%). New cell uses `text-orange-400` when value > 0, `text-confirmed` when 0 (zero IS the all-clear signal). Also added an optional `tooltip` prop on `BigStat` and wired it as `data-tooltip` on the wrapper for hover/focus surfacing via the existing CSS tooltip system.

### Iron-law compliance

- ✅ Existing 4 BigStat cells unchanged
- ✅ Existing `actionable` row in the secondary stats block at lines 113-115 **preserved** (operator's existing visual stays exactly where it was)
- ✅ Zero deletions / replacements / reorderings
- ✅ Only `SystemPulse.tsx` touched, +11/-2 LOC

### Out of scope (explicitly deferred)

- Pipeline Diagnostics collapse (RecentSignalsPeek + DroppedFindingDrift) — would be a reorder/demote of the dense view; iron-law violation. Belongs only inside a future parallel `?expert=0` simple view if we go there.
- Parallel `/Overview` route — separate decision after re-running the 5-second test against this PR.

### Validation plan

After merge: re-run the 5-second test the audit proposed. Open the dashboard, look at it for 5 seconds, then answer "how many actionable findings right now?" If correct on first glance → polish path is sufficient and we don't need a parallel simple view. If still wrong → escalate to PR-F (parallel-simple-view).

### Context

Audit and consensus reasoning lives in:
- Visual-pass memory: `/Users/goku/.claude/projects/-Users-goku-Desktop-gossip/memory/project_dashboard_visual_pass.md`
- Empathy-pass series predecessor: #330 #331 #332 #333

Pre-existing `tsc -b` error at `useElementWidth.ts:23` (unrelated, on master since #217). Vite build itself is clean.