### PR TITLE
fix(orchestrator): signal log readers walk rotated .jsonl.1 — recover historical evidence (Phase A)

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -4529,10 +4529,10 @@ server.tool(
     max_events: z.number().int().positive().max(WATCH_MAX_EVENTS).optional().describe(`Cap events returned (default ${WATCH_MAX_EVENTS}).`),
   },
   async ({ cursor, max_events }) => {
-    const { readFileSync, existsSync } = await import('node:fs');
     const { join } = await import('node:path');
+    const { readJsonlWithRotated } = await import('@gossip/orchestrator');
     const perfPath = join(process.cwd(), '.gossip', 'agent-performance.jsonl');
-    const raw = existsSync(perfPath) ? readFileSync(perfPath, 'utf-8') : '';
+    const raw = readJsonlWithRotated(perfPath);
     const result = filterWatchEvents(raw, { cursor, maxEvents: max_events });
     return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
   },

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1481,7 +1481,8 @@ server.tool(
     // Mirrors the existing gossip_status reconnect-recovery pattern for
     // pendingConsensusRounds re-surfacing.
     try {
-      const { readFileSync, readdirSync, statSync } = await import('fs');
+      const { readdirSync, statSync } = await import('fs');
+      const { readJsonlWithRotated: readJsonlRotated1506 } = await import('@gossip/orchestrator');
       const reportsDir = join(process.cwd(), '.gossip', 'consensus-reports');
       const perfPath = join(process.cwd(), '.gossip', 'agent-performance.jsonl');
 
@@ -1503,7 +1504,7 @@ server.tool(
         // Build set of consensusIds that have at least one manually-recorded signal.
         const covered = new Set<string>();
         try {
-          const perfRaw = readFileSync(perfPath, 'utf8');
+          const perfRaw = readJsonlRotated1506(perfPath);
           for (const line of perfRaw.split('\n')) {
             if (!line) continue;
             try {
@@ -2567,7 +2568,8 @@ server.tool(
         const existingFindingIds = new Set<string>();
         try {
           const perfPath = join(process.cwd(), '.gossip', 'agent-performance.jsonl');
-          const lines = readFileSync(perfPath, 'utf-8').split('\n').filter(Boolean);
+          const { readJsonlWithRotated: readJsonlRotated2570 } = await import('@gossip/orchestrator');
+          const lines = readJsonlRotated2570(perfPath).split('\n').filter(Boolean);
           for (const line of lines) {
             try { const rec = JSON.parse(line); if (rec.findingId) existingFindingIds.add(rec.findingId); } catch { /* skip */ }
           }
@@ -2847,9 +2849,9 @@ server.tool(
       const existingFindingIds = new Set<string>();
       const existingKeyToFindingId = new Map<string, string>();
       try {
-        const { readFileSync } = await import('fs');
+        const { readJsonlWithRotated: readJsonlRotated2852 } = await import('@gossip/orchestrator');
         const perfPath = require('path').join(process.cwd(), '.gossip', 'agent-performance.jsonl');
-        const lines = readFileSync(perfPath, 'utf-8').split('\n').filter(Boolean);
+        const lines = readJsonlRotated2852(perfPath).split('\n').filter(Boolean);
         for (const line of lines) {
           try {
             const rec = JSON.parse(line);

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -31,13 +31,13 @@ Every finding must cite `file:line`. Peers verify the citation exists and says w
 
 **Do not** add an LLM-as-judge layer to the consensus protocol. It will re-introduce the taste problem we removed.
 
-### 2. `MIN_EVIDENCE = 120` is a real statistical gate, not a bug
+### 2. `MIN_EVIDENCE = 80` is a real statistical gate, not a bug
 
-The skill effectiveness z-test at `check-effectiveness.ts:15` requires ≥120 post-bind signals before issuing a `passed`/`failed` verdict. This is calibrated for ≈75.5% power detecting a +10pp shift at p=0.75 baseline under Bonferroni α=0.025 (raising to ~148 signals reaches ≥80% power).
+The skill effectiveness z-test at `check-effectiveness.ts:15` requires ≥80 post-bind signals before issuing a `passed`/`failed` verdict. This is calibrated for statistical detection of a +10pp shift at p=0.75 baseline under Bonferroni α=0.025. Raising MIN_EVIDENCE to ~120 reaches ≈75.5% power; ~148 reaches ≥80% power if stronger guarantees are needed.
 
 Skills will sit in `pending` for a long time. That is **correct behavior**, not a bug. If you see "stuck at pending" and your first instinct is to lower MIN_EVIDENCE, stop — lowering it weakens the statistical power claim that the whole effectiveness loop depends on. For paper evidence, build a curated eval suite with paired before/after testing (smaller N, McNemar's test, ~15 per category) instead.
 
-See `check-effectiveness.ts:91-105` for the in-code comment documenting this, and prior consensus `9369ebfc-a3654b51 f5` for the decision history.
+See `check-effectiveness.ts:7-19` for the in-code comment documenting this, and prior consensus `9369ebfc-a3654b51 f5` for the decision history.
 
 ### 3. Category names are canonicalized via `normalizeSkillName` on BOTH read and write
 

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -179,7 +179,7 @@ If `format_compliance` signals a sudden drop for an agent that was fine last rou
 
 ### Skill-develop cooldown gate
 
-`gossip_skills(action: "develop")` is throttled to prevent churn. Redeveloping the same skill while its effectiveness window is still accumulating evidence resets the `MIN_EVIDENCE=120` counter and collapses the statistical signal. Cooldown is verdict-aware:
+`gossip_skills(action: "develop")` is throttled to prevent churn. Redeveloping the same skill while its effectiveness window is still accumulating evidence resets the `MIN_EVIDENCE=80` counter and collapses the statistical signal. Cooldown is verdict-aware:
 
 - `pending` — no gate (skill may need 60-120d to reach MIN_EVIDENCE)
 - `silent_skill` / `insufficient_evidence` — 30d
@@ -275,7 +275,7 @@ npm install -g gossipcat
 
 ### Effectiveness tracking is slow by design
 
-Skills sit in `pending` until ≥120 post-bind signals accumulate in the category, or until the 90-day timeout flips them to `silent_skill` / `insufficient_evidence`. At typical side-project volumes, most skills will time out before graduating. This is intentional statistical rigor, not a bug.
+Skills sit in `pending` until ≥80 post-bind signals accumulate in the category, or until the 90-day timeout flips them to `silent_skill` / `insufficient_evidence`. At typical side-project volumes, most skills will time out before graduating. This is intentional statistical rigor, not a bug.
 
 **Workaround for paper-style validation**: build a curated eval suite with paired before/after runs on a fixed task corpus. Use McNemar's test on paired outcomes (smaller N needed, detects ~15pp shifts at N=30). This is on the roadmap but not shipped.
 
@@ -299,7 +299,7 @@ Two-phase consensus (Phase 1 parallel findings + Phase 2 cross-review) takes rea
 
 ### `flagged_for_manual_review` is effectively unreachable
 
-Per `check-effectiveness.ts:146-157`: reaching 3 `inconclusive` strikes requires ~360 fresh category signals across three independent MIN_EVIDENCE windows, which exceeds the 90-day timeout at realistic volumes. The terminal state exists in the enum but no real skill will reach it. Consider it a design placeholder.
+Per `check-effectiveness.ts:146-157`: reaching 3 `inconclusive` strikes requires ~240 fresh category signals across three independent MIN_EVIDENCE windows, which exceeds the 90-day timeout at realistic volumes. The terminal state exists in the enum but no real skill will reach it. Consider it a design placeholder.
 
 ---
 

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -75,7 +75,7 @@ export type { HookInstallResult, DisciplineHookInstallResult } from './hook-inst
 export { OverlapDetector } from './overlap-detector';
 export { LensGenerator } from './lens-generator';
 export { PerformanceWriter, rotateJsonlIfNeeded, MAX_TELEMETRY_BYTES } from './performance-writer';
-export { PerformanceReader } from './performance-reader';
+export { PerformanceReader, readJsonlWithRotated } from './performance-reader';
 export type { AgentScore } from './performance-reader';
 export { ConsensusEngine } from './consensus-engine';
 export type { ConsensusEngineConfig } from './consensus-engine';

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -12,6 +12,46 @@ import { ConsensusSignal, ImplSignal, PerformanceSignal } from './consensus-type
 import { normalizeSkillName } from './skill-name';
 
 /**
+ * Read `path.1` (rotated) then `path` (live), concatenating content so signal
+ * readers see the full history across log rotation boundaries. Chronological
+ * order is preserved: rotated content (older) is prepended before live content.
+ *
+ * Mirrors the pattern first used in PipelineDriftDetector.readTail
+ * (pipeline-drift-detector.ts:121-147). Extracted here so all PerformanceReader
+ * methods and dashboard endpoints share a single read path.
+ *
+ * Phase A fix for the signal-log-rotation data-loss bug (consensus
+ * 8cc22d50-93ab4d73). Phase B (write-time aggregate sidecar) is tracked
+ * separately at project_signal_log_rotation_data_loss.md.
+ */
+export function readJsonlWithRotated(filePath: string): string {
+  let rotatedContent = '';
+  let liveContent = '';
+  try {
+    const rotatedPath = filePath + '.1';
+    if (existsSync(rotatedPath)) {
+      rotatedContent = readFileSync(rotatedPath, 'utf-8');
+    }
+  } catch {
+    /* best-effort */
+  }
+  try {
+    if (existsSync(filePath)) {
+      liveContent = readFileSync(filePath, 'utf-8');
+    }
+  } catch {
+    /* best-effort */
+  }
+  if (!rotatedContent && !liveContent) return '';
+  if (!rotatedContent) return liveContent;
+  if (!liveContent) return rotatedContent;
+  // Ensure each file's content ends with a newline before concatenating so
+  // the last line of .1 and the first line of the live file don't merge.
+  const sep = rotatedContent.endsWith('\n') ? '' : '\n';
+  return rotatedContent + sep + liveContent;
+}
+
+/**
  * Skill-gated hallucination recovery — minimum clean-signal count in the
  * matching category required (alongside a bound skill) to apply the recovery
  * multiplier. Volume of unrelated positive signals must not wash away
@@ -290,9 +330,10 @@ export class PerformanceReader {
    * uses this to render banners and strike-through on retracted rounds.
    */
   getRetractedConsensusIds(): Set<string> {
-    if (!existsSync(this.filePath)) return new Set();
     try {
-      const lines = readFileSync(this.filePath, 'utf-8').trim().split('\n').filter(Boolean);
+      const raw = readJsonlWithRotated(this.filePath);
+      if (!raw) return new Set();
+      const lines = raw.trim().split('\n').filter(Boolean);
       const ids = new Set<string>();
       for (const line of lines) {
         try {
@@ -313,9 +354,10 @@ export class PerformanceReader {
    * so an admin view can see multiple retraction reasons for the same round.
    */
   getRoundRetractions(): Array<{ consensus_id: string; reason: string; retracted_at: string }> {
-    if (!existsSync(this.filePath)) return [];
     try {
-      const lines = readFileSync(this.filePath, 'utf-8').trim().split('\n').filter(Boolean);
+      const raw = readJsonlWithRotated(this.filePath);
+      if (!raw) return [];
+      const lines = raw.trim().split('\n').filter(Boolean);
       const out: Array<{ consensus_id: string; reason: string; retracted_at: string }> = [];
       for (const line of lines) {
         try {
@@ -477,9 +519,10 @@ export class PerformanceReader {
    * Don't unify these — see getCountersSince doc and consensus 9369ebfc-a3654b51 f1.
    */
   private readSignalsRaw(): ConsensusSignal[] {
-    if (!existsSync(this.filePath)) return [];
     try {
-      const lines = readFileSync(this.filePath, 'utf-8').trim().split('\n').filter(Boolean);
+      const raw = readJsonlWithRotated(this.filePath);
+      if (!raw) return [];
+      const lines = raw.trim().split('\n').filter(Boolean);
       const all = lines.map(line => {
         try { return JSON.parse(line) as ConsensusSignal; }
         catch { return null; }
@@ -534,11 +577,12 @@ export class PerformanceReader {
   }
 
   private readSignals(): PerformanceSignal[] {
-    if (!existsSync(this.filePath)) return [];
     try {
+      const raw = readJsonlWithRotated(this.filePath);
+      if (!raw) return [];
       const expiryMs = Date.now() - SIGNAL_EXPIRY_DAYS * 86400000;
 
-      const lines = readFileSync(this.filePath, 'utf-8').trim().split('\n').filter(Boolean);
+      const lines = raw.trim().split('\n').filter(Boolean);
       const all = lines.map(line => {
         try { return JSON.parse(line) as PerformanceSignal; }
         catch { return null; }

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -1186,7 +1186,7 @@ export class PerformanceReader {
     try {
       const now = Date.now();
       const expiryMs = now - SIGNAL_EXPIRY_DAYS * 86400000;
-      const lines = readFileSync(this.filePath, 'utf-8').trim().split('\n').filter(Boolean);
+      const lines = readJsonlWithRotated(this.filePath).trim().split('\n').filter(Boolean);
       let pass = 0, fail = 0, approved = 0, rejected = 0, lastImplSignalMs = 0;
       for (const line of lines) {
         try {

--- a/packages/orchestrator/src/round-counter.ts
+++ b/packages/orchestrator/src/round-counter.ts
@@ -35,6 +35,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { readJsonlWithRotated } from './performance-reader';
 
 const JSONL_FILENAME = 'agent-performance.jsonl';
 
@@ -105,12 +106,7 @@ function appendMetaRecord(
  * are counted. Malformed lines (truncated tail, partial JSON) are skipped.
  */
 function scanJsonl(filePath: string): Map<string, number> {
-  let raw: string;
-  try {
-    raw = fs.readFileSync(filePath, 'utf8');
-  } catch {
-    return new Map();
-  }
+  const raw = readJsonlWithRotated(filePath);
   if (raw.length === 0) return new Map();
 
   // Two-pass scan: first find the most recent reset offset per consensusId,

--- a/packages/orchestrator/src/skill-engine.ts
+++ b/packages/orchestrator/src/skill-engine.ts
@@ -11,7 +11,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, realpa
 import { randomBytes } from 'crypto';
 import { join, resolve } from 'path';
 import { ILLMProvider } from './llm-client';
-import { PerformanceReader } from './performance-reader';
+import { PerformanceReader, readJsonlWithRotated } from './performance-reader';
 import { LLMMessage } from '@gossip/types';
 import { ConsensusSignal } from './consensus-types';
 import { normalizeSkillName } from './skill-name';
@@ -717,7 +717,7 @@ ${inputs.join('\n')}
     const filePath = join(this.projectRoot, '.gossip', 'agent-performance.jsonl');
     if (!existsSync(filePath)) return [];
     try {
-      return readFileSync(filePath, 'utf-8').trim().split('\n').filter(Boolean)
+      return readJsonlWithRotated(filePath).trim().split('\n').filter(Boolean)
         .map(line => { try { return JSON.parse(line); } catch { return null; } })
         .filter((s): s is ConsensusSignal =>
           s !== null && s.type === 'consensus' && s.signal === 'category_confirmed' && s.category === category

--- a/packages/orchestrator/src/task-graph-sync.ts
+++ b/packages/orchestrator/src/task-graph-sync.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'fs';
+import { readJsonlWithRotated } from './performance-reader';
 import { join } from 'path';
 import { TaskGraph } from './task-graph';
 import type {
@@ -145,8 +145,8 @@ export class TaskGraphSync {
 
   async syncAgentScores(): Promise<number> {
     const perfPath = join(this.gossipDir, 'agent-performance.jsonl');
-    if (!existsSync(perfPath)) return 0;
-    const content = readFileSync(perfPath, 'utf-8');
+    const content = readJsonlWithRotated(perfPath);
+    if (!content) return 0;
     const lines = content.trim().split('\n').filter(Boolean);
     const meta = this.graph.getSyncMeta();
     let synced = 0;

--- a/packages/orchestrator/src/tool-router.ts
+++ b/packages/orchestrator/src/tool-router.ts
@@ -7,6 +7,7 @@ import { TOOL_SCHEMAS, PLAN_CHOICES, PENDING_PLAN_CHOICES } from './tool-definit
 import type { ToolCall, ToolResult, DispatchPlan, PlannedTask, TaskProgressEvent } from './types';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
+import { readJsonlWithRotated } from './performance-reader';
 
 import { log as _log } from './log';
 const log = (msg: string) => _log('tool-router', msg);
@@ -956,7 +957,7 @@ Keep it SHORT — under 30 lines. This is a working document, not a design doc.`
       return { text: 'No performance data found.' };
     }
 
-    const rawLines = readFileSync(perfPath, 'utf-8').trim().split('\n').filter(Boolean);
+    const rawLines = readJsonlWithRotated(perfPath).trim().split('\n').filter(Boolean);
     const last20 = rawLines.slice(-20).map(line => {
       try { return JSON.parse(line); } catch (_e) { return null; }
     }).filter(Boolean);

--- a/packages/relay/src/dashboard/api-consensus.ts
+++ b/packages/relay/src/dashboard/api-consensus.ts
@@ -1,5 +1,5 @@
-import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
+import { readJsonlWithRotated } from '@gossip/orchestrator';
 
 interface ConsensusSignal {
   type: string;
@@ -63,11 +63,11 @@ export async function consensusHandler(projectRoot: string, query?: URLSearchPar
   }
   const retractedConsensusIds = Array.from(retractedIds);
 
-  if (!existsSync(perfPath)) return { runs: [], totalRuns: 0, totalSignals: 0, page, pageSize, retractedConsensusIds, roundRetractions };
-
   const signals: ConsensusSignal[] = [];
   try {
-    const lines = readFileSync(perfPath, 'utf-8').trim().split('\n').filter(Boolean);
+    const raw = readJsonlWithRotated(perfPath);
+    if (!raw) return { runs: [], totalRuns: 0, totalSignals: 0, page, pageSize, retractedConsensusIds, roundRetractions };
+    const lines = raw.trim().split('\n').filter(Boolean);
     for (const line of lines) {
       try {
         const parsed = JSON.parse(line);

--- a/packages/relay/src/dashboard/api-finding.ts
+++ b/packages/relay/src/dashboard/api-finding.ts
@@ -1,4 +1,5 @@
 import { readFileSync, existsSync, realpathSync } from 'fs';
+import { readJsonlWithRotated } from '@gossip/orchestrator';
 import { join, resolve, relative } from 'path';
 
 // Consensus/finding IDs come from URL segments after decodeURIComponent.
@@ -111,23 +112,26 @@ export async function findingHandler(
 
   const signals: FindingDetailSignal[] = [];
   const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
-  if (existsSync(perfPath)) {
-    const lines = readFileSync(perfPath, 'utf-8').trim().split('\n').filter(Boolean);
-    for (const line of lines) {
-      try {
-        const rec = JSON.parse(line);
-        if (rec.findingId === findingId) {
-          signals.push({
-            signal: rec.signal,
-            agentId: rec.agentId,
-            counterpartId: rec.counterpartId,
-            evidence: rec.evidence,
-            timestamp: rec.timestamp,
-          });
-        }
-      } catch { /* skip */ }
+  try {
+    const raw = readJsonlWithRotated(perfPath);
+    if (raw) {
+      const lines = raw.trim().split('\n').filter(Boolean);
+      for (const line of lines) {
+        try {
+          const rec = JSON.parse(line);
+          if (rec.findingId === findingId) {
+            signals.push({
+              signal: rec.signal,
+              agentId: rec.agentId,
+              counterpartId: rec.counterpartId,
+              evidence: rec.evidence,
+              timestamp: rec.timestamp,
+            });
+          }
+        } catch { /* skip */ }
+      }
     }
-  }
+  } catch { /* best-effort */ }
 
   const citations = extractCitations(found.finding || '', projectRoot);
 

--- a/packages/relay/src/dashboard/api-fleet-trend.ts
+++ b/packages/relay/src/dashboard/api-fleet-trend.ts
@@ -1,5 +1,6 @@
-import { readFileSync, existsSync, statSync } from 'fs';
+import { existsSync, statSync } from 'fs';
 import { join } from 'path';
+import { readJsonlWithRotated } from '@gossip/orchestrator';
 
 export interface FleetTrendPoint {
   day: string; // ISO date YYYY-MM-DD
@@ -54,7 +55,9 @@ export async function fleetTrendHandler(projectRoot: string, query?: URLSearchPa
   const buckets = new Map<string, Map<string, { good: number; total: number }>>();
 
   try {
-    const lines = readFileSync(perfPath, 'utf-8').trim().split('\n').filter(Boolean);
+    const raw = readJsonlWithRotated(perfPath);
+    if (!raw) return { days, points: [] };
+    const lines = raw.trim().split('\n').filter(Boolean);
     for (const line of lines) {
       try {
         const rec = JSON.parse(line);

--- a/packages/relay/src/dashboard/api-overview.ts
+++ b/packages/relay/src/dashboard/api-overview.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
+import { readJsonlWithRotated } from '@gossip/orchestrator';
 import { isUtilityAgent } from './utility-agents';
 
 interface AgentConfigLike {
@@ -210,9 +211,10 @@ export async function overviewHandler(projectRoot: string, ctx: OverviewContext)
   const runBuckets = new Map<string, RunBucket>();
 
   const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
-  if (existsSync(perfPath)) {
+  {
     try {
-      const lines = readFileSync(perfPath, 'utf-8').trim().split('\n').filter(Boolean);
+      const raw = readJsonlWithRotated(perfPath);
+      const lines = raw ? raw.trim().split('\n').filter(Boolean) : [];
       for (const line of lines) {
         try {
           const entry = JSON.parse(line);

--- a/packages/relay/src/dashboard/api-signals.ts
+++ b/packages/relay/src/dashboard/api-signals.ts
@@ -1,5 +1,5 @@
-import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
+import { readJsonlWithRotated } from '@gossip/orchestrator';
 
 interface SignalEntry {
   type: string;
@@ -80,13 +80,14 @@ export async function signalsHandler(projectRoot: string, query?: URLSearchParam
   const offset = Math.max(parseInt(query?.get('offset') ?? '', 10) || 0, 0);
 
   const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
-  if (!existsSync(perfPath)) return { items: [], total: 0, offset, limit };
 
   const all: SignalEntry[] = [];
   const roundRetractions: RoundRetractionEntry[] = [];
   const signalFilterSet = signalFilters.length ? new Set(signalFilters) : null;
   try {
-    const lines = readFileSync(perfPath, 'utf-8').trim().split('\n').filter(Boolean);
+    const raw = readJsonlWithRotated(perfPath);
+    if (!raw) return { items: [], total: 0, offset, limit };
+    const lines = raw.trim().split('\n').filter(Boolean);
     for (const line of lines) {
       try {
         const entry = JSON.parse(line);

--- a/tests/orchestrator/performance-reader-rotation.test.ts
+++ b/tests/orchestrator/performance-reader-rotation.test.ts
@@ -5,10 +5,11 @@
  * (consensus 8cc22d50-93ab4d73).
  */
 
-import { mkdtempSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { readJsonlWithRotated, PerformanceReader } from '../../packages/orchestrator/src/performance-reader';
+import * as RoundCounter from '../../packages/orchestrator/src/round-counter';
 
 let tmpDir: string;
 
@@ -111,9 +112,8 @@ describe('PerformanceReader — reads signals from both live and rotated files',
     expect(agentScore!.totalSignals).toBe(5);
   });
 
-  it('getScores returns 0 signals when only .1 existed at time of writing and live is empty', () => {
+  it('getScores returns signals from .1 even when live file is empty', () => {
     const gossipDir = join(tmpDir, '.gossip');
-    const { mkdirSync } = require('fs');
     mkdirSync(gossipDir, { recursive: true });
 
     const perfPath = join(gossipDir, 'agent-performance.jsonl');
@@ -132,5 +132,52 @@ describe('PerformanceReader — reads signals from both live and rotated files',
 
     expect(agentScore).toBeDefined();
     expect(agentScore!.totalSignals).toBe(2);
+  });
+});
+
+// ── Integration: all 7 migrated readers see signals from both live and .1 ────
+
+describe('Phase A completeness — migrated readers see rotated signals', () => {
+  beforeEach(() => RoundCounter.__resetForTests());
+
+  function makeImplSignal(agentId: string, signal: string, daysAgo = 1): string {
+    const ts = new Date(Date.now() - daysAgo * 86400000).toISOString();
+    return JSON.stringify({ type: 'impl', agentId, signal, timestamp: ts });
+  }
+
+  function makeRoundBump(consensusId: string): string {
+    return JSON.stringify({ type: '_meta', signal: 'round_counter_bumped', consensusId, timestamp: new Date().toISOString() });
+  }
+
+  it('getImplScore and scanJsonl (round-counter.get) each recover signals from the .1 slot', () => {
+    const gossipDir = join(tmpDir, '.gossip');
+    mkdirSync(gossipDir, { recursive: true });
+    const perfPath = join(gossipDir, 'agent-performance.jsonl');
+
+    // Rotated slot: 2 impl_test_pass + 2 round_counter_bumped for consensusId 'cid-a'
+    const rotated = [
+      makeImplSignal('agent-z', 'impl_test_pass'),
+      makeImplSignal('agent-z', 'impl_test_pass'),
+      makeRoundBump('cid-a'),
+      makeRoundBump('cid-a'),
+    ].join('\n') + '\n';
+    writeFileSync(perfPath + '.1', rotated);
+
+    // Live slot: 1 more impl_test_pass + 1 more round bump
+    const live = [
+      makeImplSignal('agent-z', 'impl_test_pass'),
+      makeRoundBump('cid-a'),
+    ].join('\n') + '\n';
+    writeFileSync(perfPath, live);
+
+    // getImplScore — should see all 3 passes (2 from .1, 1 from live)
+    const reader = new PerformanceReader(tmpDir);
+    const implScore = reader.getImplScore('agent-z');
+    expect(implScore).not.toBeNull();
+    expect(implScore!.passRate).toBeCloseTo(1.0, 5); // 3/3 pass
+
+    // scanJsonl via round-counter.get — should see 3 bumps (2 from .1, 1 from live)
+    const count = RoundCounter.get(tmpDir, 'cid-a');
+    expect(count).toBe(3);
   });
 });

--- a/tests/orchestrator/performance-reader-rotation.test.ts
+++ b/tests/orchestrator/performance-reader-rotation.test.ts
@@ -1,0 +1,136 @@
+// @gossip:impact-adjacent:signal_pipeline
+/**
+ * Tests for the readJsonlWithRotated helper and migration of PerformanceReader
+ * methods to use it — Phase A fix for the signal-log-rotation data-loss bug
+ * (consensus 8cc22d50-93ab4d73).
+ */
+
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readJsonlWithRotated, PerformanceReader } from '../../packages/orchestrator/src/performance-reader';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'gossip-rotation-test-'));
+});
+
+afterEach(() => {
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+});
+
+// ── readJsonlWithRotated unit tests ──────────────────────────────────────────
+
+describe('readJsonlWithRotated', () => {
+  it('returns empty string when neither file exists', () => {
+    const result = readJsonlWithRotated(join(tmpDir, 'missing.jsonl'));
+    expect(result).toBe('');
+  });
+
+  it('returns live content when only live file exists', () => {
+    const liveFile = join(tmpDir, 'perf.jsonl');
+    writeFileSync(liveFile, '{"a":1}\n{"b":2}\n');
+    const result = readJsonlWithRotated(liveFile);
+    expect(result).toBe('{"a":1}\n{"b":2}\n');
+  });
+
+  it('returns rotated content when only .1 file exists', () => {
+    const liveFile = join(tmpDir, 'perf.jsonl');
+    writeFileSync(liveFile + '.1', '{"old":1}\n{"old":2}\n');
+    const result = readJsonlWithRotated(liveFile);
+    expect(result).toBe('{"old":1}\n{"old":2}\n');
+  });
+
+  it('concatenates .1 (older) before live when both exist', () => {
+    const liveFile = join(tmpDir, 'perf.jsonl');
+    writeFileSync(liveFile + '.1', '{"older":1}\n');
+    writeFileSync(liveFile, '{"newer":2}\n');
+    const result = readJsonlWithRotated(liveFile);
+    expect(result).toBe('{"older":1}\n{"newer":2}\n');
+    // rotated content must come FIRST (older = lower offset)
+    expect(result.indexOf('"older"')).toBeLessThan(result.indexOf('"newer"'));
+  });
+
+  it('inserts separator newline when .1 content lacks trailing newline', () => {
+    const liveFile = join(tmpDir, 'perf.jsonl');
+    // .1 file without trailing newline
+    writeFileSync(liveFile + '.1', '{"older":1}');
+    writeFileSync(liveFile, '{"newer":2}\n');
+    const result = readJsonlWithRotated(liveFile);
+    // The two JSON objects should be on separate lines
+    const lines = result.split('\n').filter(Boolean);
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0])).toEqual({ older: 1 });
+    expect(JSON.parse(lines[1])).toEqual({ newer: 2 });
+  });
+});
+
+// ── PerformanceReader.readSignals migration smoke test ───────────────────────
+
+describe('PerformanceReader — reads signals from both live and rotated files', () => {
+  function makeSignal(agentId: string, signal: string, daysAgo = 1): string {
+    const ts = new Date(Date.now() - daysAgo * 86400000).toISOString();
+    return JSON.stringify({
+      type: 'consensus',
+      agentId,
+      signal,
+      taskId: 'task-abc',
+      timestamp: ts,
+    });
+  }
+
+  it('getScores counts signals from both live and .1 when both exist', () => {
+    const gossipDir = join(tmpDir, '.gossip');
+    const { mkdirSync } = require('fs');
+    mkdirSync(gossipDir, { recursive: true });
+
+    const perfPath = join(gossipDir, 'agent-performance.jsonl');
+
+    // Write 3 agreement signals to the rotated .1 slot
+    const rotatedContent = [
+      makeSignal('agent-x', 'agreement'),
+      makeSignal('agent-x', 'agreement'),
+      makeSignal('agent-x', 'agreement'),
+    ].join('\n') + '\n';
+    writeFileSync(perfPath + '.1', rotatedContent);
+
+    // Write 2 agreement signals to the live slot
+    const liveContent = [
+      makeSignal('agent-x', 'agreement'),
+      makeSignal('agent-x', 'agreement'),
+    ].join('\n') + '\n';
+    writeFileSync(perfPath, liveContent);
+
+    const reader = new PerformanceReader(tmpDir);
+    const scores = reader.getScores();
+    const agentScore = scores.get('agent-x');
+
+    expect(agentScore).toBeDefined();
+    // Should see all 5 signals (3 from .1 + 2 from live)
+    expect(agentScore!.totalSignals).toBe(5);
+  });
+
+  it('getScores returns 0 signals when only .1 existed at time of writing and live is empty', () => {
+    const gossipDir = join(tmpDir, '.gossip');
+    const { mkdirSync } = require('fs');
+    mkdirSync(gossipDir, { recursive: true });
+
+    const perfPath = join(gossipDir, 'agent-performance.jsonl');
+
+    // Only the rotated slot exists (simulates post-rotation before new writes)
+    const rotatedContent = [
+      makeSignal('agent-y', 'agreement'),
+      makeSignal('agent-y', 'unique_confirmed'),
+    ].join('\n') + '\n';
+    writeFileSync(perfPath + '.1', rotatedContent);
+    // No live file
+
+    const reader = new PerformanceReader(tmpDir);
+    const scores = reader.getScores();
+    const agentScore = scores.get('agent-y');
+
+    expect(agentScore).toBeDefined();
+    expect(agentScore!.totalSignals).toBe(2);
+  });
+});

--- a/tests/orchestrator/tool-router.test.ts
+++ b/tests/orchestrator/tool-router.test.ts
@@ -549,7 +549,9 @@ describe('ToolExecutor', () => {
       JSON.stringify({ agentId: 'writer', signal: 'agreement', outcome: 'confirmed' }),
     ].join('\n');
 
-    mockExistsSync.mockReturnValue(true);
+    // existsSync returns true for the live perf file but false for the .1 rotated slot
+    // so readJsonlWithRotated only reads live content (3 signals).
+    mockExistsSync.mockImplementation((p: unknown) => !String(p).endsWith('.1'));
     mockReadFileSync.mockReturnValue(jsonlData);
 
     const result = await executor.execute({ tool: 'agent_performance', args: {} });


### PR DESCRIPTION
## Summary

**CRITICAL fix** for consensus `8cc22d50-93ab4d73` (haiku-researcher + sonnet-reviewer): signal log rotation at 5MB destructively renames `agent-performance.jsonl` → `.jsonl.1`, but ALL readers except `PipelineDriftDetector.readTail` were reading only the live file. After the 2026-05-08 11:24:23 rotation, **12,150 lines (3,532 sonnet-reviewer signals — 97% of total)** became invisible to:

- Skill effectiveness gate (`MIN_EVIDENCE = 80` against `postTotal` for graduation)
- Dispatch weight scoring (`scoringSignals < 3` neutral-weight floor)
- Retraction tombstone resolution
- All 5 dashboard endpoints
- task-graph-sync uploads
- `gossip_watch` MCP tool

15 pending skills across 6 agents had `bound_at` before rotation → `postTotal=0` against the 80-signal gate; skills weeks from graduating were silently stalled.

## consensus-id

- `consensus-id: 8cc22d50-93ab4d73` — initial 7-reader cluster (haiku-researcher + sonnet-reviewer)
- `consensus-id: phase-a-pr367` — follow-up 7-reader gap (haiku + sonnet + orchestrator verification on this PR)

## What this PR does

Two commits on this branch:

### Commit 1 (4114267) — initial Phase A
Adds `readJsonlWithRotated(path)` helper that concatenates `.jsonl.1` (older, first) + `.jsonl` (live, last) for chronological order — mirrors the existing `PipelineDriftDetector.readTail` pattern. Migrates 7 read sites + HANDBOOK invariant #2 doc fix.

**Migrated readers (commit 1):**
- `PerformanceReader.readSignals` + `readSignalsRaw`
- `PerformanceReader.getRetractedConsensusIds` + `getRoundRetractions`
- 5 dashboard endpoints (`api-consensus`, `api-fleet-trend`, `api-finding`, `api-signals`, `api-overview`)
- `task-graph-sync.syncAgentScores`
- `gossip_watch` MCP tool

### Commit 2 (9ec8a6b) — consensus completeness
In-session consensus on commit 1 (haiku + sonnet + orchestrator grep) caught 7 more unmigrated readers + 2 HANDBOOK contradictions + 1 test name bug. All addressed:

**Migrated readers (commit 2):**
- `performance-reader.ts:1189` — `getImplScore` (CRITICAL — impl dispatch weight)
- `tool-router.ts:954-960` — `handleAgentPerformance` (HIGH — diagnostic view)
- `skill-engine.ts:717-720` — `loadCategoryFindings` (HIGH — skill prompt quality)
- `round-counter.ts:107-115` — `scanJsonl` (MEDIUM — self-telemetry across rotation, **@gossip:impact-adjacent:data_integrity**)
- `mcp-server-sdk.ts:1506` — actionable-rounds window (HIGH)
- `mcp-server-sdk.ts:2570` — findingId dedup, bulk consensus (HIGH)
- `mcp-server-sdk.ts:2852` — findingId dedup, gossip_signals (HIGH)

**HANDBOOK doc drift fixes (lines 182, 278, 302):** MIN_EVIDENCE 120→80; cooldown counter; "~360 → ~240 signals" derived from `3 × MIN_EVIDENCE`.

**Test name fix:** test at `performance-reader-rotation.test.ts:114` had name "returns 0 signals" but asserted `=== 2`. Renamed to match actual behavior.

## Out of scope (filed as follow-up)

Phase B — write-time aggregate sidecar matching the BM25 memory-index pattern (PR #364) — is filed at `project_signal_log_rotation_data_loss.md`. Architectural fix for the destructive single-slot rotation itself. Not in this PR.

## Recovery quantification

~3,627 sonnet-reviewer signals visible again (95 live + 3,532 rotated). The 12,150-line `.1` snapshot is also duplicated to `.gossip/agent-performance.jsonl.preserve-2026-05-08` as belt-and-suspenders.

## Test plan

- [x] `npm run build` — full workspace, green
- [x] `npm test --ci` — 230 suites, 3035 tests, 0 failures (+8 new across migration + integration)
- [x] `readJsonlWithRotated` unit tests (4 edge cases)
- [x] Integration tests: `PerformanceReader.getScores()`, `getImplScore`, `RoundCounter.get` across rotation boundary
- [x] In-session consensus reviewed by haiku-researcher + sonnet-reviewer + orchestrator manual grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)