### PR TITLE
feat(orchestrator): next-session ledger auto-verify guardrail (Option B)

### DIFF
--- a/packages/orchestrator/src/bootstrap.ts
+++ b/packages/orchestrator/src/bootstrap.ts
@@ -1,6 +1,15 @@
-import { existsSync, readFileSync, readdirSync, mkdirSync, copyFileSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, mkdirSync, copyFileSync, statSync } from 'fs';
 import { resolve, join } from 'path';
+import { execFileSync } from 'child_process';
 import { readRulesContent } from './rules-loader';
+import {
+  parseNextSessionBullets,
+  readLedgerIndex,
+  annotateLedgerText,
+  triggerBackgroundVerification,
+  defaultVerifierFactory,
+  type LedgerIndexEntry,
+} from './verify-ledger-background';
 
 export interface BootstrapResult {
   prompt: string;
@@ -431,7 +440,59 @@ Skills are auto-injected from agent config. Project-wide skills in .gossip/skill
       if (content.length === 0) return null;
       // Safety net only — write side already extracts just the priorities section.
       // Generous limit so well-formed content is never cut mid-sentence.
-      return this.verifyToolClaims(content.slice(0, 3000));
+      const trimmed = content.slice(0, 3000);
+      const annotated = this.applyLedgerAnnotations(trimmed, notesPath);
+      return this.verifyToolClaims(annotated);
     } catch { return null; }
   }
