### PR TITLE
fix(dispatch): autoDiscoverWorktrees discovery-only (no auto-assign) — closes #402

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -417,7 +417,7 @@ export async function handleCollect(
         return { content: [{ type: 'text' as const, text: 'Error: No LLM configured for consensus. Check gossip_setup.' }] };
       }
 
-      const { PerformanceReader, discoverGitWorktrees } = await import('@gossip/orchestrator');
+      const { PerformanceReader, discoverGitWorktrees, hashPath } = await import('@gossip/orchestrator');
       const performanceReader = new PerformanceReader(process.cwd());
 
       // Resolve effective resolution roots (#126 PR-B):
@@ -425,11 +425,18 @@ export async function handleCollect(
       //   2. dispatch-time fallback — NOT loaded here because the pending
       //      round record is created below (resolutionRoots field flows
       //      through it for later phases, not for this first synthesis call)
-      //   3. auto-discovery when consensus.autoDiscoverWorktrees=true,
-      //      validated via the same pipeline as explicit roots.
+      //   3. auto-discovery is DISCOVERY-ONLY (consensus c6b8580d-595e48d2 +
+      //      issue #402): when consensus.autoDiscoverWorktrees=true, log a
+      //      hashed-paths breadcrumb but do NOT merge discovered roots into
+      //      effectiveRoots. Operators must pass explicit resolutionRoots.
       // Collect-time REPLACES dispatch-time (not merges) per spec.
+      //
+      // Asymmetry note: dispatch.ts surfaces the warning through a
+      // warnings[] return path. Collect's auto-discovery branch has no such
+      // channel — it's invoked inline during synthesis — so we emit to
+      // stderr only. Mirrors the discovery-only contract; no auto-promotion.
       const explicitRoots: readonly string[] = resolutionRoots ?? [];
-      let effectiveRoots: readonly string[] = explicitRoots;
+      const effectiveRoots: readonly string[] = explicitRoots;
       try {
         const { findConfigPath, loadConfig } = await import('../config');
         const cfgPath = findConfigPath(process.cwd());
@@ -441,7 +448,14 @@ export async function handleCollect(
               `[consensus] auto-discovery: +${discovered.length} discovered, ${rejected.length} rejected\n`,
             );
           }
-          effectiveRoots = [...explicitRoots, ...discovered];
+          if (discovered.length > 0) {
+            const hashedPaths = discovered.map(d => hashPath(d));
+            process.stderr.write(
+              `[consensus] autoDiscoverWorktrees: ${discovered.length} sibling worktree(s) ` +
+              `discovered but auto-promotion is disabled (issue #402). Pass resolutionRoots to ` +
+              `gossip_collect to pin cross-reviewers. Discovered (hashed): ${hashedPaths.join(', ')}\n`,
+            );
+          }
         }
       } catch (err) {
         process.stderr.write(`[consensus] auto-discovery failed: ${(err as Error).message}\n`);

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -12,6 +12,7 @@ import {
   verifyClaims,
   emitConsensusSignals,
   sanitizeForLog,
+  hashPath,
   type ClaimBlock,
   type ClaimVerdict,
   type PerformanceSignal,
@@ -725,10 +726,13 @@ export async function handleDispatchSingle(
  * Used by both handleDispatchConsensus and handleDispatchParallel(consensus:true).
  *
  * Layer 1 — when caller passed no resolutionRoots and
- * `consensus.autoDiscoverWorktrees=true`, run discoverGitWorktrees and return
- * the validated paths as effectiveRoots. Explicit caller-passed roots ALWAYS
- * win — when dispatchResolutionRoots is non-empty this function returns it
- * unchanged without running discovery.
+ * `consensus.autoDiscoverWorktrees=true`, run discoverGitWorktrees and emit a
+ * hashed-paths warning so operators know which worktrees exist. Auto-promotion
+ * to effectiveRoots is DISABLED per consensus c6b8580d-595e48d2 + issue #402:
+ * promoting discovered worktrees blindly routed cross-reviewers to the wrong
+ * branch. Operators must pass explicit resolutionRoots to gossip_dispatch.
+ * Explicit caller-passed roots ALWAYS win — when dispatchResolutionRoots is
+ * non-empty this function returns it unchanged without running discovery.
  *
  * Layer 2 — when the flag is OFF but worktrees exist on disk and
  * resolutionRoots is empty, push a non-fatal warning into the returned
@@ -762,7 +766,15 @@ async function resolveDispatchResolutionRoots(
         );
       }
       if (discovered.length > 0) {
-        effectiveRoots = discovered;
+        // Per consensus c6b8580d-595e48d2 + issue #402: auto-promotion was the
+        // bug. autoDiscoverWorktrees is discovery+warning only. Operators must
+        // pass explicit resolutionRoots to route cross-reviewers.
+        const hashedPaths = discovered.map(d => hashPath(d));
+        warnings.push(
+          `autoDiscoverWorktrees: ${discovered.length} sibling worktree(s) discovered ` +
+          `but auto-promotion is disabled. Pass resolutionRoots to gossip_dispatch ` +
+          `to pin cross-reviewers to a specific worktree. Discovered (hashed): ${hashedPaths.join(', ')}`,
+        );
       } else if (rejected.length > 0) {
         // F4 — surface "all candidates rejected" through the operator-visible
         // warnings channel instead of stderr-only.

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -252,7 +252,7 @@ gossip_collect({
 
 Without `resolutionRoots`, citations to files that only exist in the worktree resolve against `projectRoot` → `⚠ file not found` → every cross-reviewer marks UNVERIFIED → the round produces zero verified findings. `resolutionRoots` runs each path through a validator (NUL reject, `..` reject, realpath, ownership check, git-common-dir match, `git worktree list` membership) before adding it to the citation-resolver trust zone.
 
-Secondary: `consensus.autoDiscoverWorktrees: true` in `.gossip/config.json` auto-discovers all git worktrees at round start (opt-in, default off) — convenience for users who routinely run consensus on feature branches. Same validator applies.
+Secondary: `consensus.autoDiscoverWorktrees: true` in `.gossip/config.json` is DISCOVERY-ONLY (opt-in, default off). When enabled, it logs a warning listing hashed paths of sibling git worktrees so operators know which branches exist — but it does NOT auto-route cross-reviewers to any of them. You must still pass explicit `resolutionRoots` to `gossip_dispatch` (or `gossip_collect`) to pin cross-reviewers to a specific worktree. Per consensus c6b8580d-595e48d2 + issue #402, prior auto-promotion behaviour was a foot-gun: it silently routed reviews to the wrong branch when multiple worktrees existed. Same validator applies to anything you do pass explicitly.
 
 See spec `docs/specs/2026-04-17-issue-126.md` for the full design.
 

--- a/tests/cli/dispatch-autodiscover-worktrees.test.ts
+++ b/tests/cli/dispatch-autodiscover-worktrees.test.ts
@@ -143,32 +143,38 @@ describe('handleDispatchConsensus — dispatch-time worktree auto-discovery (iss
     rmSync(projectDir, { recursive: true, force: true });
   });
 
-  // Case 1 — Layer 1 happy path: flag ON, no caller-passed roots, worktrees
-  // discovered. Discovered roots must flow into both per-task relay options
-  // AND ctx.pendingDispatchResolutionRoots.
-  it('Layer 1 — auto-discovers worktrees and injects into relay options + stash', async () => {
+  // Case 1 — Layer 1 (Option D, issue #402, consensus c6b8580d-595e48d2):
+  // flag ON, no caller-passed roots, worktrees discovered. Auto-promotion is
+  // DISABLED — we emit a hashed-paths warning but do NOT inject the discovered
+  // roots into relay options or the stash. Operators must pass explicit roots.
+  it('Layer 1 — discovery-only: emits hashed warning, does NOT promote roots', async () => {
     writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
     mockedDiscover.mockResolvedValue({
       discovered: ['/tmp/worktree-a', '/tmp/worktree-b'],
       rejected: [],
     });
 
-    await handleDispatchConsensus([
+    const result: any = await handleDispatchConsensus([
       { agent_id: 'gemini-tester', task: 'Audit X' },
     ]);
 
     expect(mockedDiscover).toHaveBeenCalledWith(expect.any(String), [expect.any(String)]);
-    // Relay options carry the discovered roots
+    // Warning emitted with hashed paths (no raw paths to leak)
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/autoDiscoverWorktrees/);
+    expect(result.warnings[0]).toMatch(/2 sibling worktree\(s\) discovered/);
+    expect(result.warnings[0]).toMatch(/auto-promotion is disabled/);
+    expect(result.warnings[0]).toMatch(/Pass resolutionRoots/);
+    expect(result.warnings[0]).toMatch(/sha256:[0-9a-f]{8}/);
+    // Raw paths must NOT appear in the warning (privacy + only-hashed contract)
+    expect(result.warnings[0]).not.toContain('/tmp/worktree-a');
+    expect(result.warnings[0]).not.toContain('/tmp/worktree-b');
+    // Relay options must NOT carry the discovered roots — auto-promotion off
     const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
-    const relayDefs = dispatchParallelCall[0];
-    expect(relayDefs[0].options).toEqual({
-      resolutionRoots: ['/tmp/worktree-a', '/tmp/worktree-b'],
-    });
-    // Stash carries them too (collect-time pickup)
-    expect(ctx.pendingDispatchResolutionRoots.get('t-1')).toEqual([
-      '/tmp/worktree-a',
-      '/tmp/worktree-b',
-    ]);
+    expect(dispatchParallelCall[0][0].options).toBeUndefined();
+    // Stash must NOT carry the discovered roots
+    expect(ctx.pendingDispatchResolutionRoots.size).toBe(0);
   });
 
   // Case 2 — explicit caller-passed roots win. Auto-discovery must NOT run.
@@ -235,9 +241,11 @@ describe('handleDispatchConsensus — dispatch-time worktree auto-discovery (iss
     expect(dispatchParallelCall[0][0].options).toBeUndefined();
   });
 
-  // Case 5 — Layer 2 silent when Layer 1 fires. Discovered roots get injected,
-  // and the warning channel stays empty (operator already opted in).
-  it('Layer 2 — silent when Layer 1 fires (flag on + worktrees discovered)', async () => {
+  // Case 5 — When Layer 1 fires (flag ON + worktrees discovered), the
+  // discovery-only warning takes over the Layer 2 channel — operator already
+  // opted in to the flag, so we emit the hashed-paths warning (single warning
+  // only, not the Layer 2 "flag is off" variant) and do not promote.
+  it('Layer 1 warning fires (not Layer 2) when flag on + worktrees discovered', async () => {
     writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
     mockedDiscover.mockResolvedValue({
       discovered: ['/tmp/worktree-x'],
@@ -248,11 +256,13 @@ describe('handleDispatchConsensus — dispatch-time worktree auto-discovery (iss
       { agent_id: 'gemini-tester', task: 'Audit X' },
     ]);
 
-    expect(result.warnings).toBeUndefined();
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/auto-promotion is disabled/);
+    // Layer 2 "OFF but worktrees exist" must NOT fire (we're not OFF)
+    expect(result.warnings[0]).not.toMatch(/autoDiscoverWorktrees is OFF/);
     const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
-    expect(dispatchParallelCall[0][0].options).toEqual({
-      resolutionRoots: ['/tmp/worktree-x'],
-    });
+    expect(dispatchParallelCall[0][0].options).toBeUndefined();
   });
 
   // Case 6 — F4: flag ON, no discovered, rejected > 0 → warning in response.

--- a/tests/cli/dispatch-parallel-autodiscover-worktrees.test.ts
+++ b/tests/cli/dispatch-parallel-autodiscover-worktrees.test.ts
@@ -138,31 +138,33 @@ describe('handleDispatchParallel(consensus:true) — dispatch-time worktree auto
     rmSync(projectDir, { recursive: true, force: true });
   });
 
-  // Case 1 — Layer 1 happy path: flag ON, no caller-passed roots, worktrees
-  // discovered. Discovered roots must flow into per-task relay options.
-  it('Layer 1 — auto-discovers worktrees and injects into relay options', async () => {
+  // Case 1 — Layer 1 (Option D, issue #402, consensus c6b8580d-595e48d2):
+  // discovery-only. Flag ON + no caller-passed roots + worktrees discovered →
+  // emit hashed warning, do NOT promote to relay options or stash.
+  it('Layer 1 — discovery-only: emits hashed warning, does NOT promote roots', async () => {
     writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
     mockedDiscover.mockResolvedValue({
       discovered: ['/tmp/worktree-a', '/tmp/worktree-b'],
       rejected: [],
     });
 
-    await handleDispatchParallel(
+    const result: any = await handleDispatchParallel(
       [{ agent_id: 'gemini-tester', task: 'Audit X' }],
       /* consensus */ true,
     );
 
     expect(mockedDiscover).toHaveBeenCalledWith(expect.any(String), [expect.any(String)]);
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/autoDiscoverWorktrees/);
+    expect(result.warnings[0]).toMatch(/2 sibling worktree\(s\) discovered/);
+    expect(result.warnings[0]).toMatch(/auto-promotion is disabled/);
+    expect(result.warnings[0]).toMatch(/sha256:[0-9a-f]{8}/);
+    expect(result.warnings[0]).not.toContain('/tmp/worktree-a');
+    expect(result.warnings[0]).not.toContain('/tmp/worktree-b');
     const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
-    const relayDefs = dispatchParallelCall[0];
-    expect(relayDefs[0].options).toEqual({
-      resolutionRoots: ['/tmp/worktree-a', '/tmp/worktree-b'],
-    });
-    // Stash must carry discovered roots for Phase 2 collect-time pickup
-    // (mirrors handleDispatchConsensus stash assertion in dispatch-autodiscover-worktrees.test.ts:168)
-    expect(ctx.pendingDispatchResolutionRoots.size).toBeGreaterThanOrEqual(1);
-    const stashedValue = Array.from(ctx.pendingDispatchResolutionRoots.values())[0];
-    expect(stashedValue).toEqual(['/tmp/worktree-a', '/tmp/worktree-b']);
+    expect(dispatchParallelCall[0][0].options).toBeUndefined();
+    expect(ctx.pendingDispatchResolutionRoots.size).toBe(0);
   });
 
   // Case 2 — explicit caller-passed roots win. Auto-discovery must NOT run.
@@ -223,9 +225,9 @@ describe('handleDispatchParallel(consensus:true) — dispatch-time worktree auto
     expect(dispatchParallelCall[0][0].options).toBeUndefined();
   });
 
-  // Case 5 — Layer 2 silent when Layer 1 fires. Discovered roots get injected,
-  // and the warning channel stays empty (operator already opted in).
-  it('Layer 2 — silent when Layer 1 fires (flag on + worktrees discovered)', async () => {
+  // Case 5 — Layer 1 warning takes the channel; Layer 2 "flag is OFF" does NOT
+  // fire since the flag is ON.
+  it('Layer 1 warning fires (not Layer 2) when flag on + worktrees discovered', async () => {
     writeConfig(projectDir, { consensus: { autoDiscoverWorktrees: true } });
     mockedDiscover.mockResolvedValue({
       discovered: ['/tmp/worktree-x'],
@@ -237,11 +239,12 @@ describe('handleDispatchParallel(consensus:true) — dispatch-time worktree auto
       /* consensus */ true,
     );
 
-    expect(result.warnings).toBeUndefined();
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/auto-promotion is disabled/);
+    expect(result.warnings[0]).not.toMatch(/autoDiscoverWorktrees is OFF/);
     const dispatchParallelCall = (ctx.mainAgent.dispatchParallel as jest.Mock).mock.calls[0];
-    expect(dispatchParallelCall[0][0].options).toEqual({
-      resolutionRoots: ['/tmp/worktree-x'],
-    });
+    expect(dispatchParallelCall[0][0].options).toBeUndefined();
   });
 
   // Case 6 — F4: flag ON, no discovered, rejected > 0 → warning in response.


### PR DESCRIPTION
## Summary

Closes #402. References consensus `c6b8580d-595e48d2` (Option D verified).

Walks back `autoDiscoverWorktrees` auto-promotion. The prior behaviour silently routed cross-reviewers to whichever sibling worktree(s) `git worktree list` returned — when multiple worktrees existed, this routed reviews to the wrong branch and produced phantom UNVERIFIED findings. The flag is now discovery-only: it logs a hashed-paths warning so operators know which worktrees exist, but operators must pass explicit `resolutionRoots` to route reviews.

## Changes

- **apps/cli/src/handlers/dispatch.ts** — replaced unconditional `effectiveRoots = discovered` with a hashed-paths warning via the existing `warnings[]` return channel. Explicit caller-passed roots short-circuit unchanged. Layer 2 "flag is OFF but worktrees exist" warning unchanged. F4 ("all candidates rejected") warning unchanged.
- **apps/cli/src/handlers/collect.ts** — mirror at collect.ts:444. Replaced `effectiveRoots = [...explicitRoots, ...discovered]` with `effectiveRoots = explicitRoots` (no merge). Collect's auto-discovery branch has no `warnings[]` return channel (runs inline during synthesis), so the hashed warning is routed via `process.stderr` only. Asymmetry with dispatch documented in inline comment.
- **docs/HANDBOOK.md:255** — rewritten to frame the flag as discovery-only; references consensus + issue #402.
- **docs/specs/2026-04-17-issue-126.md** — v4 amendment block documenting the walk-back (file is gitignored per project convention; amendment lives in the local-only spec dir).
- **tests/cli/dispatch-autodiscover-worktrees.test.ts + tests/cli/dispatch-parallel-autodiscover-worktrees.test.ts** — Case 1 (Layer 1 happy path) and Case 5 (flag ON + worktrees discovered) updated to assert the new contract: discovered roots must NOT appear in relay options or the `pendingDispatchResolutionRoots` stash; warning must contain hashed paths (`sha256:xxxxxxxx`) and must not leak raw paths. Regression guards preserved: Case 2 (explicit roots win), Case 4 (Layer 2 OFF-but-worktrees-exist), Case 6 (F4 validation rejection), Case 7 (failure isolation).

## collect.ts decision (no merge, symmetric with dispatch)

The original collect.ts:444 line read `effectiveRoots = [...explicitRoots, ...discovered]` — a true merge, not a replace. Under Option D, even this defensive merge is unsafe: it silently amplifies the explicit-roots scope with sibling worktrees the operator didn't ask for. Final shape is `effectiveRoots = explicitRoots`, which matches the contract: discovery is informational, never authoritative.

## Out-of-scope (separate dispatch will handle)

Cleanup of stale signals from consensus round `71493829` that were recorded against the prior auto-promotion behaviour. That round's `unique_confirmed` entries are now historically accurate (the bug they caught was real) but the fix is going in here, not in that round's follow-ups.

## Verification

- `npm run build` — clean across all packages.
- `npx jest` — **3315 passed / 29 skipped / 250 suites pass** (no regressions).
- Specifically: 15/15 autodiscover tests pass after the contract update.

## Test plan

- [ ] CI green
- [ ] Cross-review verifies the warning text contains hashed paths only (no raw paths)
- [ ] Cross-review verifies `effectiveRoots` is never auto-populated by discovery in either handler

consensus-id: c6b8580d-595e48d2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
