### PR TITLE
fix(cli): ref-allowlist detector — drop --merges to support squash PRs

### DIFF
--- a/apps/cli/src/handlers/ref-allowlist-detection.ts
+++ b/apps/cli/src/handlers/ref-allowlist-detection.ts
@@ -1,3 +1,5 @@
+// @gossip:impact-adjacent:signal_pipeline
+
 /**
  * Ref-allowlist enforcement — Phase 1 (detection-only).
  *
@@ -35,14 +37,23 @@ export function capturePreDispatchSha(): string | null {
 }
 
 /**
- * Get commits between two SHAs that look like PR merges
- * (git log --merges --grep="(#[0-9]").
+ * Get commits between two SHAs that look like PR merges.
+ *
+ * Matches both squash-merged PRs (single-parent commit with "(#NNN)" in the
+ * subject, as produced by `gh pr merge --squash`) and traditional merge
+ * commits (two-parent merge with "(#NNN)" in the subject). The
+ * `--grep="(#[0-9]"` predicate is sufficient — both `gh pr merge --squash`
+ * and `gh pr merge --merge` prefix the commit subject with `(#NNN)`, while
+ * direct pushes typically don't include a PR ref.
+ *
+ * NOTE: `--merges` is intentionally omitted — it restricts to commits with
+ * 2+ parents, which silently excludes squash-merged PRs (single-parent).
  */
 function getPrMergeCommits(preSha: string, postSha: string): string[] {
   try {
     const out = execFileSync(
       'git',
-      ['log', `${preSha}..${postSha}`, '--merges', `--grep=(#[0-9]`, '--format=%H %s'],
+      ['log', `${preSha}..${postSha}`, `--grep=(#[0-9]`, '--format=%H %s'],
       { cwd: process.cwd(), stdio: ['ignore', 'pipe', 'ignore'] },
     ).toString().trim();
     return out ? out.split('\n').filter(Boolean) : [];

--- a/tests/cli/ref-allowlist-detection.test.ts
+++ b/tests/cli/ref-allowlist-detection.test.ts
@@ -8,6 +8,7 @@
  *   (c) SHA changed + no merge entry → violation: JSONL appended + signal emitted + stderr message
  *   (d) Multiple commits + one PR merge → no signal (batched merges)
  *   (e) preDispatchSha null → no detection, no false positive
+ *   (f) SHA changed + squash-merged PR commit → no signal (squash PR regression)
  */
 
 import * as fs from 'fs';
@@ -87,7 +88,8 @@ describe('checkRefAllowlistViolation', () => {
   it('(b) SHA changed + PR merge entry → no signal (legitimate merge)', () => {
     mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === 'rev-parse') return Buffer.from(POST_SHA + '\n');
-      if (args[0] === 'log' && args.includes('--merges')) {
+      if (args[0] === 'log' && args.includes(`--grep=(#[0-9]`) && !args.includes('--merges')) {
+        // getPrMergeCommits: returns a traditional merge commit (no --merges flag needed)
         return Buffer.from(`${POST_SHA} Merge pull request (#42) from feature/foo\n`);
       }
       return Buffer.from('');
@@ -104,7 +106,7 @@ describe('checkRefAllowlistViolation', () => {
 
     mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === 'rev-parse') return Buffer.from(POST_SHA + '\n');
-      if (args[0] === 'log' && args.includes('--merges')) return Buffer.from('');
+      if (args[0] === 'log' && args.includes(`--grep=(#[0-9]`)) return Buffer.from('');
       if (args[0] === 'log') return Buffer.from(`${POST_SHA} feat: sneak push to master\n`);
       return Buffer.from('');
     });
@@ -144,8 +146,9 @@ describe('checkRefAllowlistViolation', () => {
   it('(d) Multiple commits + one PR merge → no signal (batched merges)', () => {
     mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === 'rev-parse') return Buffer.from(POST_SHA + '\n');
-      if (args[0] === 'log' && args.includes('--merges')) {
-        // One merge commit among several
+      // getPrMergeCommits uses --grep; getCommitRange does not
+      if (args[0] === 'log' && args.includes(`--grep=(#[0-9]`)) {
+        // One PR-ref commit among several
         return Buffer.from(`${POST_SHA} Merge pull request (#99) from feature/bar\n`);
       }
       if (args[0] === 'log') {
@@ -173,6 +176,30 @@ describe('checkRefAllowlistViolation', () => {
     // Should not throw
     expect(() => checkRefAllowlistViolation('task-null', 'sonnet-implementer', PRE_SHA)).not.toThrow();
 
+    expect(mockEmitSignals).not.toHaveBeenCalled();
+    expect(mockAppendFileSync).not.toHaveBeenCalled();
+  });
+
+  it('(f) SHA changed + squash-merged PR commit → no signal (squash PR regression)', () => {
+    // Regression: previously --merges excluded single-parent squash commits,
+    // causing false-positive violations for every `gh pr merge --squash`.
+    // Empirical proof: git log 5318c87..6a3d92e --merges --grep="(#[0-9]" → empty
+    //                  git log 5318c87..6a3d92e          --grep="(#[0-9]" → 6a3d92e (#331)
+    // Fix: drop --merges so squash commits (single-parent) are matched by --grep alone.
+    const SQUASH_SHA = 'squash999aaa888bbb777ccc666ddd555eee444fff';
+
+    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === 'rev-parse') return Buffer.from(SQUASH_SHA + '\n');
+      // getPrMergeCommits (with --grep, without --merges): returns squash commit
+      if (args[0] === 'log' && args.includes(`--grep=(#[0-9]`)) {
+        return Buffer.from(`${SQUASH_SHA} fix(cli): ref-allowlist detector — drop --merges to support squash PRs (#331)\n`);
+      }
+      return Buffer.from('');
+    });
+
+    checkRefAllowlistViolation('task-squash', 'sonnet-implementer', PRE_SHA);
+
+    // No violation — squash-merged PR is a legitimate master move
     expect(mockEmitSignals).not.toHaveBeenCalled();
     expect(mockAppendFileSync).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

The ref-allowlist detector at `apps/cli/src/handlers/ref-allowlist-detection.ts:45` was generating false-positive `process_discipline` signals on every legitimate squash-merged PR. Root cause: `git log --merges` filters to commits with 2+ parents, but `gh pr merge --squash` (the project's standard merge mode) creates single-parent squash commits. Result: 3 false-positive entries in `.gossip/process-violations.jsonl` from PRs #324/#325, #329, #330/#331.

## Empirical reproduction

```
$ git log 5318c87..6a3d92e --merges --grep="(#[0-9]" --format="%H %s"
(empty)                          # ← detector saw no PR-merge → false-positive

$ git log 5318c87..6a3d92e --grep="(#[0-9]" --format="%H %s"
6a3d92e ... (#331)               # ← squash commits ARE present
1ffead2 ... (#330)
```

## Fix

Drop `--merges` from the `git log` invocation. The `--grep="(#[0-9]"` predicate alone is sufficient: `gh pr merge --squash`, `--merge`, and `--rebase` all prefix the commit subject with `(#NNN)`, while direct pushes typically don't include a PR ref.

## Changes

- `apps/cli/src/handlers/ref-allowlist-detection.ts` — drop `--merges` flag, expand JSDoc clarifying squash + merge commits both qualify, add `// @gossip:impact-adjacent:signal_pipeline` magic comment so future edits trip the impact-adjacency consensus gate.
- `tests/cli/ref-allowlist-detection.test.ts` — add regression test (f) for squash-merged-PR delta; update existing mock discriminators (b/c/d) from `args.includes('--merges')` to `args.includes('--grep=(#[0-9]')` since `--merges` is no longer present.

## Verification

- [x] `npx jest tests/cli/ref-allowlist-detection.test.ts` — 8/8 pass (including new test f)
- [x] CLI typecheck clean
- [x] Diff scope: 2 files only (detector + test)

## Follow-up (out of scope for this PR)

- 3 historical false-positive `process_discipline` signals against `sonnet-implementer` will be retracted by the orchestrator via `gossip_signals(action: "retract", ...)` after this PR merges. The `.gossip/process-violations.jsonl` entries are kept as a forensic audit trail.
- Phase 2 (preventive pre-push hook) remains blocked on Claude Code worktree-provisioning API.

## Triggering audit

`project_ref_allowlist_detection_validation.md` — 2026-05-06 deadline validation surfaced this bug. See `feedback_visual_verify_after_dashboard_pr.md` and `feedback_implementer_pushed_to_master.md` for adjacent process context.

🤖 Dispatched via gossipcat to sonnet-implementer in worktree (task d49cbf65). PR opened by orchestrator per scoped-write-mode contract.

Co-Authored-By: Claude Sonnet 4.6 (sonnet-implementer) <noreply@anthropic.com>