### PR TITLE
chore(orchestrator): doc-truth fixes — wilson-score header + cross-review anchor resolutionRoots

### DIFF
--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -125,6 +125,13 @@ export class ConsensusEngine {
   private fileCache = new Map<string, string | null>();
   private pathCache = new Map<string, string | null>();
   /**
+   * Separate path cache for anchor resolution with worktree-priority ordering.
+   * Invalidated in lockstep with pathCache (updateWorktreeRoots clears both).
+   * Keys are plain fileRefs (same as pathCache) — distinct cache because the
+   * resolution order is reversed: worktree roots FIRST, projectRoot fallback.
+   */
+  private anchorPathCache = new Map<string, string | null>();
+  /**
    * Per-task worktree paths discovered from TaskEntry.worktreeInfo. Used as
    * additional file-resolution roots so consensus auto-anchor can find files
    * created in a feature-branch worktree (which only exist there, not in the
@@ -242,6 +249,7 @@ export class ConsensusEngine {
       // Fix #4 — fileCache invalidation parity with pathCache.
       this.pathCache.clear();
       this.fileCache.clear();
+      this.anchorPathCache.clear();
     }
   }
 
@@ -257,10 +265,51 @@ export class ConsensusEngine {
     return roots;
   }
 
+  /**
+   * Resolution roots ordered for anchor snippet resolution during cross-review:
+   * worktree / resolutionRoots FIRST, projectRoot last.
+   *
+   * When a gossip_collect call supplies resolutionRoots (a feature-branch
+   * worktree), the reviewer is examining that branch. Anchor content must
+   * reflect the worktree version of a file, not the stale-from-master copy in
+   * projectRoot. If a file only exists in projectRoot (not modified in the
+   * worktree), the fallback to projectRoot still applies.
+   *
+   * Rule 1 (bare-filename recursion restricted to projectRoot) is preserved:
+   * resolveFilePath checks `isBare && !isProjectRoot` and skips recursion for
+   * non-project roots. The ordering change only affects which version wins when
+   * the same relative path exists in BOTH the worktree AND projectRoot.
+   */
+  private getAnchorPriorityRoots(): string[] {
+    const worktrees: string[] = [];
+    for (const wt of this.currentWorktreeRoots) worktrees.push(wt);
+    if (worktrees.length === 0) {
+      // No active worktree roots — fall back to standard order.
+      return this.getValidRoots();
+    }
+    const roots: string[] = [...worktrees];
+    if (this.config.projectRoot) roots.push(this.config.projectRoot);
+    return roots;
+  }
+
   private async cachedResolve(fileRef: string): Promise<string | null> {
     if (this.pathCache.has(fileRef)) return this.pathCache.get(fileRef)!;
     const resolved = await this.resolveFilePath(fileRef);
     this.pathCache.set(fileRef, resolved);
+    return resolved;
+  }
+
+  /**
+   * Path resolver for anchor snippet building during cross-review.
+   * Uses worktree-priority ordering (getAnchorPriorityRoots) so reviewers see
+   * the worktree version of a modified file, not the stale-from-master copy.
+   * Separate cache keyed by fileRef — invalidated alongside pathCache in
+   * updateWorktreeRoots when the worktree set changes.
+   */
+  private async cachedResolveForAnchor(fileRef: string): Promise<string | null> {
+    if (this.anchorPathCache.has(fileRef)) return this.anchorPathCache.get(fileRef)!;
+    const resolved = await this.resolveFilePath(fileRef, { priorityRoots: this.getAnchorPriorityRoots() });
+    this.anchorPathCache.set(fileRef, resolved);
     return resolved;
   }
 
@@ -1388,7 +1437,9 @@ Return only valid JSON.${skillsBlock}`;
    * Returns formatted anchor blocks as a string, or '' if no citations found.
    */
   protected async snippetsForFinding(findingText: string, maxSnippets = 3): Promise<string> {
-    if (!this.config.projectRoot) return '';
+    // Proceed when we have at least one root to resolve against — either
+    // projectRoot alone or worktree roots seeded from resolutionRoots.
+    if (!this.config.projectRoot && this.currentWorktreeRoots.size === 0) return '';
 
     const citationPattern = /((?:[\w./-]+\/)?([a-zA-Z][\w.-]+\.[a-z]{1,6})):(\d+)/g;
     const CONTEXT_LINES = 2;
@@ -1409,11 +1460,20 @@ Return only valid JSON.${skillsBlock}`;
 
       try {
         const safeRef = fullRef.replace(/["<>]/g, '');
-        const filePath = await this.cachedResolve(fullRef) ?? await this.cachedResolve(bareFile);
+        // Use worktree-priority resolver: resolutionRoots (worktrees) are checked
+        // BEFORE projectRoot so reviewers see the branch version of modified files.
+        const filePath = await this.cachedResolveForAnchor(fullRef) ?? await this.cachedResolveForAnchor(bareFile);
         if (!filePath) {
           anchors.push(`⚠ Agent cited \`${safeRef}:${lineNum}\` but file not found`);
           continue;
         }
+        // Defense-in-depth: warn when the resolved path falls back to projectRoot
+        // while worktree roots are active — the anchor may reflect master HEAD,
+        // not the branch under review.
+        const resolvedFromProjectRoot =
+          this.currentWorktreeRoots.size > 0 &&
+          this.config.projectRoot &&
+          filePath.startsWith(resolve(this.config.projectRoot) + '/');
         const fileStat = await stat(filePath);
         if (fileStat.size > MAX_FILE_SIZE) continue;
         const content = await this.cachedRead(filePath);
@@ -1434,7 +1494,10 @@ Return only valid JSON.${skillsBlock}`;
           .map((l, i) => `  ${start + i + 1}: ${l}`)
           .join('\n');
         const safeSnippet = snippet.replace(/<\/?(data|anchor|code)\b[^>]*>/gi, '');
-        anchors.push(`<anchor src="${safeRef}:${lineNum}">\n${safeSnippet}\n</anchor>`);
+        const projectRootWarning = resolvedFromProjectRoot
+          ? ' via="⚠ resolved against project root, NOT worktree"'
+          : '';
+        anchors.push(`<anchor src="${safeRef}:${lineNum}"${projectRootWarning}>\n${safeSnippet}\n</anchor>`);
       } catch { /* file unreadable, skip */ }
     }
 
@@ -1442,7 +1505,8 @@ Return only valid JSON.${skillsBlock}`;
     // <cite tag="file">auth.ts:38</cite> — resolved by file:line fetch (same as regex above, catches explicit citations)
     // <cite tag="fn">functionName</cite> — resolved by identifier grep
     // Also supports legacy <fn>identifier</fn> for backward compat
-    if (this.config.projectRoot) {
+    // Guard: proceed when we have any resolution root (projectRoot or worktree).
+    if (this.config.projectRoot || this.currentWorktreeRoots.size > 0) {
       const citePattern = /<cite\s+tag="(file|fn)">([^<]+)<\/cite>/g;
       let citeMatch: RegExpExecArray | null;
       while ((citeMatch = citePattern.exec(findingText)) !== null) {
@@ -1452,7 +1516,7 @@ Return only valid JSON.${skillsBlock}`;
         if (!trimmed || trimmed.length > 80) continue;
 
         if (tag === 'file') {
-          // file:line citation — resolve via existing file resolver
+          // file:line citation — resolve via worktree-priority anchor resolver
           const fileMatch = trimmed.match(/^((?:[\w./-]+\/)?([a-zA-Z][\w.-]+\.[a-z]{1,6})):(\d+)$/);
           if (fileMatch && !seen.has(trimmed)) {
             seen.add(trimmed);
@@ -1461,8 +1525,12 @@ Return only valid JSON.${skillsBlock}`;
             const lineNum = parseInt(fileMatch[3], 10);
             try {
               const safeRef = fullRef.replace(/["<>]/g, '');
-              const filePath = await this.cachedResolve(fullRef) ?? await this.cachedResolve(bareFile);
+              const filePath = await this.cachedResolveForAnchor(fullRef) ?? await this.cachedResolveForAnchor(bareFile);
               if (filePath) {
+                const resolvedFromProjectRoot =
+                  this.currentWorktreeRoots.size > 0 &&
+                  this.config.projectRoot &&
+                  filePath.startsWith(resolve(this.config.projectRoot) + '/');
                 const content = await this.cachedRead(filePath);
                 if (content) {
                   const fileLines = content.split('\n');
@@ -1471,7 +1539,10 @@ Return only valid JSON.${skillsBlock}`;
                     const end = Math.min(fileLines.length, lineNum + CONTEXT_LINES);
                     const snippet = fileLines.slice(start, end).map((l, i) => `  ${start + i + 1}: ${l}`).join('\n');
                     const safeSnippet = snippet.replace(/<\/?(data|anchor|code)\b[^>]*>/gi, '');
-                    anchors.push(`<anchor src="${safeRef}:${lineNum}" via="cite:file">\n${safeSnippet}\n</anchor>`);
+                    const projectRootWarning = resolvedFromProjectRoot
+                      ? ' via="⚠ resolved against project root, NOT worktree"'
+                      : ' via="cite:file"';
+                    anchors.push(`<anchor src="${safeRef}:${lineNum}"${projectRootWarning}>\n${safeSnippet}\n</anchor>`);
                   }
                 }
               }
@@ -1712,8 +1783,16 @@ Return only valid JSON.${skillsBlock}`;
     });
   }
 
-  private async resolveFilePath(fileRef: string): Promise<string | null> {
-    const roots = this.getValidRoots();
+  private async resolveFilePath(
+    fileRef: string,
+    opts: { priorityRoots?: string[] } = {},
+  ): Promise<string | null> {
+    // When priorityRoots is supplied (e.g. from cachedResolveForAnchor), use it
+    // instead of getValidRoots() so the caller controls resolution order. The
+    // containment check (isInsideAnyRoot) still uses getValidRoots() as the
+    // security boundary — priorityRoots only controls which root is tried first.
+    const allRoots = this.getValidRoots();
+    const roots = opts.priorityRoots ?? allRoots;
     if (roots.length === 0) return null;
     const fileName = fileRef.split('/').pop()!;
     const isBare = !fileRef.includes('/');
@@ -1721,6 +1800,8 @@ Return only valid JSON.${skillsBlock}`;
 
     // Try every root in order: projectRoot first (most files), then any
     // active worktree paths (for files only present on a feature branch).
+    // Security boundary for isInsideAnyRoot uses allRoots (full set) so a
+    // priority-reordered `roots` list cannot escape the containment check.
     for (const root of roots) {
       const rootAbs = resolve(root);
       const isProjectRoot = projectRoot !== null && rootAbs === projectRoot;
@@ -1728,7 +1809,7 @@ Return only valid JSON.${skillsBlock}`;
       // Try the reference as-is (could be a full relative path)
       try {
         const candidate = join(root, fileRef);
-        if (this.isInsideAnyRoot(candidate, roots)) {
+        if (this.isInsideAnyRoot(candidate, allRoots)) {
           await stat(candidate);
           // For non-bare refs, require matchesRelativePath against this root
           // so a monorepo sibling "packages/other/foo.ts" doesn't satisfy a
@@ -1738,7 +1819,7 @@ Return only valid JSON.${skillsBlock}`;
             // introduced by the root itself.
             let real = candidate;
             try { real = realpathSync(candidate); } catch { /* keep */ }
-            if (this.isInsideAnyRoot(real, roots)) return real;
+            if (this.isInsideAnyRoot(real, allRoots)) return real;
           }
         }
       } catch { /* not at this root */ }
@@ -1747,11 +1828,11 @@ Return only valid JSON.${skillsBlock}`;
       if (fileName !== fileRef) {
         try {
           const candidate = join(root, fileName);
-          if (this.isInsideAnyRoot(candidate, roots)) {
+          if (this.isInsideAnyRoot(candidate, allRoots)) {
             await stat(candidate);
             let real = candidate;
             try { real = realpathSync(candidate); } catch { /* keep */ }
-            if (this.isInsideAnyRoot(real, roots)) return real;
+            if (this.isInsideAnyRoot(real, allRoots)) return real;
           }
         } catch { /* not at this root */ }
       }
@@ -1767,7 +1848,7 @@ Return only valid JSON.${skillsBlock}`;
       // findFile honors Rule 3 (skip symlinked entries) internally.
       const searchDirs = ['packages', 'src', 'apps', 'tests', 'test', 'tools', 'scripts', 'lib'];
       for (const dir of searchDirs) {
-        const found = await this.findFile(join(root, dir), fileName, roots, rootAbs, fileRef);
+        const found = await this.findFile(join(root, dir), fileName, allRoots, rootAbs, fileRef);
         if (found) return found;
       }
     }

--- a/packages/orchestrator/src/wilson-score.ts
+++ b/packages/orchestrator/src/wilson-score.ts
@@ -1,8 +1,8 @@
 /**
- * PROTOTYPE — Wilson score interval as a drop-in candidate for oneSidedZTest.
+ * Wilson score interval — the live skill-graduation verdict path.
  *
- * The current one-sided z-test in check-effectiveness.ts has three known
- * statistical flaws:
+ * The legacy one-sided z-test in check-effectiveness.ts has three known
+ * statistical flaws that motivated this replacement:
  *   1. se === 0 lockout when baselineP ∈ {0, 1}. A skill with a 0/6 baseline
  *      can never graduate because the z-test's standard error collapses.
  *   2. baselineP falls back to 0.5 when baselineTotal === 0. This doubles
@@ -18,7 +18,9 @@
  *   - Sparse baselines produce wide CIs that naturally demand more evidence.
  *   - The CI overlap test has calibrated frequentist coverage.
  *
- * This file is prototype only. No integration into resolveVerdict.
+ * Integrated as the live verdict path via wilsonVerdict; the legacy
+ * oneSidedZTest in check-effectiveness.ts is retained for the
+ * diagnostic-only zScore field on snapshots. See HANDBOOK invariant #2.
  */
 
 /**

--- a/tests/orchestrator/consensus-engine-resolution-roots.test.ts
+++ b/tests/orchestrator/consensus-engine-resolution-roots.test.ts
@@ -136,4 +136,56 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
     (engine as any).updateWorktreeRoots([], [wt2]);
     expect((engine as any).pathCache.size).toBe(0);
   });
+
+  it('Test 16 — anchor snippets resolve from worktree FIRST, not project-root master HEAD', async () => {
+    // Regression for the false-absence finding root cause: when resolutionRoots
+    // supplies a worktree, anchor content for a file that exists in BOTH
+    // project root (master) and the worktree (feature branch) must come from
+    // the worktree version, not the stale master copy.
+    const proj = realpathSync(mkdtempSync(join(tmp, 'proj')));
+    const wt = realpathSync(mkdtempSync(join(tmp, 'wt')));
+
+    // Same relative path in both locations but distinct content.
+    mkdirSync(join(proj, 'src'), { recursive: true });
+    mkdirSync(join(wt, 'src'), { recursive: true });
+    writeFileSync(join(proj, 'src', 'target.ts'), 'export function old() { return "master-HEAD"; }');
+    writeFileSync(join(wt, 'src', 'target.ts'), 'export function newImpl() { return "worktree-branch"; }');
+
+    const engine = new ConsensusEngine({
+      llm: makeLlm(),
+      registryGet: () => undefined,
+      projectRoot: proj,
+      resolutionRoots: [wt],
+    } as ConsensusEngineConfig);
+
+    // snippetsForFinding is protected — invoke via cast.
+    const snippets: string = await (engine as any).snippetsForFinding(
+      'Potential issue at src/target.ts:1',
+    );
+
+    // Must show the WORKTREE content, not the master-HEAD content.
+    expect(snippets).toContain('worktree-branch');
+    expect(snippets).not.toContain('master-HEAD');
+    // Anchor block should be emitted (not a "file not found" warning).
+    expect(snippets).toContain('<anchor');
+  });
+
+  it('Test 17 — anchorPathCache is cleared when worktree roots change', async () => {
+    const proj = realpathSync(mkdtempSync(join(tmp, 'proj')));
+    mkdirSync(join(proj, 'src'), { recursive: true });
+    writeFileSync(join(proj, 'src', 'a.ts'), 'proj');
+    const wt = realpathSync(mkdtempSync(join(tmp, 'wt')));
+
+    const engine = new ConsensusEngine({
+      llm: makeLlm(), registryGet: () => undefined, projectRoot: proj,
+      resolutionRoots: [wt],
+    } as ConsensusEngineConfig);
+
+    // Seed the anchorPathCache with a stale entry.
+    (engine as any).anchorPathCache.set('src/a.ts', '/stale/path/a.ts');
+    // Changing worktree roots should clear anchorPathCache.
+    const wt2 = realpathSync(mkdtempSync(join(tmp, 'wt2')));
+    (engine as any).updateWorktreeRoots([], [wt2]);
+    expect((engine as any).anchorPathCache.size).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Two coupled doc-truth fixes — both surfaced by sonnet-reviewer's methodology audit during the gossipcat vs. ruflo comparison this session.

### Fix 1 — `wilson-score.ts:1-22` header rewrite

The header opened with "PROTOTYPE — Wilson score interval as a drop-in candidate for oneSidedZTest" and closed with "This file is prototype only. No integration into resolveVerdict." Both lines were stale: `wilsonVerdict` and `wilsonScoreInterval` are imported by `check-effectiveness.ts:15` and drive the live verdict. The legacy z-test is diagnostic-only per `check-effectiveness.ts:360-364`. Header rewritten to match reality. The three-flaw motivation block (`se===0` lockout, `baselineP` fallback, ~75% power claim) is preserved verbatim because it's the design rationale.

### Fix 2 — Anchor resolver must honor `resolutionRoots`

When `gossip_collect(consensus:true, resolutionRoots:[<worktree>])` runs Phase-2 cross-review, the prompts embed `<anchor src="path:line">` blocks showing file content. **Until this PR**, anchor contents resolved against `projectRoot` (master HEAD), NOT against the `resolutionRoots` paths. Reviewers saw stale-from-master code and emitted false-absence findings on PRs whose changes only existed on the worktree branch. Root cause of 3 false-absence CRITICAL/HIGH findings during PR #364's consensus round (memory: `project_consensus_anchor_resolutionroots_gap.md`).

**Changes in `consensus-engine.ts`:**

- New `anchorPathCache` field, cleared in lockstep with `pathCache` + `fileCache` in `updateWorktreeRoots` (line 250-252).
- New `getAnchorPriorityRoots()` (line 283): returns `[...worktreeRoots, projectRoot]` when worktree roots are active; falls back to `getValidRoots()` standard order otherwise.
- New `cachedResolveForAnchor()` (line 309): calls `resolveFilePath` with `opts.priorityRoots = getAnchorPriorityRoots()`.
- `resolveFilePath` accepts `opts: { priorityRoots? }` (line 1786). Iteration uses caller-controlled priority; **`isInsideAnyRoot` containment checks always use `allRoots` (security boundary unchanged)**.
- `snippetsForFinding` and the `<cite tag="file">` branch both route through `cachedResolveForAnchor` (lines 1465, 1528).
- Guard widened: `if (!this.config.projectRoot && this.currentWorktreeRoots.size === 0) return ''` (line 1442) — allows operation with `resolutionRoots` only.
- **Defense-in-depth**: when a citation falls back to `projectRoot` while worktree roots are active, the anchor gains `via="⚠ resolved against project root, NOT worktree"` (line 1497). Reviewers see explicit warning when stale fallback occurs.

## Consensus

Round `1d5ec0ea-61d44485` (gemini-reviewer + sonnet-reviewer): **6 confirmed, 0 disputed, 0 unverified, 0 hallucinations.**

This was a meta-test of the new `trust-boundaries-anchor-and-branch-verification` skill (v2, regenerated 2026-05-08 after the f7/f8/f9 cluster on PR #364). The cross-review pipeline still served stale master anchors (because the fix isn't merged yet), but sonnet-reviewer file_read against the worktree path for every claim and produced zero false-absence findings.

Two non-blocking gaps recorded as follow-ups:
- **Usability**: when caller forgets `resolutionRoots` AND worktree roots empty, fallback to `[projectRoot]` is silent — same surface as the original bug, just quieter. A log-warn when `cachedResolveForAnchor` returns null for an existing-on-disk path would help.
- **Test coverage**: the `via="⚠ resolved against project root, NOT worktree"` warning path lacks an automated test. 1-test follow-up.

## Test plan

- [x] `npm run build` — full workspace, all packages green
- [x] `npm test` — 229/229 suites pass, 3024 tests (delta +2 from new tests)
- [x] **Test 16** (`tests/orchestrator/consensus-engine-resolution-roots.test.ts:140`): real fs writes via `mkdtempSync` + `writeFileSync`; same relative path with distinct content in projectRoot vs worktree; asserts worktree content wins, projectRoot content absent
- [x] **Test 17** (`:173`): seeds `anchorPathCache`, calls `updateWorktreeRoots` with different path, asserts cache cleared
- [ ] CI verify on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)