### PR TITLE
feat(orchestrator): prose-resolver defense-in-depth (PR #388 follow-ups)

### DIFF
--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -130,11 +130,15 @@ export {
   extractTokens,
   proseResolverPath,
   discoverAgentIdsForRoot,
+  isProseResolverIndex,
   PROSE_RESOLVER_FILENAME,
   PROSE_RESOLVER_VERSION,
   JACCARD_THRESHOLD,
   MIN_TOKEN_MATCHES,
   AMBIGUITY_WINDOW,
+  FRONTMATTER_READ_LIMIT,
+  SIDECAR_READ_LIMIT,
+  DISCOVER_AGENT_CAP,
 } from './prose-bullet-resolver';
 export type { ProseResolverIndex, ProseResolveResult } from './prose-bullet-resolver';
 export { ToolRouter, ToolExecutor } from './tool-router';

--- a/packages/orchestrator/src/prose-bullet-resolver.ts
+++ b/packages/orchestrator/src/prose-bullet-resolver.ts
@@ -37,6 +37,13 @@ export const JACCARD_THRESHOLD = 0.3;
 export const MIN_TOKEN_MATCHES = 2;
 export const AMBIGUITY_WINDOW = 0.05; // within 5% of top score → ambiguous
 
+/** Max bytes for a single memory file's frontmatter read (64 KB). */
+export const FRONTMATTER_READ_LIMIT = 64 * 1024;
+/** Max bytes for the prose-resolver sidecar JSON (16 MB). */
+export const SIDECAR_READ_LIMIT = 16 * 1024 * 1024;
+/** Max agent-directory entries scanned before capping. */
+export const DISCOVER_AGENT_CAP = 1000;
+
 /** Closed set of skill categories (kept in sync with gossip_skills categories). */
 const CATEGORY_KEYWORDS: ReadonlySet<string> = new Set([
   'trust_boundaries',
@@ -66,6 +73,29 @@ export type ProseResolveResult =
   | { kind: 'ambiguous'; candidates: Array<{ file: string; score: number }> }
   | { kind: 'none'; reason: 'zero_tokens' | 'below_threshold' };
 
+/**
+ * Hand-rolled type guard for ProseResolverIndex.
+ * Validates inner record shapes: tokens must be Record<string, string[]>
+ * and memoryTokenCounts must be Record<string, number>.
+ */
+export function isProseResolverIndex(x: unknown): x is ProseResolverIndex {
+  if (!x || typeof x !== 'object') return false;
+  const obj = x as Record<string, unknown>;
+  if (typeof obj['version'] !== 'number') return false;
+  if (typeof obj['memoryDirMtime'] !== 'number') return false;
+  if (typeof obj['filenameHash'] !== 'string') return false;
+  if (!obj['tokens'] || typeof obj['tokens'] !== 'object') return false;
+  if (!obj['memoryTokenCounts'] || typeof obj['memoryTokenCounts'] !== 'object') return false;
+  for (const val of Object.values(obj['tokens'] as object)) {
+    if (!Array.isArray(val)) return false;
+    if (!(val as unknown[]).every((v) => typeof v === 'string')) return false;
+  }
+  for (const val of Object.values(obj['memoryTokenCounts'] as object)) {
+    if (typeof val !== 'number') return false;
+  }
+  return true;
+}
+
 /** Stable hash of the sorted *.md filename list. */
 function hashFilenames(names: string[]): string {
   const sorted = [...names].sort();
@@ -87,12 +117,17 @@ export function proseResolverPath(projectRoot: string): string {
 }
 
 /** Read the known agent-ID list by scanning .gossip/agents subdirs. */
-function discoverAgentIds(projectRoot: string): string[] {
+export function discoverAgentIds(projectRoot: string): string[] {
   const dir = join(projectRoot, '.gossip', 'agents');
   try {
-    return readdirSync(dir, { withFileTypes: true })
+    const dirs = readdirSync(dir, { withFileTypes: true })
       .filter((e) => e.isDirectory())
       .map((e) => e.name);
+    if (dirs.length > DISCOVER_AGENT_CAP) {
+      console.warn(`[prose-resolver] discoverAgentIds: ${dirs.length} entries exceed cap of ${DISCOVER_AGENT_CAP}; truncating`);
+      return dirs.slice(0, DISCOVER_AGENT_CAP);
+    }
+    return dirs;
   } catch {
     return [];
   }
@@ -142,6 +177,7 @@ export function extractTokens(text: string, agentIds: readonly string[]): Set<st
 function readFrontmatterNameDesc(file: string): string {
   let raw: string;
   try {
+    if (statSync(file).size > FRONTMATTER_READ_LIMIT) return '';
     raw = readFileSync(file, 'utf-8');
   } catch {
     return '';
@@ -209,14 +245,14 @@ function readValidSidecar(
   if (!existsSync(path)) return null;
   let parsed: unknown;
   try {
+    if (statSync(path).size > SIDECAR_READ_LIMIT) return null;
     parsed = JSON.parse(readFileSync(path, 'utf-8'));
   } catch {
     return null;
   }
-  if (!parsed || typeof parsed !== 'object') return null;
-  const idx = parsed as ProseResolverIndex;
+  if (!isProseResolverIndex(parsed)) return null;
+  const idx = parsed;
   if (idx.version !== PROSE_RESOLVER_VERSION) return null;
-  if (!idx.tokens || !idx.memoryTokenCounts) return null;
 
   // Validate against current memory dir state.
   const files = listMemoryFiles(memoryDir);

--- a/tests/orchestrator/prose-bullet-resolver.test.ts
+++ b/tests/orchestrator/prose-bullet-resolver.test.ts
@@ -120,6 +120,36 @@ describe('buildProseResolverIndex', () => {
     }
   });
 
+  it('invalidates sidecar on mtime-only change (filename set unchanged)', () => {
+    // Defense-in-depth: the rename test pins mtime to exercise the hash path.
+    // This test exercises the *other* path — same filenames, different dir mtime —
+    // so a regression in the mtime gate would be caught by the suite.
+    const { root, memDir } = mkTmp('mtime-only');
+    try {
+      writeMemory(memDir, 'a.md', 'A', 'PR #1 trust_boundaries');
+      const idx1 = buildProseResolverIndex(root, memDir);
+      const sidecarBefore = JSON.parse(
+        require('fs').readFileSync(proseResolverPath(root), 'utf-8'),
+      );
+      // Bump dir mtime forward without touching the filename set.
+      // (touch a hidden file then remove it — same final filenames, fresh mtime)
+      const sentinel = join(memDir, '.touch');
+      writeFileSync(sentinel, '');
+      rmSync(sentinel);
+      const liveMtime = statSync(memDir).mtimeMs;
+      expect(liveMtime).not.toBe(sidecarBefore.memoryDirMtime);
+      // Sidecar's stored mtime is now stale → readValidSidecar must reject it
+      // and rebuild from disk. Resulting index has the live mtime stamped.
+      const idx2 = buildProseResolverIndex(root, memDir);
+      expect(idx2.memoryDirMtime).toBe(liveMtime);
+      expect(idx2.memoryDirMtime).not.toBe(sidecarBefore.memoryDirMtime);
+      // Filename hash unchanged → confirms this is the mtime-only path.
+      expect(idx2.filenameHash).toBe(idx1.filenameHash);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('invalidates sidecar on file removal', () => {
     const { root, memDir } = mkTmp('remove');
     try {

--- a/tests/orchestrator/prose-bullet-resolver.test.ts
+++ b/tests/orchestrator/prose-bullet-resolver.test.ts
@@ -10,8 +10,12 @@ import {
   resolveProseBullet,
   extractTokens,
   proseResolverPath,
+  discoverAgentIdsForRoot,
+  isProseResolverIndex,
   PROSE_RESOLVER_VERSION,
   JACCARD_THRESHOLD,
+  FRONTMATTER_READ_LIMIT,
+  DISCOVER_AGENT_CAP,
   type ProseResolverIndex,
 } from '@gossip/orchestrator';
 
@@ -259,4 +263,113 @@ describe('resolveProseBullet', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+});
+
+describe('isProseResolverIndex (sidecar shape validation)', () => {
+  const valid = (): ProseResolverIndex => ({
+    version: PROSE_RESOLVER_VERSION,
+    memoryDirMtime: 123,
+    filenameHash: 'abc',
+    tokens: { foo: ['a.md', 'b.md'] },
+    memoryTokenCounts: { 'a.md': 2 },
+  });
+
+  it('accepts a well-shaped index', () => {
+    expect(isProseResolverIndex(valid())).toBe(true);
+  });
+
+  it('rejects non-array tokens value', () => {
+    const bad = { ...valid(), tokens: { foo: 'not-an-array' as unknown as string[] } };
+    expect(isProseResolverIndex(bad)).toBe(false);
+  });
+
+  it('rejects non-number memoryTokenCounts value', () => {
+    const bad = { ...valid(), memoryTokenCounts: { 'a.md': '2' as unknown as number } };
+    expect(isProseResolverIndex(bad)).toBe(false);
+  });
+
+  it('rejects non-string element inside tokens array', () => {
+    const bad = { ...valid(), tokens: { foo: ['a.md', 42 as unknown as string] } };
+    expect(isProseResolverIndex(bad)).toBe(false);
+  });
+
+  it('rejects null and primitives', () => {
+    expect(isProseResolverIndex(null)).toBe(false);
+    expect(isProseResolverIndex('string')).toBe(false);
+    expect(isProseResolverIndex(42)).toBe(false);
+  });
+
+  it('rejects missing tokens / memoryTokenCounts', () => {
+    expect(isProseResolverIndex({ version: 1, memoryDirMtime: 0, filenameHash: 'x', memoryTokenCounts: {} })).toBe(false);
+    expect(isProseResolverIndex({ version: 1, memoryDirMtime: 0, filenameHash: 'x', tokens: {} })).toBe(false);
+  });
+});
+
+describe('readFrontmatterNameDesc size limit (defense-in-depth)', () => {
+  it('skips oversized memory files (>64KB frontmatter cap)', () => {
+    const { root, memDir } = mkTmp('oversize-fm');
+    writeAgent(root, 'opus-implementer');
+    writeMemory(memDir, 'normal.md', 'normal memory', 'opus-implementer trust_boundaries');
+    // Oversized file: pad description with > FRONTMATTER_READ_LIMIT bytes.
+    const padding = 'x'.repeat(FRONTMATTER_READ_LIMIT + 1024);
+    const body = `---\nname: oversized\ndescription: opus-implementer ${padding}\ntype: project\nstatus: shipped\n---\n`;
+    writeFileSync(join(memDir, 'oversized.md'), body);
+    expect(statSync(join(memDir, 'oversized.md')).size).toBeGreaterThan(FRONTMATTER_READ_LIMIT);
+    try {
+      const idx = buildProseResolverIndex(root, memDir);
+      // Oversized file is read-skipped → zero tokens indexed for it.
+      expect(idx.memoryTokenCounts['oversized.md']).toBe(0);
+      // The normal file still indexes.
+      expect(idx.memoryTokenCounts['normal.md']).toBeGreaterThan(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('readValidSidecar size limit (defense-in-depth)', () => {
+  it('treats oversized sidecar as invalid and rebuilds', () => {
+    const { root, memDir } = mkTmp('oversize-sidecar');
+    writeAgent(root, 'opus-implementer');
+    writeMemory(memDir, 'a.md', 'a', 'opus-implementer trust_boundaries');
+    const sidecarPath = proseResolverPath(root);
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+    // Write a > SIDECAR_READ_LIMIT (16MB) blob — invalid JSON, but the size check
+    // fires first and short-circuits the read.
+    const huge = 'x'.repeat(16 * 1024 * 1024 + 1024);
+    writeFileSync(sidecarPath, huge);
+    expect(statSync(sidecarPath).size).toBeGreaterThan(16 * 1024 * 1024);
+    try {
+      // Should NOT throw — oversize gate returns null, triggering fresh build.
+      const idx = buildProseResolverIndex(root, memDir);
+      expect(idx.version).toBe(PROSE_RESOLVER_VERSION);
+      expect(idx.memoryTokenCounts['a.md']).toBeGreaterThan(0);
+      // After buildProseResolverIndex, a valid sidecar is written back.
+      expect(statSync(sidecarPath).size).toBeLessThan(16 * 1024 * 1024);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 30000); // generous timeout for the 16MB write
+});
+
+describe('discoverAgentIds cap (defense-in-depth)', () => {
+  it('caps directory scan at DISCOVER_AGENT_CAP entries', () => {
+    const { root } = mkTmp('agent-cap');
+    const agentsDir = join(root, '.gossip', 'agents');
+    // Create 1001 agent dirs.
+    for (let i = 0; i < DISCOVER_AGENT_CAP + 1; i++) {
+      mkdirSync(join(agentsDir, `agent-${i.toString().padStart(4, '0')}`));
+    }
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const ids = discoverAgentIdsForRoot(root);
+      expect(ids.length).toBe(DISCOVER_AGENT_CAP);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`${DISCOVER_AGENT_CAP + 1} entries exceed cap of ${DISCOVER_AGENT_CAP}`),
+      );
+    } finally {
+      warnSpy.mockRestore();
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 30000); // creating 1001 dirs may take a moment on slow disks
 });


### PR DESCRIPTION
## Summary

Three defense-in-depth follow-ups deferred from PR #388 (gemini-tester review). All edits in `packages/orchestrator/src/prose-bullet-resolver.ts` + tests.

1. **`isProseResolverIndex` type guard** — replaces the post-presence-check `as ProseResolverIndex` cast with a hand-rolled type guard that walks both inner records (`tokens: Record<string, string[]>`, `memoryTokenCounts: Record<string, number>`) and verifies each value's type. No Zod dep.
2. **Size limits on `readFileSync`** — `FRONTMATTER_READ_LIMIT` (64 KB) on memory frontmatter, `SIDECAR_READ_LIMIT` (16 MB) on the sidecar JSON. `statSync` gate before `readFileSync`. Prevents OOM on pathological files in the memory dir or `.gossip/`.
3. **`discoverAgentIds` cap** — `DISCOVER_AGENT_CAP` (1000) on the `.gossip/agents/` directory scan. Warns and truncates rather than failing closed; operator-controlled, slowdown not security.

Source memory: `project_prose_resolver_defense_in_depth.md`.

## Verification

- `npm test -- prose-bullet-resolver` → **25/25 pass** (15 existing + 9 new defense-in-depth + 1 new mtime-only invalidation test)
- `npm run build` → clean across all workspace packages
- Constants + type guard exported from `@gossip/orchestrator` for downstream consumers and tests

## Consensus

Cross-reviewed by gemini-tester (test sufficiency) and gemini-reviewer (trust-boundary / type-safety). Round v2 (5178d3e7 was retracted — orchestrator dispatched without resolutionRoots, fixed in v2).

consensus-id: 27d22652-c5c14302

Outcome: defense-in-depth strategy confirmed (size gates + cap + type guard + dual cache invalidation). Tester's 4 unique_confirmed findings on test coverage all verified accurate. Reviewer's f5 "tighten guard" suggestion was a hallucination — the `typeof obj['tokens'] !== 'object'` check already exists at `prose-bullet-resolver.ts:87`, two lines before the iteration cast. Signal recorded.

## Test plan

- [x] All 25 jest tests in `tests/orchestrator/prose-bullet-resolver.test.ts` pass
- [x] `npm run build` clean across @gossip/types, @gossip/client, @gossip/tools, @gossip/orchestrator, @gossip/relay
- [x] Consensus round (gemini-tester + gemini-reviewer) approved
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)