### PR TITLE
feat(consensus): category-resolution fix — schema + JSON plumb + bullet-fallback + allowlist

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -33,7 +33,7 @@ import { createServer as createHttpServer, IncomingMessage, ServerResponse } fro
 import { ctx } from './mcp-context';
 import { getGossipcatVersion } from './version';
 import { captureGitStatus, checkUnexpectedChanges } from './utility-guard';
-import { buildUtilityAgentPrompt, getUncategorizedStatusLine, checkDistMcpStaleness, logStalenessToMcpLog } from '@gossip/orchestrator';
+import { buildUtilityAgentPrompt, getUncategorizedStatusLine, checkDistMcpStaleness, logStalenessToMcpLog, isValidCategory } from '@gossip/orchestrator';
 
 // Prime the dist-mcp staleness cache from the running bundle path. In the bundled
 // CJS output (dist-mcp/mcp-server.js) __filename resolves to the bundle file, so
@@ -2814,7 +2814,7 @@ export function createMcpServer(): McpServer {
             counterpartId: s.counterpart_id,
             findingId: s.finding_id,
             severity: s.severity,
-            category: s.category ?? inferCategory(s),
+            category: (isValidCategory(s.category) ? s.category : undefined) ?? inferCategory(s),
             source: 'manual',
             evidence,
             timestamp: ts,

--- a/packages/orchestrator/src/category-extractor.ts
+++ b/packages/orchestrator/src/category-extractor.ts
@@ -29,6 +29,19 @@ const CATEGORY_PATTERNS: Record<string, RegExp[]> = {
   testing: [/\btest(s|ing)?\b/i, /coverage/i, /\bmock\b/i, /\bfixture\b/i, /\bunit test/i, /integration test/i, /\be2e\b/i, /test suite/i],
 };
 
+/**
+ * Canonical allowlist of category keys, derived from CATEGORY_PATTERNS so the
+ * two sources can never drift. Used by parse-findings and parseCrossReviewResponse
+ * to reject agent-supplied category strings that aren't real categories — without
+ * this guard, an agent typo would land in `categoryStrengths[<typo>]` and poison
+ * scoring permanently (see spec 2026-05-20-category-resolution-fix.md PART F).
+ */
+export const VALID_CATEGORIES: ReadonlySet<string> = new Set(Object.keys(CATEGORY_PATTERNS));
+
+export function isValidCategory(c: string | undefined): c is string {
+  return typeof c === 'string' && VALID_CATEGORIES.has(c);
+}
+
 export function extractCategories(findingText: string): string[] {
   const matched = new Set<string>();
   for (const [category, patterns] of Object.entries(CATEGORY_PATTERNS)) {

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -15,7 +15,7 @@ import { AgentConfig, TaskEntry } from './types';
 import { ConsensusReport, ConsensusFinding, ConsensusNewFinding, ConsensusSignal, CrossReviewEntry } from './consensus-types';
 import { selectCrossReviewers, FindingForSelection, AgentCandidate } from './cross-reviewer-selection';
 import { parseAgentFindingsStrict, PARSE_FINDINGS_LIMITS } from './parse-findings';
-import { extractCategories } from './category-extractor';
+import { extractCategories, isValidCategory } from './category-extractor';
 import { logUncategorizedFinding } from './uncategorized-logger';
 
 export type {
@@ -644,7 +644,9 @@ Return ONLY a JSON array. findingId format:
 - For new: "self:n<N>" — the server rewrites this to a consensus-wide ID. Do NOT reference a peer.
 [
   { "action": "agree"|"disagree"|"unverified"|"new", "findingId": "...", "finding": "brief summary", "evidence": "your reasoning", "confidence": 1-5 }
-]`;
+]
+
+Optional "category" field on action: "new" entries — one of: trust_boundaries | injection_vectors | input_validation | concurrency | resource_exhaustion | type_safety | error_handling | data_integrity | citation_grounding | observability | cli_ergonomics | performance | testing. Any other value is silently dropped to undefined. Set it only when you're confident; the system also infers category from the finding text when omitted. agree/disagree/unverified inherit category from the parent finding.`;
 
     // Inject the reviewer's skills (if any) so their Phase-2 methodology
     // matches Phase 1. Without this, a reviewer trained on citation_grounding
@@ -956,6 +958,7 @@ Return only valid JSON.${skillsBlock}`;
             originalAgentId: r.agentId,
             finding,
             findingType,
+            category: extractCategories(finding)[0],
             confirmedBy: [],
             disputedBy: [],
             unverifiedBy: [],
@@ -1134,7 +1137,7 @@ Return only valid JSON.${skillsBlock}`;
           evidence: capEvidence(entry.evidence),
           timestamp: now,
           findingId: newFindingId,
-          category: resolveSignalCategory(undefined, entry.evidence, entry.finding) ?? undefined,
+          category: resolveSignalCategory(entry.category, entry.finding, entry.evidence) ?? undefined,
         });
         continue;
       }
@@ -2535,6 +2538,8 @@ Return only valid JSON.${skillsBlock}`;
       const findingId = typeof item.findingId === 'string' ? item.findingId : '';
       const peerFromId = findingId.includes(':') ? findingId.split(':')[0] : '';
       const fallbackAgentId = typeof item.agentId === 'string' ? item.agentId : '';
+      const rawCategory = typeof item.category === 'string' ? item.category : undefined;
+      const category = isValidCategory(rawCategory) ? rawCategory : undefined;
       entries.push({
         action: item.action as CrossReviewEntry['action'],
         agentId: reviewerAgentId,
@@ -2543,6 +2548,7 @@ Return only valid JSON.${skillsBlock}`;
         finding: String(item.finding),
         evidence: String(item.evidence),
         confidence,
+        category,
       });
     }
 

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -41,6 +41,10 @@ export interface CrossReviewEntry {
   finding: string;
   evidence: string;
   confidence: number;    // 1-5
+  /** Optional category volunteered by the reviewer in the cross-review JSON.
+   *  Validated against `VALID_CATEGORIES` in `parseCrossReviewResponse`; any value
+   *  outside the 13-key allowlist is silently dropped to undefined. */
+  category?: string;
 }
 
 /** Full consensus report */

