### PR TITLE
fix(dashboard): editorial theme contrast — v2 palette with WCAG AA fixes

### DIFF
--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -74,9 +74,9 @@ body {
   --color-card: #EAE5D9;
   --color-card-foreground: #0E0E0C;
   --color-muted: #EAE5D9;
-  --color-muted-foreground: #6B6657;
-  --color-border: #D6D0BF;
-  --color-input: #D6D0BF;
+  --color-muted-foreground: #524E41;
+  --color-border: #C8C1AB;
+  --color-input: #C8C1AB;
 
   /* Primary / accent */
   --color-ring: #A4161A;
@@ -84,7 +84,7 @@ body {
   --color-primary-foreground: #F4F1EA;
   --color-secondary: #EAE5D9;
   --color-secondary-foreground: #0E0E0C;
-  --color-accent: #D6D0BF;
+  --color-accent: #C4BB9E;
   --color-accent-foreground: #0E0E0C;
 
   /* Destructive unchanged — still red */
@@ -94,19 +94,19 @@ body {
   /* Semantic finding colors */
   --color-confirmed: #2D6A4F;
   --color-disputed: #A4161A;
-  --color-unverified: #B08900;
+  --color-unverified: #7A5F00;
   --color-unique: #1D3557;
 
   /* Severity */
-  --color-severity-high: #C0383D;  /* lighter crimson, distinguishable from --color-disputed #A4161A */
+  --color-severity-high: #B83235;  /* warmer crimson, AA on card, distinguishable from --color-disputed #A4161A */
 
   /* v3 additions */
   --color-impact: #1D3557;
   --color-insight: #6B6657;
-  --color-text-dim: #9B9583;
+  --color-text-dim: #6B6657;
 
   /* Chart palette — olive/warm tones for editorial */
-  --color-chart: #6B6657;
+  --color-chart: #1E4D52;
   --color-chart-accent: #2D6A4F;
   --color-chart-deep: #1D3557;
 
@@ -141,10 +141,10 @@ html:has([data-theme="editorial"])::after,
 
 /* ───── Editorial scrollbar override ───── */
 [data-theme="editorial"] ::-webkit-scrollbar-thumb {
-  background: rgba(107, 102, 87, 0.3);
+  background: rgba(82, 78, 65, 0.3);
 }
 [data-theme="editorial"] ::-webkit-scrollbar-thumb:hover {
-  background: rgba(107, 102, 87, 0.5);
+  background: rgba(82, 78, 65, 0.5);
 }
 
 /* ───── Editorial inline-code override ───── */


### PR DESCRIPTION
## Summary

- Resolves user-reported *"editorial theme colors not bold, contrast difficult"*.
- 3 live WCAG AA failures fixed in the editorial palette, plus 6 token revisions + 2 scrollbar literals.
- CSS-only change, 10 insertions / 10 deletions in `packages/dashboard-v2/src/globals.css`.

## What changed

| Token | Old | New | Why |
|---|---|---|---|
| `--color-muted-foreground` | `#6B6657` | `#524E41` | ~6:1 on card, near-AAA body |
| `--color-border` | `#D6D0BF` | `#C8C1AB` | resyncs with new accent |
| `--color-input` | `#D6D0BF` | `#C8C1AB` | resyncs with new accent |
| `--color-accent` | `#D6D0BF` | `#C4BB9E` | perceptible hover layer |
| `--color-unverified` | `#B08900` | `#7A5F00` | fixes live 2.81/2.51 AA fail |
| `--color-severity-high` | `#C0383D` | `#B83235` | fixes live 4.31:1 AA fail |
| `--color-text-dim` | `#9B9583` | `#6B6657` | fixes live 2.75/2.45 AA fail |
| `--color-chart` | `#6B6657` | `#1E4D52` | deep teal, out of amber family |
| scrollbar thumb | `rgba(107,102,87,*)` | `rgba(82,78,65,*)` | matches new muted-fg |

`--color-insight` is left unchanged: it's currently orphaned in consumers (`FindingDetailDrawer` uses `text-muted-foreground`, `FindingsMetrics` uses hardcoded `text-zinc-500`). Wiring `text-insight` properly is a follow-up.

## Consensus round 532d78b3-d5174b9b

Three-agent gossipcat consensus (sonnet-designer × sonnet-reviewer × gemini-reviewer):

- **v1 proposal (sonnet-designer)** hit WCAG AA on every hex pick. Orchestrator independently verified the contrast arithmetic.
- **gemini-reviewer cross-review** claimed several v1 picks failed AA — orchestrator + sonnet-reviewer independently re-computed and showed gemini's math was wrong by ~1.0 across three findings. Three `hallucination_caught` signals recorded against gemini-reviewer (f1/f2/f3).
- **sonnet-reviewer cross-review** caught 5 real structural issues in v1: border/input desync with accent, scrollbar RGB literal not tracking the muted-foreground shift, orphaned insight token, chart/unverified amber collision on AgentCardBig, and text-dim/muted step collapse. All 5 addressed in v2.
- **Gap discovered**: `--color-severity-high #C0383D` is itself a live AA failure (~4.31:1 on card). v2 patch covers it.

Signals recorded:
- `hallucination_caught` × 3 → `gemini-reviewer:f1/f2/f3` (contrast math errors)
- `unique_confirmed` × 2 → `gemini-reviewer:f4/f5` (missing tokens, duplicate hex enumeration)
- `unique_confirmed` × 1 → `sonnet-reviewer:f6` (AgentCardBig amber proximity)

## Test plan

- [x] Build: `cd packages/dashboard-v2 && npm run build` — passes (77.92 kB CSS, no errors)
- [x] Visual verify (editorial theme): AgentCardBig accuracy/reliability/unique/impact bars render at distinct, readable contrast; cards have visible borders; chart teal does not collide with unverified amber.
- [ ] CI green (typecheck + workspace build)
- [ ] Reviewer eyeballs the editorial theme on the deployed dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)