+
+  /**
+   * Splice [STALE]/[UNVERIFIED]/[PROSE-ONLY]/[UNVERIFIABLE] annotations into the
+   * ledger text from the `.gossip/next-session-index.json` sidecar.
+   *
+   * Cache hit (mtime AND content-hash match): use cached verdicts.
+   * Cache miss / stale: annotate all bullets with `[UNVERIFIED]` and trigger a
+   * fire-and-forget background verification job (setImmediate; not awaited).
+   *
+   * Bootstrap critical path stays synchronous and fast.
+   */
+  private applyLedgerAnnotations(content: string, ledgerPath: string): string {
+    try {
+      const bullets = parseNextSessionBullets(content);
+      if (bullets.length === 0) return content;
+      let mtime = 0;
+      try { mtime = statSync(ledgerPath).mtimeMs; } catch { /* default 0 */ }
+      const index = readLedgerIndex(this.projectRoot, content, mtime);
+      const byHash = new Map<string, LedgerIndexEntry>();
+      if (index) {
+        for (const e of index.entries) byHash.set(e.bulletHash, e);
+      } else {
+        // Cold/stale cache: trigger background refresh. No await — fire-and-forget.
+        const verifier = defaultVerifierFactory({
+          worktree: () => liveWorktreeCount(this.projectRoot),
+        });
+        triggerBackgroundVerification(this.projectRoot, content, mtime, bullets, verifier);
+      }
+      return annotateLedgerText(content, bullets, byHash);
+    } catch {
+      // Never let annotation failure break bootstrap.
+      return content;
+    }
+  }
+}
+
+/**
+ * Synchronous live worktree count — mirrors `listWorktreePaths` (the async
+ * reader used by discoverGitWorktrees) but stays on the synchronous bootstrap
+ * critical path. Returns null on any failure so the verifier falls back to
+ * UNVERIFIABLE instead of fabricating a count.
+ */
+function liveWorktreeCount(projectRoot: string): number | null {
+  try {
+    const out = execFileSync('git', ['worktree', 'list', '--porcelain'], {
+      cwd: projectRoot, encoding: 'utf-8', timeout: 2000,
+    });
+    // Each worktree record starts with `worktree <path>` on its own line.
+    return (out.match(/^worktree\s+/gm) ?? []).length;
+  } catch { return null; }
 }

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -93,6 +93,26 @@ export { validateResolutionRoot, parseWorktreePorcelain, listWorktreePaths, gitC
 export type { ValidationResult } from './validate-resolution-root';
 export { discoverGitWorktrees } from './discover-git-worktrees';
 export type { DiscoverResult } from './discover-git-worktrees';
+export {
+  parseNextSessionBullets,
+  readLedgerIndex,
+  writeLedgerIndex,
+  runLedgerVerification,
+  defaultVerifierFactory,
+  triggerBackgroundVerification,
+  annotateLedgerText,
+  annotationPrefix,
+  hashContent,
+  ledgerIndexPath,
+  LEDGER_INDEX_FILENAME,
+} from './verify-ledger-background';
+export type {
+  ParsedBullet,
+  LedgerIndex,
+  LedgerIndexEntry,
+  LedgerVerdict,
+  BulletVerifier,
+} from './verify-ledger-background';
 export { ToolRouter, ToolExecutor } from './tool-router';
 export type { ToolExecutorConfig } from './tool-router';
 export { buildToolSystemPrompt, TOOL_SCHEMAS, PLAN_CHOICES, PENDING_PLAN_CHOICES } from './tool-definitions';

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -95,6 +95,7 @@ export { discoverGitWorktrees } from './discover-git-worktrees';
 export type { DiscoverResult } from './discover-git-worktrees';
 export {
   parseNextSessionBullets,
+  findOpenSectionLine,
   readLedgerIndex,
   writeLedgerIndex,
   runLedgerVerification,

--- a/packages/orchestrator/src/verify-ledger-background.ts
+++ b/packages/orchestrator/src/verify-ledger-background.ts
@@ -1,0 +1,340 @@
+/**
+ * verify-ledger-background — next-session ledger auto-verify guardrail (Option B).
+ *
+ * Spec: docs/specs/2026-05-14-next-session-ledger-autoverify.md
+ *
+ * Responsibilities:
+ *   1. parseNextSessionBullets(content)   — extract bullets from a `## Open ...` section.
+ *      Classifies each as memory-backed (with [link](path)), free-form prose, or numeric.
+ *   2. readLedgerIndex(...)               — load `.gossip/next-session-index.json` and validate
+ *      its `ledgerMtime` AND `ledgerContentHash` against the live ledger. Both must match,
+ *      otherwise the cache is stale and the caller should trigger refresh.
+ *   3. writeLedgerIndex(...)              — atomic-ish write of the sidecar.
+ *   4. runLedgerVerification(...)         — bounded-concurrency (default 3) walk over bullets,
+ *      delegating each verification to an injected verifier callback. Tests pass a mock.
+ *
+ * The background job NEVER awaits inside the bootstrap critical path. Bootstrap calls
+ * `triggerBackgroundVerification()` which uses `setImmediate` + a fire-and-forget Promise.
+ *
+ * Bootstrap directly reads the sidecar via readLedgerIndex; on a hit it splices verdicts
+ * into the ledger text. On a miss/stale, every bullet gets `[UNVERIFIED]` and the background
+ * job is scheduled. The dispatcher itself does NOT modify next-session.md — the sidecar is
+ * the only side-effect.
+ */
+import { createHash } from 'crypto';
+import { existsSync, readFileSync, writeFileSync, statSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+
+export type LedgerVerdict =
+  | 'FRESH'
+  | 'STALE'
+  | 'CONTRADICTED'
+  | 'INCONCLUSIVE'
+  | 'PROSE-ONLY'
+  | 'UNVERIFIABLE';
+
+export interface ParsedBullet {
+  /** The bullet text without the leading "- " marker, trimmed. */
+  text: string;
+  /** Index of the bullet within the parsed section (stable across runs given identical input). */
+  index: number;
+  /** Stable hash of `text` — primary key in the sidecar. */
+  hash: string;
+  /** Memory file path if a `[label](path.md)` link was detected; else undefined. */
+  backingFile?: string;
+  /** True if the bullet has no memory link AND no obvious numeric claim (pure prose). */
+  proseOnly: boolean;
+  /** Numeric-claim hint: extracted number + noun the bullet is about (e.g., 4 + "worktree"). */
+  numericClaim?: { n: number; noun: string };
+}
+
+export interface LedgerIndexEntry {
+  bulletHash: string;
+  verdict: LedgerVerdict;
+  details: string;
+  checkedAt: string;
+}
+
+export interface LedgerIndex {
+  ledgerMtime: number;
+  ledgerContentHash: string;
+  entries: LedgerIndexEntry[];
+}
+
+export const LEDGER_INDEX_FILENAME = 'next-session-index.json';
+
+/** Stable BLAKE2-flavored SHA256 truncation. Cheap, deterministic, no deps. */
+export function hashContent(s: string): string {
+  return createHash('sha256').update(s).digest('hex').slice(0, 16);
+}
+
+/**
+ * Extract bullets from a "## Open for next session" (or close cousin) block.
+ *
+ * Recognized bullet shapes:
+ *   - `- [label](path/to/memory.md) — description`              → memory-backed
+ *   - `- Continue work on something`                            → free-form prose
+ *   - `- Clean up "4 merged-but-locked worktree branches"`      → numeric (worktree)
+ *
+ * Lines that are not bullets (headings, blank lines) are skipped. Indented
+ * continuation lines are folded into the parent bullet.
+ */
+export function parseNextSessionBullets(content: string): ParsedBullet[] {
+  if (!content) return [];
+
+  // Try to locate the "Open for next session" block; fall back to scanning the
+  // whole document if no header is found (some ledgers are bullet-only).
+  const openIdx = content.search(/^\s{0,3}#{1,4}\s+Open[^\n]*$/im);
+  const body = openIdx === -1 ? content : content.slice(openIdx);
+  const lines = body.split('\n');
+
+  const bullets: ParsedBullet[] = [];
+  let current: string | null = null;
+  const flush = () => {
+    if (current == null) return;
+    const text = current.trim();
+    if (text.length === 0) { current = null; return; }
+    const index = bullets.length;
+    const hash = hashContent(text);
+
+    // Memory link detection: prefer `[label](path)` with .md extension or path-like.
+    let backingFile: string | undefined;
+    const linkMatch = text.match(/\[[^\]]+\]\(([^)\s]+\.md)\)/);
+    if (linkMatch) backingFile = linkMatch[1];
+
+    // Numeric claim detection — keep tight; only patterns we know how to verify live.
+    let numericClaim: ParsedBullet['numericClaim'] | undefined;
+    const worktreeMatch = text.match(/\b(\d+)\s+(?:merged-but-locked\s+)?worktrees?(?:\s+branch(?:es)?)?\b/i);
+    if (worktreeMatch) numericClaim = { n: parseInt(worktreeMatch[1], 10), noun: 'worktree' };
+
+    const proseOnly = !backingFile && !numericClaim;
+    bullets.push({ text, index, hash, backingFile, proseOnly, numericClaim });
+    current = null;
+  };
+
+  for (const raw of lines) {
+    const bulletStart = /^\s{0,3}[-*]\s+(.*)$/.exec(raw);
+    if (bulletStart) {
+      flush();
+      current = bulletStart[1];
+      continue;
+    }
+    // Heading terminates the block once we've consumed at least one bullet.
+    if (/^\s{0,3}#{1,6}\s/.test(raw) && bullets.length > 0) { flush(); break; }
+    // Continuation: indented line under current bullet.
+    if (current != null && /^\s{2,}\S/.test(raw)) {
+      current += ' ' + raw.trim();
+      continue;
+    }
+    // Blank line ends a bullet.
+    if (/^\s*$/.test(raw)) { flush(); continue; }
+  }
+  flush();
+  return bullets;
+}
+
+/** Resolve the sidecar path. Exposed for tests. */
+export function ledgerIndexPath(projectRoot: string): string {
+  return join(projectRoot, '.gossip', LEDGER_INDEX_FILENAME);
+}
+
+/**
+ * Load the sidecar AND validate it against the live ledger. Returns null on:
+ *   - missing sidecar
+ *   - parse error
+ *   - mtime mismatch
+ *   - content-hash mismatch
+ * The caller should treat null as a cold cache (annotate UNVERIFIED + trigger refresh).
+ */
+export function readLedgerIndex(
+  projectRoot: string,
+  liveLedgerContent: string,
+  liveLedgerMtime: number,
+): LedgerIndex | null {
+  const path = ledgerIndexPath(projectRoot);
+  if (!existsSync(path)) return null;
+  let parsed: LedgerIndex;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf-8')) as LedgerIndex;
+  } catch {
+    return null;
+  }
+  if (typeof parsed.ledgerMtime !== 'number' || typeof parsed.ledgerContentHash !== 'string') return null;
+  if (!Array.isArray(parsed.entries)) return null;
+  // BOTH checks required per user decision #2.
+  if (parsed.ledgerMtime !== liveLedgerMtime) return null;
+  if (parsed.ledgerContentHash !== hashContent(liveLedgerContent)) return null;
+  return parsed;
+}
+
+/** Write the sidecar. Creates `.gossip/` if missing. Best-effort; swallows write errors. */
+export function writeLedgerIndex(projectRoot: string, index: LedgerIndex): void {
+  const path = ledgerIndexPath(projectRoot);
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(index, null, 2));
+  } catch {
+    // Best-effort — cache failure must never break bootstrap or session_save.
+  }
+}
+
+/** A verifier returns an entry for a single bullet. Pluggable so tests can mock. */
+export type BulletVerifier = (b: ParsedBullet) => Promise<LedgerIndexEntry>;
+
+/**
+ * Bounded-concurrency dispatcher. Walks bullets, runs verifier with at most
+ * `concurrency` in-flight calls, returns entries in original bullet order.
+ *
+ * Simple in-file semaphore — no external deps (user decision #6).
+ */
+export async function runLedgerVerification(
+  bullets: ParsedBullet[],
+  verifier: BulletVerifier,
+  concurrency = 3,
+): Promise<LedgerIndexEntry[]> {
+  const cap = Math.max(1, concurrency | 0);
+  const results: LedgerIndexEntry[] = new Array(bullets.length);
+  let cursor = 0;
+  const workers: Promise<void>[] = [];
+  for (let w = 0; w < cap; w++) {
+    workers.push((async () => {
+      while (true) {
+        const i = cursor++;
+        if (i >= bullets.length) return;
+        try {
+          results[i] = await verifier(bullets[i]);
+        } catch (err) {
+          results[i] = {
+            bulletHash: bullets[i].hash,
+            verdict: 'INCONCLUSIVE',
+            details: `verifier threw: ${(err as Error).message || String(err)}`.slice(0, 500),
+            checkedAt: new Date().toISOString(),
+          };
+        }
+      }
+    })());
+  }
+  await Promise.all(workers);
+  return results;
+}
+
+/**
+ * Default verifier — does NOT call out to gossip_verify_memory directly because
+ * that tool is a two-phase orchestrator-side dispatch (the orchestrator must
+ * launch Agent()). In-process we can only honor the deterministic verdicts:
+ *   - PROSE-ONLY  → bullets without a memory link and without a numeric claim
+ *   - UNVERIFIABLE → numeric-claim bullets when no live counter is available
+ *   - INCONCLUSIVE → memory-linked bullets (orchestrator must run gossip_verify_memory
+ *                     explicitly; the cache surfaces this fact transparently)
+ *
+ * For numeric claims with a known live reader (currently: worktree count), the
+ * verifier returns FRESH/STALE based on actual count vs claimed N.
+ *
+ * Tests inject their own verifier to exercise full code paths.
+ */
+export function defaultVerifierFactory(
+  liveCounters: { worktree?: () => number | null } = {},
+): BulletVerifier {
+  return async (b) => {
+    const now = new Date().toISOString();
+    if (b.numericClaim && b.numericClaim.noun === 'worktree' && liveCounters.worktree) {
+      const live = liveCounters.worktree();
+      if (live != null) {
+        const verdict: LedgerVerdict = live === b.numericClaim.n ? 'FRESH' : 'STALE';
+        return {
+          bulletHash: b.hash,
+          verdict,
+          details: `live worktree count: ${live} (claim: ${b.numericClaim.n})`,
+          checkedAt: now,
+        };
+      }
+    }
+    if (b.numericClaim) {
+      return { bulletHash: b.hash, verdict: 'UNVERIFIABLE', details: 'no live counter for numeric claim', checkedAt: now };
+    }
+    if (b.proseOnly) {
+      return { bulletHash: b.hash, verdict: 'PROSE-ONLY', details: 'free-form bullet, no backing memory link', checkedAt: now };
+    }
+    // Memory-linked bullet: in-process we cannot dispatch the haiku verifier;
+    // mark INCONCLUSIVE so the orchestrator knows to call gossip_verify_memory.
+    return {
+      bulletHash: b.hash,
+      verdict: 'INCONCLUSIVE',
+      details: `memory-backed; orchestrator should run gossip_verify_memory(${b.backingFile})`,
+      checkedAt: now,
+    };
+  };
+}
+
+/**
+ * Fire-and-forget background trigger used by bootstrap.ts. Returns immediately;
+ * verification runs on `setImmediate` so the bootstrap call site is never blocked.
+ */
+export function triggerBackgroundVerification(
+  projectRoot: string,
+  liveLedgerContent: string,
+  liveLedgerMtime: number,
+  bullets: ParsedBullet[],
+  verifier: BulletVerifier,
+): void {
+  setImmediate(() => {
+    runLedgerVerification(bullets, verifier, 3)
+      .then((entries) => {
+        writeLedgerIndex(projectRoot, {
+          ledgerMtime: liveLedgerMtime,
+          ledgerContentHash: hashContent(liveLedgerContent),
+          entries,
+        });
+      })
+      .catch(() => { /* swallow; sidecar stays cold */ });
+  });
+}
+
+/** Render an annotation prefix from a verdict. Pure — used by bootstrap. */
+export function annotationPrefix(verdict: LedgerVerdict, details?: string): string {
+  switch (verdict) {
+    case 'FRESH': return '';
+    case 'STALE': return details ? `[STALE — ${details}] ` : '[STALE] ';
+    case 'CONTRADICTED': return details ? `[CONTRADICTED — ${details}] ` : '[CONTRADICTED] ';
+    case 'INCONCLUSIVE': return '[UNVERIFIED] ';
+    case 'PROSE-ONLY': return '[PROSE-ONLY] ';
+    case 'UNVERIFIABLE': return '[UNVERIFIABLE] ';
+  }
+}
+
+/**
+ * Inject annotations into the raw ledger text. Walks bullets in the SAME order
+ * as parseNextSessionBullets() produces them, so verdict-by-hash lookups stay
+ * in sync. Bullets without a matching entry get `[UNVERIFIED]`.
+ *
+ * Per user decision #1: STALE bullets are annotated inline, NEVER stripped.
+ */
+export function annotateLedgerText(
+  raw: string,
+  bullets: ParsedBullet[],
+  entriesByHash: Map<string, LedgerIndexEntry>,
+): string {
+  if (bullets.length === 0) return raw;
+  const lines = raw.split('\n');
+  let bulletCursor = 0;
+  for (let i = 0; i < lines.length; i++) {
+    if (bulletCursor >= bullets.length) break;
+    const m = /^(\s{0,3}[-*]\s+)(.*)$/.exec(lines[i]);
+    if (!m) continue;
+    const b = bullets[bulletCursor++];
+    // Only annotate if the rendered bullet text starts with the parsed text —
+    // continuation lines were folded in parse but raw text keeps original layout.
+    const restOfBullet = m[2];
+    const entry = entriesByHash.get(b.hash);
+    const verdict: LedgerVerdict = entry?.verdict ?? 'INCONCLUSIVE';
+    const prefix = annotationPrefix(verdict, entry?.details);
+    if (!prefix) continue; // FRESH → leave untouched
+    lines[i] = `${m[1]}${prefix}${restOfBullet}`;
+  }
+  return lines.join('\n');
+}
+
+/** Convenience: read live ledger mtime; returns 0 on stat failure. */
+export function ledgerMtime(ledgerPath: string): number {
+  try { return statSync(ledgerPath).mtimeMs; } catch { return 0; }
+}

