### PR TITLE
feat(dashboard): polish PR-L — cross-lens fix bundle (HALLUC color, filter banner, modal a11y, +3)

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -286,7 +286,7 @@ function TeamPage({ agents, tasks }: { agents: AgentData[]; tasks: import('@/lib
                   {/* Hallucinations */}
                   <td className="py-3 pr-4 text-right align-top font-mono text-xs tabular-nums">
                     <span
-                      className={s.hallucinations > 0 ? 'font-bold text-destructive' : 'text-muted-foreground/40'}
+                      className={s.hallucinations > 0 ? 'font-bold text-disputed' : 'text-muted-foreground/40'}
                       data-tooltip={`Agreements ${s.agreements} · Disagreements ${s.disagreements} · Hallucinations ${s.hallucinations}`}
                     >
                       {s.hallucinations}
@@ -522,6 +522,11 @@ function Dashboard() {
   } else {
     // Main dashboard — sidebar + main layout
     content = (
+      <div className="space-y-6">
+      <header>
+        <h1 className="font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">Dashboard</h1>
+        <p className="mt-0.5 font-mono text-[10px] text-muted-foreground/60">Multi-agent code review with grounded reward signals. Live activity, agent scores, and consensus rounds.</p>
+      </header>
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[280px_1fr] lg:items-start">
         {/* Left sidebar: System Pulse + Circuit Alerts + Violations */}
         <aside className="space-y-4 lg:sticky lg:top-4">
@@ -552,6 +557,7 @@ function Dashboard() {
             />
           )}
         </main>
+      </div>
       </div>
     );
   }

--- a/packages/dashboard-v2/src/components/GlossaryModal.tsx
+++ b/packages/dashboard-v2/src/components/GlossaryModal.tsx
@@ -137,7 +137,7 @@ export function GlossaryModal({ open, onClose }: GlossaryModalProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-6 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-6 backdrop-blur-sm"
       onClick={onClose}
       role="presentation"
     >
@@ -160,7 +160,7 @@ export function GlossaryModal({ open, onClose }: GlossaryModalProps) {
             ref={closeButtonRef}
             onClick={onClose}
             aria-label="Close glossary"
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-border/40 bg-card font-mono text-xs text-muted-foreground transition hover:bg-muted hover:text-foreground"
+            className="flex min-h-[44px] min-w-[44px] shrink-0 items-center justify-center rounded border border-border/40 bg-card font-mono text-xs text-muted-foreground transition hover:bg-muted hover:text-foreground"
           >
             &times;
           </button>

--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '@/lib/api';
 import { timeAgo } from '@/lib/utils';
+import { href } from '@/lib/router';
 import { SignalFilterRail, type SignalFilters } from './SignalFilterRail';
 import { FindingDetailDrawer } from './FindingDetailDrawer';
 import type { SignalEntry } from '@/lib/types';
@@ -248,6 +249,12 @@ export function SignalsPage() {
           </p>
         </div>
       </div>
+
+      {hadAnyURLParams && (
+        <div className="rounded-md border border-border/40 bg-muted/30 px-3 py-2 font-mono text-[10px] text-muted-foreground">
+          Filtered view — {filters.signals.length} signal type{filters.signals.length !== 1 ? 's' : ''}{filters.agents.length > 0 ? ` · ${filters.agents.length} agent${filters.agents.length !== 1 ? 's' : ''}` : ''}{filters.severity ? ` · severity: ${filters.severity}` : ''}{filters.source ? ` · source: ${filters.source}` : ''}. <a href={href('/signals')} className="text-primary hover:text-foreground">Clear filters</a>
+        </div>
+      )}
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-[260px_1fr] lg:items-start">
         <div className={hadAnyURLParams ? 'opacity-70 transition-opacity hover:opacity-100 focus-within:opacity-100' : undefined}>

--- a/packages/dashboard-v2/src/components/TaskRow.tsx
+++ b/packages/dashboard-v2/src/components/TaskRow.tsx
@@ -173,7 +173,7 @@ export function TaskRow({ task, onClick }: TaskRowProps) {
       <td className="py-2.5 pr-3 font-mono text-xs text-muted-foreground">
         {key === 'running' ? 'running' : formatDurationNice(task.duration)}
       </td>
-      <td className="py-2.5 pr-4 text-right font-mono text-xs text-muted-foreground">
+      <td className="py-2.5 pr-4 text-right font-mono text-xs text-muted-foreground/50">
         {timeAgo(task.timestamp)}
       </td>
     </tr>

--- a/packages/dashboard-v2/src/components/TopBar.tsx
+++ b/packages/dashboard-v2/src/components/TopBar.tsx
@@ -54,7 +54,7 @@ export function TopBar() {
         <button
           onClick={() => setGlossaryOpen(true)}
           aria-label="Open glossary"
-          className="flex items-center justify-center rounded-md border border-border/60 bg-card px-2.5 py-1 font-mono text-xs font-semibold text-muted-foreground transition hover:border-border hover:text-foreground"
+          className="flex items-center justify-center rounded-md border border-border/60 bg-card px-2.5 py-1 font-mono text-xs font-semibold text-foreground transition hover:border-border hover:text-foreground"
         >
           Glossary
         </button>

--- a/packages/dashboard-v2/src/hooks/useElementWidth.ts
+++ b/packages/dashboard-v2/src/hooks/useElementWidth.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState, type RefObject } from 'react';
  * Tracks the width of a DOM element via ResizeObserver.
  * Returns [ref, width]. Width is 0 before first measurement.
  */
-export function useElementWidth<T extends HTMLElement = HTMLDivElement>(): [RefObject<T>, number] {
+export function useElementWidth<T extends HTMLElement = HTMLDivElement>(): [RefObject<T | null>, number] {
   const ref = useRef<T>(null);
   const [width, setWidth] = useState(0);
 


### PR DESCRIPTION
Cross-lens audit fix bundle. Three independent designer/reviewer/researcher audits of live screenshots converged on these fixes — visual + a11y + first-time-user lenses each surfaced overlapping concerns.

### Fixes

| # | File | Severity | Change |
|---|---|---|---|
| 1 | `App.tsx:289` | HIGH | HALLUC column: `text-destructive` → `text-disputed` (now matches AgentPage.tsx:107 disputed-palette convention; was internally inconsistent) |
| 2 | `SignalsPage.tsx:253-257` | HIGH | Active-filter banner above table when `hadAnyURLParams` — shows "Filtered view — N signal types · M agents..." with "Clear filters" link. Closes ambient-context gap from PR #336 URL hydration. |
| 3 | `GlossaryModal.tsx:140,163` | HIGH (a11y) | Backdrop `bg-background/80` → `bg-black/70` (background no longer bleeds through). Close button `h-7 w-7` → `min-h-[44px] min-w-[44px]` (WCAG 2.5.5 touch target). Visible × glyph size unchanged. |
| 4 | `TaskRow.tsx:176` | MED | Timestamp opacity `text-muted-foreground` → `/50`. Creates 3-tier scan rhythm per row (description headline, agentId metadata, timestamp recedes). Matches TasksSection convention. |
| 5 | `App.tsx:524-528` | MED | Dashboard route: added h1 + sub-header "Multi-agent code review with grounded reward signals. Live activity, agent scores, and consensus rounds." Closes the "what is this?" gap for first-time users. |
| 6 | `TopBar.tsx:57` | MED | Glossary pill `text-muted-foreground` → `text-foreground`. More discoverable for newcomers (was blending into chrome). |

### Bonus

`hooks/useElementWidth.ts:7` — fixed long-standing React 19 type signature `RefObject<T>` → `RefObject<T | null>`. This was a pre-existing tsc error since PR #217 (file last touched in commit 5ed7a95). Vite build was clean before this PR; `tsc -b` is now also clean. Bonus correctness fix surfaced because the implementer ran tsc as part of verification.

### Iron-law compliance

- ✅ All visual changes additive (no removed/replaced/reordered operator-facing elements)
- ✅ Glossary modal: × glyph visible size unchanged, only invisible click target expanded
- ✅ Signals filter banner: net-new addition, doesn't affect default-visit path
- ✅ Dashboard h1: net-new addition, doesn't displace existing layout

### Out of scope (Tier 3 backlog)

- Sublabel contrast verification + global pass (needs WCAG audit per surface)
- Color-only encoding remediation (icons in severity/status badges) — systemic, separate track
- SignalTimeline bar height
- Verdict chip gutter alignment on Consensus Rounds
- Per-page legends for Acc/Unq/Imp color-coded bars

### Audit context

3 lenses audited live screenshots (`/tmp/dashboard-shots/`):
- **Visual craft (sonnet-designer):** flagged HALLUC color + filter banner gap as HIGH
- **A11y/interaction (sonnet-reviewer):** flagged WCAG 2.5.5 touch target + scrim opacity
- **First-time user (haiku-researcher):** flagged Dashboard 'what is this' gap + Glossary discoverability

Reference: visual-pass memory at `/Users/goku/.claude/projects/-Users-goku-Desktop-gossip/memory/project_dashboard_visual_pass.md`. This is the closing PR of the dashboard polish track unless something new surfaces.

### Build

Vite build clean: 376.74 kB / gzip 106.20 kB. tsc -b also clean (first time in months — see Bonus above).