### PR TITLE
feat(orchestrator): dist-mcp staleness dev-check

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -29,7 +29,17 @@ import { createServer as createHttpServer, IncomingMessage, ServerResponse } fro
 import { ctx } from './mcp-context';
 import { getGossipcatVersion } from './version';
 import { captureGitStatus, checkUnexpectedChanges } from './utility-guard';
-import { buildUtilityAgentPrompt, getUncategorizedStatusLine } from '@gossip/orchestrator';
+import { buildUtilityAgentPrompt, getUncategorizedStatusLine, checkDistMcpStaleness, logStalenessToMcpLog } from '@gossip/orchestrator';
+
+// Prime the dist-mcp staleness cache from the running bundle path. In the bundled
+// CJS output (dist-mcp/mcp-server.js) __filename resolves to the bundle file, so
+// the staleness check can locate the repo root via two dirname() hops. The result
+// is cached at module scope; bootstrap.ts reads it via checkDistMcpStaleness() with
+// no args. Logging is best-effort — never break boot if .gossip/mcp.log is unwritable.
+try {
+  const stalenessResult = checkDistMcpStaleness(__filename);
+  if (stalenessResult.stale) logStalenessToMcpLog(stalenessResult, process.cwd());
+} catch { /* never break boot */ }
 import { restoreNativeTaskMap, handleNativeRelay, spawnTimeoutWatcher, scheduleNativeTaskEviction } from './handlers/native-tasks';
 import { handleDispatchSingle, handleDispatchParallel, handleDispatchConsensus } from './handlers/dispatch';
 import { handleCollect } from './handlers/collect';

--- a/packages/orchestrator/src/bootstrap.ts
+++ b/packages/orchestrator/src/bootstrap.ts
@@ -10,6 +10,7 @@ import {
   defaultVerifierFactory,
   type LedgerIndexEntry,
 } from './verify-ledger-background';