--- a/packages/orchestrator/src/verify-ledger-background.ts
+++ b/packages/orchestrator/src/verify-ledger-background.ts
@@ -9,12 +9,15 @@
  *   2. readLedgerIndex(...)               — load `.gossip/next-session-index.json` and validate
  *      its `ledgerMtime` AND `ledgerContentHash` against the live ledger. Both must match,
  *      otherwise the cache is stale and the caller should trigger refresh.
- *   3. writeLedgerIndex(...)              — atomic-ish write of the sidecar.
+ *   3. writeLedgerIndex(...)              — best-effort, non-atomic write of the sidecar.
  *   4. runLedgerVerification(...)         — bounded-concurrency (default 3) walk over bullets,
  *      delegating each verification to an injected verifier callback. Tests pass a mock.
  *
- * The background job NEVER awaits inside the bootstrap critical path. Bootstrap calls
- * `triggerBackgroundVerification()` which uses `setImmediate` + a fire-and-forget Promise.
+ * Background verification (haiku dispatch + git subprocess) never blocks the bootstrap
+ * critical path. Bootstrap calls `triggerBackgroundVerification()` which uses `setImmediate`
+ * + a fire-and-forget Promise. Synchronous fs reads required for cache validation
+ * (`statSync`, `existsSync`, `readFileSync`, `JSON.parse`) DO run on the hot path —
+ * bounded by file size, unavoidable for the mtime+hash check.
  *
  * Bootstrap directly reads the sidecar via readLedgerIndex; on a hit it splices verdicts
  * into the ledger text. On a miss/stale, every bullet gets `[UNVERIFIED]` and the background
