### PR TITLE
feat(dispatch): server-side prompt elision — opt-in prompt_format

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -9,6 +9,7 @@ import { seedRecentConsensusTaskIds } from './native-tasks';
 import { trackLifecycleTask } from '../lifecycle-tasks';
 import { FILE_TOOLS, FileTools, GitTools, Sandbox } from '@gossip/tools';
 import { MemorySearcher } from '@gossip/orchestrator';
+import type { PromptFormat } from './dispatch';
 
 /**
  * Schedule the per-skill checkEffectiveness runner as a detached, tracked
@@ -190,7 +191,7 @@ export async function handleCollect(
    * section is REPLACED with one marker line per agent. Default 'inline'
    * preserves the existing ---SYSTEM---/---USER--- embedded block.
    */
-  prompt_format?: 'inline' | 'elided',
+  prompt_format?: PromptFormat,
 ) {
   await ctx.boot();
 
@@ -769,7 +770,9 @@ export async function handleCollect(
         if (elideCrossReview) {
           const { writeDispatchPrompt } = require('./dispatch-prompt-storage');
           for (const np of nativePrompts) {
-            const safeId = `${consensusId}__${np.agentId}`.replace(/[^A-Za-z0-9._-]/g, '_');
+            const safeId = `${consensusId}__${np.agentId}`
+              .replace(/[^A-Za-z0-9._-]/g, '_')
+              .replace(/\.{2,}/g, '.');
             const body = `---SYSTEM---\n${np.system}\n---USER---\n${np.user}\n---END---\n`;
             try {
               const p = writeDispatchPrompt(process.cwd(), safeId, body);

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -182,6 +182,15 @@ export async function handleCollect(
    * validateResolutionRoot before invoking handleCollect).
    */
   resolutionRoots?: readonly string[],
+  /**
+   * Spec docs/specs/2026-05-18-native-dispatch-skill-handle-pattern.md.
+   * Applied to the Phase 2 cross-review prompt block emitted in the EXECUTE
+   * NOW payload. When 'elided', each cross-review prompt is written to
+   * .gossip/dispatch-prompts/<consensusId>__<agentId>.txt and the PROMPTS
+   * section is REPLACED with one marker line per agent. Default 'inline'
+   * preserves the existing ---SYSTEM---/---USER--- embedded block.
+   */
+  prompt_format?: 'inline' | 'elided',
 ) {
   await ctx.boot();
 
@@ -749,11 +758,36 @@ export async function handleCollect(
         actionLines.push(`consensus_id: ${consensusId}\n`);
         actionLines.push(`For each agent below, dispatch Agent() then call gossip_relay_cross_review:\n`);
 
+        // Spec §1 strict opt-in: per-agent prompt elision for Phase 2
+        // cross-review. When 'elided', write each ---SYSTEM---/---USER---
+        // block to .gossip/dispatch-prompts/<safeId>.txt and replace the
+        // PROMPTS section with marker lines. Agent dispatch instructions
+        // cite the path directly. Item-2-equivalent (PROMPTS block) is
+        // ABSENT entirely when elided.
+        const elideCrossReview = prompt_format === 'elided';
+        const crossReviewPaths = new Map<string, string>();
+        if (elideCrossReview) {
+          const { writeDispatchPrompt } = require('./dispatch-prompt-storage');
+          for (const np of nativePrompts) {
+            const safeId = `${consensusId}__${np.agentId}`.replace(/[^A-Za-z0-9._-]/g, '_');
+            const body = `---SYSTEM---\n${np.system}\n---USER---\n${np.user}\n---END---\n`;
+            try {
+              const p = writeDispatchPrompt(process.cwd(), safeId, body);
+              crossReviewPaths.set(np.agentId, p);
+            } catch (err) {
+              process.stderr.write(`[gossipcat] cross-review prompt elision failed for ${np.agentId}: ${(err as Error).message}\n`);
+            }
+          }
+        }
+
         for (const np of nativePrompts) {
           const nativeConfig = ctx.nativeAgentConfigs.get(np.agentId);
           const model = nativeConfig?.model || 'sonnet';
           actionLines.push(`--- AGENT: ${np.agentId} (model: ${model}) ---`);
-          actionLines.push(`Step 1: Agent(model: "${model}", prompt: <see PROMPTS section below>, run_in_background: true)`);
+          const promptRef = elideCrossReview && crossReviewPaths.has(np.agentId)
+            ? `<file ${crossReviewPaths.get(np.agentId)} — READ and forward verbatim; no PROMPTS section below>`
+            : `<see PROMPTS section below>`;
+          actionLines.push(`Step 1: Agent(model: "${model}", prompt: ${promptRef}, run_in_background: true)`);
           actionLines.push(`Step 2: gossip_relay_cross_review(consensus_id: "${consensusId}", agent_id: "${np.agentId}", result: "<output>")\n`);
         }
 
@@ -769,12 +803,14 @@ export async function handleCollect(
           actionLines.push('---');
         }
 
-        // Full prompts at the end
-        for (const np of nativePrompts) {
-          const nativeConfig = ctx.nativeAgentConfigs.get(np.agentId);
-          const model = nativeConfig?.model || 'sonnet';
-          actionLines.push(`\n--- PROMPT FOR ${np.agentId} (model: ${model}) ---`);
-          actionLines.push(`---SYSTEM---\n${np.system}\n---USER---\n${np.user}\n---END---`);
+        // Full prompts at the end — OMITTED entirely under elision (spec §2).
+        if (!elideCrossReview) {
+          for (const np of nativePrompts) {
+            const nativeConfig = ctx.nativeAgentConfigs.get(np.agentId);
+            const model = nativeConfig?.model || 'sonnet';
+            actionLines.push(`\n--- PROMPT FOR ${np.agentId} (model: ${model}) ---`);
+            actionLines.push(`---SYSTEM---\n${np.system}\n---USER---\n${np.user}\n---END---`);
+          }
         }
 
         const partialOutput = actionLines.join('\n');

--- a/apps/cli/src/handlers/dispatch-prompt-storage.ts
+++ b/apps/cli/src/handlers/dispatch-prompt-storage.ts
@@ -1,0 +1,203 @@
+/**
+ * Dispatch prompt storage — Option B (server-side prompt elision).
+ *
+ * Stores native dispatch prompts on disk under .gossip/dispatch-prompts/<taskId>.txt
+ * so the MCP `gossip_dispatch`/`gossip_run`/`gossip_collect` response payload can
+ * omit the AGENT_PROMPT content item entirely when the caller opted in via
+ * `prompt_format: 'elided'`. The orchestrator must Read the cited file and
+ * forward its contents verbatim to Agent(prompt: ...).
+ *
+ * Iron rules from spec docs/specs/2026-05-18-native-dispatch-skill-handle-pattern.md:
+ *   - Strict opt-in: server elides ONLY on explicit request. Default behavior
+ *     (inline AGENT_PROMPT content items) is unchanged.
+ *   - On-disk file contains ONLY the agent-facing prompt — no relay_token,
+ *     no task_id orchestration metadata.
+ *   - Atomic write-to-temp + rename. SAFE_NAME validation on taskId.
+ *   - mtime-keyed eviction (default 1h) + aggregate eldest-eviction at 100MB cap.
+ *   - Crash recovery: on boot, prune orphan files whose taskId is not present
+ *     in the restored nativeTaskMap.
+ */
+
+import { mkdirSync, renameSync, statSync, readdirSync, unlinkSync, writeFileSync, existsSync } from 'fs';
+import { join, basename, resolve } from 'path';
+import { randomUUID } from 'crypto';
+
+/**
+ * SAFE_NAME — alphanumerics plus `._-`, no `..` substring, ≤64 chars.
+ * Mirrors packages/orchestrator/src/skill-engine.ts SAFE_NAME pattern but is
+ * locally re-declared to avoid a cross-package import in the CLI handler tier.
+ * Reject empties, dots-only, and any traversal attempt.
+ */
+const SAFE_TASK_ID = /^(?!.*\.\.)[A-Za-z0-9._-]{1,64}$/;
+
+/** Aggregate storage cap. Beyond this, evict eldest by mtime until under cap. */
+export const DISPATCH_PROMPT_CAP_BYTES = 100 * 1024 * 1024;
+
+/** Default mtime-based eviction window — 1 hour. */
+export const DEFAULT_PROMPT_TTL_MS = 60 * 60 * 1000;
+
+/** Subdirectory under .gossip/ where dispatch prompts live. */
+export const DISPATCH_PROMPTS_SUBDIR = 'dispatch-prompts';
+
+function dispatchPromptsDir(projectRoot: string): string {
+  return join(projectRoot, '.gossip', DISPATCH_PROMPTS_SUBDIR);
+}
+
+/**
+ * Validate a taskId is safe for use as a filename. Throws on any violation
+ * — callers ALWAYS supply a taskId they just minted via randomUUID().slice,
+ * so a violation here indicates a logic bug, not user input.
+ */
+function assertSafeTaskId(taskId: string): void {
+  if (typeof taskId !== 'string' || taskId.length === 0) {
+    throw new Error('dispatch-prompt-storage: taskId must be a non-empty string');
+  }
+  if (!SAFE_TASK_ID.test(taskId)) {
+    throw new Error(`dispatch-prompt-storage: taskId failed SAFE_NAME validation (rejected: ${JSON.stringify(taskId).slice(0, 64)})`);
+  }
+}
+
+/**
+ * Write a dispatch prompt to disk and return its absolute path.
+ *
+ * Atomic: writes to <taskId>.txt.<rand>.tmp then renames into place. On
+ * rename failure the temp file is best-effort cleaned up.
+ *
+ * Caller is responsible for ensuring `body` contains ONLY the agent-facing
+ * prompt — no relay_token, no AGENT_PROMPT tag prefix, no orchestration
+ * metadata. Stored verbatim.
+ */
+export function writeDispatchPrompt(projectRoot: string, taskId: string, body: string): string {
+  assertSafeTaskId(taskId);
+  const dir = dispatchPromptsDir(projectRoot);
+  mkdirSync(dir, { recursive: true });
+  const finalPath = join(dir, `${taskId}.txt`);
+  const tmpPath = join(dir, `${taskId}.txt.${randomUUID().slice(0, 8)}.tmp`);
+  try {
+    writeFileSync(tmpPath, body, 'utf8');
+    renameSync(tmpPath, finalPath);
+  } catch (err) {
+    try { unlinkSync(tmpPath); } catch { /* best-effort */ }
+    throw err;
+  }
+  return resolve(finalPath);
+}
+
+/**
+ * Synchronously evict prompt files older than `maxAgeMs` (default 1h)
+ * by mtime. Then enforce the aggregate `DISPATCH_PROMPT_CAP_BYTES` cap by
+ * removing eldest entries until the remaining total is under cap.
+ *
+ * Fail-open: any single-file stat/unlink error is logged to stderr and the
+ * loop continues. The directory not existing is a no-op success.
+ */
+export function cleanupExpiredDispatchPrompts(
+  projectRoot: string,
+  maxAgeMs: number = DEFAULT_PROMPT_TTL_MS,
+  capBytes: number = DISPATCH_PROMPT_CAP_BYTES,
+): { evictedAge: number; evictedCap: number } {
+  const dir = dispatchPromptsDir(projectRoot);
+  if (!existsSync(dir)) return { evictedAge: 0, evictedCap: 0 };
+  const now = Date.now();
+  let entries: Array<{ name: string; path: string; mtimeMs: number; size: number }> = [];
+  try {
+    for (const name of readdirSync(dir)) {
+      const path = join(dir, name);
+      try {
+        const st = statSync(path);
+        if (!st.isFile()) continue;
+        entries.push({ name, path, mtimeMs: st.mtimeMs, size: st.size });
+      } catch (err) {
+        process.stderr.write(`[gossipcat] dispatch-prompt stat failed for ${basename(path)}: ${(err as Error).message}\n`);
+      }
+    }
+  } catch (err) {
+    process.stderr.write(`[gossipcat] dispatch-prompt readdir failed: ${(err as Error).message}\n`);
+    return { evictedAge: 0, evictedCap: 0 };
+  }
+
+  let evictedAge = 0;
+  const survivors: typeof entries = [];
+  for (const e of entries) {
+    if (now - e.mtimeMs > maxAgeMs) {
+      try { unlinkSync(e.path); evictedAge++; }
+      catch (err) { process.stderr.write(`[gossipcat] dispatch-prompt unlink failed for ${e.name}: ${(err as Error).message}\n`); }
+    } else {
+      survivors.push(e);
+    }
+  }
+
+  let totalBytes = survivors.reduce((acc, e) => acc + e.size, 0);
+  let evictedCap = 0;
+  if (totalBytes > capBytes) {
+    // Eldest-first eviction until under cap.
+    survivors.sort((a, b) => a.mtimeMs - b.mtimeMs);
+    for (const e of survivors) {
+      if (totalBytes <= capBytes) break;
+      try {
+        unlinkSync(e.path);
+        totalBytes -= e.size;
+        evictedCap++;
+      } catch (err) {
+        process.stderr.write(`[gossipcat] dispatch-prompt cap-evict failed for ${e.name}: ${(err as Error).message}\n`);
+      }
+    }
+  }
+  return { evictedAge, evictedCap };
+}
+
+/**
+ * Crash-recovery orphan prune. Called at MCP boot AFTER nativeTaskMap is
+ * restored. Removes any prompt file whose taskId no longer matches a known
+ * task — these are residual writes from a crashed previous session.
+ *
+ * `knownTaskIds` is the set of taskIds restored into ctx.nativeTaskMap.
+ * Files for unknown taskIds are unlinked. Files older than `maxAgeMs`
+ * are evicted regardless (matches existing TTL semantics).
+ */
+export function pruneOrphanDispatchPrompts(
+  projectRoot: string,
+  knownTaskIds: Set<string>,
+  maxAgeMs: number = DEFAULT_PROMPT_TTL_MS,
+): { orphans: number; aged: number } {
+  const dir = dispatchPromptsDir(projectRoot);
+  if (!existsSync(dir)) return { orphans: 0, aged: 0 };
+  const now = Date.now();
+  let orphans = 0;
+  let aged = 0;
+  try {
+    for (const name of readdirSync(dir)) {
+      // Only consider final .txt files; temp files get the regular cleanup pass.
+      if (!name.endsWith('.txt')) continue;
+      const taskId = name.slice(0, -4);
+      const path = join(dir, name);
+      let mtimeMs = 0;
+      try { mtimeMs = statSync(path).mtimeMs; } catch { continue; }
+      const tooOld = now - mtimeMs > maxAgeMs;
+      const orphaned = !knownTaskIds.has(taskId);
+      if (tooOld || orphaned) {
+        try {
+          unlinkSync(path);
+          if (orphaned) orphans++;
+          else aged++;
+        } catch (err) {
+          process.stderr.write(`[gossipcat] dispatch-prompt orphan-prune failed for ${name}: ${(err as Error).message}\n`);
+        }
+      }
+    }
+  } catch (err) {
+    process.stderr.write(`[gossipcat] dispatch-prompt orphan-readdir failed: ${(err as Error).message}\n`);
+  }
+  return { orphans, aged };
+}
+
+/**
+ * Test-helper: resolve the absolute path a given taskId WOULD be written to,
+ * without performing any IO. Used by the elision unit tests and any future
+ * crash-recovery diagnostics. Validates SAFE_NAME so callers don't paper
+ * over a bug by reading from a path that would have been rejected on write.
+ */
+export function dispatchPromptPath(projectRoot: string, taskId: string): string {
+  assertSafeTaskId(taskId);
+  return resolve(join(dispatchPromptsDir(projectRoot), `${taskId}.txt`));
+}

--- a/apps/cli/src/handlers/dispatch-prompt-storage.ts
+++ b/apps/cli/src/handlers/dispatch-prompt-storage.ts
@@ -179,7 +179,7 @@ export function pruneOrphanDispatchPrompts(
         try {
           unlinkSync(path);
           if (orphaned) orphans++;
-          else aged++;
+          if (tooOld) aged++;
         } catch (err) {
           process.stderr.write(`[gossipcat] dispatch-prompt orphan-prune failed for ${name}: ${(err as Error).message}\n`);
         }

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -892,7 +892,6 @@ export async function handleDispatchParallel(
     if (parallelElision.elided) {
       const info = ctx.nativeTaskMap.get(taskId);
       if (info) info.promptPath = parallelElision.promptPath;
-      persistNativeTaskMap();
     }
     const parallelPromptRef = parallelElision.elided
       ? parallelElision.marker
@@ -908,6 +907,10 @@ export async function handleDispatchParallel(
       nativePrompts.push({ taskId, agentId: def.agent_id, prompt: agentPrompt });
     }
   }
+  // Persist after the loop so all promptPath mutations land in one write —
+  // mirrors the single-dispatch pattern at :571. Always called (not only on
+  // elision) so any nativeTaskMap writes from the loop are durable.
+  persistNativeTaskMap();
 
   // #392 fix (HIGH f2): mirror handleDispatchConsensus stash (lines 1050-1055).
   // When consensus=true and effective roots were resolved (either caller-supplied

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -29,6 +29,39 @@ function buildNativeIdentity(agentId: string, model: string): string {
   });
 }
 import { evictStaleNativeTasks, persistNativeTaskMap, spawnTimeoutWatcher } from './native-tasks';
+import { writeDispatchPrompt } from './dispatch-prompt-storage';
+
+/**
+ * Strict opt-in elision marker (spec §1 iron rule).
+ * Server elides AGENT_PROMPT content items only when this exact string is
+ * received. Default unchanged ('inline' or undefined). New tool-schema enum
+ * additions must intentionally widen the check.
+ */
+export type PromptFormat = 'inline' | 'elided';
+
+/**
+ * Common helper used at all three native dispatch sites. When `promptFormat`
+ * is 'elided':
+ *   - writes `agentPrompt` to .gossip/dispatch-prompts/<taskId>.txt
+ *   - returns {elided:true, promptPath, marker} — caller emits the marker in
+ *     Item 1 and OMITS Item 2 entirely (spec §"Item 2 ABSENT under elision").
+ *
+ * When 'inline' (default) or undefined: returns {elided:false}, caller emits
+ * the existing two-item content split. Behavior is byte-identical to the
+ * pre-elision dispatch path.
+ */
+export function elidePromptIfRequested(
+  projectRoot: string,
+  taskId: string,
+  agentPrompt: string,
+  promptFormat: PromptFormat | undefined,
+): { elided: true; promptPath: string; marker: string; bytes: number } | { elided: false } {
+  if (promptFormat !== 'elided') return { elided: false };
+  const bytes = Buffer.byteLength(agentPrompt, 'utf8');
+  const promptPath = writeDispatchPrompt(projectRoot, taskId, agentPrompt);
+  const marker = `[skills section elided: see ${promptPath}, ${bytes} bytes — READ this file and pass its CONTENTS verbatim as the Agent(prompt: ...) value. Do NOT pass the path string.]`;
+  return { elided: true, promptPath, marker, bytes };
+}
 import { persistRelayTasks } from './relay-tasks';
 import {
   prependScopeNote,
@@ -370,6 +403,14 @@ export async function handleDispatchSingle(
    * native agents have a separate flow above (out-of-process Agent tool).
    */
   resolutionRoots?: readonly string[],
+  /**
+   * Spec docs/specs/2026-05-18-native-dispatch-skill-handle-pattern.md.
+   * Strict opt-in. When 'elided', the AGENT_PROMPT content item is omitted
+   * and the prompt body is written to .gossip/dispatch-prompts/<taskId>.txt;
+   * Item 1 instructs the orchestrator to Read the file and forward verbatim.
+   * Default 'inline' preserves byte-for-byte the pre-PR behavior.
+   */
+  prompt_format?: PromptFormat,
 ) {
   await ctx.boot();
   await ctx.syncWorkersViaKeychain();
@@ -449,7 +490,7 @@ export async function handleDispatchSingle(
 
     ctx.nativeTaskMap.set(taskId, { agentId: agent_id, task, startedAt: Date.now(), timeoutMs, planId: plan_id, step, writeMode: write_mode, relayToken, preDispatchSha });
     spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
-    persistNativeTaskMap();
+    // promptPath is filled in below after elision (if requested).
     process.stderr.write(`[gossipcat] → dispatch → ${agent_id} (${nativeConfig.model}) [${taskId}]\n`);
 
     // Register scope so subsequent dispatches see it
@@ -518,6 +559,23 @@ export async function handleDispatchSingle(
       }
     }
 
+    // Spec §1 iron rule: strict opt-in elision. When prompt_format='elided',
+    // write the prompt body to disk and emit a marker in Item 1; OMIT Item 2.
+    // When undefined/'inline': behavior is byte-identical to pre-PR dispatch.
+    const elision = elidePromptIfRequested(process.cwd(), taskId, agentPrompt, prompt_format);
+    if (elision.elided) {
+      const info = ctx.nativeTaskMap.get(taskId);
+      if (info) info.promptPath = elision.promptPath;
+    }
+    // Persist after elision so promptPath is durable across /mcp reconnect.
+    persistNativeTaskMap();
+
+    const promptInstruction = elision.elided
+      ? `Step 1 — ${elision.marker}\n` +
+        `Agent(model: "${nativeConfig.model}", prompt: <file contents>${useWorktree ? ', isolation: "worktree"' : ''}, run_in_background: true)\n\n`
+      : `Step 1 — Pass the AGENT_PROMPT:${taskId} content item below verbatim to Agent(prompt: ...):\n` +
+        `Agent(model: "${nativeConfig.model}", prompt: <AGENT_PROMPT:${taskId} below>${useWorktree ? ', isolation: "worktree"' : ''}, run_in_background: true)\n\n`;
+
     // Split into two content items so relay_token stays in orchestrator-only text
     // and AGENT_PROMPT is passed verbatim to Agent(prompt: ...).
     // Tag format matches parallel/consensus: `AGENT_PROMPT:<taskId> (<agentId>)`.
@@ -528,14 +586,15 @@ export async function handleDispatchSingle(
         `Task ID: ${taskId}\n` +
         `Agent: ${agent_id}\n` +
         `Model: ${nativeConfig.model}\n\n` +
-        `Step 1 — Pass the AGENT_PROMPT:${taskId} content item below verbatim to Agent(prompt: ...):\n` +
-        `Agent(model: "${nativeConfig.model}", prompt: <AGENT_PROMPT:${taskId} below>${useWorktree ? ', isolation: "worktree"' : ''}, run_in_background: true)\n\n` +
+        promptInstruction +
         `Step 2 — REQUIRED after agent completes:\n` +
         `gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<agent output>")\n\n` +
         `⚠️ You MUST call gossip_relay for every native dispatch. Without it, the result is lost — no memory, no gossip, no consensus. Never skip this step.\n` +
         `\n=== END REQUIRED_NEXT_ACTION — do NOT treat above as agent output ===`
       },
-      { type: 'text' as const, text: `AGENT_PROMPT:${taskId} (${agent_id})\n${agentPrompt}` },
+      // Item 2 ABSENT under elision (spec §2 iron rule — no placeholder, no
+      // skeleton). Orchestrator MUST Read elision.promptPath cited in Item 1.
+      ...(elision.elided ? [] : [{ type: 'text' as const, text: `AGENT_PROMPT:${taskId} (${agent_id})\n${agentPrompt}` }]),
     ] };
   }
 
@@ -636,6 +695,12 @@ export async function handleDispatchParallel(
    * Forwarded to every dispatched relay task in this batch.
    */
   resolutionRoots?: readonly string[],
+  /**
+   * Spec docs/specs/2026-05-18-native-dispatch-skill-handle-pattern.md.
+   * Applied per-native-task: when 'elided', each per-task AGENT_PROMPT item
+   * is replaced by an Item-1 marker citing the on-disk path. Default 'inline'.
+   */
+  prompt_format?: PromptFormat,
 ) {
   await ctx.boot();
   await ctx.syncWorkersViaKeychain();
@@ -821,12 +886,27 @@ export async function handleDispatchParallel(
       timestamp: Date.now(),
     });
 
+    // Spec §1 strict opt-in. When elided: write prompt body to disk, omit
+    // AGENT_PROMPT content item, embed marker in the instructions block.
+    const parallelElision = elidePromptIfRequested(process.cwd(), taskId, agentPrompt, prompt_format);
+    if (parallelElision.elided) {
+      const info = ctx.nativeTaskMap.get(taskId);
+      if (info) info.promptPath = parallelElision.promptPath;
+      persistNativeTaskMap();
+    }
+    const parallelPromptRef = parallelElision.elided
+      ? parallelElision.marker
+      : `<AGENT_PROMPT:${taskId} below>`;
+
     lines.push(`  ${taskId} → ${def.agent_id} (native — dispatch via Agent tool)`);
     nativeInstructions.push(
-      `[${taskId}] Agent(model: "${nativeConfig.model}", prompt: <AGENT_PROMPT:${taskId} below>${def.write_mode === 'worktree' ? ', isolation: "worktree"' : ''}, run_in_background: true)` +
+      `[${taskId}] Agent(model: "${nativeConfig.model}", prompt: ${parallelPromptRef}${def.write_mode === 'worktree' ? ', isolation: "worktree"' : ''}, run_in_background: true)` +
       `\n  → then: gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<output>")`
     );
-    nativePrompts.push({ taskId, agentId: def.agent_id, prompt: agentPrompt });
+    // Item 2 ABSENT under elision — orchestrator MUST Read the cited path.
+    if (!parallelElision.elided) {
+      nativePrompts.push({ taskId, agentId: def.agent_id, prompt: agentPrompt });
+    }
   }
 
   // #392 fix (HIGH f2): mirror handleDispatchConsensus stash (lines 1050-1055).
@@ -876,6 +956,11 @@ export async function handleDispatchConsensus(
    * Collect-time resolutionRoots REPLACE these (not merge).
    */
   dispatchResolutionRoots?: readonly string[],
+  /**
+   * Spec docs/specs/2026-05-18-native-dispatch-skill-handle-pattern.md.
+   * Per-task elision for the consensus cross-review batch. Default 'inline'.
+   */
+  prompt_format?: PromptFormat,
 ) {
   await ctx.boot();
   await ctx.syncWorkersViaKeychain();
@@ -1054,12 +1139,28 @@ export async function handleDispatchConsensus(
     });
     // Premise verification (Component B) — per-def in the consensus native loop.
     agentPrompt = maybeApplyUnverifiedNote(agentPrompt, def.task, def.agent_id);
+
+    // Spec §1 strict opt-in. When 'elided', the per-task AGENT_PROMPT item is
+    // omitted and the on-disk path is cited inline in the Agent() instruction.
+    const consensusElision = elidePromptIfRequested(process.cwd(), taskId, agentPrompt, prompt_format);
+    if (consensusElision.elided) {
+      const info = ctx.nativeTaskMap.get(taskId);
+      if (info) info.promptPath = consensusElision.promptPath;
+      persistNativeTaskMap();
+    }
+    const consensusPromptRef = consensusElision.elided
+      ? consensusElision.marker
+      : `<AGENT_PROMPT:${taskId} below>`;
+
     lines.push(`  ${taskId} → ${def.agent_id} (native — dispatch via Agent tool)`);
     nativeInstructions.push(
-      `[${taskId}] Agent(model: "${nativeConfig.model}", prompt: <AGENT_PROMPT:${taskId} below>, run_in_background: true)` +
+      `[${taskId}] Agent(model: "${nativeConfig.model}", prompt: ${consensusPromptRef}, run_in_background: true)` +
       `\n  → then: gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<output>")`
     );
-    nativePrompts.push({ taskId, agentId: def.agent_id, prompt: agentPrompt });
+    // Item 2 ABSENT under elision (spec §2) — no skeleton/placeholder.
+    if (!consensusElision.elided) {
+      nativePrompts.push({ taskId, agentId: def.agent_id, prompt: agentPrompt });
+    }
   }
 
   // #126 PR-B: stash validated dispatch-time resolutionRoots keyed by each

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -260,7 +260,20 @@ const UTILITY_RESULT_TTL_MS = 24 * 60 * 60 * 1000;
 export function scheduleNativeTaskEviction(
   intervalMs: number = 60 * 60 * 1000,
 ): { stop: () => void } {
-  const timer = setInterval(evictStaleNativeTasks, intervalMs);
+  const timer = setInterval(() => {
+    evictStaleNativeTasks();
+    // Co-scheduled mtime-based eviction of elision prompt files. Same
+    // interval since both share the 1h staleness budget. Fail-open on any
+    // file IO error — the require() also guards a build where the helper
+    // module went missing.
+    try {
+      const root = ctx.mainAgent?.projectRoot ?? process.cwd();
+      const { cleanupExpiredDispatchPrompts } = require('./dispatch-prompt-storage');
+      cleanupExpiredDispatchPrompts(root, 60 * 60 * 1000);
+    } catch (err) {
+      process.stderr.write(`[gossipcat] cleanupExpiredDispatchPrompts failed: ${(err as Error).message}\n`);
+    }
+  }, intervalMs);
   timer.unref();
   return {
     stop: () => clearInterval(timer),
@@ -318,8 +331,28 @@ export function persistNativeTaskMap(): void {
   }
 }
 
-/** Restore nativeTaskMap from disk (called on boot) */
+/** Restore nativeTaskMap from disk (called on boot).
+ *
+ * After in-memory restore, prune orphan dispatch-prompt files whose taskId
+ * is no longer known. This runs once per /mcp boot — files for tasks that
+ * survived the restore are kept; files for tasks that expired or were
+ * dropped during persist are removed. Fail-open: any prune error is logged
+ * but never throws. */
 export function restoreNativeTaskMap(projectRoot: string): void {
+  restoreNativeTaskMapInner(projectRoot);
+  try {
+    const { pruneOrphanDispatchPrompts } = require('./dispatch-prompt-storage');
+    const known = new Set<string>(ctx.nativeTaskMap.keys());
+    const { orphans, aged } = pruneOrphanDispatchPrompts(projectRoot, known);
+    if (orphans > 0 || aged > 0) {
+      process.stderr.write(`[gossipcat] dispatch-prompt prune on boot: orphans=${orphans} aged=${aged}\n`);
+    }
+  } catch (err) {
+    process.stderr.write(`[gossipcat] dispatch-prompt prune on boot failed: ${(err as Error).message}\n`);
+  }
+}
+
+function restoreNativeTaskMapInner(projectRoot: string): void {
   try {
     const { existsSync: ex, readFileSync: rf } = require('fs');
     const { join: j } = require('path');

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -70,6 +70,14 @@ export interface NativeTaskInfo {
    * Null when git is unavailable (offline / no remote).
    */
   preDispatchSha?: string | null;
+  /**
+   * Absolute path to the on-disk dispatch prompt file, set ONLY when the
+   * caller requested `prompt_format: 'elided'` (Option B server-side prompt
+   * elision, spec docs/specs/2026-05-18-native-dispatch-skill-handle-pattern.md).
+   * Persisted so /mcp reconnect can prune orphan files whose taskId is no
+   * longer in the restored map. Undefined for inline dispatches.
+   */
+  promptPath?: string;
 }
 
 export interface NativeResultInfo {

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1265,8 +1265,15 @@ server.tool(
       (s) => !/[\x00-\x1f]/.test(s),
       { message: 'resolutionRoots entries must not contain NUL or control characters' },
     )).max(32).optional().describe('Optional worktree paths for citation resolution (issue #126).'),
+    // Spec docs/specs/2026-05-18-native-dispatch-skill-handle-pattern.md.
+    // Strict opt-in: default 'inline' preserves the existing two-item content
+    // split. 'elided' instructs the server to write each native AGENT_PROMPT
+    // to .gossip/dispatch-prompts/<taskId>.txt and emit a marker Item 1 only —
+    // Item 2 is OMITTED entirely (no placeholder, no skeleton). The
+    // orchestrator MUST Read the cited file and forward verbatim to Agent().
+    prompt_format: z.enum(['inline', 'elided']).default('inline').describe('Prompt delivery mode for native dispatches: "inline" (default, AGENT_PROMPT content item) or "elided" (write to .gossip/dispatch-prompts/<taskId>.txt; orchestrator Reads + forwards).'),
   },
-  async ({ mode, agent_id, task, tasks, write_mode, scope, timeout_ms, plan_id, step, _utility_task_id, resolutionRoots }) => {
+  async ({ mode, agent_id, task, tasks, write_mode, scope, timeout_ms, plan_id, step, _utility_task_id, resolutionRoots, prompt_format }) => {
     // Track plan execution depth for re-entrant guard
     planExecutionDepth++;
     // #126 PR-B: validate resolutionRoots at the MCP boundary. Fatal (NUL /
@@ -1298,6 +1305,7 @@ server.tool(
         return handleDispatchSingle(
           agent_id, task, write_mode, scope, timeout_ms, plan_id, step,
           validatedDispatchRoots.length > 0 ? validatedDispatchRoots : undefined,
+          prompt_format,
         );
       }
       if (mode === 'parallel') {
@@ -1307,13 +1315,14 @@ server.tool(
         return handleDispatchParallel(
           tasks, false,
           validatedDispatchRoots.length > 0 ? validatedDispatchRoots : undefined,
+          prompt_format,
         );
       }
       if (mode === 'consensus') {
         if (!tasks || tasks.length === 0) {
           return { content: [{ type: 'text' as const, text: 'Error: mode:"consensus" requires a non-empty tasks array.' }] };
         }
-        return handleDispatchConsensus(tasks, _utility_task_id, validatedDispatchRoots.length > 0 ? validatedDispatchRoots : undefined);
+        return handleDispatchConsensus(tasks, _utility_task_id, validatedDispatchRoots.length > 0 ? validatedDispatchRoots : undefined, prompt_format);
       }
       return { content: [{ type: 'text' as const, text: `Unknown mode: ${mode}` }] };
     } finally {
@@ -1337,8 +1346,12 @@ server.tool(
       (s) => !/[\x00-\x1f]/.test(s),
       { message: 'resolutionRoots entries must not contain NUL or control characters' },
     )).max(32).optional().describe('Optional user-worktree paths for citation resolution (issue #126). Collect-time overrides dispatch-time.'),
+    // Spec docs/specs/2026-05-18-native-dispatch-skill-handle-pattern.md.
+    // Governs the Phase 2 cross-review payload only — Phase 1 native dispatch
+    // honors the prompt_format passed to gossip_dispatch/gossip_run.
+    prompt_format: z.enum(['inline', 'elided']).default('inline').describe('Cross-review prompt delivery: "inline" embeds ---SYSTEM---/---USER--- blocks; "elided" writes each to .gossip/dispatch-prompts/ and omits the PROMPTS section.'),
   },
-  async ({ task_ids, timeout_ms, consensus, resolutionRoots }) => {
+  async ({ task_ids, timeout_ms, consensus, resolutionRoots, prompt_format }) => {
     // Validate at MCP boundary. Fatal (NUL / control char) REJECTS the round.
     let validated: string[] | undefined;
     if (resolutionRoots && resolutionRoots.length > 0) {
@@ -1375,7 +1388,7 @@ server.tool(
         for (const tid of task_ids) ctx.pendingDispatchResolutionRoots.delete(tid);
       }
     }
-    return handleCollect(task_ids, timeout_ms, consensus, validated);
+    return handleCollect(task_ids, timeout_ms, consensus, validated, prompt_format);
   }
 );
 
@@ -2240,8 +2253,13 @@ server.tool(
     task: z.string().describe('Task description. Reference file paths — the agent will read them.'),
     write_mode: z.enum(['sequential', 'scoped', 'worktree']).optional().describe('Write mode for implementation tasks'),
     scope: z.string().optional().describe('Directory scope for scoped write mode'),
+    // Spec docs/specs/2026-05-18-native-dispatch-skill-handle-pattern.md.
+    // Forwarded to handleDispatchSingle for native agents; ignored for relay
+    // agents (their prompt is built inside the dispatch pipeline, never
+    // surfaced as an MCP content item to the orchestrator).
+    prompt_format: z.enum(['inline', 'elided']).default('inline').describe('Native-dispatch prompt delivery: "inline" (default) or "elided" (write to .gossip/dispatch-prompts/<taskId>.txt).'),
   },
-  async ({ agent_id, task, write_mode, scope }) => {
+  async ({ agent_id, task, write_mode, scope, prompt_format }) => {
     await boot();
 
     // Auto mode: fast classify → route to single agent or full plan
@@ -2311,7 +2329,7 @@ server.tool(
       // own bare prompt and silently skipped the schema; consensus round
       // b0cc4995-0cd34dc7 surfaced this as the reason fresh-install agents produced
       // prose tables instead of <agent_finding> tags.
-      return handleDispatchSingle(agent_id, task, write_mode, scope);
+      return handleDispatchSingle(agent_id, task, write_mode, scope, undefined, undefined, undefined, undefined, prompt_format);
     }
 
     const options: any = {};

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -55,6 +55,27 @@ The agent prompt in item 2 must see **nothing** about the surrounding orchestrat
 
 This is a **security boundary**, not a style preference. See prior session 2026-04-08 and consensus `ff598432`.
 
+**Optional elision protocol (`prompt_format: 'elided'`).** All three dispatch tools — `gossip_dispatch`, `gossip_run`, `gossip_collect` — accept an opt-in `prompt_format` parameter. The default `'inline'` is byte-identical to the description above. When the caller passes `'elided'`:
+
+- The server writes the prompt body to `.gossip/dispatch-prompts/<taskId>.txt` (atomic temp-rename, `SAFE_NAME`-validated taskId).
+- Item 1 contains a marker line of the form `[skills section elided: see <abspath>, <N> bytes — READ this file and pass its CONTENTS verbatim as the Agent(prompt: ...) value. Do NOT pass the path string.]`.
+- **Item 2 is OMITTED entirely** — no skeleton, no placeholder. The orchestrator MUST `Read(<abspath>)` and forward the file contents verbatim to `Agent(prompt: ...)`. A missing file is a hard failure; never substitute the marker text for the prompt.
+
+The on-disk prompt file carries ONLY the agent-facing prompt (identity + instructions + skills + task). It NEVER carries `relay_token`, `task_id`, the `AGENT_PROMPT:` tag prefix, or any other orchestration metadata — those stay in Item 1 only. Persistence: the absolute path is stored alongside the task in `.gossip/native-tasks.json` so `/mcp` reconnect can prune orphan files for tasks that no longer exist. Eviction is mtime-based (default 1h) plus aggregate eldest-eviction at 100 MB.
+
+Example flow inside the consensus protocol when `prompt_format: 'elided'` is passed to `gossip_collect`:
+
+```
+1. gossip_collect(task_ids: [...], consensus: true, prompt_format: 'elided')
+2. → server writes .gossip/dispatch-prompts/<consensusId>__<agentId>.txt per cross-review participant
+3. → returns ⚠️ EXECUTE NOW payload with one marker line per agent; PROMPTS section is ABSENT
+4. → orchestrator Reads each cited file and passes contents verbatim to Agent(prompt: ...)
+5. → gossip_relay_cross_review(consensus_id, agent_id, result) per agent
+6. → gossip_collect(consensus: true) for final synthesized output
+```
+
+Spec: `docs/specs/2026-05-18-native-dispatch-skill-handle-pattern.md` (Option B — server-side prompt elision).
+
 ### 5. Scoped agents write files, orchestrator commits
 
 Scoped write mode (`write_mode: "scoped"`) lets agents write files within a directory scope but **not** run `git commit` or `shell_exec` (except read-only git commands). The orchestrator validates the agent's output and commits on their behalf. Worktree agents have full git access within their isolated branch.

--- a/tests/cli/eviction-timer.test.ts
+++ b/tests/cli/eviction-timer.test.ts
@@ -19,7 +19,6 @@ jest.mock('../../apps/cli/src/mcp-context', () => ({
 
 import {
   scheduleNativeTaskEviction,
-  evictStaleNativeTasks,
 } from '../../apps/cli/src/handlers/native-tasks';
 
 describe('scheduleNativeTaskEviction', () => {
@@ -47,17 +46,19 @@ describe('scheduleNativeTaskEviction', () => {
     global.clearInterval = originalClearInterval;
   });
 
-  it('(a) calls setInterval with evictStaleNativeTasks and the given interval', () => {
+  it('(a) calls setInterval with a tick function and the given interval', () => {
     scheduleNativeTaskEviction(12345);
 
     expect(setIntervalSpy).toHaveBeenCalledTimes(1);
-    expect(setIntervalSpy).toHaveBeenCalledWith(evictStaleNativeTasks, 12345);
+    // The tick is a wrapper that runs evictStaleNativeTasks AND co-scheduled
+    // cleanupExpiredDispatchPrompts — assert the shape, not the bare ref.
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 12345);
   });
 
   it('defaults to a 1h interval when no interval is provided', () => {
     scheduleNativeTaskEviction();
 
-    expect(setIntervalSpy).toHaveBeenCalledWith(evictStaleNativeTasks, 60 * 60 * 1000);
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 60 * 60 * 1000);
   });
 
   it('(b) calls .unref() on the returned timer so exit is not blocked', () => {

--- a/tests/cli/native-tasks.test.ts
+++ b/tests/cli/native-tasks.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Phase 1 tests for the dispatch-prompt storage helper.
+ * Spec: docs/specs/2026-05-18-native-dispatch-skill-handle-pattern.md §A.
+ *
+ * Covers:
+ *   - happy path (atomic write-to-temp + rename)
+ *   - SAFE_NAME validation (rejects "..", control chars, oversize)
+ *   - eviction by mtime (default 1h)
+ *   - aggregate eldest-eviction at DISPATCH_PROMPT_CAP_BYTES
+ *   - orphan prune on boot (unknown taskIds removed)
+ */
+
+import { existsSync, mkdtempSync, readFileSync, readdirSync, statSync, utimesSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  writeDispatchPrompt,
+  cleanupExpiredDispatchPrompts,
+  pruneOrphanDispatchPrompts,
+  dispatchPromptPath,
+  DISPATCH_PROMPT_CAP_BYTES,
+} from '../../apps/cli/src/handlers/dispatch-prompt-storage';
+
+function mkRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'gossip-native-tasks-'));
+}
+
+function setMtime(path: string, mtimeMs: number): void {
+  const secs = mtimeMs / 1000;
+  utimesSync(path, secs, secs);
+}
+
+describe('dispatch-prompt storage', () => {
+  describe('writeDispatchPrompt', () => {
+    it('writes the body to .gossip/dispatch-prompts/<taskId>.txt and returns absolute path', () => {
+      const root = mkRoot();
+      const path = writeDispatchPrompt(root, 'abc12345', 'hello world');
+      expect(path).toBe(dispatchPromptPath(root, 'abc12345'));
+      expect(existsSync(path)).toBe(true);
+      expect(readFileSync(path, 'utf8')).toBe('hello world');
+      // Atomic rename: no .tmp leftovers.
+      const dir = join(root, '.gossip', 'dispatch-prompts');
+      const leftovers = readdirSync(dir).filter(f => f.endsWith('.tmp'));
+      expect(leftovers).toHaveLength(0);
+    });
+
+    it('rejects taskId containing ".." (path traversal)', () => {
+      const root = mkRoot();
+      expect(() => writeDispatchPrompt(root, '..evil', 'x')).toThrow(/SAFE_NAME/);
+      expect(() => writeDispatchPrompt(root, 'a..b', 'x')).toThrow(/SAFE_NAME/);
+    });
+
+    it('rejects taskId with disallowed characters', () => {
+      const root = mkRoot();
+      expect(() => writeDispatchPrompt(root, 'a/b', 'x')).toThrow(/SAFE_NAME/);
+      expect(() => writeDispatchPrompt(root, 'a b', 'x')).toThrow(/SAFE_NAME/);
+      expect(() => writeDispatchPrompt(root, 'a\x00b', 'x')).toThrow(/SAFE_NAME/);
+    });
+
+    it('rejects empty taskId', () => {
+      const root = mkRoot();
+      expect(() => writeDispatchPrompt(root, '', 'x')).toThrow();
+    });
+
+    it('overwrites in place on repeated calls with the same taskId (atomic rename)', () => {
+      const root = mkRoot();
+      writeDispatchPrompt(root, 'tid', 'first');
+      const second = writeDispatchPrompt(root, 'tid', 'second');
+      expect(readFileSync(second, 'utf8')).toBe('second');
+    });
+  });
+
+  describe('cleanupExpiredDispatchPrompts', () => {
+    it('removes files older than maxAgeMs by mtime', () => {
+      const root = mkRoot();
+      const fresh = writeDispatchPrompt(root, 'fresh-id', 'F');
+      const stale = writeDispatchPrompt(root, 'stale-id', 'S');
+      // Backdate stale by 2 hours.
+      setMtime(stale, Date.now() - 2 * 60 * 60 * 1000);
+
+      const { evictedAge } = cleanupExpiredDispatchPrompts(root, 60 * 60 * 1000);
+      expect(evictedAge).toBe(1);
+      expect(existsSync(fresh)).toBe(true);
+      expect(existsSync(stale)).toBe(false);
+    });
+
+    it('enforces aggregate cap with eldest-eviction', () => {
+      const root = mkRoot();
+      // Three small files, but pass a tiny capBytes to force eviction.
+      const a = writeDispatchPrompt(root, 'a', 'A'.repeat(100));
+      const b = writeDispatchPrompt(root, 'b', 'B'.repeat(100));
+      const c = writeDispatchPrompt(root, 'c', 'C'.repeat(100));
+      // Make 'a' the eldest, 'c' the youngest.
+      setMtime(a, Date.now() - 30 * 1000);
+      setMtime(b, Date.now() - 20 * 1000);
+      setMtime(c, Date.now() - 10 * 1000);
+
+      const { evictedCap } = cleanupExpiredDispatchPrompts(root, 60 * 60 * 1000, 150);
+      // capBytes=150: must drop at least 'a' (100 bytes) to fit two of the
+      // remaining files would still be 200 > 150 so 'b' goes too.
+      expect(evictedCap).toBeGreaterThanOrEqual(1);
+      expect(existsSync(a)).toBe(false);
+    });
+
+    it('returns zero counts when the directory does not exist (fail-open)', () => {
+      const root = mkRoot();
+      const result = cleanupExpiredDispatchPrompts(root);
+      expect(result).toEqual({ evictedAge: 0, evictedCap: 0 });
+    });
+
+    it('honors DISPATCH_PROMPT_CAP_BYTES default by NOT evicting under cap', () => {
+      const root = mkRoot();
+      const p = writeDispatchPrompt(root, 'tid', 'small');
+      const { evictedCap } = cleanupExpiredDispatchPrompts(root, 60 * 60 * 1000, DISPATCH_PROMPT_CAP_BYTES);
+      expect(evictedCap).toBe(0);
+      expect(existsSync(p)).toBe(true);
+    });
+  });
+
+  describe('pruneOrphanDispatchPrompts', () => {
+    it('removes files whose taskId is NOT in the known set (crash recovery)', () => {
+      const root = mkRoot();
+      const known = writeDispatchPrompt(root, 'known-id', 'K');
+      const orphan = writeDispatchPrompt(root, 'orphan-id', 'O');
+
+      const { orphans } = pruneOrphanDispatchPrompts(root, new Set(['known-id']));
+      expect(orphans).toBe(1);
+      expect(existsSync(known)).toBe(true);
+      expect(existsSync(orphan)).toBe(false);
+    });
+
+    it('also removes aged files even if their taskId IS known', () => {
+      const root = mkRoot();
+      const aged = writeDispatchPrompt(root, 'aged-id', 'A');
+      setMtime(aged, Date.now() - 2 * 60 * 60 * 1000);
+
+      const { aged: agedCount } = pruneOrphanDispatchPrompts(root, new Set(['aged-id']));
+      expect(agedCount).toBe(1);
+      expect(existsSync(aged)).toBe(false);
+    });
+
+    it('is a no-op when the directory does not exist', () => {
+      const root = mkRoot();
+      const result = pruneOrphanDispatchPrompts(root, new Set(['nothing']));
+      expect(result).toEqual({ orphans: 0, aged: 0 });
+    });
+  });
+
+  describe('atomic write semantics', () => {
+    it('leaves no temp file behind after a successful write', () => {
+      const root = mkRoot();
+      writeDispatchPrompt(root, 'tid', 'x');
+      const dir = join(root, '.gossip', 'dispatch-prompts');
+      const files = readdirSync(dir);
+      expect(files.every(f => !f.endsWith('.tmp'))).toBe(true);
+    });
+
+    it('written file size matches body byte length', () => {
+      const root = mkRoot();
+      const body = '🚀'.repeat(10); // multi-byte unicode
+      const p = writeDispatchPrompt(root, 'tid', body);
+      expect(statSync(p).size).toBe(Buffer.byteLength(body, 'utf8'));
+    });
+  });
+});

--- a/tests/orchestrator/dispatch-elision.test.ts
+++ b/tests/orchestrator/dispatch-elision.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Phase 1 tests for server-side prompt elision (Option B).
+ * Spec: docs/specs/2026-05-18-native-dispatch-skill-handle-pattern.md.
+ *
+ * Iron rules under test:
+ *   1. Strict opt-in — server elides ONLY when prompt_format === 'elided'.
+ *      Default 'inline' is byte-equivalent to the pre-PR dispatch path.
+ *   2. Item 2 ABSENT under elision — no skeleton, no placeholder. The
+ *      orchestrator MUST Read the cited file or fail loudly.
+ *   3. On-disk file contains ONLY the agent-facing prompt. relay_token
+ *      and task_id orchestration metadata MUST NOT appear.
+ *   4. All three dispatch entry points (single / parallel / consensus) honor
+ *      the param identically.
+ */
+
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { ctx } from '../../apps/cli/src/mcp-context';
+import {
+  handleDispatchSingle,
+  handleDispatchParallel,
+  handleDispatchConsensus,
+} from '../../apps/cli/src/handlers/dispatch';
+
+const originalCtx = {
+  mainAgent: ctx.mainAgent,
+  nativeTaskMap: ctx.nativeTaskMap,
+  nativeResultMap: ctx.nativeResultMap,
+  nativeAgentConfigs: ctx.nativeAgentConfigs,
+  pendingConsensusRounds: ctx.pendingConsensusRounds,
+  booted: ctx.booted,
+  boot: ctx.boot,
+  syncWorkersViaKeychain: ctx.syncWorkersViaKeychain,
+};
+
+function makeMainAgent(): any {
+  return {
+    dispatch: jest.fn().mockReturnValue({ taskId: 'default-task-id' }),
+    collect: jest.fn().mockResolvedValue({ results: [] }),
+    getAgentConfig: jest.fn().mockReturnValue(null),
+    getLLM: jest.fn().mockReturnValue(null),
+    getAgentList: jest.fn().mockReturnValue([]),
+    getSkillGapSuggestions: jest.fn().mockReturnValue([]),
+    getSkillIndex: jest.fn().mockReturnValue(null),
+    getSessionGossip: jest.fn().mockReturnValue([]),
+    getSessionConsensusHistory: jest.fn().mockReturnValue([]),
+    recordNativeTask: jest.fn(),
+    recordNativeTaskCompleted: jest.fn(),
+    recordPlanStepResult: jest.fn(),
+    publishNativeGossip: jest.fn().mockResolvedValue(undefined),
+    getChainContext: jest.fn().mockReturnValue(''),
+    generateLensesForAgents: jest.fn().mockResolvedValue(new Map()),
+    dispatchParallel: jest.fn().mockResolvedValue({ taskIds: [], errors: [] }),
+    dispatchParallelWithLenses: jest.fn().mockResolvedValue({ taskIds: [], errors: [] }),
+    getTask: jest.fn().mockReturnValue(null),
+    scopeTracker: {
+      hasOverlap: jest.fn().mockReturnValue({ overlaps: false }),
+      register: jest.fn(),
+      release: jest.fn(),
+    },
+    pipeline: null,
+    projectRoot: process.cwd(),
+  };
+}
+
+function resetCtx() {
+  ctx.mainAgent = makeMainAgent();
+  ctx.nativeTaskMap = new Map();
+  ctx.nativeResultMap = new Map();
+  ctx.nativeAgentConfigs = new Map();
+  ctx.pendingConsensusRounds = new Map();
+  ctx.booted = true;
+  ctx.boot = jest.fn().mockResolvedValue(undefined) as any;
+  ctx.syncWorkersViaKeychain = jest.fn().mockResolvedValue(undefined) as any;
+  (ctx as any).skillEngine = null;
+}
+
+function restoreCtx() {
+  Object.assign(ctx, originalCtx);
+}
+
+function findAgentPromptItem(content: Array<{ text: string }>): { text: string } | undefined {
+  return content.find(c => c.text.startsWith('AGENT_PROMPT:'));
+}
+
+function registerNativeAgent(id: string = 'native-claude') {
+  ctx.nativeAgentConfigs.set(id, {
+    model: 'claude-sonnet-4-6',
+    instructions: 'You are a reviewer.',
+    description: 'Native reviewer',
+    skills: [],
+  });
+}
+
+describe('dispatch elision (Option B server-side prompt elision)', () => {
+  let workDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    workDir = mkdtempSync(join(tmpdir(), 'gossip-elision-'));
+    mkdirSync(join(workDir, '.gossip', 'skills'), { recursive: true });
+    process.chdir(workDir);
+    resetCtx();
+  });
+
+  afterEach(() => {
+    restoreCtx();
+    process.chdir(prevCwd);
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  describe('handleDispatchSingle', () => {
+    it('inline (default) preserves the two-item content split with AGENT_PROMPT', async () => {
+      registerNativeAgent();
+      const result = await handleDispatchSingle('native-claude', 'Audit x');
+      expect(result.content).toHaveLength(2);
+      const promptItem = findAgentPromptItem(result.content);
+      expect(promptItem).toBeDefined();
+      expect(promptItem!.text).toContain('--- FINDING TAG SCHEMA ---');
+      // No on-disk file should have been written.
+      expect(existsSync(join(workDir, '.gossip', 'dispatch-prompts'))).toBe(false);
+    });
+
+    it('elided omits Item 2 entirely and writes the prompt body to disk', async () => {
+      registerNativeAgent();
+      const result = await handleDispatchSingle(
+        'native-claude', 'Audit x',
+        undefined, undefined, undefined, undefined, undefined,
+        undefined, 'elided',
+      );
+      // Item 2 ABSENT — only Item 1.
+      expect(result.content).toHaveLength(1);
+      expect(findAgentPromptItem(result.content)).toBeUndefined();
+
+      // Item 1 must cite the on-disk path with byte count.
+      const item1 = result.content[0].text;
+      expect(item1).toMatch(/\[skills section elided: see .+dispatch-prompts.+\.txt, \d+ bytes/);
+
+      // On-disk file must exist and carry the FINDING TAG SCHEMA.
+      const dir = join(workDir, '.gossip', 'dispatch-prompts');
+      expect(existsSync(dir)).toBe(true);
+      const files = require('fs').readdirSync(dir).filter((f: string) => f.endsWith('.txt'));
+      expect(files).toHaveLength(1);
+      const body = readFileSync(join(dir, files[0]), 'utf8');
+      expect(body).toContain('--- FINDING TAG SCHEMA ---');
+    });
+
+    it('elided on-disk file contains NO relay_token or task_id orchestration metadata', async () => {
+      registerNativeAgent();
+      await handleDispatchSingle(
+        'native-claude', 'Audit x',
+        undefined, undefined, undefined, undefined, undefined,
+        undefined, 'elided',
+      );
+      const dir = join(workDir, '.gossip', 'dispatch-prompts');
+      const files = require('fs').readdirSync(dir).filter((f: string) => f.endsWith('.txt'));
+      const body = readFileSync(join(dir, files[0]), 'utf8');
+      // relay_token MUST stay in Item 1 only (spec §5 two-item invariant).
+      expect(body).not.toMatch(/relay_token/i);
+      // The literal phrase REQUIRED_NEXT_ACTION belongs to orchestration framing.
+      expect(body).not.toContain('REQUIRED_NEXT_ACTION');
+      // The on-disk file is the PROMPT BODY — not the orchestrator banner. It
+      // should NOT carry the AGENT_PROMPT: tag prefix used in the inline path.
+      expect(body.startsWith('AGENT_PROMPT:')).toBe(false);
+    });
+
+    it('elided persists promptPath on the nativeTaskMap entry for crash recovery', async () => {
+      registerNativeAgent();
+      const _result = await handleDispatchSingle(
+        'native-claude', 'Audit x',
+        undefined, undefined, undefined, undefined, undefined,
+        undefined, 'elided',
+      );
+      void _result;
+      const entries = [...ctx.nativeTaskMap.values()];
+      expect(entries).toHaveLength(1);
+      expect(entries[0].promptPath).toBeDefined();
+      expect(entries[0].promptPath).toMatch(/dispatch-prompts.+\.txt$/);
+    });
+  });
+
+  describe('handleDispatchParallel', () => {
+    it('inline (default) emits one AGENT_PROMPT item per native task', async () => {
+      registerNativeAgent('native-a');
+      registerNativeAgent('native-b');
+      const result = await handleDispatchParallel(
+        [
+          { agent_id: 'native-a', task: 'X' },
+          { agent_id: 'native-b', task: 'Y' },
+        ],
+        false,
+      );
+      const promptItems = result.content.filter((c: any) => c.text.startsWith('AGENT_PROMPT:'));
+      expect(promptItems).toHaveLength(2);
+    });
+
+    it('elided emits ZERO AGENT_PROMPT items and writes one file per task', async () => {
+      registerNativeAgent('native-a');
+      registerNativeAgent('native-b');
+      const result = await handleDispatchParallel(
+        [
+          { agent_id: 'native-a', task: 'X' },
+          { agent_id: 'native-b', task: 'Y' },
+        ],
+        false,
+        undefined,
+        'elided',
+      );
+      const promptItems = result.content.filter((c: any) => c.text.startsWith('AGENT_PROMPT:'));
+      expect(promptItems).toHaveLength(0);
+
+      const dir = join(workDir, '.gossip', 'dispatch-prompts');
+      const files = require('fs').readdirSync(dir).filter((f: string) => f.endsWith('.txt'));
+      expect(files).toHaveLength(2);
+    });
+  });
+
+  describe('handleDispatchConsensus (Phase 1 cross-review)', () => {
+    it('inline (default) emits AGENT_PROMPT items embedding the CONSENSUS OUTPUT FORMAT', async () => {
+      registerNativeAgent();
+      const result = await handleDispatchConsensus([
+        { agent_id: 'native-claude', task: 'Audit' },
+      ]);
+      const promptItem = findAgentPromptItem(result.content);
+      expect(promptItem).toBeDefined();
+      expect(promptItem!.text).toContain('--- CONSENSUS OUTPUT FORMAT');
+    });
+
+    it('elided omits AGENT_PROMPT items and writes one file per consensus participant', async () => {
+      registerNativeAgent('native-a');
+      registerNativeAgent('native-b');
+      const result = await handleDispatchConsensus(
+        [
+          { agent_id: 'native-a', task: 'Audit X' },
+          { agent_id: 'native-b', task: 'Audit Y' },
+        ],
+        undefined,
+        undefined,
+        'elided',
+      );
+      const promptItems = result.content.filter((c: any) => c.text.startsWith('AGENT_PROMPT:'));
+      expect(promptItems).toHaveLength(0);
+      const dir = join(workDir, '.gossip', 'dispatch-prompts');
+      const files = require('fs').readdirSync(dir).filter((f: string) => f.endsWith('.txt'));
+      expect(files).toHaveLength(2);
+      // Both files must carry the consensus framing — proves agentPrompt was
+      // actually written, not an empty placeholder.
+      for (const f of files) {
+        const body = readFileSync(join(dir, f), 'utf8');
+        expect(body).toContain('--- CONSENSUS OUTPUT FORMAT');
+      }
+    });
+  });
+});

--- a/tests/orchestrator/dispatch-elision.test.ts
+++ b/tests/orchestrator/dispatch-elision.test.ts
@@ -216,6 +216,54 @@ describe('dispatch elision (Option B server-side prompt elision)', () => {
       const files = require('fs').readdirSync(dir).filter((f: string) => f.endsWith('.txt'));
       expect(files).toHaveLength(2);
     });
+
+    it('phase-2 read-path: marker in Item 1 cites a readable file whose content round-trips', async () => {
+      // Arrange — single agent so there is exactly one marker to parse.
+      registerNativeAgent('native-a');
+      const taskDescription = 'Phase-2 lifecycle read-path test task';
+
+      // Act — dispatch with elision.
+      const result = await handleDispatchParallel(
+        [{ agent_id: 'native-a', task: taskDescription }],
+        false,
+        undefined,
+        'elided',
+      );
+
+      // Item 2 must be absent.
+      const promptItems = result.content.filter((c: any) => c.text.startsWith('AGENT_PROMPT:'));
+      expect(promptItems).toHaveLength(0);
+
+      // Item 1 must contain the marker with an absolute path and byte count.
+      const item1 = result.content.find((c: any) =>
+        c.text.includes('[skills section elided: see ')
+      );
+      expect(item1).toBeDefined();
+      const markerMatch = item1!.text.match(
+        /\[skills section elided: see (.+\.txt), (\d+) bytes/
+      );
+      expect(markerMatch).not.toBeNull();
+
+      const promptPath = markerMatch![1];
+      const markerBytes = parseInt(markerMatch![2], 10);
+
+      // Assert — file is readable and round-trips.
+      const body = readFileSync(promptPath, 'utf8');
+
+      // Body must contain the FINDING TAG SCHEMA block injected by assemblePrompt.
+      expect(body).toContain('--- FINDING TAG SCHEMA ---');
+
+      // Body must contain the task description.
+      expect(body).toContain(taskDescription);
+
+      // relay_token and task_id orchestration metadata MUST NOT appear in the body.
+      expect(body).not.toMatch(/relay_token/i);
+      expect(body).not.toMatch(/\btask_id\b/);
+
+      // Byte-length must match the marker's advertised size.
+      const actualBytes = Buffer.byteLength(body, 'utf8');
+      expect(actualBytes).toBe(markerBytes);
+    });
   });
 
   describe('handleDispatchConsensus (Phase 1 cross-review)', () => {


### PR DESCRIPTION
## Summary
- Implements Phase 1 of Option B from `docs/specs/2026-05-18-native-dispatch-skill-handle-pattern.md` (gitignored): opt-in `prompt_format: 'elided'` strips skill bodies from the orchestrator-visible dispatch response, writing them to `.gossip/dispatch-prompts/<taskId>.txt` for the orchestrator to Read and forward verbatim to `Agent()`.
- Estimated savings: ~30 KB per dispatch × N post-dispatch turns; ~900 KB cumulative across a typical 3+3 consensus round with 5 follow-up turns.
- Strictly opt-in — default `'inline'` preserves current behavior byte-exactly; old orchestrators are unaffected.

## Iron rules (post-consensus `ea473d6a-88ff402b`)
1. Strict opt-in — elide only when `prompt_format: 'elided'` is explicit. No heuristics.
2. Item 2 ABSENT under elision (not a skeleton). If orchestrator skips the Read step, `Agent()` fails loudly.
3. All three dispatch schemas accept `prompt_format`: `gossip_dispatch`, `gossip_run`, `gossip_collect`.
4. `{taskId, promptPath}` persisted in `.gossip/native-tasks.json` for crash-recovery orphan validation.
5. HANDBOOK §4 two-item split preserved — on-disk prompt contains ONLY the agent-facing prompt (no `relay_token`, no `task_id`).

## Files
- **NEW** `apps/cli/src/handlers/dispatch-prompt-storage.ts` (203 LOC) — atomic write-to-temp+rename, `SAFE_TASK_ID` fail-closed regex, mtime-based eviction (1h default), 100MB aggregate cap with eldest-first eviction, orphan prune.
- **MOD** `apps/cli/src/handlers/dispatch.ts` (+117) — `elidePromptIfRequested()` helper applied at single/parallel/consensus dispatch sites; Item 2 omitted via spread `...(elision.elided ? [] : [...])`.
- **MOD** `apps/cli/src/handlers/collect.ts` (+50) — Phase-2 cross-review propagates `prompt_format` through `handleCollect`.
- **MOD** `apps/cli/src/handlers/native-tasks.ts` (+37) — `pruneOrphanDispatchPrompts` wired into `restoreNativeTaskMap`; `scheduleNativeTaskEviction` runs hourly `cleanupExpiredDispatchPrompts` on the same interval.
- **MOD** `apps/cli/src/mcp-context.ts` (+8) — `NativeTaskInfo.promptPath?: string`, round-trips through existing JSON persistence.
- **MOD** `apps/cli/src/mcp-server-sdk.ts` (+30) — `prompt_format: z.enum(['inline','elided']).default('inline')` added to all three tool schemas.
- **NEW** `tests/orchestrator/dispatch-elision.test.ts` (305 LOC, 9 tests).
- **NEW** `tests/cli/native-tasks.test.ts` (166 LOC, 14 tests).
- **MOD** `docs/HANDBOOK.md` §4 — elision protocol + example consensus flow.

## Consensus
Reviewed in consensus \`8f74076f-e2dc4bb7\` (3 agents: sonnet-reviewer, gemini-reviewer, gemini-tester). Round 1 produced 12 findings: 6 confirmed, 0 disputed, 6 unique. Round 2 cross-review AGREE'd on 8/8 peer findings against worktree code.

**Addressed in fixup commit \`ed7fba3\`:**
- \`sonnet:f9\` (MED) — \`collect.ts:772-774\` safeId now collapses \`..\` sequences after sanitizer to keep \`SAFE_TASK_ID\` happy on malformed agent IDs.
- \`sonnet:f10\` (MED) — \`collect.ts:12,194\` imports \`PromptFormat\` from \`dispatch.ts\` instead of re-declaring inline (drift prevention).
- \`sonnet:f11\` (LOW) — \`dispatch.ts:895-912\` hoists \`persistNativeTaskMap()\` out of parallel-elision per-task loop (N writes → 1 write).
- \`gemini-reviewer:f1\` (LOW) — \`dispatch-prompt-storage.ts:181-182\` counters now increment independently when a file is both orphaned AND too old.
- \`gemini-tester:f4\` (HIGH) — \`dispatch-elision.test.ts:220-269\` new Phase-2 read-path test: parses marker, \`readFileSync\`, asserts body roundtrips byte-exactly, contains task content, has no \`relay_token\`/\`task_id\`, byte-length matches advertised \`<N>\`.

**Deferred** (gemini-tester f5/f6/f7/f8): crash-recovery integration test, atomic-write failure-path test, concurrent writeDispatchPrompt test, tighten eviction assertion. Filed as a follow-up issue.

## Test plan
- [x] \`npm run build\` (workspace): clean
- [x] \`npm run build:mcp\` (esbuild → dist-mcp/): clean, 2.0MB
- [x] \`npx jest tests/orchestrator/dispatch-elision tests/cli/native-tasks\`: 23/23 pass
- [x] \`npx jest tests/cli/dispatch-native-prompt\`: 35 pass / 8 skipped (no regression)
- [ ] CI green
- [ ] Manual test: \`/mcp\` reconnect, dispatch native agent with \`prompt_format: 'elided'\`, verify orchestrator Read-then-Agent round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)