### PR TITLE
feat(orchestrator): prose-only ledger bullet resolver

### DIFF
--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -122,7 +122,21 @@ export type {
   LedgerIndexEntry,
   LedgerVerdict,
   BulletVerifier,
+  ParseNextSessionOptions,
 } from './verify-ledger-background';
+export {
+  buildProseResolverIndex,
+  resolveProseBullet,
+  extractTokens,
+  proseResolverPath,
+  discoverAgentIdsForRoot,
+  PROSE_RESOLVER_FILENAME,
+  PROSE_RESOLVER_VERSION,
+  JACCARD_THRESHOLD,
+  MIN_TOKEN_MATCHES,
+  AMBIGUITY_WINDOW,
+} from './prose-bullet-resolver';
+export type { ProseResolverIndex, ProseResolveResult } from './prose-bullet-resolver';
 export { ToolRouter, ToolExecutor } from './tool-router';
 export type { ToolExecutorConfig } from './tool-router';
 export { buildToolSystemPrompt, TOOL_SCHEMAS, PLAN_CHOICES, PENDING_PLAN_CHOICES } from './tool-definitions';

--- a/packages/orchestrator/src/prose-bullet-resolver.ts
+++ b/packages/orchestrator/src/prose-bullet-resolver.ts
@@ -1,0 +1,318 @@
+/**
+ * prose-bullet-resolver — fuzzy slug-matching for free-form ledger bullets.
+ *
+ * Spec: docs/specs/2026-05-14-prose-only-bullet-resolver.md
+ *
+ * Problem: parseNextSessionBullets only attaches a "backingFile" when the
+ * bullet text contains an explicit markdown link "[label](path.md)". Free-form
+ * prose bullets ("PR #383 5 LOWs deferred — see project_pr383_followup_cleanups.md")
+ * fall through to the PROSE-ONLY branch even when a backing memory file
+ * obviously exists.
+ *
+ * This resolver:
+ *   1. Indexes each memory file's "name" + "description" frontmatter into
+ *      a token set (PR refs, agent IDs, file-path fragments, category keywords).
+ *   2. Extracts the same token classes from the prose bullet.
+ *   3. Scores each candidate via true Jaccard:
+ *        |bullet ∩ memory| / |bullet ∪ memory|
+ *   4. Requires Jaccard >= 0.3 AND >= 2 distinct tokens matched.
+ *   5. If multiple candidates are within 5% of the top → returns 'ambiguous'.
+ *      Single confident match → 'matched'. Otherwise → 'none'.
+ *
+ * Sidecar (".gossip/prose-resolver-index.json") is invalidated by a hash of
+ * the memory directory's filename list (catches add/remove/rename on ext4
+ * where directory mtime is unreliable) AND by the directory mtime.
+ *
+ * NOTE: file paths from agent/user prose are UNTRUSTED. We only read files
+ * inside the resolved memoryDir (which the caller derives from os.homedir()
+ * + project encoding) — we never read arbitrary attacker-supplied paths.
+ */
+import { createHash } from 'crypto';
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+export const PROSE_RESOLVER_FILENAME = 'prose-resolver-index.json';
+export const PROSE_RESOLVER_VERSION = 1;
+export const JACCARD_THRESHOLD = 0.3;
+export const MIN_TOKEN_MATCHES = 2;
+export const AMBIGUITY_WINDOW = 0.05; // within 5% of top score → ambiguous
+
+/** Closed set of skill categories (kept in sync with gossip_skills categories). */
+const CATEGORY_KEYWORDS: ReadonlySet<string> = new Set([
+  'trust_boundaries',
+  'injection_vectors',
+  'input_validation',
+  'concurrency',
+  'resource_exhaustion',
+  'type_safety',
+  'error_handling',
+  'data_integrity',
+]);
+
+export interface ProseResolverIndex {
+  version: number;
+  /** Mtime of the memory directory at index time. */
+  memoryDirMtime: number;
+  /** Hash of sorted *.md filenames; survives ext4 rename-without-dir-mtime-bump. */
+  filenameHash: string;
+  /** token → list of memory filenames whose frontmatter contained that token. */
+  tokens: Record<string, string[]>;
+  /** token-count per memory file (for true Jaccard denominator). */
+  memoryTokenCounts: Record<string, number>;
+}
+
+export type ProseResolveResult =
+  | { kind: 'matched'; backingFile: string; score: number; matchedTokens: string[] }
+  | { kind: 'ambiguous'; candidates: Array<{ file: string; score: number }> }
+  | { kind: 'none'; reason: 'zero_tokens' | 'below_threshold' };
+
+/** Stable hash of the sorted *.md filename list. */
+function hashFilenames(names: string[]): string {
+  const sorted = [...names].sort();
+  return createHash('sha256').update(sorted.join('\n')).digest('hex').slice(0, 16);
+}
+
+/** List *.md files in memoryDir. Empty array on any fs error. */
+function listMemoryFiles(memoryDir: string): string[] {
+  try {
+    return readdirSync(memoryDir).filter((f) => f.endsWith('.md') && f !== 'MEMORY.md');
+  } catch {
+    return [];
+  }
+}
+
+/** Resolve the sidecar path. */
+export function proseResolverPath(projectRoot: string): string {
+  return join(projectRoot, '.gossip', PROSE_RESOLVER_FILENAME);
+}
+
+/** Read the known agent-ID list by scanning .gossip/agents subdirs. */
+function discoverAgentIds(projectRoot: string): string[] {
+  const dir = join(projectRoot, '.gossip', 'agents');
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Extract candidate tokens from arbitrary text. Pure — no fs access.
+ * agentIds is the per-project agent list (passed in so callers can mock).
+ */
+export function extractTokens(text: string, agentIds: readonly string[]): Set<string> {
+  const out = new Set<string>();
+  if (!text) return out;
+  const lower = text.toLowerCase();
+
+  // 1. PR refs: PR #383, PR 383, pr#383
+  const prRe = /\bpr\s*#?(\d+)\b/g;
+  let prMatch: RegExpExecArray | null;
+  while ((prMatch = prRe.exec(lower)) !== null) {
+    out.add(`pr${prMatch[1]}`);
+  }
+
+  // 2. Agent IDs — match against the known list (case-insensitive).
+  for (const id of agentIds) {
+    if (id && lower.includes(id.toLowerCase())) out.add(id.toLowerCase());
+  }
+
+  // 3. File-path fragments: name.ts / name.md / name.json (underscore allowed).
+  //    Lower-case already, so use [a-z0-9_-].
+  const fileRe = /[a-z0-9_-]+\.(?:ts|md|json)/g;
+  let fileMatch: RegExpExecArray | null;
+  while ((fileMatch = fileRe.exec(lower)) !== null) {
+    out.add(fileMatch[0]);
+  }
+
+  // 4. Category keywords (closed set).
+  for (const kw of CATEGORY_KEYWORDS) {
+    if (lower.includes(kw)) out.add(kw);
+  }
+
+  return out;
+}
+
+/**
+ * Parse the "name" + "description" lines out of a memory file's frontmatter.
+ * Hand-rolled (no yaml dep). Returns concatenated text for token extraction.
+ */
+function readFrontmatterNameDesc(file: string): string {
+  let raw: string;
+  try {
+    raw = readFileSync(file, 'utf-8');
+  } catch {
+    return '';
+  }
+  if (!raw.startsWith('---')) return '';
+  const end = raw.indexOf('\n---', 3);
+  if (end < 0) return '';
+  const fm = raw.slice(3, end);
+  const parts: string[] = [];
+  for (const line of fm.split('\n')) {
+    const m = /^(name|description)\s*:\s*(.+?)\s*$/.exec(line);
+    if (m) parts.push(m[2].replace(/^["']|["']$/g, ''));
+  }
+  return parts.join(' ');
+}
+
+/**
+ * Build (or rebuild) the prose-resolver index from the memory directory.
+ * No sidecar IO here; persistence handled by "buildProseResolverIndex".
+ */
+function buildIndexFromDisk(
+  memoryDir: string,
+  agentIds: readonly string[],
+): ProseResolverIndex {
+  const files = listMemoryFiles(memoryDir);
+  const filenameHash = hashFilenames(files);
+  let memoryDirMtime = 0;
+  try { memoryDirMtime = statSync(memoryDir).mtimeMs; } catch { /* leave 0 */ }
+
+  const tokens: Record<string, string[]> = {};
+  const memoryTokenCounts: Record<string, number> = {};
+
+  for (const fname of files) {
+    const text = readFrontmatterNameDesc(join(memoryDir, fname));
+    if (!text) {
+      memoryTokenCounts[fname] = 0;
+      continue;
+    }
+    const toks = extractTokens(text, agentIds);
+    memoryTokenCounts[fname] = toks.size;
+    for (const t of toks) {
+      const list = tokens[t] ?? (tokens[t] = []);
+      if (!list.includes(fname)) list.push(fname);
+    }
+  }
+
+  return {
+    version: PROSE_RESOLVER_VERSION,
+    memoryDirMtime,
+    filenameHash,
+    tokens,
+    memoryTokenCounts,
+  };
+}
+
+/**
+ * Load a valid sidecar from disk, or null if missing / stale / malformed.
+ * Validates filenameHash + memoryDirMtime against live state.
+ */
+function readValidSidecar(
+  projectRoot: string,
+  memoryDir: string,
+): ProseResolverIndex | null {
+  const path = proseResolverPath(projectRoot);
+  if (!existsSync(path)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const idx = parsed as ProseResolverIndex;
+  if (idx.version !== PROSE_RESOLVER_VERSION) return null;
+  if (!idx.tokens || !idx.memoryTokenCounts) return null;
+
+  // Validate against current memory dir state.
+  const files = listMemoryFiles(memoryDir);
+  const liveHash = hashFilenames(files);
+  if (idx.filenameHash !== liveHash) return null;
+  let liveMtime = 0;
+  try { liveMtime = statSync(memoryDir).mtimeMs; } catch { return null; }
+  if (idx.memoryDirMtime !== liveMtime) return null;
+  return idx;
+}
+
+/** Write sidecar; best-effort, swallows errors. */
+function writeSidecar(projectRoot: string, idx: ProseResolverIndex): void {
+  const path = proseResolverPath(projectRoot);
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(idx));
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Public entry point. Returns a fresh, validated index — rebuilt from disk
+ * when the cached sidecar is missing or stale.
+ */
+export function buildProseResolverIndex(
+  projectRoot: string,
+  memoryDir: string,
+): ProseResolverIndex {
+  const agentIds = discoverAgentIds(projectRoot);
+  const cached = readValidSidecar(projectRoot, memoryDir);
+  if (cached) return cached;
+  const fresh = buildIndexFromDisk(memoryDir, agentIds);
+  writeSidecar(projectRoot, fresh);
+  return fresh;
+}
+
+/**
+ * Resolve a single prose bullet against the index.
+ * Pure aside from the agent-list scan, which uses the index implicitly.
+ */
+export function resolveProseBullet(
+  bullet: string,
+  index: ProseResolverIndex,
+  agentIds: readonly string[] = [],
+): ProseResolveResult {
+  const bulletTokens = extractTokens(bullet, agentIds);
+  if (bulletTokens.size === 0) return { kind: 'none', reason: 'zero_tokens' };
+
+  // Tally per-candidate matched-token counts.
+  const matched = new Map<string, Set<string>>(); // file → set of matched tokens
+  for (const tok of bulletTokens) {
+    const files = index.tokens[tok];
+    if (!files) continue;
+    for (const f of files) {
+      const s = matched.get(f) ?? new Set<string>();
+      s.add(tok);
+      matched.set(f, s);
+    }
+  }
+  if (matched.size === 0) return { kind: 'none', reason: 'below_threshold' };
+
+  // Score each candidate with true Jaccard.
+  const scored: Array<{ file: string; score: number; matched: string[] }> = [];
+  for (const [file, toks] of matched) {
+    const memTokens = index.memoryTokenCounts[file] ?? 0;
+    const inter = toks.size;
+    const union = bulletTokens.size + memTokens - inter;
+    if (union <= 0) continue;
+    const score = inter / union;
+    if (score >= JACCARD_THRESHOLD && inter >= MIN_TOKEN_MATCHES) {
+      scored.push({ file, score, matched: [...toks] });
+    }
+  }
+  if (scored.length === 0) return { kind: 'none', reason: 'below_threshold' };
+
+  scored.sort((a, b) => b.score - a.score);
+  const top = scored[0];
+  const winThreshold = top.score * (1 - AMBIGUITY_WINDOW);
+  const contenders = scored.filter((s) => s.score >= winThreshold);
+  if (contenders.length > 1) {
+    return {
+      kind: 'ambiguous',
+      candidates: contenders.map((c) => ({ file: c.file, score: c.score })),
+    };
+  }
+  return {
+    kind: 'matched',
+    backingFile: top.file,
+    score: top.score,
+    matchedTokens: top.matched,
+  };
+}
+
+/** Convenience: agent-ID list for callers that already have an index. */
+export function discoverAgentIdsForRoot(projectRoot: string): string[] {
+  return discoverAgentIds(projectRoot);
+}

--- a/packages/orchestrator/src/verify-ledger-background.ts
+++ b/packages/orchestrator/src/verify-ledger-background.ts
@@ -53,6 +53,8 @@ export interface ParsedBullet {
   proseOnly: boolean;
   /** Numeric-claim hint: extracted number + noun the bullet is about (e.g., 4 + "worktree"). */
   numericClaim?: { n: number; noun: string };
+  /** Multi-candidate memory files when the prose-resolver returned `ambiguous`. Surfaced in PROSE-ONLY details so the orchestrator can pick. */
+  ambiguousCandidates?: readonly string[];
 }
 
 export interface LedgerIndexEntry {
@@ -157,15 +159,18 @@ export function parseNextSessionBullets(
     // POST-PASS: prose-only bullets get a fuzzy memory-slug match attempt.
     // Single confident match → populate backingFile, clear proseOnly.
     // Ambiguous / none → leave proseOnly true (orchestrator surfaces candidates).
+    let ambiguousCandidates: readonly string[] | undefined;
     if (proseOnly && opts.proseResolver) {
       const res = resolveProseBullet(text, opts.proseResolver.index, opts.proseResolver.agentIds);
       if (res.kind === 'matched') {
         backingFile = res.backingFile;
         proseOnly = false;
+      } else if (res.kind === 'ambiguous') {
+        ambiguousCandidates = res.candidates.map((c) => c.file);
       }
     }
 
-    bullets.push({ text, index, hash, backingFile, proseOnly, numericClaim });
+    bullets.push({ text, index, hash, backingFile, proseOnly, numericClaim, ambiguousCandidates });
     current = null;
   };
 
@@ -323,7 +328,10 @@ export function defaultVerifierFactory(
       return { bulletHash: b.hash, verdict: 'UNVERIFIABLE', details: 'no live counter for numeric claim', checkedAt: now };
     }
     if (b.proseOnly) {
-      return { bulletHash: b.hash, verdict: 'PROSE-ONLY', details: 'free-form bullet, no backing memory link', checkedAt: now };
+      const details = b.ambiguousCandidates && b.ambiguousCandidates.length > 0
+        ? `multiple confident matches: ${b.ambiguousCandidates.join(', ')}`
+        : 'free-form bullet, no backing memory link';
+      return { bulletHash: b.hash, verdict: 'PROSE-ONLY', details, checkedAt: now };
     }
     // Memory-linked bullet: in-process we cannot dispatch the haiku verifier;
     // mark INCONCLUSIVE so the orchestrator knows to call gossip_verify_memory.

--- a/packages/orchestrator/src/verify-ledger-background.ts
+++ b/packages/orchestrator/src/verify-ledger-background.ts
@@ -27,6 +27,10 @@
 import { createHash } from 'crypto';
 import { existsSync, readFileSync, writeFileSync, statSync, mkdirSync } from 'fs';
 import { join, dirname, basename } from 'path';
+import {
+  resolveProseBullet,
+  type ProseResolverIndex,
+} from './prose-bullet-resolver';
 
 export type LedgerVerdict =
   | 'FRESH'
@@ -102,7 +106,25 @@ export function findOpenSectionLine(content: string): number {
  * Lines that are not bullets (headings, blank lines) are skipped. Indented
  * continuation lines are folded into the parent bullet.
  */
-export function parseNextSessionBullets(content: string): ParsedBullet[] {
+export interface ParseNextSessionOptions {
+  /**
+   * Optional prose-bullet resolver context. When provided, bullets that have
+   * no explicit `[label](path.md)` link AND no numeric claim are run through
+   * `resolveProseBullet`; a single confident match populates `backingFile`
+   * and clears `proseOnly`. Ambiguous / none results leave `proseOnly` true.
+   *
+   * Callers that want the cheap parse (no fs access) simply omit this arg.
+   */
+  proseResolver?: {
+    index: ProseResolverIndex;
+    agentIds: readonly string[];
+  };
+}
+
+export function parseNextSessionBullets(
+  content: string,
+  opts: ParseNextSessionOptions = {},
+): ParsedBullet[] {
   if (!content) return [];
 
   // Try to locate the "Open for next session" block; fall back to scanning the
@@ -130,7 +152,19 @@ export function parseNextSessionBullets(content: string): ParsedBullet[] {
     const worktreeMatch = text.match(/\b(\d+)\s+(?:merged-but-locked\s+)?worktrees?(?:\s+branch(?:es)?)?\b/i);
     if (worktreeMatch) numericClaim = { n: parseInt(worktreeMatch[1], 10), noun: 'worktree' };
 
-    const proseOnly = !backingFile && !numericClaim;
+    let proseOnly = !backingFile && !numericClaim;
+
+    // POST-PASS: prose-only bullets get a fuzzy memory-slug match attempt.
+    // Single confident match → populate backingFile, clear proseOnly.
+    // Ambiguous / none → leave proseOnly true (orchestrator surfaces candidates).
+    if (proseOnly && opts.proseResolver) {
+      const res = resolveProseBullet(text, opts.proseResolver.index, opts.proseResolver.agentIds);
+      if (res.kind === 'matched') {
+        backingFile = res.backingFile;
+        proseOnly = false;
+      }
+    }
+
     bullets.push({ text, index, hash, backingFile, proseOnly, numericClaim });
     current = null;
   };

--- a/tests/orchestrator/prose-bullet-resolver.test.ts
+++ b/tests/orchestrator/prose-bullet-resolver.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for prose-bullet-resolver (spec 2026-05-14).
+ * Uses a fixture memory dir under tmpdir — never touches ~/.claude/projects.
+ */
+import { mkdirSync, writeFileSync, rmSync, existsSync, statSync, utimesSync, renameSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  buildProseResolverIndex,
+  resolveProseBullet,
+  extractTokens,
+  proseResolverPath,
+  PROSE_RESOLVER_VERSION,
+  JACCARD_THRESHOLD,
+  type ProseResolverIndex,
+} from '@gossip/orchestrator';
+
+function mkTmp(suffix: string): { root: string; memDir: string } {
+  const root = join(tmpdir(), `prose-resolver-${suffix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  const memDir = join(root, 'memory');
+  mkdirSync(join(root, '.gossip', 'agents'), { recursive: true });
+  mkdirSync(memDir, { recursive: true });
+  return { root, memDir };
+}
+
+function writeMemory(memDir: string, fname: string, name: string, description: string): void {
+  const body = `---\nname: ${name}\ndescription: ${description}\ntype: project\nstatus: shipped\n---\n\nbody content here.\n`;
+  writeFileSync(join(memDir, fname), body);
+}
+
+function writeAgent(root: string, agentId: string): void {
+  mkdirSync(join(root, '.gossip', 'agents', agentId), { recursive: true });
+}
+
+describe('extractTokens', () => {
+  it('extracts PR refs in multiple shapes', () => {
+    const t = extractTokens('PR #383 and pr 42 and PR#7', []);
+    expect(t.has('pr383')).toBe(true);
+    expect(t.has('pr42')).toBe(true);
+    expect(t.has('pr7')).toBe(true);
+  });
+
+  it('extracts agent IDs when present in text', () => {
+    const t = extractTokens('opus-implementer found a bug', ['opus-implementer', 'gemini-reviewer']);
+    expect(t.has('opus-implementer')).toBe(true);
+    expect(t.has('gemini-reviewer')).toBe(false);
+  });
+
+  it('extracts underscore-bearing memory filenames', () => {
+    const t = extractTokens('see project_pr383_followup_cleanups.md for details', []);
+    expect(t.has('project_pr383_followup_cleanups.md')).toBe(true);
+  });
+
+  it('extracts category keywords (closed set)', () => {
+    const t = extractTokens('a trust_boundaries violation in error_handling', []);
+    expect(t.has('trust_boundaries')).toBe(true);
+    expect(t.has('error_handling')).toBe(true);
+  });
+
+  it('returns empty set for zero-token prose', () => {
+    const t = extractTokens('just some words with nothing matching', []);
+    expect(t.size).toBe(0);
+  });
+});
+
+describe('buildProseResolverIndex', () => {
+  it('builds and caches a fresh sidecar', () => {
+    const { root, memDir } = mkTmp('build');
+    try {
+      writeMemory(memDir, 'project_pr383_followup_cleanups.md', 'PR 383 follow-ups', 'next-session ledger auto-verify guardrail PR #383');
+      writeMemory(memDir, 'feedback_x.md', 'X feedback', 'something else entirely');
+      const idx = buildProseResolverIndex(root, memDir);
+      expect(idx.version).toBe(PROSE_RESOLVER_VERSION);
+      expect(idx.tokens['pr383']).toContain('project_pr383_followup_cleanups.md');
+      expect(existsSync(proseResolverPath(root))).toBe(true);
+      // Second call uses cache (filename hash matches).
+      const idx2 = buildProseResolverIndex(root, memDir);
+      expect(idx2.filenameHash).toBe(idx.filenameHash);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('invalidates sidecar when a memory file is added', () => {
+    const { root, memDir } = mkTmp('add');
+    try {
+      writeMemory(memDir, 'a.md', 'A', 'PR #1 something');
+      const idx1 = buildProseResolverIndex(root, memDir);
+      writeMemory(memDir, 'b.md', 'B', 'PR #2 something');
+      // Force a different dir mtime so cache cannot fall through on it; the
+      // filename-hash check should still trip independently.
+      const idx2 = buildProseResolverIndex(root, memDir);
+      expect(idx2.filenameHash).not.toBe(idx1.filenameHash);
+      expect(idx2.tokens['pr2']).toContain('b.md');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('invalidates sidecar on rename (ext4 mtime-stable case)', () => {
+    const { root, memDir } = mkTmp('rename');
+    try {
+      writeMemory(memDir, 'project_foo.md', 'Foo', 'PR #99 about input_validation');
+      const idx1 = buildProseResolverIndex(root, memDir);
+      // Force-pin the dir mtime back to its pre-rename value so the dir-mtime
+      // gate alone CANNOT detect the change (ext4 pathological case).
+      const st = statSync(memDir);
+      renameSync(join(memDir, 'project_foo.md'), join(memDir, 'project_bar.md'));
+      utimesSync(memDir, st.atime, st.mtime);
+      const idx2 = buildProseResolverIndex(root, memDir);
+      expect(idx2.filenameHash).not.toBe(idx1.filenameHash);
+      expect(idx2.tokens['pr99']).toContain('project_bar.md');
+      expect(idx2.tokens['pr99']).not.toContain('project_foo.md');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('invalidates sidecar on file removal', () => {
+    const { root, memDir } = mkTmp('remove');
+    try {
+      writeMemory(memDir, 'a.md', 'A', 'PR #1');
+      writeMemory(memDir, 'b.md', 'B', 'PR #2');
+      const idx1 = buildProseResolverIndex(root, memDir);
+      rmSync(join(memDir, 'b.md'));
+      const idx2 = buildProseResolverIndex(root, memDir);
+      expect(idx2.filenameHash).not.toBe(idx1.filenameHash);
+      expect(idx2.tokens['pr2']).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('resolveProseBullet', () => {
+  function setup(): { root: string; memDir: string; idx: ProseResolverIndex; agentIds: string[] } {
+    const { root, memDir } = mkTmp('resolve');
+    writeAgent(root, 'opus-implementer');
+    writeAgent(root, 'gemini-reviewer');
+    writeMemory(
+      memDir,
+      'project_pr383_followup_cleanups.md',
+      'next-session ledger auto-verify PR 383',
+      'PR #383 follow-up cleanups including project_pr383_followup_cleanups.md and 5 LOWs',
+    );
+    writeMemory(
+      memDir,
+      'feedback_opus_thing.md',
+      'Opus feedback',
+      'opus-implementer trust_boundaries note',
+    );
+    writeMemory(
+      memDir,
+      'project_unrelated.md',
+      'unrelated',
+      'something entirely different about css',
+    );
+    const idx = buildProseResolverIndex(root, memDir);
+    return { root, memDir, idx, agentIds: ['opus-implementer', 'gemini-reviewer'] };
+  }
+
+  it('regression: PR #383 5 LOWs bullet resolves to project_pr383_followup_cleanups.md', () => {
+    const { root, idx, agentIds } = setup();
+    try {
+      const res = resolveProseBullet(
+        'PR #383 5 LOWs deferred — see project_pr383_followup_cleanups.md',
+        idx,
+        agentIds,
+      );
+      expect(res.kind).toBe('matched');
+      if (res.kind === 'matched') {
+        expect(res.backingFile).toBe('project_pr383_followup_cleanups.md');
+        expect(res.score).toBeGreaterThanOrEqual(JACCARD_THRESHOLD);
+        expect(res.matchedTokens).toEqual(expect.arrayContaining(['pr383', 'project_pr383_followup_cleanups.md']));
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('agent-ID hit + category keyword matches feedback_opus_thing.md', () => {
+    const { root, idx, agentIds } = setup();
+    try {
+      const res = resolveProseBullet('opus-implementer raised a trust_boundaries question', idx, agentIds);
+      expect(res.kind).toBe('matched');
+      if (res.kind === 'matched') expect(res.backingFile).toBe('feedback_opus_thing.md');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('single-token match falls below MIN_TOKEN_MATCHES threshold', () => {
+    const { root, idx, agentIds } = setup();
+    try {
+      // Only 'pr383' matches — no second token in bullet that lands in any memory.
+      const res = resolveProseBullet('check the PR #383 status', idx, agentIds);
+      expect(res.kind).toBe('none');
+      if (res.kind === 'none') expect(res.reason).toBe('below_threshold');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('returns ambiguous when two memories tie within 5%', () => {
+    const { root, memDir } = mkTmp('ambig');
+    writeAgent(root, 'opus-implementer');
+    // Two memory files with identical frontmatter token sets.
+    writeMemory(memDir, 'a.md', 'A', 'PR #500 about trust_boundaries');
+    writeMemory(memDir, 'b.md', 'B', 'PR #500 about trust_boundaries');
+    const idx = buildProseResolverIndex(root, memDir);
+    try {
+      const res = resolveProseBullet('look into PR #500 trust_boundaries', idx, ['opus-implementer']);
+      expect(res.kind).toBe('ambiguous');
+      if (res.kind === 'ambiguous') {
+        const files = res.candidates.map((c: { file: string }) => c.file).sort();
+        expect(files).toEqual(['a.md', 'b.md']);
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('zero-token bullet returns kind=none reason=zero_tokens', () => {
+    const { root, idx, agentIds } = setup();
+    try {
+      const res = resolveProseBullet('continue working on the dashboard refactor today', idx, agentIds);
+      expect(res.kind).toBe('none');
+      if (res.kind === 'none') expect(res.reason).toBe('zero_tokens');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('Jaccard math: short bullet with many memory tokens still scores by union not recall', () => {
+    const { root, memDir } = mkTmp('jaccard');
+    writeAgent(root, 'opus-implementer');
+    // Memory with many tokens — pure recall would inflate the score to 1.0.
+    writeMemory(
+      memDir,
+      'big.md',
+      'big memory',
+      'PR #10 PR #11 PR #12 PR #13 PR #14 PR #15 trust_boundaries error_handling input_validation',
+    );
+    writeMemory(memDir, 'small.md', 'small', 'PR #10 trust_boundaries');
+    const idx = buildProseResolverIndex(root, memDir);
+    try {
+      // Bullet has tokens {pr10, trust_boundaries}. Both memories match all bullet tokens.
+      // True Jaccard:
+      //   big: 2 / (2 + 9 - 2) = 2/9 ≈ 0.222 — below threshold
+      //   small: 2 / (2 + 2 - 2) = 2/2 = 1.0
+      // Resolver should pick `small` (or report `none` for `big`).
+      const res = resolveProseBullet('look at PR #10 trust_boundaries', idx, ['opus-implementer']);
+      expect(res.kind).toBe('matched');
+      if (res.kind === 'matched') {
+        expect(res.backingFile).toBe('small.md');
+        expect(res.score).toBeCloseTo(1.0, 5);
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/orchestrator/verify-ledger-background.test.ts
+++ b/tests/orchestrator/verify-ledger-background.test.ts
@@ -389,6 +389,23 @@ describe('defaultVerifierFactory', () => {
     expect(r.details).toContain('gossip_verify_memory(passwd)');
     expect(r.details).not.toContain('..');
   });
+
+  it('PROSE-ONLY surfaces ambiguousCandidates in details when prose-resolver returns ambiguous', async () => {
+    const v = defaultVerifierFactory();
+    const r = await v(mk({
+      proseOnly: true,
+      ambiguousCandidates: ['project_alpha.md', 'project_beta.md'],
+    }));
+    expect(r.verdict).toBe('PROSE-ONLY');
+    expect(r.details).toBe('multiple confident matches: project_alpha.md, project_beta.md');
+  });
+
+  it('PROSE-ONLY falls back to generic details when ambiguousCandidates is empty/undefined', async () => {
+    const v = defaultVerifierFactory();
+    const r = await v(mk({ proseOnly: true }));
+    expect(r.verdict).toBe('PROSE-ONLY');
+    expect(r.details).toBe('free-form bullet, no backing memory link');
+  });
 });
 
 describe('writeLedgerIndex / sidecar round-trip', () => {


### PR DESCRIPTION
## Summary

Closes the `[PROSE-ONLY]` ledger gap captured in `feedback_prose_only_ledger_gap.md` (3 consecutive sessions hit the same pattern). Free-form ledger bullets without an explicit `[label](path.md)` link now get a token-based fuzzy-match against memory frontmatter; confident single matches populate `backingFile` so the existing `INCONCLUSIVE` branch engages, and the orchestrator's `gossip_verify_memory` step has a target to verify against.

- 4 token classes: PR refs, agent IDs (scanned from `.gossip/agents/` at index build time), file-path fragments (underscore-aware), category keywords
- True Jaccard scoring (`matched / (bullet ∪ memory)`) with threshold ≥0.3 + ≥2 tokens
- Tie-breaking: candidates within 5% of top → bullet stays `PROSE-ONLY` with `multiple confident matches: file1.md, file2.md` in details
- Sidecar at `.gossip/prose-resolver-index.json`, dual-keyed on filename SHA-256 + dir mtime for ext4 safety (rename without mtime bump still invalidates)

## Spec & consensus

- Spec: `docs/specs/2026-05-14-prose-only-bullet-resolver.md` (revised post-consensus `5b171030-4996426e`)
- Pre-impl spec consensus: 6 confirmed, 2 disputed (resolved via cross-review), 11 unique findings — all addressed in spec revision
- Post-impl review consensus: sonnet-reviewer + gemini-tester (relay)
  - Confirmed correct: 4 token classes, true Jaccard not recall, threshold enforcement, zero-token returns `kind:'none'`, tie returns `kind:'ambiguous'`, path safety (untrusted prose never reaches fs), sidecar dual-key ext4-resilient, existing semantics preserved (35/35 prior tests pass)
  - 1 medium addressed inline (`7f9ced7`): `ambiguousCandidates` field on `ParsedBullet`, threaded through `defaultVerifierFactory` PROSE-ONLY details

## Known follow-ups (defense-in-depth, not blockers)

Filed for future PR; attacks require write-access to the memory dir or `.gossip/`, which is itself a higher-level breach:

- Tighten sidecar JSON runtime validation — current `parsed as ProseResolverIndex` cast at `prose-bullet-resolver.ts:217-219` validates key presence but not nested `Record<string, string[]>` / `Record<string, number>` shapes
- Add size limits to `readFileSync` in `readFrontmatterNameDesc:145` and `readValidSidecar:212` — `statSync` size check before read (~3 LOC each)
- `discoverAgentIds` directory scan currently unbounded

## Test plan

- [x] `npm run test -- prose-bullet-resolver` → 15/15 pass
- [x] `npm run test -- verify-ledger-background` → 37/37 pass (35 pre-existing + 2 new for `ambiguousCandidates` rendering)
- [x] `npx tsc --noEmit -p packages/orchestrator` → clean
- [x] Regression: `PR #383 5 LOWs deferred — see project_pr383_followup_cleanups.md` bullet resolves to that memory with Jaccard ≥0.3 (would have caught the stale ledger this session opened with)
- [ ] After merge: re-run a real ledger and confirm `[PROSE-ONLY]` rate drops

consensus-id: 5b171030-4996426e

🤖 Generated with [Claude Code](https://claude.com/claude-code)