### PR TITLE
feat(dispatch): per-task cleanup for managed-worktree mode (#431 backlog #4)

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -1192,7 +1192,7 @@ export async function handleDispatchParallel(
 }
 
 export async function handleDispatchConsensus(
-  taskDefs: Array<{ agent_id: string; task: string }>,
+  taskDefs: Array<{ agent_id: string; task: string; write_mode?: string }>,
   _utility_task_id?: string,
   /**
    * #126 PR-B: optional dispatch-time resolutionRoots (post-validation,
@@ -1283,8 +1283,8 @@ export async function handleDispatchConsensus(
   // where the orchestrator picks one agent on purpose, not in explicit consensus dispatch.
 
   // Split native vs custom tasks (same pattern as parallel)
-  const nativeTasks: Array<{ agent_id: string; task: string }> = [];
-  const relayTasks: Array<{ agent_id: string; task: string }> = [];
+  const nativeTasks: Array<{ agent_id: string; task: string; write_mode?: string }> = [];
+  const relayTasks: Array<{ agent_id: string; task: string; write_mode?: string }> = [];
   for (const def of taskDefs) {
     if (ctx.nativeAgentConfigs.has(def.agent_id)) {
       nativeTasks.push(def);
@@ -1377,7 +1377,12 @@ export async function handleDispatchConsensus(
       }
     }
 
-    ctx.nativeTaskMap.set(taskId, { agentId: def.agent_id, task: def.task, startedAt: Date.now(), timeoutMs: NATIVE_TASK_TTL_MS, relayToken, worktreePath: managedWorktreePathConsensus ?? undefined });
+    // When a managed worktree was created for this consensus task, force
+    // writeMode='worktree' so the handleNativeRelay cleanup gate fires.
+    // Without this the gate (taskInfo.writeMode === 'worktree') silently
+    // skips cleanup and managed worktrees leak. (consensus cb4e7421:f5)
+    const effectiveWriteMode = managedWorktreePathConsensus ? 'worktree' : def.write_mode;
+    ctx.nativeTaskMap.set(taskId, { agentId: def.agent_id, task: def.task, startedAt: Date.now(), timeoutMs: NATIVE_TASK_TTL_MS, relayToken, writeMode: effectiveWriteMode as any, worktreePath: managedWorktreePathConsensus ?? undefined });
     spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
     try { ctx.mainAgent.recordNativeTask(taskId, def.agent_id, def.task); } catch { /* best-effort */ }
     allTaskIds.push(taskId);

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -625,10 +625,12 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
     const wtm = ctx.mainAgent.getWorktreeManager();
     if (taskInfo.worktreePath) {
       // Managed mode: per-task cleanup regardless of error state
-      try { wtm?.cleanup(task_id, taskInfo.worktreePath).catch(() => {}); } catch { /* best-effort */ }
+      // Optional-chain BOTH the call and the .catch — wtm?.op() returns
+      // undefined when wtm is undefined, and undefined.catch() throws TypeError.
+      try { wtm?.cleanup(task_id, taskInfo.worktreePath)?.catch(() => {}); } catch { /* best-effort */ }
     } else if (error) {
       // Legacy mode: orphan prune on error only
-      try { wtm?.pruneOrphans().catch(() => {}); } catch { /* best-effort */ }
+      try { wtm?.pruneOrphans()?.catch(() => {}); } catch { /* best-effort */ }
     }
   }
 

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -609,14 +609,27 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
     } catch { /* best-effort — detector must not block relay completion */ }
   }
 