+import { checkDistMcpStaleness, renderStalenessBanner } from './dist-mcp-staleness';
 
 export interface BootstrapResult {
   prompt: string;
@@ -140,7 +141,9 @@ export class BootstrapGenerator {
     const isCursor = !!process.env.CURSOR_TRACE_ID || !!process.env.CURSOR_SESSION_ID;
     const host = isClaude ? 'Claude Code' : isCursor ? 'Cursor' : 'your IDE';
 
-    return `# Gossipcat — Multi-Agent Orchestration
+    const banner = renderStalenessBanner(checkDistMcpStaleness());
+
+    return `${banner}# Gossipcat — Multi-Agent Orchestration
 
 Gossipcat is not configured yet. Set up a multi-agent team for this project.
 
@@ -243,7 +246,9 @@ When saving a \`project_*\` memory, include a \`status\` frontmatter field:
 Without it, the dashboard defaults to "backlog" and applies staleness verification conservatively.
 `;
 
-    return `# Gossipcat — Multi-Agent Orchestration
+    const banner = renderStalenessBanner(checkDistMcpStaleness());
+
+    return `${banner}# Gossipcat — Multi-Agent Orchestration
 
 ## Your Role
 

--- a/packages/orchestrator/src/dist-mcp-staleness.ts
+++ b/packages/orchestrator/src/dist-mcp-staleness.ts
@@ -1,0 +1,113 @@
+import { existsSync, statSync, readdirSync, appendFileSync } from 'fs';
+import { join, dirname, resolve } from 'path';
+
+export interface StalenessResult {
+  stale: boolean;
+  deltaMs: number;
+  newestSrc?: string;
+  bundlePath?: string;
+  skipped: 'installed' | 'no-bundle' | 'suppressed' | null;
+}
+
+const SRC_ROOTS = ['packages/orchestrator/src', 'apps/cli/src'];
+
+function walk(dir: string, onFile: (path: string, mtimeMs: number) => void): void {
+  let entries: import('fs').Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true, encoding: 'utf-8' }) as import('fs').Dirent[];
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const name = entry.name;
+    if (name === 'node_modules' || name === 'dist' || name === '__tests__') continue;
+    const full = join(dir, name);
+    if (entry.isDirectory()) {
+      walk(full, onFile);
+    } else if (entry.isFile() && name.endsWith('.ts') && !name.endsWith('.test.ts') && !name.endsWith('.d.ts')) {
+      try {
+        onFile(full, statSync(full).mtimeMs);
+      } catch { /* skip unreadable */ }
+    }
+  }
+}
+
+let cached: StalenessResult | null = null;
+
+export function checkDistMcpStaleness(bundlePath?: string): StalenessResult {
+  if (cached) return cached;
+  if (process.env.GOSSIPCAT_SUPPRESS_STALENESS === '1') {
+    return (cached = { stale: false, deltaMs: 0, skipped: 'suppressed' });
+  }
+  if (!bundlePath) {
+    // Called without explicit path before cache populated — caller (e.g. bootstrap) is
+    // a downstream consumer; the boot-time site in mcp-server-sdk.ts is responsible for
+    // priming the cache. Return a benign skip rather than guessing the bundle location.
+    return { stale: false, deltaMs: 0, skipped: 'no-bundle' };
+  }
+
+  // Bundle lives at <repoRoot>/dist-mcp/mcp-server.js → repoRoot = dirname(dirname(bundle))
+  const repoRoot = dirname(dirname(resolve(bundlePath)));
+
+  // Skip if bundle absent (cleaned tree; check has nothing to assess)
+  let bundleMtime: number;
+  try {
+    bundleMtime = statSync(bundlePath).mtimeMs;
+  } catch {
+    return (cached = { stale: false, deltaMs: 0, skipped: 'no-bundle' });
+  }
+
+  // Skip-on-installed: package.json files[] excludes src/ — if no src tree exists,
+  // we're in an npm-installed layout, not a dev clone. Never warn end users.
+  for (const root of SRC_ROOTS) {
+    if (!existsSync(join(repoRoot, root))) {
+      return (cached = { stale: false, deltaMs: 0, skipped: 'installed' });
+    }
+  }
+
+  let newestMtime = 0;
+  let newestPath: string | undefined;
+  for (const root of SRC_ROOTS) {
+    walk(join(repoRoot, root), (path, mtimeMs) => {
+      if (mtimeMs > newestMtime) {
+        newestMtime = mtimeMs;
+        newestPath = path;
+      }
+    });
+  }
+
+  const deltaMs = newestMtime - bundleMtime;
+  return (cached = {
+    stale: bundleMtime < newestMtime,
+    deltaMs,
+    newestSrc: newestPath,
+    bundlePath,
+    skipped: null,
+  });
+}
+
+export function resetStalenessCache(): void {
+  cached = null;
+}
+
+export function formatStalenessWarning(result: StalenessResult): string | null {
+  if (!result.stale || result.skipped) return null;
+  const mins = Math.round(result.deltaMs / 60000);
+  const ageLabel = mins < 60 ? `${mins}m` : mins < 1440 ? `${(mins / 60).toFixed(1)}h` : `${(mins / 1440).toFixed(1)}d`;
+  const newest = result.newestSrc ? ` (newest: ${result.newestSrc.split('/src/')[1] ?? result.newestSrc})` : '';
+  return `dist-mcp/mcp-server.js is ${ageLabel} older than source${newest} — run \`npm run build:mcp\` and \`/mcp\` reconnect`;
+}
+
+export function logStalenessToMcpLog(result: StalenessResult, projectRoot: string): void {
+  const msg = formatStalenessWarning(result);
+  if (!msg) return;
+  try {
+    appendFileSync(join(projectRoot, '.gossip', 'mcp.log'), `[gossipcat] ⚠ ${msg}\n`);
+  } catch { /* never break boot on a log-write failure */ }
+}
+
+export function renderStalenessBanner(result: StalenessResult): string {
+  const msg = formatStalenessWarning(result);
+  if (!msg) return '';
+  return `> ⚠ **Bundle staleness:** ${msg}\n\n`;
+}

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -68,6 +68,14 @@ export { createHttpBridgeServer, BridgeConfigError } from './http-bridge-server'
 export type { HttpBridgeServer, HttpBridgeServerOptions } from './http-bridge-server';
 export { WorktreeManager } from './worktree-manager';
 export { BootstrapGenerator } from './bootstrap';
