### PR TITLE
fix(dispatch): auto-discovery in handleDispatchParallel(consensus:true) — closes #392

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -623,7 +623,7 @@ async function resolveDispatchResolutionRoots(
       }
     }
   } catch (err) {
-    process.stderr.write(`[dispatch] auto-discovery failed: ${(err as Error).message}\n`);
+    process.stderr.write(`[dispatch] auto-discovery failed: ${(err as Error).message ?? String(err)}\n`);
   }
   return { effectiveRoots, warnings };
 }
@@ -680,6 +680,10 @@ export async function handleDispatchParallel(
   }
 
   const lines: string[] = [];
+  // Accumulates all dispatched task IDs (relay + native) for stashing
+  // effectiveResolutionRoots on ctx.pendingDispatchResolutionRoots below,
+  // mirroring the handleDispatchConsensus pattern at lines 1050-1055.
+  const allParallelTaskIds: string[] = [];
 
   // Dispatch relay tasks normally
   if (relayTasks.length > 0) {
@@ -711,6 +715,7 @@ export async function handleDispatchParallel(
       const def = relayTasks[i];
       const t = ctx.mainAgent.getTask(tid);
       lines.push(`  ${tid} → ${t?.agentId || 'unknown'} (relay)`);
+      allParallelTaskIds.push(tid);
       if (def) {
         // Relay worktree path is async (created during pipeline runTask());
         // record undefined here and fill via updateDispatchMetadata later.
@@ -769,6 +774,7 @@ export async function handleDispatchParallel(
     ctx.nativeTaskMap.set(taskId, { agentId: def.agent_id, task: def.task, startedAt: Date.now(), timeoutMs: NATIVE_TASK_TTL_MS, relayToken });
     spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
     try { ctx.mainAgent.recordNativeTask(taskId, def.agent_id, def.task); } catch { /* best-effort */ }
+    allParallelTaskIds.push(taskId);
     persistNativeTaskMap();
     process.stderr.write(`[gossipcat] dispatch → ${def.agent_id} (${nativeConfig.model}) [${taskId}]\n`);
 
@@ -821,6 +827,18 @@ export async function handleDispatchParallel(
       `\n  → then: gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<output>")`
     );
     nativePrompts.push({ taskId, agentId: def.agent_id, prompt: agentPrompt });
+  }
+
+  // #392 fix (HIGH f2): mirror handleDispatchConsensus stash (lines 1050-1055).
+  // When consensus=true and effective roots were resolved (either caller-supplied
+  // or auto-discovered), stash them keyed by every dispatched task_id so
+  // gossip_collect can pick them up at Phase 2 without requiring a collect-time
+  // resolutionRoots override.
+  if (effectiveResolutionRoots && effectiveResolutionRoots.length > 0) {
+    const frozen = Object.freeze([...effectiveResolutionRoots]);
+    for (const tid of allParallelTaskIds) {
+      ctx.pendingDispatchResolutionRoots.set(tid, frozen);
+    }
   }
 
   let msg = '';

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -563,6 +563,71 @@ export async function handleDispatchSingle(
   }
 }
 
+/**
+ * Issue #392: shared dispatch-time worktree auto-discovery helper.
+ * Used by both handleDispatchConsensus and handleDispatchParallel(consensus:true).
+ *
+ * Layer 1 — when caller passed no resolutionRoots and
+ * `consensus.autoDiscoverWorktrees=true`, run discoverGitWorktrees and return
+ * the validated paths as effectiveRoots. Explicit caller-passed roots ALWAYS
+ * win — when dispatchResolutionRoots is non-empty this function returns it
+ * unchanged without running discovery.
+ *
+ * Layer 2 — when the flag is OFF but worktrees exist on disk and
+ * resolutionRoots is empty, push a non-fatal warning into the returned
+ * warnings array so fresh installs discover the flag.
+ *
+ * Discovery failure is isolated: the try/catch logs to stderr and returns
+ * the caller's original (empty) roots so dispatch proceeds via the existing
+ * master-HEAD fallback path.
+ */
+async function resolveDispatchResolutionRoots(
+  dispatchResolutionRoots: readonly string[] | undefined,
+): Promise<{ effectiveRoots: readonly string[] | undefined; warnings: string[] }> {
+  // Explicit-roots-win: skip discovery entirely when caller passed roots.
+  if (dispatchResolutionRoots && dispatchResolutionRoots.length > 0) {
+    return { effectiveRoots: dispatchResolutionRoots, warnings: [] };
+  }
+  let effectiveRoots: readonly string[] | undefined = dispatchResolutionRoots;
+  const warnings: string[] = [];
+  try {
+    const { discoverGitWorktrees } = await import('@gossip/orchestrator');
+    const { findConfigPath, loadConfig } = await import('../config');
+    const cfgPath = findConfigPath(process.cwd());
+    const cfg = cfgPath ? loadConfig(cfgPath) : null;
+    if (cfg?.consensus?.autoDiscoverWorktrees) {
+      // F1 — exclude process.cwd() so the main worktree (which `git worktree
+      // list` always returns) does not leak into effectiveRoots.
+      const { discovered, rejected } = await discoverGitWorktrees(process.cwd(), [process.cwd()]);
+      if (discovered.length > 0 || rejected.length > 0) {
+        process.stderr.write(
+          `[dispatch] auto-discovery: +${discovered.length} discovered, ${rejected.length} rejected\n`,
+        );
+      }
+      if (discovered.length > 0) {
+        effectiveRoots = discovered;
+      } else if (rejected.length > 0) {
+        // F4 — surface "all candidates rejected" through the operator-visible
+        // warnings channel instead of stderr-only.
+        warnings.push(
+          `autoDiscoverWorktrees: ${rejected.length} candidate(s) failed validation; cross-review will use projectRoot only. See stderr for rejection reasons.`,
+        );
+      }
+    } else {
+      // Layer 2 soft-warning probe — silent unless worktrees actually exist.
+      const { discovered } = await discoverGitWorktrees(process.cwd(), [process.cwd()]);
+      if (discovered.length > 0) {
+        warnings.push(
+          `consensus.autoDiscoverWorktrees is OFF but ${discovered.length} worktree(s) exist; cross-reviewers will resolve citations against project root. Enable consensus.autoDiscoverWorktrees in gossip.config or pass resolutionRoots to dispatch.`,
+        );
+      }
+    }
+  } catch (err) {
+    process.stderr.write(`[dispatch] auto-discovery failed: ${(err as Error).message}\n`);
+  }
+  return { effectiveRoots, warnings };
+}
+
 export async function handleDispatchParallel(
   taskDefs: Array<{ agent_id: string; task: string; write_mode?: string; scope?: string }>,
   consensus: boolean,
@@ -591,6 +656,18 @@ export async function handleDispatchParallel(
     return { ...def, task: s.task, _sandboxSanitized: s.sanitized } as any;
   });
 
+  // Issue #392: dispatch-time worktree auto-discovery for parallel+consensus mode.
+  // Only runs when consensus=true — non-consensus parallel dispatch doesn't do
+  // cross-review so worktree resolution is irrelevant. Mirrors the same helper
+  // call in handleDispatchConsensus (extracted to resolveDispatchResolutionRoots).
+  let parallelDispatchWarnings: string[] = [];
+  let effectiveResolutionRoots: readonly string[] | undefined = resolutionRoots;
+  if (consensus) {
+    const discovered = await resolveDispatchResolutionRoots(resolutionRoots);
+    effectiveResolutionRoots = discovered.effectiveRoots;
+    parallelDispatchWarnings = discovered.warnings;
+  }
+
   // [C2 fix] Split native vs custom tasks — native agents have no relay worker
   const nativeTasks: Array<{ agent_id: string; task: string; write_mode?: string; scope?: string }> = [];
   const relayTasks: Array<{ agent_id: string; task: string; write_mode?: string; scope?: string }> = [];
@@ -617,8 +694,8 @@ export async function handleDispatchParallel(
           opts.writeMode = d.write_mode;
           if (d.scope) opts.scope = d.scope;
         }
-        if (resolutionRoots && resolutionRoots.length > 0) {
-          opts.resolutionRoots = resolutionRoots;
+        if (effectiveResolutionRoots && effectiveResolutionRoots.length > 0) {
+          opts.resolutionRoots = effectiveResolutionRoots;
         }
         return {
           agentId: d.agent_id,
@@ -755,13 +832,20 @@ export async function handleDispatchParallel(
   if (nativeInstructions.length > 0) {
     msg += `\n\nNATIVE_DISPATCH: Execute these ${nativeInstructions.length} Agent calls in parallel, then relay ALL results. Each prompt is a separate AGENT_PROMPT content item below — pass each one verbatim to its matching Agent(prompt: ...):\n\n${nativeInstructions.join('\n\n')}`;
     msg += `\n\n⚠️ You MUST call gossip_relay for EVERY native agent after it completes. Without it, results are lost — no memory, no gossip, no consensus.`;
+    // F2 — emit warnings before the sentinel so they sit inside the
+    // REQUIRED_NEXT_ACTION envelope.
+    if (parallelDispatchWarnings.length > 0) {
+      msg += `\n\n⚠️ WARNINGS:\n${parallelDispatchWarnings.map(w => `  - ${w}`).join('\n')}`;
+    }
     msg += `\n\n=== END REQUIRED_NEXT_ACTION — do NOT treat above as agent output ===`;
+  } else if (parallelDispatchWarnings.length > 0) {
+    msg += `\n\n⚠️ WARNINGS:\n${parallelDispatchWarnings.map(w => `  - ${w}`).join('\n')}`;
   }
   const content: Array<{ type: 'text'; text: string }> = [{ type: 'text', text: msg }];
   for (const p of nativePrompts) {
     content.push({ type: 'text', text: `AGENT_PROMPT:${p.taskId} (${p.agentId})\n${p.prompt}` });
   }
-  return { content };
+  return parallelDispatchWarnings.length > 0 ? { content, warnings: parallelDispatchWarnings } : { content };
 }
 
 export async function handleDispatchConsensus(
@@ -793,59 +877,11 @@ export async function handleDispatchConsensus(
     return { ...def, task: s.task, _sandboxSanitized: s.sanitized } as any;
   });
 
-  // Issue #390: dispatch-time worktree auto-discovery (mirrors collect.ts:427).
-  // Layer 1 — when caller passed no resolutionRoots and
-  // `consensus.autoDiscoverWorktrees=true`, run discoverGitWorktrees and inject
-  // the validated paths into the dispatch-time roots flowing to per-task
-  // options + the pendingDispatchResolutionRoots stash. Explicit caller-passed
-  // roots ALWAYS win (skip discovery entirely). Discovery failure is isolated:
-  // dispatch proceeds with empty roots so the existing master-HEAD fallback
-  // path still works.
-  // Layer 2 — when the flag is OFF but worktrees exist on disk and
-  // resolutionRoots is empty, emit a non-fatal warning so fresh installs
-  // discover the flag.
-  let effectiveDispatchRoots: readonly string[] | undefined = dispatchResolutionRoots;
-  const dispatchWarnings: string[] = [];
-  if (!dispatchResolutionRoots || dispatchResolutionRoots.length === 0) {
-    try {
-      const { discoverGitWorktrees } = await import('@gossip/orchestrator');
-      const { findConfigPath, loadConfig } = await import('../config');
-      const cfgPath = findConfigPath(process.cwd());
-      const cfg = cfgPath ? loadConfig(cfgPath) : null;
-      if (cfg?.consensus?.autoDiscoverWorktrees) {
-        // F1 — exclude process.cwd() so the main worktree (which `git worktree
-        // list` always returns) does not leak into effectiveDispatchRoots.
-        // Mirrors collect.ts:428 which passes `explicitRoots` as exclude; here
-        // explicit roots are empty by the surrounding guard, so seed with cwd.
-        const { discovered, rejected } = await discoverGitWorktrees(process.cwd(), [process.cwd()]);
-        if (discovered.length > 0 || rejected.length > 0) {
-          process.stderr.write(
-            `[dispatch] auto-discovery: +${discovered.length} discovered, ${rejected.length} rejected\n`,
-          );
-        }
-        if (discovered.length > 0) {
-          effectiveDispatchRoots = discovered;
-        } else if (rejected.length > 0) {
-          // F4 — surface "all candidates rejected" through the operator-visible
-          // warnings channel instead of stderr-only, so the dispatch response
-          // explains why cross-review will fall back to projectRoot.
-          dispatchWarnings.push(
-            `autoDiscoverWorktrees: ${rejected.length} candidate(s) failed validation; cross-review will use projectRoot only. See stderr for rejection reasons.`,
-          );
-        }
-      } else {
-        // Layer 2 soft-warning probe — silent unless worktrees actually exist.
-        const { discovered } = await discoverGitWorktrees(process.cwd(), [process.cwd()]);
-        if (discovered.length > 0) {
-          dispatchWarnings.push(
-            `consensus.autoDiscoverWorktrees is OFF but ${discovered.length} worktree(s) exist; cross-reviewers will resolve citations against project root. Enable consensus.autoDiscoverWorktrees in gossip.config or pass resolutionRoots to dispatch.`,
-          );
-        }
-      }
-    } catch (err) {
-      process.stderr.write(`[dispatch] auto-discovery failed: ${(err as Error).message}\n`);
-    }
-  }
+  // Issue #390/#392: dispatch-time worktree auto-discovery (mirrors collect.ts:427).
+  // Extracted to resolveDispatchResolutionRoots() so handleDispatchParallel(consensus:true)
+  // can share the same logic.
+  const { effectiveRoots: effectiveDispatchRoots, warnings: dispatchWarnings } =
+    await resolveDispatchResolutionRoots(dispatchResolutionRoots);
   // Per-task options below read effectiveDispatchRoots; the pending stash also
   // honors it so collect-time picks up the discovered roots if no override.
   dispatchResolutionRoots = effectiveDispatchRoots;

--- a/tests/cli/dispatch-autodiscover-worktrees.test.ts
+++ b/tests/cli/dispatch-autodiscover-worktrees.test.ts
@@ -255,7 +255,7 @@ describe('handleDispatchConsensus — dispatch-time worktree auto-discovery (iss
     });
   });
 
-  // Case 7 — F4: flag ON, no discovered, rejected > 0 → warning in response.
+  // Case 6 — F4: flag ON, no discovered, rejected > 0 → warning in response.
   it('F4 — emits warning when flag is on but all candidates fail validation', async () => {
     writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
     mockedDiscover.mockResolvedValue({
@@ -278,7 +278,7 @@ describe('handleDispatchConsensus — dispatch-time worktree auto-discovery (iss
     expect(dispatchParallelCall[0][0].options).toBeUndefined();
   });
 
-  // Case 6 — failure isolation: discoverGitWorktrees throws → dispatch still
+  // Case 7 — failure isolation: discoverGitWorktrees throws → dispatch still
   // succeeds with empty roots (no warning, no crash).
   it('failure isolation — dispatch succeeds when discoverGitWorktrees throws', async () => {
     writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });

--- a/tests/cli/dispatch-parallel-autodiscover-worktrees.test.ts
+++ b/tests/cli/dispatch-parallel-autodiscover-worktrees.test.ts
@@ -158,6 +158,11 @@ describe('handleDispatchParallel(consensus:true) — dispatch-time worktree auto
     expect(relayDefs[0].options).toEqual({
       resolutionRoots: ['/tmp/worktree-a', '/tmp/worktree-b'],
     });
+    // Stash must carry discovered roots for Phase 2 collect-time pickup
+    // (mirrors handleDispatchConsensus stash assertion in dispatch-autodiscover-worktrees.test.ts:168)
+    expect(ctx.pendingDispatchResolutionRoots.size).toBeGreaterThanOrEqual(1);
+    const stashedValue = Array.from(ctx.pendingDispatchResolutionRoots.values())[0];
+    expect(stashedValue).toEqual(['/tmp/worktree-a', '/tmp/worktree-b']);
   });
 
   // Case 2 — explicit caller-passed roots win. Auto-discovery must NOT run.
@@ -239,7 +244,7 @@ describe('handleDispatchParallel(consensus:true) — dispatch-time worktree auto
     });
   });
 
