### PR TITLE
fix(orchestrator): split totalSignals from scoringSignals — fix confidence/Rule A/Rule B inflation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,4 +1,8 @@
 {
+  "enabledMcpjsonServers": [
+    "gossipcat"
+  ],
+  "enableAllProjectMcpServers": true,
   "permissions": {
     "allow": [
       "Edit",
@@ -6,15 +10,9 @@
       "Bash(git *)",
       "Bash(npm *)",
       "Bash(npx *)",
-      "Bash(node *)",
-      "mcp__gossipcat__gossip_relay",
-      "mcp__gossipcat__gossip_signals"
+      "Bash(node *)"
     ]
   },
-  "enableAllProjectMcpServers": true,
-  "enabledMcpjsonServers": [
-    "gossipcat"
-  ],
   "hooks": {
     "UserPromptSubmit": [
       {

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,4 @@
 {
-  "enabledMcpjsonServers": [
-    "gossipcat"
-  ],
-  "enableAllProjectMcpServers": true,
   "permissions": {
     "allow": [
       "Edit",
@@ -10,9 +6,15 @@
       "Bash(git *)",
       "Bash(npm *)",
       "Bash(npx *)",
-      "Bash(node *)"
+      "Bash(node *)",
+      "mcp__gossipcat__gossip_relay",
+      "mcp__gossipcat__gossip_signals"
     ]
   },
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": [
+    "gossipcat"
+  ],
   "hooks": {
     "UserPromptSubmit": [
       {

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -1,3 +1,4 @@
+// @gossip:impact-adjacent:signal_pipeline
 /**
  * PerformanceReader — reads agent-performance.jsonl and computes
  * per-agent scores from consensus signals.
@@ -32,6 +33,12 @@ export interface AgentScore {
   reliability: number;   // 0-1, combined score for dispatch weighting
   impactScore: number;   // 0-1, weighted toward agents catching CRITICAL/HIGH findings
   totalSignals: number;
+  /** Signals that contributed to scoring accumulators (weightedTotal/weightedCorrect/
+   *  weightedHallucinations/weightedUnique). Excludes transport_failure, task_timeout,
+   *  task_empty, boundary_escape, and uncategorized disagreements. Used by confidence
+   *  formula, Rule A bench gate, and Rule B hallRate denominator so operational noise
+   *  cannot inflate confidence or suppress the hallucination rate threshold. */
+  scoringSignals: number;
   agreements: number;
   disagreements: number;
   uniqueFindings: number;
@@ -259,10 +266,12 @@ export class PerformanceReader {
   /** Get a reliability multiplier for dispatch weighting (0.3 to 2.0) */
   getDispatchWeight(agentId: string): number {
     const score = this.getAgentScore(agentId);
-    if (!score || score.totalSignals < 3) return 1.0; // not enough data, neutral
+    if (!score || score.scoringSignals < 3) return 1.0; // not enough data, neutral
     if (score.circuitOpen) return 0.3;
-    // Confidence increases with signal volume: 3 → ~0.26, 10 → ~0.63, 30 → ~0.95
-    const confidence = 1 - Math.exp(-score.totalSignals / 10);
+    // Confidence increases with scoring-signal volume (excludes transport_failure/
+    // task_timeout/boundary_escape so operational noise cannot inflate confidence):
+    // 3 → ~0.26, 10 → ~0.63, 30 → ~0.95
+    const confidence = 1 - Math.exp(-score.scoringSignals / 10);
     // Blend reliability toward neutral (0.5) based on confidence
     const consensusAdjusted = 0.5 + (score.reliability - 0.5) * confidence;
     return clamp(0.3 + consensusAdjusted * 1.7, 0.3, 2.0);
@@ -356,11 +365,16 @@ export class PerformanceReader {
     const score = this.getAgentScore(agentId);
     if (!score) return { benched: false };
 
-    // Rule A: chronic low accuracy (needs enough evidence to be statistically meaningful)
-    const ruleA = score.accuracy < 0.30 && score.totalSignals >= 200;
-    // Rule B: burst hallucinations (absolute floor + rate gate)
-    const hallRate = score.totalSignals > 0
-      ? score.weightedHallucinations / score.totalSignals
+    // Rule A: chronic low accuracy (needs enough scoring evidence to be statistically meaningful).
+    // Uses scoringSignals so operational noise (transport_failure, task_timeout, boundary_escape)
+    // cannot trip the 200-gate before real evidence justifies benching.
+    const ruleA = score.accuracy < 0.30 && score.scoringSignals >= 200;
+    // Rule B: burst hallucinations (absolute floor + rate gate).
+    // Denominator is scoringSignals so transport_failure rows cannot dilute the
+    // hallucination rate below the 0.40 threshold (e.g. 5 halluc + 8 transport →
+    // hallRate = 5/5 = 1.0, not 5/13 = 0.38).
+    const hallRate = score.scoringSignals > 0
+      ? score.weightedHallucinations / score.scoringSignals
       : 0;
     const ruleB = score.weightedHallucinations >= 5 && hallRate > 0.4;
 
@@ -628,6 +642,7 @@ export class PerformanceReader {
       unverifiedsEmitted: number;
       unverifiedsReceived: number;
       totalSignals: number;
+      scoringSignals: number;
       lastSignalMs: number;
       categoryStrengths: Record<string, number>;
       categoryCorrect: Record<string, number>;
@@ -643,7 +658,7 @@ export class PerformanceReader {
         tasksSeen: new Map(), taskCounter: 0,
         agreements: 0, disagreements: 0, uniqueFindings: 0, hallucinations: 0,
         unverifiedsEmitted: 0, unverifiedsReceived: 0,
-        totalSignals: 0, lastSignalMs: 0, categoryStrengths: {},
+        totalSignals: 0, scoringSignals: 0, lastSignalMs: 0, categoryStrengths: {},
         categoryCorrect: {}, categoryHallucinated: {},
         transportFailures: 0,
       });
@@ -788,6 +803,7 @@ export class PerformanceReader {
         case 'consensus_verified': {
           const diversityMul = (signal.signal === 'agreement')
             ? (peerDiversity.get(signal.agentId) ?? 1) : 1;
+          a.scoringSignals++;
           a.weightedCorrect += sevMul * decay * diversityMul;
           a.weightedTotal += sevMul * decay * diversityMul;
           a.agreements++;
@@ -809,8 +825,9 @@ export class PerformanceReader {
           // weightedTotal/disagreements. Mirrors the task_timeout/task_empty
           // no-op pattern below at :669-673.
           if (!signal.category) {
-            continue;
+            break;
           }
+          a.scoringSignals++;
           a.weightedTotal += sevMul * decay;
           a.disagreements++;
           if (signal.counterpartId && signal.counterpartId.length > 0) {
@@ -830,6 +847,7 @@ export class PerformanceReader {
           // Tracked in both directions for dashboard visibility:
           // - emitted: this agent couldn't verify a peer's finding (reviewer role)
           // - received: a peer couldn't verify THIS agent's finding (author role)
+          a.scoringSignals++;
           a.weightedTotal += decay * 0.02;
           a.unverifiedsEmitted++;
           if (signal.counterpartId && signal.counterpartId.length > 0) {
@@ -839,6 +857,7 @@ export class PerformanceReader {
           break;
         }
         case 'unique_confirmed': {
+          a.scoringSignals++;
           a.weightedCorrect += sevMul * decay;
           a.weightedTotal += sevMul * decay;
           a.weightedUnique += 0.2 * sevMul * decay;
@@ -851,11 +870,13 @@ export class PerformanceReader {
           break;
         }
         case 'unique_unconfirmed': {
+          a.scoringSignals++;
           a.weightedUnique += 0.05 * decay;
           a.uniqueFindings++;
           break;
         }
         case 'new_finding': {
+          a.scoringSignals++;
           a.weightedUnique += 0.15 * decay;
           a.uniqueFindings++;
           break;
@@ -905,6 +926,7 @@ export class PerformanceReader {
               }
             }
           }
+          a.scoringSignals++;
           a.weightedHallucinations += severity * hallucDecay * gatedMultiplier;
           a.weightedTotal += decay;
           a.hallucinations++;
@@ -1054,6 +1076,7 @@ export class PerformanceReader {
       scores.set(id, {
         agentId: id, accuracy, uniqueness, reliability, impactScore,
         totalSignals: a.totalSignals,
+        scoringSignals: a.scoringSignals,
         agreements: a.agreements,
         disagreements: a.disagreements,
         uniqueFindings: a.uniqueFindings,
@@ -1078,7 +1101,8 @@ export class PerformanceReader {
       if (!scores.has(agentId)) {
         scores.set(agentId, {
           agentId, accuracy: 0.5, uniqueness: 0.5, reliability: 0.5, impactScore: 0.5,
-          totalSignals: 0, agreements: 0, disagreements: 0, uniqueFindings: 0, hallucinations: 0,
+          totalSignals: 0, scoringSignals: 0, agreements: 0, disagreements: 0,
+          uniqueFindings: 0, hallucinations: 0,
           unverifiedsEmitted: 0, unverifiedsReceived: 0,
           weightedHallucinations: 0,
           consecutiveFailures: consec,

--- a/packages/relay/src/dashboard/api-agents.ts
+++ b/packages/relay/src/dashboard/api-agents.ts
@@ -182,7 +182,7 @@ export interface AgentResponse {
 
 const DEFAULT_SCORE: AgentScore = {
   agentId: '', accuracy: 0.5, uniqueness: 0.5, reliability: 0.5, impactScore: 0.5,
-  totalSignals: 0, agreements: 0, disagreements: 0, uniqueFindings: 0, hallucinations: 0,
+  totalSignals: 0, scoringSignals: 0, agreements: 0, disagreements: 0, uniqueFindings: 0, hallucinations: 0,
   unverifiedsEmitted: 0, unverifiedsReceived: 0,
   weightedHallucinations: 0,
   consecutiveFailures: 0, circuitOpen: false, categoryStrengths: {},

--- a/tests/orchestrator/collect-check-effectiveness.test.ts
+++ b/tests/orchestrator/collect-check-effectiveness.test.ts
@@ -38,6 +38,7 @@ function makeStubPerfReader(
     reliability: 0,
     impactScore: 0,
     totalSignals: 0,
+    scoringSignals: 0,
     agreements: 0,
     disagreements: 0,
     uniqueFindings: 0,

--- a/tests/orchestrator/dispatch-differentiator.test.ts
+++ b/tests/orchestrator/dispatch-differentiator.test.ts
@@ -6,7 +6,7 @@ function makeProfile(id: string, strengths: Record<string, number>): AgentScore 
     agentId: id,
     categoryStrengths: strengths,
     accuracy: 0.7, uniqueness: 0.5, reliability: 0.7, impactScore: 0.5,
-    totalSignals: 20, agreements: 10, disagreements: 2,
+    totalSignals: 20, scoringSignals: 20, agreements: 10, disagreements: 2,
     uniqueFindings: 3, hallucinations: 0, weightedHallucinations: 0,
     consecutiveFailures: 0, circuitOpen: false,
     categoryCorrect: {}, categoryHallucinated: {}, categoryAccuracy: {},

--- a/tests/orchestrator/is-benched.test.ts
+++ b/tests/orchestrator/is-benched.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for PerformanceReader.isBenched() — agent auto-benching v1 (GH #93).
  *
- * Rule A: accuracy < 0.30 && totalSignals >= 200 → chronic-low-accuracy
+ * Rule A: accuracy < 0.30 && scoringSignals >= 200 → chronic-low-accuracy
  * Rule B: weightedHallucinations >= 5 && rate > 0.4 → burst-hallucination
+ *         (rate denominator is scoringSignals, not totalSignals)
  * Safeguard: if candidate is sole provider of a requested category → not benched,
  *            safeguardBlocked:true.
  *
@@ -14,12 +15,13 @@
 import { PerformanceReader, AgentScore } from '../../packages/orchestrator/src/performance-reader';
 
 function makeScore(partial: Partial<AgentScore> & { agentId: string }): AgentScore {
-  return {
+  const base: AgentScore = {
     accuracy: 0.8,
     uniqueness: 0.5,
     reliability: 0.7,
     impactScore: 0.5,
     totalSignals: 10,
+    scoringSignals: 10,
     agreements: 0,
     disagreements: 0,
     uniqueFindings: 0,
@@ -34,6 +36,10 @@ function makeScore(partial: Partial<AgentScore> & { agentId: string }): AgentSco
     transport_failure_count: 0,
     ...partial,
   };
+  // Ensure scoringSignals mirrors totalSignals when not set explicitly,
+  // so legacy test assertions that set only totalSignals keep working.
+  if (!('scoringSignals' in partial)) base.scoringSignals = base.totalSignals;
+  return base;
 }
 
 /**

--- a/tests/orchestrator/performance-reader-scoring-signals.test.ts
+++ b/tests/orchestrator/performance-reader-scoring-signals.test.ts
@@ -1,0 +1,354 @@
+/**
+ * performance-reader scoringSignals split tests — consensus round 222a567b-94364123.
+ *
+ * Verifies that totalSignals++ (dashboard volume) and scoringSignals++
+ * (accuracy/bench/hallRate denominator) are tracked separately, so operational
+ * noise (transport_failure, task_timeout, task_empty, boundary_escape,
+ * uncategorized disagreement) cannot inflate confidence or suppress Rule B.
+ *
+ * Concrete failure modes this closes:
+ *   1. Confidence: 150 transport_failure + 10 agreement → confidence ≈ 1.0 (wrong)
+ *      should be ≈ 0.63 (1 - exp(-10/10))
+ *   2. Rule A: 150 real scoring + 60 noise → Rule A 200-gate fires on only 150 evidence (wrong)
+ *   3. Rule B: 5 hallucination_caught + 8 transport_failure → hallRate = 5/13 ≈ 0.38 (wrong)
+ *      should be 5/13 → actually 5/(scoring=5) but with decay... test drives via isBenched stub.
+ */
+
+import { PerformanceReader, AgentScore } from '../../packages/orchestrator/src/performance-reader';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const TEST_DIR = join(__dirname, '..', '..', '.test-perf-reader-scoring-signals');
+
+function writeSignals(signals: any[]): void {
+  mkdirSync(join(TEST_DIR, '.gossip'), { recursive: true });
+  const data = signals.map(s => JSON.stringify(s)).join('\n') + '\n';
+  writeFileSync(join(TEST_DIR, '.gossip', 'agent-performance.jsonl'), data);
+}
+
+beforeEach(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterAll(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+});
+
+const now = new Date().toISOString();
+
+function makeAgreement(taskId: string, agentId = 'agent-a'): any {
+  return {
+    type: 'consensus',
+    signal: 'agreement',
+    taskId,
+    agentId,
+    counterpartId: 'agent-b',
+    category: 'trust_boundaries',
+    severity: 'medium',
+    evidence: 'confirmed peer finding',
+    timestamp: now,
+  };
+}
+
+function makeTransportFailure(taskId: string, agentId = 'agent-a'): any {
+  return {
+    type: 'consensus',
+    signal: 'transport_failure',
+    taskId,
+    agentId,
+    consensusId: '222a567b-94364123',
+    findingId: `222a567b-94364123:${agentId}:${taskId}`,
+    evidence: 'Files are not present in the provided worktree',
+    timestamp: now,
+  };
+}
+
+function makeHallucination(taskId: string, agentId = 'agent-a'): any {
+  return {
+    type: 'consensus',
+    signal: 'hallucination_caught',
+    taskId,
+    agentId,
+    category: 'trust_boundaries',
+    evidence: 'fabricated line reference',
+    timestamp: now,
+  };
+}
+
+function makeTaskTimeout(taskId: string, agentId = 'agent-a'): any {
+  return {
+    type: 'consensus',
+    signal: 'task_timeout',
+    taskId,
+    agentId,
+    evidence: 'agent timed out',
+    timestamp: now,
+  };
+}
+
+function makeBoundaryEscape(taskId: string, agentId = 'agent-a'): any {
+  return {
+    type: 'consensus',
+    signal: 'boundary_escape',
+    taskId,
+    agentId,
+    evidence: 'wrote outside worktree',
+    timestamp: now,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scoring-signals tracking
+// ---------------------------------------------------------------------------
+
+describe('PerformanceReader — scoringSignals vs totalSignals split', () => {
+  it('totalSignals includes transport_failure; scoringSignals excludes it', () => {
+    writeSignals([
+      makeAgreement('t-1'),
+      makeAgreement('t-2'),
+      makeAgreement('t-3'),
+      makeTransportFailure('t-4'),
+      makeTransportFailure('t-5'),
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getScores().get('agent-a');
+    expect(score).toBeDefined();
+    expect(score!.totalSignals).toBe(5);
+    expect(score!.scoringSignals).toBe(3);
+  });
+
+  it('totalSignals includes task_timeout; scoringSignals excludes it', () => {
+    writeSignals([
+      makeAgreement('t-1'),
+      makeAgreement('t-2'),
+      makeTaskTimeout('t-3'),
+      makeTaskTimeout('t-4'),
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getScores().get('agent-a');
+    expect(score).toBeDefined();
+    expect(score!.totalSignals).toBe(4);
+    expect(score!.scoringSignals).toBe(2);
+  });
+
+  it('totalSignals includes boundary_escape; scoringSignals excludes it', () => {
+    writeSignals([
+      makeAgreement('t-1'),
+      makeBoundaryEscape('t-2'),
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getScores().get('agent-a');
+    expect(score).toBeDefined();
+    expect(score!.totalSignals).toBe(2);
+    expect(score!.scoringSignals).toBe(1);
+  });
+
+  it('uncategorized disagreement counts in totalSignals but not scoringSignals', () => {
+    writeSignals([
+      makeAgreement('t-1'),
+      // disagreement without category → no-op for scoring
+      {
+        type: 'consensus',
+        signal: 'disagreement',
+        taskId: 't-2',
+        agentId: 'agent-a',
+        // deliberately no category
+        evidence: 'operational disagreement',
+        timestamp: now,
+      },
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getScores().get('agent-a');
+    expect(score).toBeDefined();
+    expect(score!.totalSignals).toBe(2);
+    expect(score!.scoringSignals).toBe(1);
+  });
+
+  it('hallucination_caught counts in both totalSignals and scoringSignals', () => {
+    writeSignals([
+      makeHallucination('t-1'),
+      makeHallucination('t-2'),
+    ]);
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getScores().get('agent-a');
+    expect(score).toBeDefined();
+    expect(score!.totalSignals).toBe(2);
+    expect(score!.scoringSignals).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure mode 1 — Confidence uses scoringSignals
+// ---------------------------------------------------------------------------
+
+describe('PerformanceReader — confidence formula uses scoringSignals', () => {
+  it('10 agreement + 100 transport_failure → confidence ≈ 1 - exp(-10/10), NOT 1 - exp(-110/10)', () => {
+    const signals: any[] = [];
+    // 10 genuine scoring signals
+    for (let i = 0; i < 10; i++) signals.push(makeAgreement(`agree-${i}`));
+    // 100 operational noise — must not inflate confidence
+    for (let i = 0; i < 100; i++) signals.push(makeTransportFailure(`tf-${i}`));
+    writeSignals(signals);
+
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getScores().get('agent-a');
+    expect(score).toBeDefined();
+    expect(score!.totalSignals).toBe(110);
+    expect(score!.scoringSignals).toBe(10);
+
+    // getDispatchWeight uses scoringSignals for confidence.
+    // confidence(scoringSignals=10) = 1 - exp(-10/10) ≈ 0.632
+    // confidence(totalSignals=110)  = 1 - exp(-110/10) ≈ 1.000
+    // If confidence is derived from totalSignals the weight would be near-max.
+    // With scoringSignals=10 the weight is still elevated (all agreements) but
+    // should be significantly less than the inflated value. We verify by
+    // checking the dispatch weight lands in the correct window for 10 scoring signals.
+    const weight = reader.getDispatchWeight('agent-a');
+    // With 10 perfect agreements: reliability ≈ 1.0, confidence ≈ 0.632
+    // consensusAdjusted = 0.5 + (1.0 - 0.5) * 0.632 = 0.816
+    // weight = clamp(0.3 + 0.816 * 1.7, 0.3, 2.0) ≈ 1.687
+    // If inflated (110): confidence ≈ 1.0, weight ≈ 2.0 (max)
+    // We assert weight < 2.0 to confirm inflation didn't occur.
+    expect(weight).toBeLessThan(2.0);
+    // Also assert the weight is meaningfully above neutral (signal is real)
+    expect(weight).toBeGreaterThan(1.0);
+  });
+
+  it('returns neutral weight when scoringSignals < 3 even if totalSignals is high', () => {
+    const signals: any[] = [];
+    // 2 scoring signals (below threshold)
+    signals.push(makeAgreement('a-1'));
+    signals.push(makeAgreement('a-2'));
+    // 50 operational noise
+    for (let i = 0; i < 50; i++) signals.push(makeTransportFailure(`tf-${i}`));
+    writeSignals(signals);
+
+    const reader = new PerformanceReader(TEST_DIR);
+    const score = reader.getScores().get('agent-a');
+    expect(score!.totalSignals).toBe(52);
+    expect(score!.scoringSignals).toBe(2);
+
+    // getDispatchWeight must return neutral 1.0 when scoringSignals < 3
+    expect(reader.getDispatchWeight('agent-a')).toBe(1.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure mode 2 — Rule A uses scoringSignals
+// ---------------------------------------------------------------------------
+
+describe('PerformanceReader.isBenched — Rule A uses scoringSignals', () => {
+  function makeScoreWith(
+    agentId: string,
+    opts: { scoringSignals: number; totalSignals: number; accuracy: number },
+  ): AgentScore {
+    return {
+      agentId,
+      accuracy: opts.accuracy,
+      uniqueness: 0.5,
+      reliability: 0.5,
+      impactScore: 0.5,
+      totalSignals: opts.totalSignals,
+      scoringSignals: opts.scoringSignals,
+      agreements: 0,
+      disagreements: 0,
+      uniqueFindings: 0,
+      hallucinations: 0,
+      weightedHallucinations: 0,
+      consecutiveFailures: 0,
+      circuitOpen: false,
+      categoryStrengths: {},
+      categoryCorrect: {},
+      categoryHallucinated: {},
+      categoryAccuracy: {},
+      transport_failure_count: 0,
+    };
+  }
+
+  it('199 scoringSignals + 50 noise → NOT benched (Rule A gate needs 200 scoring evidence)', () => {
+    const reader = new PerformanceReader('/tmp/gossip-bench-scoring-unused');
+    const map = new Map<string, AgentScore>();
+    map.set('a', makeScoreWith('a', { scoringSignals: 199, totalSignals: 249, accuracy: 0.29 }));
+    (reader as any).getScores = () => map;
+
+    expect(reader.isBenched('a')).toEqual({ benched: false });
+  });
+
+  it('200 scoringSignals + 50 noise → benched (Rule A fires on scoring evidence)', () => {
+    const reader = new PerformanceReader('/tmp/gossip-bench-scoring-unused');
+    const map = new Map<string, AgentScore>();
+    map.set('a', makeScoreWith('a', { scoringSignals: 200, totalSignals: 250, accuracy: 0.29 }));
+    (reader as any).getScores = () => map;
+
+    expect(reader.isBenched('a')).toEqual({ benched: true, reason: 'chronic-low-accuracy' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure mode 3 — Rule B hallRate uses scoringSignals
+// ---------------------------------------------------------------------------
+
+describe('PerformanceReader.isBenched — Rule B hallRate uses scoringSignals', () => {
+  function makeScoreWith(
+    agentId: string,
+    opts: {
+      scoringSignals: number;
+      totalSignals: number;
+      weightedHallucinations: number;
+      accuracy?: number;
+    },
+  ): AgentScore {
+    return {
+      agentId,
+      accuracy: opts.accuracy ?? 0.8,
+      uniqueness: 0.5,
+      reliability: 0.5,
+      impactScore: 0.5,
+      totalSignals: opts.totalSignals,
+      scoringSignals: opts.scoringSignals,
+      agreements: 0,
+      disagreements: 0,
+      uniqueFindings: 0,
+      hallucinations: 5,
+      weightedHallucinations: opts.weightedHallucinations,
+      consecutiveFailures: 0,
+      circuitOpen: false,
+      categoryStrengths: {},
+      categoryCorrect: {},
+      categoryHallucinated: {},
+      categoryAccuracy: {},
+      transport_failure_count: 0,
+    };
+  }
+
+  it('5 halluc + 8 transport_failure: hallRate = 5/5 = 1.0 → Rule B opens', () => {
+    // scoringSignals=5 (5 hallucinations are scoring), totalSignals=13 (+ 8 transport)
+    // hallRate vs scoringSignals: 5/5 = 1.0 > 0.4 → BENCH
+    // hallRate vs totalSignals:   5/13 ≈ 0.38 < 0.4 → NO BENCH (wrong behavior pre-fix)
+    const reader = new PerformanceReader('/tmp/gossip-bench-ruleB-unused');
+    const map = new Map<string, AgentScore>();
+    map.set('a', makeScoreWith('a', {
+      scoringSignals: 5,
+      totalSignals: 13,
+      weightedHallucinations: 5, // exact hallucs (no decay in stub)
+    }));
+    (reader as any).getScores = () => map;
+
+    expect(reader.isBenched('a')).toEqual({ benched: true, reason: 'burst-hallucination' });
+  });
+
+  it('5 halluc + 8 real agreements: hallRate = 5/13 ≈ 0.38 → Rule B stays closed', () => {
+    // When noise is real scoring signals, Rule B should NOT fire (< 0.4)
+    const reader = new PerformanceReader('/tmp/gossip-bench-ruleB-unused');
+    const map = new Map<string, AgentScore>();
+    map.set('a', makeScoreWith('a', {
+      scoringSignals: 13,
+      totalSignals: 13,
+      weightedHallucinations: 5,
+    }));
+    (reader as any).getScores = () => map;
+
+    expect(reader.isBenched('a')).toEqual({ benched: false });
+  });
+});

--- a/tests/orchestrator/skill-engine-baseline-snapshot.test.ts
+++ b/tests/orchestrator/skill-engine-baseline-snapshot.test.ts
@@ -83,6 +83,7 @@ function makeStubPerfReader(
           reliability: 0,
           impactScore: 0,
           totalSignals: 0,
+          scoringSignals: 0,
           agreements: 0,
           disagreements: 0,
           uniqueFindings: 0,

--- a/tests/orchestrator/skill-engine-check-effectiveness.test.ts
+++ b/tests/orchestrator/skill-engine-check-effectiveness.test.ts
@@ -30,6 +30,7 @@ function makeStubPerfReader(
     reliability: 0,
     impactScore: 0,
     totalSignals: 0,
+    scoringSignals: 0,
     agreements: 0,
     disagreements: 0,
     uniqueFindings: 0,


### PR DESCRIPTION
## Summary

`a.totalSignals++` at `performance-reader.ts:773` was incrementing for every known non-retracted signal, including operational arms that contributed nothing to scoring (`task_timeout`, `task_empty`, `transport_failure`, `boundary_escape`, uncategorized `disagreement`). Three downstream scoring consumers used this inflated counter:

1. **Confidence formula at `:265`** — `1 - exp(-totalSignals/10)` overstated confidence on operational noise
2. **Rule A bench gate at `:360`** — `totalSignals >= 200` tripped earlier than the evidence base justified
3. **Rule B hallRate at `:362-363`** — `weightedHallucinations / totalSignals` diluted the rate below the 0.40 circuit-breaker threshold when transport noise dominated

## Concrete failure modes (from consensus)

- **Confidence inflation:** 150 transport_failure + 10 agreement → confidence ≈ 1.0 (should be ≈ 0.63)
- **Premature Rule A bench:** 150 real + 60 operational → 200-gate trips on only 150 actual evidence
- **Rule B masking:** 5 hallucination_caught + 8 transport_failure → hallRate = 5/13 ≈ 0.38, **below the 0.40 threshold, circuit breaker stays closed despite real hallucination spike**

## Fix

Introduces a separate `scoringSignals` counter incremented only inside switch arms that write to scoring accumulators (`agreement`, `category_confirmed`, `consensus_verified`, categorized `disagreement`, `unverified_*`, `unique_confirmed`, `unique_unconfirmed`, `hallucination_caught`). Operational arms (`task_timeout`, `task_empty`, `transport_failure`, `boundary_escape`) and the uncategorized-`disagreement` no-op are excluded.

`totalSignals` is preserved unchanged for dashboard volume display + the auto-signal pipeline; only the four scoring consumer sites swap to `scoringSignals`:
- `:265` confidence formula
- `:262` min-data guard (`< 3` signals)
- `:360` Rule A 200-gate
- `:362-363` Rule B hallRate denominator

## Bonus cosmetic fix

The uncategorized-`disagreement` no-op at `:819` used `continue` while peer no-op arms (`task_timeout`, `boundary_escape`) used `break`. No observable difference today, latent trap if post-switch loop logic is ever added. Aligned to `break`.

## Changes

- `packages/orchestrator/src/performance-reader.ts` — add `scoringSignals` to `AgentScore` + `AgentInternal`, increment in 6 scoring arms, swap 4 consumer sites, `continue → break`, add `// @gossip:impact-adjacent:signal_pipeline` magic comment
- `tests/orchestrator/performance-reader-scoring-signals.test.ts` — 11 new tests covering confidence isolation, Rule A gate, Rule B hallRate, and `totalSignals` preservation
- `tests/orchestrator/is-benched.test.ts` — `makeScore` helper updated with `scoringSignals` mirror

## Verification

- [x] 111 orchestrator tests pass (+11 new)
- [x] Orchestrator typecheck clean
- [x] Diff scope: 57 LOC + 370 test LOC

## Triggering audit

Pre-merge consensus round `222a567b-94364123` (sonnet-reviewer + gemini-reviewer, 3/3 confirmed). Pulled forward from disabled trigger `trig_018d7FvQc8vuEdUkD22Yncby` Check 1 (originally scheduled for 2026-05-07).

🤖 Dispatched via gossipcat to sonnet-implementer in worktree (task 24d0a040). PR opened by orchestrator per scoped-write-mode contract.

Co-Authored-By: Claude Sonnet 4.6 (sonnet-implementer) <noreply@anthropic.com>