### PR TITLE
feat(dashboard): bottom-right SSE toast stack for task/consensus events

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -1226,6 +1226,24 @@ export async function handleCollect(
   // Runner has its own internal try/catch + rate-limited logging.
   scheduleSkillRunner(ctx, ctx.mainAgent);
 
+  // Emit dashboard SSE notification for consensus completion.
+  // Runs after scheduleSkillRunner so order is: signals recorded → runner scheduled → notification fires.
+  if (consensusReport) {
+    try {
+      const { emitDashboardEvent } = await import('@gossip/relay');
+      const consensusId =
+        consensusReport.signals?.[0]?.consensusId ||
+        `${require('crypto').randomBytes(4).toString('hex')}-${require('crypto').randomBytes(4).toString('hex')}`;
+      emitDashboardEvent('consensus.completed', {
+        consensusId,
+        agentCount: consensusReport.agentCount ?? 0,
+        confirmed: (consensusReport.confirmed || []).length,
+        disputed: (consensusReport.disputed || []).length,
+        unverified: (consensusReport.unverified || []).length,
+      });
+    } catch { /* best-effort — dashboard notification never blocks consensus */ }
+  }
+
   // Session save reminder — only every 10th task completion to avoid nagging
   try {
     const taskCount = ctx.mainAgent.getSessionGossip().length;

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -602,6 +602,19 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
     : result;
   try { ctx.mainAgent.recordNativeTaskCompleted(task_id, completionResult, error || undefined, elapsed ?? undefined, taskInfo.memoryQueryCalled); } catch { /* best-effort */ }
 
+  // 0z. Emit dashboard SSE notification for non-utility task completions.
+  if (!taskInfo.utilityType && agentId !== '_utility' && !agentId.startsWith('_utility')) {
+    try {
+      const { emitDashboardEvent } = await import('@gossip/relay');
+      emitDashboardEvent('task.completed', {
+        taskId: task_id,
+        agentId,
+        durationMs: elapsed ?? null,
+        status: error ? 'failed' : 'completed',
+      });
+    } catch { /* best-effort — dashboard notification never blocks completion */ }
+  }
+
   // 0a. Auto-record impl signal for write-mode tasks (gate on error param only — string heuristics are unreliable)
   if (taskInfo.writeMode && !taskInfo.utilityType && agentId !== '_utility') {
     try {

--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -28,6 +28,7 @@ import { useWebSocket } from '@/hooks/useWebSocket';
 import { useDashboardData } from '@/hooks/useDashboardData';
 import { timeAgo } from '@/lib/utils';
 import { getBenchBadgeKind, needsAttention } from '@/lib/bench';
+import { NotificationStack } from '@/components/NotificationStack';
 import type { DashboardEvent, AgentData } from '@/lib/types';
 
 type SortKey = 'weight' | 'accuracy' | 'uniqueness' | 'impact' | 'signals' | 'agreements' | 'hallucinations' | 'lastTask';
@@ -582,5 +583,10 @@ export function App() {
     return <AuthGate onLogin={login} error={error} />;
   }
 
-  return <Dashboard />;
+  return (
+    <>
+      <Dashboard />
+      <NotificationStack />
+    </>
+  );
 }

--- a/packages/dashboard-v2/src/components/FindingDetailDrawer.tsx
+++ b/packages/dashboard-v2/src/components/FindingDetailDrawer.tsx
@@ -15,7 +15,7 @@ interface Props {
 // Matches FindingsMetrics SEVERITY_CLS — global severity palette.
 const SEVERITY_COLORS: Record<string, string> = {
   critical: 'text-red-400 bg-red-500/10',
-  high: 'text-orange-400 bg-orange-500/10',
+  high: 'text-severity-high bg-severity-high/10',
   medium: 'text-yellow-400 bg-yellow-500/10',
   low: 'text-muted-foreground bg-muted/50',
 };

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -47,14 +47,14 @@ const FILTER_CHIPS: { key: FilterType; label: string; cls: string; activeCls: st
 const SEV_FILTER_CHIPS: { key: 'all' | 'critical' | 'high' | 'medium' | 'low'; label: string; cls: string; activeCls: string }[] = [
   { key: 'all', label: 'All', cls: 'text-muted-foreground border-border/40 hover:border-border/60', activeCls: 'text-foreground bg-muted border-border' },
   { key: 'critical', label: 'Critical', cls: 'text-red-400/50 border-red-400/20 hover:border-red-400/40', activeCls: 'text-red-400 bg-red-400/10 border-red-400/40' },
-  { key: 'high', label: 'High', cls: 'text-orange-400/50 border-orange-400/20 hover:border-orange-400/40', activeCls: 'text-orange-400 bg-orange-400/10 border-orange-400/40' },
+  { key: 'high', label: 'High', cls: 'text-severity-high/50 border-severity-high/20 hover:border-severity-high/40', activeCls: 'text-severity-high bg-severity-high/10 border-severity-high/40' },
   { key: 'medium', label: 'Medium', cls: 'text-yellow-400/50 border-yellow-400/20 hover:border-yellow-400/40', activeCls: 'text-yellow-400 bg-yellow-400/10 border-yellow-400/40' },
   { key: 'low', label: 'Low', cls: 'text-muted-foreground/50 border-border/40 hover:border-border/60', activeCls: 'text-muted-foreground bg-muted/50 border-border' },
 ];
 
 const SEVERITY_CLS: Record<string, string> = {
   critical: 'text-red-400 bg-red-500/10',
-  high: 'text-orange-400 bg-orange-500/10',
+  high: 'text-severity-high bg-severity-high/10',
   medium: 'text-yellow-400 bg-yellow-500/10',
   low: 'text-muted-foreground bg-muted/50',
 };

--- a/packages/dashboard-v2/src/components/NotificationStack.tsx
+++ b/packages/dashboard-v2/src/components/NotificationStack.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useEventStream } from '@/lib/useEventStream';
 import { navigate } from '@/lib/router';
 import type { DashboardEvent } from '@/lib/useEventStream';
@@ -21,10 +21,6 @@ function ToastItem({
 }) {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const startTimer = useCallback(() => {
-    timerRef.current = setTimeout(() => onDismiss(toast.id), AUTO_DISMISS_MS);
-  }, [toast.id, onDismiss]);
-
   const clearTimer = useCallback(() => {
     if (timerRef.current) {
       clearTimeout(timerRef.current);
@@ -32,13 +28,16 @@ function ToastItem({
     }
   }, []);
 
-  // Start auto-dismiss on mount
-  const mountRef = useRef(false);
-  if (!mountRef.current) {
-    mountRef.current = true;
-    // Schedule after render (can't set timeout in render, but ref is synchronous)
-    setTimeout(() => startTimer(), 0);
-  }
+  const startTimer = useCallback(() => {
+    clearTimer();
+    timerRef.current = setTimeout(() => onDismiss(toast.id), AUTO_DISMISS_MS);
+  }, [toast.id, onDismiss, clearTimer]);
+
+  // Start auto-dismiss on mount; clear on unmount (3a)
+  useEffect(() => {
+    startTimer();
+    return clearTimer;
+  }, [startTimer, clearTimer]);
 
   const { type, payload } = toast.event;
 
@@ -46,8 +45,8 @@ function ToastItem({
     type === 'task.completed'
       ? <span className="text-muted-foreground">✓</span>
       : (payload.confirmed as number) > (payload.disputed as number)
-        ? <span className="text-green-600">◎</span>
-        : <span className="text-orange-500">◎</span>;
+        ? <span className="text-confirmed">◎</span>
+        : <span className="text-disputed">◎</span>;
 
   let body: string;
   if (type === 'task.completed') {
@@ -74,21 +73,21 @@ function ToastItem({
   return (
     <div
       className={[
-        'pointer-events-auto bg-card border rounded shadow-lg px-4 py-3 max-w-sm cursor-pointer',
+        'pointer-events-auto bg-card border rounded shadow-sm px-4 py-3 max-w-sm cursor-pointer',
         'transition-all duration-200',
+        'motion-reduce:transition-none motion-reduce:transform-none',
+        'hover:bg-muted/30 hover:border-border',
         toast.exiting
-          ? 'opacity-0 scale-95 translate-x-full'
+          ? 'opacity-0 scale-95 opacity-0 translate-y-2'
           : 'opacity-100 scale-100 translate-x-0',
       ].join(' ')}
       onClick={handleClick}
       onMouseEnter={clearTimer}
       onMouseLeave={startTimer}
-      role="status"
-      aria-live="polite"
     >
       <div className="flex items-center gap-2">
         <span className="shrink-0 text-sm font-bold">{icon}</span>
-        <span className="font-mono text-[11px] text-foreground min-w-0 truncate">{body}</span>
+        <span title={body} className="font-mono text-[11px] text-foreground min-w-0 truncate">{body}</span>
         <button
           className="ml-auto shrink-0 text-muted-foreground/50 hover:text-muted-foreground text-xs leading-none"
           onClick={(e) => { e.stopPropagation(); clearTimer(); onDismiss(toast.id); }}
@@ -129,12 +128,13 @@ export function NotificationStack() {
 
   useEventStream(onEvent);
 
-  if (toasts.length === 0) return null;
-
   return (
     <div
       className="fixed bottom-4 right-4 z-50 flex flex-col-reverse gap-2 pointer-events-none"
+      role="region"
       aria-label="Notifications"
+      aria-live="polite"
+      aria-atomic="false"
     >
       {toasts.map((toast) => (
         <ToastItem key={toast.id} toast={toast} onDismiss={dismiss} />

--- a/packages/dashboard-v2/src/components/NotificationStack.tsx
+++ b/packages/dashboard-v2/src/components/NotificationStack.tsx
@@ -1,0 +1,144 @@
+import { useState, useCallback, useRef } from 'react';
+import { useEventStream } from '@/lib/useEventStream';
+import { navigate } from '@/lib/router';
+import type { DashboardEvent } from '@/lib/useEventStream';
+
+interface Toast {
+  id: number;
+  event: DashboardEvent;
+  exiting: boolean;
+}
+
+const MAX_VISIBLE = 5;
+const AUTO_DISMISS_MS = 6000;
+
+function ToastItem({
+  toast,
+  onDismiss,
+}: {
+  toast: Toast;
+  onDismiss: (id: number) => void;
+}) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const startTimer = useCallback(() => {
+    timerRef.current = setTimeout(() => onDismiss(toast.id), AUTO_DISMISS_MS);
+  }, [toast.id, onDismiss]);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // Start auto-dismiss on mount
+  const mountRef = useRef(false);
+  if (!mountRef.current) {
+    mountRef.current = true;
+    // Schedule after render (can't set timeout in render, but ref is synchronous)
+    setTimeout(() => startTimer(), 0);
+  }
+
+  const { type, payload } = toast.event;
+
+  const icon =
+    type === 'task.completed'
+      ? <span className="text-muted-foreground">✓</span>
+      : (payload.confirmed as number) > (payload.disputed as number)
+        ? <span className="text-green-600">◎</span>
+        : <span className="text-orange-500">◎</span>;
+
+  let body: string;
+  if (type === 'task.completed') {
+    const agentId = String(payload.agentId ?? 'agent');
+    const durationMs = typeof payload.durationMs === 'number' ? payload.durationMs : null;
+    const durationSec = durationMs !== null ? `${(durationMs / 1000).toFixed(1)}s` : '—';
+    body = `${agentId} finished in ${durationSec}`;
+  } else {
+    const confirmed = Number(payload.confirmed ?? 0);
+    const disputed = Number(payload.disputed ?? 0);
+    body = `Consensus done — ${confirmed} confirmed · ${disputed} disputed`;
+  }
+
+  const handleClick = () => {
+    clearTimer();
+    if (type === 'task.completed' && payload.taskId) {
+      navigate(`/tasks`);
+    } else if (type === 'consensus.completed' && payload.consensusId) {
+      navigate(`/debates`);
+    }
+    onDismiss(toast.id);
+  };
+
+  return (
+    <div
+      className={[
+        'pointer-events-auto bg-card border rounded shadow-lg px-4 py-3 max-w-sm cursor-pointer',
+        'transition-all duration-200',
+        toast.exiting
+          ? 'opacity-0 scale-95 translate-x-full'
+          : 'opacity-100 scale-100 translate-x-0',
+      ].join(' ')}
+      onClick={handleClick}
+      onMouseEnter={clearTimer}
+      onMouseLeave={startTimer}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2">
+        <span className="shrink-0 text-sm font-bold">{icon}</span>
+        <span className="font-mono text-[11px] text-foreground min-w-0 truncate">{body}</span>
+        <button
+          className="ml-auto shrink-0 text-muted-foreground/50 hover:text-muted-foreground text-xs leading-none"
+          onClick={(e) => { e.stopPropagation(); clearTimer(); onDismiss(toast.id); }}
+          aria-label="Dismiss notification"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function NotificationStack() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const dismiss = useCallback((id: number) => {
+    // Mark as exiting to trigger exit animation, then remove
+    setToasts((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, exiting: true } : t))
+    );
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 250);
+  }, []);
+
+  const onEvent = useCallback((event: DashboardEvent) => {
+    setToasts((prev) => {
+      const newToast: Toast = { id: event.id, event, exiting: false };
+      const next = [...prev, newToast];
+      // Cap at MAX_VISIBLE — dismiss oldest if over limit
+      if (next.length > MAX_VISIBLE) {
+        const excess = next.length - MAX_VISIBLE;
+        return next.slice(excess);
+      }
+      return next;
+    });
+  }, []);
+
+  useEventStream(onEvent);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      className="fixed bottom-4 right-4 z-50 flex flex-col-reverse gap-2 pointer-events-none"
+      aria-label="Notifications"
+    >
+      {toasts.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} onDismiss={dismiss} />
+      ))}
+    </div>
+  );
+}

--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -76,7 +76,7 @@ const SIGNAL_CLS: Record<string, string> = {
 // "high" chip reads the same orange everywhere on the dashboard.
 const SEVERITY_BADGE: Record<string, string> = {
   critical: 'text-red-400 bg-red-500/10',
-  high: 'text-orange-400 bg-orange-500/10',
+  high: 'text-severity-high bg-severity-high/10',
   medium: 'text-yellow-400 bg-yellow-500/10',
   low: 'text-muted-foreground bg-muted/50',
 };

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -27,6 +27,9 @@
   --color-unverified: #fbbf24;
   --color-unique: #c084fc;
 
+  /* Severity palette */
+  --color-severity-high: #f87171;
+
   /* v3 additions */
   --color-impact: #60a5fa;
   --color-insight: #71717a;

--- a/packages/dashboard-v2/src/lib/useEventStream.ts
+++ b/packages/dashboard-v2/src/lib/useEventStream.ts
@@ -1,0 +1,59 @@
+import { useEffect } from 'react';
+
+// Minimal window surface needed — avoids importing full lib.dom in node test environments.
+declare const window: {
+  EventSource: typeof EventSource;
+  localStorage: { getItem(k: string): string | null; setItem(k: string, v: string): void };
+} | undefined;
+
+export interface DashboardEvent {
+  id: number;
+  type: 'task.completed' | 'consensus.completed';
+  payload: Record<string, unknown>;
+  ts: string;
+}
+
+const LS_KEY = 'dashboard:lastEventId';
+
+/** Read persisted last-seen event id from localStorage (default 0). */
+export function readLastEventId(): number {
+  if (typeof window === 'undefined') return 0;
+  const raw = window.localStorage.getItem(LS_KEY);
+  if (!raw) return 0;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Persist last-seen event id to localStorage. */
+export function writeLastEventId(id: number): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(LS_KEY, String(id));
+}
+
+/**
+ * Opens an SSE connection to /dashboard/api/events and calls `onEvent` for each
+ * message. Replays missed events using `?last_id=N` on connect.
+ * Cleans up (closes EventSource) on unmount.
+ */
+export function useEventStream(onEvent: (e: DashboardEvent) => void): void {
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.EventSource === 'undefined') return;
+
+    const lastId = readLastEventId();
+    const es = new window.EventSource(`/dashboard/api/events?last_id=${lastId}`);
+
+    es.onmessage = (evt: MessageEvent) => {
+      try {
+        const data: DashboardEvent = JSON.parse(evt.data);
+        onEvent(data);
+        writeLastEventId(data.id);
+      } catch {
+        /* malformed event — skip */
+      }
+    };
+
+    return () => { es.close(); };
+  // onEvent is intentionally excluded — callers should memoize it (useCallback)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/packages/dashboard-v2/src/lib/useEventStream.ts
+++ b/packages/dashboard-v2/src/lib/useEventStream.ts
@@ -30,29 +30,59 @@ export function writeLastEventId(id: number): void {
   window.localStorage.setItem(LS_KEY, String(id));
 }
 
+const BACKOFF_MIN_MS = 1_000;
+const BACKOFF_MAX_MS = 5_000;
+
 /**
  * Opens an SSE connection to /dashboard/api/events and calls `onEvent` for each
  * message. Replays missed events using `?last_id=N` on connect.
  * Cleans up (closes EventSource) on unmount.
+ *
+ * Uses manual reconnect (close + setTimeout) instead of relying on native
+ * EventSource auto-reconnect so that the persisted last_id is re-read on each
+ * reconnect attempt — native auto-reconnect snapshots the URL at construction
+ * time and would replay from the original last_id forever.
  */
 export function useEventStream(onEvent: (e: DashboardEvent) => void): void {
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.EventSource === 'undefined') return;
 
-    const lastId = readLastEventId();
-    const es = new window.EventSource(`/dashboard/api/events?last_id=${lastId}`);
+    let es: EventSource | null = null;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let backoff = BACKOFF_MIN_MS;
+    let destroyed = false;
 
-    es.onmessage = (evt: MessageEvent) => {
-      try {
-        const data: DashboardEvent = JSON.parse(evt.data);
-        onEvent(data);
-        writeLastEventId(data.id);
-      } catch {
-        /* malformed event — skip */
-      }
+    function open(): void {
+      if (destroyed) return;
+      const lastId = readLastEventId();
+      es = new window!.EventSource(`/dashboard/api/events?last_id=${lastId}`);
+
+      es.onmessage = (evt: MessageEvent) => {
+        try {
+          const data: DashboardEvent = JSON.parse(evt.data);
+          onEvent(data);
+          writeLastEventId(data.id);
+          backoff = BACKOFF_MIN_MS; // reset on successful message
+        } catch {
+          /* malformed event — skip */
+        }
+      };
+
+      es.onerror = () => {
+        if (es) { es.close(); es = null; }
+        if (destroyed) return;
+        retryTimer = setTimeout(() => { open(); }, backoff);
+        backoff = Math.min(backoff * 2, BACKOFF_MAX_MS);
+      };
+    }
+
+    open();
+
+    return () => {
+      destroyed = true;
+      if (retryTimer !== null) clearTimeout(retryTimer);
+      if (es) { es.close(); es = null; }
     };
-
-    return () => { es.close(); };
   // onEvent is intentionally excluded — callers should memoize it (useCallback)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/relay/src/dashboard/api-events.ts
+++ b/packages/relay/src/dashboard/api-events.ts
@@ -1,0 +1,79 @@
+import { IncomingMessage, ServerResponse } from 'http';
+
+export interface DashboardEventEntry {
+  id: number;
+  type: 'task.completed' | 'consensus.completed';
+  payload: Record<string, unknown>;
+  ts: string;
+}
+
+const RING_MAX = 100;
+const KEEPALIVE_MS = 25_000;
+
+let nextId = 1;
+const ring: DashboardEventEntry[] = [];
+const clients = new Set<ServerResponse>();
+
+/**
+ * Push a new event into the ring buffer and fan out to all connected SSE clients.
+ * Called from native-tasks.ts and collect.ts after their respective completions.
+ */
+export function emitDashboardEvent(
+  type: DashboardEventEntry['type'],
+  payload: Record<string, unknown>,
+): void {
+  const entry: DashboardEventEntry = {
+    id: nextId++,
+    type,
+    payload,
+    ts: new Date().toISOString(),
+  };
+  ring.push(entry);
+  if (ring.length > RING_MAX) ring.shift();
+
+  const data = `id: ${entry.id}\ndata: ${JSON.stringify(entry)}\n\n`;
+  for (const res of clients) {
+    try { res.write(data); } catch { /* client disconnected */ }
+  }
+}
+
+/**
+ * SSE endpoint handler at /dashboard/api/events.
+ * Supports ?last_id=N for catch-up replay on reconnect.
+ */
+export function handleEventsSSE(req: IncomingMessage, res: ServerResponse): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive',
+    'X-Accel-Buffering': 'no',
+  });
+
+  // Replay buffered events newer than the client's last known id
+  const url = req.url ?? '';
+  const qIdx = url.indexOf('?');
+  const search = qIdx >= 0 ? url.slice(qIdx + 1) : '';
+  const lastId = parseInt(new URLSearchParams(search).get('last_id') ?? '0', 10) || 0;
+
+  for (const entry of ring) {
+    if (entry.id > lastId) {
+      res.write(`id: ${entry.id}\ndata: ${JSON.stringify(entry)}\n\n`);
+    }
+  }
+
+  clients.add(res);
+
+  // Keepalive comment every 25s to prevent proxy / browser connection drops
+  const keepalive = setInterval(() => {
+    try { res.write(':keepalive\n\n'); } catch { clearInterval(keepalive); }
+  }, KEEPALIVE_MS);
+  // Unref so the timer doesn't prevent node from exiting in tests or clean shutdowns
+  if (typeof keepalive === 'object' && keepalive !== null && 'unref' in keepalive) {
+    (keepalive as NodeJS.Timeout).unref();
+  }
+
+  req.on('close', () => {
+    clearInterval(keepalive);
+    clients.delete(res);
+  });
+}

--- a/packages/relay/src/dashboard/api-events.ts
+++ b/packages/relay/src/dashboard/api-events.ts
@@ -9,10 +9,21 @@ export interface DashboardEventEntry {
 
 const RING_MAX = 100;
 const KEEPALIVE_MS = 25_000;
+const MAX_CLIENTS = 50;
+
+/** Consecutive failed writes before a client is evicted. */
+const BACKPRESSURE_EVICT_THRESHOLD = 2;
 
 let nextId = 1;
 const ring: DashboardEventEntry[] = [];
 const clients = new Set<ServerResponse>();
+
+/**
+ * Per-connection consecutive backpressure counter.
+ * Incremented when res.write() returns false; reset to 0 on a successful write.
+ * When the counter exceeds BACKPRESSURE_EVICT_THRESHOLD the connection is destroyed.
+ */
+const backpressure = new WeakMap<ServerResponse, number>();
 
 /**
  * Push a new event into the ring buffer and fan out to all connected SSE clients.
@@ -33,15 +44,40 @@ export function emitDashboardEvent(
 
   const data = `id: ${entry.id}\ndata: ${JSON.stringify(entry)}\n\n`;
   for (const res of clients) {
-    try { res.write(data); } catch { /* client disconnected */ }
+    try {
+      const ok = res.write(data);
+      if (ok) {
+        backpressure.set(res, 0);
+      } else {
+        const count = (backpressure.get(res) ?? 0) + 1;
+        backpressure.set(res, count);
+        if (count > BACKPRESSURE_EVICT_THRESHOLD) {
+          res.destroy();
+          clients.delete(res);
+        }
+      }
+    } catch {
+      /* client disconnected */
+      clients.delete(res);
+    }
   }
 }
 
 /**
  * SSE endpoint handler at /dashboard/api/events.
  * Supports ?last_id=N for catch-up replay on reconnect.
+ * Rejects new connections with 503 when MAX_CLIENTS is reached.
  */
 export function handleEventsSSE(req: IncomingMessage, res: ServerResponse): void {
+  if (clients.size >= MAX_CLIENTS) {
+    res.writeHead(503, {
+      'Content-Type': 'text/plain',
+      'Retry-After': '5',
+    });
+    res.end('Too many SSE clients — retry after 5s');
+    return;
+  }
+
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
@@ -61,6 +97,7 @@ export function handleEventsSSE(req: IncomingMessage, res: ServerResponse): void
     }
   }
 
+  backpressure.set(res, 0);
   clients.add(res);
 
   // Keepalive comment every 25s to prevent proxy / browser connection drops

--- a/packages/relay/src/dashboard/index.ts
+++ b/packages/relay/src/dashboard/index.ts
@@ -1,3 +1,4 @@
 export { DashboardAuth } from './auth';
 export { DashboardRouter } from './routes';
 export { DashboardWs, type DashboardEvent } from './ws';
+export { emitDashboardEvent, type DashboardEventEntry } from './api-events';

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -1,5 +1,6 @@
 import { IncomingMessage, ServerResponse } from 'http';
 import { DashboardAuth } from './auth';
+import { handleEventsSSE } from './api-events';
 import { overviewHandler } from './api-overview';
 import { fleetTrendHandler } from './api-fleet-trend';
 import { agentsHandler } from './api-agents';
@@ -376,6 +377,14 @@ export class DashboardRouter {
         } catch (err) {
           this.json(res, 400, { error: err instanceof Error ? err.message : 'Bad request' });
         }
+        return true;
+      }
+
+      // SSE event stream — /dashboard/api/events?last_id=N
+      // Auth already verified above (cookie or Bearer). Long-lived connection:
+      // handleEventsSSE takes over the response and must NOT go through json().
+      if (url === '/dashboard/api/events' && req.method === 'GET') {
+        handleEventsSSE(req, res);
         return true;
       }
 

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -6,6 +6,6 @@ export { MessageRouter } from './router';
 export { ChannelManager } from './channels';
 export { SubscriptionManager } from './subscription-manager';
 export { PresenceTracker } from './presence';
-export { DashboardAuth, DashboardRouter, DashboardWs } from './dashboard';
-export type { DashboardEvent } from './dashboard';
+export { DashboardAuth, DashboardRouter, DashboardWs, emitDashboardEvent } from './dashboard';
+export type { DashboardEvent, DashboardEventEntry } from './dashboard';
 export { recordMemoryQueryAttribution, hasMemoryQuery, MEMORY_QUERY_TOOLS, sweepExpiredAgents } from './memory-query-buffer';

--- a/tests/cli/api-events.test.ts
+++ b/tests/cli/api-events.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the dashboard SSE event ring buffer (packages/relay/src/dashboard/api-events.ts).
+ *
+ * Covers:
+ *   - emitDashboardEvent appends with a monotonic, auto-incrementing id
+ *   - ring caps at 100 events (oldest evicted on overflow)
+ *   - replay-since-id returns only events newer than a given cursor
+ */
+
+// Reset module state between tests by re-importing fresh each time.
+// jest does not auto-reset module-level singletons; we use jest.resetModules().
+let emitDashboardEvent: (type: any, payload: any) => void;
+let getBuffer: () => any[];
+
+function loadModule() {
+  jest.resetModules();
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const mod = require('../../packages/relay/src/dashboard/api-events');
+  emitDashboardEvent = mod.emitDashboardEvent;
+  // Expose the internal ring for assertions via a thin wrapper
+  getBuffer = () => (mod as any)._testGetRing?.() ?? [];
+  return mod;
+}
+
+// Patch the module to expose internal ring for testing
+beforeEach(() => {
+  jest.resetModules();
+  const mod = jest.requireActual('../../packages/relay/src/dashboard/api-events') as any;
+  emitDashboardEvent = mod.emitDashboardEvent;
+
+  // Re-load to reset ring state for each test
+  jest.isolateModules(() => {
+    const fresh = require('../../packages/relay/src/dashboard/api-events');
+    emitDashboardEvent = fresh.emitDashboardEvent;
+    getBuffer = () => (fresh as any).__TEST__ring ?? [];
+  });
+});
+
+// Simpler approach: use the module directly with isolation per test block
+describe('api-events ring buffer', () => {
+  it('appends events with monotonically increasing ids', () => {
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { emitDashboardEvent: emit } = require('../../packages/relay/src/dashboard/api-events');
+      // Access internals via the module's exported types — we test via exported functions
+      // by checking the SSE output format indirectly through a mock ServerResponse
+      // Emit 3 events and verify ids are sequential
+      emit('task.completed', { taskId: 'a' });
+      emit('task.completed', { taskId: 'b' });
+      emit('consensus.completed', { consensusId: 'c' });
+
+      // Capture what would be replayed to a new SSE client
+      const written: string[] = [];
+      const mockRes = {
+        writeHead: jest.fn(),
+        write: (data: string) => { written.push(data); return true; },
+        on: jest.fn(),
+      } as any;
+      const mockReq = {
+        url: '/dashboard/api/events?last_id=0',
+        on: jest.fn(),
+      } as any;
+
+      const { handleEventsSSE } = require('../../packages/relay/src/dashboard/api-events');
+      handleEventsSSE(mockReq, mockRes);
+
+      // Should have received 3 events
+      expect(written.length).toBe(3);
+
+      // Parse ids from SSE lines
+      const ids = written.map((chunk) => {
+        const match = chunk.match(/^id: (\d+)/);
+        return match ? parseInt(match[1], 10) : -1;
+      });
+
+      // Ids should be strictly increasing
+      expect(ids[1]).toBeGreaterThan(ids[0]);
+      expect(ids[2]).toBeGreaterThan(ids[1]);
+    });
+  });
+
+  it('caps ring at 100 events, evicting the oldest', () => {
+    jest.isolateModules(() => {
+      const { emitDashboardEvent: emit, handleEventsSSE } = require('../../packages/relay/src/dashboard/api-events');
+
+      // Emit 110 events
+      for (let i = 0; i < 110; i++) {
+        emit('task.completed', { seq: i });
+      }
+
+      // Replay from id=0 — should receive at most 100
+      const written: string[] = [];
+      const mockRes = {
+        writeHead: jest.fn(),
+        write: (data: string) => { written.push(data); return true; },
+        on: jest.fn(),
+      } as any;
+      const mockReq = {
+        url: '/dashboard/api/events?last_id=0',
+        on: jest.fn(),
+      } as any;
+
+      handleEventsSSE(mockReq, mockRes);
+      expect(written.length).toBe(100);
+    });
+  });
+
+  it('replay-since-id returns only events with id > last_id', () => {
+    jest.isolateModules(() => {
+      const { emitDashboardEvent: emit, handleEventsSSE } = require('../../packages/relay/src/dashboard/api-events');
+
+      emit('task.completed', { seq: 1 });
+      emit('task.completed', { seq: 2 });
+      emit('task.completed', { seq: 3 });
+      emit('task.completed', { seq: 4 });
+      emit('task.completed', { seq: 5 });
+
+      // Collect all ids first by replaying from 0
+      const allWritten: string[] = [];
+      const allRes = {
+        writeHead: jest.fn(),
+        write: (d: string) => { allWritten.push(d); return true; },
+        on: jest.fn(),
+      } as any;
+      handleEventsSSE({ url: '/dashboard/api/events?last_id=0', on: jest.fn() } as any, allRes);
+
+      const thirdId = parseInt(allWritten[2].match(/^id: (\d+)/)![1], 10);
+
+      // Replay since the third event's id — should only get events after it
+      const partialWritten: string[] = [];
+      const partialRes = {
+        writeHead: jest.fn(),
+        write: (d: string) => { partialWritten.push(d); return true; },
+        on: jest.fn(),
+      } as any;
+      handleEventsSSE({ url: `/dashboard/api/events?last_id=${thirdId}`, on: jest.fn() } as any, partialRes);
+
+      // Should receive 2 events (4th and 5th)
+      expect(partialWritten.length).toBe(2);
+      // All replayed ids should be > thirdId
+      for (const chunk of partialWritten) {
+        const id = parseInt(chunk.match(/^id: (\d+)/)![1], 10);
+        expect(id).toBeGreaterThan(thirdId);
+      }
+    });
+  });
+});

--- a/tests/dashboard/useEventStream.test.ts
+++ b/tests/dashboard/useEventStream.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Pure-logic helpers from useEventStream.ts — no jsdom integration required.
+ *
+ * Follows the precedent of tests/dashboard/useExpert.test.ts:9-13 where only
+ * the pure-logic (non-hook) surface is covered in the root jest environment
+ * (node, no DOM). The hook itself relies on EventSource + localStorage which
+ * are browser APIs.
+ */
+
+import { readLastEventId, writeLastEventId } from '../../packages/dashboard-v2/src/lib/useEventStream';
+
+describe('readLastEventId', () => {
+  it('returns 0 when window is undefined (node / SSR environment)', () => {
+    // Default jest test env is node, so window is undefined here.
+    expect(readLastEventId()).toBe(0);
+  });
+});
+
+describe('writeLastEventId', () => {
+  it('is a no-op when window is undefined — does not throw', () => {
+    expect(() => writeLastEventId(42)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds smooth bottom-right toast notifications to the dashboard for two events:
- `task.completed` — when a non-utility agent task finishes
- `consensus.completed` — when a consensus round synthesizes

Filters `_utility` agent tasks (cognitive summary, gossip publish) so the user isn't spammed.

## Architecture

- **Backend SSE:** `packages/relay/src/dashboard/api-events.ts` (NEW) — in-memory ring buffer of last 100 events with monotonic id; SSE endpoint at `/dashboard/api/events?last_id=N` registered at `packages/relay/src/dashboard/routes.ts:386`. Replays events newer than `last_id` on connect (recovers from tab reload). 25s keepalive defeats proxy idle timeouts.
- **Backend emits:**
  - `apps/cli/src/handlers/native-tasks.ts:608` — `task.completed` after `recordNativeTaskCompleted` (skips `_utility` agents)
  - `apps/cli/src/handlers/collect.ts:1237` — `consensus.completed` after `scheduleSkillRunner` so the order is signals → runner → notification
- **Frontend hook:** `packages/dashboard-v2/src/lib/useEventStream.ts` (NEW) — EventSource wrapper, persists `last_id` to localStorage for tab-reload resume.
- **Frontend toast:** `packages/dashboard-v2/src/components/NotificationStack.tsx` (NEW) — bottom-right stack, max 5 visible, auto-dismiss 6s (paused on hover), click-to-navigate, smooth Tailwind transitions.

## Test plan

- [x] `npm run build` clean (full workspace)
- [x] `npm test --ci` clean — 221 suites / 2917 tests / 0 failures
- [x] 5 new tests pass: `tests/cli/api-events.test.ts` (3 cases — monotonic id, ring cap at 100, replay-since-id) + `tests/dashboard/useEventStream.test.ts` (2 pure-logic helper cases)
- [ ] Manual: open dashboard, trigger any consensus round, observe toast bottom-right within ~1s of synthesis

## Spec deviation worth knowing

`api-events.ts` lives in `packages/relay/src/dashboard/` (not `apps/cli/src/handlers/`) because the dashboard HTTP routes are hosted by the relay package, not the CLI. Spec was wrong on path; implementer routed correctly.

## Out of scope (deferred to follow-ups)

- Notification history drawer (fire-and-forget toasts only)
- Audio/sound
- Skill graduation event (would be trivial to add via `emitDashboardEvent('skill.graduated', ...)` in `check-effectiveness-runner.ts` next to the transition log — left for a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)