### PR TITLE
feat(dashboard): editorial theme — cream/ink palette + serif typography

### DIFF
--- a/packages/dashboard-v2/index.html
+++ b/packages/dashboard-v2/index.html
@@ -17,13 +17,25 @@
 
   <!-- Theme -->
   <meta name="theme-color" content="#8b5cf6" />
-  <meta name="color-scheme" content="dark" />
+  <script>
+  (function() {
+    try {
+      var t = localStorage.getItem('dashboard:theme');
+      if (t === 'editorial') {
+        document.documentElement.dataset.theme = 'editorial';
+      }
+      var meta = document.createElement('meta');
+      meta.name = 'color-scheme';
+      meta.content = (t === 'editorial') ? 'light' : 'dark';
+      document.head.appendChild(meta);
+    } catch (e) { /* fall through */ }
+  })();
+  </script>
 
   <link rel="icon" type="image/png" href="/dashboard/favicon.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=Spectral:wght@400;500;700&family=JetBrains+Mono:wght@400;500&display=swap" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Inter+Tight:wght@400;500;600;700&family=Spectral:wght@400;500;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
 </head>
 <body>
   <div id="root"></div>

--- a/packages/dashboard-v2/index.html
+++ b/packages/dashboard-v2/index.html
@@ -21,7 +21,9 @@
 
   <link rel="icon" type="image/png" href="/dashboard/favicon.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=Spectral:wght@400;500;700&family=JetBrains+Mono:wght@400;500&display=swap" />
 </head>
 <body>
   <div id="root"></div>

--- a/packages/dashboard-v2/src/components/TopBar.tsx
+++ b/packages/dashboard-v2/src/components/TopBar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { getWsState } from '@/lib/ws';
 import { href, navigate, useRoute } from '@/lib/router';
 import { useExpert } from '@/lib/useExpert';
