### PR TITLE
fix(dashboard): editorial theme design pass — 11 findings from designer review

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -268,7 +268,7 @@ function TeamPage({ agents, tasks }: { agents: AgentData[]; tasks: import('@/lib
                   {/* Hallucinations */}
                   <td className="py-3 pr-4 text-right align-top font-mono text-xs tabular-nums">
                     <span
-                      className={s.hallucinations > 0 ? 'font-bold text-disputed' : 'text-muted-foreground/40'}
+                      className={s.hallucinations > 10 ? 'font-bold text-disputed' : s.hallucinations > 0 ? 'text-disputed' : 'text-muted-foreground/40'}
                       data-tooltip={`Agreements ${s.agreements} · Disagreements ${s.disagreements} · Hallucinations ${s.hallucinations}`}
                     >
                       {s.hallucinations}

--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -214,7 +214,10 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
           changed per agent in a way that was decorative, not informational. */}
       <div className="relative mb-6 rounded-xl border border-border bg-card p-5">
         <div className="flex items-center gap-6">
-          <div className="relative shrink-0">
+          <div
+            className="relative shrink-0"
+            data-tooltip={`Accuracy ${Math.round(s.accuracy * 100)}% · Uniqueness ${Math.round(s.uniqueness * 100)}% · Impact ${Math.round(s.impactScore * 100)}%`}
+          >
             <NeuralAvatar
               agentId={agent.id}
               size={120}
@@ -296,7 +299,7 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
           <h2 className="mb-1 font-mono text-[11px] font-bold uppercase tracking-widest text-foreground">
             Category Competency
           </h2>
-          <p className="mb-3 mt-0.5 font-mono text-[10px] text-muted-foreground/60">Raw per-category ratio — unweighted. Overall accuracy in Metrics applies a hallucination penalty.</p>
+          <p className="mb-3 mt-0.5 font-mono text-[11px] text-muted-foreground/80">◆ Raw per-category ratio — unweighted. Overall accuracy in Metrics applies a hallucination penalty.</p>
           <CategoryCompetency
             categoryAccuracy={s.categoryAccuracy}
             categoryCorrect={s.categoryCorrect}

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -421,9 +421,11 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
             const uniqueCount = report.unique.length;
             const insightCount = (report.insights || []).length;
 
-            // Determine dominant quality: confirmed > disputed > mixed/unverified
+            // Determine dominant quality: confirmed > disputed > mixed/unverified.
+            // Single-finding rounds get the same ratio logic as multi-finding rounds
+            // so a 1/1 confirmed round paints green, not neutral grey.
             const dominantBorderCls = (() => {
-              if (total <= 1) return 'border-l-border/40';
+              if (total === 0) return 'border-l-border/40';
               const confirmedRatio = confirmedCount / total;
               const disputedRatio = disputedCount / total;
               if (confirmedRatio >= 0.5) return 'border-l-confirmed/60';

--- a/packages/dashboard-v2/src/components/LogsPage.tsx
+++ b/packages/dashboard-v2/src/components/LogsPage.tsx
@@ -214,7 +214,11 @@ export function LogsPage() {
           ))}
           {filteredEntries.length === 0 && (
             <div className="py-8 text-center font-mono text-xs text-muted-foreground">
-              {entries.length === 0 ? 'Loading...' : 'No matching log entries.'}
+              {entries.length === 0
+                ? 'Loading...'
+                : filter === 'all'
+                  ? 'No log entries in current tail.'
+                  : `No ${filter} entries in current tail.`}
             </div>
           )}
           <div ref={bottomRef} />

--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -286,11 +286,11 @@ export function SignalsPage() {
                   <th className="px-2 py-1.5 font-semibold uppercase tracking-widest">Time</th>
                   <th className="px-2 py-1.5 font-semibold uppercase tracking-widest">Agent</th>
                   <th className="px-2 py-1.5 font-semibold uppercase tracking-widest">Signal</th>
-                  <th className="px-2 py-1.5 font-semibold uppercase tracking-widest" data-tooltip="The other agent in this signal — e.g. the peer who agreed or disputed">Counterpart</th>
                   <th className="px-2 py-1.5 font-semibold uppercase tracking-widest" data-tooltip="Severity of the associated finding (critical / high / medium / low)">Sev</th>
+                  <th className="px-2 py-1.5 font-semibold uppercase tracking-widest">Evidence</th>
+                  <th className="px-2 py-1.5 font-semibold uppercase tracking-widest" data-tooltip="The other agent in this signal — e.g. the peer who agreed or disputed">Counterpart</th>
                   <th className="px-2 py-1.5 font-semibold uppercase tracking-widest" data-tooltip="Finding ID — click row to open finding detail">Finding</th>
                   <th className="px-2 py-1.5 font-semibold uppercase tracking-widest">Consensus</th>
-                  <th className="px-2 py-1.5 font-semibold uppercase tracking-widest">Evidence</th>
                 </tr>
               </thead>
               <tbody>
@@ -312,7 +312,6 @@ export function SignalsPage() {
                       <td className="whitespace-nowrap px-2 py-1 text-muted-foreground/80" title={r.timestamp}>{timeAgo(r.timestamp)}</td>
                       <td className="whitespace-nowrap px-2 py-1 text-foreground">{r.agentId}</td>
                       <td className={`whitespace-nowrap px-2 py-1 ${SIGNAL_CLS[r.signal] ?? 'text-foreground'}`}>{SIGNAL_LABELS[r.signal] ?? r.signal}</td>
-                      <td className="whitespace-nowrap px-2 py-1 text-muted-foreground/80">{r.counterpartId ?? '—'}</td>
                       <td className="whitespace-nowrap px-2 py-1">
                         {r.severity ? (
                           <span className={`rounded border px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase ${SEVERITY_BADGE[r.severity] ?? 'bg-muted'}`}>
@@ -322,14 +321,15 @@ export function SignalsPage() {
                           <span className="text-muted-foreground/40">—</span>
                         )}
                       </td>
+                      <td className="max-w-[300px] truncate px-2 py-1 text-muted-foreground/80" title={r.evidence}>
+                        {truncate(r.evidence, 80)}
+                      </td>
+                      <td className="whitespace-nowrap px-2 py-1 text-muted-foreground/80">{r.counterpartId ?? '—'}</td>
                       <td className="whitespace-nowrap px-2 py-1 text-muted-foreground/70" title={r.findingId}>
                         {r.findingId ? truncate(r.findingId, 24) : '—'}
                       </td>
                       <td className="whitespace-nowrap px-2 py-1 text-muted-foreground/70" title={r.consensusId}>
                         {r.consensusId ? truncate(r.consensusId, 16) : '—'}
-                      </td>
-                      <td className="max-w-[300px] truncate px-2 py-1 text-muted-foreground/80" title={r.evidence}>
-                        {truncate(r.evidence, 80)}
                       </td>
                     </tr>
                   );

--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -113,7 +113,7 @@ export function SystemPulse({ overview, activeTasks, mode = 'dense', showActivit
           <BigStat
             value={`${confirmRate}%`}
             label="Confirmed"
-            valueClass="text-confirmed"
+            valueClass={confirmRate >= 50 ? 'text-confirmed' : confirmRate > 0 ? 'text-unverified' : 'text-muted-foreground'}
           />
         </div>
       ) : (

--- a/packages/dashboard-v2/src/components/TaskRow.tsx
+++ b/packages/dashboard-v2/src/components/TaskRow.tsx
@@ -157,7 +157,10 @@ export function TaskRow({ task, onClick }: TaskRowProps) {
         </span>
       </td>
       <td className="py-2.5 pr-3">
-        <span className="rounded border border-amber-500/25 bg-amber-500/8 px-2 py-1 font-mono text-[10px] font-semibold text-amber-400">
+        <span
+          className="rounded border border-amber-500/25 bg-amber-500/8 px-2 py-1 font-mono text-[10px] font-semibold text-amber-400"
+          title={task.taskId}
+        >
           {task.taskId.slice(0, 8)}
         </span>
       </td>

--- a/packages/dashboard-v2/src/components/TeamRoster.tsx
+++ b/packages/dashboard-v2/src/components/TeamRoster.tsx
@@ -94,7 +94,7 @@ export function TeamRoster({ agents }: TeamRosterProps) {
                     ))}
                   </div>
                   {lastTime && (
-                    <span className="shrink-0 font-mono text-[10px] text-muted-foreground/40">{lastTime}</span>
+                    <span className="shrink-0 font-mono text-[10px] text-muted-foreground/60">{lastTime}</span>
                   )}
                 </div>
               </div>

--- a/packages/dashboard-v2/src/components/ViolationsPage.tsx
+++ b/packages/dashboard-v2/src/components/ViolationsPage.tsx
@@ -110,7 +110,7 @@ export function ViolationsPage() {
             Process Violations
           </h1>
           {total > 0 && (
-            <span className="rounded-full border border-destructive/30 bg-destructive/10 px-2 py-0.5 font-mono text-xs font-bold text-destructive">
+            <span className="rounded-full border border-disputed/30 bg-disputed/10 px-2 py-0.5 font-mono text-xs font-bold text-disputed">
               {total}
             </span>
           )}
@@ -122,7 +122,7 @@ export function ViolationsPage() {
 
       <div className="overflow-hidden rounded-md border border-border/40 bg-card/80">
         {error && (
-          <div className="border-b border-border/60 bg-destructive/10 px-3 py-2 font-mono text-[10px] text-destructive">
+          <div className="border-b border-border/60 bg-disputed/10 px-3 py-2 font-mono text-[10px] text-disputed">
             {error}
           </div>
         )}

--- a/packages/dashboard-v2/src/pages/OverviewPage.tsx
+++ b/packages/dashboard-v2/src/pages/OverviewPage.tsx
@@ -61,6 +61,19 @@ export function OverviewPage({
         mode="calm"
       />
 
+      {/* Actionable stat row — present in calm mode when actionable > 0 so the
+          attention hook isn't only a small header-right link. */}
+      {actionable > 0 && (
+        <a
+          href={href('/signals?signal=disagreement&signal=hallucination_caught&signal=new_finding')}
+          className="inline-flex items-center gap-1.5 font-mono text-[12px] text-muted-foreground transition hover:text-foreground"
+        >
+          <span>◆</span>
+          <span className="font-bold text-unverified">{actionable}</span>
+          <span>actionable signals →</span>
+        </a>
+      )}
+
       {/* Live tasks (self-hides when nothing is running) */}
       <ActiveTasksBanner onCountChange={setActiveTaskCount} />
 


### PR DESCRIPTION
## Summary

Applies the 11 atomic fixes surfaced by sonnet-designer's review of all accessible dashboard pages (screenshots at /tmp/dash-shots/). Each is an additive class/attribute swap; no redesigns, no layout changes affecting operator workflow.

## HIGH (3) — semantic/hierarchy bugs

| File | Fix |
|---|---|
| `App.tsx:271` | `/team` HALLUC count: graduated threshold so 55 reads visually different from 1 (>10 = bold+disputed, >0 = disputed, =0 = muted) |
| `SignalsPage.tsx:283-333` | `/signals` columns reordered: Time · Agent · Signal · **Sev · Evidence** · Counterpart · Finding · Consensus (evidence reachable without 7-col eye hop) |
| `SystemPulse.tsx:116` | `/overview` Confirmed % BigStat: conditional color (≥50 green, >0 amber, =0 muted) — "0%" no longer reads as healthy |

## MEDIUM (5) — text visibility + palette drift

| File | Fix |
|---|---|
| `AgentPage.tsx:299` | Category Competency disclaimer: `text-[10px]/60` → `text-[11px]/80` with ◆ prefix |
| `FindingsMetrics.tsx:425` | `/debates`: drop `total <= 1` early-return so single-finding rounds paint their actual status border |
| `TaskRow.tsx:159-164` | TaskId badge gets `title={task.taskId}` — full ID on hover (slice(0,8) was silently clipping) |
| `ViolationsPage.tsx:113,125` | `destructive` palette token → `disputed` (canonical project token used elsewhere) |
| `TeamRoster.tsx:97` | Last-active opacity `text-muted-foreground/40` → `/60` (WCAG AA on dark cards) |

## LOW (3) — polish

| File | Fix |
|---|---|
| `LogsPage.tsx:215-219` | Filter-aware empty state: "No \<filter\> entries in current tail" instead of generic message |
| `OverviewPage.tsx:57-66` | Surface actionable count as inline stat row in calm mode (keeps header link too) |
| `AgentPage.tsx:215-218` | NeuralAvatar wrapper gets `data-tooltip` with Acc/Unq/Imp percentages |

## Test plan
- [x] `npm run build`: green
- [x] `npm test -- --testPathPattern=dashboard`: 167/167 passing
- [x] All 11 fixes verified on disk + in `git diff --stat` (10 files, +42/-17)

## Process notes
Two findings diverged from the designer's cited file:line during application:
- HIGH-1 HALLUC was cited as `TeamRoster.tsx:92` but the actual column lives in `App.tsx`'s `TeamPage` (the `/team` route renders TeamPage, not TeamRoster — TeamRoster is the dashboard-widget). Applied to the correct symbol.
- LOW-9 LogsPage already had an empty state at line 215 — fix is filter-aware messaging rather than adding the state from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)