### PR TITLE
fix(dispatch): capture isolationSnapshot on consensus path

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -1275,10 +1275,19 @@ export async function handleDispatchConsensus(
       emitConsensusSignals(process.cwd(), premiseResult.signals);
     }
 
+    // Option B isolation-failure detector — consensus-dispatch path.
+    let consensusIsolationSnapshot: { head: string | null; dirty: string[]; takenAt: string } | undefined;
+    if (def.write_mode === 'worktree') {
+      try {
+        const { captureIsolationSnapshot } = require('./worktree-isolation-detection');
+        consensusIsolationSnapshot = captureIsolationSnapshot(process.cwd());
+      } catch { /* best-effort */ }
+    }
+
     const consensusConcurrentWorktreeTaint = def.write_mode === 'worktree'
       ? stampConcurrencyTaint(ctx.nativeTaskMap) || undefined
       : undefined;
-    ctx.nativeTaskMap.set(taskId, { agentId: def.agent_id, task: def.task, startedAt: Date.now(), timeoutMs: NATIVE_TASK_TTL_MS, relayToken, writeMode: def.write_mode as any, concurrentWorktreeTaint: consensusConcurrentWorktreeTaint });
+    ctx.nativeTaskMap.set(taskId, { agentId: def.agent_id, task: def.task, startedAt: Date.now(), timeoutMs: NATIVE_TASK_TTL_MS, relayToken, writeMode: def.write_mode as any, isolationSnapshot: consensusIsolationSnapshot, concurrentWorktreeTaint: consensusConcurrentWorktreeTaint });
     spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
     try { ctx.mainAgent.recordNativeTask(taskId, def.agent_id, def.task); } catch { /* best-effort */ }
     allTaskIds.push(taskId);

--- a/tests/cli/dispatch-native-prompt.test.ts
+++ b/tests/cli/dispatch-native-prompt.test.ts
@@ -774,3 +774,84 @@ function buildClaimsBlock(
     });
   },
 );
+
+// Consensus path isolation-snapshot capture
+// Closes the detection gap: single + parallel paths captured isolationSnapshot;
+// consensus path omitted it, leaving checkIsolationViolation dead for all
+// consensus dispatches (it bails when snapshot is absent).
+const mockCaptureForConsensus = jest.fn();
+jest.mock(
+  '../../apps/cli/src/handlers/worktree-isolation-detection',
+  () => ({
+    __esModule: true,
+    captureIsolationSnapshot: (...args: any[]) => mockCaptureForConsensus(...args),
+    checkIsolationViolation: jest.fn(),
+  }),
+  { virtual: false },
+);
+
+describe('handleDispatchConsensus — Option B isolation snapshot capture', () => {
+  let skillDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    skillDir = mkdtempSync(join(tmpdir(), 'gossip-consensus-iso-'));
+    mkdirSync(join(skillDir, '.gossip', 'skills'), { recursive: true });
+    process.chdir(skillDir);
+    resetCtx({
+      generateLensesForAgents: jest.fn().mockResolvedValue(new Map()),
+    });
+    mockCaptureForConsensus.mockReset();
+  });
+
+  afterEach(() => {
+    restoreCtx();
+    process.chdir(prevCwd);
+    rmSync(skillDir, { recursive: true, force: true });
+  });
+
+  it('stores isolationSnapshot in nativeTaskMap when write_mode is worktree', async () => {
+    const fakeSnapshot = { head: 'c'.repeat(40), dirty: [], takenAt: new Date().toISOString() };
+    mockCaptureForConsensus.mockReturnValue(fakeSnapshot);
+
+    ctx.nativeAgentConfigs.set('native-claude', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Native reviewer',
+      skills: [],
+    });
+
+    await handleDispatchConsensus([
+      { agent_id: 'native-claude', task: 'Audit worktree code', write_mode: 'worktree' },
+    ]);
+
+    // There should be exactly one entry in nativeTaskMap (the dispatched agent).
+    expect(ctx.nativeTaskMap.size).toBeGreaterThanOrEqual(1);
+    const entries = [...ctx.nativeTaskMap.values()];
+    const worktreeEntry = entries.find(e => e.writeMode === 'worktree');
+    expect(worktreeEntry).toBeDefined();
+    expect(worktreeEntry!.isolationSnapshot).toMatchObject({
+      head: 'c'.repeat(40),
+      dirty: [],
+    });
+    expect(mockCaptureForConsensus).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not set isolationSnapshot when write_mode is not worktree', async () => {
+    ctx.nativeAgentConfigs.set('native-claude', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Native reviewer',
+      skills: [],
+    });
+
+    await handleDispatchConsensus([
+      { agent_id: 'native-claude', task: 'Audit sequential code' },
+    ]);
+
+    expect(mockCaptureForConsensus).not.toHaveBeenCalled();
+    const entries = [...ctx.nativeTaskMap.values()];
+    expect(entries.every(e => e.isolationSnapshot === undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Mirrors the Option B isolation-failure detector capture (parallel-path at `dispatch.ts:981-993`) onto the consensus-dispatch path.
- Closes detection-coverage gap from next-session backlog item #3 — consensus dispatches were storing `isolationSnapshot=undefined`, so the post-relay detector at `worktree-isolation-detection.ts` bailed silently for every consensus task.
- Pure mirror-of-existing-pattern change (handbook §impact-adjacency consensus-skip exception applies).

## Verification
- 22/22 pass on `tests/cli/dispatch-native-prompt.test.ts` + `tests/cli/relay-isolation-warning.test.ts`
- New `describe('handleDispatchConsensus — Option B isolation snapshot capture', ...)` covers worktree-mode capture + non-worktree no-call.
- `npm run build:mcp` clean.

## Test plan
- [ ] CI green
- [ ] No regression in worktree-isolation suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)