--- a/packages/orchestrator/src/finding-tag-schema.ts
+++ b/packages/orchestrator/src/finding-tag-schema.ts
@@ -17,6 +17,7 @@ export const FINDING_TAG_SCHEMA = `FINDING TAG SCHEMA (output parsing requires t
 - Wrap each verifiable claim in <agent_finding type="..." severity="...">...</agent_finding>
 - type MUST be one of: finding | suggestion | insight (any other value is silently DROPPED)
 - severity (findings only): critical | high | medium | low
+- category="..." (optional, findings only) — allowed: trust_boundaries, injection_vectors, input_validation, concurrency, resource_exhaustion, type_safety, error_handling, data_integrity, citation_grounding, observability, cli_ergonomics, performance, testing. Other values DROPPED to undefined; inferred from text when omitted.
 - Do NOT invent new types (e.g., "approval", "concern", "risk", "recommendation", "confirmed", "issue", "bug", "warning") — they will not appear in any dashboard, score, or signal.
 - Cite source files inline: <cite tag="file">path:line</cite>`;
 

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -153,7 +153,7 @@ export type { TeamManagerConfig } from './team-manager';
 export { normalizeSkillName } from './skill-name';
 export { parseSkillFrontmatter } from './skill-parser';
 export type { SkillFrontmatter, SkillScope } from './skill-parser';
-export { extractCategories } from './category-extractor';
+export { extractCategories, isValidCategory, VALID_CATEGORIES } from './category-extractor';
 export { logUncategorizedFinding, getUncategorizedStatusLine } from './uncategorized-logger';
 export type { UncategorizedFindingContext, UncategorizedFindingRecord } from './uncategorized-logger';
 export { selectCrossReviewers } from './cross-reviewer-selection';

--- a/packages/orchestrator/src/parse-findings.ts
+++ b/packages/orchestrator/src/parse-findings.ts
@@ -19,6 +19,8 @@
  * which agent outputs parse.
  */
 
+import { isValidCategory } from './category-extractor';
+
 const MAX_FINDING_CONTENT = 8000;
 const MIN_FINDING_CONTENT = 15;
 const AGENT_FINDING_PATTERN = /<agent_finding\s+([^>]*)>([\s\S]*?)<\/agent_finding>/g;
