### PR TITLE
fix(dashboard): wire insight consumers to --color-insight token

### DIFF
--- a/packages/dashboard-v2/src/components/FindingDetailDrawer.tsx
+++ b/packages/dashboard-v2/src/components/FindingDetailDrawer.tsx
@@ -25,7 +25,7 @@ const TAG_COLORS: Record<string, string> = {
   disputed: 'text-disputed bg-disputed/10 border border-disputed/20',
   unverified: 'text-unverified bg-unverified/10 border border-unverified/20',
   unique: 'text-unique bg-unique/10 border border-unique/20',
-  insight: 'text-muted-foreground bg-muted border border-border/40',
+  insight: 'text-insight bg-insight/10 border border-insight/20',
   newFinding: 'text-unique bg-unique/10 border border-unique/20',
 };
 

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -41,7 +41,7 @@ const FILTER_CHIPS: { key: FilterType; label: string; cls: string; activeCls: st
   { key: 'unique', label: 'Unique', cls: 'text-unique/50 border-unique/20 hover:border-unique/40', activeCls: 'text-unique bg-unique/10 border-unique/40' },
   { key: 'disputed', label: 'Disputed', cls: 'text-disputed/50 border-disputed/20 hover:border-disputed/40', activeCls: 'text-disputed bg-disputed/10 border-disputed/40' },
   { key: 'unverified', label: 'Unverified', cls: 'text-unverified/50 border-unverified/20 hover:border-unverified/40', activeCls: 'text-unverified bg-unverified/10 border-unverified/40' },
-  { key: 'insight', label: 'Insight', cls: 'text-zinc-500 border-zinc-500/20 hover:border-zinc-500/40', activeCls: 'text-zinc-400 bg-zinc-500/10 border-zinc-500/40', tooltip: 'Observations without a specific file:line anchor. Not scored — cannot be confirmed or disputed by peers.' },
+  { key: 'insight', label: 'Insight', cls: 'text-insight/60 border-insight/20 hover:border-insight/40', activeCls: 'text-insight bg-insight/10 border-insight/40', tooltip: 'Observations without a specific file:line anchor. Not scored — cannot be confirmed or disputed by peers.' },
 ];
 
 const SEV_FILTER_CHIPS: { key: 'all' | 'critical' | 'high' | 'medium' | 'low'; label: string; cls: string; activeCls: string }[] = [


### PR DESCRIPTION
## Summary

- Closes the orphan token flagged in PR #368 cross-review (consensus `532d78b3-d5174b9b`).
- Two consumer files now actually use `--color-insight` instead of `text-muted-foreground` / hardcoded `text-zinc-500`.
- 2 insertions / 2 deletions across `FindingDetailDrawer.tsx` and `FindingsMetrics.tsx`.

## Why

Both themes already define `--color-insight` (default `#71717a`, editorial `#6B6657`), but no component was using it. Future palette work on insight findings would silently fail to reach the UI.

## Changes

- `FindingDetailDrawer.tsx:28` — insight tag class: `text-muted-foreground bg-muted border border-border/40` → `text-insight bg-insight/10 border border-insight/20` (matches sibling tags' shape)
- `FindingsMetrics.tsx:44` — insight filter chip: `text-zinc-500 border-zinc-500/20 ... text-zinc-400 bg-zinc-500/10 border-zinc-500/40` → `text-insight/60 border-insight/20 ... text-insight bg-insight/10 border-insight/40`

## Test plan

- [x] Build: `cd packages/dashboard-v2 && npm run build` — passes (CSS bumped 77.92→78.28 kB as Tailwind generates the insight utility classes)
- [x] Visual verify on running dashboard, editorial theme — insight chip renders, drawer pill renders
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)