### PR TITLE
tests(dispatch-elision): backfill 4 deferred test gaps from consensus 8f74076f

### DIFF
--- a/tests/cli/native-tasks.test.ts
+++ b/tests/cli/native-tasks.test.ts
@@ -85,7 +85,7 @@ describe('dispatch-prompt storage', () => {
       expect(existsSync(stale)).toBe(false);
     });
 
-    it('enforces aggregate cap with eldest-eviction', () => {
+    it('enforces aggregate cap with eldest-eviction (exact count + ordering)', () => {
       const root = mkRoot();
       // Three small files, but pass a tiny capBytes to force eviction.
       const a = writeDispatchPrompt(root, 'a', 'A'.repeat(100));
@@ -97,10 +97,14 @@ describe('dispatch-prompt storage', () => {
       setMtime(c, Date.now() - 10 * 1000);
 
       const { evictedCap } = cleanupExpiredDispatchPrompts(root, 60 * 60 * 1000, 150);
-      // capBytes=150: must drop at least 'a' (100 bytes) to fit two of the
-      // remaining files would still be 200 > 150 so 'b' goes too.
-      expect(evictedCap).toBeGreaterThanOrEqual(1);
+      // capBytes=150 / total=300: drop a (300→200, still >150), drop b
+      // (200→100, ≤150). c (newest) must survive. Exact count enforces the
+      // eldest-first invariant — a >=1 assertion would let a bug that evicts
+      // c instead of a slip through.
+      expect(evictedCap).toBe(2);
       expect(existsSync(a)).toBe(false);
+      expect(existsSync(b)).toBe(false);
+      expect(existsSync(c)).toBe(true);
     });
 
     it('returns zero counts when the directory does not exist (fail-open)', () => {
@@ -161,6 +165,49 @@ describe('dispatch-prompt storage', () => {
       const body = '🚀'.repeat(10); // multi-byte unicode
       const p = writeDispatchPrompt(root, 'tid', body);
       expect(statSync(p).size).toBe(Buffer.byteLength(body, 'utf8'));
+    });
+
+    it('on renameSync failure: throws, cleans up .tmp, leaves no partial target', () => {
+      const root = mkRoot();
+      // Seed the directory so subsequent readdir is non-empty after failure.
+      writeDispatchPrompt(root, 'seed', 'seed');
+      const fs = require('fs');
+      const spy = jest.spyOn(fs, 'renameSync').mockImplementationOnce(() => {
+        throw new Error('simulated rename failure');
+      });
+      try {
+        expect(() => writeDispatchPrompt(root, 'failtid', 'body')).toThrow(/simulated rename failure/);
+      } finally {
+        spy.mockRestore();
+      }
+      const dir = join(root, '.gossip', 'dispatch-prompts');
+      const files = readdirSync(dir);
+      // No .tmp leftover (catch block must unlink).
+      expect(files.some(f => f.startsWith('failtid.') && f.endsWith('.tmp'))).toBe(false);
+      // No partial target file at the final path.
+      expect(files.includes('failtid.txt')).toBe(false);
+      // Seed survives — failure is isolated to the failing call.
+      expect(files.includes('seed.txt')).toBe(true);
+    });
+  });
+
+  describe('writeDispatchPrompt concurrency (same taskId)', () => {
+    it('N concurrent calls all resolve, no .tmp leftover, final body is one of the inputs', async () => {
+      const root = mkRoot();
+      const bodies = Array.from({ length: 5 }, (_, i) => `body-${i}`);
+      // Promise.all over sync writeFileSync/renameSync — last-write-wins semantics
+      // since rename is atomic and each call has a unique random .tmp suffix.
+      const paths = await Promise.all(bodies.map(b => Promise.resolve().then(() => writeDispatchPrompt(root, 'tid', b))));
+      // All calls returned the same final path.
+      expect(new Set(paths).size).toBe(1);
+      const dir = join(root, '.gossip', 'dispatch-prompts');
+      const files = readdirSync(dir);
+      // No temp files leaked.
+      expect(files.every(f => !f.endsWith('.tmp'))).toBe(true);
+      // Final file exists with content equal to one of the 5 inputs.
+      expect(files).toContain('tid.txt');
+      const final = readFileSync(join(dir, 'tid.txt'), 'utf8');
+      expect(bodies).toContain(final);
     });
   });
 });

--- a/tests/orchestrator/dispatch-elision.test.ts
+++ b/tests/orchestrator/dispatch-elision.test.ts
@@ -180,6 +180,42 @@ describe('dispatch elision (Option B server-side prompt elision)', () => {
       expect(entries[0].promptPath).toBeDefined();
       expect(entries[0].promptPath).toMatch(/dispatch-prompts.+\.txt$/);
     });
+
+    it('crash-recovery integration: restoreNativeTaskMap prunes orphan prompt files but preserves tracked tasks', async () => {
+      // Arrange — one elided dispatch creates a tracked prompt file.
+      registerNativeAgent();
+      await handleDispatchSingle(
+        'native-claude', 'Audit x',
+        undefined, undefined, undefined, undefined, undefined,
+        undefined, 'elided',
+      );
+      const trackedIds = [...ctx.nativeTaskMap.keys()];
+      expect(trackedIds).toHaveLength(1);
+      const trackedId = trackedIds[0];
+
+      const dir = join(workDir, '.gossip', 'dispatch-prompts');
+      const trackedPath = join(dir, `${trackedId}.txt`);
+      expect(existsSync(trackedPath)).toBe(true);
+
+      // Simulate a previous-session abandonment: an extra prompt file on disk
+      // whose taskId is not present in the restored nativeTaskMap.
+      const { writeFileSync } = require('fs');
+      const orphanPath = join(dir, 'orphan-from-crash.txt');
+      writeFileSync(orphanPath, 'stranded body from a crashed prior session', 'utf8');
+      expect(existsSync(orphanPath)).toBe(true);
+
+      // Act — simulate /mcp boot. restoreNativeTaskMap reads (absent)
+      // native-tasks.json and then calls pruneOrphanDispatchPrompts with the
+      // known set derived from ctx.nativeTaskMap.keys() (= {trackedId}).
+      const { restoreNativeTaskMap } = require('../../apps/cli/src/handlers/native-tasks');
+      // Wire projectRoot on mainAgent so the dispatch-prompts dir resolves under workDir.
+      ctx.mainAgent.projectRoot = workDir;
+      restoreNativeTaskMap(workDir);
+
+      // Assert — orphan gone, tracked file survives.
+      expect(existsSync(orphanPath)).toBe(false);
+      expect(existsSync(trackedPath)).toBe(true);
+    });
   });
 
   describe('handleDispatchParallel', () => {


### PR DESCRIPTION
## Summary
Closes the four MEDIUM/LOW findings deferred out of PR #398 (Phase 1 prompt elision). All four target dispatch-prompt storage edge cases that were unit-covered for the happy path but lacked failure / concurrency / integration coverage.

- **f5 (crash-recovery integration)** — `tests/orchestrator/dispatch-elision.test.ts`: dispatch elided, plant orphan, call `restoreNativeTaskMap`, assert orphan pruned + tracked survives.
- **f6 (atomic-write failure)** — `tests/cli/native-tasks.test.ts`: mock `renameSync` to throw; assert no `.tmp`, no partial target, seed survives.
- **f7 (concurrent same-taskId writes)** — `tests/cli/native-tasks.test.ts`: `Promise.all` of 5 writes; documents last-write-wins, no `.tmp` leak.
- **f8 (tighten cap-eviction)** — `tests/cli/native-tasks.test.ts`: `>=1` → exact `2`; assert eldest-first ordering (a + b gone, c survives).

## Test plan
- [x] `npx jest tests/cli/native-tasks.test.ts tests/orchestrator/dispatch-elision.test.ts` — 26/26 pass
- [x] Pre-existing typecheck errors unchanged (dashboard-v2 JSX, PerformanceWriter.appendSignals — unrelated)
- [x] f5 stderr log `prune on boot: orphans=1 aged=0` confirms integration path exercised

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)