### PR TITLE
feat(cli): bootstrap-hook-trim — mtime-keyed sentinel suppression

### DIFF
--- a/apps/cli/src/hook-argv.ts
+++ b/apps/cli/src/hook-argv.ts
@@ -1,0 +1,15 @@
+/**
+ * Argv parser for `gossipcat hook <sub>`.
+ *
+ * Returns `'run'` only when the user typed `--run` or `run` explicitly.
+ * Bare `gossipcat hook` (sub === undefined) and any unknown subcommand
+ * return `'usage'` — fix MEDIUM f2 from consensus d88f27db-c0454640
+ * (previously, undefined fell through and silently fired the hook).
+ *
+ * Extracted from index.ts so the guard can be unit-tested without
+ * spawning the full CLI (importing index.ts runs `main()` on load).
+ */
+export function parseHookSubcommand(sub: string | undefined): 'run' | 'usage' {
+  if (sub === '--run' || sub === 'run') return 'run';
+  return 'usage';
+}

--- a/apps/cli/src/hook-run.ts
+++ b/apps/cli/src/hook-run.ts
@@ -1,0 +1,122 @@
+/**
+ * `gossipcat hook --run` — UserPromptSubmit hook body.
+ *
+ * Replaces the unconditional `cat .gossip/bootstrap.md` hook from prior
+ * `gossip_setup` versions. Emits the full bootstrap on the first prompt of a
+ * Claude Code session AND whenever bootstrap.md regenerates mid-session
+ * (via `/mcp` reconnect or `gossip_status()` calls). Suppresses to a single
+ * one-liner otherwise.
+ *
+ * Sentinel design (mtime-keyed, NOT PPID-keyed):
+ *   - Path: `<tmpdir>/.gossipcat-bootstrap-<ppid>`
+ *   - Contents: string form of bootstrap.md's `mtimeMs`
+ *   - PPID in the filename only prevents collisions between parallel Claude
+ *     Code sessions; correctness comes from comparing the stored mtime to the
+ *     current file's mtime. See docs/specs/2026-05-07-bootstrap-hook-trim.md.
+ *
+ * Fail-open contract: ANY thrown error → fall through to printing the full
+ * bootstrap. This subcommand runs on EVERY user prompt; a crash would block
+ * the user's input.
+ */
+import { existsSync, statSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const NO_BOOTSTRAP_HINT =
+  '[gossipcat] No bootstrap yet. Load tools first: ToolSearch(query: "select:mcp__gossipcat__gossip_status") then call gossip_status()';
+const SUPPRESSED_LINE =
+  '[gossipcat: bootstrap already loaded — call gossip_status() if you need a refresh]';
+
+export interface HookRunOptions {
+  /** Override `process.cwd()` for tests. */
+  cwd?: string;
+  /** Override the sentinel file path for tests. */
+  sentinelPath?: string;
+  /** Override stdout for tests. Defaults to `process.stdout.write`. */
+  write?: (chunk: string) => void;
+}
+
+/**
+ * Execute the hook body. Always exits cleanly (no throws) — callers can
+ * rely on this from the CLI entrypoint without a try/catch.
+ */
+export function runHook(opts: HookRunOptions = {}): void {
+  const cwd = opts.cwd ?? process.cwd();
+  const write = opts.write ?? ((s: string) => { process.stdout.write(s); });
+  const bootstrapPath = join(cwd, '.gossip', 'bootstrap.md');
+
+  // Outer try/catch enforces the fail-open contract. Any unexpected error
+  // (permission denied on /tmp, OOM on read, etc.) falls through to a
+  // best-effort full-bootstrap print so the user's prompt is never blocked.
+  try {
+    if (!existsSync(bootstrapPath)) {
+      write(NO_BOOTSTRAP_HINT + '\n');
+      return;
+    }
+
+    let currentMtime: string | null = null;
+    try {
+      currentMtime = String(statSync(bootstrapPath).mtimeMs);
+    } catch {
+      // statSync threw (race with delete, perm change, etc.) — fail open
+      // by printing the full bootstrap if we can read it.
+      currentMtime = null;
+    }
+
+    const sentinelPath = opts.sentinelPath ?? defaultSentinelPath();
+
+    if (currentMtime !== null && sentinelPath && existsSync(sentinelPath)) {
+      let stored: string | null = null;
+      try {
+        stored = readFileSync(sentinelPath, 'utf-8').trim();
+      } catch {
+        stored = null;
+      }
+      if (stored !== null && stored === currentMtime) {
+        write(SUPPRESSED_LINE + '\n');
+        return;
+      }
+    }
+
+    // First fire of session, OR bootstrap regenerated since last fire, OR
+    // statSync failed (fail-open). Print full content.
+    let content: string;
+    try {
+      content = readFileSync(bootstrapPath, 'utf-8');
+    } catch {
+      // Bootstrap unreadable for some reason — fall back to hint and bail.
+      write(NO_BOOTSTRAP_HINT + '\n');
+      return;
+    }
+    write(content);
+    if (!content.endsWith('\n')) write('\n');
+
+    // Update sentinel best-effort (any failure is silent).
+    if (currentMtime !== null && sentinelPath) {
+      try {
+        writeFileSync(sentinelPath, currentMtime, 'utf-8');
+      } catch {
+        // best-effort
+      }
+    }
+  } catch {
+    // Outermost fail-open: try to spit out the bootstrap so the orchestrator
+    // still has the rules; if even that fails, emit the no-bootstrap hint.
+    try {
+      const content = readFileSync(bootstrapPath, 'utf-8');
+      write(content);
+      if (!content.endsWith('\n')) write('\n');
+    } catch {
+      try { write(NO_BOOTSTRAP_HINT + '\n'); } catch { /* truly silent */ }
+    }
+  }
+}
+
+/**
+ * Default sentinel path. PPID in the filename keeps parallel Claude Code
+ * sessions from colliding; mtime stored INSIDE the file is what enforces
+ * correctness.
+ */
+export function defaultSentinelPath(): string {
+  return join(tmpdir(), `.gossipcat-bootstrap-${process.ppid}`);
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -54,6 +54,19 @@ async function main(): Promise<void> {
       return;
     }
 
+    case 'hook': {
+      // UserPromptSubmit bootstrap hook body. Currently the only flag is
+      // `--run`; accept it (or no flag) and execute. Anything else → help.
+      const sub = args[1];
+      if (sub && sub !== '--run' && sub !== 'run') {
+        console.log('Usage: gossipcat hook --run');
+        process.exit(2);
+      }
+      const { runHook } = await import('./hook-run');
+      runHook();
+      return;
+    }
+
     case 'help':
     case '--help':
     case '-h':
@@ -187,6 +200,7 @@ function printHelp(): void {
     gossipcat sync --setup     Configure Supabase connection
     gossipcat sync --status    Show sync status
     gossipcat mcp-serve        Start MCP server (for Claude Code / Cursor)
+    gossipcat hook --run       Run UserPromptSubmit bootstrap hook (internal)
     gossipcat help             Show this help
 
   Write modes:

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -4,6 +4,7 @@ import { runSetupWizard } from './setup-wizard';
 import { startChat } from './chat';
 import { createAgent, listAgents, removeAgent } from './create-agent';
 import { createTeam } from './create-team';
+import { parseHookSubcommand } from './hook-argv';
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
@@ -55,11 +56,13 @@ async function main(): Promise<void> {
     }
 
     case 'hook': {
-      // UserPromptSubmit bootstrap hook body. Currently the only flag is
-      // `--run`; accept it (or no flag) and execute. Anything else → help.
-      const sub = args[1];
-      if (sub && sub !== '--run' && sub !== 'run') {
-        console.log('Usage: gossipcat hook --run');
+      // UserPromptSubmit bootstrap hook body. Only valid invocation is
+      // `gossipcat hook --run` (or `gossipcat hook run`). Bare `gossipcat
+      // hook` previously fell through and silently fired the hook — fix
+      // MEDIUM f2 from consensus d88f27db-c0454640.
+      const decision = parseHookSubcommand(args[1]);
+      if (decision === 'usage') {
+        process.stderr.write('Usage: gossipcat hook --run\n');
         process.exit(2);
       }
       const { runHook } = await import('./hook-run');

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2092,6 +2092,21 @@ server.tool(
       process.stderr.write(`[gossipcat] gossip_setup: discipline hook install failed: ${e}\n`);
     }
 
+    // Bootstrap UserPromptSubmit hook (mtime-keyed sentinel) — spec
+    // 2026-05-07-bootstrap-hook-trim. Idempotent: upgrades legacy
+    // `cat .gossip/bootstrap.md` hooks, no-ops if already current, leaves
+    // user-custom commands alone.
+    let bootstrapHookSummary = '';
+    try {
+      const { installBootstrapHook } = require('@gossip/orchestrator') as typeof import('@gossip/orchestrator');
+      const r = installBootstrapHook(root);
+      bootstrapHookSummary = `Bootstrap hook: ${r.action}${r.reason ? ` (${r.reason})` : ''}`;
+    } catch (e) {
+      bootstrapHookSummary = `Bootstrap hook: skipped (${(e as Error).message})`;
+      process.stderr.write(`[gossipcat] gossip_setup: bootstrap hook install failed: ${e}\n`);
+    }
+    process.stderr.write(`[gossipcat] gossip_setup: ${bootstrapHookSummary}\n`);
+
     // Memory hygiene CLAUDE.md seeding — spec 2026-04-17-memory-hygiene-propagation.
     // Idempotent: appends convention block if CLAUDE.md exists but lacks the heading;
     // no-ops if heading present; skips silently if CLAUDE.md missing.

--- a/packages/orchestrator/src/hook-installer.ts
+++ b/packages/orchestrator/src/hook-installer.ts
@@ -284,6 +284,123 @@ function mergeHookEntry(
   return true;
 }
 
+// ── Bootstrap UserPromptSubmit hook (mtime-keyed sentinel) ──────────────────
+
+/**
+ * Result of `installBootstrapHook`.
+ *
+ *   action:
+ *     - "installed"  — wrote a fresh entry (no existing UserPromptSubmit hook)
+ *     - "upgraded"   — replaced an old `cat .gossip/bootstrap.md` command
+ *     - "already-current" — `gossipcat hook --run` already registered
+ *     - "skipped-user-custom" — user has a custom command we won't touch
+ *     - "skipped-malformed" — settings.local.json is unparseable
+ *     - "error"      — unexpected fs error
+ */
+export interface BootstrapHookInstallResult {
+  action:
+    | 'installed'
+    | 'upgraded'
+    | 'already-current'
+    | 'skipped-user-custom'
+    | 'skipped-malformed'
+    | 'error';
+  reason?: string;
+}
+
+/** Command we want every UserPromptSubmit hook to run, post-spec. */
+export const BOOTSTRAP_HOOK_COMMAND = 'gossipcat hook --run';
+
+/** Regex matching legacy `cat .gossip/bootstrap.md ...` hook commands. */
+const LEGACY_BOOTSTRAP_CMD_RE = /cat\s+\.gossip\/bootstrap\.md/;
+
+/**
+ * Install or upgrade the UserPromptSubmit bootstrap hook in
+ * `<projectRoot>/.claude/settings.local.json`.
+ *
+ * Rules:
+ *   - No UserPromptSubmit entry yet → append one with `gossipcat hook --run`.
+ *   - Existing entry matching the legacy `cat .gossip/bootstrap.md` form →
+ *     rewrite the command in place.
+ *   - Existing entry whose command is already `gossipcat hook --run` → no-op.
+ *   - Existing entry with a user-custom command → leave alone, log a one-line
+ *     stderr warning so the user knows the upgrade was deferred.
+ *
+ * Atomic: writes to a `.tmp.<pid>` sibling then renameSyncs. Preserves all
+ * other settings keys (permissions, other hooks).
+ */
+export function installBootstrapHook(projectRoot: string): BootstrapHookInstallResult {
+  try {
+    const settingsPath = join(projectRoot, '.claude', 'settings.local.json');
+    mkdirSync(dirname(settingsPath), { recursive: true });
+
+    let settings: Record<string, any>;
+    try {
+      settings = loadLocalSettings(settingsPath);
+    } catch (err) {
+      process.stderr.write(
+        `[gossipcat] settings.local.json at ${settingsPath} is malformed; skipping bootstrap hook install. ` +
+        `Fix the file or delete it and re-run gossip_setup.\n`,
+      );
+      return { action: 'skipped-malformed', reason: (err as Error).message };
+    }
+
+    if (!settings.hooks || typeof settings.hooks !== 'object') settings.hooks = {};
+    const hooks = settings.hooks as Record<string, any>;
+    if (!Array.isArray(hooks.UserPromptSubmit)) hooks.UserPromptSubmit = [];
+    const ups = hooks.UserPromptSubmit as any[];
+
+    // Walk every UserPromptSubmit entry's inner hooks. Track first match
+    // we can act on.
+    let upgraded = false;
+    let alreadyCurrent = false;
+    let userCustomFound = false;
+
+    for (const entry of ups) {
+      if (!entry || !Array.isArray(entry.hooks)) continue;
+      for (const h of entry.hooks) {
+        if (!h || typeof h !== 'object' || typeof h.command !== 'string') continue;
+        if (h.command === BOOTSTRAP_HOOK_COMMAND) {
+          alreadyCurrent = true;
+        } else if (LEGACY_BOOTSTRAP_CMD_RE.test(h.command)) {
+          h.command = BOOTSTRAP_HOOK_COMMAND;
+          upgraded = true;
+        } else {
+          userCustomFound = true;
+        }
+      }
+    }
+
+    if (alreadyCurrent && !upgraded) {
+      return { action: 'already-current' };
+    }
+
+    if (!alreadyCurrent && !upgraded) {
+      if (userCustomFound) {
+        process.stderr.write(
+          `[gossipcat] UserPromptSubmit hook in ${settingsPath} has a custom command; leaving as-is. ` +
+          `To enable bootstrap suppression, set command to "${BOOTSTRAP_HOOK_COMMAND}".\n`,
+        );
+        return { action: 'skipped-user-custom' };
+      }
+      // No matching hook at all — install fresh.
+      ups.push({
+        matcher: '',
+        hooks: [{ type: 'command', command: BOOTSTRAP_HOOK_COMMAND }],
+      });
+    }
+
+    // Atomic write via tmp + rename.
+    const tmp = settingsPath + '.tmp.' + process.pid;
+    writeFileSync(tmp, JSON.stringify(settings, null, 2) + '\n');
+    renameSync(tmp, settingsPath);
+
+    return { action: upgraded ? 'upgraded' : 'installed' };
+  } catch (err) {
+    return { action: 'error', reason: (err as Error).message };
+  }
+}
+
 /**
  * Install the v1 orchestrator-discipline hook bundle into
  * `<projectRoot>/.claude/settings.local.json` (personal hooks, gitignored).

--- a/packages/orchestrator/src/hook-installer.ts
+++ b/packages/orchestrator/src/hook-installer.ts
@@ -11,7 +11,7 @@
  * PostToolUse collect reminder). These write into `.claude/settings.local.json`
  * (personal discipline hooks, not project-shared security controls).
  */
-import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync, chmodSync, renameSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync, chmodSync, renameSync, unlinkSync } from 'fs';
 import { join, resolve, dirname } from 'path';
 
 export interface HookInstallResult {
@@ -356,14 +356,31 @@ export function installBootstrapHook(projectRoot: string): BootstrapHookInstallR
     let alreadyCurrent = false;
     let userCustomFound = false;
 
+    // Walk every entry's inner hooks in reverse so we can splice duplicates
+    // without skipping indices. When we find a second `gossipcat hook --run`
+    // entry (or a legacy entry alongside a current one), DROP it instead of
+    // rewriting — otherwise the file would contain two identical commands and
+    // the hook would fire twice per prompt (HIGH n1 from consensus
+    // d88f27db-c0454640).
     for (const entry of ups) {
       if (!entry || !Array.isArray(entry.hooks)) continue;
-      for (const h of entry.hooks) {
+      for (let i = entry.hooks.length - 1; i >= 0; i--) {
+        const h = entry.hooks[i];
         if (!h || typeof h !== 'object' || typeof h.command !== 'string') continue;
         if (h.command === BOOTSTRAP_HOOK_COMMAND) {
-          alreadyCurrent = true;
+          if (alreadyCurrent) {
+            entry.hooks.splice(i, 1);
+            upgraded = true;
+          } else {
+            alreadyCurrent = true;
+          }
         } else if (LEGACY_BOOTSTRAP_CMD_RE.test(h.command)) {
-          h.command = BOOTSTRAP_HOOK_COMMAND;
+          if (alreadyCurrent) {
+            entry.hooks.splice(i, 1);
+          } else {
+            h.command = BOOTSTRAP_HOOK_COMMAND;
+            alreadyCurrent = true;
+          }
           upgraded = true;
         } else {
           userCustomFound = true;
@@ -371,7 +388,23 @@ export function installBootstrapHook(projectRoot: string): BootstrapHookInstallR
       }
     }
 
+    // Prune entries whose hooks[] became empty after splicing — don't leave
+    // dangling matcher stubs behind.
+    for (let i = ups.length - 1; i >= 0; i--) {
+      const entry = ups[i];
+      if (entry && Array.isArray(entry.hooks) && entry.hooks.length === 0) {
+        ups.splice(i, 1);
+      }
+    }
+
     if (alreadyCurrent && !upgraded) {
+      if (userCustomFound) {
+        // Fix MEDIUM f3: emit the warning even when alreadyCurrent is also
+        // true — previously the early return silenced it.
+        process.stderr.write(
+          `[gossipcat] UserPromptSubmit hook in ${settingsPath} also has a custom command alongside the gossipcat hook; leaving as-is.\n`,
+        );
+      }
       return { action: 'already-current' };
     }
 
@@ -390,10 +423,17 @@ export function installBootstrapHook(projectRoot: string): BootstrapHookInstallR
       });
     }
 
-    // Atomic write via tmp + rename.
+    // Atomic write via tmp + rename. Fix MEDIUM f1: if rename throws (e.g.
+    // EXDEV across filesystems, EACCES), unlink the leftover .tmp.<pid> so
+    // we don't litter the .claude/ dir on repeated failures.
     const tmp = settingsPath + '.tmp.' + process.pid;
     writeFileSync(tmp, JSON.stringify(settings, null, 2) + '\n');
-    renameSync(tmp, settingsPath);
+    try {
+      renameSync(tmp, settingsPath);
+    } catch (renameErr) {
+      try { unlinkSync(tmp); } catch { /* best-effort */ }
+      throw renameErr;
+    }
 
     return { action: upgraded ? 'upgraded' : 'installed' };
   } catch (err) {
@@ -464,11 +504,17 @@ export function installDisciplineHooks(projectRoot: string): DisciplineHookInsta
       }
     }
 
-    // 4. Atomic write via tmp + rename to avoid partial writes.
+    // 4. Atomic write via tmp + rename to avoid partial writes. Fix MEDIUM f1:
+    // unlink leftover .tmp.<pid> on rename failure.
     if (anyMutated) {
       const tmp = settingsPath + '.tmp.' + process.pid;
       writeFileSync(tmp, JSON.stringify(settings, null, 2) + '\n');
-      renameSync(tmp, settingsPath);
+      try {
+        renameSync(tmp, settingsPath);
+      } catch (renameErr) {
+        try { unlinkSync(tmp); } catch { /* best-effort */ }
+        throw renameErr;
+      }
     }
 
     return { installed, skipped };

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -78,8 +78,8 @@ export {
 export type { StalenessResult } from './dist-mcp-staleness';
 export type { BootstrapResult } from './bootstrap';
 export { findBundledRules, ensureRulesFile, readRulesContent } from './rules-loader';
-export { installWorktreeSandboxHook, findBundledHook, writeOrchestratorRoleMarker, installDisciplineHooks } from './hook-installer';
-export type { HookInstallResult, DisciplineHookInstallResult } from './hook-installer';
+export { installWorktreeSandboxHook, findBundledHook, writeOrchestratorRoleMarker, installDisciplineHooks, installBootstrapHook, BOOTSTRAP_HOOK_COMMAND } from './hook-installer';
+export type { HookInstallResult, DisciplineHookInstallResult, BootstrapHookInstallResult } from './hook-installer';
 export { OverlapDetector } from './overlap-detector';
 export { LensGenerator } from './lens-generator';
 export { PerformanceWriter, rotateJsonlIfNeeded, MAX_TELEMETRY_BYTES } from './performance-writer';

--- a/tests/cli/hook-argv.test.ts
+++ b/tests/cli/hook-argv.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Unit tests for the `gossipcat hook` argv guard — MEDIUM f2 from consensus
+ * d88f27db-c0454640. Bare `gossipcat hook` must NOT silently fire the hook.
+ */
+import { parseHookSubcommand } from '../../apps/cli/src/hook-argv';
+
+describe('parseHookSubcommand', () => {
+  it('returns "run" for the canonical --run flag', () => {
+    expect(parseHookSubcommand('--run')).toBe('run');
+  });
+
+  it('returns "run" for the bare-word `run` form', () => {
+    expect(parseHookSubcommand('run')).toBe('run');
+  });
+
+  it('returns "usage" for bare `gossipcat hook` (sub === undefined)', () => {
+    expect(parseHookSubcommand(undefined)).toBe('usage');
+  });
+
+  it('returns "usage" for an unknown subcommand', () => {
+    expect(parseHookSubcommand('install')).toBe('usage');
+  });
+
+  it('returns "usage" for the empty string', () => {
+    expect(parseHookSubcommand('')).toBe('usage');
+  });
+});

--- a/tests/cli/hook-run.test.ts
+++ b/tests/cli/hook-run.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for `gossipcat hook --run` (apps/cli/src/hook-run.ts).
+ *
+ * Covers the mtime-keyed sentinel logic from
+ * docs/specs/2026-05-07-bootstrap-hook-trim.md:
+ *   1. bootstrap missing → one-liner hint, exit 0 (no throw)
+ *   2. bootstrap present, no sentinel → full content + sentinel created
+ *   3. sentinel matches current mtime → short suppression line
+ *   4. sentinel mtime differs (regen simulated) → full content + sentinel updated
+ *   5. statSync throws → fail-open, full content emitted
+ */
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, mkdirSync, rmSync, statSync, utimesSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runHook } from '../../apps/cli/src/hook-run';
+
+function makeTmpProject(): string {
+  return mkdtempSync(join(tmpdir(), 'gossip-hook-run-'));
+}
+
+function makeSentinelPath(): string {
+  // Use a unique tmp file path that doesn't exist yet.
+  return join(tmpdir(), `gossipcat-hook-run-sentinel-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+}
+
+interface Captured {
+  out: string;
+  write: (chunk: string) => void;
+}
+
+function captureWrite(): Captured {
+  let out = '';
+  return {
+    get out() { return out; },
+    write(chunk: string) { out += chunk; },
+  } as Captured;
+}
+
+describe('runHook (gossipcat hook --run)', () => {
+  const created: string[] = [];
+  const sentinels: string[] = [];
+
+  afterEach(() => {
+    while (created.length) {
+      const dir = created.pop()!;
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+    while (sentinels.length) {
+      const f = sentinels.pop()!;
+      try { rmSync(f, { force: true }); } catch { /* best-effort */ }
+    }
+  });
+
+  it('bootstrap missing → prints one-liner hint and does not throw', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    const sentinel = makeSentinelPath();
+    sentinels.push(sentinel);
+    const cap = captureWrite();
+
+    expect(() => runHook({ cwd: root, sentinelPath: sentinel, write: cap.write })).not.toThrow();
+
+    expect(cap.out).toContain('[gossipcat] No bootstrap yet.');
+    expect(cap.out).toContain('select:mcp__gossipcat__gossip_status');
+    // Sentinel must NOT be created when bootstrap is absent.
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  it('bootstrap present, no sentinel → emits full content and writes sentinel with current mtime', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+    const bootstrapPath = join(root, '.gossip', 'bootstrap.md');
+    writeFileSync(bootstrapPath, '# bootstrap v1\nhello world\n');
+
+    const sentinel = makeSentinelPath();
+    sentinels.push(sentinel);
+    const cap = captureWrite();
+
+    runHook({ cwd: root, sentinelPath: sentinel, write: cap.write });
+
+    expect(cap.out).toContain('# bootstrap v1');
+    expect(cap.out).toContain('hello world');
+    expect(existsSync(sentinel)).toBe(true);
+    const stored = readFileSync(sentinel, 'utf-8').trim();
+    const expected = String(statSync(bootstrapPath).mtimeMs);
+    expect(stored).toBe(expected);
+  });
+
+  it('sentinel matches current mtime → emits short suppression line only', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+    const bootstrapPath = join(root, '.gossip', 'bootstrap.md');
+    writeFileSync(bootstrapPath, '# bootstrap v1\nfull body\n');
+
+    const sentinel = makeSentinelPath();
+    sentinels.push(sentinel);
+    // Seed sentinel with the current mtime.
+    writeFileSync(sentinel, String(statSync(bootstrapPath).mtimeMs), 'utf-8');
+
+    const cap = captureWrite();
+    runHook({ cwd: root, sentinelPath: sentinel, write: cap.write });
+
+    expect(cap.out).toContain('[gossipcat: bootstrap already loaded');
+    expect(cap.out).not.toContain('full body');
+  });
+
+  it('sentinel mtime differs (regen simulated) → emits full content and updates sentinel', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+    const bootstrapPath = join(root, '.gossip', 'bootstrap.md');
+    writeFileSync(bootstrapPath, '# bootstrap v2\nregenerated\n');
+
+    const sentinel = makeSentinelPath();
+    sentinels.push(sentinel);
+    // Seed sentinel with a stale mtime — guaranteed not to match.
+    writeFileSync(sentinel, '0', 'utf-8');
+
+    const cap = captureWrite();
+    runHook({ cwd: root, sentinelPath: sentinel, write: cap.write });
+
+    expect(cap.out).toContain('# bootstrap v2');
+    expect(cap.out).toContain('regenerated');
+    expect(cap.out).not.toContain('[gossipcat: bootstrap already loaded');
+
+    const after = readFileSync(sentinel, 'utf-8').trim();
+    const current = String(statSync(bootstrapPath).mtimeMs);
+    expect(after).toBe(current);
+    expect(after).not.toBe('0');
+  });
+
+  it('touching bootstrap after suppression re-fires full content (mtime advanced)', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+    const bootstrapPath = join(root, '.gossip', 'bootstrap.md');
+    writeFileSync(bootstrapPath, 'initial content\n');
+
+    const sentinel = makeSentinelPath();
+    sentinels.push(sentinel);
+
+    // Fire 1 — full
+    runHook({ cwd: root, sentinelPath: sentinel, write: captureWrite().write });
+    // Fire 2 — suppressed
+    const cap2 = captureWrite();
+    runHook({ cwd: root, sentinelPath: sentinel, write: cap2.write });
+    expect(cap2.out).toContain('[gossipcat: bootstrap already loaded');
+
+    // Simulate regen by bumping mtime forward by 5s.
+    const now = Date.now() / 1000;
+    utimesSync(bootstrapPath, now + 5, now + 5);
+
+    const cap3 = captureWrite();
+    runHook({ cwd: root, sentinelPath: sentinel, write: cap3.write });
+    expect(cap3.out).toContain('initial content');
+    expect(cap3.out).not.toContain('[gossipcat: bootstrap already loaded');
+  });
+
+  it('fail-open: even when sentinel path is unwritable, full content is emitted on first fire', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+    const bootstrapPath = join(root, '.gossip', 'bootstrap.md');
+    writeFileSync(bootstrapPath, 'content for failopen\n');
+
+    // Use a sentinel path inside a non-existent directory to force writeFileSync to fail silently.
+    const sentinel = join(tmpdir(), 'no-such-dir-xyz-' + Date.now(), 'sentinel');
+    const cap = captureWrite();
+    expect(() => runHook({ cwd: root, sentinelPath: sentinel, write: cap.write })).not.toThrow();
+    expect(cap.out).toContain('content for failopen');
+  });
+});

--- a/tests/orchestrator/hook-installer-bootstrap.test.ts
+++ b/tests/orchestrator/hook-installer-bootstrap.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for `installBootstrapHook` — the UserPromptSubmit hook upgrader from
+ * docs/specs/2026-05-07-bootstrap-hook-trim.md.
+ */
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { installBootstrapHook, BOOTSTRAP_HOOK_COMMAND } from '../../packages/orchestrator/src/hook-installer';
+
+function makeTmpProject(): string {
+  return mkdtempSync(join(tmpdir(), 'gossip-bootstrap-hook-'));
+}
+
+describe('installBootstrapHook', () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    while (created.length) {
+      const dir = created.pop()!;
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+  });
+
+  it('creates settings.local.json with the new hook when no settings exist', () => {
+    const root = makeTmpProject();
+    created.push(root);
+
+    const r = installBootstrapHook(root);
+    expect(r.action).toBe('installed');
+
+    const settingsPath = join(root, '.claude', 'settings.local.json');
+    expect(existsSync(settingsPath)).toBe(true);
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    expect(Array.isArray(settings.hooks?.UserPromptSubmit)).toBe(true);
+    const cmds = settings.hooks.UserPromptSubmit.flatMap((e: any) =>
+      (e.hooks ?? []).map((h: any) => h.command),
+    );
+    expect(cmds).toContain(BOOTSTRAP_HOOK_COMMAND);
+  });
+
+  it('upgrades a legacy `cat .gossip/bootstrap.md` hook command in place', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const settingsPath = join(root, '.claude', 'settings.local.json');
+    const legacy = {
+      permissions: { allow: ['Edit'] },
+      hooks: {
+        UserPromptSubmit: [
+          {
+            matcher: '',
+            hooks: [
+              { type: 'command', command: "cat .gossip/bootstrap.md 2>/dev/null || echo '[gossipcat] No bootstrap yet...'" },
+            ],
+          },
+        ],
+      },
+    };
+    writeFileSync(settingsPath, JSON.stringify(legacy));
+
+    const r = installBootstrapHook(root);
+    expect(r.action).toBe('upgraded');
+
+    const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    // Other settings preserved.
+    expect(after.permissions).toEqual(legacy.permissions);
+    // Command rewritten.
+    expect(after.hooks.UserPromptSubmit[0].hooks[0].command).toBe(BOOTSTRAP_HOOK_COMMAND);
+  });
+
+  it('preserves a user-custom UserPromptSubmit command and warns to stderr', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const settingsPath = join(root, '.claude', 'settings.local.json');
+    const custom = {
+      hooks: {
+        UserPromptSubmit: [
+          {
+            matcher: '',
+            hooks: [{ type: 'command', command: 'echo custom-thing' }],
+          },
+        ],
+      },
+    };
+    writeFileSync(settingsPath, JSON.stringify(custom));
+
+    // Capture stderr.
+    const writes: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    (process.stderr as any).write = (chunk: any) => {
+      writes.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    };
+
+    let r: ReturnType<typeof installBootstrapHook>;
+    try {
+      r = installBootstrapHook(root);
+    } finally {
+      (process.stderr as any).write = orig;
+    }
+
+    expect(r!.action).toBe('skipped-user-custom');
+    const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    expect(after.hooks.UserPromptSubmit[0].hooks[0].command).toBe('echo custom-thing');
+    expect(writes.join('')).toMatch(/custom command/i);
+  });
+
+  it('is idempotent — second call reports already-current and does not change content', () => {
+    const root = makeTmpProject();
+    created.push(root);
+
+    installBootstrapHook(root);
+    const settingsPath = join(root, '.claude', 'settings.local.json');
+    const before = readFileSync(settingsPath, 'utf-8');
+
+    const r2 = installBootstrapHook(root);
+    expect(r2.action).toBe('already-current');
+    const after = readFileSync(settingsPath, 'utf-8');
+    expect(after).toBe(before);
+  });
+
+  it('preserves unrelated settings keys and existing non-UserPromptSubmit hooks', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const settingsPath = join(root, '.claude', 'settings.local.json');
+    const initial = {
+      permissions: { allow: ['Edit', 'Write'], deny: ['Bash'] },
+      hooks: {
+        PreToolUse: [
+          { matcher: 'Bash', hooks: [{ type: 'command', command: 'echo pretool' }] },
+        ],
+      },
+    };
+    writeFileSync(settingsPath, JSON.stringify(initial));
+
+    installBootstrapHook(root);
+
+    const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    expect(after.permissions).toEqual(initial.permissions);
+    expect(after.hooks.PreToolUse).toEqual(initial.hooks.PreToolUse);
+    expect(after.hooks.UserPromptSubmit[0].hooks[0].command).toBe(BOOTSTRAP_HOOK_COMMAND);
+  });
+
+  it('does not throw and reports skipped-malformed on bad JSON; file is byte-preserved', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const settingsPath = join(root, '.claude', 'settings.local.json');
+    const malformed = '{not valid';
+    writeFileSync(settingsPath, malformed);
+
+    let r: ReturnType<typeof installBootstrapHook>;
+    expect(() => { r = installBootstrapHook(root); }).not.toThrow();
+    expect(r!.action).toBe('skipped-malformed');
+    expect(readFileSync(settingsPath, 'utf-8')).toBe(malformed);
+  });
+});

--- a/tests/orchestrator/hook-installer-bootstrap.test.ts
+++ b/tests/orchestrator/hook-installer-bootstrap.test.ts
@@ -2,7 +2,7 @@
  * Tests for `installBootstrapHook` — the UserPromptSubmit hook upgrader from
  * docs/specs/2026-05-07-bootstrap-hook-trim.md.
  */
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, mkdirSync, rmSync } from 'fs';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, mkdirSync, rmSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { installBootstrapHook, BOOTSTRAP_HOOK_COMMAND } from '../../packages/orchestrator/src/hook-installer';
@@ -141,6 +141,152 @@ describe('installBootstrapHook', () => {
     expect(after.permissions).toEqual(initial.permissions);
     expect(after.hooks.PreToolUse).toEqual(initial.hooks.PreToolUse);
     expect(after.hooks.UserPromptSubmit[0].hooks[0].command).toBe(BOOTSTRAP_HOOK_COMMAND);
+  });
+
+  it('collapses duplicate hook entries when alreadyCurrent and legacy both present (HIGH n1)', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const settingsPath = join(root, '.claude', 'settings.local.json');
+    const seeded = {
+      hooks: {
+        UserPromptSubmit: [
+          {
+            matcher: '',
+            hooks: [{ type: 'command', command: BOOTSTRAP_HOOK_COMMAND }],
+          },
+          {
+            matcher: '',
+            hooks: [
+              { type: 'command', command: "cat .gossip/bootstrap.md 2>/dev/null || echo '[gossipcat] No bootstrap yet...'" },
+            ],
+          },
+        ],
+      },
+    };
+    writeFileSync(settingsPath, JSON.stringify(seeded));
+
+    const r = installBootstrapHook(root);
+    expect(r.action).toBe('upgraded');
+
+    const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    const cmds: string[] = (after.hooks.UserPromptSubmit as any[]).flatMap((e: any) =>
+      (e.hooks ?? []).map((h: any) => h.command),
+    );
+    // Exactly one current command — duplicates collapsed.
+    expect(cmds.filter(c => c === BOOTSTRAP_HOOK_COMMAND)).toHaveLength(1);
+    // No leftover legacy command.
+    expect(cmds.some(c => /cat\s+\.gossip\/bootstrap\.md/.test(c))).toBe(false);
+    // No empty `hooks` entries left dangling.
+    for (const entry of after.hooks.UserPromptSubmit as any[]) {
+      expect(entry.hooks.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('also collapses two duplicate `gossipcat hook --run` entries down to one', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const settingsPath = join(root, '.claude', 'settings.local.json');
+    const seeded = {
+      hooks: {
+        UserPromptSubmit: [
+          { matcher: '', hooks: [{ type: 'command', command: BOOTSTRAP_HOOK_COMMAND }] },
+          { matcher: '', hooks: [{ type: 'command', command: BOOTSTRAP_HOOK_COMMAND }] },
+        ],
+      },
+    };
+    writeFileSync(settingsPath, JSON.stringify(seeded));
+
+    installBootstrapHook(root);
+
+    const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    const cmds: string[] = (after.hooks.UserPromptSubmit as any[]).flatMap((e: any) =>
+      (e.hooks ?? []).map((h: any) => h.command),
+    );
+    expect(cmds.filter(c => c === BOOTSTRAP_HOOK_COMMAND)).toHaveLength(1);
+  });
+
+  it('emits stderr warning when alreadyCurrent and userCustomFound both true (MEDIUM f3)', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const settingsPath = join(root, '.claude', 'settings.local.json');
+    const seeded = {
+      hooks: {
+        UserPromptSubmit: [
+          { matcher: '', hooks: [{ type: 'command', command: BOOTSTRAP_HOOK_COMMAND }] },
+          { matcher: '', hooks: [{ type: 'command', command: 'echo my-custom-thing' }] },
+        ],
+      },
+    };
+    writeFileSync(settingsPath, JSON.stringify(seeded));
+    const before = readFileSync(settingsPath, 'utf-8');
+
+    const writes: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    (process.stderr as any).write = (chunk: any) => {
+      writes.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    };
+
+    let r: ReturnType<typeof installBootstrapHook>;
+    try {
+      r = installBootstrapHook(root);
+    } finally {
+      (process.stderr as any).write = orig;
+    }
+
+    expect(r!.action).toBe('already-current');
+    expect(writes.join('')).toMatch(/custom command/i);
+    // File unchanged when already-current.
+    expect(readFileSync(settingsPath, 'utf-8')).toBe(before);
+  });
+
+  it('unlinks .tmp.<pid> when renameSync throws (MEDIUM f1)', () => {
+    // Use jest.isolateModules + jest.doMock to give hook-installer.ts a
+    // patched fs where renameSync throws while writeFileSync + unlinkSync
+    // still hit the real fs. Validates the try/catch around renameSync
+    // unlinks the leftover tmp.
+    const root = makeTmpProject();
+    created.push(root);
+    const claudeDir = join(root, '.claude');
+    const settingsPath = join(claudeDir, 'settings.local.json');
+
+    let renameCalls = 0;
+    let unlinkedTmp: string | null = null;
+    const renameErr = new Error('simulated EXDEV');
+
+    jest.isolateModules(() => {
+      jest.doMock('fs', () => {
+        const real = jest.requireActual('fs');
+        return {
+          ...real,
+          renameSync: (_src: string, _dst: string) => {
+            renameCalls++;
+            throw renameErr;
+          },
+          unlinkSync: (p: string) => {
+            if (typeof p === 'string' && p.includes('.tmp.')) unlinkedTmp = p;
+            return real.unlinkSync(p);
+          },
+        };
+      });
+      // require the module AFTER doMock so it picks up the mocked fs.
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { installBootstrapHook: patched } = require('../../packages/orchestrator/src/hook-installer');
+      const r = patched(root);
+      expect(r.action).toBe('error');
+      expect(r.reason).toMatch(/simulated EXDEV/);
+    });
+
+    expect(renameCalls).toBe(1);
+    expect(unlinkedTmp).not.toBeNull();
+    expect(unlinkedTmp!).toBe(settingsPath + '.tmp.' + process.pid);
+    // And it really is gone on disk.
+    const files = existsSync(claudeDir) ? readdirSync(claudeDir) : [];
+    const leftovers = files.filter(f => f.includes('.tmp.'));
+    expect(leftovers).toEqual([]);
   });
 
   it('does not throw and reports skipped-malformed on bad JSON; file is byte-preserved', () => {


### PR DESCRIPTION
## Summary

Implements `docs/specs/2026-05-07-bootstrap-hook-trim.md` — mtime-keyed sentinel suppression for the gossipcat UserPromptSubmit hook. Replaces unconditional `cat .gossip/bootstrap.md` with `gossipcat hook --run`, an mtime-keyed sentinel that suppresses re-fires when bootstrap.md is unchanged but correctly re-emits on `/mcp` reconnect or `gossip_status()` regen.

- **`gossipcat hook --run`** (`apps/cli/src/hook-run.ts`) — mtime-keyed sentinel + fail-open on every fs error.
- **`installBootstrapHook`** (`packages/orchestrator/src/hook-installer.ts`) — `gossip_setup` writes/upgrades `.claude/settings.local.json`, atomic `.tmp` + `renameSync`, preserves all other settings keys, warns on user-custom commands.

## Consensus

consensus-id: d88f27db-c0454640

Consensus round caught 4 findings (1 HIGH cross-review discovery + 3 MEDIUM), all fixed in fixup `09701f5`:
- **HIGH n1**: duplicate hook entry when `alreadyCurrent` && legacy coexist — loop now drops duplicates instead of rewriting (was 2× hook fires per prompt).
- **MEDIUM f1**: `.tmp.<pid>` cleanup on `renameSync` failure — try/catch + `unlinkSync` at both install sites.
- **MEDIUM f2**: bare `gossipcat hook` silently ran the hook — now prints usage + exits 2.
- **MEDIUM f3**: user-custom warning silenced when `alreadyCurrent` also true — now emitted before early return.

## Tests

- `tests/cli/hook-run.test.ts` — 6/6 PASS (mtime-keyed sentinel)
- `tests/cli/hook-argv.test.ts` — 5/5 PASS (new, argv guard via extracted `parseHookSubcommand`)
- `tests/orchestrator/hook-installer-bootstrap.test.ts` — 10/10 PASS (6 original + 4 new for consensus findings)
- Full workspace `npm run build` — PASS

## Test plan (spec validation scenarios)

- [x] Sentinel correctness across `/mcp` reconnect — `utimesSync` regen test
- [x] Sentinel correctness across reboot — fresh-PID/wiped-tmp test
- [x] Idempotency — second `gossip_setup` produces byte-identical settings
- [x] Backwards compat — legacy `cat .gossip/bootstrap.md` upgraded; user-custom preserved
- [x] Dedup invariant — duplicate hook entries collapsed (added in fixup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>