### PR TITLE
feat(dispatch): detect native worktree isolation failure (Option B)

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -559,7 +559,19 @@ export async function handleDispatchSingle(
       preDispatchSha = capturePreDispatchSha();
     }
 
-    ctx.nativeTaskMap.set(taskId, { agentId: agent_id, task, startedAt: Date.now(), timeoutMs, planId: plan_id, step, writeMode: write_mode, relayToken, preDispatchSha });
+    // Option B isolation-failure detector — snapshot parent-checkout state for
+    // worktree-mode native dispatches so handleNativeRelay can detect writes
+    // that leaked outside the Agent(isolation:"worktree") sandbox.
+    // Spec: docs/specs/2026-05-20-native-worktree-isolation-fix.md
+    let isolationSnapshot: { head: string | null; dirty: string[]; takenAt: string } | undefined;
+    if (write_mode === 'worktree') {
+      try {
+        const { captureIsolationSnapshot } = require('./worktree-isolation-detection');
+        isolationSnapshot = captureIsolationSnapshot(process.cwd());
+      } catch { /* best-effort — snapshot failure must not block dispatch */ }
+    }
+
+    ctx.nativeTaskMap.set(taskId, { agentId: agent_id, task, startedAt: Date.now(), timeoutMs, planId: plan_id, step, writeMode: write_mode, relayToken, preDispatchSha, isolationSnapshot });
     spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
     // promptPath is filled in below after elision (if requested).
     process.stderr.write(`[gossipcat] → dispatch → ${agent_id} (${nativeConfig.model}) [${taskId}]\n`);
@@ -947,7 +959,16 @@ export async function handleDispatchParallel(
       emitConsensusSignals(process.cwd(), premiseResult.signals);
     }
 
-    ctx.nativeTaskMap.set(taskId, { agentId: def.agent_id, task: def.task, startedAt: Date.now(), timeoutMs: NATIVE_TASK_TTL_MS, relayToken });
+    // Option B isolation-failure detector — parallel-dispatch path.
+    let parallelIsolationSnapshot: { head: string | null; dirty: string[]; takenAt: string } | undefined;
+    if (def.write_mode === 'worktree') {
+      try {
+        const { captureIsolationSnapshot } = require('./worktree-isolation-detection');
+        parallelIsolationSnapshot = captureIsolationSnapshot(process.cwd());
+      } catch { /* best-effort */ }
+    }
+
+    ctx.nativeTaskMap.set(taskId, { agentId: def.agent_id, task: def.task, startedAt: Date.now(), timeoutMs: NATIVE_TASK_TTL_MS, relayToken, writeMode: def.write_mode as any, isolationSnapshot: parallelIsolationSnapshot });
     spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
     try { ctx.mainAgent.recordNativeTask(taskId, def.agent_id, def.task); } catch { /* best-effort */ }
     allParallelTaskIds.push(taskId);

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -592,6 +592,23 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
     } catch { /* best-effort — violation detection must not block relay completion */ }
   }
 
+  // Option B isolation-failure detector — re-snapshot parent checkout and
+  // emit worktree_isolation_failed if HEAD moved or new dirty paths appeared
+  // that weren't in the dispatch-time snapshot. Spec:
+  // docs/specs/2026-05-20-native-worktree-isolation-fix.md
+  let isolationDiff: { headChanged: boolean; dirtyPathsAdded: string[]; isViolation: boolean } | null = null;
+  if (taskInfo.writeMode === 'worktree' && taskInfo.isolationSnapshot) {
+    try {
+      const { checkIsolationViolation } = require('./worktree-isolation-detection');
+      isolationDiff = checkIsolationViolation(
+        taskInfo.agentId,
+        task_id,
+        taskInfo.isolationSnapshot,
+        process.cwd(),
+      );
+    } catch { /* best-effort — detector must not block relay completion */ }
+  }
+
   // Bug f13: prune orphaned worktrees on native error — mirrors dispatch-pipeline.ts:473-475.
   // Native worktrees use Claude Code's Agent(isolation:"worktree") so there's no
   // worktreePath in NativeTaskInfo. pruneOrphans() iterates all gossip-wt-* worktrees