+export {
+  checkDistMcpStaleness,
+  resetStalenessCache,
+  formatStalenessWarning,
+  logStalenessToMcpLog,
+  renderStalenessBanner,
+} from './dist-mcp-staleness';
+export type { StalenessResult } from './dist-mcp-staleness';
 export type { BootstrapResult } from './bootstrap';
 export { findBundledRules, ensureRulesFile, readRulesContent } from './rules-loader';
 export { installWorktreeSandboxHook, findBundledHook, writeOrchestratorRoleMarker, installDisciplineHooks } from './hook-installer';

--- a/tests/orchestrator/dist-mcp-staleness.test.ts
+++ b/tests/orchestrator/dist-mcp-staleness.test.ts
@@ -1,0 +1,165 @@
+import { mkdirSync, writeFileSync, rmSync, utimesSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  checkDistMcpStaleness,
+  resetStalenessCache,
+  formatStalenessWarning,
+  renderStalenessBanner,
+} from '@gossip/orchestrator';
+
+function setMtime(path: string, secondsAgo: number): void {
+  const now = Date.now() / 1000;
+  utimesSync(path, now - secondsAgo, now - secondsAgo);
+}
+
+function makeRepo(testDir: string, layout: { withSrc: boolean; withBundle: boolean }): string {
+  rmSync(testDir, { recursive: true, force: true });
+  mkdirSync(testDir, { recursive: true });
+  if (layout.withBundle) {
+    mkdirSync(join(testDir, 'dist-mcp'), { recursive: true });
+    writeFileSync(join(testDir, 'dist-mcp', 'mcp-server.js'), '// bundle');
+  }
+  if (layout.withSrc) {
+    mkdirSync(join(testDir, 'packages', 'orchestrator', 'src'), { recursive: true });
+    mkdirSync(join(testDir, 'apps', 'cli', 'src'), { recursive: true });
+    writeFileSync(join(testDir, 'packages', 'orchestrator', 'src', 'a.ts'), '// orch');
+    writeFileSync(join(testDir, 'apps', 'cli', 'src', 'b.ts'), '// cli');
+  }
+  return testDir;
+}
+
+describe('checkDistMcpStaleness', () => {
+  const baseDir = join(tmpdir(), `gossip-staleness-${Date.now()}`);
+  let counter = 0;
+
+  beforeEach(() => {
+    resetStalenessCache();
+    delete process.env.GOSSIPCAT_SUPPRESS_STALENESS;
+  });
+
+  afterAll(() => { rmSync(baseDir, { recursive: true, force: true }); });
+
+  function fresh(): string { return join(baseDir, `case-${++counter}`); }
+
+  it('returns stale=true when src is newer than bundle', () => {
+    const dir = makeRepo(fresh(), { withSrc: true, withBundle: true });
+    const bundle = join(dir, 'dist-mcp', 'mcp-server.js');
+    setMtime(bundle, 3600); // bundle 1h old
+    setMtime(join(dir, 'apps', 'cli', 'src', 'b.ts'), 3600); // b.ts same age as bundle
+    setMtime(join(dir, 'packages', 'orchestrator', 'src', 'a.ts'), 60); // a.ts is newest
+
+    const r = checkDistMcpStaleness(bundle);
+    expect(r.stale).toBe(true);
+    expect(r.deltaMs).toBeGreaterThan(0);
+    expect(r.newestSrc).toContain('a.ts');
+    expect(r.skipped).toBe(null);
+  });
+
+  it('returns stale=false with negative deltaMs when bundle is newer than all src', () => {
+    const dir = makeRepo(fresh(), { withSrc: true, withBundle: true });
+    const bundle = join(dir, 'dist-mcp', 'mcp-server.js');
+    setMtime(join(dir, 'packages', 'orchestrator', 'src', 'a.ts'), 3600);
+    setMtime(join(dir, 'apps', 'cli', 'src', 'b.ts'), 3600);
+    setMtime(bundle, 60);
+
+    const r = checkDistMcpStaleness(bundle);
+    expect(r.stale).toBe(false);
+    expect(r.deltaMs).toBeLessThan(0);
+    expect(r.skipped).toBe(null);
+  });
+
+  it('short-circuits to skipped=installed when src dirs do not exist', () => {
+    const dir = makeRepo(fresh(), { withSrc: false, withBundle: true });
+    const bundle = join(dir, 'dist-mcp', 'mcp-server.js');
+
+    const r = checkDistMcpStaleness(bundle);
+    expect(r.stale).toBe(false);
+    expect(r.skipped).toBe('installed');
+  });
+
+  it('returns skipped=no-bundle when bundle file is missing', () => {
+    const dir = makeRepo(fresh(), { withSrc: true, withBundle: false });
+    const r = checkDistMcpStaleness(join(dir, 'dist-mcp', 'mcp-server.js'));
+    expect(r.stale).toBe(false);
+    expect(r.skipped).toBe('no-bundle');
+  });
+
+  it('returns skipped=suppressed when GOSSIPCAT_SUPPRESS_STALENESS=1', () => {
+    process.env.GOSSIPCAT_SUPPRESS_STALENESS = '1';
+    const dir = makeRepo(fresh(), { withSrc: true, withBundle: true });
+    const r = checkDistMcpStaleness(join(dir, 'dist-mcp', 'mcp-server.js'));
+    expect(r.skipped).toBe('suppressed');
+  });
+
+  it('returns skipped=no-bundle when called with no bundlePath and cache is empty', () => {
+    const r = checkDistMcpStaleness();
+    expect(r.skipped).toBe('no-bundle');
+  });
+
+  it('picks newest across BOTH src roots, not just the first', () => {
+    const dir = makeRepo(fresh(), { withSrc: true, withBundle: true });
+    const bundle = join(dir, 'dist-mcp', 'mcp-server.js');
+    setMtime(bundle, 3600);
+    setMtime(join(dir, 'packages', 'orchestrator', 'src', 'a.ts'), 1800); // older
+    setMtime(join(dir, 'apps', 'cli', 'src', 'b.ts'), 60); // newer — in second root
+
+    const r = checkDistMcpStaleness(bundle);
+    expect(r.stale).toBe(true);
+    expect(r.newestSrc).toContain('b.ts');
+  });
+
+  it('ignores .test.ts and .d.ts files during walk', () => {
+    const dir = makeRepo(fresh(), { withSrc: true, withBundle: true });
+    const bundle = join(dir, 'dist-mcp', 'mcp-server.js');
+    // All production .ts files older than bundle
+    setMtime(bundle, 1800);
+    setMtime(join(dir, 'packages', 'orchestrator', 'src', 'a.ts'), 3600);
+    setMtime(join(dir, 'apps', 'cli', 'src', 'b.ts'), 3600);
+
+    // Fresh .test.ts and .d.ts would be newer — should be ignored
+    writeFileSync(join(dir, 'packages', 'orchestrator', 'src', 'a.test.ts'), '// test');
+    writeFileSync(join(dir, 'packages', 'orchestrator', 'src', 'a.d.ts'), '// dts');
+
+    const r = checkDistMcpStaleness(bundle);
+    expect(r.stale).toBe(false);
+  });
+
+  it('caches result across calls (second call ignores arg)', () => {
+    const dir = makeRepo(fresh(), { withSrc: true, withBundle: true });
+    const bundle = join(dir, 'dist-mcp', 'mcp-server.js');
+    setMtime(bundle, 3600);
+    setMtime(join(dir, 'packages', 'orchestrator', 'src', 'a.ts'), 60);
+
+    const first = checkDistMcpStaleness(bundle);
+    const second = checkDistMcpStaleness(); // no arg
+    expect(second).toBe(first); // same object reference = cached
+  });
+});
+
+describe('formatStalenessWarning + renderStalenessBanner', () => {
+  it('returns null when not stale', () => {
+    expect(formatStalenessWarning({ stale: false, deltaMs: 0, skipped: null })).toBe(null);
+    expect(renderStalenessBanner({ stale: false, deltaMs: 0, skipped: null })).toBe('');
+  });
+
+  it('returns null when skipped', () => {
+    expect(formatStalenessWarning({ stale: true, deltaMs: 1000, skipped: 'installed' })).toBe(null);
+  });
+
+  it('formats with minute granularity under an hour', () => {
+    const msg = formatStalenessWarning({ stale: true, deltaMs: 5 * 60 * 1000, skipped: null });
+    expect(msg).toContain('5m older');
+  });
+
+  it('formats with hour granularity under a day', () => {
+    const msg = formatStalenessWarning({ stale: true, deltaMs: 3 * 60 * 60 * 1000, skipped: null });
+    expect(msg).toContain('3.0h older');
+  });
+
+  it('renders banner as blockquote markdown', () => {
+    const banner = renderStalenessBanner({ stale: true, deltaMs: 60 * 60 * 1000, skipped: null });
+    expect(banner).toMatch(/^> ⚠ \*\*Bundle staleness:\*\*/);
+    expect(banner).toContain('npm run build:mcp');
+  });
+});


