### PR TITLE
feat(dashboard): polish PR-O — Signals filter rail conditional on empty state

### DIFF
--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -221,6 +221,11 @@ export function SignalsPage() {
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const clampedPage = Math.min(page, totalPages - 1);
 
+  // Diagnosis 3: hide the 260px filter rail on first-glance empty states so
+  // operators land on data, not chrome. Keep it visible when there's data,
+  // when filters are active (need to clear them), or while loading (no flash).
+  const showRail = total > 0 || hadAnyURLParams || loading;
+
   const openDrawer = (consensusId?: string, findingId?: string) => {
     if (!consensusId || !findingId) return;
     setDrawerConsensusId(consensusId);
@@ -256,15 +261,17 @@ export function SignalsPage() {
         </div>
       )}
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[260px_1fr] lg:items-start">
-        <div className={hadAnyURLParams ? 'opacity-70 transition-opacity hover:opacity-100 focus-within:opacity-100' : undefined}>
-          <SignalFilterRail
-            filters={filters}
-            onChange={onFilterChange}
-            agents={agents}
-            signalTypes={SIGNAL_TYPES}
-          />
-        </div>
+      <div className={`grid grid-cols-1 gap-4 ${showRail ? 'lg:grid-cols-[260px_1fr]' : ''} lg:items-start`}>
+        {showRail && (
+          <div className={hadAnyURLParams ? 'opacity-70 transition-opacity hover:opacity-100 focus-within:opacity-100' : undefined}>
+            <SignalFilterRail
+              filters={filters}
+              onChange={onFilterChange}
+              agents={agents}
+              signalTypes={SIGNAL_TYPES}
+            />
+          </div>
+        )}
 
         <section className="min-w-0 overflow-hidden rounded-md border border-border/60 bg-card/70">
           {error && (


### PR DESCRIPTION
## Summary
- Diagnosis 3 from `project_dashboard_visual_pass.md` — the 260px filter rail rendered unconditionally meant fresh-install operators landed on chrome instead of data when no signals existed.
- Iron-law-safe: `showRail = total > 0 || hadAnyURLParams || loading`. Populated, filtered-empty, and loading states all keep the rail; only true empty + unfiltered hides it.
- Grid drops to single column when rail is hidden so the data section gets full width.
- Orthogonal to PR #339 (which de-emphasized via opacity on pre-filtered URLs); both fixes coexist.

## Test plan
- [x] `npm run build` clean (no TS errors, vite build succeeds)
- [x] Visual verify: populated `/signals` page renders rail + data unchanged
- [ ] Verify empty state in browser (logic-only path; needs fresh install or empty `.gossip/agent-performance.jsonl` to exercise)
- [ ] Filtered-empty (apply impossible filter) still shows rail with Clear filters affordance

🤖 Generated with [Claude Code](https://claude.com/claude-code)