### PR TITLE
fix(hook): make mcp-server.js arg-aware so 'gossipcat hook --run' works

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -8,6 +8,61 @@
  */
 import { createWriteStream, mkdirSync } from 'fs';
 import { join } from 'path';
+import { runHook } from './hook-run';
+import { parseHookSubcommand } from './hook-argv';
+
+// ── Argv dispatch shim ──────────────────────────────────────────────────
+//
+// `package.json:bin` ships this file as the `gossipcat` binary, so
+// `gossipcat hook --run` (the UserPromptSubmit hook installed by
+// `gossip_setup` / `installBootstrapHook`) lands HERE — not in
+// `apps/cli/src/index.ts` (which is not bundled into the published
+// artifact). Without this shim the hook would silently boot a duplicate
+// MCP server on every user prompt, racing the real one on `.gossip/`
+// lockfiles and port 51838 → relay crash-loop.
+//
+// Rules (handled BEFORE the stderr redirect / heavy imports below):
+//   - `gossipcat hook --run` or `gossipcat hook run` → execute hook body, exit 0
+//   - `gossipcat hook` or `gossipcat hook <unknown>` → usage to stderr, exit 2
+//   - `gossipcat help|--help|-h`                     → usage to stdout, exit 0
+//   - `gossipcat <unknown>`                          → error to stderr, exit 2
+//   - no args                                        → fall through, boot MCP server
+//
+// See memory `project_bootstrap_hook_command_dispatch_bug.md` for the
+// full diagnosis and the dist-mcp-only build context.
+{
+  const argv = process.argv.slice(2);
+  const sub = argv[0];
+  if (sub === 'hook') {
+    const decision = parseHookSubcommand(argv[1]);
+    if (decision === 'usage') {
+      process.stderr.write('Usage: gossipcat hook --run\n');
+      process.exit(2);
+    }
+    runHook();
+    process.exit(0);
+  }
+  if (sub === 'help' || sub === '--help' || sub === '-h') {
+    process.stdout.write(
+      'gossipcat — Multi-Agent Orchestration\n' +
+      '\n' +
+      'Usage:\n' +
+      '  gossipcat                Start MCP server (for Claude Code / Cursor)\n' +
+      '  gossipcat hook --run     Run UserPromptSubmit bootstrap hook (internal)\n' +
+      '  gossipcat help           Show this help\n' +
+      '\n' +
+      'The published binary is the MCP server bundle. The full CLI\n' +
+      '(setup wizard, create-agent, chat, etc.) lives in apps/cli/src/index.ts\n' +
+      'and is available via `npm start` / `npx ts-node` in the source repo.\n'
+    );
+    process.exit(0);
+  }
+  if (sub !== undefined) {
+    process.stderr.write(`gossipcat: unknown subcommand '${sub}'. Try 'gossipcat help'.\n`);
+    process.exit(2);
+  }
+  // No args → fall through; the MCP server boots below.
+}
 
 // Redirect stderr to log file BEFORE any other imports.
 // Suppressed in test runs (GOSSIPCAT_MCP_NO_MAIN=1) so jest can surface assertion

