### PR TITLE
fix(cli): drop pending from runner transition tally + JSDoc fixes

### DIFF
--- a/apps/cli/src/handlers/check-effectiveness-runner.ts
+++ b/apps/cli/src/handlers/check-effectiveness-runner.ts
@@ -140,10 +140,11 @@ export async function runCheckEffectivenessForAllSkills(opts: RunnerOptions): Pr
                   `\n`,
                 );
               }
-              // Tally only verdict-bearing transitions; pending/inconclusive
-              // states without shouldUpdate aren't operator-relevant.
-              if ((transitions as any)[verdict.status] != null) {
-                (transitions as any)[verdict.status]++;
+              // Reuse loggedStates so the tally stays in sync with the stderr
+              // log: pending can reach here with shouldUpdate=true on lazy
+              // migrations and would otherwise inflate the health counter.
+              if (loggedStates.has(verdict.status)) {
+                (transitions as TransitionCounts)[verdict.status as keyof TransitionCounts]++;
               }
             }
           }

--- a/packages/orchestrator/src/check-effectiveness.ts
+++ b/packages/orchestrator/src/check-effectiveness.ts
@@ -99,6 +99,10 @@ export interface VerdictResult {
    * (stderr logs, health-file transition counters, etc.). `undefined` means
    * either there was no writeback (shouldUpdate=false) or the writeback
    * succeeded — both are normal cases.
+   *
+   * Note: when shouldUpdate=true but newSnapshotFields is absent or empty,
+   * writeSkillFileFromParts is not called and `persisted` stays `undefined`
+   * (treated as success — no disk write was needed).
    */
   persisted?: boolean;
 }

--- a/packages/orchestrator/src/skill-engine.ts
+++ b/packages/orchestrator/src/skill-engine.ts
@@ -1021,8 +1021,9 @@ ${inputs.join('\n')}
    * contents fully present — never a torn file. The tmp file is cleaned
    * up on the failure path.
    *
-   * Returns `true` if the write landed, `false` if drift was detected and
-   * the write was aborted.
+   * Returns `{ ok: true }` if the write landed, or
+   * `{ ok: false, drift: { expectedVersion, diskVersion } }` if version drift
+   * was detected and the write was aborted.
    */
   private writeSkillFileFromParts(
     skillPath: string,

--- a/tests/cli/check-effectiveness-runner-drift-suppression.test.ts
+++ b/tests/cli/check-effectiveness-runner-drift-suppression.test.ts
@@ -134,4 +134,54 @@ describe('runCheckEffectivenessForAllSkills — drift suppression', () => {
     const finalRaw = readFileSync(skillPath, 'utf-8');
     expect(finalRaw).toMatch(/version:\s*5/);
   });
+
+  it('does not increment transitions.pending when verdict has status=pending and shouldUpdate=true (f1 regression)', async () => {
+    // Regression for consensus 16e8e74b-f0ba4106 f1:
+    // Before the fix, `(transitions as any)[verdict.status]++` would increment
+    // transitions.pending whenever shouldUpdate=true and status==='pending',
+    // because 'pending' was a key in TransitionCounts. After the fix the tally
+    // is guarded by `loggedStates` (passed/failed/flagged_for_manual_review),
+    // so pending never increments even if shouldUpdate is set.
+
+    const agentId = 'test-agent';
+    const category = 'trust_boundaries';
+
+    // Seed a minimal skill file so the runner can discover the (agentId, category) pair.
+    const skillsDir = join(projectRoot, '.gossip', 'agents', agentId, 'skills');
+    mkdirSync(skillsDir, { recursive: true });
+    writeFileSync(
+      join(skillsDir, `${category}.md`),
+      `---\nstatus: pending\nversion: 1\n---\n# stub\n`,
+    );
+
+    // Stub the skillEngine to return status=pending + shouldUpdate=true.
+    // This combination can be produced by external callers or future code paths
+    // and must not corrupt the transition tally.
+    const stubEngine = {
+      checkEffectiveness: jest.fn().mockResolvedValue({
+        status: 'pending',
+        shouldUpdate: true,
+        // persisted is intentionally absent — the guard should still not tally
+      }),
+    } as any;
+
+    await runCheckEffectivenessForAllSkills({
+      skillEngine: stubEngine,
+      registryGet: (_id: string) => ({ role: 'reviewer' }),
+      projectRoot,
+    });
+
+    const healthPath = join(projectRoot, '.gossip', 'skill-runner-health.json');
+    expect(existsSync(healthPath)).toBe(true);
+    const health = JSON.parse(readFileSync(healthPath, 'utf8'));
+
+    // CRITICAL: pending must remain 0 — it is not an operator-relevant transition.
+    expect(health.transitions.pending).toBe(0);
+
+    // Other counters must also be 0 — the stub emits no terminal verdict.
+    expect(health.transitions.passed).toBe(0);
+    expect(health.transitions.failed).toBe(0);
+    expect(health.transitions.flagged_for_manual_review).toBe(0);
+    expect(health.transitions.inconclusive).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

- `check-effectiveness-runner.ts` was tallying `transitions[pending]` whenever a verdict arrived with `shouldUpdate=true && status='pending'` (e.g. on lazy migrations), inflating the health-file counter with non-events. Fix: reuse the existing `loggedStates` Set so the tally and the stderr log stay in lockstep.
- Replace `(transitions as any)[...]++` with a typed access against `TransitionCounts`.
- JSDoc fixes on `VerdictResult.persisted` (note the `newSnapshotFields` dependency) and `writeSkillFileFromParts` (was stale post-5d3274e — described boolean return, but signature is `{ ok, drift? }`).
- Regression test added.

Consensus `16e8e74b-f0ba4106`, findings `f1`, `f2`, `f6`, `f9`.

## Test plan

- [x] `npm run build` — clean across all 5 workspaces
- [x] `npx jest tests/cli/check-effectiveness-runner-drift-suppression.test.ts --ci` — both tests pass (existing + new regression)
- [x] `npx jest --ci` — 2924 / 2924 pass
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)