### PR TITLE
feat(dashboard): /overview calm landing route + ?expert=1 toggle

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useRoute } from '@/lib/router';
+import { useExpert } from '@/lib/useExpert';
+import { OverviewPage } from '@/pages/OverviewPage';
 import { AuthGate } from '@/components/AuthGate';
 import { TopBar } from '@/components/TopBar';
 import { SystemPulse } from '@/components/SystemPulse';
@@ -462,6 +464,7 @@ function FindingsPage({
 
 function Dashboard() {
   const route = useRoute();
+  const expert = useExpert();
   const { overview, agents, tasks, consensus, consensusReports, nativeMemories, gossipMemories, loading, refresh } = useDashboardData();
   const [activeTaskCount, setActiveTaskCount] = useState(0);
 
@@ -498,6 +501,16 @@ function Dashboard() {
     content = <SignalsPage />;
   } else if (route === '/violations') {
     content = <ViolationsPage />;
+  } else if ((route === '/' && !expert) || route === '/overview') {
+    content = (
+      <OverviewPage
+        overview={overview}
+        agents={agents}
+        tasks={tasks}
+        activeTaskCount={activeTaskCount}
+        setActiveTaskCount={setActiveTaskCount}
+      />
+    );
   } else {
     // Main dashboard — sidebar + main layout
     content = (
@@ -541,10 +554,17 @@ function Dashboard() {
     );
   }
 
+  // Overview owns its own outer container (max-w-5xl). For everything else,
+  // the historical max-w-7xl + space-y-6 wrapper applies.
+  const isOverview = (route === '/' && !expert) || route === '/overview';
+  const mainClass = isOverview
+    ? 'px-6 py-6'
+    : 'mx-auto max-w-7xl space-y-6 px-6 py-6';
+
   return (
     <div className="min-h-screen bg-background">
       <TopBar />
-      <main className="mx-auto max-w-7xl space-y-6 px-6 py-6">
+      <main className={mainClass}>
         {content}
       </main>
     </div>

--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -1,10 +1,24 @@
 import type { OverviewData } from '@/lib/types';
 import { timeAgo } from '@/lib/utils';
 import { href } from '@/lib/router';
+import { EmptyState } from './EmptyState';
 
 interface SystemPulseProps {
   overview: OverviewData;
   activeTasks: number;
+  /**
+   * 'dense' (default) — full operator strip with 3-row agent block,
+   * secondary-stats list, Actionable BigStat, and ActivityBars.
+   * 'calm' — Overview/landing variant: only 3 BigStats
+   * (Agents online / Active tasks / Confirmed %).
+   */
+  mode?: 'dense' | 'calm';
+  /**
+   * Whether to show the ActivityBars row. Defaults to `true` (matching
+   * historical behavior). On `mode='calm'` the OverviewPage passes `false`
+   * to keep the strip hero-proportioned (~80px shorter).
+   */
+  showActivity?: boolean;
 }
 
 function formatDuration(ms: number | null | undefined): string {
@@ -43,7 +57,7 @@ function BigStat({ value, unit, label, valueClass, pulse, tooltip }: BigStatProp
   );
 }
 
-export function SystemPulse({ overview, activeTasks }: SystemPulseProps) {
+export function SystemPulse({ overview, activeTasks, mode = 'dense', showActivity }: SystemPulseProps) {
   const totalAgents = overview.relayCount + overview.nativeCount;
   const successRate = overview.tasksCompleted + overview.tasksFailed > 0
     ? Math.round((overview.tasksCompleted / (overview.tasksCompleted + overview.tasksFailed)) * 100)
@@ -51,6 +65,14 @@ export function SystemPulse({ overview, activeTasks }: SystemPulseProps) {
   const confirmRate = overview.totalFindings > 0
     ? Math.round((overview.confirmedFindings / overview.totalFindings) * 100)
     : 0;
+
+  const isCalm = mode === 'calm';
+  // ActivityBars default: visible in dense, hidden in calm. Prop overrides.
+  const activityVisible = showActivity ?? !isCalm;
+
+  // Day-1 onboarding empty state: only meaningful in calm mode when the fleet
+  // is unregistered. Avoids three "0" stats reading as a broken dashboard.
+  const day1Empty = isCalm && totalAgents === 0;
 
   return (
     <div className="rounded-lg border border-border bg-card">
@@ -65,87 +87,120 @@ export function SystemPulse({ overview, activeTasks }: SystemPulseProps) {
         </div>
       </div>
 
-      {/* Primary 2x2 grid with cross dividers, then full-width actionable row below */}
-      <div className="border-b border-border">
-        <div className="relative grid grid-cols-2">
-          <span className="pointer-events-none absolute left-0 right-0 top-1/2 h-px bg-border" />
-          <span className="pointer-events-none absolute bottom-0 left-1/2 top-0 w-px bg-border" />
-          {/* Three-row agent stat (stacked to fit narrow cell) */}
-          <div className="flex flex-col items-stretch justify-center gap-1.5 px-4 py-3">
-            <div className="flex items-baseline justify-between gap-2">
-              <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Agents currently executing a task">Dispatched</span>
-              <span className={`font-mono text-base font-bold leading-none ${overview.agentsOnline > 0 ? 'text-primary' : 'text-foreground'}`}>{overview.agentsOnline}</span>
-            </div>
-            <div className="flex items-baseline justify-between gap-2">
-              <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Relay agents with an active WebSocket connection">Connected</span>
-              <span className={`font-mono text-base font-bold leading-none ${overview.relayConnected > 0 ? 'text-confirmed' : 'text-muted-foreground'}`}>{overview.relayConnected}</span>
-            </div>
-            <div className="flex items-baseline justify-between gap-2">
-              <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Total agents in gossipcat config">Registered</span>
-              <span className="font-mono text-base font-bold leading-none text-muted-foreground">{totalAgents}</span>
-            </div>
+      {day1Empty ? (
+        <EmptyState
+          title="No agents registered yet"
+          hint="Run `gossip_setup` or see docs/ to get started."
+        />
+      ) : isCalm ? (
+        // Calm: 3 BigStats — Agents online / Active tasks / Confirmed %.
+        <div className="grid grid-cols-3 border-b border-border">
+          <div className="border-r border-border">
+            <BigStat
+              value={overview.agentsOnline}
+              label="Agents Online"
+              valueClass={overview.agentsOnline > 0 ? 'text-primary' : 'text-foreground'}
+            />
           </div>
-          <BigStat
-            value={activeTasks}
-            label="Active Tasks"
-            valueClass={activeTasks > 0 ? 'text-unverified' : 'text-muted-foreground'}
-            pulse={activeTasks > 0}
-          />
-          <BigStat
-            value={overview.consensusRuns}
-            label="Consensus"
-            valueClass="text-foreground"
-          />
+          <div className="border-r border-border">
+            <BigStat
+              value={activeTasks}
+              label="Active Tasks"
+              valueClass={activeTasks > 0 ? 'text-unverified' : 'text-muted-foreground'}
+              pulse={activeTasks > 0}
+            />
+          </div>
           <BigStat
             value={`${confirmRate}%`}
             label="Confirmed"
             valueClass="text-confirmed"
           />
         </div>
-        <a
-          href={href('/signals?signal=disagreement&signal=hallucination_caught&signal=new_finding')}
-          className="block cursor-pointer border-t border-border transition-colors hover:bg-accent/30"
-          aria-label="View actionable findings on Signals page"
-        >
-          <BigStat
-            value={overview.actionableFindings}
-            label="Actionable"
-            valueClass={overview.actionableFindings > 0 ? 'text-orange-400' : 'text-confirmed'}
-            tooltip="Findings still open and need operator review (disagreements + hallucinations + new findings)"
-          />
-        </a>
-      </div>
-
-      {/* Secondary stats */}
-      <div className="px-3.5 py-3">
-        <div className="flex items-center justify-between py-1 font-mono text-[11px]">
-          <span className="text-muted-foreground">tasks completed</span>
-          <span className="font-semibold text-foreground tabular-nums">{overview.tasksCompleted}</span>
-        </div>
-        <div className="flex items-center justify-between py-1 font-mono text-[11px]">
-          <span className="text-muted-foreground">signals total</span>
-          <span className="font-semibold text-foreground tabular-nums">{overview.totalSignals}</span>
-        </div>
-        {overview.tasksFailed > 0 && (
-          <div className="flex items-center justify-between py-1 font-mono text-[11px]">
-            <span className="text-muted-foreground">tasks failed</span>
-            <span className="font-semibold text-destructive tabular-nums">{overview.tasksFailed}</span>
+      ) : (
+        // Dense: original 2x2 grid with 3-row agent block + Actionable row.
+        <div className="border-b border-border">
+          <div className="relative grid grid-cols-2">
+            <span className="pointer-events-none absolute left-0 right-0 top-1/2 h-px bg-border" />
+            <span className="pointer-events-none absolute bottom-0 left-1/2 top-0 w-px bg-border" />
+            {/* Three-row agent stat (stacked to fit narrow cell) */}
+            <div className="flex flex-col items-stretch justify-center gap-1.5 px-4 py-3">
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Agents currently executing a task">Dispatched</span>
+                <span className={`font-mono text-base font-bold leading-none ${overview.agentsOnline > 0 ? 'text-primary' : 'text-foreground'}`}>{overview.agentsOnline}</span>
+              </div>
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Relay agents with an active WebSocket connection">Connected</span>
+                <span className={`font-mono text-base font-bold leading-none ${overview.relayConnected > 0 ? 'text-confirmed' : 'text-muted-foreground'}`}>{overview.relayConnected}</span>
+              </div>
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground" data-tooltip="Total agents in gossipcat config">Registered</span>
+                <span className="font-mono text-base font-bold leading-none text-muted-foreground">{totalAgents}</span>
+              </div>
+            </div>
+            <BigStat
+              value={activeTasks}
+              label="Active Tasks"
+              valueClass={activeTasks > 0 ? 'text-unverified' : 'text-muted-foreground'}
+              pulse={activeTasks > 0}
+            />
+            <BigStat
+              value={overview.consensusRuns}
+              label="Consensus"
+              valueClass="text-foreground"
+            />
+            <BigStat
+              value={`${confirmRate}%`}
+              label="Confirmed"
+              valueClass="text-confirmed"
+            />
           </div>
-        )}
-        <div className="flex items-center justify-between py-1 font-mono text-[11px]">
-          <span className="text-muted-foreground">avg duration</span>
-          <span className="font-semibold text-foreground tabular-nums">{formatDuration(overview.avgDurationMs)}</span>
+          <a
+            href={href('/signals?signal=disagreement&signal=hallucination_caught&signal=new_finding')}
+            className="block cursor-pointer border-t border-border transition-colors hover:bg-accent/30"
+            aria-label="View actionable findings on Signals page"
+          >
+            <BigStat
+              value={overview.actionableFindings}
+              label="Actionable"
+              valueClass={overview.actionableFindings > 0 ? 'text-orange-400' : 'text-confirmed'}
+              tooltip="Findings still open and need operator review (disagreements + hallucinations + new findings)"
+            />
+          </a>
         </div>
-        <div className="flex items-center justify-between py-1 font-mono text-[11px]">
-          <span className="text-muted-foreground">success rate</span>
-          <span className={`font-semibold tabular-nums ${successRate === null ? 'text-muted-foreground' : successRate >= 95 ? 'text-confirmed' : successRate >= 80 ? 'text-unverified' : 'text-destructive'}`}>
-            {successRate === null ? '—' : `${successRate}%`}
-          </span>
-        </div>
-      </div>
+      )}
 
-      {/* Activity last 12h */}
-      <ActivityBars hourly={overview.hourlyActivity || []} />
+      {/* Secondary stats — dense only */}
+      {!isCalm && (
+        <div className="px-3.5 py-3">
+          <div className="flex items-center justify-between py-1 font-mono text-[11px]">
+            <span className="text-muted-foreground">tasks completed</span>
+            <span className="font-semibold text-foreground tabular-nums">{overview.tasksCompleted}</span>
+          </div>
+          <div className="flex items-center justify-between py-1 font-mono text-[11px]">
+            <span className="text-muted-foreground">signals total</span>
+            <span className="font-semibold text-foreground tabular-nums">{overview.totalSignals}</span>
+          </div>
+          {overview.tasksFailed > 0 && (
+            <div className="flex items-center justify-between py-1 font-mono text-[11px]">
+              <span className="text-muted-foreground">tasks failed</span>
+              <span className="font-semibold text-destructive tabular-nums">{overview.tasksFailed}</span>
+            </div>
+          )}
+          <div className="flex items-center justify-between py-1 font-mono text-[11px]">
+            <span className="text-muted-foreground">avg duration</span>
+            <span className="font-semibold text-foreground tabular-nums">{formatDuration(overview.avgDurationMs)}</span>
+          </div>
+          <div className="flex items-center justify-between py-1 font-mono text-[11px]">
+            <span className="text-muted-foreground">success rate</span>
+            <span className={`font-semibold tabular-nums ${successRate === null ? 'text-muted-foreground' : successRate >= 95 ? 'text-confirmed' : successRate >= 80 ? 'text-unverified' : 'text-destructive'}`}>
+              {successRate === null ? '—' : `${successRate}%`}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Activity last 12h — gated by activityVisible (default: dense=true, calm=false) */}
+      {activityVisible && <ActivityBars hourly={overview.hourlyActivity || []} />}
 
       {/* Last consensus footer */}
       {overview.lastConsensusTimestamp && (

--- a/packages/dashboard-v2/src/components/TopBar.tsx
+++ b/packages/dashboard-v2/src/components/TopBar.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
 import { getWsState } from '@/lib/ws';
-import { href, useRoute } from '@/lib/router';
+import { href, navigate, useRoute } from '@/lib/router';
+import { useExpert } from '@/lib/useExpert';
 import { GlossaryModal } from './GlossaryModal';
 
 const TABS = [
-  { to: '/', label: 'Dashboard', match: (r: string) => r === '/' },
+  { to: '/', label: 'Dashboard', match: (r: string) => r === '/' || r === '/overview' },
   { to: '/team', label: 'Team', match: (r: string) => r === '/team' || r.startsWith('/agent/') },
   { to: '/debates', label: 'Consensus Rounds', match: (r: string) => r === '/debates' },
   { to: '/tasks', label: 'Tasks', match: (r: string) => r === '/tasks' },
@@ -16,6 +17,7 @@ export function TopBar() {
   const [online, setOnline] = useState(false);
   const [glossaryOpen, setGlossaryOpen] = useState(false);
   const route = useRoute();
+  const expert = useExpert();
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -51,6 +53,17 @@ export function TopBar() {
         </div>
       </div>
       <div className="flex items-center gap-2">
+        <button
+          onClick={() => navigate(expert ? '/' : '/?expert=1')}
+          aria-label={expert ? 'Return to overview' : 'Switch to expert view'}
+          className={`font-mono text-[10px] uppercase tracking-widest border border-border/40 rounded-sm px-2.5 py-1 transition ${
+            expert
+              ? 'text-foreground hover:text-foreground'
+              : 'text-muted-foreground/50 hover:text-muted-foreground'
+          }`}
+        >
+          {expert ? '← Overview' : 'Expert view →'}
+        </button>
         <button
           onClick={() => setGlossaryOpen(true)}
           aria-label="Open glossary"

--- a/packages/dashboard-v2/src/lib/useExpert.ts
+++ b/packages/dashboard-v2/src/lib/useExpert.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+// Local declaration of the tiny `window` surface this module touches. The
+// dashboard-v2 package's own tsconfig pulls in lib.dom; this guard keeps the
+// file compilable when ts-jest (root tsconfig, lib.dom NOT included) loads it.
+declare const window: {
+  location: { search: string };
+  addEventListener: (event: string, fn: () => void) => void;
+  removeEventListener: (event: string, fn: () => void) => void;
+} | undefined;
+
+/**
+ * Internal helper — pure URL parse. Exposed for testing without a DOM.
+ */
+export function expertFromSearch(search: string): boolean {
+  return new URLSearchParams(search).get('expert') === '1';
+}
+
+export function readExpert(): boolean {
+  if (typeof window === 'undefined') return false;
+  return expertFromSearch(window.location.search);
+}
+
+/**
+ * Reads the `?expert=1` query param and re-renders on `dashboard:navigate`.
+ *
+ * Important: subscribes to `dashboard:navigate` ONLY, not `popstate`. The
+ * router's module-level handler at `router.ts:42-44` already converts every
+ * `popstate` into a `dashboard:navigate` event — adding a `popstate` listener
+ * here would fire `update()` twice per back/forward navigation. (The existing
+ * `useRoute` hook has a separate, pre-existing double-fire bug that is being
+ * tracked as a follow-up cleanup.)
+ */
+export function useExpert(): boolean {
+  const [expert, setExpert] = useState(readExpert);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const w = window;
+    const update = () => setExpert(readExpert());
+    w.addEventListener('dashboard:navigate', update);
+    return () => w.removeEventListener('dashboard:navigate', update);
+  }, []);
+  return expert;
+}

--- a/packages/dashboard-v2/src/pages/OverviewPage.tsx
+++ b/packages/dashboard-v2/src/pages/OverviewPage.tsx
@@ -1,0 +1,77 @@
+import { SystemPulse } from '@/components/SystemPulse';
+import { ActiveTasksBanner } from '@/components/ActiveTasksBanner';
+import { TeamHero } from '@/components/TeamHero';
+import { TasksSection } from '@/components/TasksSection';
+import { RecentSignalsPeek } from '@/components/RecentSignalsPeek';
+import { href } from '@/lib/router';
+import type { OverviewData, AgentData, TasksData } from '@/lib/types';
+
+interface OverviewPageProps {
+  overview: OverviewData;
+  agents: AgentData[] | null;
+  tasks: TasksData | null;
+  activeTaskCount: number;
+  setActiveTaskCount: (n: number) => void;
+}
+
+/**
+ * Calm landing page (Variant A from consensus df14d789-6b714276) at /overview
+ * and at / when ?expert=1 is not set. Composes 6 widgets in a narrow readable
+ * column. The dense /Dashboard view is reachable via ?expert=1 and is
+ * byte-identical to the historical layout — that's the iron law.
+ *
+ * Spec: docs/specs/2026-05-04-overview-route-design.md (gitignored — refer by path).
+ */
+export function OverviewPage({
+  overview,
+  agents,
+  tasks,
+  activeTaskCount,
+  setActiveTaskCount,
+}: OverviewPageProps) {
+  const actionable = overview.actionableFindings;
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-8">
+      {/* Page header */}
+      <header>
+        <div className="flex items-baseline justify-between gap-4">
+          <h1 className="font-mono text-2xl font-bold tracking-tight text-foreground">
+            Overview
+          </h1>
+          {actionable > 0 && (
+            <a
+              href={href('/signals?signal=disagreement&signal=hallucination_caught&signal=new_finding')}
+              className="font-mono text-[11px] text-orange-400 transition hover:underline"
+              data-tooltip="Findings open for operator review"
+            >
+              {actionable} actionable →
+            </a>
+          )}
+        </div>
+        <p className="mt-1 font-mono text-[13px] text-muted-foreground">
+          What your agents are doing right now.
+        </p>
+      </header>
+
+      {/* Hero strip — calm SystemPulse */}
+      <SystemPulse
+        overview={overview}
+        activeTasks={activeTaskCount}
+        mode="calm"
+      />
+
+      {/* Live tasks (self-hides when nothing is running) */}
+      <ActiveTasksBanner onCountChange={setActiveTaskCount} />
+
+      {/* Top-4 agents */}
+      {agents && <TeamHero agents={agents} />}
+
+      {/* Recent dispatches — limit 3 (vs dense view's 5) */}
+      {tasks && <TasksSection tasks={tasks} limit={3} />}
+
+      {/* Last 5 signals */}
+      <RecentSignalsPeek />
+    </div>
+  );
+}

--- a/tests/dashboard/useExpert.test.ts
+++ b/tests/dashboard/useExpert.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Spec: docs/specs/2026-05-04-overview-route-design.md (gitignored — refer by path).
+ *
+ * Covers the pure-logic side of `useExpert`:
+ *   - expertFromSearch returns false when the `expert` query param is absent
+ *   - expertFromSearch returns true only when expert=1 (strict equality)
+ *   - readExpert is null-safe when window is undefined (SSR / node)
+ *
+ * The React-hook side (subscribing to `dashboard:navigate` and re-rendering)
+ * needs jsdom + @testing-library/react which are not yet wired up for
+ * dashboard-v2. That harness arrives in a follow-up PR; for now the static
+ * URL-parse logic — the part most likely to silently regress — is covered.
+ */
+
+import { expertFromSearch, readExpert } from '../../packages/dashboard-v2/src/lib/useExpert';
+
+describe('expertFromSearch', () => {
+  it('returns false when the search string is empty', () => {
+    expect(expertFromSearch('')).toBe(false);
+  });
+
+  it('returns false when expert is absent', () => {
+    expect(expertFromSearch('?foo=bar')).toBe(false);
+  });
+
+  it('returns true when expert=1', () => {
+    expect(expertFromSearch('?expert=1')).toBe(true);
+  });
+
+  it('returns true when expert=1 alongside other params', () => {
+    expect(expertFromSearch('?foo=bar&expert=1&baz=qux')).toBe(true);
+  });
+
+  it('returns false for non-1 values (strict equality with "1")', () => {
+    expect(expertFromSearch('?expert=0')).toBe(false);
+    expect(expertFromSearch('?expert=true')).toBe(false);
+    expect(expertFromSearch('?expert=')).toBe(false);
+  });
+});
+
+describe('readExpert', () => {
+  it('returns false when window is undefined (SSR / node-only context)', () => {
+    // Default jest test env is node, so window is undefined here.
+    expect(readExpert()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a calm landing page at `/overview` (and `/` when `?expert=1` is not set) that lets first-time visitors and returning operators answer in 5 seconds: (a) what is gossipcat, (b) is it healthy, (c) where do I look first.

The dense `/Dashboard` view is preserved **byte-identical** via `?expert=1` — that's the iron-law constraint from the spec. A toggle button in `TopBar` swaps between the two views without a page reload (uses `navigate`, not `location.assign`).

Spec: `docs/specs/2026-05-04-overview-route-design.md` (gitignored by repo policy — refer by path). Variant A from consensus `df14d789-6b714276`.

## File diff (5 files, ~154 production LOC, 2 new)

| File | Change |
|---|---|
| `packages/dashboard-v2/src/lib/useExpert.ts` (NEW) | Query-param hook reading `?expert=1`. Subscribes to `dashboard:navigate` ONLY — the router's module-level handler at `router.ts:42-44` already converts every `popstate` into a `dashboard:navigate` event, so adding a `popstate` listener would double-fire. |
| `packages/dashboard-v2/src/pages/OverviewPage.tsx` (NEW) | Composes `SystemPulse(mode='calm')` + `ActiveTasksBanner` + `TeamHero` + `TasksSection limit={3}` + `RecentSignalsPeek` inside `max-w-5xl space-y-8`. |
| `packages/dashboard-v2/src/components/SystemPulse.tsx` | Adds `mode?: 'dense' \| 'calm'` (default `'dense'`) + `showActivity?: boolean` props. Calm mode renders 3 BigStats (Agents online / Active tasks / Confirmed %) and folds the 3-row agent block, secondary-stats list, Actionable BigStat, and ActivityBars. Day-1 onboarding `EmptyState` shown when `totalAgents === 0` in calm. |
| `packages/dashboard-v2/src/App.tsx` | Route branch `(route === '/' && !expert) \|\| route === '/overview'` → `<OverviewPage>`. Outer `<main>` className becomes route-conditional: transparent `px-6 py-6` for /overview (page owns its container); historical `mx-auto max-w-7xl space-y-6 px-6 py-6` everywhere else. |
| `packages/dashboard-v2/src/components/TopBar.tsx` | Toggle button next to Glossary with active-state class swap (`text-foreground` when expert, `text-muted-foreground/50` when calm). Dashboard tab match widened to `r === '/' \|\| r === '/overview'`. |

## Verification

- `npm run build` — clean (full workspace, all 5 packages)
- `npm run build:dashboard` — clean (vite, 78 modules)
- `tsc -b` (dashboard-v2) — clean
- `npm test` — **212 suites, 2895 passed, 29 skipped** (was 211/2889 — +1 suite, +6 tests from `useExpert.test.ts`; no regressions)

Verified base before commit: `git log -1 origin/master` → `c475c31` (PR #350 merged 2026-05-03), branched fresh from there.

## Tests added

`tests/dashboard/useExpert.test.ts` (6 tests):

- `expertFromSearch`: returns `false` for empty / missing / `?expert=0` / `?expert=true` / `?expert=`; returns `true` only for `?expert=1` (strict equality), works with multi-param URLs
- `readExpert`: SSR-safe when `window` is undefined (returns `false`)

**React-component tests (`SystemPulse.test.tsx`, `OverviewPage.test.tsx`) are deferred** — `dashboard-v2` has no jsdom + `@testing-library/react` harness today (the workspace runs jest with `testEnvironment: 'node'` and existing `tests/dashboard/*` only cover pure-logic from `src/lib/*`). Wiring up React DOM testing is a meaningful infrastructure change that belongs in a separate PR; the URL-parse logic — the part most likely to silently regress on a copy-paste — is covered here.

## Visual verification

Screenshots will be attached after running the dev server. The visual checks per spec:

- [ ] `/dashboard/?expert=1` is **byte-identical** to current `/dashboard/` on master (iron-law check)
- [ ] `/dashboard/` (calm) — hero is 3 BigStats only, no Actionable row, no ActivityBars
- [ ] Day-1 (zero data) — calm hero shows "No agents registered yet — run `gossip_setup` or see docs/" instead of three "0" stats
- [ ] Toggle button label flips: `Expert view →` on calm, `← Overview` on dense

## Out of scope

- Pre-existing `useRoute` `popstate`-double-fire bug at `packages/dashboard-v2/src/lib/router.ts:52,57` — surfaced during spec review; addressed in followup #TBD. Not a correctness bug (React `setState` is idempotent) — wasted render cycle only.
- React DOM test infrastructure for `dashboard-v2` — tracked separately.
- Capping `ActiveTasksBanner` at 1 row + "+N more" — kept as-is for v1; revisit if it dominates calm view in practice.

## Test plan

- [ ] CI green on master base `c475c31`
- [ ] Visual diff `/dashboard/?expert=1` vs current master is pixel-identical
- [ ] `/dashboard/` renders calm hero (3 BigStats), `/dashboard/?expert=1` renders historical dense layout
- [ ] Toggle preserves scroll position and triggers no full reload
- [ ] Browser back button after toggling restores prior URL state
- [ ] Dashboard tab in TopBar highlights on `/dashboard/`, `/dashboard/?expert=1`, AND `/dashboard/overview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