--- a/tests/cli/mcp-server-argv-dispatch.test.ts
+++ b/tests/cli/mcp-server-argv-dispatch.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Integration test for the argv-dispatch shim at the top of
+ * `apps/cli/src/mcp-server-sdk.ts` — i.e. the shim that makes the
+ * published `gossipcat` binary (which is `dist-mcp/mcp-server.js`)
+ * route `hook --run` / `--help` / unknown / no-arg invocations
+ * correctly instead of always booting the MCP server.
+ *
+ * Spawns the built bundle (`dist-mcp/mcp-server.js`) with `node` so we
+ * test the exact artifact users install from npm.
+ *
+ * If the bundle is missing the test is skipped with a hint to run
+ * `npm run build:mcp` first.
+ *
+ * Covers the bug from
+ * `project_bootstrap_hook_command_dispatch_bug.md`:
+ *   - `gossipcat hook --run` MUST NOT boot a second MCP server.
+ *   - It must read .gossip/bootstrap.md, print it, exit 0, no .gossip/mcp.log
+ *     spam, no stdin hang.
+ */
+import { spawn } from 'child_process';
+import { existsSync, mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join, resolve } from 'path';
+import { tmpdir } from 'os';
+
+const BUNDLE_PATH = resolve(__dirname, '..', '..', 'dist-mcp', 'mcp-server.js');
+
+interface RunResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runBundle(args: string[], opts: { cwd?: string; timeoutMs?: number; killAfterMs?: number } = {}): Promise<RunResult> {
+  return new Promise((resolveP, reject) => {
+    const child = spawn(process.execPath, [BUNDLE_PATH, ...args], {
+      cwd: opts.cwd ?? process.cwd(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (b) => { stdout += b.toString(); });
+    child.stderr.on('data', (b) => { stderr += b.toString(); });
+    // Close stdin so the bundle doesn't hang reading MCP stdio.
+    child.stdin.end();
+
+    const timeoutMs = opts.timeoutMs ?? 10_000;
+    const killAfterMs = opts.killAfterMs;
+    let killTimer: NodeJS.Timeout | undefined;
+    if (killAfterMs !== undefined) {
+      killTimer = setTimeout(() => {
+        try { child.kill('SIGTERM'); } catch { /* */ }
+      }, killAfterMs);
+    }
+    const hardTimer = setTimeout(() => {
+      try { child.kill('SIGKILL'); } catch { /* */ }
+      reject(new Error(`bundle did not exit within ${timeoutMs}ms (args=${args.join(' ')})`));
+    }, timeoutMs);
+
+    child.on('exit', (code, signal) => {
+      if (killTimer) clearTimeout(killTimer);
+      clearTimeout(hardTimer);
+      resolveP({ code, signal, stdout, stderr });
+    });
+    child.on('error', (err) => {
+      if (killTimer) clearTimeout(killTimer);
+      clearTimeout(hardTimer);
+      reject(err);
+    });
+  });
+}
+
+const describeOrSkip = existsSync(BUNDLE_PATH) ? describe : describe.skip;
+
+describeOrSkip('dist-mcp/mcp-server.js argv dispatch shim', () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    while (created.length) {
+      const dir = created.pop()!;
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ }
+    }
+  });
+
+  it('`hook --run` with a bootstrap fixture exits 0, prints content, no .gossip/mcp.log spam', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossipcat-argv-shim-'));
+    created.push(root);
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+    const bootstrapPath = join(root, '.gossip', 'bootstrap.md');
+    writeFileSync(bootstrapPath, '# fixture bootstrap\nHELLO_FIXTURE_TOKEN\n');
+
+    const res = await runBundle(['hook', '--run'], { cwd: root, timeoutMs: 8_000 });
+
+    expect(res.code).toBe(0);
+    expect(res.signal).toBeNull();
+    expect(res.stdout).toContain('HELLO_FIXTURE_TOKEN');
+    // The hook path must NOT trigger the stderr redirect (which would
+    // create .gossip/mcp.log). The shim runs BEFORE that block.
+    expect(existsSync(join(root, '.gossip', 'mcp.log'))).toBe(false);
+  });
+
+  it('`hook` with no subcommand prints usage to stderr and exits 2', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossipcat-argv-shim-'));
+    created.push(root);
+    const res = await runBundle(['hook'], { cwd: root, timeoutMs: 8_000 });
+    expect(res.code).toBe(2);
+    expect(res.stderr).toContain('Usage: gossipcat hook --run');
+  });
+
+  it('`--help` exits 0 with usage on stdout', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossipcat-argv-shim-'));
+    created.push(root);
+    const res = await runBundle(['--help'], { cwd: root, timeoutMs: 8_000 });
+    expect(res.code).toBe(0);
+    expect(res.stdout.toLowerCase()).toContain('usage');
+    expect(res.stdout).toContain('gossipcat hook --run');
+  });
+
+  it('unknown subcommand exits 2 with an error on stderr', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossipcat-argv-shim-'));
+    created.push(root);
+    const res = await runBundle(['nosuchcommand'], { cwd: root, timeoutMs: 8_000 });
+    expect(res.code).toBe(2);
+    expect(res.stderr).toContain("unknown subcommand 'nosuchcommand'");
+  });
+
+  it('no args → MCP server boots (stderr redirect activates); SIGTERM after 1.5s ends it', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossipcat-argv-shim-'));
+    created.push(root);
+    // No bootstrap fixture; we just verify the server starts and keeps running
+    // until SIGTERM. Closing stdin would cause the stdio transport to exit, so
+    // we must send SIGTERM explicitly. The runBundle helper closes stdin
+    // unconditionally though, so the stdio transport will end almost
+    // immediately — that's still a "MCP server booted" signal (it processed
+    // stdio close, didn't exit 2 from the shim).
+    const res = await runBundle([], { cwd: root, timeoutMs: 8_000, killAfterMs: 2_000 });
+    // Critical assertion: shim did NOT short-circuit with exit code 2.
+    expect(res.code).not.toBe(2);
+    // And the heavy-import path was taken — .gossip/mcp.log exists.
+    expect(existsSync(join(root, '.gossip', 'mcp.log'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a real shipping bug: `installBootstrapHook()` writes `BOOTSTRAP_HOOK_COMMAND = "gossipcat hook --run"` into `.claude/settings.local.json` UserPromptSubmit (called from `gossip_setup` at `apps/cli/src/mcp-server-sdk.ts:2156`), but the published `gossipcat` binary (`package.json:bin → dist-mcp/mcp-server.js`) is the MCP-server-only bundle with NO CLI argument parsing.

Every UserPromptSubmit fires a duplicate MCP server that collides on `.gossip/` lockfiles + HTTP MCP port 51838 → relay crash-loop. Users see "gossipcat keeps crashing" with no signal of why.

Full diagnosis: `project_bootstrap_hook_command_dispatch_bug.md` in the orchestrator's memory. This also explains the earlier peer report about `.gossip/agents/<id>/memory/` causing crashes (`project_gossip_setup_memory_dir_init_gap.md`) — same crash, different misdiagnosed cause.

## Fix

Added a ~50-line argv-dispatch shim at the top of `apps/cli/src/mcp-server-sdk.ts`, BEFORE the stderr redirect and all heavy imports. Reuses the existing `parseHookSubcommand` + `runHook` helpers (pure modules, fs/path/os only — no MCP server boot side effects).

- `gossipcat hook --run` → run hook body → exit 0
- `gossipcat --help` / `-h` / `help` → print usage → exit 0
- Unknown subcommand → stderr error → exit 2
- No subcommand → boot MCP server (unchanged)

No new bundle entry needed — the shim is small enough to live alongside the MCP server entry. esbuild output: 2.1MB (unchanged scale).

## Verification gates (all 6 pass)

1. `npm run build:mcp` — clean (esbuild 56ms)
2. `node dist-mcp/mcp-server.js hook --run` — exit 0, bootstrap fixture content emitted, no `.gossip/mcp.log` created (i.e. no MCP boot)
3. `node dist-mcp/mcp-server.js --help` — exit 0, usage on stdout including `gossipcat hook --run`
4. `node dist-mcp/mcp-server.js` (no args) — boots MCP server, `.gossip/mcp.log` appears, SIGTERM after 2s ends it cleanly
5. New integration tests in `tests/cli/mcp-server-argv-dispatch.test.ts` — 5/5 pass (4.4s). No regression: `hook-run.test.ts` + `hook-argv.test.ts` → 11/11 pass.
6. `npm run build` (full workspace `build:all`) — clean across `@gossip/types`, `client`, `tools`, `orchestrator`, `relay`.

## User-side workaround (for any user already affected)

If you've already run `gossip_setup` and the broken hook is installed, strip it manually before the fix lands:

```bash
# Inspect: look for `"command": "gossipcat hook --run"` in UserPromptSubmit
$EDITOR .claude/settings.local.json
```

Remove that hook entry. The other 3 discipline hooks (SessionStart bootstrap, PreToolUse signals validator, PostToolUse collect reminder) all invoke proper scripts in `.claude/hooks/discipline/` and are fine — leave them.

## Test plan

- [x] CI green
- [ ] Reviewer confirms the argv shim runs BEFORE any MCP server side-effects (stdio bind, port allocation, lockfile creation) — read `apps/cli/src/mcp-server-sdk.ts` top-of-file ordering
- [ ] Reviewer confirms `parseHookSubcommand` + `runHook` are reused (not reimplemented) — these are the same helpers used by the CLI dispatcher at `apps/cli/src/index.ts:60-65`
- [ ] Reviewer confirms `hook --run` exits with no port/lockfile contention via the integration test