@@ -66,6 +69,22 @@ export const LEDGER_INDEX_FILENAME = 'next-session-index.json';
 /** Stable BLAKE2-flavored SHA256 truncation. Cheap, deterministic, no deps. */
 export function hashContent(s: string): string {
   return createHash('sha256').update(s).digest('hex').slice(0, 16);
+}
+
+/**
+ * Find the line number (0-based) in `content` where the "## Open ..." section starts.
+ * Returns -1 when no such heading is found (fall-back: scan the whole document).
+ *
+ * Shared by `parseNextSessionBullets` and `annotateLedgerText` so both operate on the
+ * same section boundary, preventing bullet-cursor misalignment when there are bullets
+ * above the Open heading (e.g. in a "## Shipped this session" block).
+ */
+export function findOpenSectionLine(content: string): number {
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\s{0,3}#{1,4}\s+Open[^\n]*$/.test(lines[i])) return i;
+  }
+  return -1;
 }
 
 /**
@@ -307,6 +326,10 @@ export function annotationPrefix(verdict: LedgerVerdict, details?: string): stri
  * as parseNextSessionBullets() produces them, so verdict-by-hash lookups stay
  * in sync. Bullets without a matching entry get `[UNVERIFIED]`.
  *
+ * Uses `findOpenSectionLine` to skip any bullets that appear BEFORE the
+ * `## Open ...` heading (e.g. in a "## Shipped this session" block), preventing
+ * bullet-cursor misalignment when the ledger has multi-section structure.
+ *
  * Per user decision #1: STALE bullets are annotated inline, NEVER stripped.
  */
 export function annotateLedgerText(
@@ -316,8 +339,12 @@ export function annotateLedgerText(
 ): string {
   if (bullets.length === 0) return raw;
   const lines = raw.split('\n');
+  // Start the cursor only from the Open-section line so bullets before that
+  // heading (e.g. "## Shipped") do not consume slots and misalign annotations.
+  const openLineStart = findOpenSectionLine(raw);
+  const startLine = openLineStart === -1 ? 0 : openLineStart;
   let bulletCursor = 0;
-  for (let i = 0; i < lines.length; i++) {
+  for (let i = startLine; i < lines.length; i++) {
     if (bulletCursor >= bullets.length) break;
     const m = /^(\s{0,3}[-*]\s+)(.*)$/.exec(lines[i]);
     if (!m) continue;

--- a/tests/orchestrator/verify-ledger-background.test.ts
+++ b/tests/orchestrator/verify-ledger-background.test.ts
@@ -7,6 +7,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   parseNextSessionBullets,
+  findOpenSectionLine,
   readLedgerIndex,
   writeLedgerIndex,
   runLedgerVerification,
@@ -207,6 +208,84 @@ describe('annotateLedgerText / annotationPrefix — rendering', () => {
     });
     const out = annotateLedgerText(ledger, bullets, byHash);
     expect(out).toContain('[UNVERIFIABLE] Clean up 4 merged-but-locked');
+  });
+
+  it('f5 regression — bullets before ## Open do NOT consume cursor slots', () => {
+    // Multi-section ledger: Shipped section has bullets BEFORE Open section.
+    // Without the fix, foo/bar would advance the cursor and Open bullets would
+    // be annotated on wrong lines (or not at all).
+    const multiSectionLedger = `## Shipped this session
+- foo
+- bar
+
+## Open for next session
+- [target1](memory.md) — backing memory bullet
+- some prose
+`;
+    const openBullets = parseNextSessionBullets(multiSectionLedger);
+    // parseNextSessionBullets should only return Open-section bullets
+    expect(openBullets).toHaveLength(2);
+    expect(openBullets[0].backingFile).toBe('memory.md');
+    expect(openBullets[1].proseOnly).toBe(true);
+
+    // annotateLedgerText should annotate the Open bullets, NOT foo/bar
+    const byHash = new Map<string, LedgerIndexEntry>();
+    byHash.set(openBullets[0].hash, {
+      bulletHash: openBullets[0].hash, verdict: 'STALE',
+      details: 'already shipped', checkedAt: 'now',
+    });
+    byHash.set(openBullets[1].hash, {
+      bulletHash: openBullets[1].hash, verdict: 'PROSE-ONLY', details: '', checkedAt: 'now',
+    });
+    const out = annotateLedgerText(multiSectionLedger, openBullets, byHash);
+
+    // Shipped-section bullets must be untouched
+    expect(out).toContain('- foo');
+    expect(out).not.toContain('[STALE] foo');
+    expect(out).toContain('- bar');
+    expect(out).not.toContain('[STALE] bar');
+
+    // Open-section bullets must carry their annotations
+    expect(out).toContain('[STALE — already shipped] [target1](memory.md)');
+    expect(out).toContain('[PROSE-ONLY] some prose');
+  });
+
+  it('f5 regression — no Open header: fall-through leaves behavior unchanged', () => {
+    // When there is no ## Open heading, findOpenSectionLine returns -1 and
+    // annotateLedgerText falls back to scanning from line 0 (whole document).
+    const plainBullets = `- alpha
+- beta
+`;
+    const bs = parseNextSessionBullets(plainBullets);
+    expect(bs).toHaveLength(2);
+    const byHash = new Map<string, LedgerIndexEntry>();
+    byHash.set(bs[0].hash, { bulletHash: bs[0].hash, verdict: 'FRESH', details: '', checkedAt: 'now' });
+    byHash.set(bs[1].hash, { bulletHash: bs[1].hash, verdict: 'PROSE-ONLY', details: '', checkedAt: 'now' });
+    const out = annotateLedgerText(plainBullets, bs, byHash);
+    expect(out).toContain('- alpha'); // FRESH → untouched
+    expect(out).toContain('[PROSE-ONLY] beta');
+  });
+});
+
+describe('findOpenSectionLine', () => {
+  it('returns -1 when no Open heading exists', () => {
+    expect(findOpenSectionLine('- just bullets\n- more bullets\n')).toBe(-1);
+    expect(findOpenSectionLine('')).toBe(-1);
+  });
+
+  it('returns the correct 0-based line number for ## Open heading', () => {
+    const content = `# Title\n\n## Open for next session\n\n- bullet\n`;
+    expect(findOpenSectionLine(content)).toBe(2);
+  });
+
+  it('handles Open heading on line 0', () => {
+    const content = `## Open for next session\n- bullet\n`;
+    expect(findOpenSectionLine(content)).toBe(0);
+  });
+
+  it('ignores headings that do not start with Open', () => {
+    const content = `## Shipped this session\n- foo\n## Open for next session\n- bar\n`;
+    expect(findOpenSectionLine(content)).toBe(2);
   });
 });
 

