### PR TITLE
fix(dashboard): SystemPulse divider lines extending through actionable row

### DIFF
--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -65,44 +65,46 @@ export function SystemPulse({ overview, activeTasks }: SystemPulseProps) {
         </div>
       </div>
 
-      {/* Primary 2x2 grid with cross dividers */}
-      <div className="relative grid grid-cols-2 border-b border-border">
-        <span className="pointer-events-none absolute left-0 right-0 top-1/2 h-px bg-border" />
-        <span className="pointer-events-none absolute bottom-0 left-1/2 top-0 w-px bg-border" />
-        {/* Three-row agent stat (stacked to fit narrow cell) */}
-        <div className="flex flex-col items-stretch justify-center gap-1.5 px-4 py-3">
-          <div className="flex items-baseline justify-between gap-2">
-            <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Agents currently executing a task">Dispatched</span>
-            <span className={`font-mono text-base font-bold leading-none ${overview.agentsOnline > 0 ? 'text-primary' : 'text-foreground'}`}>{overview.agentsOnline}</span>
+      {/* Primary 2x2 grid with cross dividers, then full-width actionable row below */}
+      <div className="border-b border-border">
+        <div className="relative grid grid-cols-2">
+          <span className="pointer-events-none absolute left-0 right-0 top-1/2 h-px bg-border" />
+          <span className="pointer-events-none absolute bottom-0 left-1/2 top-0 w-px bg-border" />
+          {/* Three-row agent stat (stacked to fit narrow cell) */}
+          <div className="flex flex-col items-stretch justify-center gap-1.5 px-4 py-3">
+            <div className="flex items-baseline justify-between gap-2">
+              <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Agents currently executing a task">Dispatched</span>
+              <span className={`font-mono text-base font-bold leading-none ${overview.agentsOnline > 0 ? 'text-primary' : 'text-foreground'}`}>{overview.agentsOnline}</span>
+            </div>
+            <div className="flex items-baseline justify-between gap-2">
+              <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Relay agents with an active WebSocket connection">Connected</span>
+              <span className={`font-mono text-base font-bold leading-none ${overview.relayConnected > 0 ? 'text-confirmed' : 'text-muted-foreground'}`}>{overview.relayConnected}</span>
+            </div>
+            <div className="flex items-baseline justify-between gap-2">
+              <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Total agents in gossipcat config">Registered</span>
+              <span className="font-mono text-base font-bold leading-none text-muted-foreground">{totalAgents}</span>
+            </div>
           </div>
-          <div className="flex items-baseline justify-between gap-2">
-            <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Relay agents with an active WebSocket connection">Connected</span>
-            <span className={`font-mono text-base font-bold leading-none ${overview.relayConnected > 0 ? 'text-confirmed' : 'text-muted-foreground'}`}>{overview.relayConnected}</span>
-          </div>
-          <div className="flex items-baseline justify-between gap-2">
-            <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Total agents in gossipcat config">Registered</span>
-            <span className="font-mono text-base font-bold leading-none text-muted-foreground">{totalAgents}</span>
-          </div>
+          <BigStat
+            value={activeTasks}
+            label="Active Tasks"
+            valueClass={activeTasks > 0 ? 'text-unverified' : 'text-muted-foreground'}
+            pulse={activeTasks > 0}
+          />
+          <BigStat
+            value={overview.consensusRuns}
+            label="Consensus"
+            valueClass="text-foreground"
+          />
+          <BigStat
+            value={`${confirmRate}%`}
+            label="Confirmed"
+            valueClass="text-confirmed"
+          />
         </div>
-        <BigStat
-          value={activeTasks}
-          label="Active Tasks"
-          valueClass={activeTasks > 0 ? 'text-unverified' : 'text-muted-foreground'}
-          pulse={activeTasks > 0}
-        />
-        <BigStat
-          value={overview.consensusRuns}
-          label="Consensus"
-          valueClass="text-foreground"
-        />
-        <BigStat
-          value={`${confirmRate}%`}
-          label="Confirmed"
-          valueClass="text-confirmed"
-        />
         <a
           href={href('/signals?signal=disagreement&signal=hallucination_caught&signal=new_finding')}
-          className="col-span-2 block cursor-pointer border-t border-border transition-colors hover:bg-accent/30"
+          className="block cursor-pointer border-t border-border transition-colors hover:bg-accent/30"
           aria-label="View actionable findings on Signals page"
         >
           <BigStat


### PR DESCRIPTION
## Symptom

The SystemPulse card's cross-divider lines (horizontal at row-midpoint, vertical between columns) extend through the col-span-2 `Actionable` row added by PR #334, creating visually misaligned dividers. Specifically the vertical line cuts through the actionable cell that's supposed to be column-spanning, and the horizontal line sits at the wrong vertical position relative to the original 2x2 grid.

## Cause

`SystemPulse.tsx:70-71` defines absolutely-positioned divider spans whose anchors (`top-1/2`, `top-0`, `bottom-0`) reference the full grid container. PR #334 added a 5th col-span-2 cell, taking the container from a 2x2 grid to a 2x2 + 1 wide row. The dividers still position relative to the now-taller container.

## Fix

Wrap the original 2x2 grid in its own `<div>`, scoping the absolute-positioned dividers to that subset. Move the actionable row to a sibling `<a>` outside the 2x2 wrapper. Net structural change: one wrapper div + sibling reorder. No visual element removed or reordered. `col-span-2` removed from the actionable row since it's no longer inside the grid.

## Verification

- ✅ Vite build clean
- ✅ `git diff origin/master --stat` shows only `SystemPulse.tsx` (1 file, +36/-34)
- ✅ All children (Dispatched/Connected/Registered, Active Tasks, Consensus, Confirmed, Actionable) preserved
- [ ] Visual check after merge: dividers stay inside 2x2 grid; actionable row sits cleanly below with one top border

Reference: visual-pass memory. Companion to PR-M (Team metric schema alignment, separate).