### PR TITLE
feat(dispatch): native worktree managed mode (Option A, gated)

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -677,6 +677,8 @@ export async function handleDispatchSingle(
           managedWorktreePath = created.path;
           const info = ctx.nativeTaskMap.get(taskId);
           if (info) info.worktreePath = managedWorktreePath;
+        } else {
+          process.stderr.write('[gossipcat] managed-worktree gate ON but WorktreeManager unavailable; falling back to harness path\n');
         }
       } catch (err) {
         process.stderr.write(`[gossipcat] managed-worktree create failed (falling back to harness): ${(err as Error).message}\n`);
@@ -716,9 +718,14 @@ export async function handleDispatchSingle(
     // is the actor that runs cd; the spawned sub-agent inherits the chdir-d
     // shell. Leaking orchestration into Item 2 would be read as credential
     // injection by modern Sonnet and the sub-agent will refuse.
+    // POSIX-safe single-quote the worktree path. `mkdtemp(tmpdir())` paths are
+    // generally safe but TMPDIR is user-controlled (e.g. `/Users/Some User/tmp`
+    // on macOS dev machines), so unquoted interpolation would silently chdir
+    // into the wrong directory and defeat the load-bearing isolation step.
+    // Embedded single quotes are escaped via the standard POSIX `'\''` pattern.
     const cdPrefix = managedWorktreePath
       ? `Step 0 — chdir into the gossipcat-managed worktree BEFORE invoking Agent():\n` +
-        `  cd ${managedWorktreePath}\n` +
+        `  cd '${managedWorktreePath.replace(/'/g, "'\\''")}'\n` +
         `(Worktree was created by gossipcat at dispatch time. The Agent(isolation:"worktree") flag below is belt-and-suspenders; the cd above is the load-bearing isolation step.)\n\n`
       : '';
 

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -644,21 +644,6 @@ export async function handleDispatchSingle(
     // (enforcement boundary); UNVERIFIED note layered on top (behavioral).
     agentPrompt = maybeApplyUnverifiedNote(agentPrompt, task, agent_id);
 
-    // Record dispatch metadata for the post-task audit.
-    // For native worktree dispatch the path is created by Claude Code's
-    // Agent({isolation:"worktree"}) out-of-process and not returned to us;
-    // it stays undefined. The Layer 3 audit relies on its blanket
-    // `.claude/worktrees/` exclusion (see buildAuditExclusions) so native
-    // worktree writes are not falsely flagged.
-    recordDispatchMetadata(process.cwd(), {
-      taskId,
-      agentId: agent_id,
-      writeMode: write_mode,
-      scope,
-      worktreePath: undefined,
-      timestamp: Date.now(),
-    });
-
     // Only use worktree if explicitly requested AND project is a git repo
     let useWorktree = write_mode === 'worktree';
     if (useWorktree) {
@@ -669,6 +654,50 @@ export async function handleDispatchSingle(
         useWorktree = false; // not a git repo, skip worktree
       }
     }
+
+    // Option A (structural fix) — gated behind GOSSIP_NATIVE_WORKTREE_MANAGED=1.
+    // Spec: docs/specs/2026-05-20-native-worktree-isolation-fix.md §3.
+    //
+    // When enabled, gossipcat creates the worktree synchronously here via
+    // WorktreeManager.create() and captures the absolute path. The Item 1
+    // orchestrator instructions then prepend an explicit `cd <path>` so the
+    // sub-agent enters the worktree deterministically — no longer trusting
+    // Claude Code's Agent({isolation:"worktree"}) to chdir us out-of-process.
+    // The `isolation:"worktree"` flag is retained as belt-and-suspenders.
+    //
+    // Failure mode: if create() throws (e.g. git unavailable mid-flight even
+    // though rev-parse succeeded), we fall back to the legacy path rather
+    // than block dispatch. The Option B HEAD-drift detector still fires.
+    let managedWorktreePath: string | null = null;
+    if (useWorktree && process.env.GOSSIP_NATIVE_WORKTREE_MANAGED === '1') {
+      try {
+        const wtm = ctx.mainAgent.getWorktreeManager();
+        if (wtm) {
+          const created = await wtm.create(taskId);
+          managedWorktreePath = created.path;
+          const info = ctx.nativeTaskMap.get(taskId);
+          if (info) info.worktreePath = managedWorktreePath;
+        }
+      } catch (err) {
+        process.stderr.write(`[gossipcat] managed-worktree create failed (falling back to harness): ${(err as Error).message}\n`);
+        managedWorktreePath = null;
+      }
+    }
+
+    // Record dispatch metadata for the post-task audit.
+    // Under the legacy harness-managed path the worktree path is created by
+    // Claude Code's Agent({isolation:"worktree"}) out-of-process and not
+    // returned to us; it stays undefined and the Layer 3 audit relies on
+    // its blanket `.claude/worktrees/` exclusion. Under the managed path
+    // (GOSSIP_NATIVE_WORKTREE_MANAGED=1) we now have a concrete path.
+    recordDispatchMetadata(process.cwd(), {
+      taskId,
+      agentId: agent_id,
+      writeMode: write_mode,
+      scope,
+      worktreePath: managedWorktreePath ?? undefined,
+      timestamp: Date.now(),
+    });
 
     // Spec §1 iron rule: strict opt-in elision. When prompt_format='elided',
     // write the prompt body to disk and emit a marker in Item 1; OMIT Item 2.
@@ -681,11 +710,23 @@ export async function handleDispatchSingle(
     // Persist after elision so promptPath is durable across /mcp reconnect.
     persistNativeTaskMap();
 
-    const promptInstruction = elision.elided
+    // HANDBOOK invariant #4 — the cd line lives in Item 1 (orchestrator
+    // instructions), NEVER in Item 2 (verbatim agent prompt) and NEVER in
+    // the elided on-disk prompt file. The orchestrator that invokes Agent()
+    // is the actor that runs cd; the spawned sub-agent inherits the chdir-d
+    // shell. Leaking orchestration into Item 2 would be read as credential
+    // injection by modern Sonnet and the sub-agent will refuse.
+    const cdPrefix = managedWorktreePath
+      ? `Step 0 — chdir into the gossipcat-managed worktree BEFORE invoking Agent():\n` +
+        `  cd ${managedWorktreePath}\n` +
+        `(Worktree was created by gossipcat at dispatch time. The Agent(isolation:"worktree") flag below is belt-and-suspenders; the cd above is the load-bearing isolation step.)\n\n`
+      : '';
+
+    const promptInstruction = cdPrefix + (elision.elided
       ? `Step 1 — ${elision.marker}\n` +
         `Agent(model: "${nativeConfig.model}", prompt: <file contents>${useWorktree ? ', isolation: "worktree"' : ''}, run_in_background: true)\n\n`
       : `Step 1 — Pass the AGENT_PROMPT:${taskId} content item below verbatim to Agent(prompt: ...):\n` +
-        `Agent(model: "${nativeConfig.model}", prompt: <AGENT_PROMPT:${taskId} below>${useWorktree ? ', isolation: "worktree"' : ''}, run_in_background: true)\n\n`;
+        `Agent(model: "${nativeConfig.model}", prompt: <AGENT_PROMPT:${taskId} below>${useWorktree ? ', isolation: "worktree"' : ''}, run_in_background: true)\n\n`);
 
     // Split into two content items so relay_token stays in orchestrator-only text
     // and AGENT_PROMPT is passed verbatim to Agent(prompt: ...).

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -90,6 +90,16 @@ export interface NativeTaskInfo {
    * longer in the restored map. Undefined for inline dispatches.
    */
   promptPath?: string;
+  /**
+   * Absolute path to the gossipcat-managed worktree created at dispatch time.
+   * Populated ONLY when `writeMode === 'worktree'` AND
+   * `process.env.GOSSIP_NATIVE_WORKTREE_MANAGED === '1'` (Option A structural
+   * fix, spec docs/specs/2026-05-20-native-worktree-isolation-fix.md §3).
+   * Stays undefined under the legacy harness-managed path; in that mode
+   * Claude Code's Agent({isolation:"worktree"}) owns the path out-of-process
+   * and gossipcat has no handle on it.
+   */
+  worktreePath?: string;
 }
 
 export interface NativeResultInfo {

--- a/tests/cli/dispatch-native-worktree-managed.test.ts
+++ b/tests/cli/dispatch-native-worktree-managed.test.ts
@@ -217,7 +217,7 @@ describe('native dispatch — Option A managed worktree (GOSSIP_NATIVE_WORKTREE_
       const res = await handleDispatchSingle('native-claude', 'audit x', 'worktree');
       const item1 = findItem1(res.content);
       expect(item1).toMatch(/Step 0 — chdir into the gossipcat-managed worktree/);
-      expect(item1).toMatch(/cd \/tmp\/managed-wt-abc12345/);
+      expect(item1).toMatch(/cd '\/tmp\/managed-wt-abc12345'/);
       // Step 0 must precede Step 1
       const step0 = item1.indexOf('Step 0');
       const step1 = item1.indexOf('Step 1');
@@ -229,7 +229,7 @@ describe('native dispatch — Option A managed worktree (GOSSIP_NATIVE_WORKTREE_
       const res = await handleDispatchSingle('native-claude', 'audit x', 'worktree');
       const agentPrompt = findAgentPromptItem(res.content);
       expect(agentPrompt).not.toBeNull();
-      expect(agentPrompt!).not.toMatch(/cd \/tmp\/managed-wt-abc12345/);
+      expect(agentPrompt!).not.toMatch(/cd '\/tmp\/managed-wt-abc12345'/);
       expect(agentPrompt!).not.toMatch(/Step 0 — chdir/);
       // Sanity: AGENT_PROMPT still starts with its tag — no orchestration prefix
       expect(agentPrompt!.startsWith('AGENT_PROMPT:')).toBe(true);
@@ -286,10 +286,10 @@ describe('native dispatch — Option A managed worktree (GOSSIP_NATIVE_WORKTREE_
       expect(existsSync(onDiskPath)).toBe(true);
       const body = readFileSync(onDiskPath, 'utf8');
       // Iron-rule: agent-facing prompt file MUST NOT contain orchestration text.
-      expect(body).not.toMatch(/cd \/tmp\/managed-wt-abc12345/);
+      expect(body).not.toMatch(/cd '\/tmp\/managed-wt-abc12345'/);
       expect(body).not.toMatch(/Step 0 — chdir/);
       // But Item 1 STILL emits the cd line for the orchestrator.
-      expect(item1).toMatch(/cd \/tmp\/managed-wt-abc12345/);
+      expect(item1).toMatch(/cd '\/tmp\/managed-wt-abc12345'/);
     });
 
     it('under elision, Item 2 is ABSENT (spec §2) — no AGENT_PROMPT content item', async () => {

--- a/tests/cli/dispatch-native-worktree-managed.test.ts
+++ b/tests/cli/dispatch-native-worktree-managed.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Tests for Option A — structural fix for native Agent(isolation:"worktree")
+ * dispatch (spec: docs/specs/2026-05-20-native-worktree-isolation-fix.md §3).
+ *
+ * Contracts asserted:
+ *  1. ENV-GATE: with GOSSIP_NATIVE_WORKTREE_MANAGED unset (or != "1"),
+ *     dispatch behavior is byte-identical to the pre-PR path — no cd line
+ *     in Item 1, no worktreePath persisted on the task record,
+ *     WorktreeManager.create() not invoked.
+ *  2. MANAGED MODE: with the env var set, dispatch.ts pre-creates the
+ *     worktree via WorktreeManager.create(taskId), persists the absolute
+ *     path on the NativeTaskInfo entry, and injects `Step 0 — cd <path>` as
+ *     a prefix of the Item 1 orchestrator instructions.
+ *  3. HANDBOOK invariant #4: the cd line is in Item 1 ONLY — Item 2
+ *     (verbatim AGENT_PROMPT) MUST NOT contain it, otherwise modern Sonnet
+ *     reads orchestration leakage as credential injection and refuses.
+ *  4. ELIDED FORMAT: the on-disk prompt file at .gossip/dispatch-prompts/
+ *     <taskId>.txt MUST NOT contain the cd line under prompt_format='elided'
+ *     — the cd line still belongs ONLY in the Item 1 marker block.
+ */
+
+import { execSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { ctx } from '../../apps/cli/src/mcp-context';
+import { handleDispatchSingle } from '../../apps/cli/src/handlers/dispatch';
+
+function makeMainAgent(overrides: Record<string, any> = {}): any {
+  return {
+    dispatch: jest.fn().mockReturnValue({ taskId: 'default-task-id' }),
+    collect: jest.fn().mockResolvedValue({ results: [] }),
+    getAgentConfig: jest.fn().mockReturnValue(null),
+    getLlm: jest.fn().mockReturnValue(null),
+    getLLM: jest.fn().mockReturnValue(null),
+    getAgentList: jest.fn().mockReturnValue([]),
+    getSkillGapSuggestions: jest.fn().mockReturnValue([]),
+    getSkillIndex: jest.fn().mockReturnValue(null),
+    getSessionGossip: jest.fn().mockReturnValue([]),
+    getSessionConsensusHistory: jest.fn().mockReturnValue([]),
+    recordNativeTask: jest.fn(),
+    recordNativeTaskCompleted: jest.fn(),
+    recordPlanStepResult: jest.fn(),
+    publishNativeGossip: jest.fn().mockResolvedValue(undefined),
+    getChainContext: jest.fn().mockReturnValue(''),
+    generateLensesForAgents: jest.fn().mockResolvedValue(new Map()),
+    dispatchParallel: jest.fn().mockResolvedValue({ taskIds: [], errors: [] }),
+    dispatchParallelWithLenses: jest.fn().mockResolvedValue({ taskIds: [], errors: [] }),
+    getTask: jest.fn().mockReturnValue(null),
+    scopeTracker: {
+      hasOverlap: jest.fn().mockReturnValue({ overlaps: false }),
+      register: jest.fn(),
+      release: jest.fn(),
+    },
+    pipeline: null,
+    projectRoot: '/tmp/gossip-test-project',
+    ...overrides,
+  };
+}
+
+const originalCtx = {
+  mainAgent: ctx.mainAgent,
+  relay: ctx.relay,
+  workers: ctx.workers,
+  keychain: ctx.keychain,
+  skillEngine: ctx.skillEngine,
+  nativeTaskMap: ctx.nativeTaskMap,
+  nativeResultMap: ctx.nativeResultMap,
+  nativeAgentConfigs: ctx.nativeAgentConfigs,
+  pendingConsensusRounds: ctx.pendingConsensusRounds,
+  booted: ctx.booted,
+  boot: ctx.boot,
+  syncWorkersViaKeychain: ctx.syncWorkersViaKeychain,
+};
+
+function resetCtx(mainAgentOverrides: Record<string, any> = {}) {
+  ctx.mainAgent = makeMainAgent(mainAgentOverrides);
+  ctx.nativeTaskMap = new Map();
+  ctx.nativeResultMap = new Map();
+  ctx.nativeAgentConfigs = new Map();
+  ctx.pendingConsensusRounds = new Map();
+  ctx.booted = true;
+  ctx.boot = jest.fn().mockResolvedValue(undefined) as any;
+  ctx.syncWorkersViaKeychain = jest.fn().mockResolvedValue(undefined) as any;
+  (ctx as any).skillEngine = null;
+}
+
+function restoreCtx() {
+  Object.assign(ctx, originalCtx);
+}
+
+/**
+ * Initialize a minimal git repo so `git rev-parse --git-dir` succeeds in
+ * handleDispatchSingle's useWorktree guard. WorktreeManager.create() is
+ * mocked separately on the mainAgent stub — we do not exercise the real
+ * git-worktree machinery here.
+ */
+function initGitRepo(dir: string): void {
+  execSync('git init -q', { cwd: dir });
+  execSync('git config user.email "t@t.t"', { cwd: dir });
+  execSync('git config user.name "t"', { cwd: dir });
+  execSync('git commit --allow-empty -q -m init', { cwd: dir });
+}
+
+function findItem1(content: Array<{ text: string }>): string {
+  // Item 1 is the orchestrator-instruction banner (content[0]).
+  return content[0].text;
+}
+
+function findAgentPromptItem(content: Array<{ text: string }>): string | null {
+  const m = content.find(c => c.text.startsWith('AGENT_PROMPT:'));
+  return m ? m.text : null;
+}
+
+describe('native dispatch — Option A managed worktree (GOSSIP_NATIVE_WORKTREE_MANAGED)', () => {
+  let workDir: string;
+  let prevCwd: string;
+  let prevEnv: string | undefined;
+  let createMock: jest.Mock;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    prevEnv = process.env.GOSSIP_NATIVE_WORKTREE_MANAGED;
+    workDir = mkdtempSync(join(tmpdir(), 'gossip-native-managed-wt-'));
+    mkdirSync(join(workDir, '.gossip', 'skills'), { recursive: true });
+    initGitRepo(workDir);
+    process.chdir(workDir);
+
+    createMock = jest.fn().mockResolvedValue({
+      path: '/tmp/managed-wt-abc12345',
+      branch: 'gossip-task-stub',
+    });
+
+    resetCtx({
+      getWorktreeManager: jest.fn().mockReturnValue({
+        create: createMock,
+        cleanup: jest.fn().mockResolvedValue(undefined),
+        pruneOrphans: jest.fn().mockResolvedValue(undefined),
+      }),
+    });
+
+    ctx.nativeAgentConfigs.set('native-claude', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Native reviewer',
+      skills: [],
+    });
+  });
+
+  afterEach(() => {
+    restoreCtx();
+    process.chdir(prevCwd);
+    rmSync(workDir, { recursive: true, force: true });
+    if (prevEnv === undefined) delete process.env.GOSSIP_NATIVE_WORKTREE_MANAGED;
+    else process.env.GOSSIP_NATIVE_WORKTREE_MANAGED = prevEnv;
+  });
+
+  describe('ENV-GATE — env var unset / != "1"', () => {
+    it('does NOT call WorktreeManager.create() when env var is unset', async () => {
+      delete process.env.GOSSIP_NATIVE_WORKTREE_MANAGED;
+      const res = await handleDispatchSingle('native-claude', 'audit x', 'worktree');
+      expect(createMock).not.toHaveBeenCalled();
+      const item1 = findItem1(res.content);
+      expect(item1).not.toMatch(/Step 0 — chdir/);
+      expect(item1).not.toMatch(/^cd /m);
+    });
+
+    it('does NOT call WorktreeManager.create() when env var is "0"', async () => {
+      process.env.GOSSIP_NATIVE_WORKTREE_MANAGED = '0';
+      const res = await handleDispatchSingle('native-claude', 'audit x', 'worktree');
+      expect(createMock).not.toHaveBeenCalled();
+      expect(findItem1(res.content)).not.toMatch(/Step 0 — chdir/);
+    });
+
+    it('does NOT call WorktreeManager.create() when write_mode != "worktree"', async () => {
+      process.env.GOSSIP_NATIVE_WORKTREE_MANAGED = '1';
+      const res = await handleDispatchSingle('native-claude', 'audit x', 'sequential');
+      expect(createMock).not.toHaveBeenCalled();
+      expect(findItem1(res.content)).not.toMatch(/Step 0 — chdir/);
+    });
+
+    it('does NOT persist worktreePath on the task record when env var is unset', async () => {
+      delete process.env.GOSSIP_NATIVE_WORKTREE_MANAGED;
+      await handleDispatchSingle('native-claude', 'audit x', 'worktree');
+      // task IDs are randomUUID().slice(0, 8) — pick the only entry.
+      const entries = [...ctx.nativeTaskMap.entries()];
+      expect(entries.length).toBe(1);
+      const [, info] = entries[0];
+      expect(info.worktreePath).toBeUndefined();
+    });
+  });
+
+  describe('MANAGED MODE — env var = "1"', () => {
+    beforeEach(() => {
+      process.env.GOSSIP_NATIVE_WORKTREE_MANAGED = '1';
+    });
+
+    it('calls WorktreeManager.create() exactly once with the taskId', async () => {
+      await handleDispatchSingle('native-claude', 'audit x', 'worktree');
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const [arg] = createMock.mock.calls[0];
+      // taskId is randomUUID().slice(0, 8) — 8 hex chars
+      expect(typeof arg).toBe('string');
+      expect(arg).toMatch(/^[0-9a-f-]{6,}$/i);
+    });
+
+    it('persists the worktreePath on the NativeTaskInfo entry', async () => {
+      await handleDispatchSingle('native-claude', 'audit x', 'worktree');
+      const entries = [...ctx.nativeTaskMap.entries()];
+      expect(entries.length).toBe(1);
+      const [, info] = entries[0];
+      expect(info.worktreePath).toBe('/tmp/managed-wt-abc12345');
+    });
+
+    it('injects "Step 0 — cd <managed-path>" into Item 1', async () => {
+      const res = await handleDispatchSingle('native-claude', 'audit x', 'worktree');
+      const item1 = findItem1(res.content);
+      expect(item1).toMatch(/Step 0 — chdir into the gossipcat-managed worktree/);
+      expect(item1).toMatch(/cd \/tmp\/managed-wt-abc12345/);
+      // Step 0 must precede Step 1
+      const step0 = item1.indexOf('Step 0');
+      const step1 = item1.indexOf('Step 1');
+      expect(step0).toBeGreaterThan(-1);
+      expect(step1).toBeGreaterThan(step0);
+    });
+
+    it('does NOT inject cd line into Item 2 (AGENT_PROMPT) — HANDBOOK invariant #4', async () => {
+      const res = await handleDispatchSingle('native-claude', 'audit x', 'worktree');
+      const agentPrompt = findAgentPromptItem(res.content);
+      expect(agentPrompt).not.toBeNull();
+      expect(agentPrompt!).not.toMatch(/cd \/tmp\/managed-wt-abc12345/);
+      expect(agentPrompt!).not.toMatch(/Step 0 — chdir/);
+      // Sanity: AGENT_PROMPT still starts with its tag — no orchestration prefix
+      expect(agentPrompt!.startsWith('AGENT_PROMPT:')).toBe(true);
+    });
+
+    it('retains the isolation:"worktree" flag in the Agent() call (belt-and-suspenders)', async () => {
+      const res = await handleDispatchSingle('native-claude', 'audit x', 'worktree');
+      const item1 = findItem1(res.content);
+      expect(item1).toMatch(/isolation: "worktree"/);
+    });
+
+    it('falls back gracefully when WorktreeManager.create() throws', async () => {
+      createMock.mockRejectedValueOnce(new Error('git not happy'));
+      const res = await handleDispatchSingle('native-claude', 'audit x', 'worktree');
+      // Dispatch must still succeed — fallback to legacy harness-managed path.
+      expect(createMock).toHaveBeenCalledTimes(1);
+      const item1 = findItem1(res.content);
+      expect(item1).not.toMatch(/Step 0 — chdir/); // no cd injected when create failed
+      expect(item1).toMatch(/isolation: "worktree"/); // legacy isolation flag preserved
+      const entries = [...ctx.nativeTaskMap.entries()];
+      const [, info] = entries[0];
+      expect(info.worktreePath).toBeUndefined();
+    });
+
+    it('does NOT call create() when write_mode is not worktree even if env var is set', async () => {
+      await handleDispatchSingle('native-claude', 'audit x', 'sequential');
+      expect(createMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ELIDED FORMAT — on-disk prompt file MUST NOT carry the cd line', () => {
+    beforeEach(() => {
+      process.env.GOSSIP_NATIVE_WORKTREE_MANAGED = '1';
+    });
+
+    it('does NOT write the cd line into .gossip/dispatch-prompts/<taskId>.txt', async () => {
+      const res = await handleDispatchSingle(
+        'native-claude',
+        'audit x',
+        'worktree',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'elided',
+      );
+      // Find the elision marker in Item 1 — extract the on-disk path it cites.
+      const item1 = findItem1(res.content);
+      expect(item1).toMatch(/skills section elided/);
+      const m = item1.match(/elided: see ([^,]+),/);
+      expect(m).not.toBeNull();
+      const onDiskPath = m![1];
+      expect(existsSync(onDiskPath)).toBe(true);
+      const body = readFileSync(onDiskPath, 'utf8');
+      // Iron-rule: agent-facing prompt file MUST NOT contain orchestration text.
+      expect(body).not.toMatch(/cd \/tmp\/managed-wt-abc12345/);
+      expect(body).not.toMatch(/Step 0 — chdir/);
+      // But Item 1 STILL emits the cd line for the orchestrator.
+      expect(item1).toMatch(/cd \/tmp\/managed-wt-abc12345/);
+    });
+
+    it('under elision, Item 2 is ABSENT (spec §2) — no AGENT_PROMPT content item', async () => {
+      const res = await handleDispatchSingle(
+        'native-claude',
+        'audit x',
+        'worktree',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'elided',
+      );
+      // content[0] = Item 1 banner; no second AGENT_PROMPT item under elision.
+      expect(findAgentPromptItem(res.content)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the structural side of the `Agent(isolation:"worktree")` gap that Option B (PR #426) only detects. Behind `GOSSIP_NATIVE_WORKTREE_MANAGED=1`, gossipcat creates the worktree itself via `WorktreeManager.create()` before emitting the AGENT_PROMPT, and injects `cd <abspath>` into Item 1 (orchestrator instructions). The isolation contract no longer depends on Claude Code's harness-managed semantics.

Spec: `docs/specs/2026-05-20-native-worktree-isolation-fix.md` (Option A).

## Behavior

| Env var | Behavior |
|---|---|
| Unset (default) | Existing harness-managed path. **No change.** |
| `=1`, `create()` ok | cd injected in Item 1; `worktreePath` persisted on `NativeTaskInfo`; `Agent(isolation:"worktree")` flag preserved as belt-and-suspenders. |
| `=1`, `create()` fails | Falls back to the harness path with a stderr breadcrumb. Env var **cannot** make dispatch more failure-prone than unset — critical for the "flip default after one clean week" rollout criterion. |

## Files

- `apps/cli/src/mcp-context.ts` — new `worktreePath?: string` on `NativeTaskInfo`.
- `apps/cli/src/handlers/dispatch.ts` — gated `WorktreeManager.create()` call in `handleDispatchSingle`, path persisted, `cd` injected in Item 1 (never Item 2 or the elided on-disk prompt file).
- `tests/cli/dispatch-native-worktree-managed.test.ts` — 13 new tests covering env-gate, managed mode, HANDBOOK invariant #4 (cd absent from Item 2), elided format (cd absent from prompt file), and fallback-on-create-failure.

## HANDBOOK invariant #4

The two-item content split is a security boundary. `cd` goes in Item 1 only. Two tests regression-fence this for both inline and elided dispatch paths.

## Known limitations / follow-ups

- **Single-dispatch only.** `handleDispatchParallel` and `handleDispatchConsensus` remain on the legacy harness path even with the env var set. **Parallel is where the concurrent-write race actually bites** — extending Option A there is the obvious follow-up.
- **`WorktreeManager.create()` writes to `/tmp/gossip-wt-<rand>`**, not `.claude/worktrees/agent-*`. The `cd` line points to `/tmp`. This is parity with the relay-agent dispatch path that already uses the same primitive. If we want in-repo worktrees, that's a behavior change at the `WorktreeManager` level (affects both dispatch and relay).
- **Cleanup is unconditional `pruneOrphans()` sweep**, not per-task `cleanup(taskId, path)`. Risk: a sweep firing while an agent is mid-write could orphan uncommitted work. Worth a per-task cleanup contract in a follow-up.

## Test plan

- [x] `npm run build` — clean
- [x] `npx jest tests/cli/dispatch-native-worktree-managed.test.ts` — 13/13 pass
- [x] `npx jest tests/cli` — 774 pass, 8 skipped, 66/66 suites
- [ ] **Manual smoke**: dispatch a native task with the env var set, confirm `cd` appears in Item 1, agent writes only to `/tmp/gossip-wt-*`, parent checkout stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

consensus-id: 1d20b64c-48b448a4
Pre-merge consensus (3 agents — sonnet-reviewer, gemini-reviewer, gemini-tester; 2 rounds). 16 confirmed, 0 disputed, 1 new (severity escalation by sonnet on the unquoted-cd finding).

**Confirmed MEDIUMs addressed in fixup commit cf86485:**
- f10 / f1 (unquoted `cd ${managedWorktreePath}` breaks on TMPDIR with spaces) — fixed with POSIX-safe single-quote escaping.
- f11 (silent fallback when `getWorktreeManager()` returns null) — added stderr breadcrumb mirroring the catch-block contract.

**LOWs deferred to follow-ups:**
- f12: tightening `getWorktreeManager()` return type to `WorktreeManager | undefined` (touches `packages/orchestrator/`, out of scope for this PR).
- f13: orphan-worktree test for downstream-dispatch failure after successful `WorktreeManager.create()` (spec defers full cleanup contract to a separate PR).

**Insights** (9 confirmed by both reviewers): the test suite correctly fences HANDBOOK invariant #4 for both inline and elided paths, env-gate symmetry is verified, fallback paths preserve `isolation:"worktree"` belt-and-suspenders, mock shape matches real `WorktreeManager.create()`. Trust-boundary surface for the `cd` injection is bounded to operator-controlled `TMPDIR` (now mitigated by the quoting fix).
