### PR TITLE
chore(types): tighten getWorktreeManager() return type to WorktreeManager | undefined

### DIFF
--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -309,9 +309,13 @@ export class MainAgent {
     } catch { /* best-effort */ }
   }
 
-  /** Get the WorktreeManager from the dispatch pipeline (for native worktree cleanup). */
-  getWorktreeManager(): import('./worktree-manager').WorktreeManager {
-    return (this.pipeline as any).worktreeManager;
+  /**
+   * Get the WorktreeManager from the dispatch pipeline (for native worktree cleanup).
+   * Returns `undefined` when the pipeline hasn't been constructed yet or the
+   * field is absent — callers already defensively `?.`/`if (wtm)` the result.
+   */
+  getWorktreeManager(): import('./worktree-manager').WorktreeManager | undefined {
+    return (this.pipeline as any)?.worktreeManager;
   }
 
   /** Get current orchestrator model info */


### PR DESCRIPTION
## Summary
Closes LOW finding `1d20b64c-48b448a4:f12` from PR #427 review.

`MainAgent.getWorktreeManager()` was typed as `WorktreeManager`, but the implementation reaches via `(this.pipeline as any).worktreeManager` — which returns `undefined` whenever the pipeline hasn't been wired up. Both call sites already defensively unwrap:

- `apps/cli/src/handlers/native-tasks.ts:619` → `?.pruneOrphans()`
- `apps/cli/src/handlers/dispatch.ts:674` → `if (wtm)`

So the type was lying about a nullability that callers were already prepared for. Fix: return `WorktreeManager | undefined`, and add `?.` to the cast for symmetry.

## Test plan
- [x] `npx tsc --noEmit` on orchestrator + cli — clean.
- [x] `npx jest tests/cli/dispatch-native-worktree-managed.test.ts` — 13/13 passing.
- [ ] CI green.

consensus-id: 1d20b64c-48b448a4

🤖 Generated with [Claude Code](https://claude.com/claude-code)