### PR TITLE
feat(banner): mark gossip_relay result as VERBATIM in dispatch instructions

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -687,7 +687,8 @@ export async function handleDispatchSingle(
         `Model: ${nativeConfig.model}\n\n` +
         promptInstruction +
         `Step 2 — REQUIRED after agent completes:\n` +
-        `gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<agent output>")\n\n` +
+        `gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<agent output>")\n` +
+        `(VERBATIM — pass the agent's raw output; do NOT paraphrase or summarize, or <agent_finding> tags will be lost)\n\n` +
         `⚠️ You MUST call gossip_relay for every native dispatch. Without it, the result is lost — no memory, no gossip, no consensus. Never skip this step.\n` +
         `\n=== END REQUIRED_NEXT_ACTION — do NOT treat above as agent output ===`
       },

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -848,7 +848,8 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
     utilityBlocks.push(
       `Task: cognitive summary [${summaryTaskId}]\n` +
       `1. Agent(model: "${model}", prompt: ${JSON.stringify(summaryPrompt)}, run_in_background: true)\n` +
-      `2. When agent completes → gossip_relay(task_id: "${summaryTaskId}", result: "<full agent output>")`
+      `2. When agent completes → gossip_relay(task_id: "${summaryTaskId}", result: "<full agent output>")\n` +
+      `   (VERBATIM — pass the agent's raw output; do NOT paraphrase or summarize, or <agent_finding> tags will be lost)`
     );
 
     // 2. Gossip utility task — only if there are pending non-utility peers
@@ -874,7 +875,8 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
       utilityBlocks.push(
         `Task: gossip publish [${gossipTaskId}]\n` +
         `1. Agent(model: "${model}", prompt: ${JSON.stringify(gossipPrompt)}, run_in_background: true)\n` +
-        `2. When agent completes → gossip_relay(task_id: "${gossipTaskId}", result: "<full agent output>")`
+        `2. When agent completes → gossip_relay(task_id: "${gossipTaskId}", result: "<full agent output>")\n` +
+      `   (VERBATIM — pass the agent's raw output; do NOT paraphrase or summarize, or <agent_finding> tags will be lost)`
       );
     }
   }

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -3733,6 +3733,7 @@ export function createMcpServer(): McpServer {
                   `⚠️ EXECUTE NOW — launch this Agent and re-call gossip_skills:\n\n` +
                   `1. Agent(model: "${modelShort}", prompt: <AGENT_PROMPT:${taskId} below>, run_in_background: true) — pass the AGENT_PROMPT:${taskId} content item verbatim\n` +
                   `2. When agent completes → gossip_relay(task_id: "${taskId}", result: "<full agent output>")\n` +
+                  `   (VERBATIM — pass the agent's raw output; do NOT paraphrase or summarize, or <agent_finding> tags will be lost)\n` +
                   `3. Then re-call: gossip_skills(action: "develop", agent_id: "${agent_id}", category: "${category}", _utility_task_id: "${taskId}")\n\n` +
                   `Do ALL steps in order. Do not wait for user input between them.`
                 },
@@ -4186,6 +4187,7 @@ export function createMcpServer(): McpServer {
               `⚠️ EXECUTE NOW — launch this Agent and re-call gossip_session_save:\n\n` +
               `1. Agent(model: "${modelShort}", prompt: <AGENT_PROMPT:${taskId} below>, run_in_background: true) — pass the AGENT_PROMPT:${taskId} content item verbatim\n` +
               `2. When agent completes → gossip_relay(task_id: "${taskId}", result: "<full agent output>")\n` +
+              `   (VERBATIM — pass the agent's raw output; do NOT paraphrase or summarize, or <agent_finding> tags will be lost)\n` +
               `3. Then re-call: gossip_session_save(notes: ${JSON.stringify(notes || '')}, _utility_task_id: "${taskId}")\n\n` +
               `Do ALL steps in order. Do not wait for user input between them.`
             },
@@ -4441,6 +4443,7 @@ export function createMcpServer(): McpServer {
             `⚠️ EXECUTE NOW — launch this Agent and re-call gossip_verify_memory:\n\n` +
             `1. Agent(model: "${modelShort}", prompt: <AGENT_PROMPT:${taskId} below>, run_in_background: true) — pass the AGENT_PROMPT:${taskId} content item verbatim\n` +
             `2. When agent completes → gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<full agent output>")\n` +
+            `   (VERBATIM — pass the agent's raw output; do NOT paraphrase or summarize, or <agent_finding> tags will be lost)\n` +
             `3. Then re-call: gossip_verify_memory(memory_path: ${JSON.stringify(memory_path)}, claim: ${JSON.stringify(claim)}, _utility_task_id: "${taskId}")\n\n` +
             `Do ALL steps in order. Do not wait for user input between them.`
           },

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -136,6 +136,18 @@ A graduated skill (`status: 'passed'`) is NOT a permanent verdict. The drift det
 
 **Do not** add a Bonferroni correction to drift α. The graduation, drift, and fast-path tests operate on disjoint signal populations (anchored at `bound_at`/`inconclusive_at`, `passed_at`/`drift_strike_at`, and `regressed_from_passed_at` respectively). Sequential gates on different evidence pools each spend their own α=0.025 without leakage. See `docs/specs/2026-05-13-passed-skill-drift-detection.md` for the full statistical argument.
 