+import { useTheme } from '@/lib/useTheme';
 import { GlossaryModal } from './GlossaryModal';
 
 const TABS = [
@@ -18,6 +19,7 @@ export function TopBar() {
   const [glossaryOpen, setGlossaryOpen] = useState(false);
   const route = useRoute();
   const expert = useExpert();
+  const { theme, toggle: toggleTheme } = useTheme();
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -63,6 +65,14 @@ export function TopBar() {
           }`}
         >
           {expert ? '← Overview' : 'Expert view →'}
+        </button>
+        <button
+          onClick={toggleTheme}
+          aria-label={theme === 'editorial' ? 'Switch to default theme' : 'Switch to editorial theme'}
+          title={theme === 'editorial' ? 'Switch to default theme' : 'Switch to editorial theme'}
+          className="font-mono text-[10px] uppercase tracking-widest border border-border/40 rounded-sm px-2.5 py-1 transition text-muted-foreground/50 hover:text-muted-foreground"
+        >
+          {theme === 'editorial' ? 'Default' : 'Editorial'}
         </button>
         <button
           onClick={() => setGlossaryOpen(true)}

--- a/packages/dashboard-v2/src/components/TopBar.tsx
+++ b/packages/dashboard-v2/src/components/TopBar.tsx
@@ -70,7 +70,11 @@ export function TopBar() {
           onClick={toggleTheme}
           aria-label={theme === 'editorial' ? 'Switch to default theme' : 'Switch to editorial theme'}
           title={theme === 'editorial' ? 'Switch to default theme' : 'Switch to editorial theme'}
-          className="font-mono text-[10px] uppercase tracking-widest border border-border/40 rounded-sm px-2.5 py-1 transition text-muted-foreground/50 hover:text-muted-foreground"
+          className={`font-mono text-[10px] uppercase tracking-widest border border-border/40 rounded-sm px-2.5 py-1 transition ${
+            theme === 'editorial'
+              ? 'text-foreground border-border'
+              : 'text-muted-foreground/50 hover:text-muted-foreground'
+          }`}
         >
           {theme === 'editorial' ? 'Default' : 'Editorial'}
         </button>

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -51,6 +51,11 @@
   --radius-lg: 0.5rem;
 }
 
+/* ───── Serif utility — no-op in default theme, serif in editorial ───── */
+.font-serif-editorial {
+  font-family: inherit;
+}
+
 body {
   background-color: var(--color-background);
   color: var(--color-foreground);
@@ -59,6 +64,58 @@ body {
   line-height: 1.55;
   font-variant-numeric: tabular-nums;
   -webkit-font-smoothing: antialiased;
+}
+
+/* ───── Editorial theme — cream/ink palette + serif typography ───── */
+[data-theme="editorial"] {
+  /* Background / surface */
+  --color-background: #F4F1EA;
+  --color-foreground: #0E0E0C;
+  --color-card: #EAE5D9;
+  --color-card-foreground: #0E0E0C;
+  --color-muted: #EAE5D9;
+  --color-muted-foreground: #6B6657;
+  --color-border: #D6D0BF;
+  --color-input: #D6D0BF;
+
+  /* Primary / accent */
+  --color-ring: #A4161A;
+  --color-primary: #A4161A;
+  --color-primary-foreground: #F4F1EA;
+  --color-secondary: #EAE5D9;
+  --color-secondary-foreground: #0E0E0C;
+  --color-accent: #D6D0BF;
+  --color-accent-foreground: #0E0E0C;
+
+  /* Destructive unchanged — still red */
+  --color-destructive: #A4161A;
+  --color-destructive-foreground: #F4F1EA;
+
+  /* Semantic finding colors */
+  --color-confirmed: #2D6A4F;
+  --color-disputed: #A4161A;
+  --color-unverified: #B08900;
+  --color-unique: #1D3557;
+
+  /* Severity */
+  --color-severity-high: #A4161A;
+
+  /* Chart palette — olive/warm tones for editorial */
+  --color-chart: #6B6657;
+  --color-chart-accent: #2D6A4F;
+  --color-chart-deep: #1D3557;
+
+  /* Typography */
+  --font-sans: 'Inter Tight', 'Inter', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'IBM Plex Mono', ui-monospace, monospace;
+}
+
+[data-theme="editorial"] body {
+  font-family: var(--font-sans);
+}
+
+[data-theme="editorial"] .font-serif-editorial {
+  font-family: 'Spectral', 'GT Sectra', Georgia, serif;
 }
 
 /* Subtle vignette — no scanlines (they wash out avatar glows) */

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -98,7 +98,12 @@ body {
   --color-unique: #1D3557;
 
   /* Severity */
-  --color-severity-high: #A4161A;
+  --color-severity-high: #C0383D;  /* lighter crimson, distinguishable from --color-disputed #A4161A */
+
+  /* v3 additions */
+  --color-impact: #1D3557;
+  --color-insight: #6B6657;
+  --color-text-dim: #9B9583;
 
   /* Chart palette — olive/warm tones for editorial */
   --color-chart: #6B6657;
@@ -116,6 +121,46 @@ body {
 
 [data-theme="editorial"] .font-serif-editorial {
   font-family: 'Spectral', 'GT Sectra', Georgia, serif;
+}
+
+/* ───── Editorial tooltip overrides ───── */
+[data-theme="editorial"] [data-tooltip]::after {
+  background: rgba(14, 14, 12, 0.95);
+  border-color: var(--color-border);
+  color: var(--color-card);
+}
+[data-theme="editorial"] [data-tooltip]::before {
+  border-top-color: rgba(14, 14, 12, 0.95);
+}
+
+/* ───── Editorial vignette suppression ───── */
+html:has([data-theme="editorial"])::after,
+[data-theme="editorial"]::after {
+  display: none;
+}
+
+/* ───── Editorial scrollbar override ───── */
+[data-theme="editorial"] ::-webkit-scrollbar-thumb {
+  background: rgba(107, 102, 87, 0.3);
+}
+[data-theme="editorial"] ::-webkit-scrollbar-thumb:hover {
+  background: rgba(107, 102, 87, 0.5);
+}
+
+/* ───── Editorial inline-code override ───── */
+[data-theme="editorial"] .task-md code.md-inline-code,
+[data-theme="editorial"] .finding-md code.md-inline-code {
+  background: rgba(214, 208, 191, 0.5);
+  border-color: var(--color-border);
+}
+
+/* ───── Editorial CRT logo glow suppression ───── */
+[data-theme="editorial"] .crt-logo:hover::after,
+[data-theme="editorial"] .crt-logo--glitch::after {
+  display: none;
+}
+[data-theme="editorial"] .crt-logo:hover .crt-logo-img {
+  filter: brightness(0.95) contrast(1.05);
 }
 
 /* Subtle vignette — no scanlines (they wash out avatar glows) */

--- a/packages/dashboard-v2/src/lib/useTheme.ts
+++ b/packages/dashboard-v2/src/lib/useTheme.ts
@@ -50,12 +50,14 @@ export function useTheme(): { theme: Theme; setTheme: (t: Theme) => void; toggle
     }
   }, [theme]);
 
-  const setTheme = (t: Theme) => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(STORAGE_KEY, t);
-    }
+  function setTheme(t: Theme): void {
     setThemeState(t);
-  };
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, t);
+      } catch { /* private browsing or quota — UI still updates */ }
+    }
+  }
 
   const toggle = () => {
     setTheme(theme === 'default' ? 'editorial' : 'default');

--- a/packages/dashboard-v2/src/lib/useTheme.ts
+++ b/packages/dashboard-v2/src/lib/useTheme.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+
+// Local declaration of the tiny `window` surface this module touches.
+// The dashboard-v2 package's own tsconfig pulls in lib.dom; this guard keeps the
+// file compilable when ts-jest (root tsconfig, lib.dom NOT included) loads it.
+declare const window: {
+  localStorage: { getItem: (key: string) => string | null; setItem: (key: string, value: string) => void };
+} | undefined;
+
+declare const document: {
+  documentElement: { dataset: Record<string, string> };
+} | undefined;
+
+export type Theme = 'default' | 'editorial';
+
+export const STORAGE_KEY = 'dashboard:theme';
+
+const KNOWN_THEMES: Theme[] = ['default', 'editorial'];
+
+/**
+ * Sanitize an unknown localStorage value to a valid Theme.
+ * Unknown / null values fall back to 'default'.
+ */
+export function parseTheme(raw: string | null): Theme {
+  if (raw !== null && (KNOWN_THEMES as string[]).includes(raw)) {
+    return raw as Theme;
+  }
+  return 'default';
+}
+
+function readTheme(): Theme {
+  if (typeof window === 'undefined') return 'default';
+  return parseTheme(window.localStorage.getItem(STORAGE_KEY));
+}
+
+/**
+ * Hook that persists the active theme to localStorage and writes
+ * `document.documentElement.dataset.theme` so CSS `[data-theme="editorial"]`
+ * selectors activate.
+ */
+export function useTheme(): { theme: Theme; setTheme: (t: Theme) => void; toggle: () => void } {
+  const [theme, setThemeState] = useState<Theme>(readTheme);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    if (theme === 'default') {
+      delete document.documentElement.dataset.theme;
+    } else {
+      document.documentElement.dataset.theme = theme;
+    }
+  }, [theme]);
+
+  const setTheme = (t: Theme) => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, t);
+    }
+    setThemeState(t);
+  };
+
+  const toggle = () => {
+    setTheme(theme === 'default' ? 'editorial' : 'default');
+  };
+
+  return { theme, setTheme, toggle };
+}

--- a/packages/dashboard-v2/src/pages/OverviewPage.tsx
+++ b/packages/dashboard-v2/src/pages/OverviewPage.tsx
@@ -36,7 +36,7 @@ export function OverviewPage({
       {/* Page header */}
       <header>
         <div className="flex items-baseline justify-between gap-4">
-          <h1 className="font-mono text-2xl font-bold tracking-tight text-foreground font-serif-editorial">
+          <h1 className="text-4xl font-bold tracking-tight text-foreground font-serif-editorial">
             Overview
           </h1>
           {actionable > 0 && (

--- a/packages/dashboard-v2/src/pages/OverviewPage.tsx
+++ b/packages/dashboard-v2/src/pages/OverviewPage.tsx
@@ -36,7 +36,7 @@ export function OverviewPage({
       {/* Page header */}
       <header>
         <div className="flex items-baseline justify-between gap-4">
-          <h1 className="font-mono text-2xl font-bold tracking-tight text-foreground">
+          <h1 className="font-mono text-2xl font-bold tracking-tight text-foreground font-serif-editorial">
             Overview
           </h1>
           {actionable > 0 && (

--- a/tests/dashboard/useTheme.test.ts
+++ b/tests/dashboard/useTheme.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Covers the pure-logic helpers in `useTheme`:
+ *   - parseTheme returns 'default' for null
+ *   - parseTheme returns 'default' for the 'default' string
+ *   - parseTheme returns 'editorial' for the 'editorial' string
+ *   - parseTheme returns 'default' for unrecognised strings
+ *   - STORAGE_KEY constant equals 'dashboard:theme'
+ *
+ * The React-hook side needs jsdom + @testing-library/react which are not yet
+ * wired up for dashboard-v2. Precedent: tests/dashboard/useExpert.test.ts:9-13.
+ */
+
+import { parseTheme, STORAGE_KEY } from '../../packages/dashboard-v2/src/lib/useTheme';
+
+describe('parseTheme', () => {
+  it('returns "default" when raw is null', () => {
+    expect(parseTheme(null)).toBe('default');
+  });
+
+  it('returns "default" when raw is "default"', () => {
+    expect(parseTheme('default')).toBe('default');
+  });
+
+  it('returns "editorial" when raw is "editorial"', () => {
+    expect(parseTheme('editorial')).toBe('editorial');
+  });
+
+  it('returns "default" for an unrecognised string', () => {
+    expect(parseTheme('garbage')).toBe('default');
+  });
+});
+
+describe('STORAGE_KEY', () => {
+  it('equals "dashboard:theme"', () => {
+    expect(STORAGE_KEY).toBe('dashboard:theme');
+  });
+});


### PR DESCRIPTION
## Summary

Adds an "editorial" theme variant alongside the existing default. Toggleable from the TopBar, persists in localStorage.

- **Palette:** cream paper (#F4F1EA) + ink black (#0E0E0C) + crimson accent (#A4161A); semantic finding colors override (deep green confirmed, ink-blue unique, amber-ochre unverified).
- **Typography:** Inter Tight body, Spectral serif headlines via `.font-serif-editorial` utility (no-op in default theme, applies serif in editorial), JetBrains Mono for IDs/timestamps. Webfonts loaded via Google Fonts CDN with `display=swap`.
- **TopBar toggle:** small text button ("Editorial" / "Default") next to Glossary.
- **Persistence:** `localStorage['dashboard:theme']`.

## Files
- `packages/dashboard-v2/src/globals.css` — `[data-theme="editorial"]` override block + `.font-serif-editorial` utility
- `packages/dashboard-v2/index.html` — webfont preconnect + stylesheet
- `packages/dashboard-v2/src/lib/useTheme.ts` (NEW) — `parseTheme`, `STORAGE_KEY`, `useTheme` hook
- `packages/dashboard-v2/src/components/TopBar.tsx` — toggle button
- `packages/dashboard-v2/src/pages/OverviewPage.tsx` — `font-serif-editorial` on top h1
- `tests/dashboard/useTheme.test.ts` (NEW) — 5 pure-logic cases

## Test plan
- [x] `npm run build` clean
- [x] `npm test --ci` clean — 2922 tests pass, useTheme tests green
- [ ] Manual: load dashboard, click Editorial → cream surface + serif headline appears, fonts swap without reload, persists across page reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)