-  // Bug f13: prune orphaned worktrees on native error — mirrors dispatch-pipeline.ts:473-475.
-  // Native worktrees use Claude Code's Agent(isolation:"worktree") so there's no
-  // worktreePath in NativeTaskInfo. pruneOrphans() iterates all gossip-wt-* worktrees
-  // and removes any whose task IDs no longer have active entries — broader than a
-  // single-task cleanup but actually works (cleanup(taskId, undefined) would run
-  // `git worktree remove undefined --force` and silently fail).
-  if (error && taskInfo.writeMode === 'worktree') {
-    try { ctx.mainAgent.getWorktreeManager()?.pruneOrphans().catch(() => {}); } catch { /* best-effort */ }
+  // Worktree cleanup — two paths depending on managed mode (GOSSIP_NATIVE_WORKTREE_MANAGED=1):
+  //
+  // MANAGED MODE (taskInfo.worktreePath is defined, set by dispatch.ts after WorktreeManager.create()):
+  //   Per-task cleanup via wtm.cleanup(taskId, worktreePath) on BOTH success and error paths.
+  //   Fire-and-forget (.catch(() => {})) to match dispatch-pipeline.ts:566,690 idiom.
+  //   Mirrors PR #431 which added worktreePath to nativeTaskMap parallel entries.
+  //
+  // LEGACY PATH (taskInfo.worktreePath is undefined — env var off or Claude Code harness-managed):
+  //   Fall back to pruneOrphans() on the error path only (original Bug f13 fix).
+  //   pruneOrphans() iterates all gossip-wt-* worktrees and removes any whose task IDs
+  //   no longer have active entries — broader than a single-task cleanup but works
+  //   when there's no worktreePath to pass to cleanup().
+  if (taskInfo.writeMode === 'worktree') {
+    const wtm = ctx.mainAgent.getWorktreeManager();
+    if (taskInfo.worktreePath) {
+      // Managed mode: per-task cleanup regardless of error state
+      try { wtm?.cleanup(task_id, taskInfo.worktreePath).catch(() => {}); } catch { /* best-effort */ }
+    } else if (error) {
+      // Legacy mode: orphan prune on error only
+      try { wtm?.pruneOrphans().catch(() => {}); } catch { /* best-effort */ }
+    }
   }
 
   // Run the same post-collect pipeline as custom agents:

--- a/tests/cli/dispatch-native-worktree-managed-cleanup.test.ts
+++ b/tests/cli/dispatch-native-worktree-managed-cleanup.test.ts
@@ -177,6 +177,40 @@ describe('handleNativeRelay — managed-worktree per-task cleanup', () => {
     });
   });
 
