### PR TITLE
feat(orchestrator): signal-aggregate sidecar Phase B follow-ups — reader cache, tamper validation, bucket cap

### DIFF
--- a/packages/orchestrator/src/signal-aggregate-index.ts
+++ b/packages/orchestrator/src/signal-aggregate-index.ts
@@ -45,11 +45,16 @@ import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSyn
 import { join, dirname } from 'path';
 import { ConsensusSignal } from './consensus-types';
 import { readJsonlWithRotated } from './performance-reader';
+import { SAFE_NAME } from './skill-engine';
 
 export const SIDECAR_VERSION = 1;
 export const SIDECAR_FILENAME = 'signal-aggregate-index.json';
 export const AGENT_PERFORMANCE_FILENAME = 'agent-performance.jsonl';
 const RECENT_RETRACTIONS_CAP = 16;
+
+// Fix 1: mtime-keyed reader cache — mirrors PerformanceReader.cachedScores pattern.
+let cachedAggregateData: SignalAggregateIndexData | null = null;
+let cachedAggregateMtimeMs = 0;
 
 export interface SignalAggregateBucket {
   correct: number;
@@ -105,10 +110,30 @@ export function classifyForAggregate(signal: string): 'correct' | 'hallucinated'
 /**
  * Read the sidecar JSON from disk. Returns `null` if missing, malformed, or
  * carrying a version we don't recognise — callers must rebuild on `null`.
+ *
+ * Fix 1: mtime-keyed reader cache — skips readFileSync+JSON.parse when the
+ *   file has not changed since the last read (mirrors PerformanceReader.getScores).
+ * Fix 2: SAFE_NAME tamper validation — rejects hostile agentId/category keys
+ *   that could cause identity mis-attribution (e.g. "../../etc/passwd").
  */
 export function readAggregateIndex(projectRoot: string): SignalAggregateIndexData | null {
   const path = join(projectRoot, '.gossip', SIDECAR_FILENAME);
-  if (!existsSync(path)) return null;
+  if (!existsSync(path)) {
+    cachedAggregateData = null;
+    cachedAggregateMtimeMs = 0;
+    return null;
+  }
+  let mtimeMs = 0;
+  try {
+    mtimeMs = statSync(path).mtimeMs;
+  } catch (err) {
+    logSidecarError('stat', err);
+    return null;
+  }
+  // Fix 1: cache hit — return without re-reading disk.
+  if (cachedAggregateData !== null && mtimeMs === cachedAggregateMtimeMs) {
+    return cachedAggregateData;
+  }
   let raw: string;
   try {
     raw = readFileSync(path, 'utf-8');
@@ -127,12 +152,23 @@ export function readAggregateIndex(projectRoot: string): SignalAggregateIndexDat
   const obj = parsed as Partial<SignalAggregateIndexData>;
   if (obj.version !== SIDECAR_VERSION) return null;
   if (!obj.agents || typeof obj.agents !== 'object' || Array.isArray(obj.agents)) return null;
-  return {
+  // Fix 2: SAFE_NAME validation — reject any hostile key before caching.
+  for (const agentId of Object.keys(obj.agents)) {
+    if (!SAFE_NAME.test(agentId)) return null;
+    for (const category of Object.keys((obj.agents as Record<string, Record<string, unknown>>)[agentId] ?? {})) {
+      if (!SAFE_NAME.test(category)) return null;
+    }
+  }
+  const result: SignalAggregateIndexData = {
     version: SIDECAR_VERSION,
     rebuiltAt: typeof obj.rebuiltAt === 'string' ? obj.rebuiltAt : new Date(0).toISOString(),
     lastRawTimestampMs: typeof obj.lastRawTimestampMs === 'number' ? obj.lastRawTimestampMs : 0,
     agents: obj.agents as SignalAggregateIndexData['agents'],
   };
+  // Store in cache only after validation passes.
+  cachedAggregateData = result;
+  cachedAggregateMtimeMs = mtimeMs;
+  return result;
 }
 
 /**
@@ -207,6 +243,8 @@ export function recordRetraction(
   return touched;
 }
 
+const BUCKET_CAP = 5;
+
 function ensureBucket(
   data: SignalAggregateIndexData,
   agentId: string,
@@ -219,6 +257,13 @@ function ensureBucket(
   const byBound = byCat[category];
   const key = String(boundAtMs);
   if (!byBound[key]) {
+    // Fix 3: evict oldest bucket when at capacity to prevent unbounded growth
+    // across frequent skill-rebind epochs. Numeric sort is critical — lexical
+    // sort mangles "9" > "10".
+    const sorted = Object.keys(byBound).map(k => parseInt(k, 10)).sort((a, b) => a - b);
+    if (sorted.length >= BUCKET_CAP) {
+      delete byBound[String(sorted[0])];
+    }
     byBound[key] = {
       correct: 0,
       hallucinated: 0,

--- a/packages/orchestrator/src/signal-aggregate-index.ts
+++ b/packages/orchestrator/src/signal-aggregate-index.ts
@@ -130,8 +130,10 @@ export function readAggregateIndex(projectRoot: string): SignalAggregateIndexDat
     logSidecarError('stat', err);
     return null;
   }
-  // Fix 1: cache hit — return without re-reading disk.
-  if (cachedAggregateData !== null && mtimeMs === cachedAggregateMtimeMs) {
+  // Fix 1+2: cache hit — return without re-reading disk. The +1ms guard mirrors
+  // sidecarIsStale's buffer and closes the same-ms external-write race where a
+  // write lands at the same millisecond tick as the stat call.
+  if (cachedAggregateData !== null && mtimeMs === cachedAggregateMtimeMs && Date.now() > cachedAggregateMtimeMs + 1) {
     return cachedAggregateData;
   }
   let raw: string;
@@ -153,10 +155,14 @@ export function readAggregateIndex(projectRoot: string): SignalAggregateIndexDat
   if (obj.version !== SIDECAR_VERSION) return null;
   if (!obj.agents || typeof obj.agents !== 'object' || Array.isArray(obj.agents)) return null;
   // Fix 2: SAFE_NAME validation — reject any hostile key before caching.
+  // Fix 3: also validate third-level boundAtMs keys (must be all-digit timestamps).
   for (const agentId of Object.keys(obj.agents)) {
     if (!SAFE_NAME.test(agentId)) return null;
     for (const category of Object.keys((obj.agents as Record<string, Record<string, unknown>>)[agentId] ?? {})) {
       if (!SAFE_NAME.test(category)) return null;
+      for (const bucketKey of Object.keys((obj.agents as Record<string, Record<string, Record<string, unknown>>>)[agentId][category] ?? {})) {
+        if (!/^\d+$/.test(bucketKey)) return null;
+      }
     }
   }
   const result: SignalAggregateIndexData = {
@@ -183,6 +189,10 @@ export function writeAggregateIndex(projectRoot: string, data: SignalAggregateIn
     const tmp = path + '.tmp';
     writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n');
     renameSync(tmp, path);
+    // Fix 1: proactively update the reader cache after a successful write so
+    // in-process reads return the fresh data without a disk round-trip.
+    cachedAggregateData = data;
+    cachedAggregateMtimeMs = statSync(path).mtimeMs;
   } catch (err) {
     logSidecarError('write', err);
   }
@@ -243,7 +253,7 @@ export function recordRetraction(
   return touched;
 }
 
-const BUCKET_CAP = 5;
+export const BUCKET_CAP = 5;
 
 function ensureBucket(
   data: SignalAggregateIndexData,
@@ -257,12 +267,13 @@ function ensureBucket(
   const byBound = byCat[category];
   const key = String(boundAtMs);
   if (!byBound[key]) {
-    // Fix 3: evict oldest bucket when at capacity to prevent unbounded growth
-    // across frequent skill-rebind epochs. Numeric sort is critical — lexical
-    // sort mangles "9" > "10".
+    // Fix 3+4: evict oldest bucket(s) until below cap before inserting — while-loop
+    // self-heals a pre-existing overcount (e.g. from a crash mid-eviction). Numeric
+    // sort is critical — lexical sort mangles "9" > "10".
     const sorted = Object.keys(byBound).map(k => parseInt(k, 10)).sort((a, b) => a - b);
-    if (sorted.length >= BUCKET_CAP) {
+    while (sorted.length >= BUCKET_CAP) {
       delete byBound[String(sorted[0])];
+      sorted.shift();
     }
     byBound[key] = {
       correct: 0,

--- a/packages/orchestrator/src/skill-engine.ts
+++ b/packages/orchestrator/src/skill-engine.ts
@@ -24,7 +24,7 @@ import {
   type VerdictStatus,
 } from './check-effectiveness';
 
-const SAFE_NAME = /^[a-z0-9][a-z0-9_-]{0,62}$/;
+export const SAFE_NAME = /^[a-z0-9][a-z0-9_-]{0,62}$/;
 
 /**
  * Test-only deterministic-interleaving hook for writeSkillFileFromParts.

--- a/tests/orchestrator/signal-aggregate-index.test.ts
+++ b/tests/orchestrator/signal-aggregate-index.test.ts
@@ -34,6 +34,7 @@ import {
   foldSignal,
   SIDECAR_FILENAME,
   SIDECAR_VERSION,
+  BUCKET_CAP,
   type SignalAggregateIndexData,
 } from '../../packages/orchestrator/src/signal-aggregate-index';
 import { PerformanceWriter } from '../../packages/orchestrator/src/performance-writer';
@@ -458,11 +459,17 @@ describe('reader cache (Fix 1)', () => {
       (args: unknown[]) => typeof args[0] === 'string' && (args[0] as string).includes(SIDECAR_FILENAME),
     ).length;
 
+    // Advance real clock slightly so Date.now() > mtime + 1 (required by the +1ms
+    // mtime buffer introduced in consensus Fix 2 to close the same-ms write race).
+    jest.useFakeTimers({ now: Date.now() + 10 });
+
     // Second call with same mtime — should hit cache, no extra readFileSync
     const second = readAggregateIndex(tmpDir);
     const callsAfterSecond = readFileSyncSpy.mock.calls.filter(
       (args: unknown[]) => typeof args[0] === 'string' && (args[0] as string).includes(SIDECAR_FILENAME),
     ).length;
+
+    jest.useRealTimers();
 
     expect(first).not.toBeNull();
     expect(second).not.toBeNull();
@@ -568,5 +575,133 @@ describe('bucket growth cap (Fix 3)', () => {
     expect(Object.keys(byBound).length).toBe(5);
     expect(byBound['9']).toBeUndefined();  // correctly evicted (numeric oldest)
     expect(byBound['10']).toBeDefined();   // should survive
+  });
+});
+
+// ── Consensus e72d8085-6cfb4ff6 follow-up fixes ──────────────────────────────
+
+describe('write-side cache invalidation (consensus Fix 1)', () => {
+  it('second write is visible to subsequent readAggregateIndex in same process', () => {
+    const writer = new PerformanceWriter(tmpDir);
+    writer[WRITER_INTERNAL].appendSignal(makeSignal('agent-u', 'agreement', { category: 'security' }));
+
+    const first = readAggregateIndex(tmpDir);
+    expect(first).not.toBeNull();
+    expect(readCountersSince(first!, 'agent-u', 'security', 0).correct).toBe(1);
+
+    // Second write with different data — without write-side invalidation the stale
+    // cached object would be returned even though the file changed.
+    writer[WRITER_INTERNAL].appendSignal(makeSignal('agent-u', 'hallucination_caught', { category: 'security' }));
+
+    const second = readAggregateIndex(tmpDir);
+    expect(second).not.toBeNull();
+    const counters = readCountersSince(second!, 'agent-u', 'security', 0);
+    expect(counters.correct).toBe(1);
+    expect(counters.hallucinated).toBe(1);
+  });
+});
+
+describe('bucket key validation — digits only (consensus Fix 3)', () => {
+  it('returns null for sidecar with non-numeric boundAtMs key ("constructor")', () => {
+    // Note: "__proto__" is silently dropped by JSON.stringify. "constructor" serializes.
+    const raw = JSON.stringify({
+      version: SIDECAR_VERSION,
+      rebuiltAt: new Date().toISOString(),
+      lastRawTimestampMs: 0,
+      agents: {
+        'agent-v': {
+          security: {
+            constructor: {
+              correct: 1, hallucinated: 0, total: 1, lastUpdateMs: Date.now(),
+              recentRetractedConsensusIds: [],
+            },
+          },
+        },
+      },
+    }, null, 2);
+    writeFileSync(sidecarPath, raw + '\n');
+    expect(readAggregateIndex(tmpDir)).toBeNull();
+  });
+
+  it('returns null for alphabetic bucket key ("abc")', () => {
+    const raw = JSON.stringify({
+      version: SIDECAR_VERSION,
+      rebuiltAt: new Date().toISOString(),
+      lastRawTimestampMs: 0,
+      agents: {
+        'agent-w': {
+          security: {
+            abc: {
+              correct: 1, hallucinated: 0, total: 1, lastUpdateMs: Date.now(),
+              recentRetractedConsensusIds: [],
+            },
+          },
+        },
+      },
+    }, null, 2);
+    writeFileSync(sidecarPath, raw + '\n');
+    expect(readAggregateIndex(tmpDir)).toBeNull();
+  });
+
+  it('accepts valid all-numeric bucket keys', () => {
+    const raw = JSON.stringify({
+      version: SIDECAR_VERSION,
+      rebuiltAt: new Date().toISOString(),
+      lastRawTimestampMs: 0,
+      agents: {
+        'agent-x': {
+          security: {
+            '1715000000000': {
+              correct: 2, hallucinated: 0, total: 2, lastUpdateMs: Date.now(),
+              recentRetractedConsensusIds: [],
+            },
+          },
+        },
+      },
+    }, null, 2);
+    writeFileSync(sidecarPath, raw + '\n');
+    const data = readAggregateIndex(tmpDir);
+    expect(data).not.toBeNull();
+    expect(readCountersSince(data!, 'agent-x', 'security', 0).correct).toBe(2);
+  });
+});
+
+describe('bucket cap while-loop self-healing (consensus Fix 4)', () => {
+  it(`folding ${BUCKET_CAP + 2} distinct buckets leaves exactly ${BUCKET_CAP}`, () => {
+    const data: SignalAggregateIndexData = {
+      version: SIDECAR_VERSION,
+      rebuiltAt: new Date().toISOString(),
+      lastRawTimestampMs: 0,
+      agents: {},
+    };
+    const baseMs = 1_700_000_000_000;
+    for (let i = 0; i < BUCKET_CAP + 2; i++) {
+      foldSignal(data, 'agent-y', 'security', baseMs + i * 1000, 'agreement', baseMs + i * 1000);
+    }
+    expect(Object.keys(data.agents['agent-y'].security).length).toBe(BUCKET_CAP);
+  });
+
+  it('while-loop self-heals pre-existing overflow to exactly BUCKET_CAP', () => {
+    // Manually create an overflowed sidecar (BUCKET_CAP+2 buckets) to simulate
+    // a state that arose before the cap was enforced.
+    const data: SignalAggregateIndexData = {
+      version: SIDECAR_VERSION,
+      rebuiltAt: new Date().toISOString(),
+      lastRawTimestampMs: 0,
+      agents: { 'agent-z': { security: Object.create(null) } },
+    };
+    const baseMs = 1_700_000_000_000;
+    // Bypass ensureBucket to inject the overflow directly
+    for (let i = 0; i < BUCKET_CAP + 2; i++) {
+      data.agents['agent-z'].security[String(baseMs + i * 1000)] = {
+        correct: 1, hallucinated: 0, total: 1, lastUpdateMs: baseMs + i * 1000,
+        recentRetractedConsensusIds: [],
+      };
+    }
+    expect(Object.keys(data.agents['agent-z'].security).length).toBe(BUCKET_CAP + 2);
+
+    // Now fold one more — while-loop must drain overcount down to BUCKET_CAP
+    foldSignal(data, 'agent-z', 'security', baseMs + (BUCKET_CAP + 2) * 1000, 'agreement', Date.now());
+    expect(Object.keys(data.agents['agent-z'].security).length).toBe(BUCKET_CAP);
   });
 });

--- a/tests/orchestrator/signal-aggregate-index.test.ts
+++ b/tests/orchestrator/signal-aggregate-index.test.ts
@@ -31,8 +31,10 @@ import {
   readCountersSince,
   recordRetraction,
   sidecarIsStale,
+  foldSignal,
   SIDECAR_FILENAME,
   SIDECAR_VERSION,
+  type SignalAggregateIndexData,
 } from '../../packages/orchestrator/src/signal-aggregate-index';
 import { PerformanceWriter } from '../../packages/orchestrator/src/performance-writer';
 import { PerformanceReader } from '../../packages/orchestrator/src/performance-reader';
@@ -438,5 +440,133 @@ describe('readCountersSince', () => {
   it('returns zero counters for unknown agent/category', () => {
     const data = rebuildAggregateIndex(tmpDir);
     expect(readCountersSince(data, 'ghost', 'security', 0)).toEqual({ correct: 0, hallucinated: 0 });
+  });
+});
+
+// ── Fix 1: mtime-keyed reader cache ─────────────────────────────────────────
+
+describe('reader cache (Fix 1)', () => {
+  it('returns cached result on second call without re-reading disk', () => {
+    const writer = new PerformanceWriter(tmpDir);
+    writer[WRITER_INTERNAL].appendSignal(makeSignal('agent-q', 'agreement', { category: 'security' }));
+
+    const readFileSyncSpy = jest.spyOn(require('fs'), 'readFileSync');
+
+    // First call — populates cache
+    const first = readAggregateIndex(tmpDir);
+    const callsAfterFirst = readFileSyncSpy.mock.calls.filter(
+      (args: unknown[]) => typeof args[0] === 'string' && (args[0] as string).includes(SIDECAR_FILENAME),
+    ).length;
+
+    // Second call with same mtime — should hit cache, no extra readFileSync
+    const second = readAggregateIndex(tmpDir);
+    const callsAfterSecond = readFileSyncSpy.mock.calls.filter(
+      (args: unknown[]) => typeof args[0] === 'string' && (args[0] as string).includes(SIDECAR_FILENAME),
+    ).length;
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(callsAfterSecond).toBe(callsAfterFirst); // no extra disk read
+
+    readFileSyncSpy.mockRestore();
+  });
+
+  it('busts cache when mtime changes', () => {
+    const writer = new PerformanceWriter(tmpDir);
+    writer[WRITER_INTERNAL].appendSignal(makeSignal('agent-r', 'agreement', { category: 'security' }));
+
+    const first = readAggregateIndex(tmpDir);
+    expect(first).not.toBeNull();
+    expect(readCountersSince(first!, 'agent-r', 'security', 0).correct).toBe(1);
+
+    // Append another signal — writer rewrites sidecar, bumping mtime
+    writer[WRITER_INTERNAL].appendSignal(makeSignal('agent-r', 'agreement', { category: 'security' }));
+
+    const second = readAggregateIndex(tmpDir);
+    expect(second).not.toBeNull();
+    expect(readCountersSince(second!, 'agent-r', 'security', 0).correct).toBe(2);
+  });
+});
+
+// ── Fix 2: SAFE_NAME tamper validation ──────────────────────────────────────
+
+describe('tamper validation (Fix 2)', () => {
+  it('returns null for hostile agentId key (path traversal)', () => {
+    writeFileSync(sidecarPath, JSON.stringify({
+      version: SIDECAR_VERSION,
+      rebuiltAt: new Date().toISOString(),
+      lastRawTimestampMs: 0,
+      agents: {
+        '../../etc/passwd': { security: {} },
+      },
+    }));
+    expect(readAggregateIndex(tmpDir)).toBeNull();
+  });
+
+  it('returns null for hostile category key (script injection)', () => {
+    writeFileSync(sidecarPath, JSON.stringify({
+      version: SIDECAR_VERSION,
+      rebuiltAt: new Date().toISOString(),
+      lastRawTimestampMs: 0,
+      agents: {
+        'valid-agent': { '<script>': {} },
+      },
+    }));
+    expect(readAggregateIndex(tmpDir)).toBeNull();
+  });
+
+  it('accepts valid agentId and category keys', () => {
+    const writer = new PerformanceWriter(tmpDir);
+    writer[WRITER_INTERNAL].appendSignal(makeSignal('valid-agent', 'agreement', { category: 'security' }));
+    const data = readAggregateIndex(tmpDir);
+    expect(data).not.toBeNull();
+  });
+});
+
+// ── Fix 3: Bucket growth cap ─────────────────────────────────────────────────
+
+describe('bucket growth cap (Fix 3)', () => {
+  it('caps byBound at 5 buckets, evicting the oldest', () => {
+    const data: SignalAggregateIndexData = {
+      version: SIDECAR_VERSION,
+      rebuiltAt: new Date().toISOString(),
+      lastRawTimestampMs: 0,
+      agents: {},
+    };
+
+    // Fold 6 signals with distinct boundAtMs values (ascending: 100, 200, ... 600)
+    for (let i = 1; i <= 6; i++) {
+      foldSignal(data, 'agent-s', 'security', i * 100, 'agreement', Date.now());
+    }
+
+    const byBound = data.agents['agent-s'].security;
+    const keys = Object.keys(byBound);
+    expect(keys.length).toBe(5);
+    // Oldest bucket (boundAtMs=100, key="100") should have been evicted
+    expect(byBound['100']).toBeUndefined();
+    // Newest bucket (boundAtMs=600) should be present
+    expect(byBound['600']).toBeDefined();
+  });
+
+  it('numeric sort is correct — does not evict "9" before "10"', () => {
+    const data: SignalAggregateIndexData = {
+      version: SIDECAR_VERSION,
+      rebuiltAt: new Date().toISOString(),
+      lastRawTimestampMs: 0,
+      agents: {},
+    };
+
+    // Simulate 5 buckets with values that would sort incorrectly under lexical ordering:
+    // lexical: "10" < "200" < "9" — numeric: 9 < 10 < 200
+    for (const bound of [9, 10, 200, 300, 400]) {
+      foldSignal(data, 'agent-t', 'security', bound, 'agreement', Date.now());
+    }
+    // Now add a 6th — should evict numeric oldest (9), not lexical oldest ("10")
+    foldSignal(data, 'agent-t', 'security', 500, 'agreement', Date.now());
+
+    const byBound = data.agents['agent-t'].security;
+    expect(Object.keys(byBound).length).toBe(5);
+    expect(byBound['9']).toBeUndefined();  // correctly evicted (numeric oldest)
+    expect(byBound['10']).toBeDefined();   // should survive
   });
 });


### PR DESCRIPTION
consensus-id: e72d8085-6cfb4ff6

## Summary

Three follow-ups from PR #371 (signal-aggregate sidecar) bundled into one PR + 4 consensus findings addressed in fixup. ~60 LOC src + 265 LOC tests across `signal-aggregate-index.ts` and `skill-engine.ts`.

Origin: PR #371 consensus `bafd8bbb-99944c8b` flagged three open items. PR #372 fresh consensus `e72d8085-6cfb4ff6` (sonnet-reviewer + gemini-reviewer) found 4 additional findings (1 HIGH on cache invalidation), all addressed in fixup commit.

### Fix 1 — Reader cache (mtime-keyed)
`readAggregateIndex` now uses module-scope mtime-keyed cache mirroring `performance-reader.ts:172-302`. `writeAggregateIndex` proactively invalidates after `renameSync`. Cache hit requires `Date.now() > cachedAggregateMtimeMs + 1` to close same-ms external-write race.

### Fix 2 — SAFE_NAME tamper validation
`SAFE_NAME = /^[a-z0-9][a-z0-9_-]{0,62}$/` exported from `skill-engine.ts:27`, reused in `readAggregateIndex` for agentId/category keys. Plus `/^\d+$/` validation on third-level `boundAtMs` keys (consensus finding). Fail-closed on any non-matching key.

### Fix 3 — Bucket growth cap (K=5)
`ensureBucket` trims to last 5 buckets per `(agentId, category)` via while-loop with numeric `parseInt` sort — self-heals pre-existing on-disk overcounts.

## Test plan
- [x] 36 tests in `tests/orchestrator/signal-aggregate-index.test.ts` (cache invariants, tamper, bucket cap, self-heal)
- [x] `npm test`: 3071/3071 pass across 231 suites
- [x] `npm run build`: green
- [x] 2-agent consensus `e72d8085-6cfb4ff6`: 11 confirmed, 1 unique, 0 disputed
- [x] 12 signals recorded; 4 actionable findings addressed in fixup commit `7579976`

Closes project memory files:
- `project_signal_aggregate_reader_cache.md`
- `project_signal_aggregate_sidecar_tamper_validation.md`
- `project_signal_aggregate_bucket_growth.md`

Retroactive note (issue #373): impact-adjacency gate was blind to this PR because `signal-aggregate-index.ts` annotation used `signal_pipeline` (underscore) instead of `signal-pipeline` (hyphen). Real consensus coverage existed even though the CI audit trail did not see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)