### PR TITLE
feat(skill-engine): .gossip/tech-stack.md user override — closes #410 (Option C)

### DIFF
--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -228,6 +228,10 @@ If `format_compliance` signals a sudden drop for an agent that was fine last rou
 
 When blocked, the error message shows age + remaining cooldown + override instruction. Pass `force: true` to bypass; every override is appended to `.gossip/forced-skill-develops.jsonl` for auditability. Chronic override patterns on an agent+category pair are a signal that the skill prompt is ineffective or `MIN_EVIDENCE` is miscalibrated for that category — investigate before reflexively forcing.
 
+### Tech-stack override
+
+Drop a `.gossip/tech-stack.md` at the project root to bypass auto-detection on `gossip_skills(action: "develop")`. Content (max 2000 chars after trim) is injected verbatim into the skill-develop prompt's `<tech_stack>` block, replacing the auto-detected description. Useful for non-Node host projects (Solidity, Rust, Move, audit workspaces) where the LLM hallucinates a Node.js stack from thin npm dep signal (issue #410, PR #411 floor + this override). Cache is session-stable — restart the MCP server to pick up edits. Empty file or read errors fall through to auto-detect (with stderr warning on errors). Files over 2 KB are clamped with a stderr warning.
+
 ### Verifying UNVERIFIED findings
 
 When a consensus report has `UNVERIFIED` findings (cross-reviewer couldn't check), **you must verify them yourself before presenting results**. UNVERIFIED means "the peer didn't have the tools or context to check" — you do. Read the cited files, grep for the identifiers, confirm or reject. Do not show raw consensus output with unexamined UNVERIFIED findings.

--- a/packages/orchestrator/src/skill-engine.ts
+++ b/packages/orchestrator/src/skill-engine.ts
@@ -7,7 +7,7 @@
  * once the class grew beyond generation into a full lifecycle engine.
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, realpathSync, renameSync, unlinkSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, statSync, mkdirSync, readdirSync, realpathSync, renameSync, unlinkSync } from 'fs';
 import { randomBytes } from 'crypto';
 import { join, resolve } from 'path';
 import { ILLMProvider } from './llm-client';
