### PR TITLE
fix(consensus-engine): anchor warning false-positive on nested worktrees — closes #401

### DIFF
--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -1489,11 +1489,10 @@ Return only valid JSON.${skillsBlock}`;
         }
         // Defense-in-depth: warn when the resolved path falls back to projectRoot
         // while worktree roots are active — the anchor may reflect master HEAD,
-        // not the branch under review.
-        const resolvedFromProjectRoot =
-          this.currentWorktreeRoots.size > 0 &&
-          this.config.projectRoot &&
-          filePath.startsWith(resolve(this.config.projectRoot) + '/');
+        // not the branch under review.  Uses isResolvedFromProjectRootOnly to
+        // avoid false-positives when the worktree is nested under projectRoot
+        // (e.g. the standard .claude/worktrees/agent-X layout).
+        const resolvedFromProjectRoot = this.isResolvedFromProjectRootOnly(filePath);
         const fileStat = await stat(filePath);
         if (fileStat.size > MAX_FILE_SIZE) continue;
         const content = await this.cachedRead(filePath);
@@ -1547,10 +1546,7 @@ Return only valid JSON.${skillsBlock}`;
               const safeRef = fullRef.replace(/["<>]/g, '');
               const filePath = await this.cachedResolveForAnchor(fullRef) ?? await this.cachedResolveForAnchor(bareFile);
               if (filePath) {
-                const resolvedFromProjectRoot =
-                  this.currentWorktreeRoots.size > 0 &&
-                  this.config.projectRoot &&
-                  filePath.startsWith(resolve(this.config.projectRoot) + '/');
+                const resolvedFromProjectRoot = this.isResolvedFromProjectRootOnly(filePath);
                 const content = await this.cachedRead(filePath);
                 if (content) {
                   const fileLines = content.split('\n');
@@ -1724,6 +1720,29 @@ Return only valid JSON.${skillsBlock}`;
    * worktree can still be auto-anchored when consensus runs back in the main
    * MCP process).
    */
+  /**
+   * Returns true when filePath falls under projectRoot but NOT inside any
+   * active worktree root.  This is the condition that warrants the
+   * "⚠ resolved against project root, NOT worktree" attribute — the file
+   * was found via the projectRoot fallback, meaning it reflects master HEAD,
+   * not the branch under review.
+   *
+   * The previous inline check used only a startsWith(projectRoot) test, which
+   * produced a false-positive when the worktree itself is nested under
+   * projectRoot (the standard `.claude/worktrees/agent-X` layout): a worktree
+   * file like /x/.claude/worktrees/agent-Y/foo.ts passes startsWith(/x/)
+   * even though it was correctly resolved via the worktree priority root.
+   *
+   * Fix: additionally verify the path is NOT inside any currentWorktreeRoot
+   * via isInsideAnyRoot, which applies realpath-safe containment checks.
+   */
+  private isResolvedFromProjectRootOnly(filePath: string): boolean {
+    if (this.currentWorktreeRoots.size === 0) return false;
+    if (!this.config.projectRoot) return false;
+    if (!filePath.startsWith(resolve(this.config.projectRoot) + '/')) return false;
+    return !this.isInsideAnyRoot(filePath, [...this.currentWorktreeRoots]);
+  }
+
   /**
    * Guard: resolved path must stay inside one of the valid roots, with
    * symlink-safe containment.

--- a/tests/orchestrator/consensus-engine-resolution-roots.test.ts
+++ b/tests/orchestrator/consensus-engine-resolution-roots.test.ts
@@ -200,6 +200,72 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
     expect(snippets).toContain('via="⚠ resolved against project root, NOT worktree"');
   });
 
+  it('Test 19 — nested worktree-resolved file does NOT get projectRoot warning', async () => {
+    // Regression for issue #401: when the worktree lives under projectRoot
+    // (standard .claude/worktrees/agent-X layout), a file resolved via the
+    // worktree priority root still passes startsWith(projectRoot + '/') —
+    // the old inline check falsely attached the ⚠ warning.
+    const proj = realpathSync(mkdtempSync(join(tmp, 'proj')));
+    // Nest the worktree under projectRoot, mimicking .claude/worktrees/agent-X
+    const wtDir = join(proj, '.claude', 'worktrees', 'agent-test');
+    mkdirSync(wtDir, { recursive: true });
+    const wt = realpathSync(wtDir);
+
+    // File exists only in the worktree (e.g. a new file on the branch).
+    mkdirSync(join(wt, 'src'), { recursive: true });
+    writeFileSync(join(wt, 'src', 'new-feature.ts'), 'export function newFeature() { return "branch"; }');
+
+    const engine = new ConsensusEngine({
+      llm: makeLlm(),
+      registryGet: () => undefined,
+      projectRoot: proj,
+      resolutionRoots: [wt],
+    } as ConsensusEngineConfig);
+
+    const snippets: string = await (engine as any).snippetsForFinding(
+      'Potential issue at src/new-feature.ts:1',
+    );
+
+    // Anchor must render.
+    expect(snippets).toContain('<anchor');
+    expect(snippets).toContain('newFeature');
+    // Must NOT carry the false-positive warning — file was resolved from worktree.
+    expect(snippets).not.toContain('⚠ resolved against project root, NOT worktree');
+  });
+
+  it('Test 20 — project-root-only file still gets warning (regression guard)', async () => {
+    // Mirror of Test 18 but using the nested-worktree layout.  A file that
+    // lives ONLY at projectRoot (not in the nested worktree) must still get
+    // the warning attribute so the regression from #401 fix doesn't silently
+    // suppress legitimate warnings.
+    const proj = realpathSync(mkdtempSync(join(tmp, 'proj')));
+    const wtDir = join(proj, '.claude', 'worktrees', 'agent-test');
+    mkdirSync(wtDir, { recursive: true });
+    const wt = realpathSync(wtDir);
+
+    // File lives only at projectRoot — not in the worktree.
+    mkdirSync(join(proj, 'src'), { recursive: true });
+    writeFileSync(join(proj, 'src', 'master-only.ts'), 'export function masterFn() { return 42; }');
+    // No corresponding file in wt/src/master-only.ts
+
+    const engine = new ConsensusEngine({
+      llm: makeLlm(),
+      registryGet: () => undefined,
+      projectRoot: proj,
+      resolutionRoots: [wt],
+    } as ConsensusEngineConfig);
+
+    const snippets: string = await (engine as any).snippetsForFinding(
+      'Potential issue at src/master-only.ts:1',
+    );
+
+    // Snippet must render via projectRoot fallback.
+    expect(snippets).toContain('<anchor');
+    expect(snippets).toContain('masterFn');
+    // Warning must still be present — file resolved from projectRoot, not worktree.
+    expect(snippets).toContain('via="⚠ resolved against project root, NOT worktree"');
+  });
+
   it('Test 17 — anchorPathCache is cleared when worktree roots change', async () => {
     const proj = realpathSync(mkdtempSync(join(tmp, 'proj')));
     mkdirSync(join(proj, 'src'), { recursive: true });


### PR DESCRIPTION
## Summary

Fixes #401. When a worktree lives at `<projectRoot>/.claude/worktrees/agent-X` (the standard layout — nested INSIDE projectRoot), the consensus-engine anchor resolver correctly returned the worktree path, but the warning attribution check fired anyway:

```ts
filePath.startsWith(resolve(this.config.projectRoot) + '/')
```

That predicate is true for any path under projectRoot — including paths under nested worktrees — so the misleading `via="⚠ resolved against project root, NOT worktree"` attribute attached to every worktree-resolved anchor. Cross-reviewers compensated via direct `file_read`, but the warning looked like the resolver was broken.

## Fix

Extracted a private helper `isResolvedFromProjectRootOnly` that returns true only when the file is under projectRoot AND NOT inside any active worktree root. Uses the existing `isInsideAnyRoot` helper (consensus-engine.ts:1748) which does realpath normalization for symlinked worktrees.

```ts
private isResolvedFromProjectRootOnly(filePath: string): boolean {
  if (this.currentWorktreeRoots.size === 0) return false;
  if (!this.config.projectRoot) return false;
  if (!filePath.startsWith(resolve(this.config.projectRoot) + '/')) return false;
  return !isInsideAnyRoot(filePath, [...this.currentWorktreeRoots]);
}
```

Both call sites (lines ~1495 and ~1549) now call the helper.

## Test plan

Added Tests 19 and 20 in `tests/orchestrator/consensus-engine-resolution-roots.test.ts`:

- **Test 19** — file at `<projectRoot>/.claude/worktrees/agent-Y/foo.ts` → anchor does NOT carry the warning attribute (the fix path)
- **Test 20** — file at `<projectRoot>/foo.ts` (no worktree match) → warning still fires (regression guard)

- Full orchestrator suite: 145/145 suites, 2132 tests pass
- `npm run build` clean

## Notes

Priority resolver itself (`resolveFilePath` at ~:1825) and the security boundary unchanged. The bug was purely in warning attribution. References consensus round `71493829-1261487e` (where the false-positive was surfaced).

consensus-id: 06606bd2-56fd4015