+  describe('DEFENSIVE EDGES (consensus cb4e7421-6a2e4128)', () => {
+    it('does not throw when getWorktreeManager() returns undefined (managed task)', async () => {
+      seedWorktreeTask(TASK_ID, { managed: true });
+      (ctx.mainAgent.getWorktreeManager as jest.Mock).mockReturnValueOnce(undefined);
+
+      // wtm?.cleanup()?.catch() must short-circuit on undefined wtm,
+      // not throw TypeError on the .catch call.
+      await expect(handleNativeRelay(TASK_ID, VALID_RESULT)).resolves.not.toThrow();
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(cleanupMock).not.toHaveBeenCalled();
+      expect(pruneOrphansMock).not.toHaveBeenCalled();
+    });
+
+    it('treats empty-string worktreePath identically to undefined (falsy guard)', async () => {
+      // Direct seed with worktreePath: '' (bypasses seedWorktreeTask's helper).
+      ctx.nativeTaskMap.set(TASK_ID, {
+        agentId: AGENT_ID,
+        task: 'implement thing',
+        startedAt: Date.now() - 1000,
+        timeoutMs: 120_000,
+        writeMode: 'worktree' as any,
+        worktreePath: '',
+      });
+
+      await handleNativeRelay(TASK_ID, '', 'agent errored');
+      await new Promise(resolve => setImmediate(resolve));
+
+      // Empty string is falsy → takes the legacy branch → pruneOrphans on error
+      expect(cleanupMock).not.toHaveBeenCalled();
+      expect(pruneOrphansMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('NON-WORKTREE writeMode', () => {
     it('does not call cleanup() or pruneOrphans() for scoped write mode', async () => {
       seedWorktreeTask(TASK_ID, { managed: true, writeMode: 'scoped' });

--- a/tests/cli/dispatch-native-worktree-managed-cleanup.test.ts
+++ b/tests/cli/dispatch-native-worktree-managed-cleanup.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Per-task cleanup for managed-worktree mode in handleNativeRelay.
+ *
+ * Spec: PR post-#431 cleanup contract (dispatch-native-worktree-managed-cleanup.test.ts).
+ *
+ * Contracts asserted:
+ *  1. MANAGED SUCCESS: when taskInfo.worktreePath is defined and relay succeeds,
+ *     wtm.cleanup(taskId, worktreePath) is called exactly once — no pruneOrphans.
+ *  2. MANAGED ERROR: when taskInfo.worktreePath is defined and relay errors,
+ *     wtm.cleanup(taskId, worktreePath) is called exactly once — no pruneOrphans.
+ *  3. LEGACY ERROR: when taskInfo.worktreePath is undefined and relay errors,
+ *     wtm.pruneOrphans() is called exactly once — cleanup() is NOT called.
+ *  4. LEGACY SUCCESS: when taskInfo.worktreePath is undefined and relay succeeds,
+ *     neither cleanup() nor pruneOrphans() is called.
+ *  5. NON-WORKTREE: when writeMode is not 'worktree', no cleanup is triggered
+ *     regardless of worktreePath presence.
+ */
+
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { handleNativeRelay } from '../../apps/cli/src/handlers/native-tasks';
+import { ctx } from '../../apps/cli/src/mcp-context';
+
+const AGENT_ID = 'sonnet-implementer';
+const TASK_ID = 'wt-cleanup-task-1';
+const MANAGED_WT_PATH = '/tmp/gossip-wt-managed-abc12345';
+
+// Mock modules used by handleNativeRelay internals so they don't require
+// real git repos or live signal pipelines.
+jest.mock('../../apps/cli/src/handlers/worktree-isolation-detection', () => ({
+  __esModule: true,
+  checkIsolationViolation: jest.fn().mockReturnValue({ headChanged: false, dirtyPathsAdded: [], isViolation: false }),
+}));
+
+jest.mock('../../apps/cli/src/handlers/ref-allowlist-detection', () => ({
+  __esModule: true,
+  checkRefAllowlistViolation: jest.fn(),
+}));
+
+let cleanupMock: jest.Mock;
+let pruneOrphansMock: jest.Mock;
+
+function makeMainAgent(): any {
+  cleanupMock = jest.fn().mockResolvedValue(undefined);
+  pruneOrphansMock = jest.fn().mockResolvedValue(undefined);
+  return {
+    dispatch: jest.fn().mockReturnValue({ taskId: 'mock' }),
+    collect: jest.fn().mockResolvedValue({ results: [] }),
+    getAgentConfig: jest.fn().mockReturnValue(null),
+    getLLM: jest.fn().mockReturnValue(null),
+    getAgentList: jest.fn().mockReturnValue([]),
+    getSessionGossip: jest.fn().mockReturnValue([]),
+    getPerfReader: jest.fn().mockReturnValue(undefined),
+    recordNativeTask: jest.fn(),
+    recordNativeTaskCompleted: jest.fn(),
+    recordPlanStepResult: jest.fn(),
+    publishNativeGossip: jest.fn().mockResolvedValue(undefined),
+    scopeTracker: { release: jest.fn() },
+    getWorktreeManager: jest.fn().mockReturnValue({
+      cleanup: cleanupMock,
+      pruneOrphans: pruneOrphansMock,
+    }),
+    projectRoot: '/tmp/gossip-test-project',
+  };
+}
+
+let testDir: string;
+let originalCwd: string;
+let stderrSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'gossip-wt-cleanup-test-'));
+  originalCwd = process.cwd();
+  process.chdir(testDir);
+
+  ctx.nativeTaskMap = new Map();
+  ctx.nativeResultMap = new Map();
+  ctx.nativeUtilityResultMap = new Map();
+  ctx.pendingConsensusRounds = new Map();
+  ctx.recentConsensusTaskIds = new Map();
+  ctx.recentConsensusAgentIds = new Map();
+  ctx.mainAgent = makeMainAgent();
+  ctx.nativeUtilityConfig = null;
+  ctx.booted = true;
+  ctx.boot = jest.fn().mockResolvedValue(undefined) as any;
+
+  stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  process.chdir(originalCwd);
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+/**
+ * Seed nativeTaskMap with a worktree-mode task.
+ * worktreePath is set only when managed=true (mirrors how dispatch.ts writes it).
+ */
+function seedWorktreeTask(
+  taskId: string,
+  opts: { managed?: boolean; writeMode?: string } = {},
+): void {
+  const { managed = false, writeMode = 'worktree' } = opts;
+  ctx.nativeTaskMap.set(taskId, {
+    agentId: AGENT_ID,
+    task: 'implement thing in worktree',
+    startedAt: Date.now() - 1000,
+    timeoutMs: 120_000,
+    writeMode: writeMode as any,
+    ...(managed ? { worktreePath: MANAGED_WT_PATH } : {}),
+  });
+}
+
+const VALID_RESULT = '<agent_finding type="finding" severity="low">x</agent_finding>';
+
+describe('handleNativeRelay — managed-worktree per-task cleanup', () => {
+  describe('MANAGED MODE (worktreePath defined)', () => {
+    it('calls cleanup(taskId, worktreePath) on SUCCESS — not pruneOrphans', async () => {
+      seedWorktreeTask(TASK_ID, { managed: true });
+
+      await handleNativeRelay(TASK_ID, VALID_RESULT);
+
+      // Allow one tick for fire-and-forget promise to flush
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(cleanupMock).toHaveBeenCalledTimes(1);
+      expect(cleanupMock).toHaveBeenCalledWith(TASK_ID, MANAGED_WT_PATH);
+      expect(pruneOrphansMock).not.toHaveBeenCalled();
+    });
+
+    it('calls cleanup(taskId, worktreePath) on ERROR — not pruneOrphans', async () => {
+      seedWorktreeTask(TASK_ID, { managed: true });
+
+      await handleNativeRelay(TASK_ID, '', 'agent failed with exit code 1');
+
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(cleanupMock).toHaveBeenCalledTimes(1);
+      expect(cleanupMock).toHaveBeenCalledWith(TASK_ID, MANAGED_WT_PATH);
+      expect(pruneOrphansMock).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when cleanup() rejects (fire-and-forget contract)', async () => {
+      seedWorktreeTask(TASK_ID, { managed: true });
+      cleanupMock.mockRejectedValueOnce(new Error('git worktree remove failed'));
+
+      // Must not throw
+      await expect(handleNativeRelay(TASK_ID, VALID_RESULT)).resolves.not.toThrow();
+      await new Promise(resolve => setImmediate(resolve));
+    });
+  });
+
+  describe('LEGACY MODE (worktreePath undefined)', () => {
+    it('calls pruneOrphans() on ERROR — not cleanup()', async () => {
+      seedWorktreeTask(TASK_ID, { managed: false });
+
+      await handleNativeRelay(TASK_ID, '', 'agent errored');
+
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(pruneOrphansMock).toHaveBeenCalledTimes(1);
+      expect(cleanupMock).not.toHaveBeenCalled();
+    });
+
+    it('calls NEITHER cleanup() NOR pruneOrphans() on SUCCESS', async () => {
+      seedWorktreeTask(TASK_ID, { managed: false });
+
+      await handleNativeRelay(TASK_ID, VALID_RESULT);
+
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(cleanupMock).not.toHaveBeenCalled();
+      expect(pruneOrphansMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('NON-WORKTREE writeMode', () => {
+    it('does not call cleanup() or pruneOrphans() for scoped write mode', async () => {
+      seedWorktreeTask(TASK_ID, { managed: true, writeMode: 'scoped' });
+
+      await handleNativeRelay(TASK_ID, '', 'agent errored');
+
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(cleanupMock).not.toHaveBeenCalled();
+      expect(pruneOrphansMock).not.toHaveBeenCalled();
+    });
+
+    it('does not call cleanup() or pruneOrphans() for sequential write mode', async () => {
+      seedWorktreeTask(TASK_ID, { managed: false, writeMode: 'sequential' });
+
+      await handleNativeRelay(TASK_ID, VALID_RESULT);
+
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(cleanupMock).not.toHaveBeenCalled();
+      expect(pruneOrphansMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/cli/relay-isolation-warning.test.ts
+++ b/tests/cli/relay-isolation-warning.test.ts
@@ -49,6 +49,10 @@ function makeMainAgent(projectRoot: string): any {
     recordPlanStepResult: jest.fn(),
     publishNativeGossip: jest.fn().mockResolvedValue(undefined),
     scopeTracker: { release: jest.fn() },
+    getWorktreeManager: jest.fn().mockReturnValue({
+      cleanup: jest.fn().mockResolvedValue(undefined),
+      pruneOrphans: jest.fn().mockResolvedValue(undefined),
+    }),
     projectRoot,
   };
 }


### PR DESCRIPTION
## Summary

Closes the managed-worktree cleanup gap left open after PR #431. Adds per-task `wtm.cleanup(taskId, worktreePath)` in `handleNativeRelay` on both success and error paths, fixes a stale `nativeTaskMap` field omission in the consensus dispatch path that silently defeated the new gate, and hardens the optional-chain idiom against `TypeError` when the WorktreeManager is unavailable.

consensus-id: cb4e7421-6a2e4128

## What changed

**`apps/cli/src/handlers/native-tasks.ts:612-633`** — replaced the stale error-only `pruneOrphans()` block with a two-path cleanup gate:
- **Managed mode** (`taskInfo.worktreePath` defined): `wtm?.cleanup(taskId, worktreePath)?.catch(() => {})` on success AND error.
- **Legacy mode** (`worktreePath` undefined): `pruneOrphans()?.catch(() => {})` on error only (Bug f13 behavior preserved).

**`apps/cli/src/handlers/dispatch.ts:1195,1286,1380-1384`** — consensus dispatch path was missing `writeMode` on `nativeTaskMap.set`, so the cleanup gate at `native-tasks.ts:624` never fired for consensus tasks (managed worktrees + `gossip-<taskId>` branches would leak permanently under `GOSSIP_NATIVE_WORKTREE_MANAGED=1`). Caught in consensus review `cb4e7421-6a2e4128:f5`. Fix: extend `taskDefs` + `nativeTasks` types to declare `write_mode`, and when a managed worktree was created, force `effectiveWriteMode='worktree'` regardless of the caller's declaration.

**`tests/cli/dispatch-native-worktree-managed-cleanup.test.ts`** (new, 9 tests, 230+ lines) — covers managed success/error, fire-and-forget contract, legacy success/error, scoped + sequential writeModes, plus the two defensive edges added after review: `getWorktreeManager() → undefined` and empty-string `worktreePath`.

**`tests/cli/relay-isolation-warning.test.ts:52`** — side-fix: `makeMainAgent` stub was missing `getWorktreeManager`, breaking 5 pre-existing tests after PR #431 introduced the universal `getWorktreeManager()` call on `writeMode === 'worktree'` tasks. Verified necessary in cross-review (`cb4e7421-6a2e4128:f8`).

## Consensus review

Cross-review consensus `cb4e7421-6a2e4128` surfaced 1 medium + 2 lows in the original commit `4f5811b`, all addressed in fixup `ac5486c`. Plus 2 disputed findings (sonnet correctly refuted both with file:line evidence):
- gemini:f1 (empty-string explicit-check suggestion) — functionally identical to truthy check given the type and call-site shape.
- gemini:f3 (race between snapshot and cleanup) — snapshot uses `execFileSync` (synchronous), completes before async cleanup begins.

## Deferred follow-up

gemini-reviewer flagged a real **medium** that's out of scope for this PR — `WorktreeManager.cleanup` uses `git worktree remove --force`, which silently discards uncommitted agent work. Touches `WorktreeManager` and an operator contract decision ("agents must commit before relay"). Tracking separately.

## Test plan

- [x] Jest: 5 affected suites pass (46/46 tests). Specifically: `dispatch-native-worktree-managed-cleanup`, `relay-isolation-warning`, `dispatch-native-worktree-managed`, `dispatch-parallel-native-worktree-managed`, `dispatch-consensus-native-worktree-managed`.
- [x] Typecheck clean (`npx tsc --noEmit -p apps/cli/tsconfig.json`).
- [x] Cross-reviewed by sonnet-reviewer + gemini-reviewer; all confirmed findings addressed in fixup.
- [ ] Manual smoke: dispatch a task with `GOSSIP_NATIVE_WORKTREE_MANAGED=1` and verify `.claude/worktrees/agent-<hash>/` is removed after relay completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)