### PR TITLE
ci(impact-gate): fire on PR `edited` so post-open consensus-id is seen

### DIFF
--- a/.github/workflows/impact-adjacency-gate.yml
+++ b/.github/workflows/impact-adjacency-gate.yml
@@ -2,6 +2,14 @@ name: Impact-Adjacency Gate
 
 on:
   pull_request:
+    # Default activity types are opened/synchronize/reopened. We add `edited`
+    # so that updating the PR body to include a `consensus-id: <hex>-<hex>`
+    # marker re-runs the gate against the new body. Without this, the gate
+    # reads from a frozen event payload and `gh run rerun` replays the
+    # original (stale) body — the gate fails identically until an empty
+    # commit forces a `synchronize` event. See
+    # ~/.claude/projects/-Users-goku-Desktop-gossip/memory/project_impact_adjacency_gate_rerun_staleness.md
+    types: [opened, synchronize, reopened, edited]
     branches: [master]
 
 jobs:


### PR DESCRIPTION
## Summary

- 1-line workflow change: add `edited` to the impact-adjacency gate's `pull_request` activity types.
- Closes the rerun-staleness footgun documented in `project_impact_adjacency_gate_rerun_staleness.md`.

## Why

The gate triggers on the default `pull_request` activity types (`opened`, `synchronize`, `reopened`). When an operator opens a PR without the `consensus-id: <hex>-<hex>` marker and adds it later via "Edit description", no workflow fires.

Running `gh run rerun` on the failed job replays the *original* event payload (the body at open-time). The gate reads from `${{ github.event.pull_request.body }}` which is frozen on the event, so it fails identically. The only workaround was pushing an empty commit to fire `synchronize` with the current body.

PR #367 (signal-log-rotation Phase A) hit this twice in the same session, which is what surfaced the bug.

## Risk

`edited` also fires on title changes, base-branch changes, milestone changes — so the gate will run a few extra times per PR. The gate is ~10s, so cost is negligible.

## Test plan

- [x] `actionlint` clean — this is comment-only + a single `types:` line
- [x] CI will run on this PR itself (which is `opened`), proving the trigger still fires under the default activity
- [ ] After merge, the next PR that gets its body edited to add `consensus-id` will validate the new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)