### PR TITLE
feat(orchestrator): SkillFrontmatter adds regressed_from_passed_at for drift-detector quarantine

### DIFF
--- a/packages/orchestrator/src/skill-parser.ts
+++ b/packages/orchestrator/src/skill-parser.ts
@@ -54,6 +54,13 @@ export interface SkillFrontmatter {
   sources?: string;
   status: SkillStatus;
   /**
+   * ISO-8601 timestamp set when a `passed` skill is demoted to `inconclusive`
+   * by the drift detector; absent for organically-inconclusive skills. Read by
+   * the skill-loader quarantine filter to suppress regressed skills from
+   * dispatch injection until they re-pass effectiveness checks.
+   */
+  regressed_from_passed_at?: string;
+  /**
    * Dispatch scope. Default 'any' preserves backwards-compatibility with skills
    * authored before this axis was introduced — they activate for all dispatches.
    * Explicit values ('review'|'implement'|'research') hard-reject on mismatch in
@@ -154,6 +161,7 @@ export function parseSkillFrontmatter(content: string): SkillFrontmatter | null 
     generated_by: fields.generated_by,
     sources: fields.sources,
     status: fields.status as SkillStatus,
+    regressed_from_passed_at: fields.regressed_from_passed_at || undefined,
     task_type,
     scope,
   };

--- a/tests/orchestrator/skill-parser.test.ts
+++ b/tests/orchestrator/skill-parser.test.ts
@@ -73,4 +73,16 @@ Check endpoints.`;
     const result = parseSkillFrontmatter(md);
     expect(result?.status).toBe('pending');
   });
+
+  it('round-trips regressed_from_passed_at when set by drift detector', () => {
+    const md = `---\nname: t\ndescription: d\nkeywords: [k]\nstatus: inconclusive\nregressed_from_passed_at: "2026-05-14T10:00:00.000Z"\n---\nBody`;
+    const result = parseSkillFrontmatter(md);
+    expect(result?.regressed_from_passed_at).toBe('2026-05-14T10:00:00.000Z');
+  });
+
+  it('leaves regressed_from_passed_at undefined for organically-inconclusive skills', () => {
+    const md = `---\nname: t\ndescription: d\nkeywords: [k]\nstatus: inconclusive\n---\nBody`;
+    const result = parseSkillFrontmatter(md);
+    expect(result?.regressed_from_passed_at).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- **Prerequisite #2** for the passed-skill drift detector spec (`docs/specs/2026-05-13-passed-skill-drift-detection.md`). Caught by consensus `05bbbf4c-fd4c4c89:sonnet-reviewer:f7`: the planned skill-loader quarantine filter (`status === 'inconclusive' && frontmatter.regressed_from_passed_at != null`) is a structural no-op until the parser returns this field.
- Adds `regressed_from_passed_at?: string` (ISO-8601 timestamp) to `SkillFrontmatter` in `packages/orchestrator/src/skill-parser.ts`. Set when a `passed` skill is demoted to `inconclusive` by the drift detector; absent for organically-inconclusive skills.
- Pure-additive change — leverages the existing flat key-value scanner at `skill-parser.ts:87-103` which reads any key into `fields`. Only the return statement at line 148-159 needed extension. Mirrors the pattern already approved in consensus `05bbbf4c-fd4c4c89:sonnet-reviewer:f7` Option A.

## Diff
- `packages/orchestrator/src/skill-parser.ts` +8 LOC — interface field + doc comment + parser return wiring
- `tests/orchestrator/skill-parser.test.ts` +12 LOC — 2 new tests (round-trip with field, undefined when absent)

Total: 2 files, +20 LOC.

## Out of scope (deferred to drift-detector PR)
- The other 4 drift-detector snapshot fields (`passed_at`, `passed_baseline_rate`, `passed_backfilled`, `drift_strikes`). Those live on `SkillSnapshot` in `check-effectiveness.ts`, not `SkillFrontmatter`, and ship with the v3 migration.
- The skill-loader quarantine filter itself. This PR just makes the field readable; the filter lands with the drift-detector PR.

## Consensus
No fresh round — change applies the exact pattern approved in consensus `05bbbf4c-fd4c4c89:sonnet-reviewer:f7` (Option A: extend `SkillFrontmatter` + `parseSkillFrontmatter`). Per HANDBOOK: "Small mirror-of-existing-pattern changes don't need a fresh round; the pattern is already validated."

## Test plan
- [x] `tsc --noEmit -p packages/orchestrator/tsconfig.json` — clean
- [x] `jest tests/orchestrator/skill-parser.test.ts` — 10/10 pass (2 new)
- [x] `jest tests/orchestrator/` — 1951 pass, 20 skipped, 0 fail across 133 suites
- [x] `npm run build` — clean across all 5 workspace packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)