### PR TITLE
feat(dashboard): CSS-craft PR-K1 — ActivityBars zero-fix + tabular-nums + badge polish

### DIFF
--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -301,7 +301,7 @@ export function SignalsPage() {
                       <td className="whitespace-nowrap px-2 py-1 text-muted-foreground/80">{r.counterpartId ?? '—'}</td>
                       <td className="whitespace-nowrap px-2 py-1">
                         {r.severity ? (
-                          <span className={`rounded px-1 py-0.5 text-[9px] uppercase ${SEVERITY_BADGE[r.severity] ?? 'bg-muted'}`}>
+                          <span className={`rounded border px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase ${SEVERITY_BADGE[r.severity] ?? 'bg-muted'}`}>
                             {r.severity}
                           </span>
                         ) : (

--- a/packages/dashboard-v2/src/components/SkillCard.tsx
+++ b/packages/dashboard-v2/src/components/SkillCard.tsx
@@ -21,7 +21,7 @@ const STATUS_CLS: Record<SkillStatus, string> = {
   failed: 'border-disputed/40 bg-disputed/10 text-disputed',
   silent_skill: 'border-unverified/40 bg-unverified/10 text-unverified',
   insufficient_evidence: 'border-unverified/40 bg-unverified/10 text-unverified',
-  inconclusive: 'border-unique/40 bg-unique/10 text-unique',
+  inconclusive: 'border-orange-400/40 bg-orange-500/10 text-orange-400',
   flagged_for_manual_review: 'border-disputed/40 bg-disputed/10 text-disputed',
 };
 

--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -178,9 +178,9 @@ function ActivityBars({ hourly }: ActivityBarsProps) {
             <div
               key={i}
               className={`relative flex-1 cursor-pointer rounded-sm transition-opacity hover:opacity-100 ${
-                isNow ? 'bg-chart opacity-90' : 'bg-chart opacity-40'
+                count === 0 ? 'opacity-0' : isNow ? 'bg-chart opacity-90' : 'bg-chart opacity-40'
               }`}
-              style={{ height: `${Math.max(8, heightPct)}%` }}
+              style={{ height: count === 0 ? '0%' : `${Math.max(8, heightPct)}%` }}
               data-tooltip={`${label}\n${count} task${count === 1 ? '' : 's'}`}
               data-tooltip-pos="bottom"
             />

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -54,6 +54,7 @@ body {
   font-family: var(--font-sans);
   font-size: 15px;
   line-height: 1.55;
+  font-variant-numeric: tabular-nums;
   -webkit-font-smoothing: antialiased;
 }
 


### PR DESCRIPTION
Bundles 4 small craft fixes from the post-empathy CSS-craft audit. ~10 LOC, 4 files. Iron-law-safe additive.

### Changes

1. **HIGH — SystemPulse ActivityBars zero-bar fix.** Empty hours were rendering as 2px stubs indistinguishable from real low-frequency activity (data accuracy bug). Now `count === 0` returns `height: 0%` + `opacity-0`; non-zero bars keep the 8% min for readability.

2. **Premium-touch — globals.css body `tabular-nums`.** Added `font-variant-numeric: tabular-nums` to body declaration. Eliminates layout shimmy on every numeric render including live WebSocket-updated SystemPulse counts. Fixes current and future numeric sites.

3. **LOW — SignalsPage severity badge alignment.** Was `rounded px-1 py-0.5 text-[9px] uppercase`; now matches FindingsMetrics canonical chip styling: `rounded border px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase`. CRITICAL rows now scannable in dense table.

4. **LOW — SkillCard inconclusive color.** Was `text-unique` (purple = novel/identity globally); changed to `text-orange-400` per stated convention for inconclusive verdicts. Now sits semantically between amber neighbors and red failed.

### Iron-law compliance
- ✅ All changes additive
- ✅ No element removed or reordered
- ✅ `globals.css` body font-family untouched (deferred to PR-K2)
- ✅ Per-component `font-mono` overrides untouched (PR-K2)

### Out of scope (deferred)
- PR-K2: body font-family swap + redundant font-mono cleanup
- Type-scale lock (text-[8px]→text-[17px] consolidation to 3 tiers)
- Transition-spelling standardization
- bg-card opacity-tier consolidation

Reference: visual-pass memory at `/Users/goku/.claude/projects/-Users-goku-Desktop-gossip/memory/project_dashboard_visual_pass.md`. Continues the dashboard polish series after PR #338 + #339.

### Note
Implementer worktree had a boundary-escape edge case (writes landed in main repo not the sandboxed worktree). Diff content was correct per spec; orchestrator moved the staged changes onto a fresh branch for the PR. Worth flagging — see `feedback_worktree_boundary_escape.md` and the worktree-sandbox investigation backlog item.