### PR TITLE
fix(deps): patch ip-address XSS via npm override (CVE-2026-42338)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gossipcat",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gossipcat",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -3962,9 +3962,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "tsconfig-paths": "^4.2.0",
     "ws": "^8.19.0"
+  },
+  "overrides": {
+    "ip-address": "^10.1.1"
   }
 }


### PR DESCRIPTION
## Summary

Closes dependabot alert [#23](https://github.com/gossipcat-ai/gossipcat-ai/security/dependabot/23) — `ip-address` XSS in Address6 HTML-emitting methods (GHSA-v2v4-37r5-5v8g, CVE-2026-42338).

Transitive via `@modelcontextprotocol/sdk → express-rate-limit → ip-address@10.1.0`. Adds an `overrides` entry pinning `ip-address` to `^10.1.1`; lockfile now resolves to `10.2.0`.

## Real-world exposure

Near-zero for gossipcat. The advisory covers `Address6.group()`, `link()`, `spanAll()`, and `AddressError.parseMessage` — HTML-emitting surfaces. Gossipcat does not call any of them, and no code path accepts untrusted IPv6 input. Fixing to clear the alert and keep the transitive tree current.

## Test plan

- [x] `npm install` — override resolves cleanly
- [x] `npm ls ip-address` confirms `10.2.0`
- [x] `npm run build` — clean across all 5 workspaces
- [x] `npx jest --ci` — 2991/2991 pass
- [ ] CI green on PR

## Follow-up not in this PR

There's a separate `hono` advisory (GHSA-9vqf-7f2p-gf9v + GHSA-69xw-7hcm-h432) also transitive via `@modelcontextprotocol/sdk`. Same class of fix — can be bundled in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)