### PR TITLE
fix(dashboard): drop duplicate popstate listener in useRoute

### DIFF
--- a/packages/dashboard-v2/src/lib/router.ts
+++ b/packages/dashboard-v2/src/lib/router.ts
@@ -48,13 +48,12 @@ export function useRoute(): string {
   const [route, setRoute] = useState(currentRoute());
 
   useEffect(() => {
+    // popstate is re-dispatched as 'dashboard:navigate' by the module-level
+    // handler above, so subscribing to both here would fire setRoute twice
+    // on browser back/forward.
     const sync = () => setRoute(currentRoute());
-    window.addEventListener('popstate', sync);
-
     window.addEventListener('dashboard:navigate', sync as EventListener);
-
     return () => {
-      window.removeEventListener('popstate', sync);
       window.removeEventListener('dashboard:navigate', sync as EventListener);
     };
   }, []);


### PR DESCRIPTION
## Summary
- `useRoute` was listening to both `popstate` and `dashboard:navigate`, but the module-level router handler at `router.ts:42-44` already re-dispatches every `popstate` as `dashboard:navigate`. Result: browser back/forward fired `setRoute` twice — the double render flagged in `next-session.md`.
- Drop the redundant `popstate` subscription. Now matches the correct pattern PR #351 (c79ad4b) established for `useExpert`: subscribe to `dashboard:navigate` only.

## Why
`next-session.md` carry-over from the prior session: "Fix the redundant `popstate` event listener causing double renders, surfaced in `packages/dashboard-v2/src/lib/router.ts`."

## Test plan
- [ ] `npx tsc -p packages/dashboard-v2 --noEmit` clean (verified locally)
- [ ] Manual: open `/dashboard`, navigate to a sub-route, browser-back, confirm route component mounts once (was: twice)
- [ ] No jsdom in the dashboard test harness yet (see `tests/dashboard/useExpert.test.ts:9-13`); listener-side unit test deferred until that follow-up lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)