### PR TITLE
feat(dashboard): visual pass PR-G — actionable BigStat → /signals filter link

### DIFF
--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -82,6 +82,44 @@ const SEVERITY_BADGE: Record<string, string> = {
 
 const PAGE_SIZE = 100;
 
+function hydrateFromURL(): SignalFilters {
+  if (typeof window === 'undefined') return EMPTY_FILTERS;
+  const q = new URLSearchParams(window.location.search);
+  const signals = q.getAll('signal').filter(Boolean);
+  const agent = q.get('agent');
+  const counterpart = q.get('counterpart') ?? undefined;
+  const category = q.get('category') ?? undefined;
+  const rawSeverity = q.get('severity');
+  const severity = (rawSeverity === 'critical' || rawSeverity === 'high' || rawSeverity === 'medium' || rawSeverity === 'low')
+    ? rawSeverity
+    : undefined;
+  const since = q.get('since') ?? undefined;
+  const until = q.get('until') ?? undefined;
+  const consensusId = q.get('consensus_id') ?? undefined;
+  const findingId = q.get('finding_id') ?? undefined;
+  const rawSource = q.get('source');
+  const source = (rawSource === 'manual' || rawSource === 'impl' || rawSource === 'meta' || rawSource === 'auto-provisional')
+    ? rawSource
+    : undefined;
+
+  const hasAny = signals.length > 0 || agent || counterpart || category || severity ||
+    since || until || consensusId || findingId || source;
+  if (!hasAny) return EMPTY_FILTERS;
+
+  return {
+    agents: agent ? [agent] : [],
+    signals,
+    counterpart,
+    category,
+    severity,
+    since,
+    until,
+    consensusId,
+    findingId,
+    source,
+  };
+}
+
 function buildQuery(filters: SignalFilters, offset: number, limit = PAGE_SIZE): URLSearchParams {
   const q = new URLSearchParams();
   q.set('limit', String(limit));
@@ -105,7 +143,7 @@ function truncate(s: string | undefined, n: number): string {
 }
 
 export function SignalsPage() {
-  const [filters, setFilters] = useState<SignalFilters>(EMPTY_FILTERS);
+  const [filters, setFilters] = useState<SignalFilters>(() => hydrateFromURL());
   const [rows, setRows] = useState<SignalEntry[]>([]);
   const [page, setPage] = useState(0);
   const [total, setTotal] = useState<number>(0);

--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -1,5 +1,6 @@
 import type { OverviewData } from '@/lib/types';
 import { timeAgo } from '@/lib/utils';
+import { href } from '@/lib/router';
 
 interface SystemPulseProps {
   overview: OverviewData;
@@ -99,14 +100,18 @@ export function SystemPulse({ overview, activeTasks }: SystemPulseProps) {
           label="Confirmed"
           valueClass="text-confirmed"
         />
-        <div className="col-span-2 border-t border-border">
+        <a
+          href={href('/signals?signal=disagreement&signal=hallucination_caught&signal=new_finding')}
+          className="col-span-2 block cursor-pointer border-t border-border transition-colors hover:bg-accent/30"
+          aria-label="View actionable findings on Signals page"
+        >
           <BigStat
             value={overview.actionableFindings}
             label="Actionable"
             valueClass={overview.actionableFindings > 0 ? 'text-orange-400' : 'text-confirmed'}
             tooltip="Findings still open and need operator review (disagreements + hallucinations + new findings)"
           />
-        </div>
+        </a>
       </div>
 
       {/* Secondary stats */}


### PR DESCRIPTION
## Summary

Operator gap callout from this session: PR #334 surfaced `actionableFindings` as a BigStat in `SystemPulse`, but the count had no path to the underlying items. This PR closes that loop — clicking the BigStat lands on `/signals` pre-filtered to the 3 signal types that compose the actionable count.

### Changes

- **`packages/dashboard-v2/src/components/SystemPulse.tsx`** — replaced the wrapper `<div>` around the 5th BigStat (Actionable) with an `<a>` linked to `/signals?signal=disagreement&signal=hallucination_caught&signal=new_finding` using the existing `href()` router helper. Added `cursor-pointer hover:bg-accent/30 transition-colors block` and `aria-label="View actionable findings on Signals page"`. Inner `<BigStat>` unchanged. The other 4 BigStats are unchanged.

- **`packages/dashboard-v2/src/components/SignalsPage.tsx`** — added `hydrateFromURL()` that reads `window.location.search` and parses every key `buildQuery` serializes: `signal` (multi-value), `agent`, `counterpart`, `category`, `severity`, `since`, `until`, `consensus_id`, `finding_id`, `source`. Lazy `useState` initializer (`useState(() => hydrateFromURL())`) seeds filters before the first fetch — no flicker. One-way URL → state only; bidirectional URL ↔ filter sync deferred.

### Iron-law compliance

- ✅ Wrapper element type swap (div → a) preserves all existing children and styling
- ✅ Other BigStats unchanged
- ✅ EMPTY_FILTERS path preserved when no URL params present
- ✅ buildQuery semantics unchanged

### Out of scope (deferred)

- Bidirectional URL sync (filter changes don't push to URL yet)
- Click affordance on other BigStats
- `SignalFilterRail` hide-when-empty (Diagnosis 3 from audit)

### Test plan

- [x] Vite build clean (76 modules, 653ms)
- [ ] Click Actionable → lands on `/signals?signal=...` with rail showing 3 types pre-checked
- [ ] Direct visit to `/signals` (no params) → EMPTY_FILTERS, no pre-selection
- [ ] Other BigStats not clickable

Reference: visual-pass memory at `/Users/goku/.claude/projects/-Users-goku-Desktop-gossip/memory/project_dashboard_visual_pass.md`. Continues the post-empathy visual pass (PR #334, #335).