### PR TITLE
fix(orchestrator): hook-installer must not wipe malformed settings.json

### DIFF
--- a/packages/orchestrator/src/hook-installer.ts
+++ b/packages/orchestrator/src/hook-installer.ts
@@ -47,16 +47,32 @@ export function findBundledHook(): string | null {
   return null;
 }
 
-/** Load `.claude/settings.json`, returning `{}` if missing or malformed. */
+/**
+ * Load `.claude/settings.json`.
+ *
+ * - File doesn't exist → return `{}`
+ * - File exists, valid JSON object → return parsed object
+ * - File exists but malformed JSON or not a plain object → THROW with a
+ *   descriptive message so the caller can skip the write rather than
+ *   silently replacing the user's file with `{}`.
+ */
 function loadSettings(settingsPath: string): Record<string, any> {
   if (!existsSync(settingsPath)) return {};
+  const raw = readFileSync(settingsPath, 'utf-8');
+  let parsed: unknown;
   try {
-    const raw = readFileSync(settingsPath, 'utf-8');
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
-  } catch {
-    return {};
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `settings.json at ${settingsPath} contains malformed JSON: ${(err as Error).message}`,
+    );
   }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(
+      `settings.json at ${settingsPath} is not a JSON object (got ${Array.isArray(parsed) ? 'array' : typeof parsed})`,
+    );
+  }
+  return parsed as Record<string, any>;
 }
 
 /** Merge the PreToolUse entry idempotently — skip if the exact command is already registered. */
@@ -130,7 +146,18 @@ export function installWorktreeSandboxHook(projectRoot: string): HookInstallResu
     // 2. Merge the PreToolUse registration into settings.json.
     const settingsPath = join(projectRoot, '.claude', 'settings.json');
     mkdirSync(dirname(settingsPath), { recursive: true });
-    const settings = loadSettings(settingsPath);
+
+    let settings: Record<string, any>;
+    try {
+      settings = loadSettings(settingsPath);
+    } catch (err) {
+      process.stderr.write(
+        `[gossipcat] settings.json at ${settingsPath} is malformed; skipping hook install. ` +
+        `Fix the file or delete it and re-run gossip_setup.\n`,
+      );
+      return { installed: false, reason: (err as Error).message };
+    }
+
     const mutated = mergePreToolUseEntry(settings);
     if (mutated) {
       writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');

--- a/tests/orchestrator/hook-installer-malformed-settings.test.ts
+++ b/tests/orchestrator/hook-installer-malformed-settings.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the malformed-settings data-loss guard in installWorktreeSandboxHook.
+ *
+ * When .claude/settings.json exists but is unparseable or is not a plain JSON
+ * object, the installer must:
+ *   1. Return { installed: false } without throwing to the caller.
+ *   2. Leave the file byte-identical to its original content (zero data loss).
+ */
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { rmSync } from 'fs';
+import { installWorktreeSandboxHook } from '../../packages/orchestrator/src/hook-installer';
+
+function makeTmpProject(): string {
+  return mkdtempSync(join(tmpdir(), 'gossip-hook-malformed-'));
+}
+
+describe('installWorktreeSandboxHook — malformed settings.json guard', () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    while (created.length) {
+      const dir = created.pop()!;
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+  });
+
+  it('does not throw and skips write when settings.json contains malformed JSON', () => {
+    const root = makeTmpProject();
+    created.push(root);
+
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const malformed = '{not valid json';
+    writeFileSync(join(root, '.claude', 'settings.json'), malformed);
+
+    // Must not throw — best-effort install, callers expect HookInstallResult.
+    let result: ReturnType<typeof installWorktreeSandboxHook>;
+    expect(() => {
+      result = installWorktreeSandboxHook(root);
+    }).not.toThrow();
+
+    expect(result!.installed).toBe(false);
+    expect(typeof result!.reason).toBe('string');
+
+    // File must be byte-identical to malformed input.
+    const after = readFileSync(join(root, '.claude', 'settings.json'), 'utf-8');
+    expect(after).toBe(malformed);
+  });
+
+  it('does not throw and skips write when settings.json is a JSON array (not an object)', () => {
+    const root = makeTmpProject();
+    created.push(root);
+
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const arrayJson = '[]';
+    writeFileSync(join(root, '.claude', 'settings.json'), arrayJson);
+
+    let result: ReturnType<typeof installWorktreeSandboxHook>;
+    expect(() => {
+      result = installWorktreeSandboxHook(root);
+    }).not.toThrow();
+
+    expect(result!.installed).toBe(false);
+    expect(typeof result!.reason).toBe('string');
+
+    // File must be byte-identical to the original non-object JSON.
+    const after = readFileSync(join(root, '.claude', 'settings.json'), 'utf-8');
+    expect(after).toBe(arrayJson);
+  });
+
+  it('does not throw and skips write when settings.json is a JSON string (not an object)', () => {
+    const root = makeTmpProject();
+    created.push(root);
+
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const stringJson = '"just a string"';
+    writeFileSync(join(root, '.claude', 'settings.json'), stringJson);
+
+    let result: ReturnType<typeof installWorktreeSandboxHook>;
+    expect(() => {
+      result = installWorktreeSandboxHook(root);
+    }).not.toThrow();
+
+    expect(result!.installed).toBe(false);
+    expect(typeof result!.reason).toBe('string');
+
+    const after = readFileSync(join(root, '.claude', 'settings.json'), 'utf-8');
+    expect(after).toBe(stringJson);
+  });
+});

