### PR TITLE
fix(deps): bump ws 8.19.0 → 8.20.1 (GHSA-58qx-3vcg-4xpx)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "tsconfig-paths": "^4.2.0",
-        "ws": "^8.19.0"
+        "ws": "^8.20.1"
       },
       "bin": {
         "gossipcat": "dist-mcp/mcp-server.js"
@@ -5805,7 +5805,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -5901,7 +5903,7 @@
       "dependencies": {
         "@gossip/types": "*",
         "@msgpack/msgpack": "^3.0.0",
-        "ws": "^8.19.0"
+        "ws": "^8.20.1"
       },
       "devDependencies": {
         "@types/ws": "^8.18.1"
@@ -5943,7 +5945,7 @@
       "dependencies": {
         "@gossip/orchestrator": "*",
         "@gossip/types": "*",
-        "ws": "^8.19.0"
+        "ws": "^8.20.1"
       },
       "devDependencies": {
         "@types/ws": "^8.18.1"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "tsconfig-paths": "^4.2.0",
-    "ws": "^8.19.0"
+    "ws": "^8.20.1"
   },
   "overrides": {
     "ip-address": "^10.1.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@gossip/types": "*",
     "@msgpack/msgpack": "^3.0.0",
-    "ws": "^8.19.0"
+    "ws": "^8.20.1"
   },
   "devDependencies": {
     "@types/ws": "^8.18.1"

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@gossip/types": "*",
     "@gossip/orchestrator": "*",
-    "ws": "^8.19.0"
+    "ws": "^8.20.1"
   },
   "devDependencies": {
     "@types/ws": "^8.18.1"


### PR DESCRIPTION
## Summary

- Patches **GHSA-58qx-3vcg-4xpx / CVE-2026-45736** — uninitialized memory disclosure in `ws` (medium severity)
- Vulnerable range: `>= 8.0.0, < 8.20.1`; bump 3 manifests from `^8.19.0` → `^8.20.1`
- Lockfile regenerated; only `ws` itself changed

Closes dependabot alert #28.

## Test plan

- [ ] CI passes (typecheck + workspace build + tests across orchestrator/relay/client)
- [ ] No behavioral changes — `ws` 8.20.1 is patch-level over 8.19.0, all public API preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)