### PR DESCRIPTION
## Summary

- Warns when `dist-mcp/mcp-server.js` is older than newest source under `packages/orchestrator/src` or `apps/cli/src`.
- Two surfaces: `.gossip/mcp.log` breadcrumb at MCP boot + blockquote banner at top of `gossip_status` output (both `renderTier1` and `renderTeamPrompt`).
- Dev-loop ergonomics only — CI/publish paths already enforce freshness; this closes the local-only gap that hid PR #383's autoverify pipeline for 17.5 days.

## Why now

PR #383 (`f8421b8`, 2026-05-14) shipped the next-session ledger auto-verify. The autoverify code compiled into `packages/orchestrator/dist/` but the bundled `dist-mcp/mcp-server.js` was never rebuilt locally — so every `gossip_status` call between merge and the next manual `npm run build:mcp` served stale code. CI was green (rebuilds bundle in `ci.yml:128-129`), `prepublishOnly` would have rebuilt for publish, but the **local feedback loop** had no signal. This change closes that gap.

## How it works

- `packages/orchestrator/src/dist-mcp-staleness.ts` walks both src trees (skipping `node_modules`, `dist`, `__tests__`, `.test.ts`, `.d.ts`), finds newest mtime, compares to bundle mtime.
- `apps/cli/src/mcp-server-sdk.ts` primes the module-scope singleton cache at boot via `__filename` (CJS-bundled output resolves to the bundle path) and writes a breadcrumb to `.gossip/mcp.log`.
- `packages/orchestrator/src/bootstrap.ts` reads the cached result via `checkDistMcpStaleness()` (no args) and prepends a blockquote banner to both render paths.
- Skip-on-installed: `existsSync(packages/orchestrator/src)` returns false in npm-installed layouts (src not in `files[]`), so end users never see the warning.
- Opt-out: `GOSSIPCAT_SUPPRESS_STALENESS=1`.

