### PR TITLE
fix(wizard): use canonical 'gossipcat mcp' invocation in generated .mcp.json

### DIFF
--- a/apps/cli/src/setup-wizard.ts
+++ b/apps/cli/src/setup-wizard.ts
@@ -244,7 +244,7 @@ export async function runSetupWizard(): Promise<void> {
       mcpServers: {
         gossipcat: {
           command: 'npx',
-          args: ['gossipcat-mcp'],
+          args: ['gossipcat', 'mcp'],
           cwd: process.cwd(),
         },
       },


### PR DESCRIPTION
## Summary

- setup-wizard generated `.mcp.json` with `args: ['gossipcat-mcp']`, but `package.json` `bin` only exposes `gossipcat`. New users got a broken config on first onboarding.
- PR #445 added `mcp` as a back-compat subcommand alias that falls through to MCP boot. Switch the wizard to generate `npx gossipcat mcp`, which works against the registered bin.
- One-line fix at `apps/cli/src/setup-wizard.ts:247`. No behavior change for existing installs (only affects newly-generated `.mcp.json` files).

## Context

Surfaced as a follow-up bullet in the v0.4.29 release notes (hotfix bundle for PR #443's argv shim regression). Filed as a pre-existing footgun to fix on next wizard touch.

## Test plan

- [x] Source edit verified — `grep gossipcat-mcp apps/cli/src/setup-wizard.ts` returns no hits
- [x] `tsc --noEmit` clean for setup-wizard.ts (3 unrelated pre-existing errors in dashboard-v2 + 2 test files; none touch this file)
- [ ] Manual: run `gossipcat setup` in a fresh dir; confirm generated `.mcp.json` contains `args: ["gossipcat", "mcp"]` and that `npx gossipcat mcp` launches the MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)