### PR TITLE
refactor(dashboard): CSS-craft PR-K2 — body font-family swap to mono

### DIFF
--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -51,7 +51,7 @@
 body {
   background-color: var(--color-background);
   color: var(--color-foreground);
-  font-family: var(--font-sans);
+  font-family: var(--font-mono);
   font-size: 15px;
   line-height: 1.55;
   font-variant-numeric: tabular-nums;


### PR DESCRIPTION
Per CSS-craft audit finding #4 (orphaned default chain): body declared `font-family: var(--font-sans)` but every component opted into `font-mono` explicitly. Inter was the document default but never observed except through explicit `font-inter` opt-ins on prose elements.

### Change

`packages/dashboard-v2/src/globals.css:54` body rule: `var(--font-sans)` → `var(--font-mono)`. Single line.

### Why this is safe

Verified via grep that every component that renders text falls into one of:
- Has explicit `font-mono` (now redundant but still a no-op — 37 .tsx files)
- Has explicit `font-inter` (continues to override mono — 6 prose contexts: TasksSection.tsx:151, FindingsMetrics.tsx:200/559, App.tsx:303, TaskRow.tsx:170, AgentCardBig.tsx:95)
- Renders no text directly (containers + decorative spans)

No component relies on the body-default sans, so flipping the default to mono is invisible at the user surface but architecturally cleaner.

### Out of scope (logged as backlog)

Cleanup of the 332 now-redundant `font-mono` className strings across 37 .tsx files. They're no-ops post-swap. The full cleanup was scoped at ~10-15 files but turned out to be 37 — implementer hit the scope-stop threshold. Deferred to opportunistic cleanup as components get touched naturally.

### Iron-law compliance
- ✅ Single line CSS change
- ✅ All operator-visible elements unchanged
- ✅ All font-inter prose contexts preserved
- ✅ No component flipped between mono and sans

Reference: visual-pass memory at `/Users/goku/.claude/projects/-Users-goku-Desktop-gossip/memory/project_dashboard_visual_pass.md`. Closes the post-empathy CSS-craft polish series after PR-K1 #340.