### PR TITLE
fix(orchestrator): memory-index prototype-key collision crashes gossip_remember(_project)

### DIFF
--- a/packages/orchestrator/src/memory-index-sidecar.ts
+++ b/packages/orchestrator/src/memory-index-sidecar.ts
@@ -274,7 +274,10 @@ function buildDocEntry(filename: string, content: string, mtime: number): Memory
     ...bodyTokens,
   ];
 
-  const terms: { [term: string]: number } = {};
+  // Prototype-less — terms keyed by tokens from user content; "constructor",
+  // "toString", etc. would otherwise return inherited prototype values from
+  // doc.terms[term] lookups in bm25Score.
+  const terms: { [term: string]: number } = Object.create(null);
   for (const t of allTokens) {
     terms[t] = (terms[t] || 0) + 1;
   }
@@ -297,7 +300,16 @@ function buildDocEntry(filename: string, content: string, mtime: number): Memory
 }
 
 function buildPostings(docs: MemoryIndex['docs']): MemoryIndex['postings'] {
-  const postings: MemoryIndex['postings'] = {};
+  // Object.create(null) — postings/docs are tokenized term keys. A term that
+  // collides with a built-in prototype name ('constructor', 'toString',
+  // 'valueOf', '__proto__', etc.) would otherwise return the inherited
+  // prototype value on lookup, making `postings[term]` truthy without ever
+  // having been set. The `if (!postings[term])` init branch would skip,
+  // and `postings[term].docs.push(...)` would crash on `undefined.push`.
+  // Reproduced as "Cannot read properties of undefined (reading 'push')"
+  // when a memory file contains the word "constructor" (issue: contributor
+  // bug report 2026-05-19). Prototype-less object closes the class.
+  const postings: MemoryIndex['postings'] = Object.create(null);
   for (const [filename, doc] of Object.entries(docs)) {
     for (const term of Object.keys(doc.terms)) {
       if (!postings[term]) {
@@ -327,17 +339,51 @@ function tryLoadIndex(indexPath: string): MemoryIndex | null {
     const raw = readFileSync(indexPath, 'utf-8');
     const parsed = JSON.parse(raw) as MemoryIndex;
     if (parsed.version !== 1) return null;
-    return parsed;
+    // JSON.parse always returns objects inheriting Object.prototype. Rewrap
+    // the term-keyed maps as prototype-less so reader-side `postings[term]`
+    // lookups for prototype-name collisions (e.g. "constructor") return
+    // undefined instead of the inherited prototype value. Mirrors the
+    // buildPostings(Object.create(null)) write-side fix.
+    return reseatPrototypelessMaps(parsed);
   } catch {
     return null;
   }
 }
 
 /**
+ * Rebind the term-keyed sub-maps (`postings`) and filename-keyed sub-map
+ * (`docs`) on a parsed-from-JSON MemoryIndex onto prototype-less objects.
+ * Without this rewrap, a memory file whose body contains a token equal to
+ * any `Object.prototype` member name causes lookup-side crashes — see
+ * `buildPostings` comment above for the failure mode.
+ */
+function reseatPrototypelessMaps(index: MemoryIndex): MemoryIndex {
+  const safeDocs: MemoryIndex['docs'] = Object.create(null);
+  for (const [filename, doc] of Object.entries(index.docs ?? {})) {
+    // Rewrap each doc's per-term frequency map as well — bm25Score reads
+    // `doc.terms[term]` and a 'constructor' collision would otherwise leak
+    // through to a non-numeric inherited function value.
+    const safeTerms: { [term: string]: number } = Object.create(null);
+    for (const [term, tf] of Object.entries(doc.terms ?? {})) {
+      safeTerms[term] = tf;
+    }
+    safeDocs[filename] = { ...doc, terms: safeTerms };
+  }
+  const safePostings: MemoryIndex['postings'] = Object.create(null);
+  for (const [term, entry] of Object.entries(index.postings ?? {})) {
+    safePostings[term] = { df: entry.df, docs: [...(entry.docs ?? [])] };
+  }
+  return { ...index, docs: safeDocs, postings: safePostings };
+}
+
+/**
  * Build a complete fresh index from the corpus directory.
  */
 export function buildFullIndex(corpusDirectory: string): MemoryIndex {
-  const docs: MemoryIndex['docs'] = {};
+  // Filename keys are user-controlled (markdown files in the auto-memory
+  // dir). A file literally named "constructor.md" would hit the same
+  // prototype-name lookup hazard as the postings map. Prototype-less map.
+  const docs: MemoryIndex['docs'] = Object.create(null);
 
   if (existsSync(corpusDirectory)) {
     let files: string[];
@@ -396,7 +442,10 @@ function incrementalRebuild(
     return { index: existing, changed: false };
   }
 
-  const newDocs: MemoryIndex['docs'] = { ...existing.docs };
+  // Prototype-less to match buildFullIndex/tryLoadIndex contract — see
+  // reseatPrototypelessMaps + buildPostings comments above. Without this,
+  // existing.docs from JSON.parse leaks Object.prototype back in.
+  const newDocs: MemoryIndex['docs'] = Object.assign(Object.create(null), existing.docs);
   let changed = false;
 
   const diskFilenames = new Set(files);

--- a/tests/orchestrator/memory-index-sidecar.test.ts
+++ b/tests/orchestrator/memory-index-sidecar.test.ts
@@ -683,3 +683,82 @@ describe('tryAcquireLockOnce', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Prototype-key collision regression — reported 2026-05-19 by audit-team
+// orchestrator. _project corpus containing the token "constructor" crashed
+// gossip_remember with "Cannot read properties of undefined (reading 'push')"
+// because `postings = {}` inherits Object.prototype.constructor. Fixed by
+// switching the relevant maps to Object.create(null). These tests lock the
+// fix and exercise both fresh-corpus and reload-from-disk paths.
+// ---------------------------------------------------------------------------
+
+describe('prototype-key collision in index maps', () => {
+  let projectRoot: string;
+  let corpus: string;
+  beforeEach(() => {
+    projectRoot = makeProjectDir();
+    corpus = join(homedir(), '.claude', 'projects', projectRoot.replace(/\//g, '-'), 'memory');
+    mkdirSync(corpus, { recursive: true });
+  });
+  afterEach(() => {
+    try { rmSync(projectRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+    try { rmSync(corpus, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('buildFullIndex does not throw when a corpus file body contains "constructor"', () => {
+    writeMd(corpus, 'project_a.md', frontmatterMd({ name: 'A', type: 'project' }, 'discusses constructor patterns'));
+    writeMd(corpus, 'project_b.md', frontmatterMd({ name: 'B', type: 'project' }, 'tostring valueof hasownproperty'));
+    expect(() => buildFullIndex(corpus)).not.toThrow();
+  });
+
+  it('postings/constructor is a real entry, not Object.prototype.constructor', () => {
+    writeMd(corpus, 'doc.md', frontmatterMd({ name: 'D' }, 'this body talks about constructor and tostring'));
+    const index = buildFullIndex(corpus);
+    // 'constructor' would otherwise be Object.prototype.constructor (the Object function).
+    // After the Object.create(null) fix, the entry is either a proper {df, docs} record
+    // or undefined — never the prototype function.
+    const proto = index.postings['constructor'];
+    if (proto !== undefined) {
+      expect(typeof proto).toBe('object');
+      expect(Array.isArray(proto.docs)).toBe(true);
+      expect(proto.df).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('rankDocuments does not throw when query terms include prototype-name tokens', () => {
+    writeMd(corpus, 'doc.md', frontmatterMd({ name: 'D' }, 'mentions constructor here'));
+    const index = buildFullIndex(corpus);
+    expect(() => rankDocuments(['constructor'], index)).not.toThrow();
+    // The "tostring" token never appears in the corpus, so any prototype-name
+    // lookup must return zero matches rather than crashing on inherited props.
+    expect(() => rankDocuments(['tostring'], index)).not.toThrow();
+    expect(rankDocuments(['tostring'], index)).toEqual([]);
+  });
+
+  it('rebuildIndex round-trips through JSON without re-introducing prototype leakage', () => {
+    writeMd(corpus, 'doc.md', frontmatterMd({ name: 'D' }, 'body with constructor and tostring'));
+    rebuildIndex(projectRoot);
+    // Reload via the public loadIndex path (the one searchCorpus uses).
+    // tryLoadIndex re-wraps maps prototype-less; rankDocuments must not throw.
+    // We deliberately exercise the read path that previously crashed.
+    expect(() => {
+      const second = rebuildIndex(projectRoot);
+      rankDocuments(['constructor', 'tostring'], second);
+    }).not.toThrow();
+  });
+
+  it('gossip_remember(_project) repro returns without throwing on "constructor" corpus', async () => {
+    // Black-box test using the exact MemorySearcher path that gossip_remember
+    // wires up in mcp-server-sdk.ts.
+    const { MemorySearcher } = await import('@gossip/orchestrator');
+    writeMd(corpus, 'project_solidity.md', frontmatterMd(
+      { name: 'solidity-notes', type: 'project' },
+      'audit findings: missing visibility on constructor; reentrancy in fallback',
+    ));
+    const searcher = new MemorySearcher(projectRoot);
+    expect(() => searcher.search('_project', 'constructor reentrancy', 5)).not.toThrow();
+    const results = searcher.search('_project', 'constructor reentrancy', 5);
+    expect(Array.isArray(results)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a prototype-key collision in the memory-index sidecar that crashes `gossip_remember(_project)` when the corpus contains the token `"constructor"` (or any other `Object.prototype` member name). Reported by an audit-team Claude Code orchestrator — independently reproduced and root-caused by this orchestrator on master.

## Symptom

```
mcp__gossipcat__gossip_remember(agent_id: "_project", query: "anything")
→ Error: Cannot read properties of undefined (reading 'push')
```

Per-agent queries (`rust-auditor`, etc.) are unaffected — only `_project` routes through `searchCorpus → loadIndex → buildPostings`, which is the bug site. Severity: medium-high for users with audit/engineering markdown notes — `constructor` is extremely common in Solidity/Rust/JS auditing memory.

## Root cause

`buildPostings` at `packages/orchestrator/src/memory-index-sidecar.ts:307`:

```ts
const postings: MemoryIndex['postings'] = {};   // ← inherits Object.prototype
...
if (!postings[term]) { postings[term] = { df: 0, docs: [] }; }  // ← skipped for 'constructor'
postings[term].df++;                                            // ← writes on Object.prototype.constructor
postings[term].docs.push(filename);                             // ← crashes: Object.prototype.constructor.docs is undefined
```

When `term === 'constructor'`, `postings['constructor']` returns `Object.prototype.constructor` (the `Object` function — truthy). The init branch is skipped, `docs` is undefined on the function, `.push` crashes.

Silent secondary impact: corrupts the global `Object` function with a `df` property on first failing call.

## Fix — `Object.create(null)` at every term/filename-keyed map

Five mutation sites covered:
- **`buildPostings`** — `postings = Object.create(null)` (the crash site)
- **`buildFullIndex`** — `docs = Object.create(null)` (filename keys, same risk class — a file literally named `constructor.md` would also trigger)
- **`incrementalRebuild`** — `newDocs` reseated prototype-less
- **`buildDocEntry`** — `doc.terms = Object.create(null)` (token-keyed; `bm25Score` reads `doc.terms[term]`)
- **`tryLoadIndex`** — new `reseatPrototypelessMaps()` rewraps `docs`/`postings`/`terms` after `JSON.parse`, since `JSON.parse` always returns prototype-bearing objects. Closes the read-side analogue.

## Tests — 5 new in `tests/orchestrator/memory-index-sidecar.test.ts`

1. `buildFullIndex` does not throw on corpus body containing `"constructor"`
2. `postings['constructor']` is a real entry (or undefined), never `Object.prototype.constructor`
3. `rankDocuments` does not throw on prototype-name query terms (`constructor`, `tostring`)
4. `rebuildIndex` round-trip through JSON preserves prototype-less maps
5. **Black-box repro** — `MemorySearcher.search('_project', ...)` returns without throwing when the corpus contains `"constructor"`

## Verification
- [x] 247 suites / 3282 tests pass (5 new, 0 failures)
- [x] Typecheck clean (pre-existing dashboard-v2 + DOM errors unchanged)
- [x] Manual repro on cwd: pre-fix → `TypeError: Cannot read properties of undefined (reading 'push')`; post-fix → 5 results returned

## References
- Bug report: `/Users/goku/Desktop/audit-team/audits/_meta/gossipcat-bug-remember-project.md`
- Affected versions: gossipcat 0.4.25 (current latest) and all prior versions with the BM25 sidecar (since PR #360)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
