### PR TITLE
fix(isolation): auto-revert leaked paths on worktree_isolation_failed detection

### DIFF
--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -5,6 +5,7 @@
 import { randomUUID } from 'crypto';
 import { hasMemoryQuery } from '@gossip/relay';
 import { ctx, NATIVE_TASK_TTL_MS, defaultImportanceScores } from '../mcp-context';
+import { revertLeakedPaths } from './worktree-isolation-detection';
 
 /**
  * Lazy-prune entries in `ctx.recentConsensusTaskIds` whose TTL has expired.
@@ -977,18 +978,40 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
       // leaked paths from HEAD so detect-and-escalate becomes detect-and-recover.
       // Gated on the same non-tainted branch — attribution is only safe here.
       // Fail-open: any error becomes a receipt line, never throws.
+      //
+      // KNOWN LIMITATION (post-#446 consensus dace5336-73384bc9 f9): two
+      // parallel native relays leaking overlapping paths could invoke
+      // `git restore` concurrently on the parent checkout. `git restore` is
+      // idempotent on unmodified files, so the realistic harm is moderate, but
+      // a torn mid-restore state is theoretically possible. Closing this
+      // requires a worktree-level mutex or a serialized recovery queue —
+      // tracked as a follow-up; not addressed in this PR.
       if (isolationDiff.dirtyPathsAdded.length > 0) {
         try {
-          const { revertLeakedPaths } = require('./worktree-isolation-detection');
           const revertRoot = ctx.mainAgent?.projectRoot ?? process.cwd();
           const revertResult = revertLeakedPaths(revertRoot, isolationDiff.dirtyPathsAdded);
+          const auditSuspectedReason =
+            revertResult.error
+              ? `isolation_recovery_failed err=${revertResult.error.slice(0, 80)}`
+              : `isolation_recovery_attempted restored=${revertResult.restored.length} skipped=${revertResult.skipped.length} rejected=${revertResult.rejected.length}`;
+          appendRelayWarning(revertRoot, {
+            taskId: task_id,
+            agentId: taskInfo.agentId,
+            reason: revertResult.error ? 'isolation_recovery_failed' : 'isolation_recovery_attempted',
+            resultLength: isolationDiff.dirtyPathsAdded.length,
+            suspectedReason: auditSuspectedReason,
+            timestamp: new Date().toISOString(),
+          });
           if (revertResult.error) {
             responseText += `\n  → auto-recovery FAILED: ${revertResult.error}. Run 'git restore <paths>' manually.`;
           } else {
             const skippedPart = revertResult.skipped.length > 0
               ? ` (${revertResult.skipped.length} path(s) skipped — no longer present)`
               : '';
-            responseText += `\n  → auto-recovered ${revertResult.restored.length} leaked path(s) via 'git restore'${skippedPart}.`;
+            const rejectedPart = revertResult.rejected.length > 0
+              ? ` (${revertResult.rejected.length} path(s) rejected — security filter)`
+              : '';
+            responseText += `\n  → auto-recovered ${revertResult.restored.length} leaked path(s) via 'git restore'${skippedPart}${rejectedPart}.`;
           }
         } catch (err) {
           responseText += `\n  → auto-recovery FAILED: ${(err as Error).message}. Run 'git restore <paths>' manually.`;

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -972,6 +972,28 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
         ? ` +${isolationDiff.dirtyPathsAdded.length - 5} more`
         : '';
       responseText += `\n⚠ worktree_isolation_failed: Agent(isolation:"worktree") write leaked into parent checkout (${headPart}, ${isolationDiff.dirtyPathsAdded.length} new dirty path(s)${list ? `: ${list}${more}` : ''}).`;
+
+      // Option A auto-revert (design consensus c15cb1d8-c66840b7): restore the
+      // leaked paths from HEAD so detect-and-escalate becomes detect-and-recover.
+      // Gated on the same non-tainted branch — attribution is only safe here.
+      // Fail-open: any error becomes a receipt line, never throws.
+      if (isolationDiff.dirtyPathsAdded.length > 0) {
+        try {
+          const { revertLeakedPaths } = require('./worktree-isolation-detection');
+          const revertRoot = ctx.mainAgent?.projectRoot ?? process.cwd();
+          const revertResult = revertLeakedPaths(revertRoot, isolationDiff.dirtyPathsAdded);
+          if (revertResult.error) {
+            responseText += `\n  → auto-recovery FAILED: ${revertResult.error}. Run 'git restore <paths>' manually.`;
+          } else {
+            const skippedPart = revertResult.skipped.length > 0
+              ? ` (${revertResult.skipped.length} path(s) skipped — no longer present)`
+              : '';
+            responseText += `\n  → auto-recovered ${revertResult.restored.length} leaked path(s) via 'git restore'${skippedPart}.`;
+          }
+        } catch (err) {
+          responseText += `\n  → auto-recovery FAILED: ${(err as Error).message}. Run 'git restore <paths>' manually.`;
+        }
+      }
     }
   }
   if (utilityBlocks.length > 0) {

--- a/apps/cli/src/handlers/worktree-isolation-detection.ts
+++ b/apps/cli/src/handlers/worktree-isolation-detection.ts
@@ -74,6 +74,75 @@ export function parsePorcelain(output: string): string[] {
   return paths.sort();
 }
 
+/** Result of an auto-revert attempt — surfaced in the relay receipt. */
+export interface IsolationRevertResult {
+  /** Paths actually restored to HEAD content. */
+  restored: string[];
+  /** Paths that were skipped (e.g. no longer present). */
+  skipped: string[];
+  /** Set when `git restore` itself failed; receipt should display this message. */
+  error?: string;
+}
+
+/**
+ * Auto-revert leaked paths via `git restore --source=HEAD -- <paths>`.
+ *
+ * Design consensus c15cb1d8-c66840b7: when checkIsolationViolation reports a
+ * leak AND the violation is not concurrency-tainted, restore the leaked paths
+ * from HEAD so the parent checkout is recovered automatically.
+ *
+ * - Skips files that no longer exist on disk (rename / delete races) so a
+ *   single missing path doesn't fail the whole batch.
+ * - Quiet on success: git restore inherits no stdio.
+ * - Fail-open: any throw is caught and surfaced through `error`; callers
+ *   continue rendering the relay receipt.
+ *
+ * Paths are passed to git via `--` to disarm any leading dashes; absolute
+ * paths are filtered out as a defence-in-depth measure since dirtyPathsAdded
+ * normally comes from `git status --porcelain` (always repo-relative).
+ */
+export function revertLeakedPaths(
+  cwd: string,
+  paths: string[],
+): IsolationRevertResult {
+  const result: IsolationRevertResult = { restored: [], skipped: [] };
+  if (!paths || paths.length === 0) return result;
+
+  // Defence-in-depth: filter absolute paths and obvious traversal.
+  const safePaths = paths.filter(
+    p => typeof p === 'string' && p.length > 0 && !p.startsWith('/') && !p.startsWith('-'),
+  );
+
+  // Skip paths that no longer exist on disk — restore would still attempt them
+  // but we want a clean "skipped" tally for the receipt.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const fs = require('fs') as typeof import('fs');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const path = require('path') as typeof import('path');
+  const present: string[] = [];
+  for (const p of safePaths) {
+    const abs = path.isAbsolute(p) ? p : path.join(cwd, p);
+    if (fs.existsSync(abs)) {
+      present.push(p);
+    } else {
+      result.skipped.push(p);
+    }
+  }
+
+  if (present.length === 0) return result;
+
+  try {
+    execFileSync('git', ['restore', '--source=HEAD', '--', ...present], {
+      cwd,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    result.restored = present;
+  } catch (err) {
+    result.error = (err as Error).message || String(err);
+  }
+  return result;
+}
+
 /** Run `git status --porcelain` from `cwd`. Returns [] on any failure. */
 function readPorcelain(cwd: string): string[] {
   try {

--- a/apps/cli/src/handlers/worktree-isolation-detection.ts
+++ b/apps/cli/src/handlers/worktree-isolation-detection.ts
@@ -78,8 +78,10 @@ export function parsePorcelain(output: string): string[] {
 export interface IsolationRevertResult {
   /** Paths actually restored to HEAD content. */
   restored: string[];
-  /** Paths that were skipped (e.g. no longer present). */
+  /** Paths that were skipped because the file no longer exists on disk. */
   skipped: string[];
+  /** Paths rejected by the defense-in-depth filter (absolute / leading-dash). */
+  rejected: string[];
   /** Set when `git restore` itself failed; receipt should display this message. */
   error?: string;
 }
@@ -105,23 +107,34 @@ export function revertLeakedPaths(
   cwd: string,
   paths: string[],
 ): IsolationRevertResult {
-  const result: IsolationRevertResult = { restored: [], skipped: [] };
+  const result: IsolationRevertResult = { restored: [], skipped: [], rejected: [] };
   if (!paths || paths.length === 0) return result;
 
-  // Defence-in-depth: filter absolute paths and obvious traversal.
-  const safePaths = paths.filter(
-    p => typeof p === 'string' && p.length > 0 && !p.startsWith('/') && !p.startsWith('-'),
-  );
+  // Defence-in-depth: filter absolute paths and leading-dash args. The `--`
+  // separator in execFileSync (line ~135) is the real guard against
+  // git-flag-injection; this filter exists so a rejected path is auditable in
+  // the receipt rather than vanishing silently. Note: `../` traversal is NOT
+  // filtered here — git restore resolves it relative to cwd, and dirtyPathsAdded
+  // from `git status --porcelain` never contains it.
+  const safePaths: string[] = [];
+  for (const p of paths) {
+    if (typeof p === 'string' && p.length > 0 && !p.startsWith('/') && !p.startsWith('-')) {
+      safePaths.push(p);
+    } else if (typeof p === 'string' && p.length > 0) {
+      result.rejected.push(p);
+    }
+  }
 
-  // Skip paths that no longer exist on disk — restore would still attempt them
-  // but we want a clean "skipped" tally for the receipt.
+  // Skip paths that no longer exist on disk (rename / delete races). All entries
+  // in safePaths are repo-relative after the filter above, so path.join(cwd, p)
+  // is the only resolution mode needed.
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const fs = require('fs') as typeof import('fs');
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const path = require('path') as typeof import('path');
   const present: string[] = [];
   for (const p of safePaths) {
-    const abs = path.isAbsolute(p) ? p : path.join(cwd, p);
+    const abs = path.join(cwd, p);
     if (fs.existsSync(abs)) {
       present.push(p);
     } else {

--- a/tests/cli/relay-isolation-warning.test.ts
+++ b/tests/cli/relay-isolation-warning.test.ts
@@ -27,9 +27,11 @@ import { ctx } from '../../apps/cli/src/mcp-context';
 // `require('./worktree-isolation-detection')` at the call site, so this mock
 // path matches the resolved module identity.
 const mockCheck = jest.fn();
+const mockRevert = jest.fn();
 jest.mock('../../apps/cli/src/handlers/worktree-isolation-detection', () => ({
   __esModule: true,
   checkIsolationViolation: (...args: any[]) => mockCheck(...args),
+  revertLeakedPaths: (...args: any[]) => mockRevert(...args),
 }));
 
 const AGENT_ID = 'sonnet-implementer';
@@ -77,6 +79,10 @@ beforeEach(() => {
   ctx.boot = jest.fn().mockResolvedValue(undefined) as any;
 
   mockCheck.mockReset();
+  mockRevert.mockReset();
+  // Default: auto-revert returns a successful no-op so existing tests that
+  // trigger a violation don't blow up; tests that care assert explicitly.
+  mockRevert.mockReturnValue({ restored: [], skipped: [] });
   stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
 });
 
@@ -209,6 +215,123 @@ describe('handleNativeRelay — worktree isolation warning integration', () => {
 
     const text = (res.content[0] as { text: string }).text;
     expect(text).not.toContain('worktree_isolation_failed');
+  });
+
+  // ─── Option A auto-revert (design consensus c15cb1d8-c66840b7) ─────────────
+
+  it('auto-recovers leaked paths via revertLeakedPaths on non-tainted violation', async () => {
+    seedWorktreeTask(TASK_ID, AGENT_ID);
+    mockCheck.mockReturnValue({
+      headChanged: false,
+      dirtyPathsAdded: ['apps/cli/src/leaked.ts', 'packages/x/y.ts'],
+      isViolation: true,
+    });
+    mockRevert.mockReturnValue({
+      restored: ['apps/cli/src/leaked.ts', 'packages/x/y.ts'],
+      skipped: [],
+    });
+
+    const res = await handleNativeRelay(TASK_ID, '<agent_finding type="finding" severity="LOW">x</agent_finding>');
+
+    expect(mockRevert).toHaveBeenCalledTimes(1);
+    const [revertCwd, revertPaths] = mockRevert.mock.calls[0];
+    expect(revertCwd).toBe(testDir);
+    expect(revertPaths).toEqual(['apps/cli/src/leaked.ts', 'packages/x/y.ts']);
+
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain('⚠ worktree_isolation_failed');
+    expect(text).toContain("auto-recovered 2 leaked path(s) via 'git restore'");
+  });
+
+  it('reports skipped-path count in receipt when some paths no longer exist', async () => {
+    seedWorktreeTask(TASK_ID, AGENT_ID);
+    mockCheck.mockReturnValue({
+      headChanged: false,
+      dirtyPathsAdded: ['exists.ts', 'gone.ts'],
+      isViolation: true,
+    });
+    mockRevert.mockReturnValue({
+      restored: ['exists.ts'],
+      skipped: ['gone.ts'],
+    });
+
+    const res = await handleNativeRelay(TASK_ID, '<agent_finding type="finding" severity="LOW">x</agent_finding>');
+
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain("auto-recovered 1 leaked path(s) via 'git restore'");
+    expect(text).toContain('1 path(s) skipped');
+  });
+
+  it('reports auto-recovery FAILED in receipt without throwing when revertLeakedPaths reports an error', async () => {
+    seedWorktreeTask(TASK_ID, AGENT_ID);
+    mockCheck.mockReturnValue({
+      headChanged: false,
+      dirtyPathsAdded: ['weird.ts'],
+      isViolation: true,
+    });
+    mockRevert.mockReturnValue({
+      restored: [],
+      skipped: [],
+      error: 'fatal: pathspec did not match any file',
+    });
+
+    const res = await handleNativeRelay(TASK_ID, '<agent_finding type="finding" severity="LOW">x</agent_finding>');
+
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain('⚠ worktree_isolation_failed');
+    expect(text).toContain('auto-recovery FAILED');
+    expect(text).toContain('pathspec did not match');
+    expect(text).toContain("Run 'git restore <paths>' manually");
+  });
+
+  it('reports auto-recovery FAILED in receipt when revertLeakedPaths itself throws', async () => {
+    seedWorktreeTask(TASK_ID, AGENT_ID);
+    mockCheck.mockReturnValue({
+      headChanged: false,
+      dirtyPathsAdded: ['x.ts'],
+      isViolation: true,
+    });
+    mockRevert.mockImplementation(() => { throw new Error('require crashed'); });
+
+    const res = await handleNativeRelay(TASK_ID, '<agent_finding type="finding" severity="LOW">x</agent_finding>');
+
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain('⚠ worktree_isolation_failed');
+    expect(text).toContain('auto-recovery FAILED');
+    expect(text).toContain('require crashed');
+  });
+
+  it('does NOT auto-recover when concurrencyTainted=true (attribution ambiguous)', async () => {
+    seedWorktreeTask(TASK_ID, AGENT_ID, { withSnapshot: true, concurrentWorktreeTaint: true });
+    mockCheck.mockReturnValue({
+      headChanged: false,
+      dirtyPathsAdded: ['foo.ts', 'bar.ts'],
+      isViolation: true,
+    });
+
+    const res = await handleNativeRelay(TASK_ID, '<agent_finding type="finding" severity="LOW">x</agent_finding>');
+
+    expect(mockRevert).not.toHaveBeenCalled();
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain('worktree_isolation_skipped');
+    expect(text).not.toContain('auto-recovered');
+    expect(text).not.toContain('auto-recovery FAILED');
+  });
+
+  it('does NOT auto-recover when dirtyPathsAdded is empty (HEAD-drift-only violation)', async () => {
+    seedWorktreeTask(TASK_ID, AGENT_ID);
+    mockCheck.mockReturnValue({
+      headChanged: true,
+      dirtyPathsAdded: [],
+      isViolation: true,
+    });
+
+    const res = await handleNativeRelay(TASK_ID, '<agent_finding type="finding" severity="LOW">x</agent_finding>');
+
+    expect(mockRevert).not.toHaveBeenCalled();
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain('worktree_isolation_failed');
+    expect(text).not.toContain('auto-recovered');
   });
 
   it('routes to worktree_isolation_skipped when task has concurrentWorktreeTaint=true', async () => {

--- a/tests/cli/relay-isolation-warning.test.ts
+++ b/tests/cli/relay-isolation-warning.test.ts
@@ -82,7 +82,7 @@ beforeEach(() => {
   mockRevert.mockReset();
   // Default: auto-revert returns a successful no-op so existing tests that
   // trigger a violation don't blow up; tests that care assert explicitly.
-  mockRevert.mockReturnValue({ restored: [], skipped: [] });
+  mockRevert.mockReturnValue({ restored: [], skipped: [], rejected: [] });
   stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
 });
 
@@ -229,6 +229,7 @@ describe('handleNativeRelay — worktree isolation warning integration', () => {
     mockRevert.mockReturnValue({
       restored: ['apps/cli/src/leaked.ts', 'packages/x/y.ts'],
       skipped: [],
+      rejected: [],
     });
 
     const res = await handleNativeRelay(TASK_ID, '<agent_finding type="finding" severity="LOW">x</agent_finding>');
@@ -253,6 +254,7 @@ describe('handleNativeRelay — worktree isolation warning integration', () => {
     mockRevert.mockReturnValue({
       restored: ['exists.ts'],
       skipped: ['gone.ts'],
+      rejected: [],
     });
 
     const res = await handleNativeRelay(TASK_ID, '<agent_finding type="finding" severity="LOW">x</agent_finding>');
@@ -260,6 +262,26 @@ describe('handleNativeRelay — worktree isolation warning integration', () => {
     const text = (res.content[0] as { text: string }).text;
     expect(text).toContain("auto-recovered 1 leaked path(s) via 'git restore'");
     expect(text).toContain('1 path(s) skipped');
+  });
+
+  it('reports rejected-path count in receipt when defense-in-depth filter blocked entries', async () => {
+    seedWorktreeTask(TASK_ID, AGENT_ID);
+    mockCheck.mockReturnValue({
+      headChanged: false,
+      dirtyPathsAdded: ['ok.ts', '/etc/passwd'],
+      isViolation: true,
+    });
+    mockRevert.mockReturnValue({
+      restored: ['ok.ts'],
+      skipped: [],
+      rejected: ['/etc/passwd'],
+    });
+
+    const res = await handleNativeRelay(TASK_ID, '<agent_finding type="finding" severity="LOW">x</agent_finding>');
+
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain("auto-recovered 1 leaked path(s) via 'git restore'");
+    expect(text).toContain('1 path(s) rejected — security filter');
   });
 
   it('reports auto-recovery FAILED in receipt without throwing when revertLeakedPaths reports an error', async () => {
@@ -272,6 +294,7 @@ describe('handleNativeRelay — worktree isolation warning integration', () => {
     mockRevert.mockReturnValue({
       restored: [],
       skipped: [],
+      rejected: [],
       error: 'fatal: pathspec did not match any file',
     });
 

--- a/tests/cli/worktree-isolation-detection.test.ts
+++ b/tests/cli/worktree-isolation-detection.test.ts
@@ -300,7 +300,7 @@ describe('revertLeakedPaths — Option A auto-revert (consensus c15cb1d8-c66840b
 
   it('no-op on empty paths', () => {
     const r = revertLeakedPaths(tmpRoot, []);
-    expect(r).toEqual({ restored: [], skipped: [] });
+    expect(r).toEqual({ restored: [], skipped: [], rejected: [] });
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -355,7 +355,7 @@ describe('revertLeakedPaths — Option A auto-revert (consensus c15cb1d8-c66840b
     expect(r.error).toMatch(/pathspec did not match/);
   });
 
-  it('filters absolute paths and leading-dash paths defensively', () => {
+  it('filters absolute paths and leading-dash paths defensively, recording rejects', () => {
     touch('ok.ts');
     touch('also-ok.ts');
     mockExec.mockReturnValueOnce(Buffer.from(''));
@@ -364,6 +364,9 @@ describe('revertLeakedPaths — Option A auto-revert (consensus c15cb1d8-c66840b
     // absolute + leading-dash filtered out before git invocation
     expect(args).toEqual(['restore', '--source=HEAD', '--', 'ok.ts', 'also-ok.ts']);
     expect(r.restored).toEqual(['ok.ts', 'also-ok.ts']);
+    // rejected paths surface separately from skipped (different reason)
+    expect(r.rejected).toEqual(['/etc/passwd', '--force']);
+    expect(r.skipped).toEqual([]);
   });
 });
 

--- a/tests/cli/worktree-isolation-detection.test.ts
+++ b/tests/cli/worktree-isolation-detection.test.ts
@@ -28,12 +28,14 @@ jest.mock('child_process', () => ({
 
 // ── imports after mocks ──────────────────────────────────────────────────────
 
+import * as fs from 'fs';
 import {
   parsePorcelain,
   diffIsolationSnapshots,
   buildIsolationSignal,
   checkIsolationViolation,
   captureIsolationSnapshot,
+  revertLeakedPaths,
   IsolationSnapshot,
 } from '../../apps/cli/src/handlers/worktree-isolation-detection';
 import { emitConsensusSignals } from '@gossip/orchestrator';
@@ -271,6 +273,97 @@ describe('checkIsolationViolation — concurrencyTainted 5th param', () => {
 
     expect(diff.isViolation).toBe(true);
     expect(mockEmit).not.toHaveBeenCalled();
+  });
+});
+
+describe('revertLeakedPaths — Option A auto-revert (consensus c15cb1d8-c66840b7)', () => {
+  let tmpRoot: string;
+
+  function touch(rel: string): void {
+    const abs = require('path').join(tmpRoot, rel);
+    fs.mkdirSync(require('path').dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, '');
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // revertLeakedPaths uses fs.existsSync to skip vanished paths. We can't
+    // jest.spyOn(fs, 'existsSync') (non-configurable in Node 20+), so we
+    // exercise the existence check by passing a real tmpRoot as cwd and
+    // creating the files the test expects to be present.
+    tmpRoot = fs.mkdtempSync(require('path').join(require('os').tmpdir(), 'revert-leaked-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('no-op on empty paths', () => {
+    const r = revertLeakedPaths(tmpRoot, []);
+    expect(r).toEqual({ restored: [], skipped: [] });
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('happy path: invokes `git restore --source=HEAD -- <paths>` and reports restored', () => {
+    touch('apps/cli/src/leaked.ts');
+    touch('packages/x/y.ts');
+    mockExec.mockReturnValueOnce(Buffer.from(''));
+    const r = revertLeakedPaths(tmpRoot, ['apps/cli/src/leaked.ts', 'packages/x/y.ts']);
+    expect(r.restored).toEqual(['apps/cli/src/leaked.ts', 'packages/x/y.ts']);
+    expect(r.skipped).toEqual([]);
+    expect(r.error).toBeUndefined();
+    expect(mockExec).toHaveBeenCalledTimes(1);
+    const [cmd, args, opts] = mockExec.mock.calls[0];
+    expect(cmd).toBe('git');
+    expect(args).toEqual([
+      'restore',
+      '--source=HEAD',
+      '--',
+      'apps/cli/src/leaked.ts',
+      'packages/x/y.ts',
+    ]);
+    expect((opts as any).cwd).toBe(tmpRoot);
+  });
+
+  it('skips paths that no longer exist on disk', () => {
+    touch('ok.ts');
+    touch('also-ok.ts');
+    // gone.ts intentionally NOT created → revertLeakedPaths' existsSync check skips it
+    mockExec.mockReturnValueOnce(Buffer.from(''));
+    const r = revertLeakedPaths(tmpRoot, ['ok.ts', 'gone.ts', 'also-ok.ts']);
+    expect(r.restored).toEqual(['ok.ts', 'also-ok.ts']);
+    expect(r.skipped).toEqual(['gone.ts']);
+    const [, args] = mockExec.mock.calls[0];
+    expect(args).toEqual(['restore', '--source=HEAD', '--', 'ok.ts', 'also-ok.ts']);
+  });
+
+  it('all paths missing → no git invocation, restored:[]', () => {
+    // No touch() calls — none of the paths exist under tmpRoot
+    const r = revertLeakedPaths(tmpRoot, ['a.ts', 'b.ts']);
+    expect(r.restored).toEqual([]);
+    expect(r.skipped).toEqual(['a.ts', 'b.ts']);
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('git restore failure → error message surfaced, no throw', () => {
+    touch('weird.ts');
+    mockExec.mockImplementationOnce(() => {
+      throw new Error('fatal: pathspec did not match');
+    });
+    const r = revertLeakedPaths(tmpRoot, ['weird.ts']);
+    expect(r.restored).toEqual([]);
+    expect(r.error).toMatch(/pathspec did not match/);
+  });
+
+  it('filters absolute paths and leading-dash paths defensively', () => {
+    touch('ok.ts');
+    touch('also-ok.ts');
+    mockExec.mockReturnValueOnce(Buffer.from(''));
+    const r = revertLeakedPaths(tmpRoot, ['ok.ts', '/etc/passwd', '--force', 'also-ok.ts']);
+    const [, args] = mockExec.mock.calls[0];
+    // absolute + leading-dash filtered out before git invocation
+    expect(args).toEqual(['restore', '--source=HEAD', '--', 'ok.ts', 'also-ok.ts']);
+    expect(r.restored).toEqual(['ok.ts', 'also-ok.ts']);
   });
 });
 


### PR DESCRIPTION
## Summary

When native `Agent(isolation:"worktree")` dispatches leak writes into the parent checkout, the existing detector at `apps/cli/src/handlers/worktree-isolation-detection.ts` already captures the exact leaked paths via git status diff. Previously the orchestrator had to manually branch-from-uncommitted + commit each leak (per `feedback_agent_isolation_worktree_sandbox_gap.md` recovery procedure). This PR closes the gap by auto-reverting on detection.

## Why this, not Layer 2 escalation

Design consensus `c15cb1d8-c66840b7` (12 signals, 2 reviewers, prior session) ruled out escalating the Layer 2 PreToolUse hook to block mode for two reasons:

1. The Layer 2 hook is **already deny-only** (`worktree-sandbox.sh:36-60`) — no warn/block toggle to flip. The warn/block enforcement lives at Layer 3 (`sandbox.ts:1410-1434` via `readSandboxMode`).
2. The hook's `IS_SUBAGENT` gate **cannot fire** for native `Agent(isolation:"worktree")` dispatches — gossipcat doesn't control the agent's cwd or `CLAUDE_PROJECT_DIR`, so the orchestrator-role marker exemption at `worktree-sandbox.sh:262` triggers and the hook exits 0 before any path check runs.

Root cause is upstream Claude Code (cwd reset between tool invocations). Until that's fixed, auto-revert is the most tractable mitigation — ~20 LOC, no new infrastructure, no upstream dependency.

## Implementation

**`apps/cli/src/handlers/worktree-isolation-detection.ts`** — new exported helper `revertLeakedPaths(cwd, paths) → { restored, skipped, error? }`:
- Filters absolute paths and leading-dash args (defense-in-depth — never let an agent-controlled path become a git flag)
- Pre-checks `fs.existsSync` for each path, separating present from skipped
- Calls `execFileSync('git', ['restore', '--source=HEAD', '--', ...paths], { cwd, stdio: 'ignore' })`
- Fail-open: any throw becomes `result.error`, never escapes

**`apps/cli/src/handlers/native-tasks.ts:974`** — when the existing violation block fires (the non-concurrency-tainted else branch), invoke `revertLeakedPaths` on `isolationDiff.dirtyPathsAdded` and append a recovery confirmation (or failure note) to the relay receipt.

The recovery is gated on `!concurrencyTainted` because PR #436's lifetime-taint pattern means we can't attribute the dirty paths to this specific dispatch when a concurrent worktree task overlapped.

## Test coverage

**`tests/cli/worktree-isolation-detection.test.ts`** — new `describe('revertLeakedPaths …')` block with 6 cases:
- no-op on empty paths
- happy path (invokes git with correct argv, reports restored)
- skips paths that no longer exist on disk
- all paths missing → no git invocation
- git restore failure → error in receipt, no throw
- absolute paths + leading-dash filtered defensively

**`tests/cli/relay-isolation-warning.test.ts`** — extends existing relay receipt assertions for the recovery confirmation + failure paths.

Total: 41/41 tests pass.

## Verification gates

1. `npm run build` (full workspace): ✓ clean across all 5 packages
2. `npx jest tests/cli/worktree-isolation-detection.test.ts tests/cli/relay-isolation-warning.test.ts`: ✓ 41/41 pass
3. `grep -n 'isolationDiff' apps/cli/src/handlers/native-tasks.ts` shows recovery block in the non-concurrency-tainted branch
4. `grep -n 'concurrencyTainted' apps/cli/src/handlers/native-tasks.ts` confirms the taint flag gates the recovery (recovery only fires in the else branch)

## References

- Design consensus (Option A vs B vs C): `c15cb1d8-c66840b7`
- **Pre-merge code consensus on this diff: PENDING** — will be added before merge per the impact-adjacency contract.
- Memory: `project_worktree_isolation_native_dispatch_gap.md`
- Related: `feedback_agent_isolation_worktree_sandbox_gap`
- Original gap: PR #422 (2026-05-20)
- Lifetime-taint pattern: PR #436 (`checkIsolationViolation` concurrency guard)

## What this does NOT fix

The upstream engagement gap (Claude Code resetting cwd between tool invocations) remains open. This PR turns "detect-and-escalate-to-human" into "detect-and-auto-recover" — leaked files are restored from HEAD automatically, but writes still happen to the parent checkout first. An upstream FR for stable cwd semantics on `Agent()` is the only path to true prevention. Tracked at issue #437.
consensus-id: dace5336-73384bc9