### PR TITLE
feat(orchestrator): LoadSkillsResult.paths — prerequisite for Phase 2 warm cache

### DIFF
--- a/packages/orchestrator/src/skill-loader.ts
+++ b/packages/orchestrator/src/skill-loader.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync, readdirSync } from 'fs';
+import { readFileSync, existsSync, readdirSync, realpathSync } from 'fs';
 import { resolve, sep } from 'path';
 import type { SkillIndex } from './skill-index';
 import { parseSkillFrontmatter } from './skill-parser';
@@ -108,6 +108,14 @@ export interface LoadSkillsResult {
    * `dispatchTaskType` is provided and a skill's `scope` array matches it.
    */
   loadedScoped: string[];
+  /**
+   * Resolved absolute paths of every skill file successfully loaded into `content`.
+   * Index-aligned with `loaded` (paths[i] is the resolved path of loaded[i]).
+   * Realpath-normalized so symlinked skills dedupe correctly. Empty array when
+   * no skills loaded. Consumers (e.g. dispatch-prompt warm cache) use these paths
+   * + their mtimeMs to build a skill-set fingerprint without re-walking the FS.
+   */
+  paths: string[];
 }
 
 /**
@@ -167,17 +175,19 @@ export function loadSkills(
   // Load kill-switch config once per invocation (not inside the loop).
   const memConfig = loadMemoryConfig(projectRoot);
 
-  const permanent: Array<{ name: string; content: string }> = [];
-  const scoped: Array<{ name: string; content: string }> = [];
-  const contextualCandidates: Array<{ name: string; content: string; hits: number; rawHits: number; boost: number }> = [];
+  const permanent: Array<{ name: string; content: string; path: string }> = [];
+  const scoped: Array<{ name: string; content: string; path: string }> = [];
+  const contextualCandidates: Array<{ name: string; content: string; path: string; hits: number; rawHits: number; boost: number }> = [];
   const loaded: string[] = [];
+  const paths: string[] = [];
   const dropped: DroppedSkill[] = [];
   const activatedContextual: string[] = [];
   const loadedScoped: string[] = [];
 
   for (const skill of effectiveSkills) {
-    const content = resolveSkill(agentId, skill, projectRoot);
-    if (!content) continue;
+    const resolved = resolveSkill(agentId, skill, projectRoot);
+    if (!resolved) continue;
+    const { content, path: resolvedPath } = resolved;
 
     // Filter by skill effectiveness status written by checkEffectiveness().
     // 'failed' and 'silent_skill' are suppressed — injecting a skill the RL loop
@@ -271,7 +281,7 @@ export function loadSkills(
     if (skillScope && skillScope.length > 0) {
       if (!dispatchTaskType || skillScope.includes(dispatchTaskType)) {
         // Scope matches (or no dispatch type known) — inject unconditionally.
-        scoped.push({ name: skill, content });
+        scoped.push({ name: skill, content, path: resolvedPath });
       } else {
         // Scope declared but dispatch type not in the list.
         dropped.push({ skill, reason: 'scope-type-mismatch', hits: 0 });
@@ -298,7 +308,7 @@ export function loadSkills(
     const mode = index?.getSkillMode(agentId, skill) ?? 'permanent';
 
     if (mode === 'permanent') {
-      permanent.push({ name: skill, content });
+      permanent.push({ name: skill, content, path: resolvedPath });
     } else if (task) {
       const rawHits = countKeywordHits(content, skill, task);
       const frontmatter = parseSkillFrontmatter(content);
@@ -309,7 +319,7 @@ export function loadSkills(
       // but a 1-hit skill with boost passes (1.5 >= 1) and outranks plain
       // 1-hit candidates during the descending sort below.
       if (effectiveHits >= MIN_KEYWORD_HITS) {
-        contextualCandidates.push({ name: skill, content, hits: effectiveHits, rawHits, boost });
+        contextualCandidates.push({ name: skill, content, path: resolvedPath, hits: effectiveHits, rawHits, boost });
       } else {
         // Report raw hits so operators see the real keyword-match count; boost
         // already failed to rescue, so recording effective hits would hide the
@@ -335,13 +345,22 @@ export function loadSkills(
   const accepted = contextualCandidates.slice(0, MAX_CONTEXTUAL_SKILLS);
   const rejected = contextualCandidates.slice(MAX_CONTEXTUAL_SKILLS);
 
-  for (const s of permanent) loaded.push(s.name);
+  // Iteration order here defines the index-alignment of `paths` with `loaded`:
+  // permanent → scoped → accepted (contextual). Both arrays must push in the
+  // same order so consumers can rely on paths[i] being the resolved path of
+  // loaded[i] (see LoadSkillsResult.paths docstring).
+  for (const s of permanent) {
+    loaded.push(s.name);
+    paths.push(s.path);
+  }
   for (const s of scoped) {
     loaded.push(s.name);
+    paths.push(s.path);
     loadedScoped.push(s.name);
   }
   for (const s of accepted) {
     loaded.push(s.name);
+    paths.push(s.path);
     activatedContextual.push(s.name);
   }
   for (const s of rejected) dropped.push({ skill: s.name, reason: 'budget-exceeded', hits: s.hits });
@@ -358,7 +377,7 @@ export function loadSkills(
     ? '\n\n--- SKILLS ---\n\n' + sections.join('\n\n---\n\n') + '\n\n--- END SKILLS ---\n\n'
     : '';
 
-  return { content: contentStr, loaded, dropped, activatedContextual, loadedScoped };
+  return { content: contentStr, loaded, paths, dropped, activatedContextual, loadedScoped };
 }
 
 /** Cache compiled regex patterns to avoid per-dispatch recompilation */
