### PR TITLE
feat(mcp): gossip_status slim:true to skip handbook inline

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -973,7 +973,7 @@ const server = new McpServer(
   },
   {
     instructions:
-      'gossipcat — multi-agent orchestration. ALWAYS call gossip_status() first when starting work in this project — this is the bootstrap call that returns your orchestrator role, dispatch rules, consensus workflow, sandbox enforcement, agent list, and the full operator playbook (docs/HANDBOOK.md inlined into the response). On native dispatches, every signal you record MUST include a finding_id formatted as <consensus_id>:<agent:fN> so dashboard scores are auditable. When resolving backlog items older than the current session, call gossip_verify_memory before acting to avoid stale premises. These rules live in gossip_status output, not this instruction text, so they can update with the server binary without requiring reinstall.',
+      'gossipcat — multi-agent orchestration. ALWAYS call gossip_status() first when starting work in this project — this is the bootstrap call that returns your orchestrator role, dispatch rules, consensus workflow, sandbox enforcement, agent list, and by default the full operator playbook (docs/HANDBOOK.md inlined; pass slim:true to skip the handbook section on reconnect refreshes). On native dispatches, every signal you record MUST include a finding_id formatted as <consensus_id>:<agent:fN> so dashboard scores are auditable. When resolving backlog items older than the current session, call gossip_verify_memory before acting to avoid stale premises. These rules live in gossip_status output, not this instruction text, so they can update with the server binary without requiring reinstall.',
   }
 );
 

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1397,9 +1397,15 @@ server.tool(
 // ── Info: status + agents (merged) ────────────────────────────────────────
 server.tool(
   'gossip_status',
-  'Check Gossip Mesh system status, host environment, available agents, dashboard URL/key, and agent list with provider/model/skills.',
-  {},
-  async () => {
+  'Check Gossip Mesh system status, host environment, available agents, dashboard URL/key, and agent list with provider/model/skills. Pass slim:true to skip the handbook inline (~21KB savings) on reconnect refreshes.',
+  {
+    slim: z.boolean().optional().describe('When true, omit the ## Project Handbook inline section to save ~21KB on reconnect refreshes where the orchestrator already has the handbook in working memory. Default false.'),
+  },
+  async (args) => {
+    // Type-guard: non-boolean inputs are treated as false (do NOT throw).
+    const slim = typeof (args as { slim?: unknown })?.slim === 'boolean'
+      ? (args as { slim: boolean }).slim
+      : false;
     const { findConfigPath, loadConfig, configToAgentConfigs, loadClaudeSubagents } = await import('./config');
 
     // Refresh MEMORY.md status tags BEFORE building the response, so any
@@ -1658,36 +1664,39 @@ server.tool(
     // inherits the operator wisdom (architectural invariants, caveats, lessons,
     // hallucination patterns to watch for). This is how earned wisdom transfers
     // across sessions and installations without living only in chat history.
+    // Skipped entirely when slim:true (~21KB savings on reconnect refreshes).
     let handbookSection = '';
-    const { existsSync: exHB } = require('fs');
-    const { join: jHB } = require('path');
-    // Fallback chain: (a) dev-repo cwd, (b) npm-installed __dirname=dist-mcp/ → HANDBOOK sibling, (c) defensive __dirname
-    const handbookCandidates: string[] = [
-      jHB(process.cwd(), 'docs', 'HANDBOOK.md'),
-      jHB(__dirname, '..', 'docs', 'HANDBOOK.md'),
-      jHB(__dirname, 'docs', 'HANDBOOK.md'),
-    ];
-    try {
-      const { readFileSync: rfHB, statSync: stHB } = require('fs');
-      const handbookPath = handbookCandidates.find(p => exHB(p)) ?? handbookCandidates[0];
-      const stat = stHB(handbookPath);
-      // Cap at 24KB of handbook content so the status response doesn't balloon
-      // beyond the context window on very large handbooks. If capped, append a
-      // pointer so the orchestrator knows to read the full file manually.
-      const HANDBOOK_CAP_BYTES = 24 * 1024;
-      let body = rfHB(handbookPath, 'utf-8');
-      const truncated = body.length > HANDBOOK_CAP_BYTES;
-      if (truncated) {
-        body = body.slice(0, HANDBOOK_CAP_BYTES);
-      }
-      handbookSection =
-        '\n─────────────────────────────────\n' +
-        '## Project Handbook (auto-loaded from docs/HANDBOOK.md)\n\n' +
-        body.trim() +
-        (truncated
-          ? `\n\n[handbook truncated at ${HANDBOOK_CAP_BYTES / 1024}KB — full file at docs/HANDBOOK.md, ${stat.size} bytes total]`
-          : '');
-    } catch { if (!handbookCandidates.some((p: string) => exHB(p))) { process.stderr.write('[gossipcat] gossip_status: HANDBOOK.md not found in any candidate path — add docs/HANDBOOK.md to capture operator wisdom\n'); } }
+    if (!slim) {
+      const { existsSync: exHB } = require('fs');
+      const { join: jHB } = require('path');
+      // Fallback chain: (a) dev-repo cwd, (b) npm-installed __dirname=dist-mcp/ → HANDBOOK sibling, (c) defensive __dirname
+      const handbookCandidates: string[] = [
+        jHB(process.cwd(), 'docs', 'HANDBOOK.md'),
+        jHB(__dirname, '..', 'docs', 'HANDBOOK.md'),
+        jHB(__dirname, 'docs', 'HANDBOOK.md'),
+      ];
+      try {
+        const { readFileSync: rfHB, statSync: stHB } = require('fs');
+        const handbookPath = handbookCandidates.find(p => exHB(p)) ?? handbookCandidates[0];
+        const stat = stHB(handbookPath);
+        // Cap at 24KB of handbook content so the status response doesn't balloon
+        // beyond the context window on very large handbooks. If capped, append a
+        // pointer so the orchestrator knows to read the full file manually.
+        const HANDBOOK_CAP_BYTES = 24 * 1024;
+        let body = rfHB(handbookPath, 'utf-8');
+        const truncated = body.length > HANDBOOK_CAP_BYTES;
+        if (truncated) {
+          body = body.slice(0, HANDBOOK_CAP_BYTES);
+        }
+        handbookSection =
+          '\n─────────────────────────────────\n' +
+          '## Project Handbook (auto-loaded from docs/HANDBOOK.md)\n\n' +
+          body.trim() +
+          (truncated
+            ? `\n\n[handbook truncated at ${HANDBOOK_CAP_BYTES / 1024}KB — full file at docs/HANDBOOK.md, ${stat.size} bytes total]`
+            : '');
+      } catch { if (!handbookCandidates.some((p: string) => exHB(p))) { process.stderr.write('[gossipcat] gossip_status: HANDBOOK.md not found in any candidate path — add docs/HANDBOOK.md to capture operator wisdom\n'); } }
+    }
 
     // Surface uncategorized-findings count via extracted helper (testable).
     // 7-day window matches skill-gap decay semantics. Skip entirely when count is 0.

--- a/tests/cli/gossip-status-slim.test.ts
+++ b/tests/cli/gossip-status-slim.test.ts
@@ -1,0 +1,125 @@
+/**
+ * gossip_status `slim:true` parameter tests.
+ *
+ * Verifies the slim flag's two contracts:
+ *   1. Type-guard: non-boolean inputs are coerced to false (no throw).
+ *   2. Handbook gate: when slim=true, the "## Project Handbook" section is
+ *      omitted from the assembled response text.
+ *
+ * Mirrors the inline-resolver test pattern used by handbook-resolver.test.ts —
+ * the slim guard + handbook builder are extracted as pure helpers so tests
+ * don't need to boot the full MCP server.
+ *
+ * If the production code in mcp-server-sdk.ts changes its slim coercion or
+ * its handbook-injection branch, update the mirrors below to match.
+ */
+
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+// ── Inline mirrors of production logic ─────────────────────────────────────
+
+/** Mirror of gossip_status's type-guard at mcp-server-sdk.ts (slim coercion). */
+function coerceSlim(args: unknown): boolean {
+  return typeof (args as { slim?: unknown })?.slim === 'boolean'
+    ? (args as { slim: boolean }).slim
+    : false;
+}
+
+/**
+ * Mirror of gossip_status's handbook injection branch — returns the
+ * `handbookSection` string that would be appended to the response.
+ * When slim=true the section is the empty string (block skipped entirely).
+ */
+function buildHandbookSection(opts: { slim: boolean; cwd: string }): string {
+  let handbookSection = '';
+  if (!opts.slim) {
+    const handbookCandidates = [path.join(opts.cwd, 'docs', 'HANDBOOK.md')];
+    try {
+      const handbookPath = handbookCandidates.find(p => fs.existsSync(p)) ?? handbookCandidates[0];
+      const stat = fs.statSync(handbookPath);
+      const HANDBOOK_CAP_BYTES = 24 * 1024;
+      let body = fs.readFileSync(handbookPath, 'utf-8');
+      const truncated = body.length > HANDBOOK_CAP_BYTES;
+      if (truncated) body = body.slice(0, HANDBOOK_CAP_BYTES);
+      handbookSection =
+        '\n─────────────────────────────────\n' +
+        '## Project Handbook (auto-loaded from docs/HANDBOOK.md)\n\n' +
+        body.trim() +
+        (truncated
+          ? `\n\n[handbook truncated at ${HANDBOOK_CAP_BYTES / 1024}KB — full file at docs/HANDBOOK.md, ${stat.size} bytes total]`
+          : '');
+    } catch { /* missing file — section stays empty */ }
+  }
+  return handbookSection;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('gossip_status — slim coercion (type-guard)', () => {
+  it('returns false when slim is omitted', () => {
+    expect(coerceSlim({})).toBe(false);
+  });
+
+  it('returns false when slim is undefined', () => {
+    expect(coerceSlim({ slim: undefined })).toBe(false);
+  });
+
+  it('returns true when slim is the literal boolean true', () => {
+    expect(coerceSlim({ slim: true })).toBe(true);
+  });
+
+  it('returns false when slim is the literal boolean false', () => {
+    expect(coerceSlim({ slim: false })).toBe(false);
+  });
+
+  it('does NOT throw when slim is a non-boolean string — coerces to false', () => {
+    expect(() => coerceSlim({ slim: 'true' })).not.toThrow();
+    expect(coerceSlim({ slim: 'true' })).toBe(false);
+  });
+
+  it('does NOT throw when slim is a number — coerces to false', () => {
+    expect(coerceSlim({ slim: 1 })).toBe(false);
+  });
+
+  it('does NOT throw when slim is null — coerces to false', () => {
+    expect(coerceSlim({ slim: null })).toBe(false);
+  });
+});
+
+describe('gossip_status — handbook section is gated by slim', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gossip-status-slim-'));
+    const docs = path.join(tmpRoot, 'docs');
+    fs.mkdirSync(docs, { recursive: true });
+    fs.writeFileSync(path.join(docs, 'HANDBOOK.md'), '# Test Handbook\n\nOperator wisdom.', 'utf-8');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('includes "## Project Handbook" by default (slim omitted/false)', () => {
+    const out = buildHandbookSection({ slim: false, cwd: tmpRoot });
+    expect(out).toContain('## Project Handbook');
+    expect(out).toContain('Operator wisdom.');
+  });
+
+  it('skips the handbook section entirely when slim=true', () => {
+    const out = buildHandbookSection({ slim: true, cwd: tmpRoot });
+    expect(out).toBe('');
+    expect(out).not.toContain('## Project Handbook');
+  });
+
+  it('produces a non-trivial byte savings when slim=true (≥ ~21KB on large handbooks)', () => {
+    // Write a ~24KB handbook to mimic real-world dimensions
+    const big = 'x'.repeat(24 * 1024);
+    fs.writeFileSync(path.join(tmpRoot, 'docs', 'HANDBOOK.md'), big, 'utf-8');
+    const full = buildHandbookSection({ slim: false, cwd: tmpRoot });
+    const trimmed = buildHandbookSection({ slim: true, cwd: tmpRoot });
+    expect(full.length - trimmed.length).toBeGreaterThanOrEqual(21 * 1024);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an optional `slim: boolean` parameter to the `gossip_status` MCP tool. When `slim:true`, the inline `## Project Handbook` block (auto-loaded from `docs/HANDBOOK.md`, capped at 24KB) is omitted from the response.

- **Why:** After `/mcp` reconnects, the orchestrator already has the handbook in working memory. Re-injecting ~21KB on every `gossip_status()` refresh is pure context waste.
- **Default behavior unchanged:** Omitting `slim` (or passing `false`) returns the full response including the handbook. No callers need to migrate.
- **Type-guarded:** Non-boolean inputs (string `"true"`, numbers, `null`, etc.) coerce to `false` rather than throwing — defensive against MCP clients that may pass loosely-typed args.

## Changes

- `apps/cli/src/mcp-server-sdk.ts` (~17 LOC): Zod schema `{ slim?: boolean }` on the `gossip_status` tool definition, type-guard in handler, `if (!slim)` wrapper around the handbook injection block. Tool description updated.
- `tests/cli/gossip-status-slim.test.ts` (new, 124 LOC): 10 tests across two groups:
  - Type-guard coercion (7 cases: omitted, undefined, true, false, string, number, null)
  - Handbook gate (3 cases: default-on, slim-off, ≥21KB savings on a 24KB handbook)

## Test plan

- [x] `npm run build` — clean
- [x] `npx tsc -p apps/cli` — clean
- [x] `npx jest tests/cli/gossip-status-slim.test.ts` — 10/10 pass
- [x] `npx jest tests/cli/` — 712/712 pass (60 suites, no regressions)
- [x] `npm run build:mcp` — bundle rebuilt
- [ ] Cross-review by consensus round (orchestrator)

consensus-id: 52d342a3-285546d9