@@ -307,7 +309,7 @@ export function parseAgentFindingsStrict(
     findings.push({
       type: normalizedType as FindingType,
       severity: severityMatch?.[1] as Severity | undefined,
-      category: categoryMatch?.[1],
+      category: isValidCategory(categoryMatch?.[1]) ? categoryMatch![1] : undefined,
       content,
       hasAnchor: ANCHOR_PATTERN.test(content),
       findingIdx,

--- a/tests/orchestrator/consensus-engine-category-parse.test.ts
+++ b/tests/orchestrator/consensus-engine-category-parse.test.ts
@@ -507,3 +507,97 @@ describe('record-undefined policy — hallucination_caught with projectRoot (cit
     expect(Array.isArray(report.signals)).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Spec 2026-05-20-category-resolution-fix PART G — three new cases for the
+// JSON / schema / fallback plumbing introduced by PARTS C, F, and D.
+// ---------------------------------------------------------------------------
+
+describe('parseCrossReviewResponse — category attribute (PARTS C + F)', () => {
+  it('extracts a valid category from cross-review JSON', () => {
+    const engine = new ConsensusEngine({} as any);
+    const raw = JSON.stringify([{
+      action: 'new',
+      findingId: 'self:n1',
+      finding: 'race condition between writers',
+      evidence: 'two callers can write without a lock',
+      confidence: 4,
+      category: 'concurrency',
+    }]);
+    const entries = (engine as any).parseCrossReviewResponse('reviewer-x', raw, 50) as CrossReviewEntry[];
+    expect(entries).toHaveLength(1);
+    expect(entries[0].category).toBe('concurrency');
+  });
+
+  it('rejects invalid category — yields undefined silently', () => {
+    const engine = new ConsensusEngine({} as any);
+    const raw = JSON.stringify([{
+      action: 'new',
+      findingId: 'self:n1',
+      finding: 'something is off',
+      evidence: 'whatever',
+      confidence: 3,
+      category: 'my_made_up_category',
+    }]);
+    const entries = (engine as any).parseCrossReviewResponse('reviewer-x', raw, 50) as CrossReviewEntry[];
+    expect(entries).toHaveLength(1);
+    expect(entries[0].category).toBeUndefined();
+  });
+});
+
+describe('synthesize() — bullet-fallback populates category at insertion (PART D)', () => {
+  it('bullet-fallback finding gets category from extractCategories', async () => {
+    // makeEngine + makeTask are defined at the top of this file.
+    const engine = (() => new ConsensusEngine({
+      llm: { generate: jest.fn() } as any,
+      registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: `preset-${id}`, skills: [] }),
+    } as any))();
+
+    // Agent A emits NO <agent_finding> tags but a bullet containing "race condition"
+    // (matches concurrency per category-extractor.ts).
+    const resultA: TaskEntry = {
+      id: 'task-a',
+      agentId: 'agent-a',
+      task: 'review',
+      status: 'completed',
+      result: '## Findings\n- race condition between writers at db.ts:42 — two callers can write without a lock',
+      startedAt: Date.now(),
+      completedAt: Date.now(),
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+    // Agent B has a real tag so synthesize still has a successful peer.
+    const resultB: TaskEntry = {
+      id: 'task-b',
+      agentId: 'agent-b',
+      task: 'review',
+      status: 'completed',
+      result: '<agent_finding type="finding" severity="low">Unrelated finding at util.ts:10</agent_finding>',
+      startedAt: Date.now(),
+      completedAt: Date.now(),
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+
+    const crossReview: CrossReviewEntry[] = [
+      {
+        action: 'agree',
+        agentId: 'agent-b',
+        peerAgentId: 'agent-a',
+        finding: 'race condition between writers at db.ts:42 — two callers can write without a lock',
+        evidence: 'confirmed by reading the code',
+        confidence: 4,
+      },
+    ];
+
+    const report = await engine.synthesize([resultA, resultB], crossReview);
+
+    // The agreement signal (or any signal targeting the bullet-fallback finding)
+    // must carry category === "concurrency", NOT undefined.
+    const agreement = report.signals.find(
+      s => s.signal === 'agreement' && s.agentId === 'agent-b',
+    );
+    expect(agreement).toBeDefined();
+    expect(agreement!.category).toBe('concurrency');
+  });
+});

--- a/tests/orchestrator/prompt-assembler.test.ts
+++ b/tests/orchestrator/prompt-assembler.test.ts
@@ -311,10 +311,10 @@ describe('assemblePrompt suffix cap (F14 — priority-ordered drop)', () => {
 
   it('drops AGENT MEMORY before MEMORY when only one drop is needed (priority 4 > priority 3)', () => {
     // Size MEMORY just over the reserve budget so AGENT_MEMORY's removal
-    // alone brings total back under reserve. Schema ~600 + OUTPUT_DELIVERY ~400
-    // + AGENT_MEMORY ~500 + task tiny → memory body of ~16700 pushes total
-    // just over 18K reserve.
-    const memoryBlock = 'actual memory: ' + 'y'.repeat(16_700);
+    // alone brings total back under reserve. Schema ~900 (category attr added) +
+    // OUTPUT_DELIVERY ~400 + AGENT_MEMORY ~500 + task tiny → memory body of
+    // ~16400 pushes total just over 18K reserve.
+    const memoryBlock = 'actual memory: ' + 'y'.repeat(16_400);
     const result = assemblePrompt({
       task: 'x',
       memory: memoryBlock,


### PR DESCRIPTION
## Summary

Closes the JSON / schema / fallback gaps in category resolution per spec `docs/specs/2026-05-20-category-resolution-fix.md`. Makes `category` a first-class, schema-documented attribute on `<agent_finding>` tags and cross-review JSON, plumbs the value through the parser/cross-review entry type/bullet-fallback so every code path reading `f.category` gets a real value, and validates any explicit category against the canonical 13-key allowlist.

**consensus-id:** `1a8b2cde-30724534`

## Changes

- **PART A** — `finding-tag-schema.ts`: schema documents `category="..."` with all 13 canonical values, optional, drops to `undefined` on mismatch.
- **PART F** — `category-extractor.ts` + `parse-findings.ts`: `VALID_CATEGORIES` (derived from `CATEGORY_PATTERNS` keys, single-source) + `isValidCategory` type guard wired into `CATEGORY_ATTR_PATTERN` capture.
- **PART C** — `consensus-types.ts` + `consensus-engine.ts`: `category?: string` on `CrossReviewEntry`; `parseCrossReviewResponse` extracts `item.category` with allowlist validation.
- **PART E** — `consensus-engine.ts:1140`: `resolveSignalCategory(entry.category, entry.finding, entry.evidence)` — hard-coded `undefined` first slot replaced with explicit category-from-PART-C, with finding text preferred over evidence per spec.
- **PART D** — `consensus-engine.ts:961`: bullet-fallback `findingMap.set` computes `category: extractCategories(finding)[0]` at insertion; downstream resolvers no longer read `f.category` as `undefined` for bullet-parsed findings.
- **PART B** — `consensus-engine.ts:649`: cross-review JSON template advertises optional `"category"` field scoped to `action: "new"`.
- **PART G** — `tests/orchestrator/consensus-engine-category-parse.test.ts`: 3 new cases (valid extraction, invalid rejection, bullet-fallback end-to-end signal carries category).

**Fixup commit (`7f390f6`):** sonnet-reviewer flagged in consensus that the `gossip_signals` manual-record path also writes unvalidated category strings. The enforcement loop at `mcp-server-sdk.ts:2872` only fires for `hallucination_caught` signals (early-return for others), so an orchestrator typo on `agreement`/`unique_confirmed` signals could poison `categoryStrengths` the same way an agent typo would have before PART F. Single-line guard at the write site (`:2817`); reuses the same `isValidCategory` helper.

## Consensus

3-agent round (sonnet-reviewer + gemini-reviewer + gemini-tester): **8 confirmed, 1 disputed (resolved), 0 unverified, 3 unique, 0 insights, 2 new**. Sonnet self-corrected one Phase-1 LOW finding (false concern about test identity at :466) and expanded the trust-boundary medium with deeper evidence (location of the guard at :2872). All non-suggestion findings addressed.

Schema growth: `FINDING_TAG_SCHEMA` went from ~498 to ~866 bytes (+334 well within the 18K `SUFFIX_RESERVE`). `prompt-assembler.test.ts` `memoryBlock` reduced 16700 → 16400 to preserve the test's "just over reserve" calibration. Confirmed by all 3 reviewers as correct accommodation, not test-weakening.

## Test plan

- [x] `npm run build:mcp` clean (2.0mb bundle, 39ms)
- [x] 146 orchestrator suites: 2141/2141 pass (3 new PART G tests included)
- [x] `tests/orchestrator/prompt-assembler.test.ts` passes with the calibrated `memoryBlock` adjustment
- [x] Worktree branch verified isolated from master (consensus citations resolved against `.claude/worktrees/agent-a2fed245d39be4d71/` via `resolutionRoots`)

## Out of scope

- Source C "bound-skill fallback" (multi-binding ambiguity) — defers cleanly per spec
- Historical signal backfill in `agent-performance.jsonl` (verifier already no-ops uncategorized signals)
- Suggested-only edge case tests for category-on-agree-action + case-sensitivity (filed as follow-up; current behavior is correct, suggested tests would harden regression coverage only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)