### PR TITLE
fix(dashboard): drop duplicate actionable row from SystemPulse

### DIFF
--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -119,10 +119,6 @@ export function SystemPulse({ overview, activeTasks }: SystemPulseProps) {
           <span className="text-muted-foreground">signals total</span>
           <span className="font-semibold text-foreground tabular-nums">{overview.totalSignals}</span>
         </div>
-        <div className="flex items-center justify-between py-1 font-mono text-[11px]">
-          <span className="text-muted-foreground">actionable</span>
-          <span className={`font-semibold tabular-nums ${overview.actionableFindings > 0 ? 'text-orange-400' : 'text-foreground'}`}>{overview.actionableFindings}</span>
-        </div>
         {overview.tasksFailed > 0 && (
           <div className="flex items-center justify-between py-1 font-mono text-[11px]">
             <span className="text-muted-foreground">tasks failed</span>


### PR DESCRIPTION
Follow-up to #334. The new actionableFindings BigStat is the better surface; the original secondary-stats row at SystemPulse.tsx:122-125 was kept for one cycle as a safety net but the operator flagged it as visible duplication after the BigStat shipped.

Operator-authorized iron-law deviation. Pure deletion (4 lines), no other changes.

```
- <div className="flex items-center justify-between py-1 font-mono text-[11px]">
-   <span className="text-muted-foreground">actionable</span>
-   <span className={...}>{overview.actionableFindings}</span>
- </div>
```