--- a/tests/orchestrator/hook-installer.test.ts
+++ b/tests/orchestrator/hook-installer.test.ts
@@ -120,16 +120,20 @@ describe('installWorktreeSandboxHook', () => {
     expect(typeof result.reason).toBe('string');
   });
 
-  it('recovers when settings.json is malformed (treats as empty)', () => {
+  it('skips install (does not overwrite) when settings.json is malformed', () => {
     const root = makeTmpProject();
     created.push(root);
     require('fs').mkdirSync(join(root, '.claude'), { recursive: true });
-    writeFileSync(join(root, '.claude', 'settings.json'), '{not valid json');
+    const malformed = '{not valid json';
+    writeFileSync(join(root, '.claude', 'settings.json'), malformed);
 
     const result = installWorktreeSandboxHook(root);
-    expect(result.installed).toBe(true);
+    // Best-effort: must not throw, must not write.
+    expect(result.installed).toBe(false);
+    expect(typeof result.reason).toBe('string');
 
-    const settings = JSON.parse(readFileSync(join(root, '.claude', 'settings.json'), 'utf-8'));
-    expect(settings.hooks.PreToolUse[0].hooks[0].command).toBe(HOOK_COMMAND);
+    // File must be byte-identical to malformed input — zero data loss.
+    const after = readFileSync(join(root, '.claude', 'settings.json'), 'utf-8');
+    expect(after).toBe(malformed);
   });
 });


### PR DESCRIPTION
## Summary

When `.claude/settings.json` existed but contained invalid JSON, `loadSettings()` silently returned `{}` and the caller wrote `{ hooks: { PreToolUse: [<sandbox>] } }` back to disk — wiping every custom permission, env var, hook, and statusLine the user had configured.

## Fix

- `loadSettings()` now throws on malformed JSON or non-object roots with a descriptive error.
- `installWorktreeSandboxHook()` catches the throw, prints a stderr warning (`"settings.json at <path> is malformed; skipping hook install. Fix the file or delete it and re-run gossip_setup."`) and returns `{ installed: false, reason }` without writing.

## Tests

- **NEW** `tests/orchestrator/hook-installer-malformed-settings.test.ts` — covers malformed JSON (`'{not valid json'`), array root (`'[]'`), and string root (`'\"just a string\"'`). All three assert the file is byte-identical after the call — zero data loss.
- **UPDATED** existing `"recovers when settings.json is malformed (treats as empty)"` test — now asserts the correct non-destructive behavior. The old test was asserting the bug.

## Test plan

- [x] `npm run build` — clean across all 5 workspaces
- [x] `npx jest --ci tests/orchestrator/hook-installer*` — 10/10 pass
- [x] `npx jest --ci` — 2994/2994 pass (no regressions)
- [ ] CI green on PR

## Discovery

Found during consensus `922fc3b6-b05e44dd` review of the orchestrator-discipline hook bundle proposal. Sonnet's cross-review uncovered the data-loss path in the existing installer (independent of the new bundle proposal). Bug had been latent since the installer was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)