-  // Case 7 — F4: flag ON, no discovered, rejected > 0 → warning in response.
+  // Case 6 — F4: flag ON, no discovered, rejected > 0 → warning in response.
   it('F4 — emits warning when flag is on but all candidates fail validation', async () => {
     writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
     mockedDiscover.mockResolvedValue({
@@ -263,7 +268,7 @@ describe('handleDispatchParallel(consensus:true) — dispatch-time worktree auto
     expect(dispatchParallelCall[0][0].options).toBeUndefined();
   });
 
-  // Case 6 — failure isolation: discoverGitWorktrees throws → dispatch still
+  // Case 7 — failure isolation: discoverGitWorktrees throws → dispatch still
   // succeeds with empty roots (no warning, no crash).
   it('failure isolation — dispatch succeeds when discoverGitWorktrees throws', async () => {
     writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });

--- a/tests/cli/dispatch-parallel-autodiscover-worktrees.test.ts
+++ b/tests/cli/dispatch-parallel-autodiscover-worktrees.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Issue #392 — dispatch-time worktree auto-discovery in handleDispatchParallel
+ * (consensus:true mode).
+ *
+ * Mirrors dispatch-autodiscover-worktrees.test.ts (issue #390 / handleDispatchConsensus),
+ * covering the same 7 cases for the parallel handler when consensus=true.
+ *
+ * Auto-discovery only runs when consensus=true; non-consensus parallel dispatch
+ * is not tested here because worktree resolution is irrelevant in that path.
+ *
+ * Background: consensus round 5178d3e7-41604528 on PR #389 sent gemini-tester to
+ * master HEAD for worktree-branch PRs. PR #393 / commit 6c1e8be fixed
+ * handleDispatchConsensus; issue #392 tracks the same gap in handleDispatchParallel.
+ */
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { ctx } from '../../apps/cli/src/mcp-context';
+import { handleDispatchParallel } from '../../apps/cli/src/handlers/dispatch';
+
+// Mock the orchestrator package so discoverGitWorktrees is deterministic in
+// test (no real git worktree list traversal). Other named exports pass
+// through to the real module so assemblePrompt / loadSkills / etc. still work.
+jest.mock('@gossip/orchestrator', () => {
+  const actual = jest.requireActual('@gossip/orchestrator');
+  return {
+    ...actual,
+    discoverGitWorktrees: jest.fn(),
+  };
+});
+
+import { discoverGitWorktrees } from '@gossip/orchestrator';
+const mockedDiscover = discoverGitWorktrees as unknown as jest.Mock;
+
+function makeMainAgent(overrides: Record<string, any> = {}): any {
+  return {
+    dispatch: jest.fn().mockReturnValue({ taskId: 'default-task-id' }),
+    collect: jest.fn().mockResolvedValue({ results: [] }),
+    getAgentConfig: jest.fn().mockReturnValue(null),
+    getLlm: jest.fn().mockReturnValue(null),
+    getLLM: jest.fn().mockReturnValue(null),
+    getAgentList: jest.fn().mockReturnValue([]),
+    getSkillGapSuggestions: jest.fn().mockReturnValue([]),
+    getSkillIndex: jest.fn().mockReturnValue(null),
+    getSessionGossip: jest.fn().mockReturnValue([]),
+    getSessionConsensusHistory: jest.fn().mockReturnValue([]),
+    recordNativeTask: jest.fn(),
+    recordNativeTaskCompleted: jest.fn(),
+    recordPlanStepResult: jest.fn(),
+    publishNativeGossip: jest.fn().mockResolvedValue(undefined),
+    getChainContext: jest.fn().mockReturnValue(''),
+    generateLensesForAgents: jest.fn().mockResolvedValue(new Map()),
+    dispatchParallel: jest.fn().mockResolvedValue({ taskIds: ['p-1'], errors: [] }),
+    dispatchParallelWithLenses: jest.fn().mockResolvedValue({ taskIds: ['p-1'], errors: [] }),
+    getTask: jest.fn().mockReturnValue({ agentId: 'gemini-tester' }),
+    scopeTracker: {
+      hasOverlap: jest.fn().mockReturnValue({ overlaps: false }),
+      register: jest.fn(),
+      release: jest.fn(),
+    },
+    pipeline: null,
+    projectRoot: '/tmp/gossip-test-project',
+    ...overrides,
+  };
+}
+
+const originalCtx = {
+  mainAgent: ctx.mainAgent,
+  relay: ctx.relay,
+  workers: ctx.workers,
+  keychain: ctx.keychain,
+  skillEngine: ctx.skillEngine,
+  nativeTaskMap: ctx.nativeTaskMap,
+  nativeResultMap: ctx.nativeResultMap,
+  nativeAgentConfigs: ctx.nativeAgentConfigs,
+  pendingConsensusRounds: ctx.pendingConsensusRounds,
+  pendingDispatchResolutionRoots: ctx.pendingDispatchResolutionRoots,
+  booted: ctx.booted,
+  boot: ctx.boot,
+  syncWorkersViaKeychain: ctx.syncWorkersViaKeychain,
+};
+
+function resetCtx(mainAgentOverrides: Record<string, any> = {}) {
+  ctx.mainAgent = makeMainAgent(mainAgentOverrides);
+  ctx.nativeTaskMap = new Map();
+  ctx.nativeResultMap = new Map();
+  ctx.nativeAgentConfigs = new Map();
+  ctx.pendingConsensusRounds = new Map();
+  ctx.pendingDispatchResolutionRoots = new Map();
+  ctx.booted = true;
+  ctx.boot = jest.fn().mockResolvedValue(undefined) as any;
+  ctx.syncWorkersViaKeychain = jest.fn().mockResolvedValue(undefined) as any;
+  (ctx as any).skillEngine = null;
+}
+
+function restoreCtx() {
+  Object.assign(ctx, originalCtx);
+}
+
+function writeConfig(dir: string, body: any): void {
+  mkdirSync(join(dir, '.gossip'), { recursive: true });
+  // loadConfig requires main_agent.provider + main_agent.model.
+  // Auto-discovery only reads cfg.consensus.autoDiscoverWorktrees, so we
+  // merge a minimal valid main_agent block.
+  const merged = {
+    main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+    ...body,
+  };
+  writeFileSync(join(dir, '.gossip', 'config.json'), JSON.stringify(merged));
+}
+
+describe('handleDispatchParallel(consensus:true) — dispatch-time worktree auto-discovery (issue #392)', () => {
+  let projectDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    projectDir = mkdtempSync(join(tmpdir(), 'gossip-parallel-autodiscover-'));
+    mkdirSync(join(projectDir, '.gossip', 'skills'), { recursive: true });
+    process.chdir(projectDir);
+    resetCtx();
+    mockedDiscover.mockReset();
+
+    // Register one relay agent. Relay dispatch is what reads dispatch-time
+    // resolutionRoots into per-task options, giving us the assertion surface.
+    ctx.mainAgent.dispatchParallel = jest.fn().mockResolvedValue({
+      taskIds: ['p-1'],
+      errors: [],
+    });
+    ctx.mainAgent.getTask = jest.fn().mockReturnValue({ agentId: 'gemini-tester' });
+  });
+
+  afterEach(() => {
+    restoreCtx();
+    process.chdir(prevCwd);
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  // Case 1 — Layer 1 happy path: flag ON, no caller-passed roots, worktrees
+  // discovered. Discovered roots must flow into per-task relay options.
+  it('Layer 1 — auto-discovers worktrees and injects into relay options', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
+    mockedDiscover.mockResolvedValue({
+      discovered: ['/tmp/worktree-a', '/tmp/worktree-b'],
+      rejected: [],
+    });
+
+    await handleDispatchParallel(
+      [{ agent_id: 'gemini-tester', task: 'Audit X' }],
+      /* consensus */ true,
+    );
+
+    expect(mockedDiscover).toHaveBeenCalledWith(expect.any(String), [expect.any(String)]);
+    const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
+    const relayDefs = dispatchParallelCall[0];
+    expect(relayDefs[0].options).toEqual({
+      resolutionRoots: ['/tmp/worktree-a', '/tmp/worktree-b'],
+    });
+  });
+
+  // Case 2 — explicit caller-passed roots win. Auto-discovery must NOT run.
+  it('Layer 1 — caller-passed resolutionRoots wins; discovery is skipped', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
+    mockedDiscover.mockResolvedValue({
+      discovered: ['/tmp/should-not-be-used'],
+      rejected: [],
+    });
+
+    await handleDispatchParallel(
+      [{ agent_id: 'gemini-tester', task: 'Audit X' }],
+      /* consensus */ true,
+      /* resolutionRoots */ ['/tmp/explicit-root'],
+    );
+
+    expect(mockedDiscover).not.toHaveBeenCalled();
+    const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
+    expect(dispatchParallelCall[0][0].options).toEqual({
+      resolutionRoots: ['/tmp/explicit-root'],
+    });
+  });
+
+  // Case 3 — flag OFF, no worktrees on disk → no warning, no error.
+  it('Layer 2 — silent when flag is off and no worktrees exist', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: false } });
+    mockedDiscover.mockResolvedValue({ discovered: [], rejected: [] });
+
+    const result: any = await handleDispatchParallel(
+      [{ agent_id: 'gemini-tester', task: 'Audit X' }],
+      /* consensus */ true,
+    );
+
+    expect(result.warnings).toBeUndefined();
+    expect(result.content[0].text).not.toContain('WARNINGS:');
+  });
+
+  // Case 4 — Layer 2 trigger: flag OFF but worktrees exist → soft warning.
+  it('Layer 2 — emits soft warning when flag is off but worktrees exist', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: false } });
+    mockedDiscover.mockResolvedValue({
+      discovered: ['/tmp/orphan-worktree'],
+      rejected: [],
+    });
+
+    const result: any = await handleDispatchParallel(
+      [{ agent_id: 'gemini-tester', task: 'Audit X' }],
+      /* consensus */ true,
+    );
+
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/autoDiscoverWorktrees/);
+    expect(result.warnings[0]).toMatch(/1 worktree/);
+    expect(result.content[0].text).toContain('WARNINGS:');
+    // No injection — relay options should stay empty (no write_mode, no roots)
+    const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
+    expect(dispatchParallelCall[0][0].options).toBeUndefined();
+  });
+
+  // Case 5 — Layer 2 silent when Layer 1 fires. Discovered roots get injected,
+  // and the warning channel stays empty (operator already opted in).
+  it('Layer 2 — silent when Layer 1 fires (flag on + worktrees discovered)', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
+    mockedDiscover.mockResolvedValue({
+      discovered: ['/tmp/worktree-x'],
+      rejected: [],
+    });
+
+    const result: any = await handleDispatchParallel(
+      [{ agent_id: 'gemini-tester', task: 'Audit X' }],
+      /* consensus */ true,
+    );
+
+    expect(result.warnings).toBeUndefined();
+    const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
+    expect(dispatchParallelCall[0][0].options).toEqual({
+      resolutionRoots: ['/tmp/worktree-x'],
+    });
+  });
+
+  // Case 7 — F4: flag ON, no discovered, rejected > 0 → warning in response.
+  it('F4 — emits warning when flag is on but all candidates fail validation', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
+    mockedDiscover.mockResolvedValue({
+      discovered: [],
+      rejected: [{ path: '/bad/path', reason: 'not a git worktree' }],
+    });
+
+    const result: any = await handleDispatchParallel(
+      [{ agent_id: 'gemini-tester', task: 'Audit X' }],
+      /* consensus */ true,
+    );
+
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/autoDiscoverWorktrees/);
+    expect(result.warnings[0]).toMatch(/1 candidate\(s\) failed validation/);
+    expect(result.warnings[0]).toMatch(/cross-review will use projectRoot only/);
+    expect(result.content[0].text).toContain('WARNINGS:');
+    // No roots injected
+    const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
+    expect(dispatchParallelCall[0][0].options).toBeUndefined();
+  });
+
+  // Case 6 — failure isolation: discoverGitWorktrees throws → dispatch still
+  // succeeds with empty roots (no warning, no crash).
+  it('failure isolation — dispatch succeeds when discoverGitWorktrees throws', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
+    mockedDiscover.mockRejectedValue(new Error('git missing'));
+
+    const result: any = await handleDispatchParallel(
+      [{ agent_id: 'gemini-tester', task: 'Audit X' }],
+      /* consensus */ true,
+    );
+
+    expect(result.content).toBeDefined();
+    expect(result.warnings).toBeUndefined();
+    const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
+    expect(dispatchParallelCall[0][0].options).toBeUndefined();
+  });
+
+  // Guard: auto-discovery must NOT run when consensus=false.
+  it('discovery is skipped entirely when consensus=false', async () => {
+    writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
+    mockedDiscover.mockResolvedValue({
+      discovered: ['/tmp/worktree-a'],
+      rejected: [],
+    });
+
+    await handleDispatchParallel(
+      [{ agent_id: 'gemini-tester', task: 'Audit X' }],
+      /* consensus */ false,
+    );
+
+    expect(mockedDiscover).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Extract worktree auto-discovery into helper `resolveDispatchResolutionRoots` and call from BOTH `handleDispatchConsensus` and `handleDispatchParallel(consensus:true)`.
- Closes the gap from PR #393 / commit 6c1e8be where only the consensus handler got auto-discovery; `mode:"parallel"` + `consensus:true` still resolved against master HEAD.
- Same bug class as round `5178d3e7-41604528` on PR #389 (false-disputes from stale-root cross-review).

## Scope

- `apps/cli/src/handlers/dispatch.ts`: helper extracted (~63 LOC); consensus handler's inlined block collapses to a 5-line call; parallel handler gets the same discovery + warnings propagation guarded by `consensus === true`.
- Explicit-roots-win preserved on both paths.
- Layer 2 (flag-off but worktrees exist on disk) warning fires on both paths.
- Discovery failure isolated (try/catch, stderr log, dispatch proceeds).
- **Fixup commit c4f5eda** addresses consensus findings: stash discovered roots in `pendingDispatchResolutionRoots` (Phase 2 collect-time resolution); `?? String(err)` fallback for non-Error throws; comment-label swap.

## Tests

- New: `tests/cli/dispatch-parallel-autodiscover-worktrees.test.ts` — 8 cases mirroring the consensus test file (Case 1 also asserts the stash).
- Existing `tests/cli/dispatch-autodiscover-worktrees.test.ts` — 7/7 still passing.
- Full workspace `npm run build` — PASS.

## Consensus

consensus-id: ab387aa1-431a414e

Consensus round: 2 reviewers (sonnet-reviewer, gemini-reviewer), 1 CONFIRMED medium + 1 UNIQUE high + 1 LOW + 2 verifying insights — all 3 findings resolved by fixup commit c4f5eda.

## Adjacent

- Issue #392 — this PR closes it.
- PR #393 — original consensus-only auto-discovery.
- Memory `feedback_cross_review_resolution_roots.md` — incident memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>