### PR TITLE
feat(dashboard): visual pass PR-H — task-row type chip from agentId suffix

### DIFF
--- a/packages/dashboard-v2/src/components/TasksSection.tsx
+++ b/packages/dashboard-v2/src/components/TasksSection.tsx
@@ -72,6 +72,17 @@ function shortTaskId(id: string): string {
   return id.length > 8 ? id.slice(0, 8) : id;
 }
 
+// Derive a visual kind chip from the agentId suffix.
+// Returns null for unrecognized suffixes so the chip is omitted entirely.
+function taskKindFromAgentId(agentId: string): { label: string; cls: string } | null {
+  if (agentId.endsWith('-implementer')) return { label: 'IMPL', cls: 'text-unique' };
+  if (agentId.endsWith('-reviewer'))    return { label: 'REVIEW', cls: 'text-chart' };
+  if (agentId.endsWith('-tester'))      return { label: 'TEST', cls: 'text-unique' };
+  if (agentId.endsWith('-researcher'))  return { label: 'RESEARCH', cls: 'text-muted-foreground' };
+  if (agentId.endsWith('-designer'))    return { label: 'DESIGN', cls: 'text-chart' };
+  return null;
+}
+
 export function TasksSection({ tasks, limit = DEFAULT_PAGE_SIZE }: TasksSectionProps) {
   const visible = tasks.items.slice(0, limit);
   const hasMore = tasks.items.length > limit;
@@ -98,6 +109,7 @@ export function TasksSection({ tasks, limit = DEFAULT_PAGE_SIZE }: TasksSectionP
           visible.map((task, i) => {
             const key = normaliseStatus(task.status);
             const meta = STATUS_META[key];
+            const kind = taskKindFromAgentId(task.agentId);
             return (
               <div
                 key={task.taskId}
@@ -128,6 +140,14 @@ export function TasksSection({ tasks, limit = DEFAULT_PAGE_SIZE }: TasksSectionP
                 >
                   {shortTaskId(task.taskId)}
                 </span>
+                {kind && (
+                  <span
+                    className={`shrink-0 rounded-sm border border-border/40 bg-background/40 px-1 py-0.5 font-mono text-[9px] font-bold uppercase tracking-wider ${kind.cls}`}
+                    data-tooltip={task.agentId}
+                  >
+                    {kind.label}
+                  </span>
+                )}
                 <span className="min-w-0 flex-1 line-clamp-2 font-inter text-[11px] leading-snug text-muted-foreground">
                   {task.task}
                 </span>


### PR DESCRIPTION
## Summary

Operator gap callout from this session: the Tasks page row was `[status][taskId pill][description][agentId][time]` — the only signal of task kind was the bare `agentId` text. No visual differentiation between implementer / reviewer / tester / etc.

Adds a tiny chip between the taskId pill and the description, derived from the `agentId` suffix. Zero backend change — purely a frontend rendering tweak.

### Changes

`packages/dashboard-v2/src/components/TasksSection.tsx` (+20):
- Helper `taskKindFromAgentId(agentId)` after `shortTaskId` (returns `null` for unrecognized suffixes so the chip is omitted entirely).
- Conditional chip render between taskId pill and description, with `data-tooltip={agentId}` for full-identity hover.

### Suffix → chip mapping

| agentId suffix | Chip | Tailwind color |
|---|---|---|
| `-implementer` | `IMPL` | `text-unique` (purple) |
| `-reviewer` | `REVIEW` | `text-chart` (blue) |
| `-tester` | `TEST` | `text-unique` |
| `-researcher` | `RESEARCH` | `text-muted-foreground` |
| `-designer` | `DESIGN` | `text-chart` |
| else | _(no chip)_ | — |

Chip styling intentionally smaller/quieter than the taskId pill: `text-[9px]` vs `text-[10px]`, `rounded-sm` vs `rounded`.

### Iron-law compliance

- ✅ All other row elements unchanged (status circle, taskId pill, agentId text, timeAgo, description)
- ✅ Chip is conditional — unrecognized agentIds render exactly the same as before
- ✅ One file, +20 lines, no deletions

### Out of scope (deferred)

- Backend `kind` field on `TaskItem` (would let us distinguish consensus vs single dispatch and add proper grouping)
- Filter-by-kind on the Tasks page
- Consensus-round grouping (which tasks belong to the same round) — requires backend `consensus_id` exposure

### Context

Reference: visual-pass memory at `/Users/goku/.claude/projects/-Users-goku-Desktop-gossip/memory/project_dashboard_visual_pass.md`. Continues the visual pass after PR #334, #335, #336.