@@ -929,6 +946,14 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
   }
   if (relayLintFired) {
     responseText += `\n⚠ relay_findings_dropped: result has 0 <agent_finding> tags but task was a consensus dispatch — orchestrator may have paraphrased; original tagged findings are lost from the dashboard.`;
+  }
+  if (isolationDiff && isolationDiff.isViolation) {
+    const headPart = isolationDiff.headChanged ? 'HEAD moved' : 'HEAD unchanged';
+    const list = isolationDiff.dirtyPathsAdded.slice(0, 5).join(', ');
+    const more = isolationDiff.dirtyPathsAdded.length > 5
+      ? ` +${isolationDiff.dirtyPathsAdded.length - 5} more`
+      : '';
+    responseText += `\n⚠ worktree_isolation_failed: Agent(isolation:"worktree") write leaked into parent checkout (${headPart}, ${isolationDiff.dirtyPathsAdded.length} new dirty path(s)${list ? `: ${list}${more}` : ''}).`;
   }
   if (utilityBlocks.length > 0) {
     responseText += `\n\n⚠️ EXECUTE NOW — ${utilityBlocks.length} utility task(s) queued:\n\n${utilityBlocks.join('\n\n')}`;

--- a/apps/cli/src/handlers/worktree-isolation-detection.ts
+++ b/apps/cli/src/handlers/worktree-isolation-detection.ts
@@ -1,0 +1,217 @@
+// @gossip:impact-adjacent:signal-pipeline
+
+/**
+ * Native worktree isolation detection — Option B (detection-only safety net).
+ *
+ * Spec: docs/specs/2026-05-20-native-worktree-isolation-fix.md §"Option B"
+ *
+ * Agent(isolation:"worktree") native dispatches occasionally land writes in the
+ * parent checkout instead of the requested .claude/worktrees/<id>/ sandbox
+ * (e.g. PR #422). This module captures a snapshot of parent-checkout state at
+ * dispatch time (HEAD SHA + `git status --porcelain` paths) and re-checks on
+ * relay completion. If EITHER HEAD moved OR new dirty paths appeared that
+ * weren't in the snapshot, emit a `worktree_isolation_failed` operational
+ * signal so the failure is auditable.
+ *
+ * IMPORTANT: HEAD-drift alone wouldn't have caught PR #422 (clean fork case);
+ * the working-tree dirty diff is the canonical detector.
+ *
+ * Fail-open everywhere — detection MUST NOT block a real relay completion.
+ */
+import { execFileSync } from 'child_process';
+
+export interface IsolationSnapshot {
+  /** HEAD SHA of parent checkout at dispatch time, or null on git failure. */
+  head: string | null;
+  /**
+   * Sorted list of `path` portions from `git status --porcelain`. Each entry
+   * is the raw path string (porcelain v1 columns 3+). Stored sorted so set
+   * diffs are stable across runs.
+   */
+  dirty: string[];
+  /** ISO timestamp of when the snapshot was taken. */
+  takenAt: string;
+}
+
+/** Parsed diff between two snapshots. */
+export interface IsolationDiff {
+  headChanged: boolean;
+  dirtyPathsAdded: string[];
+  isViolation: boolean;
+}
+
+/** Read `git rev-parse HEAD` from `cwd`. Returns null on any failure. */
+function readHead(cwd: string): string | null {
+  try {
+    const out = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse `git status --porcelain` into a sorted list of path strings.
+ *
+ * Porcelain v1 format per line: `XY <path>` where XY is a 2-char status code
+ * and `<path>` extends to end-of-line (renames use `orig -> new`, we keep the
+ * raw line content after the leading 3 chars for diff stability).
+ */
+export function parsePorcelain(output: string): string[] {
+  const lines = output.split('\n').map(l => l.replace(/\r$/, '')).filter(Boolean);
+  const paths: string[] = [];
+  for (const line of lines) {
+    // porcelain v1: 2-char XY, 1 space, then path. Length < 4 → malformed, skip.
+    if (line.length < 4) continue;
+    const path = line.slice(3);
+    if (path) paths.push(path);
+  }
+  return paths.sort();
+}
+
+/** Run `git status --porcelain` from `cwd`. Returns [] on any failure. */
+function readPorcelain(cwd: string): string[] {
+  try {
+    const out = execFileSync('git', ['status', '--porcelain'], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString();
+    return parsePorcelain(out);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Capture parent-checkout state at dispatch time. Called from dispatch.ts
+ * BEFORE Agent(isolation:"worktree") is invoked; only for writeMode === 'worktree'.
+ *
+ * Both probes fail-open: on git error, head stays null and dirty stays [] —
+ * the diff function gracefully degrades (a null `before.head` short-circuits
+ * the HEAD-drift check; an empty `before.dirty` means every observed dirty
+ * path on relay counts as "added").
+ */
+export function captureIsolationSnapshot(cwd: string = process.cwd()): IsolationSnapshot {
+  return {
+    head: readHead(cwd),
+    dirty: readPorcelain(cwd),
+    takenAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Diff two snapshots. Violation if HEAD moved OR new dirty paths appeared
+ * that weren't in the `before` set.
+ *
+ * `before.head === null` short-circuits the HEAD comparison — we can't claim
+ * drift if we never read the baseline. The dirty-path diff still runs and is
+ * sufficient to catch the PR #422 pattern (HEAD untouched, files written
+ * directly to parent checkout).
+ */
+export function diffIsolationSnapshots(
+  before: IsolationSnapshot,
+  after: IsolationSnapshot,
+): IsolationDiff {
+  const headChanged =
+    before.head !== null && after.head !== null && before.head !== after.head;
+
+  const beforeSet = new Set(before.dirty);
+  const dirtyPathsAdded = after.dirty.filter(p => !beforeSet.has(p));
+
+  return {
+    headChanged,
+    dirtyPathsAdded,
+    isViolation: headChanged || dirtyPathsAdded.length > 0,
+  };
+}
+
+/**
+ * Build the operational-signal payload for a detected isolation failure.
+ *
+ * NOTE: The signal name `worktree_isolation_failed` is NOT yet in
+ * `OPERATIONAL_SIGNAL_NAMES` in `packages/orchestrator/src/consensus-types.ts`
+ * (out of this dispatch's scope). Emitting it through `emitConsensusSignals`
+ * will succeed (the allowlist is read-side, used by classifySignal), but
+ * `classifySignal` will return undefined until the allowlist is updated in a
+ * follow-up PR. See finding emitted by this dispatch.
+ */
+export function buildIsolationSignal(args: {
+  agentId: string;
+  taskId: string;
+  before: IsolationSnapshot;
+  after: IsolationSnapshot;
+  diff: IsolationDiff;
+}): {
+  type: 'consensus';
+  signal: 'worktree_isolation_failed';
+  agentId: string;
+  taskId: string;
+  evidence: string;
+  timestamp: string;
+  head_before: string | null;
+  head_after: string | null;
+  dirty_paths_added: string[];
+} {
+  const { agentId, taskId, before, after, diff } = args;
+  const headSummary = diff.headChanged
+    ? `HEAD ${before.head?.slice(0, 8) ?? 'null'}→${after.head?.slice(0, 8) ?? 'null'}`
+    : 'HEAD unchanged';
+  const dirtySummary = diff.dirtyPathsAdded.length > 0
+    ? `${diff.dirtyPathsAdded.length} new dirty path(s)`
+    : 'no new dirty paths';
+  return {
+    type: 'consensus',
+    signal: 'worktree_isolation_failed',
+    agentId,
+    taskId,
+    evidence: `Agent(isolation:"worktree") write leaked into parent checkout: ${headSummary}, ${dirtySummary}`,
+    timestamp: new Date().toISOString(),
+    head_before: before.head,
+    head_after: after.head,
+    dirty_paths_added: diff.dirtyPathsAdded,
+  };
+}
+
+/**
+ * End-to-end check called from native-tasks.handleNativeRelay. Re-runs the
+ * probes, diffs against the dispatch-time snapshot, and emits the signal if
+ * a violation is detected. Returns the diff so the caller can surface a
+ * warning in the relay receipt.
+ *
+ * Fail-open: any throw is swallowed; returns a no-violation diff.
+ */
+export function checkIsolationViolation(
+  agentId: string,
+  taskId: string,
+  before: IsolationSnapshot,
+  cwd: string = process.cwd(),
+): IsolationDiff {
+  try {
+    const after = captureIsolationSnapshot(cwd);
+    const diff = diffIsolationSnapshots(before, after);
+    if (diff.isViolation) {
+      try {
+        const { emitConsensusSignals } = require('@gossip/orchestrator');
+        emitConsensusSignals(cwd, [buildIsolationSignal({ agentId, taskId, before, after, diff })]);
+      } catch {
+        /* best-effort — signal emission must not block relay completion */
+      }
+      try {
+        const list = diff.dirtyPathsAdded.slice(0, 5).join(', ');
+        const more = diff.dirtyPathsAdded.length > 5 ? ` +${diff.dirtyPathsAdded.length - 5} more` : '';
+        process.stderr.write(
+          `[gossipcat] ⚠️  worktree_isolation_failed [${taskId}] agent=${agentId} ` +
+          `headChanged=${diff.headChanged} dirtyAdded=${diff.dirtyPathsAdded.length}${list ? ` (${list}${more})` : ''}\n`,
+        );
+      } catch { /* best-effort */ }
+    }
+    return diff;
+  } catch {
+    return { headChanged: false, dirtyPathsAdded: [], isViolation: false };
+  }
+}

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -71,6 +71,18 @@ export interface NativeTaskInfo {
    */
   preDispatchSha?: string | null;
   /**
+   * Snapshot of parent-checkout state at dispatch time, used by the
+   * Option B isolation-failure detector. Only populated for
+   * `writeMode === 'worktree'` native dispatches. See
+   * `apps/cli/src/handlers/worktree-isolation-detection.ts` and
+   * docs/specs/2026-05-20-native-worktree-isolation-fix.md §"Option B".
+   */
+  isolationSnapshot?: {
+    head: string | null;
+    dirty: string[];
+    takenAt: string;
+  };
+  /**
    * Absolute path to the on-disk dispatch prompt file, set ONLY when the
    * caller requested `prompt_format: 'elided'` (Option B server-side prompt
    * elision, spec docs/specs/2026-05-18-native-dispatch-skill-handle-pattern.md).

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -186,7 +186,17 @@ export interface ConsensusSignal {
      * from accuracy / uniqueness / circuit-breaker arithmetic — it tracks
      * separately as `AgentScore.transport_failure_count`.
      */
-    | 'transport_failure';
+    | 'transport_failure'
+    /**
+     * Native worktree isolation gap (spec
+     * docs/specs/2026-05-20-native-worktree-isolation-fix.md). Emitted by the
+     * relay-side detector in apps/cli/src/handlers/worktree-isolation-detection.ts
+     * when an `Agent(isolation:"worktree")` dispatch leaves the parent checkout
+     * with moved HEAD or new dirty paths — i.e. the native subagent wrote to
+     * the parent checkout instead of its isolated worktree. Detection-only;
+     * no automatic recovery.
+     */
+    | 'worktree_isolation_failed';
   agentId: string;
   counterpartId?: string;
   skill?: string;
@@ -345,6 +355,7 @@ export const OPERATIONAL_SIGNAL_NAMES: ReadonlySet<string> = new Set([
   'consensus_round_retracted',
   'unverified',
   'transport_failure',
+  'worktree_isolation_failed',
 ]);
 
 export function classifySignal(signalName: string): SignalClass | undefined {

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -225,6 +225,16 @@ export interface ConsensusSignal {
   source?: 'auto' | 'manual';
   evidence: string;
   timestamp: string;
+  /**
+   * `worktree_isolation_failed` payload fields — populated by the native-worktree
+   * isolation detector at apps/cli/src/handlers/worktree-isolation-detection.ts.
+   * Optional on the union so other signals don't need to carry them; typed
+   * readers (dashboards, gossip_signals consumers) can surface them without a
+   * side-channel JSON parse. Closes consensus 68283116-20504c9d:f5.
+   */
+  head_before?: string | null;
+  head_after?: string | null;
+  dirty_paths_added?: string[];
 }
 
 /** Implementation quality signal from verify_write */

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -152,6 +152,11 @@ const KNOWN_SIGNALS: Record<ConsensusSignal['signal'], true> = {
   // scoring switch's exhaustiveness check holds; it's a no-op for accuracy /
   // uniqueness / circuit breaker — only `transport_failure_count` is bumped.
   transport_failure: true,
+  // Operational signal emitted by the native-worktree isolation detector
+  // (apps/cli/src/handlers/worktree-isolation-detection.ts) when an
+  // Agent(isolation:"worktree") dispatch leaves the parent checkout dirty.
+  // No-op for accuracy / uniqueness — surfaces in dashboards/operational counters only.
+  worktree_isolation_failed: true,
 };
 
 const SEVERITY_MULTIPLIER: Record<string, number> = {

--- a/packages/orchestrator/src/performance-writer.ts
+++ b/packages/orchestrator/src/performance-writer.ts
@@ -68,6 +68,11 @@ export const VALID_CONSENSUS_SIGNALS = new Set([
   // per performance-reader.ts:950 + L75. Pre-PR #329: rejected by validateSignal
   // and silently dropped, masking the fail-closed signal emit added in PR #328.
   'transport_failure',
+  // Native-worktree isolation gap detector (spec
+  // docs/specs/2026-05-20-native-worktree-isolation-fix.md). Emitted when an
+  // Agent(isolation:"worktree") dispatch leaves the parent checkout with moved
+  // HEAD or new dirty paths. Operational signal — zero weight in scoring.
+  'worktree_isolation_failed',
 ]);
 
 export const VALID_IMPL_SIGNALS = new Set([

--- a/tests/cli/worktree-isolation-detection.test.ts
+++ b/tests/cli/worktree-isolation-detection.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for Option B native worktree isolation-failure detector.
+ * Spec: docs/specs/2026-05-20-native-worktree-isolation-fix.md §"Option B"
+ *
+ * Covers:
+ *   parsePorcelain           — porcelain v1 parsing + CRLF tolerance + sort stability
+ *   diffIsolationSnapshots   — HEAD-equal + clean dirty → no violation
+ *                             HEAD-equal + new dirty paths → violation (PR #422 case)
+ *                             HEAD-moved + clean dirty → violation (drift-only)
+ *                             null before.head → headChanged false, dirty diff still active
+ *                             dirty paths present in both → not flagged as new
+ *   buildIsolationSignal     — payload shape (type, signal, agentId, taskId, head_before/after, dirty_paths_added)
+ *   checkIsolationViolation  — emits emitConsensusSignals when violation detected; silent when clean
+ */
+
+import * as childProcess from 'child_process';
+
+// ── mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('@gossip/orchestrator', () => ({
+  emitConsensusSignals: jest.fn(),
+}));
+
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  execFileSync: jest.fn(),
+}));
+
+// ── imports after mocks ──────────────────────────────────────────────────────
+
+import {
+  parsePorcelain,
+  diffIsolationSnapshots,
+  buildIsolationSignal,
+  checkIsolationViolation,
+  captureIsolationSnapshot,
+  IsolationSnapshot,
+} from '../../apps/cli/src/handlers/worktree-isolation-detection';
+import { emitConsensusSignals } from '@gossip/orchestrator';
+
+const mockExec = childProcess.execFileSync as jest.Mock;
+const mockEmit = emitConsensusSignals as jest.Mock;
+
+const SHA_BEFORE = 'aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111';
+const SHA_AFTER  = 'bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222';
+
+describe('parsePorcelain', () => {
+  it('parses standard porcelain v1 lines', () => {
+    const out = ' M apps/cli/src/foo.ts\n?? new/file.ts\nMM packages/orchestrator/bar.ts\n';
+    expect(parsePorcelain(out)).toEqual([
+      'apps/cli/src/foo.ts',
+      'new/file.ts',
+      'packages/orchestrator/bar.ts',
+    ]);
+  });
+
+  it('tolerates CRLF line endings', () => {
+    const out = ' M a.ts\r\n M b.ts\r\n';
+    expect(parsePorcelain(out)).toEqual(['a.ts', 'b.ts']);
+  });
+
+  it('returns [] on empty input', () => {
+    expect(parsePorcelain('')).toEqual([]);
+    expect(parsePorcelain('\n\n')).toEqual([]);
+  });
+
+  it('skips malformed short lines', () => {
+    expect(parsePorcelain('ab\n M ok.ts\n')).toEqual(['ok.ts']);
+  });
+
+  it('returns paths sorted for diff stability', () => {
+    const out = ' M z.ts\n M a.ts\n M m.ts\n';
+    expect(parsePorcelain(out)).toEqual(['a.ts', 'm.ts', 'z.ts']);
+  });
+});
+
+describe('diffIsolationSnapshots', () => {
+  function snap(head: string | null, dirty: string[]): IsolationSnapshot {
+    return { head, dirty: [...dirty].sort(), takenAt: '2026-05-20T00:00:00Z' };
+  }
+
+  it('clean → no violation', () => {
+    const d = diffIsolationSnapshots(snap(SHA_BEFORE, []), snap(SHA_BEFORE, []));
+    expect(d).toEqual({ headChanged: false, dirtyPathsAdded: [], isViolation: false });
+  });
+
+  it('HEAD unchanged + new dirty path → violation (PR #422 case)', () => {
+    const before = snap(SHA_BEFORE, []);
+    const after = snap(SHA_BEFORE, ['apps/cli/src/leaked.ts']);
+    const d = diffIsolationSnapshots(before, after);
+    expect(d.headChanged).toBe(false);
+    expect(d.dirtyPathsAdded).toEqual(['apps/cli/src/leaked.ts']);
+    expect(d.isViolation).toBe(true);
+  });
+
+  it('HEAD moved + clean dirty → violation (drift-only)', () => {
+    const d = diffIsolationSnapshots(snap(SHA_BEFORE, []), snap(SHA_AFTER, []));
+    expect(d.headChanged).toBe(true);
+    expect(d.dirtyPathsAdded).toEqual([]);
+    expect(d.isViolation).toBe(true);
+  });
+
+  it('pre-existing dirty paths in both snapshots → not flagged', () => {
+    const before = snap(SHA_BEFORE, ['existing.ts']);
+    const after = snap(SHA_BEFORE, ['existing.ts', 'new.ts']);
+    const d = diffIsolationSnapshots(before, after);
+    expect(d.dirtyPathsAdded).toEqual(['new.ts']);
+    expect(d.isViolation).toBe(true);
+  });
+
+  it('null before.head → headChanged false; dirty-diff still active', () => {
+    const before = snap(null, []);
+    const after = snap(SHA_AFTER, ['x.ts']);
+    const d = diffIsolationSnapshots(before, after);
+    expect(d.headChanged).toBe(false);
+    expect(d.dirtyPathsAdded).toEqual(['x.ts']);
+    expect(d.isViolation).toBe(true);
+  });
+
+  it('null after.head → headChanged false (fail-open)', () => {
+    const before = snap(SHA_BEFORE, []);
+    const after = snap(null, []);
+    const d = diffIsolationSnapshots(before, after);
+    expect(d.headChanged).toBe(false);
+    expect(d.isViolation).toBe(false);
+  });
+});
+
+describe('buildIsolationSignal', () => {
+  it('produces a well-formed worktree_isolation_failed payload', () => {
+    const before: IsolationSnapshot = { head: SHA_BEFORE, dirty: [], takenAt: 'T0' };
+    const after: IsolationSnapshot = { head: SHA_BEFORE, dirty: ['leaked.ts'], takenAt: 'T1' };
+    const diff = diffIsolationSnapshots(before, after);
+    const sig = buildIsolationSignal({
+      agentId: 'opus-implementer',
+      taskId: 'task-abc',
+      before,
+      after,
+      diff,
+    });
+    expect(sig.type).toBe('consensus');
+    expect(sig.signal).toBe('worktree_isolation_failed');
+    expect(sig.agentId).toBe('opus-implementer');
+    expect(sig.taskId).toBe('task-abc');
+    expect(sig.head_before).toBe(SHA_BEFORE);
+    expect(sig.head_after).toBe(SHA_BEFORE);
+    expect(sig.dirty_paths_added).toEqual(['leaked.ts']);
+    expect(sig.evidence).toMatch(/HEAD unchanged/);
+    expect(sig.evidence).toMatch(/1 new dirty path/);
+    expect(sig.timestamp).toMatch(/T/);
+  });
+
+  it('summarises HEAD drift in evidence', () => {
+    const before: IsolationSnapshot = { head: SHA_BEFORE, dirty: [], takenAt: 'T0' };
+    const after: IsolationSnapshot = { head: SHA_AFTER, dirty: [], takenAt: 'T1' };
+    const sig = buildIsolationSignal({
+      agentId: 'a',
+      taskId: 't',
+      before,
+      after,
+      diff: diffIsolationSnapshots(before, after),
+    });
+    expect(sig.evidence).toMatch(/HEAD aaaa1111→bbbb2222/);
+  });
+});
+
+describe('checkIsolationViolation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('emits consensus signal when dirty paths leak in', () => {
+    const before: IsolationSnapshot = { head: SHA_BEFORE, dirty: [], takenAt: 'T0' };
+    // Mock re-snapshot: git rev-parse HEAD, then git status --porcelain
+    mockExec
+      .mockReturnValueOnce(Buffer.from(SHA_BEFORE + '\n'))   // rev-parse HEAD
+      .mockReturnValueOnce(Buffer.from(' M apps/cli/src/leaked.ts\n')); // status
+
+    const diff = checkIsolationViolation('opus-implementer', 'task-abc', before, '/tmp');
+
+    expect(diff.isViolation).toBe(true);
+    expect(diff.dirtyPathsAdded).toEqual(['apps/cli/src/leaked.ts']);
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+    const [, signals] = mockEmit.mock.calls[0];
+    expect(signals[0].signal).toBe('worktree_isolation_failed');
+    expect(signals[0].dirty_paths_added).toEqual(['apps/cli/src/leaked.ts']);
+  });
+
+  it('no emit when after-state matches before-state', () => {
+    const before: IsolationSnapshot = { head: SHA_BEFORE, dirty: [], takenAt: 'T0' };
+    mockExec
+      .mockReturnValueOnce(Buffer.from(SHA_BEFORE + '\n'))
+      .mockReturnValueOnce(Buffer.from(''));
+    const diff = checkIsolationViolation('a', 't', before, '/tmp');
+    expect(diff.isViolation).toBe(false);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('fail-open: git error during re-snapshot → no violation, no throw', () => {
+    const before: IsolationSnapshot = { head: SHA_BEFORE, dirty: [], takenAt: 'T0' };
+    mockExec.mockImplementation(() => { throw new Error('git not found'); });
+    const diff = checkIsolationViolation('a', 't', before, '/tmp');
+    expect(diff.isViolation).toBe(false);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+});
+
+describe('captureIsolationSnapshot', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('captures HEAD + porcelain output', () => {
+    mockExec
+      .mockReturnValueOnce(Buffer.from(SHA_BEFORE + '\n'))   // rev-parse
+      .mockReturnValueOnce(Buffer.from(' M a.ts\n M b.ts\n')); // status
+    const snap = captureIsolationSnapshot('/tmp');
+    expect(snap.head).toBe(SHA_BEFORE);
+    expect(snap.dirty).toEqual(['a.ts', 'b.ts']);
+    expect(snap.takenAt).toMatch(/T/);
+  });
+
+  it('fail-open: HEAD probe failure → head:null', () => {
+    mockExec
+      .mockImplementationOnce(() => { throw new Error('not a git repo'); })
+      .mockReturnValueOnce(Buffer.from(''));
+    const snap = captureIsolationSnapshot('/tmp');
+    expect(snap.head).toBeNull();
+    expect(snap.dirty).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a relay-side detector for the `Agent(isolation:"worktree")` gap documented in `project_worktree_isolation_native_dispatch_gap`. When a native-subagent dispatch leaves the parent checkout with moved HEAD or new dirty paths, the orchestrator emits a `worktree_isolation_failed` operational signal and surfaces a one-line warning + capped dirty-path list in the `gossip_relay` receipt. Detection-only — no automatic recovery.

This is **Option B** from `docs/specs/2026-05-20-native-worktree-isolation-fix.md`. Option A (gossipcat owns the worktree + `cd` prefix injection) is a follow-up PR per the rollout plan.

### Why both HEAD drift AND porcelain dirty-tree?

PR #422's failure mode left HEAD intact — only the working tree was dirty on the parent checkout. A HEAD-only snapshot would not have caught the canonical case that motivated this work. The detector checks BOTH and OR's the signals.

## Changes

- **New module** `apps/cli/src/handlers/worktree-isolation-detection.ts` (~200 LOC) — `captureIsolationSnapshot`, `parsePorcelain` (v1, CRLF tolerant), `diffIsolationSnapshots`, `buildIsolationSignal`, `checkIsolationViolation`. Fail-open everywhere.
- **Wiring**:
  - `apps/cli/src/handlers/dispatch.ts` — snapshot in single + parallel dispatch paths when `writeMode === 'worktree'`.
  - `apps/cli/src/handlers/native-tasks.ts` — re-snapshot on `handleNativeRelay`, emit + surface warning.
  - `apps/cli/src/mcp-context.ts` — new `isolationSnapshot` field on `NativeTaskInfo`.
- **Signal plumbing**:
  - `packages/orchestrator/src/consensus-types.ts` — new `worktree_isolation_failed` member on `ConsensusSignal.signal` union and in `OPERATIONAL_SIGNAL_NAMES`.
  - `packages/orchestrator/src/performance-reader.ts` — added to `KNOWN_SIGNALS` exhaustive Record (no-op for accuracy/uniqueness).
- **Tests**: 18 new unit tests in `tests/cli/worktree-isolation-detection.test.ts` covering porcelain parsing, the PR #422 HEAD-stable-but-dirty case, signal payload shape, and fail-open paths.

## Test plan

- [x] `npm run build` — clean
- [x] `npx jest tests/cli` — 761 passed, 8 skipped, 65/65 suites
- [x] New module's 18 unit tests — all green
- [ ] Real-world verification: dispatch a native worktree task that intentionally writes outside its worktree, confirm signal fires + receipt warning appears

## Follow-ups (deferred to Option A)

- Gossipcat-managed worktree via `WorktreeManager.create()` + `cd ${path}` prefix in dispatch Item 1
- Dirty-path denylist (node_modules, dist, .gossip) to suppress false positives from concurrent unrelated git operations
- Rename-entry token cleanup in the receipt warning's path list

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

consensus-id: 68283116-20504c9d
Pre-merge consensus (2 reviewers, 1 round): sonnet-reviewer APPROVE with one MEDIUM (f5 — fixed in commit ec477f8); gemini-tester surfaced two CONFIRMED test-coverage gaps:
- [f1, MEDIUM] handleNativeRelay isolation-warning integration test missing — **deferred to stacked follow-up PR** (coverage gap, not a correctness defect; the detection path itself has 18 unit tests).
- [f2, insight] tests/cli/native-tasks.test.ts is misnamed — pre-existing, not introduced here.
- [f3/f6, LOW] parsePorcelain rename-entry path untested — already deferred per spec §7.
- [f7, LOW] parsePorcelain v1 newline-filename corruption — deferred (edge case, not blocking detection-only contract).
- gemini-reviewer Phase 1 returned malformed_function_call; consensus proceeded with degraded coverage (2/3 agents).