--- a/tests/orchestrator/verify-ledger-background.test.ts
+++ b/tests/orchestrator/verify-ledger-background.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for next-session ledger auto-verify guardrail (Option B).
+ * Spec: docs/specs/2026-05-14-next-session-ledger-autoverify.md
+ */
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  parseNextSessionBullets,
+  readLedgerIndex,
+  writeLedgerIndex,
+  runLedgerVerification,
+  annotateLedgerText,
+  annotationPrefix,
+  hashContent,
+  ledgerIndexPath,
+  defaultVerifierFactory,
+  type LedgerIndexEntry,
+  type LedgerVerdict,
+  type ParsedBullet,
+  type BulletVerifier,
+} from '@gossip/orchestrator';
+
+const mkTmp = (suffix: string) => {
+  const dir = join(tmpdir(), `gossip-ledger-${suffix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(join(dir, '.gossip'), { recursive: true });
+  return dir;
+};
+
+describe('parseNextSessionBullets', () => {
+  it('classifies memory-linked bullets via [label](path.md)', () => {
+    const md = `# Next Session
+
+## Open for next session
+
+- [Backlog item A](memory/feedback_x.md) — description here
+- [Backlog item B](docs/specs/y.md): more text
+`;
+    const out = parseNextSessionBullets(md);
+    expect(out).toHaveLength(2);
+    expect(out[0].backingFile).toBe('memory/feedback_x.md');
+    expect(out[0].proseOnly).toBe(false);
+    expect(out[1].backingFile).toBe('docs/specs/y.md');
+  });
+
+  it('classifies free-form prose bullets', () => {
+    const md = `## Open for next session
+
+- Continue work on the dashboard refactor
+- Investigate flaky test in foo.test.ts
+`;
+    const out = parseNextSessionBullets(md);
+    expect(out).toHaveLength(2);
+    expect(out[0].backingFile).toBeUndefined();
+    expect(out[0].proseOnly).toBe(true);
+    expect(out[1].proseOnly).toBe(true);
+  });
+
+  it('extracts numeric worktree claims', () => {
+    const md = `## Open for next session
+
+- Clean up "4 merged-but-locked worktree branches"
+- Audit 7 worktrees for stale base
+`;
+    const out = parseNextSessionBullets(md);
+    expect(out).toHaveLength(2);
+    expect(out[0].numericClaim).toEqual({ n: 4, noun: 'worktree' });
+    expect(out[0].proseOnly).toBe(false);
+    expect(out[1].numericClaim).toEqual({ n: 7, noun: 'worktree' });
+  });
+
+  it('returns [] for empty / missing content', () => {
+    expect(parseNextSessionBullets('')).toEqual([]);
+    expect(parseNextSessionBullets('no bullets here, just prose')).toEqual([]);
+  });
+
+  it('produces stable hashes across runs', () => {
+    const md = `## Open for next session\n\n- Same bullet text\n`;
+    const a = parseNextSessionBullets(md);
+    const b = parseNextSessionBullets(md);
+    expect(a[0].hash).toBe(b[0].hash);
+    expect(a[0].hash).toBe(hashContent(a[0].text));
+  });
+});
+
+describe('readLedgerIndex — cache validation', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkTmp('cache'); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  const ledger = '## Open for next session\n\n- [A](a.md) — x\n';
+  const writeLedger = () => {
+    const p = join(dir, '.gossip', 'next-session.md');
+    writeFileSync(p, ledger);
+    return p;
+  };
+
+  it('returns null when sidecar is missing', () => {
+    writeLedger();
+    expect(readLedgerIndex(dir, ledger, 1)).toBeNull();
+  });
+
+  it('returns null when ledgerMtime mismatches', () => {
+    writeLedgerIndex(dir, {
+      ledgerMtime: 100,
+      ledgerContentHash: hashContent(ledger),
+      entries: [],
+    });
+    expect(readLedgerIndex(dir, ledger, 999)).toBeNull();
+  });
+
+  it('returns null when content hash mismatches (even if mtime matches)', () => {
+    writeLedgerIndex(dir, {
+      ledgerMtime: 100,
+      ledgerContentHash: 'wronghash',
+      entries: [],
+    });
+    expect(readLedgerIndex(dir, ledger, 100)).toBeNull();
+  });
+
+  it('returns parsed index when BOTH mtime and content hash match', () => {
+    const entries: LedgerIndexEntry[] = [
+      { bulletHash: 'abc', verdict: 'FRESH', details: 'ok', checkedAt: '2026-05-14T00:00:00Z' },
+    ];
+    writeLedgerIndex(dir, {
+      ledgerMtime: 100,
+      ledgerContentHash: hashContent(ledger),
+      entries,
+    });
+    const out = readLedgerIndex(dir, ledger, 100);
+    expect(out).not.toBeNull();
+    expect(out!.entries).toEqual(entries);
+  });
+
+  it('returns null when sidecar is malformed JSON', () => {
+    const p = ledgerIndexPath(dir);
+    writeFileSync(p, '{not valid json');
+    expect(readLedgerIndex(dir, ledger, 100)).toBeNull();
+  });
+});
+
+describe('annotateLedgerText / annotationPrefix — rendering', () => {
+  const ledger = `## Open for next session
+
+- [Item A](a.md) — first
+- Continue free-form work
+- Clean up 4 merged-but-locked worktree branches
+`;
+  const bullets = parseNextSessionBullets(ledger);
+
+  it('produces "" for FRESH (no marker)', () => {
+    expect(annotationPrefix('FRESH')).toBe('');
+  });
+
+  it('STALE includes inline details (user decision #1)', () => {
+    expect(annotationPrefix('STALE', 'shipped PR #X')).toContain('[STALE — shipped PR #X]');
+  });
+
+  it('PROSE-ONLY / UNVERIFIABLE / UNVERIFIED prefixes', () => {
+    expect(annotationPrefix('PROSE-ONLY')).toBe('[PROSE-ONLY] ');
+    expect(annotationPrefix('UNVERIFIABLE')).toBe('[UNVERIFIABLE] ');
+    expect(annotationPrefix('INCONCLUSIVE')).toBe('[UNVERIFIED] ');
+  });
+
+  it('keeps STALE bullets in place (does not strip)', () => {
+    const byHash = new Map<string, LedgerIndexEntry>();
+    byHash.set(bullets[0].hash, {
+      bulletHash: bullets[0].hash, verdict: 'STALE',
+      details: 'shipped PR #X', checkedAt: 'now',
+    });
+    const out = annotateLedgerText(ledger, bullets, byHash);
+    expect(out).toContain('[STALE — shipped PR #X]');
+    expect(out).toContain('[Item A](a.md) — first');
+  });
+
+  it('cold cache annotates everything as [UNVERIFIED]', () => {
+    const out = annotateLedgerText(ledger, bullets, new Map());
+    expect(out).toContain('[UNVERIFIED] [Item A](a.md) — first');
+    expect(out).toContain('[UNVERIFIED] Continue free-form work');
+    expect(out).toContain('[UNVERIFIED] Clean up 4 merged-but-locked');
+  });
+
+  it('FRESH bullets are NOT prefixed', () => {
+    const byHash = new Map<string, LedgerIndexEntry>();
+    for (const b of bullets) {
+      byHash.set(b.hash, { bulletHash: b.hash, verdict: 'FRESH', details: '', checkedAt: 'now' });
+    }
+    const out = annotateLedgerText(ledger, bullets, byHash);
+    expect(out).not.toContain('[UNVERIFIED]');
+    expect(out).not.toContain('[STALE');
+    expect(out).not.toContain('[PROSE-ONLY]');
+  });
+
+  it('PROSE-ONLY marker renders for prose bullets', () => {
+    const byHash = new Map<string, LedgerIndexEntry>();
+    byHash.set(bullets[1].hash, {
+      bulletHash: bullets[1].hash, verdict: 'PROSE-ONLY', details: '', checkedAt: 'now',
+    });
+    const out = annotateLedgerText(ledger, bullets, byHash);
+    expect(out).toContain('[PROSE-ONLY] Continue free-form work');
+  });
+
+  it('UNVERIFIABLE marker renders for numeric bullets without live counter', () => {
+    const byHash = new Map<string, LedgerIndexEntry>();
+    byHash.set(bullets[2].hash, {
+      bulletHash: bullets[2].hash, verdict: 'UNVERIFIABLE', details: '', checkedAt: 'now',
+    });
+    const out = annotateLedgerText(ledger, bullets, byHash);
+    expect(out).toContain('[UNVERIFIABLE] Clean up 4 merged-but-locked');
+  });
+});
+
+describe('runLedgerVerification — concurrency cap', () => {
+  const makeBullets = (n: number): ParsedBullet[] =>
+    Array.from({ length: n }, (_, i) => ({
+      text: `bullet ${i}`, index: i, hash: `h${i}`, proseOnly: true,
+    }));
+
+  it('runs all bullets and preserves order', async () => {
+    const verifier: BulletVerifier = async (b) => ({
+      bulletHash: b.hash, verdict: 'PROSE-ONLY', details: '', checkedAt: 'now',
+    });
+    const out = await runLedgerVerification(makeBullets(5), verifier, 3);
+    expect(out).toHaveLength(5);
+    out.forEach((e, i) => expect(e.bulletHash).toBe(`h${i}`));
+  });
+
+  it('honors concurrency cap of 3 — never more than 3 in-flight at once', async () => {
+    let inFlight = 0;
+    let maxObserved = 0;
+    const verifier: BulletVerifier = async (b) => {
+      inFlight++;
+      maxObserved = Math.max(maxObserved, inFlight);
+      await new Promise(r => setTimeout(r, 20));
+      inFlight--;
+      return { bulletHash: b.hash, verdict: 'INCONCLUSIVE', details: '', checkedAt: 'now' };
+    };
+    await runLedgerVerification(makeBullets(10), verifier, 3);
+    expect(maxObserved).toBeLessThanOrEqual(3);
+    expect(maxObserved).toBeGreaterThan(0);
+  });
+
+  it('catches verifier exceptions as INCONCLUSIVE — does NOT crash the batch', async () => {
+    const verifier: BulletVerifier = async (b) => {
+      if (b.index === 1) throw new Error('boom');
+      return { bulletHash: b.hash, verdict: 'FRESH', details: 'ok', checkedAt: 'now' };
+    };
+    const out = await runLedgerVerification(makeBullets(3), verifier, 3);
+    expect(out).toHaveLength(3);
+    expect(out[0].verdict).toBe('FRESH');
+    expect(out[1].verdict).toBe('INCONCLUSIVE');
+    expect(out[1].details).toContain('verifier threw');
+    expect(out[2].verdict).toBe('FRESH');
+  });
+});
+
+describe('defaultVerifierFactory', () => {
+  const mk = (overrides: Partial<ParsedBullet>): ParsedBullet => ({
+    text: 't', index: 0, hash: 'h', proseOnly: false, ...overrides,
+  });
+
+  it('returns PROSE-ONLY for free-form bullets', async () => {
+    const v = defaultVerifierFactory();
+    const r = await v(mk({ proseOnly: true }));
+    expect(r.verdict).toBe('PROSE-ONLY');
+  });
+
+  it('returns FRESH when live worktree count matches the claim', async () => {
+    const v = defaultVerifierFactory({ worktree: () => 4 });
+    const r = await v(mk({ numericClaim: { n: 4, noun: 'worktree' } }));
+    expect(r.verdict).toBe('FRESH');
+    expect(r.details).toContain('live worktree count: 4');
+  });
+
+  it('returns STALE when live worktree count differs from the claim', async () => {
+    const v = defaultVerifierFactory({ worktree: () => 21 });
+    const r = await v(mk({ numericClaim: { n: 4, noun: 'worktree' } }));
+    expect(r.verdict).toBe('STALE');
+    expect(r.details).toContain('live worktree count: 21 (claim: 4)');
+  });
+
+  it('returns UNVERIFIABLE for numeric claims with no live counter', async () => {
+    const v = defaultVerifierFactory();
+    const r = await v(mk({ numericClaim: { n: 4, noun: 'worktree' } }));
+    expect(r.verdict).toBe('UNVERIFIABLE');
+  });
+
+  it('returns INCONCLUSIVE for memory-linked bullets (orchestrator-side dispatch)', async () => {
+    const v = defaultVerifierFactory();
+    const r = await v(mk({ backingFile: 'memory/foo.md' }));
+    expect(r.verdict).toBe('INCONCLUSIVE');
+    expect(r.details).toContain('gossip_verify_memory');
+  });
+});
+
+describe('writeLedgerIndex / sidecar round-trip', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkTmp('rt'); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('writes sidecar JSON that readLedgerIndex parses back', () => {
+    const ledger = 'content';
+    const mtime = 12345;
+    const entries: LedgerIndexEntry[] = [
+      { bulletHash: 'x', verdict: 'FRESH' as LedgerVerdict, details: 'ok', checkedAt: '2026-05-14T00:00:00Z' },
+    ];
+    writeLedgerIndex(dir, {
+      ledgerMtime: mtime, ledgerContentHash: hashContent(ledger), entries,
+    });
+    expect(existsSync(ledgerIndexPath(dir))).toBe(true);
+    const out = readLedgerIndex(dir, ledger, mtime);
+    expect(out).not.toBeNull();
+    expect(out!.entries).toEqual(entries);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the next-session ledger auto-verify guardrail per `docs/specs/2026-05-14-next-session-ledger-autoverify.md` (Option B). Bootstrap now annotates `.gossip/next-session.md` bullets with verdict markers from a `.gossip/next-session-index.json` sidecar; cold/stale cache triggers a fire-and-forget background refresh.

Closes the gap from session 2026-05-14 where 5 next-session bullets opened a session despite all 5 being shipped — orchestrator now sees `[STALE]` / `[UNVERIFIED]` / `[PROSE-ONLY]` / `[UNVERIFIABLE]` annotations and pauses before dispatching.

consensus-id: 0e4dbd10-16cf4804

## User Decisions (final, not re-litigated)

1. **[STALE] handling**: annotate inline, KEEP the bullet (do not strip).
2. **Cache invalidation**: invalidate `.gossip/next-session-index.json` when `next-session.md` mtime OR content-hash changes. Both checks. No wall-clock TTL.
3. **Free-form prose bullets**: marked `[PROSE-ONLY]` so orchestrator knows the guardrail couldn't verify.
4. **Numeric runtime-state claims**: inject live counts from existing utility functions. Fall back to `[UNVERIFIABLE]` when no matching utility exists — do NOT invent new scanners. (Currently wired: worktree count via synchronous `git worktree list --porcelain`.)
5. **MVP scope**: full Option B in ONE PR (~130 LOC target; actual ~220 production LOC + ~270 LOC tests).
6. **Concurrency cap**: at most 3 parallel verifier dispatches. Simple in-file semaphore — no external dep.

## Architecture Notes

- `gossip_verify_memory` is a two-phase orchestrator-side dispatch (must launch `Agent()`), so the in-process default verifier returns `INCONCLUSIVE` for memory-linked bullets — the orchestrator is expected to run `gossip_verify_memory` explicitly when they see `[UNVERIFIED]`. Tests inject mock verifiers to exercise full state-machine paths.
- Bootstrap critical path stays synchronous. Background refresh uses `setImmediate` + fire-and-forget Promise — `readNextSessionNotes()` returns immediately on cache miss.
- Sidecar is purely additive in `.gossip/`. Existing files (`next-session.md`, `verify-memory.ts`) are not modified.

## Test plan

- [x] `parseNextSessionBullets`: memory-link vs prose vs numeric-claim shapes
- [x] Cache mtime+hash validation: mismatch → invalidate
- [x] Annotation injection rendering: cold/fresh/stale/prose-only/unverifiable
- [x] Concurrency cap: no more than 3 in-flight (mock verifier with timed promise, assert max concurrent)
- [x] `npm run build` from repo root — green
- [x] `npx jest --testPathPattern=verify-ledger` — 27 pass / 0 fail
- [x] `npx jest --testPathPattern=bootstrap` — 19 pass / 0 fail (no regression)
- [ ] Live exercise on real `.gossip/next-session.md` post-merge

## Files

- `packages/orchestrator/src/verify-ledger-background.ts` (new, ~340 lines incl. JSDoc)
- `packages/orchestrator/src/bootstrap.ts` (+65 LOC)
- `packages/orchestrator/src/index.ts` (+20 LOC re-exports)
- `tests/orchestrator/verify-ledger-background.test.ts` (new, 27 tests)

Generated with Claude Code