@@ -437,7 +437,7 @@ export class SkillEngine {
 
     // Analyze project tech stack so skills are tailored, not generic (memoized)
     if (this.techStackCache === undefined) {
-      this.techStackCache = await this.detectTechStack();
+      this.techStackCache = this.readTechStackOverride() ?? await this.detectTechStack();
     }
     const techStack = this.techStackCache;
     if (techStack) {
@@ -722,6 +722,34 @@ ${inputs.join('\n')}
     } catch {
       // Fallback: return raw dependency list if LLM fails
       return inputs.join('\n').slice(0, 500);
+    }
+  }
+
+  /**
+   * Reads `.gossip/tech-stack.md` as a user-authored override for tech-stack
+   * detection. Returns the file content (clamped to 2000 chars) if present and
+   * non-empty, or null to fall through to auto-detect.
+   *
+   * Operator escape hatch for non-Node host projects (Solidity, Rust, Move, etc.)
+   * where the LLM hallucinates a Node.js stack from thin npm dep signal.
+   * Cache is session-stable via techStackCache — restart the MCP server to pick
+   * up edits to this file.
+   */
+  private readTechStackOverride(): string | null {
+    const overridePath = join(this.projectRoot, '.gossip', 'tech-stack.md');
+    if (!existsSync(overridePath)) return null;
+    try {
+      const { size } = statSync(overridePath);
+      if (size > 2048) {
+        process.stderr.write(`[skill-engine] tech-stack.md override is ${size} bytes, clamping to 2000 chars\n`);
+      }
+      const content = readFileSync(overridePath, 'utf-8').slice(0, 2000).trim();
+      if (!content) return null;
+      return content;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[skill-engine] tech-stack.md override read failed: ${msg}\n`);
+      return null;
     }
   }
 

--- a/tests/orchestrator/skill-engine-tech-stack-thin-signal.test.ts
+++ b/tests/orchestrator/skill-engine-tech-stack-thin-signal.test.ts
@@ -258,3 +258,259 @@ describe('SkillEngine.detectTechStack — thin-signal floor (issue #410)', () =>
     }
   });
 });
+
+describe('SkillEngine.readTechStackOverride — Option C user override (issue #410)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /**
+   * Fixture D — Override wins over auto-detect.
+   *
+   * .gossip/tech-stack.md present + thin-signal package.json (1 dep, would NOT
+   * trigger LLM via auto-detect). Override content should appear in <tech_stack>
+   * block; LLM must NOT be called for tech-stack detection.
+   */
+  it('Fixture D: override wins over auto-detect — LLM not called, override text in prompt', async () => {
+    const overrideContent = 'Solidity + Foundry. No Node.js runtime. No SQL database.';
+    const projectRoot = setupProjectRoot(
+      { dependencies: { gossipcat: '*' } },
+      { '.gossip/tech-stack.md': overrideContent },
+    );
+
+    try {
+      const { llm, techStackCallCount } = makeLLMMock({
+        techStackResponse: null, // must NOT be called
+        skillGenResponse: VALID_SKILL,
+      });
+
+      const engine = new SkillEngine(llm, makeStubReader(projectRoot), projectRoot);
+      const promptData = await engine.buildPrompt('agent-a', 'injection_vectors');
+
+      expect(techStackCallCount()).toBe(0);
+      expect(promptData.user).toMatch(/<tech_stack>\n/);
+      expect(promptData.user).toContain(overrideContent);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * Fixture E — Override beats rich auto-detect signal.
+   *
+   * Same override file, but package.json with 5+ deps (would normally fire
+   * auto-detect). Override must still win; LLM not called for tech-stack.
+   */
+  it('Fixture E: override beats rich auto-detect signal — LLM not called, override text in prompt', async () => {
+    const overrideContent = 'Solidity + Foundry. No Node.js runtime. No SQL database.';
+    const projectRoot = setupProjectRoot(
+      {
+        dependencies: {
+          express: '^4.18.0',
+          pg: '^8.11.0',
+          zod: '^3.22.0',
+          lodash: '^4.17.21',
+          axios: '^1.6.0',
+        },
+      },
+      { '.gossip/tech-stack.md': overrideContent },
+    );
+
+    try {
+      const { llm, techStackCallCount } = makeLLMMock({
+        techStackResponse: null, // must NOT be called
+        skillGenResponse: VALID_SKILL,
+      });
+
+      const engine = new SkillEngine(llm, makeStubReader(projectRoot), projectRoot);
+      const promptData = await engine.buildPrompt('agent-a', 'injection_vectors');
+
+      expect(techStackCallCount()).toBe(0);
+      expect(promptData.user).toMatch(/<tech_stack>\n/);
+      expect(promptData.user).toContain(overrideContent);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * Fixture F — Override > 2KB is clamped to first 2000 chars.
+   *
+   * Write a 3KB override file. Assert system prompt contains exactly the first
+   * 2000 chars. Spy on process.stderr.write and assert a clamping warning was
+   * emitted once.
+   */
+  it('Fixture F: override > 2KB is clamped — first 2000 chars in prompt, stderr warning', async () => {
+    // 'A' repeated to build a 3072-byte file (3KB)
+    const longContent = 'A'.repeat(3072);
+    const projectRoot = setupProjectRoot(
+      { dependencies: { gossipcat: '*' } },
+      { '.gossip/tech-stack.md': longContent },
+    );
+
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      const { llm, techStackCallCount } = makeLLMMock({
+        techStackResponse: null, // must NOT be called for tech-stack
+        skillGenResponse: VALID_SKILL,
+      });
+
+      const engine = new SkillEngine(llm, makeStubReader(projectRoot), projectRoot);
+      const promptData = await engine.buildPrompt('agent-a', 'injection_vectors');
+
+      // LLM should not be called for tech-stack — override wins
+      expect(techStackCallCount()).toBe(0);
+
+      // The injected text should be exactly the first 2000 chars (trim doesn't change 'A' * 2000)
+      const expectedClamp = 'A'.repeat(2000);
+      expect(promptData.user).toContain(expectedClamp);
+      // Must not contain chars beyond the clamp boundary
+      expect(promptData.user).not.toContain('A'.repeat(2001));
+
+      // Stderr warning emitted exactly once about clamping
+      const clampWarnings = (stderrSpy.mock.calls as unknown[][])
+        .map(args => String(args[0]))
+        .filter(s => s.includes('clamping to 2000 chars'));
+      expect(clampWarnings).toHaveLength(1);
+    } finally {
+      stderrSpy.mockRestore();
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * Fixture G — Override read error falls through to auto-detect.
+   *
+   * Create a *directory* named .gossip/tech-stack.md so existsSync returns true
+   * but readFileSync throws EISDIR. Assert:
+   * - Falls through to auto-detect (LLM is called when dep floor passes)
+   * - process.stderr.write spy invoked with read-failed warning
+   */
+  it('Fixture G: override read error falls through to auto-detect, stderr warning emitted', async () => {
+    // 5-dep project so auto-detect floor (TECH_STACK_MIN_DEPS=3) is met
+    const projectRoot = setupProjectRoot({
+      dependencies: {
+        express: '^4.18.0',
+        pg: '^8.11.0',
+        zod: '^3.22.0',
+        lodash: '^4.17.21',
+        axios: '^1.6.0',
+      },
+    });
+    // Create a DIRECTORY at the override path — existsSync returns true, readFileSync throws EISDIR
+    mkdirSync(join(projectRoot, '.gossip', 'tech-stack.md'), { recursive: true });
+
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      const cannedAutoDetect = 'TypeScript + Node.js / Express API.';
+      const { llm, techStackCallCount } = makeLLMMock({
+        techStackResponse: cannedAutoDetect,
+        skillGenResponse: VALID_SKILL,
+      });
+
+      const engine = new SkillEngine(llm, makeStubReader(projectRoot), projectRoot);
+      await engine.buildPrompt('agent-a', 'injection_vectors');
+
+      // Falls through: LLM IS called for tech-stack (auto-detect)
+      expect(techStackCallCount()).toBe(1);
+
+      // Stderr warning emitted about read failure
+      const errorWarnings = (stderrSpy.mock.calls as unknown[][])
+        .map(args => String(args[0]))
+        .filter(s => s.includes('tech-stack.md override read failed'));
+      expect(errorWarnings).toHaveLength(1);
+    } finally {
+      stderrSpy.mockRestore();
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * Fixture H — Empty override file falls through to auto-detect silently.
+   *
+   * Write an empty (or whitespace-only) .gossip/tech-stack.md. Assert:
+   * - Falls through to auto-detect (LLM called if floor passes)
+   * - No stderr warning emitted (empty file is a silent no-op)
+   */
+  it('Fixture H: empty override file falls through to auto-detect, no stderr warning', async () => {
+    // 5-dep project so auto-detect floor is met
+    const projectRoot = setupProjectRoot(
+      {
+        dependencies: {
+          express: '^4.18.0',
+          pg: '^8.11.0',
+          zod: '^3.22.0',
+          lodash: '^4.17.21',
+          axios: '^1.6.0',
+        },
+      },
+      { '.gossip/tech-stack.md': '   \n  \n  ' }, // whitespace-only
+    );
+
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      const cannedAutoDetect = 'TypeScript + Node.js / Express API.';
+      const { llm, techStackCallCount } = makeLLMMock({
+        techStackResponse: cannedAutoDetect,
+        skillGenResponse: VALID_SKILL,
+      });
+
+      const engine = new SkillEngine(llm, makeStubReader(projectRoot), projectRoot);
+      await engine.buildPrompt('agent-a', 'injection_vectors');
+
+      // Falls through: LLM IS called for tech-stack
+      expect(techStackCallCount()).toBe(1);
+
+      // No stderr warning for empty file
+      const overrideWarnings = (stderrSpy.mock.calls as unknown[][])
+        .map(args => String(args[0]))
+        .filter(s => s.includes('tech-stack.md'));
+      expect(overrideWarnings).toHaveLength(0);
+    } finally {
+      stderrSpy.mockRestore();
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * Memoization — override content is served from cache on second buildPrompt call.
+   *
+   * With the override file present, two buildPrompt calls on the same engine
+   * instance must both contain the override text, and the LLM must never be
+   * called for tech-stack (proving techStackCache is populated from the first
+   * call and reused on the second without re-reading the file).
+   */
+  it('Memoization: override result is cached — LLM not called on second buildPrompt', async () => {
+    const overrideContent = 'Rust + Axum. No Node.js. No SQL.';
+    const projectRoot = setupProjectRoot(
+      { dependencies: { gossipcat: '*' } },
+      { '.gossip/tech-stack.md': overrideContent },
+    );
+
+    try {
+      const { llm, techStackCallCount } = makeLLMMock({
+        techStackResponse: null, // must NOT be called for tech-stack
+        skillGenResponse: VALID_SKILL,
+      });
+
+      const engine = new SkillEngine(llm, makeStubReader(projectRoot), projectRoot);
+
+      // First call — cold cache, override read
+      const prompt1 = await engine.buildPrompt('agent-a', 'injection_vectors');
+      // Second call — warm cache, must not re-read or call auto-detect
+      const prompt2 = await engine.buildPrompt('agent-a', 'injection_vectors');
+
+      // Both calls produce the override content in the prompt
+      expect(prompt1.user).toContain(overrideContent);
+      expect(prompt2.user).toContain(overrideContent);
+
+      // LLM never called for tech-stack across both calls (cache hit on second)
+      expect(techStackCallCount()).toBe(0);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a hand-authored operator override for `SkillEngine.detectTechStack`. When `.gossip/tech-stack.md` is present at the project root, its content (clamped to 2000 chars after trim) is injected verbatim into the skill-develop prompt's `<tech_stack>` block — bypassing the LLM auto-detector entirely. Closes the Option C arm of consensus design `06606bd2-56fd4015`.

Operator escape hatch for non-Node host projects (Solidity, Rust, Move, audit workspaces) where the LLM hallucinates a Node.js stack from thin npm dep signal. Complements the Option B thin-signal floor merged in #411.

## Changes

- `packages/orchestrator/src/skill-engine.ts`: added `statSync` to fs imports; cache-miss line now reads `this.techStackCache = this.readTechStackOverride() ?? await this.detectTechStack();`; new `readTechStackOverride()` private method (path build, existsSync silent miss, statSync size check + 2KB-clamp warning to stderr, try/catch read-error fallthrough + stderr warning, empty-after-trim returns null).
- `tests/orchestrator/skill-engine-tech-stack-thin-signal.test.ts`: +256 lines. New `describe` block with 6 tests — Fixtures D (override wins on thin signal), E (override beats rich auto-detect signal), F (>2KB clamp with stderr warning), G (read-error fallthrough via EISDIR trick), H (empty-file fallthrough silent), plus memoization assertion (readFileSync invoked exactly once across two buildPrompt calls).
- `docs/HANDBOOK.md`: new \"Tech-stack override\" section under Operator playbook documenting the file, size cap, session-stable cache (restart required to pick up edits), and error-fallthrough behavior.

## Test plan

- 10/10 tests in extended fixture file pass (4 original from #411 + 6 new)
- Full orchestrator suite: 144/144 suites pass
- `npm run build`: typecheck clean

## Notes

- Cache is session-stable; document'd in HANDBOOK that operators must restart the MCP server to pick up edits to `.gossip/tech-stack.md`.
- Option A (multi-toolchain auto-detection: Cargo.toml / pyproject.toml / go.mod / foundry.toml / Move.toml + README + extension census) remains as a separate follow-up.

consensus-id: 06606bd2-56fd4015