### PR TITLE
feat(dashboard): polish PR-N — real task-completion rate replaces composite-score reliability

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -251,7 +251,7 @@ function TeamPage({ agents, tasks }: { agents: AgentData[]; tasks: import('@/lib
                         fillClass={s.accuracy >= 0.7 ? 'bg-confirmed' : s.accuracy >= 0.4 ? 'bg-unverified' : 'bg-disputed'}
                         tooltip="Adjusted accuracy = raw signal ratio × 1/(1 + weighted hallucinations × 0.3). The penalty is recoverable via skill-gated multiplier in the same category."
                       />
-                      <MiniBar label="Rel" value={s.reliability} fillClass="bg-chart" tooltip="Reliability — fraction of dispatched tasks that finished without pipeline error or timeout" />
+                      <MiniBar label="Rel" value={s.taskCompletionRate ?? 0} fillClass="bg-chart" tooltip="Reliability — fraction of dispatched tasks that finished without pipeline error or timeout" />
                       <MiniBar label="U" value={s.uniqueness} fillClass="bg-unique" tooltip="Uniqueness — findings this agent surfaced that no other agent found" />
                       <MiniBar label="I" value={s.impactScore} fillClass="bg-[var(--color-impact)]" tooltip="Impact — severity-weighted finding score; critical and high findings count more" />
                     </div>

--- a/packages/dashboard-v2/src/components/AgentCardBig.tsx
+++ b/packages/dashboard-v2/src/components/AgentCardBig.tsx
@@ -115,9 +115,9 @@ export function AgentCardBig({ agent }: AgentCardBigProps) {
         />
         <BarRow
           label="reliability"
-          value={s.reliability}
+          value={s.taskCompletionRate ?? 0}
           fillClass="bg-chart"
-          tooltip={`Reliability ${pct(s.reliability)}\nTask completion rate — fraction of dispatched tasks that finished without pipeline error or timeout.`}
+          tooltip={`Reliability ${pct(s.taskCompletionRate ?? 0)}\nTask completion rate — fraction of dispatched tasks that finished without pipeline error or timeout.`}
         />
         <BarRow
           label="unique"
@@ -146,7 +146,7 @@ interface BarRowProps {
 function BarRow({ label, value, fillClass, tooltip }: BarRowProps) {
   const v = Number.isFinite(value) ? value : 0;
   return (
-    <div className="grid grid-cols-[60px_1fr_38px] items-center gap-2.5">
+    <div className="grid grid-cols-[72px_1fr_38px] items-center gap-2.5">
       <span
         className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground"
         data-tooltip={tooltip}

--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -86,7 +86,7 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
 
   const metricBars = [
     { label: 'accuracy', value: s.accuracy, fill: s.accuracy >= 0.7 ? 'bg-confirmed' : s.accuracy >= 0.4 ? 'bg-unverified' : 'bg-disputed' },
-    { label: 'reliability', value: s.reliability, fill: 'bg-chart', tooltip: 'Task completion rate — fraction of dispatched tasks that finished without pipeline error or timeout' },
+    { label: 'reliability', value: s.taskCompletionRate ?? 0, fill: 'bg-chart', tooltip: 'Task completion rate — fraction of dispatched tasks that finished without pipeline error or timeout' },
     { label: 'unique', value: s.uniqueness, fill: 'bg-unique' },
     { label: 'impact', value: s.impactScore, fill: 'bg-[var(--color-impact)]' },
   ];

--- a/packages/dashboard-v2/src/components/TeamRoster.tsx
+++ b/packages/dashboard-v2/src/components/TeamRoster.tsx
@@ -31,7 +31,7 @@ export function TeamRoster({ agents }: TeamRosterProps) {
             s.dispatchWeight >= 0.8 ? 'text-foreground' : 'text-muted-foreground';
           const metricBars = [
             { label: 'Acc', value: s.accuracy, fill: s.accuracy >= 0.7 ? 'bg-confirmed' : s.accuracy >= 0.4 ? 'bg-unverified' : 'bg-disputed' },
-            { label: 'Rel', value: s.reliability, fill: 'bg-chart', tooltip: 'Reliability — fraction of dispatched tasks that finished without pipeline error or timeout' },
+            { label: 'Rel', value: s.taskCompletionRate ?? 0, fill: 'bg-chart', tooltip: 'Reliability — fraction of dispatched tasks that finished without pipeline error or timeout' },
             { label: 'Unq', value: s.uniqueness, fill: 'bg-unique' },
             { label: 'Imp', value: s.impactScore, fill: 'bg-[var(--color-impact)]' },
           ];

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -76,6 +76,11 @@ export interface AgentData {
   lastTask: { task: string; timestamp: string } | null;
   scores: {
     accuracy: number; uniqueness: number; reliability: number;
+    /** Real task-completion rate: completed / (completed + failed). Null when
+     * no terminal tasks exist. Use this for the "Reliability" bar on all
+     * dashboard surfaces — score.reliability is a composite formula kept only
+     * for internal dispatch-weight arithmetic. */
+    taskCompletionRate: number | null;
     impactScore: number; dispatchWeight: number; signals: number;
     agreements: number; disagreements: number; hallucinations: number; uniqueFindings: number;
     unverifiedsEmitted?: number; unverifiedsReceived?: number;

--- a/packages/relay/src/dashboard/api-agents.ts
+++ b/packages/relay/src/dashboard/api-agents.ts
@@ -166,6 +166,13 @@ export interface AgentResponse {
      * dashboard observability so operators can spot agents whose hallucination
      * counts were inflated by relay-cwd transport failures. */
     transportFailureCount: number;
+    /** Real task-completion rate: completed / (completed + failed).
+     * Null when no completed-or-failed tasks exist (new/never-dispatched agent).
+     * Excludes cancelled and in-flight tasks — only terminal outcomes count.
+     * This is the ground-truth source for the "Reliability" tooltip on all
+     * dashboard surfaces; score.reliability (composite formula) stays for
+     * internal dispatch-weight arithmetic only. */
+    taskCompletionRate: number | null;
     bench: {
       state: 'benched' | 'kept-for-coverage' | 'none';
       reason?: 'chronic-low-accuracy' | 'burst-hallucination';
@@ -196,6 +203,8 @@ interface TaskGraphEntry {
 interface AgentTaskData {
   totalTokens: number;
   lastTask: LastTask | null;
+  tasksCompleted: number;
+  tasksFailed: number;
 }
 
 function readTaskGraphByAgent(projectRoot: string): Map<string, AgentTaskData> {
@@ -213,8 +222,10 @@ function readTaskGraphByAgent(projectRoot: string): Map<string, AgentTaskData> {
 
   // First pass: collect task.created events keyed by taskId for task description + agentId
   const created = new Map<string, { agentId: string; task: string; timestamp: string }>();
-  // Second pass: collect completed events keyed by taskId for tokens
+  // Collect completed events keyed by taskId for tokens
   const completed = new Map<string, { inputTokens: number; outputTokens: number; timestamp: string }>();
+  // Track failed taskIds to attribute per-agent
+  const failed = new Set<string>();
 
   for (const line of lines) {
     let entry: TaskGraphEntry;
@@ -228,6 +239,8 @@ function readTaskGraphByAgent(projectRoot: string): Map<string, AgentTaskData> {
         outputTokens: entry.outputTokens ?? 0,
         timestamp: entry.timestamp ?? '',
       });
+    } else if (entry.type === 'task.failed' && entry.taskId) {
+      failed.add(entry.taskId);
     }
   }
 
@@ -236,13 +249,16 @@ function readTaskGraphByAgent(projectRoot: string): Map<string, AgentTaskData> {
     const { agentId, task, timestamp } = createdData;
     if (isUtilityAgent(agentId)) continue;
     if (!result.has(agentId)) {
-      result.set(agentId, { totalTokens: 0, lastTask: null });
+      result.set(agentId, { totalTokens: 0, lastTask: null, tasksCompleted: 0, tasksFailed: 0 });
     }
     const agentData = result.get(agentId)!;
 
     const comp = completed.get(taskId);
     if (comp) {
       agentData.totalTokens += comp.inputTokens + comp.outputTokens;
+      agentData.tasksCompleted++;
+    } else if (failed.has(taskId)) {
+      agentData.tasksFailed++;
     }
 
     // Track latest task by timestamp
@@ -272,7 +288,7 @@ export async function agentsHandler(
 
   return configs.map(config => {
     const score = scores.get(config.id) ?? { ...DEFAULT_SCORE, agentId: config.id };
-    const agentTask = taskDataByAgent.get(config.id) ?? { totalTokens: 0, lastTask: null };
+    const agentTask = taskDataByAgent.get(config.id) ?? { totalTokens: 0, lastTask: null, tasksCompleted: 0, tasksFailed: 0 };
 
     const categories = Object.keys({ ...score.categoryCorrect, ...score.categoryHallucinated });
     const benchResult = reader.isBenched(config.id, categories, allIds);
@@ -310,6 +326,12 @@ export async function agentsHandler(
       }
     } catch { /* return empty on error */ }
 
+    const { tasksCompleted, tasksFailed } = agentTask;
+    const completionDenominator = tasksCompleted + tasksFailed;
+    const taskCompletionRate = completionDenominator > 0
+      ? tasksCompleted / completionDenominator
+      : null;
+
     return {
       id: config.id,
       provider: config.provider,
@@ -325,6 +347,7 @@ export async function agentsHandler(
         accuracy: score.accuracy,
         uniqueness: score.uniqueness,
         reliability: score.reliability,
+        taskCompletionRate,
         impactScore: score.impactScore ?? 0.5,
         dispatchWeight: reader.getDispatchWeight(config.id),
         signals: score.totalSignals,


### PR DESCRIPTION
## Bug

Dashboard tooltip claims "Reliability — task completion rate — fraction of dispatched tasks that finished without pipeline error or timeout" but the displayed value was `score.reliability` from PerformanceReader formula `accuracy*0.75 + uniqueness*0.15 + impactScore*0.10` — a weighted composite of the other 3 metrics, not a task-completion rate.

Verified mismatch: sonnet-implementer Acc 48% / Unq 61% / Imp 29% → composite computes 0.48*0.75 + 0.61*0.15 + 0.29*0.10 = **48.05%** — exactly the 48% the dashboard was showing as "reliability". Operator caught the suspicious Acc=Rel coincidence.

This is double-counting AND a tooltip lie.

## Fix (Option C)

Keep the tooltip wording. Change the data source to actual task-completion rate, computed per-agent from task-graph events.

### Backend (`packages/relay/src/dashboard/api-agents.ts`)

- Track `task.failed` events in `readTaskGraphByAgent` alongside `task.created` and `task.completed` (same JSONL pass).
- Bucket per-agent: `tasksCompleted` increments when a created task has a matching completed event; `tasksFailed` increments when its taskId appears in the failed set.
- Compute `taskCompletionRate = completed / (completed + failed)`. Returns `null` when no terminal tasks exist (new/never-dispatched agent — frontend renders 0% bar).
- Cancelled and in-flight tasks excluded from the rate (matches `api-overview.ts` global-counter convention).

### Type (`packages/dashboard-v2/src/lib/types.ts`)

`scores.taskCompletionRate: number | null` added to `AgentData` with JSDoc.

### Frontend — 4 surfaces swap `s.reliability` → `s.taskCompletionRate ?? 0`

- `AgentPage.tsx` metricBars
- `TeamRoster.tsx` Dashboard sidebar
- `App.tsx` /team Rel MiniBar
- `AgentCardBig.tsx` TeamHero BarRow

### Bonus layout fix

`AgentCardBig.tsx` BarRow grid: `60px_1fr_38px` → `72px_1fr_38px`. "RELIABILITY" was overflowing the 60px label column and touching the bar.

## Iron-law compliance

- ✅ `score.reliability` composite stays intact in PerformanceReader (still used for dispatch weighting at performance-reader.ts:259, etc.)
- ✅ `reliability` field still in API response — only render path swapped
- ✅ All 4 surfaces continue to show 4 bars; only the data source for one bar changed
- ✅ Tooltip wording already correct, untouched

## Test plan

- ✅ tsc --noEmit clean (relay + dashboard-v2)
- ✅ npm run build:mcp clean
- ✅ Vite build clean
- [ ] Visual: verify Acc and Rel are no longer suspiciously identical for sonnet-implementer; "RELIABILITY" label no longer touches its bar

## Reference

Visual-pass memory: `/Users/goku/.claude/projects/-Users-goku-Desktop-gossip/memory/project_dashboard_visual_pass.md`. Caps the dashboard polish track unless something else surfaces.