### PR TITLE
feat(dashboard): polish PR-M — align Team metric schema across 3 surfaces (Acc / Rel / Unq / Imp)

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -242,40 +242,19 @@ function TeamPage({ agents, tasks }: { agents: AgentData[]; tasks: import('@/lib
                     <span className={`font-mono text-sm font-bold tabular-nums ${weightColor}`}>{s.dispatchWeight.toFixed(2)}</span>
                   </td>
 
-                  {/* Metrics: four mini bars stacked */}
+                  {/* Metrics: four mini bars stacked — Acc / Rel / Unq / Imp */}
                   <td className="py-3 pr-4 align-top">
-                    {(() => {
-                      const rawDenom = s.agreements + s.uniqueFindings + s.disagreements + s.hallucinations;
-                      const rawRatio = rawDenom > 0
-                        ? (s.agreements + s.uniqueFindings) / rawDenom
-                        : null;
-                      return (
-                        <div className="space-y-1">
-                          <MiniBar
-                            label="A"
-                            value={s.accuracy}
-                            fillClass={s.accuracy >= 0.7 ? 'bg-confirmed' : s.accuracy >= 0.4 ? 'bg-unverified' : 'bg-disputed'}
-                            tooltip="Adjusted accuracy = raw signal ratio × 1/(1 + weighted hallucinations × 0.3). The penalty is recoverable via skill-gated multiplier in the same category."
-                          />
-                          <MiniBar label="U" value={s.uniqueness} fillClass="bg-unique" tooltip="Uniqueness — findings this agent surfaced that no other agent found" />
-                          <MiniBar label="I" value={s.impactScore} fillClass="bg-[var(--color-impact)]" tooltip="Impact — severity-weighted finding score; critical and high findings count more" />
-                          {rawRatio !== null ? (
-                            <MiniBar
-                              label="R"
-                              value={rawRatio}
-                              fillClass={rawRatio >= 0.7 ? 'bg-confirmed/60' : rawRatio >= 0.4 ? 'bg-unverified/60' : 'bg-disputed/60'}
-                              tooltip="(agreements + unique) / (agreements + unique + disagreements + hallucinations). Unweighted base ratio before the hallucination penalty."
-                            />
-                          ) : (
-                            <div className="flex items-center gap-2">
-                              <span className="w-2 font-mono text-[8px] uppercase text-muted-foreground/50">R</span>
-                              <div className="h-1 flex-1 overflow-hidden rounded-full bg-background/60" />
-                              <span className="w-8 text-right font-mono text-[10px] tabular-nums text-muted-foreground/30">—</span>
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })()}
+                    <div className="space-y-1">
+                      <MiniBar
+                        label="A"
+                        value={s.accuracy}
+                        fillClass={s.accuracy >= 0.7 ? 'bg-confirmed' : s.accuracy >= 0.4 ? 'bg-unverified' : 'bg-disputed'}
+                        tooltip="Adjusted accuracy = raw signal ratio × 1/(1 + weighted hallucinations × 0.3). The penalty is recoverable via skill-gated multiplier in the same category."
+                      />
+                      <MiniBar label="Rel" value={s.reliability} fillClass="bg-chart" tooltip="Reliability — fraction of dispatched tasks that finished without pipeline error or timeout" />
+                      <MiniBar label="U" value={s.uniqueness} fillClass="bg-unique" tooltip="Uniqueness — findings this agent surfaced that no other agent found" />
+                      <MiniBar label="I" value={s.impactScore} fillClass="bg-[var(--color-impact)]" tooltip="Impact — severity-weighted finding score; critical and high findings count more" />
+                    </div>
                   </td>
 
                   {/* Signals */}
@@ -322,7 +301,7 @@ function TeamPage({ agents, tasks }: { agents: AgentData[]; tasks: import('@/lib
 function MiniBar({ label, value, fillClass, tooltip }: { label: string; value: number; fillClass: string; tooltip?: string }) {
   return (
     <div className="flex items-center gap-2" data-tooltip={tooltip} data-tooltip-pos="top">
-      <span className="w-2 font-mono text-[8px] uppercase text-muted-foreground/50">{label}</span>
+      <span className="w-6 font-mono text-[8px] uppercase text-muted-foreground/50">{label}</span>
       <div className="h-1 flex-1 overflow-hidden rounded-full bg-background/60">
         <div className={`h-full rounded-full ${fillClass}`} style={{ width: `${Math.max(0, Math.min(100, value * 100))}%` }} />
       </div>

--- a/packages/dashboard-v2/src/components/TeamRoster.tsx
+++ b/packages/dashboard-v2/src/components/TeamRoster.tsx
@@ -29,9 +29,12 @@ export function TeamRoster({ agents }: TeamRosterProps) {
           const weightColor =
             s.dispatchWeight >= 1.2 ? 'text-confirmed' :
             s.dispatchWeight >= 0.8 ? 'text-foreground' : 'text-muted-foreground';
-          const barColor =
-            s.accuracy >= 0.7 ? 'bg-confirmed' :
-            s.accuracy >= 0.4 ? 'bg-unverified' : 'bg-disputed';
+          const metricBars = [
+            { label: 'Acc', value: s.accuracy, fill: s.accuracy >= 0.7 ? 'bg-confirmed' : s.accuracy >= 0.4 ? 'bg-unverified' : 'bg-disputed' },
+            { label: 'Rel', value: s.reliability, fill: 'bg-chart', tooltip: 'Reliability — fraction of dispatched tasks that finished without pipeline error or timeout' },
+            { label: 'Unq', value: s.uniqueness, fill: 'bg-unique' },
+            { label: 'Imp', value: s.impactScore, fill: 'bg-[var(--color-impact)]' },
+          ];
 
           return (
             <a
@@ -77,13 +80,18 @@ export function TeamRoster({ agents }: TeamRosterProps) {
                   </div>
                 </div>
 
-                {/* Line 2: accuracy bar + last active */}
-                <div className="mt-1.5 flex items-center gap-2">
-                  <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted/30">
-                    <div
-                      className={`h-full rounded-full transition-all ${barColor}`}
-                      style={{ width: `${s.accuracy * 100}%` }}
-                    />
+                {/* Line 2: 4-metric bars + last active */}
+                <div className="mt-1.5 flex items-end gap-2">
+                  <div className="flex-1 space-y-1">
+                    {metricBars.map(m => (
+                      <div key={m.label} className="flex items-center gap-2 text-[9px]">
+                        <span className="w-6 uppercase text-muted-foreground" data-tooltip={m.tooltip}>{m.label}</span>
+                        <div className="h-1 flex-1 overflow-hidden rounded-full bg-background/60">
+                          <div className={`h-full ${m.fill}`} style={{ width: `${m.value * 100}%` }} />
+                        </div>
+                        <span className="w-8 text-right tabular-nums text-foreground">{Math.round(m.value * 100)}%</span>
+                      </div>
+                    ))}
                   </div>
                   {lastTime && (
                     <span className="shrink-0 font-mono text-[10px] text-muted-foreground/40">{lastTime}</span>


### PR DESCRIPTION
## Summary

Operator decisions (Q1: 4 bars Acc/Rel/Unq/Imp, drop legacy R = rawSignalRatio; Q2: same schema across all 3 Team surfaces).

## Per-surface change

| Surface | Before | After |
|---|---|---|
| /team table MiniBars (App.tsx) | A · U · I · R (rawSignalRatio, conditional) | A · Rel · U · I |
| Dashboard sidebar (TeamRoster.tsx) | Single accuracy bar | 4-row stacked: Acc / Rel / Unq / Imp |
| /agent/:id (AgentPage.tsx) | accuracy / reliability / unique / impact | unchanged — canonical reference |

## Implementation

- **App.tsx**: removed `rawDenom` / `rawRatio` computation + the conditional R MiniBar block (lines 248-275 of master). Inserted new MiniBar `label="Rel" value={s.reliability} fillClass="bg-chart"` between A and U. Widened MiniBar label span `w-2` → `w-6` to fit 3-char "Rel".
- **TeamRoster.tsx**: replaced single `h-2` accuracy bar with 4-row stacked `text-[9px]` rows (label / mini-bar / percentage), local `metricBars` array matching AgentPage colors and tooltips. Header line (agent name, circuit badge, weight, accuracy %) untouched.
- **AgentPage.tsx**: untouched. Canonical reference.
- **Data layer**: rawSignalRatio remains in types/API — only removed from render paths.

## Iron-law compliance

- ✅ All visible operator-facing element changes are additive (new bars added, R bar removed which was the explicitly-requested change)
- ✅ AgentPage canonical reference unchanged
- ✅ Header line of TeamRoster unchanged

## Test plan

- ✅ Vite build clean (76 modules, 649ms)
- ✅ `git diff origin/master --stat` shows only App.tsx + TeamRoster.tsx
- ✅ No `rawRatio` / `rawSignalRatio` / `rawDenom` in render paths
- ✅ Metric order matches AgentPage everywhere: Acc, Rel, Unq, Imp
- [ ] Visual check after merge: sidebar shows 4 stacked bars; /team shows Rel between A and U

Reference: visual-pass memory at `/Users/goku/.claude/projects/-Users-goku-Desktop-gossip/memory/project_dashboard_visual_pass.md`. Companion: PR for SystemPulse divider line fix (separate, fix/system-pulse-divider-line).