@@ -424,7 +443,20 @@ function getKeywords(content: string, skillName: string): string[] {
   return [skillName.replace(/-/g, ' ')];
 }
 
-function resolveSkill(agentId: string, skill: string, projectRoot: string): string | null {
+/**
+ * Resolve a skill name to its file content and resolved absolute path.
+ * Returns `null` if no resolution path produced a readable file.
+ *
+ * The `path` field is realpath-normalized (so symlinked skills dedupe with
+ * their target) when realpathSync succeeds; on realpathSync failure we fall
+ * back to the non-realpath'd absolute path so a transient FS error never
+ * fails the load.
+ */
+function resolveSkill(
+  agentId: string,
+  skill: string,
+  projectRoot: string,
+): { content: string; path: string } | null {
   // Sanitize agentId to prevent path traversal
   if (!SAFE_AGENT_ID.test(agentId)) return null;
 
@@ -450,7 +482,18 @@ function resolveSkill(agentId: string, skill: string, projectRoot: string): stri
       // entire gossip_dispatch call. Now we log and fall through to the next
       // base (or return null) instead.
       try {
-        return readFileSync(candidate, 'utf-8');
+        const content = readFileSync(candidate, 'utf-8');
+        // Realpath-normalize so symlinked skills collapse to a single fingerprint
+        // entry. If realpathSync throws (broken symlink, permissions), fall back
+        // to the non-realpath'd candidate — a fingerprint glitch is better than
+        // failing the load entirely.
+        let path: string;
+        try {
+          path = realpathSync(candidate);
+        } catch {
+          path = candidate;
+        }
+        return { content, path };
       } catch (err: any) {
         _log('skill-loader', `Failed to read skill file ${candidate}: ${err?.message ?? err}`);
         continue;

--- a/tests/orchestrator/skill-loader.test.ts
+++ b/tests/orchestrator/skill-loader.test.ts
@@ -1,7 +1,7 @@
 import { loadSkills } from '@gossip/orchestrator';
 import { listAvailableSkills } from '../../packages/orchestrator/src/skill-loader';
 import { SkillIndex } from '../../packages/orchestrator/src/skill-index';
-import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdirSync, writeFileSync, rmSync, symlinkSync, realpathSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -276,5 +276,122 @@ LRU probe body.
     expect(patternCache.has('keep-hot')).toBe(true);
     expect(patternCache.has('will-evict')).toBe(false);
     expect(patternCache.has('final-key')).toBe(true);
+  });
+});
+
+describe('LoadSkillsResult.paths (warm-cache fingerprint prerequisite)', () => {
+  let tmpDir: string;
+  let index: SkillIndex;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `gossip-paths-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    mkdirSync(join(tmpDir, '.gossip', 'agents', 'test-agent', 'skills'), { recursive: true });
+    mkdirSync(join(tmpDir, '.gossip', 'skills'), { recursive: true });
+    index = new SkillIndex(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns paths: [] when no skills loaded', () => {
+    const result = loadSkills('test-agent', [], tmpDir, index);
+    expect(result.loaded).toEqual([]);
+    expect(result.paths).toEqual([]);
+  });
+
+  it('returns paths: [] when requested skill does not resolve', () => {
+    const result = loadSkills('test-agent', ['definitely-not-a-real-skill-xyz'], tmpDir);
+    expect(result.loaded).toEqual([]);
+    expect(result.paths).toEqual([]);
+  });
+
+  it('paths is index-aligned with loaded for permanent skills', () => {
+    const skillPathA = join(tmpDir, '.gossip', 'skills', 'perm-a.md');
+    const skillPathB = join(tmpDir, '.gossip', 'skills', 'perm-b.md');
+    writeFileSync(skillPathA, `---
+name: perm-a
+description: A
+keywords: []
+mode: permanent
+status: active
+---
+
+permanent A
+`);
+    writeFileSync(skillPathB, `---
+name: perm-b
+description: B
+keywords: []
+mode: permanent
+status: active
+---
+
+permanent B
+`);
+    index.bind('test-agent', 'perm-a', { source: 'config', mode: 'permanent' });
+    index.bind('test-agent', 'perm-b', { source: 'config', mode: 'permanent' });
+
+    const result = loadSkills('test-agent', [], tmpDir, index);
+    expect(result.loaded.length).toBe(result.paths.length);
+    expect(result.loaded.length).toBeGreaterThanOrEqual(2);
+
+    const aIdx = result.loaded.indexOf('perm-a');
+    const bIdx = result.loaded.indexOf('perm-b');
+    expect(aIdx).toBeGreaterThanOrEqual(0);
+    expect(bIdx).toBeGreaterThanOrEqual(0);
+    expect(result.paths[aIdx]).toBe(realpathSync(skillPathA));
+    expect(result.paths[bIdx]).toBe(realpathSync(skillPathB));
+  });
+
+  it('paths is index-aligned with loaded for contextual skills activated by keyword match', () => {
+    const ctxPath = join(tmpDir, '.gossip', 'agents', 'test-agent', 'skills', 'ctx-trust.md');
+    writeFileSync(ctxPath, `---
+name: ctx-trust
+description: Trust ctx
+keywords: [auth, session]
+category: trust_boundaries
+mode: contextual
+status: active
+---
+
+ctx trust body
+`);
+    index.bind('test-agent', 'ctx-trust', { source: 'auto', mode: 'contextual' });
+
+    const result = loadSkills('test-agent', [], tmpDir, index, 'review the auth session handler');
+    expect(result.activatedContextual).toContain('ctx-trust');
+    expect(result.loaded.length).toBe(result.paths.length);
+
+    const idx = result.loaded.indexOf('ctx-trust');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(result.paths[idx]).toBe(realpathSync(ctxPath));
+  });
+
+  it('paths contains realpath-resolved values for symlinked skills', () => {
+    const targetDir = join(tmpDir, 'real-skills');
+    mkdirSync(targetDir, { recursive: true });
+    const targetFile = join(targetDir, 'real-skill.md');
+    writeFileSync(targetFile, `---
+name: linked-skill
+description: linked
+keywords: []
+mode: permanent
+status: active
+---
+
+linked body
+`);
+
+    const linkPath = join(tmpDir, '.gossip', 'agents', 'test-agent', 'skills', 'linked-skill.md');
+    symlinkSync(targetFile, linkPath);
+    index.bind('test-agent', 'linked-skill', { source: 'config', mode: 'permanent' });
+
+    const result = loadSkills('test-agent', [], tmpDir, index);
+    expect(result.loaded).toContain('linked-skill');
+    const idx = result.loaded.indexOf('linked-skill');
+    const expected = realpathSync(targetFile);
+    expect(result.paths[idx]).toBe(expected);
+    expect(result.paths[idx]).not.toBe(linkPath);
   });
 });


### PR DESCRIPTION
## Summary
Prerequisite for Phase 2 dispatch-prompt warm cache (spec at `docs/specs/2026-05-18-dispatch-prompt-warm-cache.md`, consensus `335e8be5-336648b5` f1+f15 — both reviewers independently flagged `LoadSkillsResult.paths` as a blocker before any cache work can start).

- `LoadSkillsResult` gains a `paths: string[]` field — index-aligned with the existing `loaded: string[]`. `paths[i]` is the realpath-normalized absolute path of `loaded[i]`. Empty array when no skills loaded.
- `resolveSkill` refactored to return `{content, path} | null`. Realpath is applied only on the success branch (file exists). If `realpathSync` throws (deletion race between `existsSync` and `realpath`), falls back to the non-normalized path — never fails the load.
- Iteration order in the paths assembly loop (permanent → scoped → accepted) is documented as load-bearing with an explicit comment; consumers rely on the index alignment.

The field is additive — existing callers destructure specific fields, none of which change. Verified by full typecheck pass.

## What's next
After this lands, a follow-up PR adds `packages/orchestrator/src/dispatch-prompt-cache.ts` and the invalidation hooks at the consensus-flagged sites (`skill-engine.ts:548` saveFromRaw, `skill-engine.ts:878` checkEffectiveness writes, `create-agent.ts:107,450` direct instruction writes, plus the existing `gossip_skills` + `gossip_setup` paths). Spec carries the full design.

## Test plan
- [x] `npx jest tests/orchestrator/skill-loader.test.ts` — 22/22 pass (5 new)
- [x] `npx jest tests/orchestrator/skill-loader` — full skill-loader sibling suite 65/65
- [x] `npx tsc --noEmit -p tsconfig.json` — no new errors (pre-existing dashboard-v2 JSX + `PerformanceWriter.appendSignals` errors unchanged)
- [x] Realpath symlink resolution covered by dedicated test
- [x] Index alignment for permanent + contextual skill paths covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
