### PR TITLE
feat(relay): gemini MALFORMED_FUNCTION_CALL retry-once + transport_failure signal

### DIFF
--- a/packages/orchestrator/src/completion-signals.allowlist.ts
+++ b/packages/orchestrator/src/completion-signals.allowlist.ts
@@ -21,6 +21,10 @@ export const COMPLETION_SIGNAL_ALLOWLIST: readonly string[] = [
   'format_compliance',
   'finding_dropped_format',
   'citation_fabricated',
+  // Emitted by emitCompletionSignals when the result is a provider placeholder
+  // (MALFORMED_FUNCTION_CALL, blocked safety, empty candidates). Suppresses
+  // format_compliance:0 emission so transport errors don't mislabel agent skill.
+  'transport_failure',
 ] as const;
 
 /**
@@ -50,6 +54,14 @@ export const COMPLETION_SIGNAL_AUTHORIZED_PATHS: Readonly<Record<string, Readonl
   // is signal-helpers-pipeline; see project_drift_bypass_finding_dropped_format.
   finding_dropped_format: new Set(['completion-signals-helper', 'signal-helpers-pipeline']),
   citation_fabricated: new Set(['completion-signals-helper']),
+  // transport_failure is emitted from the placeholder-detection branch in
+  // emitCompletionSignals (completion-signals.ts) when the result matches
+  // PROVIDER_PLACEHOLDER_RE. Also legitimately emitted from dispatch-pipeline
+  // (resolutionRoots missing/invalid) and signal-helpers-consensus (relay worker
+  // failures) — these are separate emit sites and are NOT covered by this authorized
+  // path list (which is completion-signals-scoped). The L3 drift detector only
+  // fires on signals in this map that land on an unauthorized path.
+  transport_failure: new Set(['completion-signals-helper', 'dispatch-pipeline', 'signal-helpers-consensus']),
 };
 
 /**

--- a/packages/orchestrator/src/completion-signals.ts
+++ b/packages/orchestrator/src/completion-signals.ts
@@ -96,7 +96,11 @@ export function emitCompletionSignals(projectRoot: string, input: CompletionSign
         signal_class: 'operational',
         agentId,
         taskId,
-        evidence: `provider placeholder (kind=${placeholder_kind}, retried=true): ${result.slice(0, 200)}`,
+        // retried-state intentionally omitted — emitCompletionSignals is called from
+        // dispatch-pipeline at completion time and has no view of worker-agent's
+        // providerRetryAttempted flag. Consensus c520ef0b-88114e21:f6 flagged the
+        // prior hardcoded "retried=true" as misleading.
+        evidence: `provider placeholder (kind=${placeholder_kind}): ${result.slice(0, 200)}`,
         timestamp: now,
         source: 'auto',
       };

--- a/packages/orchestrator/src/completion-signals.ts
+++ b/packages/orchestrator/src/completion-signals.ts
@@ -19,7 +19,8 @@
 import { PerformanceWriter } from './performance-writer';
 import { WRITER_INTERNAL } from './_writer-internal';
 import { detectFormatCompliance } from './dispatch-pipeline';
-import type { MetaSignal, PipelineSignal } from './consensus-types';
+import { PROVIDER_PLACEHOLDER_RE } from './llm-client';
+import type { ConsensusSignal, MetaSignal, PipelineSignal } from './consensus-types';
 
 export interface CompletionSignalInput {
   agentId: string;
@@ -74,6 +75,52 @@ export function emitCompletionSignals(projectRoot: string, input: CompletionSign
       return;
     }
     const now = new Date().toISOString();
+
+    // Detect provider-side placeholder strings (MALFORMED_FUNCTION_CALL, safety block, etc.).
+    // When the entire result is a placeholder, suppress format_compliance:0 — the agent never
+    // had the chance to comply or fail to comply. Emit transport_failure (operational signal,
+    // excluded from accuracy arithmetic) so the dashboard surfaces a clear diagnostic instead
+    // of mislabelling a transport error as a skill-quality failure.
+    // @gossip:impact-adjacent:signal-pipeline
+    const isProviderPlaceholder = !!result && PROVIDER_PLACEHOLDER_RE.test(result);
+    if (isProviderPlaceholder) {
+      // Classify placeholder_kind from the text prefix for downstream observability.
+      const placeholder_kind = result.startsWith('[Response blocked by ')
+        ? 'blocked_safety'
+        : result.includes('malformed_function_call')
+          ? 'malformed_function_call'
+          : 'no_candidates';
+      const transportSignal: ConsensusSignal = {
+        type: 'consensus',
+        signal: 'transport_failure',
+        signal_class: 'operational',
+        agentId,
+        taskId,
+        evidence: `provider placeholder (kind=${placeholder_kind}, retried=true): ${result.slice(0, 200)}`,
+        timestamp: now,
+        source: 'auto',
+      };
+      const writer = new PerformanceWriter(projectRoot);
+      writer[WRITER_INTERNAL].appendSignal(transportSignal, 'completion-signals-helper');
+      // Still emit task_completed (duration telemetry is valid) but skip format_compliance
+      // and finding_dropped_format — those metrics are meaningless for placeholder responses.
+      const durationValue = elapsedMs !== null ? elapsedMs : 0;
+      const metadataEntries: Record<string, unknown> = { transport_failure: true };
+      if (elapsedMs === null) metadataEntries.estimated = true;
+      if (error) metadataEntries.error = true;
+      const completedSignal: MetaSignal = {
+        type: 'meta',
+        signal: 'task_completed',
+        agentId,
+        taskId,
+        value: durationValue,
+        metadata: metadataEntries,
+        timestamp: now,
+      };
+      writer[WRITER_INTERNAL].appendSignal(completedSignal, 'completion-signals-helper');
+      return;
+    }
+
     const compliance = detectFormatCompliance(result);
 
     const signals: (MetaSignal | PipelineSignal)[] = [];

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -18,6 +18,7 @@ export {
   GeminiProvider,
   OllamaProvider,
   QuotaExhaustedException,
+  PROVIDER_PLACEHOLDER_RE,
 } from './llm-client';
 export type { ILLMProvider, LLMGenerateOptions } from './llm-client';
 export * from './types';

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -65,7 +65,11 @@ async function fetchWithRetry503(
 // worker-agent.ts imports this to detect placeholder responses and retry once.
 // dispatch-pipeline.ts / completion-signals.ts use it to suppress format_compliance:0
 // and emit transport_failure instead (so the mislabelling never reaches scoring).
-export const PROVIDER_PLACEHOLDER_RE = /^\[(?:No response from |Response blocked by )/;
+//
+// Requires a known provider token (Gemini/Anthropic/OpenAI) after "No response from" so
+// the worker's own "[No response from agent]" fallback (worker-agent.ts FINAL_RESULT path)
+// does NOT match — consensus c520ef0b-88114e21:f5 caught the false-positive.
+export const PROVIDER_PLACEHOLDER_RE = /^\[(?:No response from (?:Gemini|Anthropic|OpenAI|OpenClaw)|Response blocked by )/;
 
 // ─── Quota Exception ────────────────────────────────────────────────────────
 

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -55,6 +55,18 @@ async function fetchWithRetry503(
   return fetch(url, init);
 }
 
+// ─── Provider Placeholder Detection ─────────────────────────────────────────
+//
+// Matches placeholder strings that llm-client emits when a provider returns
+// an unrecoverable transport-level error (MALFORMED_FUNCTION_CALL, safety
+// block, empty candidates). Shared between llm-client.ts and worker-agent.ts
+// so both files use the same literal — no drift between emission and detection.
+//
+// worker-agent.ts imports this to detect placeholder responses and retry once.
+// dispatch-pipeline.ts / completion-signals.ts use it to suppress format_compliance:0
+// and emit transport_failure instead (so the mislabelling never reaches scoring).
+export const PROVIDER_PLACEHOLDER_RE = /^\[(?:No response from |Response blocked by )/;
+
 // ─── Quota Exception ────────────────────────────────────────────────────────
 
 export class QuotaExhaustedException extends Error {
@@ -535,7 +547,7 @@ export class GeminiProvider implements ILLMProvider {
     if (!parts?.length) {
       // UNEXPECTED_TOOL_CALL: Gemini tried to call a function but the call was malformed.
       // The function call data may be in candidate.content.functionCall or similar.
-      // Log and return empty — the orchestrator's retry mechanism will handle this.
+      // Return placeholder; worker-agent.ts retries once on placeholder match, then surfaces the diagnostic.
       if (finishReason !== 'SAFETY') {
         _log('GeminiProvider', `Empty response parts (finishReason: ${finishReason || 'unknown'}). Returning empty to trigger retry.`);
       }

--- a/packages/orchestrator/src/worker-agent.ts
+++ b/packages/orchestrator/src/worker-agent.ts
@@ -9,7 +9,7 @@ import { randomUUID } from 'crypto';
 import { GossipAgent } from '@gossip/client';
 import { MessageType, MessageEnvelope, Message, ToolDefinition, LLMMessage } from '@gossip/types';
 import { encode as msgpackEncode } from '@msgpack/msgpack';
-import { ILLMProvider } from './llm-client';
+import { ILLMProvider, PROVIDER_PLACEHOLDER_RE } from './llm-client';
 import {
   TaskStreamEvent,
   TaskStreamEventType,
@@ -258,6 +258,7 @@ export class WorkerAgent {
       let lastToolSig = '';   // signature of last tool call for repetition detection
       let repeatCount = 0;    // consecutive identical tool calls
       let consecutiveErrors = 0; // consecutive turns where ALL tool calls return errors
+      let providerRetryAttempted = false; // one retry per dispatch for provider-side placeholders
 
       for (let turn = 0; turn < MAX_TOOL_TURNS; turn++) {
         // Inject any pending gossip before the next LLM turn
@@ -304,6 +305,29 @@ export class WorkerAgent {
             yield logAndYield(`turn ${turn} — no native FC, but found ${textCalls.length} text-based tool calls: ${textCalls.map(tc => tc.name).join(', ')}`);
             response = { ...response, toolCalls: textCalls };
           }
+        }
+
+        // @gossip:impact-adjacent:signal-pipeline
+        // Detect provider-side transport failures that returned a placeholder.
+        // llm-client.ts emits these for MALFORMED_FUNCTION_CALL, blocked safety, empty candidates, etc.
+        // One retry per dispatch (providerRetryAttempted flag) — repeated MALFORMED at the same
+        // conversation depth indicates a real model issue, not transient API flakiness.
+        // Do NOT push the placeholder onto messages — the model never produced real output.
+        if (
+          !response.toolCalls?.length &&
+          response.text &&
+          PROVIDER_PLACEHOLDER_RE.test(response.text) &&
+          !providerRetryAttempted
+        ) {
+          providerRetryAttempted = true;
+          yield logAndYield(`turn ${turn} — provider placeholder detected, retrying once: "${response.text.slice(0, 100)}"`);
+          response = await this.llm.generate(messages, {
+            tools: this.tools,
+            ...(this.webSearchEnabled ? { webSearch: true } : {}),
+          });
+          yield logAndYield(`turn ${turn} — retry returned: text=${response.text?.length ?? 0}chars, toolCalls=${response.toolCalls?.length ?? 0}`);
+          // If retry still placeholder, fall through to existing "no tool calls" exit
+          // with the explicit error text — caller sees a clear diagnostic, not a fake review.
         }
 
         if (response.text) {

--- a/tests/orchestrator/worker-agent-provider-retry.test.ts
+++ b/tests/orchestrator/worker-agent-provider-retry.test.ts
@@ -244,4 +244,26 @@ describe('transport_failure signal emission on placeholder dispatch', () => {
     // task_completed metadata should flag this as a transport failure
     expect(completedSig.metadata?.transport_failure).toBe(true);
   });
+
+  // Regression test for consensus c520ef0b-88114e21:f5 — worker's own fallback
+  // string MUST NOT be classified as a provider placeholder. Before the regex was
+  // tightened to require a provider token, "[No response from agent]" matched and
+  // silently routed empty-result tasks into transport_failure + suppressed
+  // format_compliance, corrupting the operational/skill signal split.
+  it('(e) worker fallback "[No response from agent]" is NOT a provider placeholder', () => {
+    expect(PROVIDER_PLACEHOLDER_RE.test('[No response from agent]')).toBe(false);
+
+    emitCompletionSignals(testDir, {
+      agentId: 'sonnet-implementer',
+      taskId: 'task-empty',
+      result: '[No response from agent]',
+      elapsedMs: 200,
+      toolCalls: 0,
+    });
+
+    const sigs = readSignals();
+    expect(sigs.find((s: { signal: string }) => s.signal === 'transport_failure')).toBeUndefined();
+    // format_compliance MUST fire (the agent really did produce zero findings)
+    expect(sigs.find((s: { signal: string }) => s.signal === 'format_compliance')).toBeDefined();
+  });
 });

--- a/tests/orchestrator/worker-agent-provider-retry.test.ts
+++ b/tests/orchestrator/worker-agent-provider-retry.test.ts
@@ -1,0 +1,247 @@
+// @gossip:impact-adjacent:signal-pipeline
+/**
+ * Tests for the provider-placeholder retry logic introduced in
+ * packages/orchestrator/src/worker-agent.ts (spec: 2026-05-17-gemini-malformed-retry.md).
+ *
+ * Covers:
+ *  (a) retry succeeds — placeholder turn 3 → real response on retry → loop continues
+ *  (b) retry also fails — placeholder twice → exits with placeholder text
+ *  (c) one retry per dispatch — placeholder turn 2 (retry succeeds → turn 3 normal)
+ *      → placeholder turn 5 → no second retry, exits immediately
+ *  (d) signal-emission — placeholder dispatch emits transport_failure, NOT format_compliance:0
+ */
+
+import { readFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { PROVIDER_PLACEHOLDER_RE, emitCompletionSignals } from '@gossip/orchestrator';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PLACEHOLDER_MALFORMED = '[No response from Gemini: malformed_function_call finishReason=MALFORMED_FUNCTION_CALL]';
+const PLACEHOLDER_SAFETY = '[Response blocked by Gemini safety filter]';
+const REAL_RESPONSE_TEXT = 'Task complete. <agent_finding type="finding" severity="low">No issues found.<cite tag="file">src/foo.ts:1</cite></agent_finding>';
+
+interface LLMResponse {
+  text?: string;
+  toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
+}
+
+interface LLMProvider {
+  generate: (messages: unknown[]) => Promise<LLMResponse>;
+}
+
+/**
+ * Simulate the worker-agent retry loop logic in isolation, mirroring the
+ * production code in worker-agent.ts executeTask. Extracted as a standalone
+ * function so we can test it without spinning up GossipAgent / relay sockets.
+ *
+ * Mirrors the production code structure faithfully — any drift between this
+ * simulator and the real loop is a test quality risk.
+ */
+async function simulateRetryLoop(
+  llm: LLMProvider,
+  maxTurns = 10,
+): Promise<{ result: string; logLines: string[]; retryAttempted: boolean }> {
+  const messages: unknown[] = [{ role: 'user', content: 'Do work' }];
+  const logLines: string[] = [];
+  let providerRetryAttempted = false;
+
+  for (let turn = 0; turn < maxTurns; turn++) {
+    let response = await llm.generate(messages);
+    logLines.push(`turn ${turn}: text=${response.text?.slice(0, 80) ?? 'none'} toolCalls=${response.toolCalls?.length ?? 0}`);
+
+    // @gossip:impact-adjacent:signal-pipeline
+    // Mirror of worker-agent.ts placeholder-detection + retry
+    if (
+      !response.toolCalls?.length &&
+      response.text &&
+      PROVIDER_PLACEHOLDER_RE.test(response.text) &&
+      !providerRetryAttempted
+    ) {
+      providerRetryAttempted = true;
+      logLines.push(`turn ${turn} — provider placeholder detected, retrying once: "${response.text.slice(0, 80)}"`);
+      response = await llm.generate(messages);
+      logLines.push(`turn ${turn} — retry returned: text=${response.text?.length ?? 0}chars, toolCalls=${response.toolCalls?.length ?? 0}`);
+      // If retry still placeholder, fall through to existing "no tool calls" exit
+    }
+
+    if (!response.toolCalls?.length) {
+      logLines.push(`turn ${turn} — NO tool calls, exiting`);
+      return { result: response.text ?? '[No response]', logLines, retryAttempted: providerRetryAttempted };
+    }
+
+    // Push assistant + tool results for the next turn
+    messages.push({ role: 'assistant', content: response.text ?? '', toolCalls: response.toolCalls });
+    for (const tc of response.toolCalls!) {
+      messages.push({ role: 'tool', content: 'tool result', toolCallId: tc.id, name: tc.name });
+    }
+  }
+
+  return { result: 'Max turns reached', logLines, retryAttempted: providerRetryAttempted };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests (a) – (c): retry-loop behaviour
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('worker-agent provider placeholder retry', () => {
+  // (a) Retry succeeds: placeholder on turn 3, retry returns real toolCalls → loop continues
+  it('(a) retry succeeds: placeholder → real response with toolCalls → loop continues', async () => {
+    let callCount = 0;
+    const llm: LLMProvider = {
+      async generate() {
+        callCount++;
+        // Turns 1–2: normal tool calls
+        if (callCount <= 2) {
+          return { text: `Turn ${callCount}`, toolCalls: [{ id: `c${callCount}`, name: 'noop', arguments: {} }] };
+        }
+        // Turn 3 (callCount=3): placeholder
+        if (callCount === 3) {
+          return { text: PLACEHOLDER_MALFORMED, toolCalls: [] };
+        }
+        // Turn 3 RETRY (callCount=4): real toolCalls → loop continues
+        if (callCount === 4) {
+          return { text: 'Recovered', toolCalls: [{ id: 'c4', name: 'noop', arguments: {} }] };
+        }
+        // Turn 4 (callCount=5): done
+        return { text: REAL_RESPONSE_TEXT };
+      },
+    };
+
+    const { result, logLines, retryAttempted } = await simulateRetryLoop(llm, 10);
+
+    expect(retryAttempted).toBe(true);
+    // The loop continued past the retry and got a real final result
+    expect(result).toBe(REAL_RESPONSE_TEXT);
+    // 5 calls total: turns 1, 2, 3 (placeholder), 3-retry, 4 (done)
+    expect(callCount).toBe(5);
+    // Log must record the retry
+    expect(logLines.some(l => l.includes('provider placeholder detected, retrying once'))).toBe(true);
+    expect(logLines.some(l => l.includes('retry returned'))).toBe(true);
+  });
+
+  // (b) Retry also fails: placeholder twice → exit with placeholder text
+  it('(b) retry also fails: placeholder returned twice → exits with placeholder diagnostic', async () => {
+    let callCount = 0;
+    const llm: LLMProvider = {
+      async generate() {
+        callCount++;
+        // First call: returns placeholder
+        if (callCount === 1) {
+          return { text: PLACEHOLDER_MALFORMED };
+        }
+        // Retry (callCount=2): also placeholder
+        return { text: PLACEHOLDER_SAFETY };
+      },
+    };
+
+    const { result, logLines, retryAttempted } = await simulateRetryLoop(llm, 10);
+
+    expect(retryAttempted).toBe(true);
+    // Loop exits with the placeholder text from the retry — diagnostic is visible
+    expect(result).toBe(PLACEHOLDER_SAFETY);
+    expect(callCount).toBe(2);
+    // First attempt must be logged
+    expect(logLines.some(l => l.includes('provider placeholder detected, retrying once'))).toBe(true);
+    // Exit must be logged
+    expect(logLines.some(l => l.includes('NO tool calls, exiting'))).toBe(true);
+  });
+
+  // (c) One retry per dispatch: placeholder turn 2 (retry succeeds) → placeholder turn 5 → NO retry
+  it('(c) one retry per dispatch: second placeholder does not trigger another retry', async () => {
+    let callCount = 0;
+    const llm: LLMProvider = {
+      async generate() {
+        callCount++;
+        // Turn 1: normal tool call
+        if (callCount === 1) {
+          return { text: 'Turn 1', toolCalls: [{ id: 'c1', name: 'noop', arguments: {} }] };
+        }
+        // Turn 2 (callCount=2): placeholder
+        if (callCount === 2) {
+          return { text: PLACEHOLDER_MALFORMED };
+        }
+        // Turn 2 RETRY (callCount=3): real response → loop continues
+        if (callCount === 3) {
+          return { text: 'Turn 2 recovered', toolCalls: [{ id: 'c3', name: 'noop', arguments: {} }] };
+        }
+        // Turn 3 (callCount=4): another tool call
+        if (callCount === 4) {
+          return { text: 'Turn 3', toolCalls: [{ id: 'c4', name: 'noop', arguments: {} }] };
+        }
+        // Turn 4 (callCount=5): second placeholder — providerRetryAttempted is already true
+        // → NO retry, falls through to "NO tool calls" exit immediately
+        return { text: PLACEHOLDER_MALFORMED };
+      },
+    };
+
+    const { result, logLines, retryAttempted } = await simulateRetryLoop(llm, 10);
+
+    expect(retryAttempted).toBe(true);
+    // Only one retry was attempted (callCount stops at 5, not 6)
+    expect(callCount).toBe(5);
+    // Second placeholder exits immediately — diagnostic text preserved
+    expect(result).toBe(PLACEHOLDER_MALFORMED);
+    // Exactly one "retrying once" log line
+    const retryLogs = logLines.filter(l => l.includes('provider placeholder detected, retrying once'));
+    expect(retryLogs).toHaveLength(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test (d): signal emission — transport_failure, NOT format_compliance:0
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('transport_failure signal emission on placeholder dispatch', () => {
+  const testDir = join(tmpdir(), 'gossip-provider-retry-signals-' + Date.now());
+  const gossipDir = join(testDir, '.gossip');
+  const perfFile = join(gossipDir, 'agent-performance.jsonl');
+
+  beforeAll(() => mkdirSync(gossipDir, { recursive: true }));
+  afterAll(() => rmSync(testDir, { recursive: true, force: true }));
+
+  const readSignals = () =>
+    readFileSync(perfFile, 'utf-8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map(l => JSON.parse(l));
+
+  beforeEach(() => {
+    try { rmSync(perfFile); } catch { /* may not exist */ }
+  });
+
+  it('(d) placeholder result → emits transport_failure (consensus), does NOT emit format_compliance', () => {
+    emitCompletionSignals(testDir, {
+      agentId: 'gemini-reviewer',
+      taskId: 'task-xyz',
+      result: PLACEHOLDER_MALFORMED,
+      elapsedMs: 1500,
+      toolCalls: 3,
+    });
+
+    const sigs = readSignals();
+
+    // Must emit transport_failure
+    const transportSig = sigs.find((s: { signal: string }) => s.signal === 'transport_failure');
+    expect(transportSig).toBeDefined();
+    expect(transportSig.type).toBe('consensus');
+    expect(transportSig.agentId).toBe('gemini-reviewer');
+    expect(transportSig.taskId).toBe('task-xyz');
+    expect(transportSig.evidence).toContain('malformed_function_call');
+
+    // Must NOT emit format_compliance
+    const formatSig = sigs.find((s: { signal: string }) => s.signal === 'format_compliance');
+    expect(formatSig).toBeUndefined();
+
+    // Must still emit task_completed (duration telemetry)
+    const completedSig = sigs.find((s: { signal: string }) => s.signal === 'task_completed');
+    expect(completedSig).toBeDefined();
+    expect(completedSig.value).toBe(1500);
+    // task_completed metadata should flag this as a transport failure
+    expect(completedSig.metadata?.transport_failure).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **retry-once** in `worker-agent.ts` for provider-side transport failures (Gemini MALFORMED_FUNCTION_CALL, blocked-safety, no-candidates). Loop-scoped `providerRetryAttempted` flag — one retry per dispatch, retry does not push placeholder onto message history.
- Adds **transport_failure** signal class (operational, excluded from accuracy arithmetic) — emitted via `completion-signals.ts` when the result is a placeholder. Suppresses the spurious `format_compliance:0` + `finding_dropped_format` that previously disguised infrastructure failures as skill problems.
- Tightens `PROVIDER_PLACEHOLDER_RE` to require a known provider token after "No response from" so the worker's own `[No response from agent]` fallback does NOT false-positive (regression caught in consensus).

## Why

Investigation of 4 ZERO-tag rounds in `.gossip/agent-performance.jsonl` over the last 30d found all 4 were infrastructure failures, not prose-shape deficits:
- 3 transient Gemini API fetch failures (May 13-15)
- 1 `finishReason=MALFORMED_FUNCTION_CALL` on turn-3 of a complex multi-file security review (round `633d4e6e`, consensus `d88f27db-c0454640`, 2026-05-17)

Output literal (round 4):
```
[No response from Gemini: malformed_function_call finishReason=MALFORMED_FUNCTION_CALL]
```

The misleading comment at `llm-client.ts:540` said *"the orchestrator's retry mechanism will handle this"* — no such retry existed. `worker-agent.ts` treated the placeholder string as a legitimate "no tool calls → done" exit, relaying the diagnostic text into the consensus pipeline as if it were a real review.

Closes the `format_compliance:0` disguise from the 4 prior ZERO-tag rounds.

## Test plan

- [x] 5/5 tests in `tests/orchestrator/worker-agent-provider-retry.test.ts` pass:
  - (a) retry succeeds — placeholder turn 3 → real response → loop continues
  - (b) retry also fails — placeholder twice → exits with placeholder diagnostic
  - (c) one retry per dispatch — second placeholder at turn 5 does NOT retry again
  - (d) signal emission — `transport_failure` present, `format_compliance` suppressed, `task_completed.metadata.transport_failure=true`
  - (e) regression — worker fallback `[No response from agent]` is NOT a provider placeholder
- [x] 8/8 `allowlist-drift` tests pass
- [x] Full workspace build clean (4 packages)
- [x] No new entries in `.gossip/boundary-escapes.jsonl`

## Files changed (378 insertions, 3 deletions)

- `packages/orchestrator/src/worker-agent.ts` — retry-once block + flag
- `packages/orchestrator/src/llm-client.ts` — PROVIDER_PLACEHOLDER_RE export + tightened regex + comment fix
- `packages/orchestrator/src/completion-signals.ts` — transport_failure emission + format_compliance suppression
- `packages/orchestrator/src/completion-signals.allowlist.ts` — Layer 1 allowlist entries
- `packages/orchestrator/src/index.ts` — re-export
- `tests/orchestrator/worker-agent-provider-retry.test.ts` — 5 jest tests (~269 lines)

## Consensus

Spec: `docs/specs/2026-05-17-gemini-malformed-retry.md` (local — gitignored).

Phase 1 implementation reviewed via consensus round `c520ef0b-88114e21` (sonnet-reviewer + gemini-tester):
- **6 confirmed** (retry loop structure, allowlist consistency, test negative coverage)
- **0 disputed, 0 unverified**
- **2 NEW issues caught at cross-review** — fixed in fixup commit `3db1f94`:
  - f5 (HIGH): PROVIDER_PLACEHOLDER_RE false-positive on worker's own fallback
  - f6 (MEDIUM): `retried=true` hardcoded in evidence string

consensus-id: c520ef0b-88114e21

## Impact-adjacency

Touches `signal-pipeline` (annotated `// @gossip:impact-adjacent:signal-pipeline` in `worker-agent.ts` + `completion-signals.ts`). CI gate (PR #348/#370) will verify the consensus-id line above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)