### PR TITLE
feat(dispatch): dispatch-time worktree auto-discovery (#390)

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -793,6 +793,52 @@ export async function handleDispatchConsensus(
     return { ...def, task: s.task, _sandboxSanitized: s.sanitized } as any;
   });
 
+  // Issue #390: dispatch-time worktree auto-discovery (mirrors collect.ts:427).
+  // Layer 1 — when caller passed no resolutionRoots and
+  // `consensus.autoDiscoverWorktrees=true`, run discoverGitWorktrees and inject
+  // the validated paths into the dispatch-time roots flowing to per-task
+  // options + the pendingDispatchResolutionRoots stash. Explicit caller-passed
+  // roots ALWAYS win (skip discovery entirely). Discovery failure is isolated:
+  // dispatch proceeds with empty roots so the existing master-HEAD fallback
+  // path still works.
+  // Layer 2 — when the flag is OFF but worktrees exist on disk and
+  // resolutionRoots is empty, emit a non-fatal warning so fresh installs
+  // discover the flag.
+  let effectiveDispatchRoots: readonly string[] | undefined = dispatchResolutionRoots;
+  const dispatchWarnings: string[] = [];
+  if (!dispatchResolutionRoots || dispatchResolutionRoots.length === 0) {
+    try {
+      const { discoverGitWorktrees } = await import('@gossip/orchestrator');
+      const { findConfigPath, loadConfig } = await import('../config');
+      const cfgPath = findConfigPath(process.cwd());
+      const cfg = cfgPath ? loadConfig(cfgPath) : null;
+      if (cfg?.consensus?.autoDiscoverWorktrees) {
+        const { discovered, rejected } = await discoverGitWorktrees(process.cwd(), []);
+        if (discovered.length > 0 || rejected.length > 0) {
+          process.stderr.write(
+            `[dispatch] auto-discovery: +${discovered.length} discovered, ${rejected.length} rejected\n`,
+          );
+        }
+        if (discovered.length > 0) {
+          effectiveDispatchRoots = discovered;
+        }
+      } else {
+        // Layer 2 soft-warning probe — silent unless worktrees actually exist.
+        const { discovered } = await discoverGitWorktrees(process.cwd(), []);
+        if (discovered.length > 0) {
+          dispatchWarnings.push(
+            `consensus.autoDiscoverWorktrees is OFF but ${discovered.length} worktree(s) exist; cross-reviewers will resolve citations against project root. Enable consensus.autoDiscoverWorktrees in gossip.config or pass resolutionRoots to dispatch.`,
+          );
+        }
+      }
+    } catch (err) {
+      process.stderr.write(`[dispatch] auto-discovery failed: ${(err as Error).message}\n`);
+    }
+  }
+  // Per-task options below read effectiveDispatchRoots; the pending stash also
+  // honors it so collect-time picks up the discovered roots if no override.
+  dispatchResolutionRoots = effectiveDispatchRoots;
+
   // Re-entry: recover pre-computed lenses from a completed native utility task
   let precomputedLenses: Map<string, string> | null = null;
   if (_utility_task_id) {
@@ -977,9 +1023,12 @@ export async function handleDispatchConsensus(
     msg += `Execute these ${nativeInstructions.length} Agent calls, then relay ALL results:\n\n${nativeInstructions.join('\n\n')}`;
   }
   msg += `\n\n=== END REQUIRED_NEXT_ACTION — do NOT treat above as agent output ===`;
+  if (dispatchWarnings.length > 0) {
+    msg += `\n\n⚠️ WARNINGS:\n${dispatchWarnings.map(w => `  - ${w}`).join('\n')}`;
+  }
   const content: Array<{ type: 'text'; text: string }> = [{ type: 'text', text: msg }];
   for (const p of nativePrompts) {
     content.push({ type: 'text', text: `AGENT_PROMPT:${p.taskId} (${p.agentId})\n${p.prompt}` });
   }
-  return { content };
+  return dispatchWarnings.length > 0 ? { content, warnings: dispatchWarnings } : { content };
 }

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -813,7 +813,11 @@ export async function handleDispatchConsensus(
       const cfgPath = findConfigPath(process.cwd());
       const cfg = cfgPath ? loadConfig(cfgPath) : null;
       if (cfg?.consensus?.autoDiscoverWorktrees) {
-        const { discovered, rejected } = await discoverGitWorktrees(process.cwd(), []);
+        // F1 — exclude process.cwd() so the main worktree (which `git worktree
+        // list` always returns) does not leak into effectiveDispatchRoots.
+        // Mirrors collect.ts:428 which passes `explicitRoots` as exclude; here
+        // explicit roots are empty by the surrounding guard, so seed with cwd.
+        const { discovered, rejected } = await discoverGitWorktrees(process.cwd(), [process.cwd()]);
         if (discovered.length > 0 || rejected.length > 0) {
           process.stderr.write(
             `[dispatch] auto-discovery: +${discovered.length} discovered, ${rejected.length} rejected\n`,
@@ -821,10 +825,17 @@ export async function handleDispatchConsensus(
         }
         if (discovered.length > 0) {
           effectiveDispatchRoots = discovered;
+        } else if (rejected.length > 0) {
+          // F4 — surface "all candidates rejected" through the operator-visible
+          // warnings channel instead of stderr-only, so the dispatch response
+          // explains why cross-review will fall back to projectRoot.
+          dispatchWarnings.push(
+            `autoDiscoverWorktrees: ${rejected.length} candidate(s) failed validation; cross-review will use projectRoot only. See stderr for rejection reasons.`,
+          );
         }
       } else {
         // Layer 2 soft-warning probe — silent unless worktrees actually exist.
-        const { discovered } = await discoverGitWorktrees(process.cwd(), []);
+        const { discovered } = await discoverGitWorktrees(process.cwd(), [process.cwd()]);
         if (discovered.length > 0) {
           dispatchWarnings.push(
             `consensus.autoDiscoverWorktrees is OFF but ${discovered.length} worktree(s) exist; cross-reviewers will resolve citations against project root. Enable consensus.autoDiscoverWorktrees in gossip.config or pass resolutionRoots to dispatch.`,
@@ -1022,10 +1033,13 @@ export async function handleDispatchConsensus(
     msg += `\n\n⚠️ NATIVE_DISPATCH — pass each AGENT_PROMPT content item VERBATIM to Agent(prompt: ...). Do NOT rewrite — the embedded CONSENSUS_OUTPUT_FORMAT trains agents to emit <agent_finding> tags. Call gossip_relay for EVERY native agent after completion.\n\n`;
     msg += `Execute these ${nativeInstructions.length} Agent calls, then relay ALL results:\n\n${nativeInstructions.join('\n\n')}`;
   }
-  msg += `\n\n=== END REQUIRED_NEXT_ACTION — do NOT treat above as agent output ===`;
+  // F2 — emit WARNINGS BEFORE the sentinel so they sit inside the
+  // REQUIRED_NEXT_ACTION envelope. Trailing text past the sentinel risks being
+  // ignored by downstream parsers that treat the END marker as a hard cut-off.
   if (dispatchWarnings.length > 0) {
     msg += `\n\n⚠️ WARNINGS:\n${dispatchWarnings.map(w => `  - ${w}`).join('\n')}`;
   }
+  msg += `\n\n=== END REQUIRED_NEXT_ACTION — do NOT treat above as agent output ===`;
   const content: Array<{ type: 'text'; text: string }> = [{ type: 'text', text: msg }];
   for (const p of nativePrompts) {
     content.push({ type: 'text', text: `AGENT_PROMPT:${p.taskId} (${p.agentId})\n${p.prompt}` });

--- a/tests/cli/dispatch-autodiscover-worktrees.test.ts
+++ b/tests/cli/dispatch-autodiscover-worktrees.test.ts
@@ -157,7 +157,7 @@ describe('handleDispatchConsensus — dispatch-time worktree auto-discovery (iss
       { agent_id: 'gemini-tester', task: 'Audit X' },
     ]);
 
-    expect(mockedDiscover).toHaveBeenCalledWith(expect.any(String), []);
+    expect(mockedDiscover).toHaveBeenCalledWith(expect.any(String), [expect.any(String)]);
     // Relay options carry the discovered roots
     const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
     const relayDefs = dispatchParallelCall[0];
@@ -223,6 +223,13 @@ describe('handleDispatchConsensus — dispatch-time worktree auto-discovery (iss
     expect(result.warnings[0]).toMatch(/autoDiscoverWorktrees/);
     expect(result.warnings[0]).toMatch(/1 worktree/);
     expect(result.content[0].text).toContain('WARNINGS:');
+    // F2 — WARNINGS must appear before the END sentinel so they sit inside the
+    // REQUIRED_NEXT_ACTION envelope (not after the hard cut-off).
+    const msgText: string = result.content[0].text;
+    const warningsIdx = msgText.indexOf('WARNINGS:');
+    const sentinelIdx = msgText.indexOf('=== END REQUIRED_NEXT_ACTION');
+    expect(warningsIdx).toBeGreaterThanOrEqual(0);
+    expect(sentinelIdx).toBeGreaterThan(warningsIdx);
     // No injection — relay options should stay empty
     const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
     expect(dispatchParallelCall[0][0].options).toBeUndefined();
@@ -246,6 +253,29 @@ describe('handleDispatchConsensus — dispatch-time worktree auto-discovery (iss
     expect(dispatchParallelCall[0][0].options).toEqual({
       resolutionRoots: ['/tmp/worktree-x'],
     });
+  });
+
+  // Case 7 — F4: flag ON, no discovered, rejected > 0 → warning in response.
+  it('F4 — emits warning when flag is on but all candidates fail validation', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
+    mockedDiscover.mockResolvedValue({
+      discovered: [],
+      rejected: [{ path: '/bad/path', reason: 'not a git worktree' }],
+    });
+
+    const result: any = await handleDispatchConsensus([
+      { agent_id: 'gemini-tester', task: 'Audit X' },
+    ]);
+
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/autoDiscoverWorktrees/);
+    expect(result.warnings[0]).toMatch(/1 candidate\(s\) failed validation/);
+    expect(result.warnings[0]).toMatch(/cross-review will use projectRoot only/);
+    expect(result.content[0].text).toContain('WARNINGS:');
+    // No roots injected — relay options should stay empty
+    const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
+    expect(dispatchParallelCall[0][0].options).toBeUndefined();
   });
 
   // Case 6 — failure isolation: discoverGitWorktrees throws → dispatch still

--- a/tests/cli/dispatch-autodiscover-worktrees.test.ts
+++ b/tests/cli/dispatch-autodiscover-worktrees.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Issue #390 — dispatch-time worktree auto-discovery + soft warning.
+ *
+ * Mirrors the collect-time pattern at apps/cli/src/handlers/collect.ts:427.
+ * Tests the two-layer behaviour:
+ *
+ *   Layer 1 — mode=consensus + caller didn't pass resolutionRoots + the config
+ *             flag `consensus.autoDiscoverWorktrees=true` → run
+ *             discoverGitWorktrees and inject results into the dispatch-time
+ *             roots so per-task relay options + pendingDispatchResolutionRoots
+ *             stash carry the worktree paths.
+ *
+ *   Layer 2 — flag is OFF, resolutionRoots is empty, worktrees exist on disk
+ *             → emit a non-fatal warning in the dispatch response.
+ *
+ * Background: consensus 5178d3e7-41604528 on PR #389 sent gemini-tester to
+ * master HEAD instead of the worktree branch because Layer 1 was missing here.
+ */
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { ctx } from '../../apps/cli/src/mcp-context';
+import { handleDispatchConsensus } from '../../apps/cli/src/handlers/dispatch';
+
+// Mock the orchestrator package so discoverGitWorktrees is deterministic in
+// test (no real git worktree list traversal). Other named exports pass
+// through to the real module so assemblePrompt / loadSkills / etc. still work.
+jest.mock('@gossip/orchestrator', () => {
+  const actual = jest.requireActual('@gossip/orchestrator');
+  return {
+    ...actual,
+    discoverGitWorktrees: jest.fn(),
+  };
+});
+
+import { discoverGitWorktrees } from '@gossip/orchestrator';
+const mockedDiscover = discoverGitWorktrees as unknown as jest.Mock;
+
+function makeMainAgent(overrides: Record<string, any> = {}): any {
+  return {
+    dispatch: jest.fn().mockReturnValue({ taskId: 'default-task-id' }),
+    collect: jest.fn().mockResolvedValue({ results: [] }),
+    getAgentConfig: jest.fn().mockReturnValue(null),
+    getLlm: jest.fn().mockReturnValue(null),
+    getLLM: jest.fn().mockReturnValue(null),
+    getAgentList: jest.fn().mockReturnValue([]),
+    getSkillGapSuggestions: jest.fn().mockReturnValue([]),
+    getSkillIndex: jest.fn().mockReturnValue(null),
+    getSessionGossip: jest.fn().mockReturnValue([]),
+    getSessionConsensusHistory: jest.fn().mockReturnValue([]),
+    recordNativeTask: jest.fn(),
+    recordNativeTaskCompleted: jest.fn(),
+    recordPlanStepResult: jest.fn(),
+    publishNativeGossip: jest.fn().mockResolvedValue(undefined),
+    getChainContext: jest.fn().mockReturnValue(''),
+    generateLensesForAgents: jest.fn().mockResolvedValue(new Map()),
+    dispatchParallel: jest.fn().mockResolvedValue({ taskIds: [], errors: [] }),
+    dispatchParallelWithLenses: jest.fn().mockResolvedValue({ taskIds: [], errors: [] }),
+    getTask: jest.fn().mockReturnValue(null),
+    scopeTracker: {
+      hasOverlap: jest.fn().mockReturnValue({ overlaps: false }),
+      register: jest.fn(),
+      release: jest.fn(),
+    },
+    pipeline: null,
+    projectRoot: '/tmp/gossip-test-project',
+    ...overrides,
+  };
+}
+
+const originalCtx = {
+  mainAgent: ctx.mainAgent,
+  relay: ctx.relay,
+  workers: ctx.workers,
+  keychain: ctx.keychain,
+  skillEngine: ctx.skillEngine,
+  nativeTaskMap: ctx.nativeTaskMap,
+  nativeResultMap: ctx.nativeResultMap,
+  nativeAgentConfigs: ctx.nativeAgentConfigs,
+  pendingConsensusRounds: ctx.pendingConsensusRounds,
+  pendingDispatchResolutionRoots: ctx.pendingDispatchResolutionRoots,
+  booted: ctx.booted,
+  boot: ctx.boot,
+  syncWorkersViaKeychain: ctx.syncWorkersViaKeychain,
+};
+
+function resetCtx(mainAgentOverrides: Record<string, any> = {}) {
+  ctx.mainAgent = makeMainAgent(mainAgentOverrides);
+  ctx.nativeTaskMap = new Map();
+  ctx.nativeResultMap = new Map();
+  ctx.nativeAgentConfigs = new Map();
+  ctx.pendingConsensusRounds = new Map();
+  ctx.pendingDispatchResolutionRoots = new Map();
+  ctx.booted = true;
+  ctx.boot = jest.fn().mockResolvedValue(undefined) as any;
+  ctx.syncWorkersViaKeychain = jest.fn().mockResolvedValue(undefined) as any;
+  (ctx as any).skillEngine = null;
+}
+
+function restoreCtx() {
+  Object.assign(ctx, originalCtx);
+}
+
+function writeConfig(dir: string, body: any): void {
+  mkdirSync(join(dir, '.gossip'), { recursive: true });
+  // loadConfig requires main_agent.provider + main_agent.model. Auto-discovery
+  // only reads cfg.consensus.autoDiscoverWorktrees, so we merge a minimal
+  // valid main_agent block with whatever the test passed in.
+  const merged = {
+    main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+    ...body,
+  };
+  writeFileSync(join(dir, '.gossip', 'config.json'), JSON.stringify(merged));
+}
+
+describe('handleDispatchConsensus — dispatch-time worktree auto-discovery (issue #390)', () => {
+  let projectDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    projectDir = mkdtempSync(join(tmpdir(), 'gossip-dispatch-autodiscover-'));
+    mkdirSync(join(projectDir, '.gossip', 'skills'), { recursive: true });
+    process.chdir(projectDir);
+    resetCtx();
+    mockedDiscover.mockReset();
+
+    // Register one relay agent. Relay dispatch is what reads dispatch-time
+    // resolutionRoots into per-task options at dispatch.ts:911-912, so this
+    // gives us the assertion surface.
+    ctx.mainAgent.dispatchParallel = jest.fn().mockResolvedValue({
+      taskIds: ['t-1'],
+      errors: [],
+    });
+    ctx.mainAgent.getTask = jest.fn().mockReturnValue({ agentId: 'gemini-tester' });
+  });
+
+  afterEach(() => {
+    restoreCtx();
+    process.chdir(prevCwd);
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  // Case 1 — Layer 1 happy path: flag ON, no caller-passed roots, worktrees
+  // discovered. Discovered roots must flow into both per-task relay options
+  // AND ctx.pendingDispatchResolutionRoots.
+  it('Layer 1 — auto-discovers worktrees and injects into relay options + stash', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
+    mockedDiscover.mockResolvedValue({
+      discovered: ['/tmp/worktree-a', '/tmp/worktree-b'],
+      rejected: [],
+    });
+
+    await handleDispatchConsensus([
+      { agent_id: 'gemini-tester', task: 'Audit X' },
+    ]);
+
+    expect(mockedDiscover).toHaveBeenCalledWith(expect.any(String), []);
+    // Relay options carry the discovered roots
+    const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
+    const relayDefs = dispatchParallelCall[0];
+    expect(relayDefs[0].options).toEqual({
+      resolutionRoots: ['/tmp/worktree-a', '/tmp/worktree-b'],
+    });
+    // Stash carries them too (collect-time pickup)
+    expect(ctx.pendingDispatchResolutionRoots.get('t-1')).toEqual([
+      '/tmp/worktree-a',
+      '/tmp/worktree-b',
+    ]);
+  });
+
+  // Case 2 — explicit caller-passed roots win. Auto-discovery must NOT run.
+  it('Layer 1 — caller-passed resolutionRoots wins; discovery is skipped', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
+    mockedDiscover.mockResolvedValue({
+      discovered: ['/tmp/should-not-be-used'],
+      rejected: [],
+    });
+
+    await handleDispatchConsensus(
+      [{ agent_id: 'gemini-tester', task: 'Audit X' }],
+      undefined,
+      ['/tmp/explicit-root'],
+    );
+
+    expect(mockedDiscover).not.toHaveBeenCalled();
+    const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
+    expect(dispatchParallelCall[0][0].options).toEqual({
+      resolutionRoots: ['/tmp/explicit-root'],
+    });
+    expect(ctx.pendingDispatchResolutionRoots.get('t-1')).toEqual(['/tmp/explicit-root']);
+  });
+
+  // Case 3 — flag OFF, no worktrees on disk → no warning, no error.
+  it('Layer 2 — silent when flag is off and no worktrees exist', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: false } });
+    mockedDiscover.mockResolvedValue({ discovered: [], rejected: [] });
+
+    const result: any = await handleDispatchConsensus([
+      { agent_id: 'gemini-tester', task: 'Audit X' },
+    ]);
+
+    expect(result.warnings).toBeUndefined();
+    expect(result.content[0].text).not.toContain('WARNINGS:');
+  });
+
+  // Case 4 — Layer 2 trigger: flag OFF but worktrees exist → soft warning.
+  it('Layer 2 — emits soft warning when flag is off but worktrees exist', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: false } });
+    mockedDiscover.mockResolvedValue({
+      discovered: ['/tmp/orphan-worktree'],
+      rejected: [],
+    });
+
+    const result: any = await handleDispatchConsensus([
+      { agent_id: 'gemini-tester', task: 'Audit X' },
+    ]);
+
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/autoDiscoverWorktrees/);
+    expect(result.warnings[0]).toMatch(/1 worktree/);
+    expect(result.content[0].text).toContain('WARNINGS:');
+    // No injection — relay options should stay empty
+    const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
+    expect(dispatchParallelCall[0][0].options).toBeUndefined();
+  });
+
+  // Case 5 — Layer 2 silent when Layer 1 fires. Discovered roots get injected,
+  // and the warning channel stays empty (operator already opted in).
+  it('Layer 2 — silent when Layer 1 fires (flag on + worktrees discovered)', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
+    mockedDiscover.mockResolvedValue({
+      discovered: ['/tmp/worktree-x'],
+      rejected: [],
+    });
+
+    const result: any = await handleDispatchConsensus([
+      { agent_id: 'gemini-tester', task: 'Audit X' },
+    ]);
+
+    expect(result.warnings).toBeUndefined();
+    const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
+    expect(dispatchParallelCall[0][0].options).toEqual({
+      resolutionRoots: ['/tmp/worktree-x'],
+    });
+  });
+
+  // Case 6 — failure isolation: discoverGitWorktrees throws → dispatch still
+  // succeeds with empty roots (no warning, no crash).
+  it('failure isolation — dispatch succeeds when discoverGitWorktrees throws', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
+    mockedDiscover.mockRejectedValue(new Error('git missing'));
+
+    const result: any = await handleDispatchConsensus([
+      { agent_id: 'gemini-tester', task: 'Audit X' },
+    ]);
+
+    expect(result.content).toBeDefined();
+    expect(result.warnings).toBeUndefined();
+    const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
+    expect(dispatchParallelCall[0][0].options).toBeUndefined();
+    expect(ctx.pendingDispatchResolutionRoots.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #390. Mirrors the `collect.ts:427` auto-discovery pattern into `apps/cli/src/handlers/dispatch.ts` so Phase 1 consensus dispatch picks up worktree paths *before* relay workers launch — not after.

Concrete failure this fixes: consensus round `5178d3e7-41604528` on PR #389 dispatched `gemini-tester` with `cwd = projectRoot` (master HEAD), producing 3 false-dispute findings against code that only existed on the worktree branch. Round was retracted; both agents protected from scoring penalty.

## Layers

- **Layer 1** — when `mode === "consensus"`, caller `resolutionRoots` is empty, AND `cfg.consensus.autoDiscoverWorktrees === true`, call `discoverGitWorktrees(cwd, [cwd])` and inject validated roots into the dispatch-time `resolutionRoots` flowing to per-task options. Explicit caller-passed roots always win.
- **Layer 2** — soft warning in `dispatchWarnings` when the flag is OFF but worktrees exist on disk, nudging operators to opt in.

## Commits

- `192f7f8` — initial implementation (Layer 1 + Layer 2 + 6 test cases)
- `b6992df` — consensus follow-ups (F1/F2/F4) from cross-review round on the first commit, kept as a separate commit to preserve the review-loop audit trail:
  - **F1**: `discoverGitWorktrees(cwd, [])` → `discoverGitWorktrees(cwd, [cwd])` at both call sites. Without the exclude, `git worktree list` returns the main worktree alongside agent worktrees and cwd leaks into `effectiveDispatchRoots`. Mirrors `collect.ts:428`.
  - **F2**: WARNINGS block moved BEFORE the `=== END REQUIRED_NEXT_ACTION ===` sentinel. Sentinel-splitting MCP parsers were silently dropping operator-visible warnings.
  - **F4**: when `autoDiscoverWorktrees=true` AND all discovered candidates fail `validateResolutionRoot`, surface a warning via `dispatchWarnings` instead of stderr-only. Operator can now distinguish "no worktrees" from "worktrees rejected by validator".

## Tests

`tests/cli/dispatch-autodiscover-worktrees.test.ts` — 7 cases, all pass:

1. Layer 1 happy path
2. Explicit `resolutionRoots` override skips discovery
3. Flag off, no worktrees → silent
4. Layer 2 trigger (flag off, worktrees exist → soft warning)
5. Layer 2 silent when Layer 1 fires
6. Failure isolation (`discoverGitWorktrees` rejects → dispatch succeeds)
7. **NEW**: all candidates rejected → operator-visible warning (F4)

## Consensus audit

- Round on `192f7f8` (sonnet-reviewer + gemini-reviewer with `resolutionRoots: ['.claude/worktrees/agent-a1c84a4b2bf4daf45']`)
- 3 medium findings (F1/F2/F4) addressed in `b6992df`
- 1 high finding (F3 — `handleDispatchParallel` scope gap) deferred to #392
- Signals recorded with `finding_id` prefixed `manual-2026-05-15`

## Out of scope

- Auto-discovery for `mode: "parallel"` with `consensus: true` task flag → #392
- Auto-discovery for `single` / non-consensus `parallel` modes
- Changing the global default of `autoDiscoverWorktrees` (stays opt-in)

## Test plan

- [x] 7/7 new tests pass
- [x] Adjacent regression suites — 20 passed / 8 skipped / 0 failed
- [x] Typecheck clean on changed files
- [x] Consensus cross-review with `resolutionRoots` (the meta-test of this feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)