### PR TITLE
fix(dashboard): TeamHero AgentCardBig — add Reliability bar (4 bars canonical)

### DIFF
--- a/packages/dashboard-v2/src/components/AgentCardBig.tsx
+++ b/packages/dashboard-v2/src/components/AgentCardBig.tsx
@@ -114,6 +114,12 @@ export function AgentCardBig({ agent }: AgentCardBigProps) {
           tooltip={`Accuracy ${pct(s.accuracy)}\nRatio of confirmed findings.\nHigher = more trustworthy.`}
         />
         <BarRow
+          label="reliability"
+          value={s.reliability}
+          fillClass="bg-chart"
+          tooltip={`Reliability ${pct(s.reliability)}\nTask completion rate — fraction of dispatched tasks that finished without pipeline error or timeout.`}
+        />
+        <BarRow
           label="unique"
           value={s.uniqueness}
           fillClass="bg-unique"


### PR DESCRIPTION
Operator caught: TeamHero on Dashboard main column was still showing 3 bars (accuracy / unique / impact) after PR-M #343 aligned the rest. PR-M missed `AgentCardBig` (used by `TeamHero`) since I was looking at TeamRoster (sidebar component).

### Change

`packages/dashboard-v2/src/components/AgentCardBig.tsx:115-121` — inserted Reliability `BarRow` between accuracy and unique, matching the canonical AgentPage.tsx:88-91 metric order. Uses `bg-chart` fill and the established Reliability tooltip copy from AgentPage.

### Now consistent across all 4 Team surfaces

| Surface | Bars |
|---|---|
| Dashboard sidebar (TeamRoster) | Acc · Rel · Unq · Imp ✓ |
| Dashboard main (TeamHero/AgentCardBig) | Acc · Rel · Unq · Imp ✓ (this PR) |
| /team MiniBars (App.tsx) | A · Rel · U · I ✓ |
| /agent/:id (AgentPage canonical) | accuracy · reliability · unique · impact ✓ |

Closes the PR-M oversight.