+### 12. Relay result must be passed verbatim — paraphrase silently drops `<agent_finding>` tags
+
+When the orchestrator calls `gossip_relay(task_id, result)` after a native agent completes, the `result` value **must be the agent's raw output, unchanged.** If the orchestrator summarizes or paraphrases (e.g., `"HIGH — recordCreated lacks redaction"` instead of the full `<agent_finding>` block), the consensus engine's regex at `consensus-engine.ts:802` finds zero tags, the agent's findings are counted as zero, and the dashboard shows an empty native-agent column. Data loss is invisible — no error, no retry.
+
+**Failure mode:** the bullet-parse fallback at `consensus-engine.ts:917-932` may partially recover prose summaries, but it loses citation data, severity grading, and confidence scores. Recovered bullets are unverifiable.
+
+**Parser-side defense (PR #270):** `handleNativeRelay()` in `native-tasks.ts` detects zero tags on a consensus-dispatch relay and appends a `relay_findings_dropped` signal to `.gossip/relay-warnings.jsonl` plus a receipt warning in the `gossip_relay` response. This is detection, not prevention.
+
+**Orchestrator-side rule (this invariant):** every dispatch banner and utility relay instruction now carries an explicit `(VERBATIM — pass the agent's raw output; do NOT paraphrase or summarize, or <agent_finding> tags will be lost)` qualifier on the `gossip_relay` step. Treat this line as a hard contract, not a hint.
+
+**Related:** invariant #8 (`FINDING_TAG_SCHEMA` — parsers are strict). Consensus: `edbf8675-87b24107`.
+
 ---
 
 ## Operator playbook (for orchestrator LLMs)

--- a/tests/cli/relay-verbatim-banner.test.ts
+++ b/tests/cli/relay-verbatim-banner.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Relay verbatim banner — 6 sites assert that dispatch/utility banners
+ * contain the VERBATIM qualifier instructing orchestrators not to paraphrase.
+ *
+ * Spec: docs/specs/2026-05-20-relay-verbatim-contract.md
+ * Consensus: edbf8675-87b24107
+ * Related: PR #270 (parser-side relay_findings_dropped warning), PR A (this PR)
+ *
+ * The 6 sites checked:
+ *  1. mcp-server-sdk.ts — gossip_skills utility banner
+ *  2. mcp-server-sdk.ts — gossip_session_save utility banner
+ *  3. mcp-server-sdk.ts — gossip_verify_memory utility banner
+ *  4. native-tasks.ts  — cognitive-summary utility
+ *  5. native-tasks.ts  — gossip-publish utility
+ *  6. dispatch.ts      — PRIMARY dispatch path (handleDispatchSingle)
+ */
+
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { ctx } from '../../apps/cli/src/mcp-context';
+import { handleDispatchSingle } from '../../apps/cli/src/handlers/dispatch';
+
+/** The literal phrase every banner must contain. */
+const VERBATIM_PHRASE = 'VERBATIM — pass the agent\'s raw output; do NOT paraphrase or summarize, or <agent_finding> tags will be lost';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeMainAgent(overrides: Record<string, any> = {}): any {
+  return {
+    dispatch: jest.fn().mockReturnValue({ taskId: 'mock-task-id' }),
+    collect: jest.fn().mockResolvedValue({ results: [] }),
+    getAgentConfig: jest.fn().mockReturnValue(null),
+    getLlm: jest.fn().mockReturnValue(null),
+    getLLM: jest.fn().mockReturnValue(null),
+    getAgentList: jest.fn().mockReturnValue([]),
+    getSkillGapSuggestions: jest.fn().mockReturnValue([]),
+    getSkillIndex: jest.fn().mockReturnValue(null),
+    getSessionGossip: jest.fn().mockReturnValue([]),
+    getSessionConsensusHistory: jest.fn().mockReturnValue([]),
+    recordNativeTask: jest.fn(),
+    recordNativeTaskCompleted: jest.fn(),
+    recordPlanStepResult: jest.fn(),
+    publishNativeGossip: jest.fn().mockResolvedValue(undefined),
+    getChainContext: jest.fn().mockReturnValue(''),
+    generateLensesForAgents: jest.fn().mockResolvedValue(new Map()),
+    dispatchParallel: jest.fn().mockResolvedValue({ taskIds: [], errors: [] }),
+    dispatchParallelWithLenses: jest.fn().mockResolvedValue({ taskIds: [], errors: [] }),
+    getTask: jest.fn().mockReturnValue(null),
+    scopeTracker: {
+      hasOverlap: jest.fn().mockReturnValue({ overlaps: false }),
+      register: jest.fn(),
+      release: jest.fn(),
+    },
+    pipeline: null,
+    projectRoot: '/tmp/gossip-test-project',
+    ...overrides,
+  };
+}
+
+const savedCtx = {
+  mainAgent: ctx.mainAgent,
+  relay: ctx.relay,
+  workers: ctx.workers,
+  keychain: ctx.keychain,
+  skillEngine: ctx.skillEngine,
+  nativeTaskMap: ctx.nativeTaskMap,
+  nativeResultMap: ctx.nativeResultMap,
+  nativeAgentConfigs: ctx.nativeAgentConfigs,
+  pendingConsensusRounds: ctx.pendingConsensusRounds,
+  booted: ctx.booted,
+  boot: ctx.boot,
+  syncWorkersViaKeychain: ctx.syncWorkersViaKeychain,
+};
+
+function resetCtx() {
+  ctx.mainAgent = makeMainAgent();
+  ctx.nativeTaskMap = new Map();
+  ctx.nativeResultMap = new Map();
+  ctx.nativeAgentConfigs = new Map();
+  ctx.pendingConsensusRounds = new Map();
+  ctx.booted = true;
+  ctx.boot = jest.fn().mockResolvedValue(undefined) as any;
+  ctx.syncWorkersViaKeychain = jest.fn().mockResolvedValue(undefined) as any;
+  (ctx as any).skillEngine = null;
+}
+
+function restoreCtx() {
+  Object.assign(ctx, savedCtx);
+}
+
+// ── Site 6: dispatch.ts PRIMARY dispatch path ─────────────────────────────
+
+describe('relay-verbatim-banner — site 6: handleDispatchSingle (primary dispatch)', () => {
+  let tmpDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    tmpDir = mkdtempSync(join(tmpdir(), 'gossip-verbatim-dispatch-'));
+    process.chdir(tmpDir);
+    resetCtx();
+  });
+
+  afterEach(() => {
+    restoreCtx();
+    process.chdir(prevCwd);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('orchestrator banner contains VERBATIM qualifier after gossip_relay line', async () => {
+    ctx.nativeAgentConfigs.set('sonnet-reviewer', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Reviewer',
+      skills: [],
+    });
+
+    const result = await handleDispatchSingle('sonnet-reviewer', 'Audit the codebase');
+    const orchestratorText = (result.content[0] as { text: string }).text;
+
+    expect(orchestratorText).toContain('gossip_relay');
+    expect(orchestratorText).toContain(VERBATIM_PHRASE);
+  });
+});
+
+// ── Sites 1-5: banner strings in source ───────────────────────────────────
+//
+// Sites 1-5 produce banners inside tool-handler closures that require a fully
+// booted MCP server context (live config, relay workers, etc). Rather than
+// standing up the entire MCP server in unit tests, we assert the VERBATIM
+// phrase is present in the compiled source strings directly. This matches the
+// relay-lint.test.ts philosophy: validate the contract at the code-string
+// level when the runtime wiring is expensive to replicate.
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+function readSource(relPath: string): string {
+  return readFileSync(resolve(__dirname, '../../', relPath), 'utf8');
+}
+
+describe('relay-verbatim-banner — site 1: gossip_skills utility banner (mcp-server-sdk.ts)', () => {
+  it('banner after gossip_relay(...result: "<full agent output>") contains VERBATIM qualifier', () => {
+    const src = readSource('apps/cli/src/mcp-server-sdk.ts');
+    // The skills banner has "gossip_relay(task_id: " followed shortly by VERBATIM.
+    // Verify both strings coexist in the file and the VERBATIM line follows the relay line.
+    const relayIdx = src.indexOf('gossip_relay(task_id: "${taskId}", result: "<full agent output>")\\n` +\n                  `   (VERBATIM');
+    expect(relayIdx).toBeGreaterThan(-1);
+  });
+});
+
+describe('relay-verbatim-banner — site 2: gossip_session_save utility banner (mcp-server-sdk.ts)', () => {
+  it('banner after gossip_relay(...result: "<full agent output>") contains VERBATIM qualifier', () => {
+    const src = readSource('apps/cli/src/mcp-server-sdk.ts');
+    // session_save banner: relay line + VERBATIM + re-call gossip_session_save
+    const sessionSaveIdx = src.indexOf('gossip_session_save(notes:');
+    expect(sessionSaveIdx).toBeGreaterThan(-1);
+    // VERBATIM must appear before the re-call line in the same banner block
+    const bannerRegion = src.slice(Math.max(0, sessionSaveIdx - 400), sessionSaveIdx);
+    expect(bannerRegion).toContain(VERBATIM_PHRASE);
+  });
+});
+
+describe('relay-verbatim-banner — site 3: gossip_verify_memory utility banner (mcp-server-sdk.ts)', () => {
+  it('banner after gossip_relay(...relay_token, result: "<full agent output>") contains VERBATIM qualifier', () => {
+    const src = readSource('apps/cli/src/mcp-server-sdk.ts');
+    const verifyIdx = src.indexOf('gossip_verify_memory(memory_path:');
+    expect(verifyIdx).toBeGreaterThan(-1);
+    const bannerRegion = src.slice(Math.max(0, verifyIdx - 500), verifyIdx);
+    expect(bannerRegion).toContain(VERBATIM_PHRASE);
+  });
+});
+
+describe('relay-verbatim-banner — site 4: cognitive-summary utility (native-tasks.ts)', () => {
+  it('banner after gossip_relay(...summaryTaskId) contains VERBATIM qualifier', () => {
+    const src = readSource('apps/cli/src/handlers/native-tasks.ts');
+    const summaryIdx = src.indexOf('gossip_relay(task_id: "${summaryTaskId}", result: "<full agent output>")');
+    expect(summaryIdx).toBeGreaterThan(-1);
+    // VERBATIM must appear immediately after (within 300 chars)
+    const after = src.slice(summaryIdx, summaryIdx + 300);
+    expect(after).toContain(VERBATIM_PHRASE);
+  });
+});
+
+describe('relay-verbatim-banner — site 5: gossip-publish utility (native-tasks.ts)', () => {
+  it('banner after gossip_relay(...gossipTaskId) contains VERBATIM qualifier', () => {
+    const src = readSource('apps/cli/src/handlers/native-tasks.ts');
+    const publishIdx = src.indexOf('gossip_relay(task_id: "${gossipTaskId}", result: "<full agent output>")');
+    expect(publishIdx).toBeGreaterThan(-1);
+    const after = src.slice(publishIdx, publishIdx + 300);
+    expect(after).toContain(VERBATIM_PHRASE);
+  });
+});