## Spec & consensus

Spec at `docs/specs/2026-05-14-dist-mcp-staleness-dev-check.md` (gitignored, local-only per `feedback_specs_stay_local`). Consensus round `6f0ddb50-c759411b` (2 reviewers, 2 rounds) caught 5 real pre-impl errors that this PR addresses: wrong class name (`BootstrapBuilder` → `BootstrapGenerator` at `bootstrap.ts:33`), wrong package location (`orchestrator` can't import from `apps/cli/src/` per build topology), missing `renderTier1` coverage, test dir convention, nonexistent `walkSync` utility.

## Test plan

- [x] `tests/orchestrator/dist-mcp-staleness.test.ts` — 14/14 pass (stale, fresh, installed-skip, no-bundle, suppressed, both-src-roots-scanned, .test.ts/.d.ts filter, cache reuse, banner format)
- [x] `tests/orchestrator/bootstrap.test.ts` — 11/11 still pass (no regression)
- [x] E2E negative: fresh bundle + `/mcp` reconnect → no banner, no log line
- [x] E2E positive: `touch packages/orchestrator/src/bootstrap.ts` + `/mcp` reconnect → banner at top of `gossip_status` output, `[gossipcat] ⚠ dist-mcp/mcp-server.js is 1m older than source (newest: bootstrap.ts) — run \`npm run build:mcp\` and \`/mcp\` reconnect` in `.gossip/mcp.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)