### PR TITLE
fix(ci): impact-adjacency gate fails loud on unknown categories — closes #373

### DIFF
--- a/apps/cli/src/handlers/ref-allowlist-detection.ts
+++ b/apps/cli/src/handlers/ref-allowlist-detection.ts
@@ -1,4 +1,4 @@
-// @gossip:impact-adjacent:signal_pipeline
+// @gossip:impact-adjacent:signal-pipeline
 
 /**
  * Ref-allowlist enforcement — Phase 1 (detection-only).

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -1,4 +1,4 @@
-// @gossip:impact-adjacent:signal_pipeline
+// @gossip:impact-adjacent:signal-pipeline
 /**
  * PerformanceReader — reads agent-performance.jsonl and computes
  * per-agent scores from consensus signals.

--- a/packages/orchestrator/src/signal-aggregate-index.ts
+++ b/packages/orchestrator/src/signal-aggregate-index.ts
@@ -1,4 +1,4 @@
-// @gossip:impact-adjacent:signal_pipeline
+// @gossip:impact-adjacent:signal-pipeline
 /**
  * Signal aggregate sidecar — Phase B complement to readJsonlWithRotated.
  *

--- a/scripts/impact-adjacency-gate.mjs
+++ b/scripts/impact-adjacency-gate.mjs
@@ -10,8 +10,24 @@ import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-const ANNOTATION_RE =
-  /\/\/\s*@gossip:impact-adjacent:(map-lifecycle|ttl-semantics|config-writes|signal-pipeline|auth-boundaries|bootstrap-paths|shared-state-with-lifecycle|waived-pattern-mirror)\b/g;
+const ALLOWED_CATEGORIES = [
+  'map-lifecycle',
+  'ttl-semantics',
+  'config-writes',
+  'signal-pipeline',
+  'auth-boundaries',
+  'bootstrap-paths',
+  'shared-state-with-lifecycle',
+  'waived-pattern-mirror',
+];
+const ANNOTATION_RE = new RegExp(
+  `\\/\\/\\s*@gossip:impact-adjacent:(${ALLOWED_CATEGORIES.join('|')})\\b`,
+  'g',
+);
+// Broad regex matches any `@gossip:impact-adjacent:<token>` shape — used to
+// detect malformed category names (e.g. underscore variants) that the narrow
+// regex would silently skip. See issue #373.
+const BROAD_ANNOTATION_RE = /\/\/\s*@gossip:impact-adjacent:([A-Za-z0-9_-]+)\b/g;
 const ROOT = process.cwd();
 const GOSSIP_DIR = path.join(ROOT, '.gossip');
 const WAIVER_LOG = path.join(GOSSIP_DIR, 'waived-impact-adjacency.jsonl');
@@ -92,6 +108,21 @@ function annotationsIn(file) {
   }
   if (!fs.existsSync(abs)) return [];
   const txt = safeRead(abs);
+  // Fail loud on malformed categories: an annotation with the right shape but
+  // a token outside the allowlist would silently pass through ANNOTATION_RE
+  // (see issue #373). Catch those here before the narrow match so the gate
+  // never treats a misannotated file as unannotated.
+  const allowed = new Set(ALLOWED_CATEGORIES);
+  for (const m of txt.matchAll(BROAD_ANNOTATION_RE)) {
+    const tok = m[1];
+    if (!allowed.has(tok)) {
+      process.stderr.write(
+        `${file}: unknown category "${tok}" in @gossip:impact-adjacent annotation.\n` +
+          `Allowed values: ${ALLOWED_CATEGORIES.join(', ')}\n`,
+      );
+      process.exit(1);
+    }
+  }
   const cats = new Set();
   for (const m of txt.matchAll(ANNOTATION_RE)) cats.add(m[1]);
   return [...cats];

--- a/tests/orchestrator/performance-reader-rotation.test.ts
+++ b/tests/orchestrator/performance-reader-rotation.test.ts
@@ -1,4 +1,4 @@
-// @gossip:impact-adjacent:signal_pipeline
+// @gossip:impact-adjacent:signal-pipeline
 /**
  * Tests for the readJsonlWithRotated helper and migration of PerformanceReader
  * methods to use it — Phase A fix for the signal-log-rotation data-loss bug

--- a/tests/orchestrator/signal-aggregate-index.test.ts
+++ b/tests/orchestrator/signal-aggregate-index.test.ts
@@ -1,4 +1,4 @@
-// @gossip:impact-adjacent:signal_pipeline
+// @gossip:impact-adjacent:signal-pipeline
 /**
  * Phase B — signal-aggregate sidecar.
  *

--- a/tests/orchestrator/signal-allowlist-drift.test.ts
+++ b/tests/orchestrator/signal-allowlist-drift.test.ts
@@ -1,4 +1,4 @@
-// @gossip:impact-adjacent:signal_pipeline
+// @gossip:impact-adjacent:signal-pipeline
 //
 // Drift detector: catches the PR #329 class of bug.
 //

--- a/tests/scripts/impact-adjacency-gate.test.ts
+++ b/tests/scripts/impact-adjacency-gate.test.ts
@@ -175,6 +175,53 @@ describe('impact-adjacency-gate', () => {
     }
   });
 
+  it('(l) annotated source with valid hyphen category + consensus-id → exit 0 (regression: issue #373)', () => {
+    const dir = mkRepo();
+    const base = baseSha(dir);
+    fs.writeFileSync(
+      path.join(dir, 'src.ts'),
+      '// @gossip:impact-adjacent:signal-pipeline\nexport const x = 1;\n',
+    );
+    commitAll(dir, 'valid hyphen category');
+    const res = runGate(dir, {
+      GITHUB_BASE_REF: base,
+      PR_TITLE: 'fix: thing (consensus-id: abcdef12-34567890)',
+    });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/OK \(annotated/);
+  });
+
+  it('(m) annotated source with underscore variant (signal_pipeline) → exit 1 with category-mismatch error (regression: issue #373)', () => {
+    const dir = mkRepo();
+    const base = baseSha(dir);
+    fs.writeFileSync(
+      path.join(dir, 'src.ts'),
+      '// @gossip:impact-adjacent:signal_pipeline\nexport const x = 1;\n',
+    );
+    commitAll(dir, 'underscore variant — bug case from issue #373');
+    const res = runGate(dir, {
+      GITHUB_BASE_REF: base,
+      PR_TITLE: 'fix: thing (consensus-id: abcdef12-34567890)',
+    });
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/unknown category "signal_pipeline"/);
+    expect(res.stderr).toMatch(/Allowed values:/);
+  });
+
+  it('(n) annotated source with arbitrary unknown category → exit 1 with category-mismatch error', () => {
+    const dir = mkRepo();
+    const base = baseSha(dir);
+    fs.writeFileSync(
+      path.join(dir, 'src.ts'),
+      '// @gossip:impact-adjacent:bogus_category\nexport const x = 1;\n',
+    );
+    commitAll(dir, 'arbitrary unknown category');
+    const res = runGate(dir, { GITHUB_BASE_REF: base });
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/unknown category "bogus_category"/);
+    expect(res.stderr).toMatch(/Allowed values:/);
+  });
+
   it('(k) consensus-id regex: accepts hyphen and underscore separators, rejects loose forms', () => {
     const dir = mkRepo();
     const base = baseSha(dir);


### PR DESCRIPTION
consensus-id: 7ee0ec73-e9054a73

Closes #373

## Summary

The impact-adjacency CI gate matched only hyphen-separated category names. Three source files annotated with `signal_pipeline` (underscore) instead of `signal-pipeline` (hyphen) silently slipped through the gate as unannotated. Three merged PRs (#348, #371, #372) had no real gate coverage.

## Changes

**1. Three source-file annotation renames** (`signal_pipeline` → `signal-pipeline`):
- `packages/orchestrator/src/performance-reader.ts:1`
- `packages/orchestrator/src/signal-aggregate-index.ts:1`
- `apps/cli/src/handlers/ref-allowlist-detection.ts:1`

**2. Three test-file annotation renames** (stale underscore form, skipped by `TEST_PATH_RE` so harmless but inconsistent — caught by gemini-reviewer in consensus cross-review):
- `tests/orchestrator/performance-reader-rotation.test.ts:1`
- `tests/orchestrator/signal-aggregate-index.test.ts:1`
- `tests/orchestrator/signal-allowlist-drift.test.ts:1`

**3. Gate hardening** — `scripts/impact-adjacency-gate.mjs`:
- Extract `ALLOWED_CATEGORIES` as a constant; `ANNOTATION_RE` now derived from it (single source of truth).
- Add `BROAD_ANNOTATION_RE = /\/\/\s*@gossip:impact-adjacent:([A-Za-z0-9_-]+)\b/g` matching any annotation shape, allowlist-agnostic.
- In `annotationsIn`, iterate broad matches first; any token not in `ALLOWED_CATEGORIES` fails the gate with the file path, the offending token, and the allowed values.
- No `signal_pipeline` alias — per HANDBOOK invariant #8 ("make the contract loud, not normalize bad input").

**4. Regression tests** — `tests/scripts/impact-adjacency-gate.test.ts`:
- `(l)` valid hyphen category + consensus-id → exit 0.
- `(m)` underscore variant (`signal_pipeline`) — the bug case from issue #373 → exit 1 with category-mismatch error.
- `(n)` arbitrary unknown category → exit 1 with category-mismatch error.

## Test plan
- [x] `npm test`: 3074+ pass, 231+ suites
- [x] `npm run build`: green
- [x] `(m)` reproduces the original bug — would silently pass without the BROAD_ANNOTATION_RE check
- [x] 2-agent consensus `7ee0ec73-e9054a73` — 9 confirmed, 1 disputed (resolved in favor of gemini-reviewer, test-file annotations fixed in followup commit)

## Known low-severity findings (deferred follow-ups, not blocking)
- Block-comment evasion (`/* */`) — symmetric with the old behavior, not a regression. Comment at line 31 overstates coverage; could be tightened.
- Unescaped `.join('|')` in `new RegExp(...)` — latent risk if a future category name contains a regex metacharacter. Defensive escape would harden.
- String-literal false-positives in non-test source files — fail-loud intent appropriate but undocumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)