### PR DESCRIPTION
consensus-id: edbf8675-87b24107

Appends `(VERBATIM — pass the agent's raw output; do NOT paraphrase or summarize, or <agent_finding> tags will be lost)` after every `gossip_relay` step across all 6 dispatch/utility banners. Adds HANDBOOK invariant #12 and 6 assertion-based tests.

## Background

Follow-up to PR #270 (commit `12a6140`) which added parser-side `relay_findings_dropped` detection in `handleNativeRelay`. A v0.4.27 user reported that orchestrator LLMs paraphrase the agent output before calling `gossip_relay`, silently dropping `<agent_finding>` tags. This PR adds the orchestrator-side **prevention** to complement the parser-side detection.

## Touch points (6 sites)

| # | File | Line | Banner |
|---|------|------|--------|
| 1 | apps/cli/src/mcp-server-sdk.ts | ~3735 | gossip_skills utility |
| 2 | apps/cli/src/mcp-server-sdk.ts | ~4188 | gossip_session_save utility |
| 3 | apps/cli/src/mcp-server-sdk.ts | ~4443 | gossip_verify_memory utility |
| 4 | apps/cli/src/handlers/native-tasks.ts | ~851 | cognitive-summary utility |
| 5 | apps/cli/src/handlers/native-tasks.ts | ~877 | gossip-publish utility |
| 6 | apps/cli/src/handlers/dispatch.ts | ~690 | PRIMARY consensus dispatch |

## Tests

- `tests/cli/relay-verbatim-banner.test.ts` (new, 6 tests) — asserts VERBATIM phrase present at each site
- `tests/cli/relay-lint.test.ts` (existing, 26 tests) — no regression
- `npm run build` clean

## Docs

- HANDBOOK invariant #12: "Relay result must be passed verbatim"
- Spec: `docs/specs/2026-05-20-relay-verbatim-contract.md` (gitignored, local-only per repo convention)

## Out of scope (deferred to PR B)

- `zeroTagAgents` field in `ConsensusReport` + collect-side lint for relay-only rounds
- `ctx.pendingConsensusRounds as any` cleanup at native-tasks.ts:706

🤖 Generated with [Claude Code](https://claude.com/claude-code)