### PR TITLE
feat(consensus): surface zeroTagAgents in ConsensusReport + collect response

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -1185,7 +1185,9 @@ export async function handleCollect(
   // native-tasks.ts:931 — orchestrator sees in-band that some agents silently
   // emitted no `<agent_finding>` tags this round, not just a stderr log.
   if (consensusReport?.zeroTagAgents && consensusReport.zeroTagAgents.length > 0) {
-    const shown = consensusReport.zeroTagAgents.join(', ');
+    const shown = consensusReport.zeroTagAgents
+      .map((id: string) => id.replace(/[\r\n]/g, ' '))
+      .join(', ');
     const overflow = consensusReport.zeroTagOverflow ?? 0;
     const suffix = overflow > 0 ? ` (+${overflow} more)` : '';
     output += `\n⚠ zeroTagAgents: ${shown}${suffix}`;

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -907,6 +907,11 @@ export async function handleCollect(
         // renders a banner on the consensus card when present, so this MUST
         // round-trip through the JSON payload or the feature is invisible.
         ...(consensusReport.authorDiagnostics ? { authorDiagnostics: consensusReport.authorDiagnostics } : {}),
+        // Surface zero-tag agents (strict parser saw no `<agent_finding>` tags
+        // at all) in the persisted report so the dashboard can render the
+        // same silent-dropout indicator the gossip_collect tool response shows.
+        ...(consensusReport.zeroTagAgents ? { zeroTagAgents: consensusReport.zeroTagAgents } : {}),
+        ...(consensusReport.zeroTagOverflow ? { zeroTagOverflow: consensusReport.zeroTagOverflow } : {}),
       }, null, 2));
     } catch (e) {
       // Best-effort still applies (we don't throw to the caller), but the
@@ -1173,6 +1178,17 @@ export async function handleCollect(
 
   if (consensusReport?.summary) {
     output += '\n\n' + consensusReport.summary;
+  }
+
+  // Surface zero-tag agents (consensus-engine.ts: rawTagCount === 0 branch).
+  // Mirrors the `relay_findings_dropped` warning pattern from
+  // native-tasks.ts:931 — orchestrator sees in-band that some agents silently
+  // emitted no `<agent_finding>` tags this round, not just a stderr log.
+  if (consensusReport?.zeroTagAgents && consensusReport.zeroTagAgents.length > 0) {
+    const shown = consensusReport.zeroTagAgents.join(', ');
+    const overflow = consensusReport.zeroTagOverflow ?? 0;
+    const suffix = overflow > 0 ? ` (+${overflow} more)` : '';
+    output += `\n⚠ zeroTagAgents: ${shown}${suffix}`;
   }
 
   if (provisionalSignalCount > 0) {

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -199,6 +199,15 @@ export interface ConsensusReport {
    * banner on affected finding cards so silent parse failures become loud.
    */
   authorDiagnostics?: Record<string, ParseDiagnostic[]>;
+  /**
+   * Agents whose raw output contained zero `<agent_finding>` tags. Mirrors
+   * the orchestrator `ConsensusReport.zeroTagAgents` field so dashboard JSON
+   * parsing preserves the in-band signal. Capped at 5 entries; overflow is
+   * carried separately in `zeroTagOverflow`.
+   */
+  zeroTagAgents?: string[];
+  /** Count of zero-tag agents past the 5-entry `zeroTagAgents` cap. */
+  zeroTagOverflow?: number;
 }
 
 export type ParseDiagnostic =

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -859,6 +859,14 @@ Return only valid JSON.${skillsBlock}`;
     // dashboard can render a banner when agent output was unparseable (e.g.
     // HTML-entity-encoded tags from an upstream-sanitizer layer).
     const authorDiagnostics: Record<string, import('./parse-findings').ParseDiagnostic[]> = {};
+    // Agents whose raw output contained ZERO `<agent_finding>` tags. Capped at
+    // the first 5 `originalAgentId`s for compactness; overflow is counted in
+    // `zeroTagOverflow` and surfaced separately. Mirrors the stderr `_log`
+    // warning at the `rawTagCount === 0` branch below, but in-band so the
+    // `gossip_collect` tool response and dashboard JSON can highlight it.
+    const zeroTagAgents: string[] = [];
+    let zeroTagOverflow = 0;
+    const ZERO_TAG_CAP = 5;
 
     for (const r of successful) {
       // Parse findings from the FULL raw result so tags placed before the
@@ -916,6 +924,11 @@ Return only valid JSON.${skillsBlock}`;
       // different root causes (skill conflict vs type-enum drift) and need different fixes.
       if (agentFindingsFound === 0) {
         if (parseResult.rawTagCount === 0) {
+          if (zeroTagAgents.length < ZERO_TAG_CAP) {
+            zeroTagAgents.push(r.agentId);
+          } else {
+            zeroTagOverflow++;
+          }
           _log('consensus',
             `⚠ agent "${r.agentId}" emitted ZERO tags — falling back to bullet parsing. ` +
             `Check if skill Output Format conflicts with FINDING TAG SCHEMA.`
@@ -1449,6 +1462,9 @@ Return only valid JSON.${skillsBlock}`;
       ...(Object.keys(droppedFindingsByType).length > 0 ? { droppedFindingsByType } : {}),
       // Same pattern for per-author parse diagnostics.
       ...(Object.keys(authorDiagnostics).length > 0 ? { authorDiagnostics } : {}),
+      // Surface zero-tag agents in-band so the gossip_collect tool response
+      // + dashboard JSON can highlight the silent dropout, not just stderr.
+      ...(zeroTagAgents.length > 0 ? { zeroTagAgents, ...(zeroTagOverflow > 0 ? { zeroTagOverflow } : {}) } : {}),
     };
   }
 

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -103,6 +103,19 @@ export interface ConsensusReport {
    * failures loud. Keyed by `originalAgentId`.
    */
   authorDiagnostics?: Record<string, import('./parse-findings').ParseDiagnostic[]>;
+  /**
+   * Agents whose raw output contained ZERO `<agent_finding>` tags (the strict
+   * parser saw no tags at all). Surfaces the same silent dropout that
+   * `consensus-engine.ts:917` logs to stderr, but in-band so the
+   * `gossip_collect` tool response and the dashboard JSON payload can
+   * highlight it. Capped at the first 5 `originalAgentId`s for compactness —
+   * any agents past that quota are counted via `zeroTagOverflow`. Populated
+   * only when `zeroTagAgents.length > 0`; clean rounds keep both fields
+   * undefined.
+   */
+  zeroTagAgents?: string[];
+  /** Count of zero-tag agents past the 5-entry `zeroTagAgents` cap. */
+  zeroTagOverflow?: number;
 }
 
 /** Return type for collect() */

--- a/tests/orchestrator/zero-tag-agents.test.ts
+++ b/tests/orchestrator/zero-tag-agents.test.ts
@@ -79,4 +79,58 @@ describe('ConsensusEngine — zeroTagAgents accumulator', () => {
     expect(report.zeroTagAgents).toBeUndefined();
     expect(report.zeroTagOverflow).toBeUndefined();
   });
+
+  it('exactly 5 zero-tag agents — cap full, no overflow', async () => {
+    const engine = makeEngine();
+
+    const zeroTagIds = ['z1', 'z2', 'z3', 'z4', 'z5'];
+    const tasks: TaskEntry[] = [
+      ...zeroTagIds.map(id => makeTask(id, zeroTagResult(id))),
+      makeTask('agent-keeper', taggedResult),
+    ];
+
+    const report = await engine.synthesize(tasks, []);
+
+    expect(report.zeroTagAgents?.length).toBe(5);
+    expect(report.zeroTagOverflow).toBeUndefined();
+  });
+
+  it('exactly 6 zero-tag agents — cap full, overflow exactly 1', async () => {
+    const engine = makeEngine();
+
+    const zeroTagIds = ['z1', 'z2', 'z3', 'z4', 'z5', 'z6'];
+    const tasks: TaskEntry[] = [
+      ...zeroTagIds.map(id => makeTask(id, zeroTagResult(id))),
+      makeTask('agent-keeper', taggedResult),
+    ];
+
+    const report = await engine.synthesize(tasks, []);
+
+    expect(report.zeroTagAgents?.length).toBe(5);
+    expect(report.zeroTagOverflow).toBe(1);
+  });
+
+  it('mixed round with zero-tag agent and bad-type-tag agent does not cross-contaminate', async () => {
+    const engine = makeEngine();
+
+    // Agent A: zero <agent_finding> tags → zeroTagAgents accumulator
+    const agentAResult = zeroTagResult('agent-a');
+
+    // Agent B: all findings have wrong type "approval" → droppedFindingsByType accumulator
+    const agentBResult = `<agent_finding type="approval">Approval note at file.ts:5 something descriptive enough for the parser</agent_finding>`;
+
+    const tasks: TaskEntry[] = [
+      makeTask('agent-a', agentAResult),
+      makeTask('agent-b', agentBResult),
+      makeTask('agent-keeper', taggedResult),
+    ];
+
+    const report = await engine.synthesize(tasks, []);
+
+    // Only agent-a (zero tags) appears in zeroTagAgents
+    expect(report.zeroTagAgents).toEqual(['agent-a']);
+    // agent-b's "approval" type should land in droppedFindingsByType, not zeroTagAgents
+    expect(report.droppedFindingsByType?.['approval']).toBeGreaterThanOrEqual(1);
+    expect(report.zeroTagOverflow).toBeUndefined();
+  });
 });

--- a/tests/orchestrator/zero-tag-agents.test.ts
+++ b/tests/orchestrator/zero-tag-agents.test.ts
@@ -1,0 +1,82 @@
+import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
+import { TaskEntry } from '../../packages/orchestrator/src/types';
+
+// Minimal engine config so formatReport's registryGet call doesn't throw.
+const makeEngine = () => new ConsensusEngine({
+  llm: { generate: jest.fn() } as any,
+  registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: `preset-${id}`, skills: [] }),
+} as any);
+
+const makeTask = (agentId: string, result: string): TaskEntry => ({
+  id: `task-${agentId}`,
+  agentId,
+  task: 'review',
+  status: 'completed',
+  result,
+  startedAt: Date.now(),
+  completedAt: Date.now(),
+  inputTokens: 0,
+  outputTokens: 0,
+});
+
+// A response that contains ZERO `<agent_finding>` tags — strict parser sees
+// no tags at all, falls back to bullet parsing. This drives the rawTagCount===0
+// branch where the new zeroTagAgents accumulator lives.
+const zeroTagResult = (note: string) => `## Consensus Summary
+- Some prose bullet ${note} that has no tagged finding wrapper at all
+- Second bullet without any <agent_finding> tag wrapper either
+`;
+
+// At least one agent must emit a real tagged finding so the report has SOME
+// content; otherwise the report shape (still valid) is fine but we mostly
+// want to exercise the accumulator path on the zero-tag agents.
+const taggedResult = `<agent_finding type="finding" severity="high">Tagged finding at file.ts:10 for the keeper</agent_finding>`;
+
+describe('ConsensusEngine — zeroTagAgents accumulator', () => {
+  it('collects zeroTagAgents for 3 agents that emit no tags, no overflow', async () => {
+    const engine = makeEngine();
+
+    const tasks: TaskEntry[] = [
+      makeTask('agent-a', zeroTagResult('a')),
+      makeTask('agent-b', zeroTagResult('b')),
+      makeTask('agent-c', zeroTagResult('c')),
+      // One real tagged result so the surrounding round still makes sense
+      makeTask('agent-keeper', taggedResult),
+    ];
+
+    const report = await engine.synthesize(tasks, []);
+
+    expect(report.zeroTagAgents).toEqual(['agent-a', 'agent-b', 'agent-c']);
+    expect(report.zeroTagOverflow).toBeUndefined();
+  });
+
+  it('caps zeroTagAgents at 5 entries and counts overflow for the rest', async () => {
+    const engine = makeEngine();
+
+    // 7 zero-tag agents → first 5 land in zeroTagAgents, last 2 in zeroTagOverflow.
+    const zeroTagIds = ['z1', 'z2', 'z3', 'z4', 'z5', 'z6', 'z7'];
+    const tasks: TaskEntry[] = [
+      ...zeroTagIds.map(id => makeTask(id, zeroTagResult(id))),
+      makeTask('agent-keeper', taggedResult),
+    ];
+
+    const report = await engine.synthesize(tasks, []);
+
+    expect(report.zeroTagAgents).toEqual(['z1', 'z2', 'z3', 'z4', 'z5']);
+    expect(report.zeroTagOverflow).toBe(2);
+  });
+
+  it('omits both fields entirely when no agent emits zero tags', async () => {
+    const engine = makeEngine();
+
+    const tasks: TaskEntry[] = [
+      makeTask('agent-a', `<agent_finding type="finding" severity="high">Finding A at a.ts:1 something descriptive</agent_finding>`),
+      makeTask('agent-b', `<agent_finding type="finding" severity="low">Finding B at b.ts:2 also descriptive enough</agent_finding>`),
+    ];
+
+    const report = await engine.synthesize(tasks, []);
+
+    expect(report.zeroTagAgents).toBeUndefined();
+    expect(report.zeroTagOverflow).toBeUndefined();
+  });
+});


### PR DESCRIPTION
consensus-id: edbf8675-87b24107

Follow-up to PR #422 (b9fbe72). Closes the detection gap for the v0.4.27 user bug: relay-only consensus rounds where orchestrator paraphrased the agent output before `gossip_relay`, leaving a stderr-only warning the orchestrator couldn't see.

## What changed

| File | Change |
|---|---|
| `packages/orchestrator/src/consensus-types.ts` | `ConsensusReport` gains optional `zeroTagAgents?: string[]` and `zeroTagOverflow?: number` |
| `packages/orchestrator/src/consensus-engine.ts` | ZERO-tags branch at `rawTagCount === 0` accumulates `agentId` (cap 5, overflow counter for the rest) and attaches to the report |
| `apps/cli/src/handlers/collect.ts` | Conditional spread into persisted JSON sidecar + `⚠ zeroTagAgents: ...` line in the `gossip_collect` tool response |
| `packages/dashboard-v2/src/lib/types.ts` | `ConsensusStoredReport` mirrors both fields so dashboard JSON parsing preserves them |
| `tests/orchestrator/zero-tag-agents.test.ts` | 3 assertion-based tests |

## Tests

- `npm test zero-tag-agents` — 3/3 pass (3 agents → list, 7 agents → cap+overflow=2, clean round → undefined fields)
- `npm test consensus-engine` — 148/148 pass (no regression)
- `npm test collect` — 59/59 pass (no regression)
- `npm run build` — clean

## Why this matters

PR #270 added parser-side detection in `handleNativeRelay`, but that only fires when the orchestrator paraphrases a native subagent's output. Relay-only consensus rounds (4 custom Solidity-auditor agents in the reporter's case) bypass `handleNativeRelay` entirely and `runConsensus()` is called directly. The fallback warning at `consensus-engine.ts:920` only emitted to mcp.log via `_log('consensus', ...)` — the orchestrator had to scrape server logs to discover the failure.

After this PR, the `gossip_collect` tool response itself carries the warning, with bounded payload growth (5 agents listed + overflow counter).

## Out of scope (deferred)

- `ctx.pendingConsensusRounds as any` cleanup at `native-tasks.ts:706` (gemini-reviewer:f2 from consensus edbf8675)
- Worktree isolation gap recurrence (filed as `project_worktree_isolation_native_dispatch_gap.md` for next session)
- API surface expansion (`result_format` param, `gossip_relay_correct` recovery tool — reporter's suggestions #3 and #4)

## Related

- Consensus `edbf8675-87b24107` (plan review found 5 confirmed + 6 unique findings; 1 hallucination caught on gemini-reviewer:f5 citation)
- PR #270 (commit `12a6140`) — parser-side defense (`relay_findings_dropped`)
- PR #422 (commit `b9fbe72`) — orchestrator-side prevention (VERBATIM banners) + HANDBOOK invariant #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)