### PR TITLE
fix(dispatch): harden worktree-isolation prompt emission

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -89,10 +89,22 @@ export function elidePromptIfRequested(
   agentPrompt: string,
   promptFormat: PromptFormat | undefined,
   warmCached: boolean = false,
+  writeMode?: string,
 ): { elided: true; promptPath: string; marker: string; bytes: number } | { elided: false } {
   if (promptFormat !== 'elided') return { elided: false };
-  const bytes = Buffer.byteLength(agentPrompt, 'utf8');
-  const promptPath = writeDispatchPrompt(projectRoot, taskId, agentPrompt);
+  // Spec 2026-05-22 worktree-isolation-prompt-hardening Change 3: when the
+  // dispatch is in worktree mode, prepend a structural header to the on-disk
+  // prompt body. The header survives even if the orchestrator paraphrases the
+  // Item 1 banner, anchoring the isolation contract in the prompt file itself.
+  const body = writeMode === 'worktree'
+    ? `// GOSSIP_ISOLATION: worktree\n` +
+      `// This task was dispatched with write_mode: "worktree".\n` +
+      `// The orchestrator MUST invoke Agent() with isolation: "worktree".\n` +
+      `// Do not paraphrase this requirement.\n\n` +
+      agentPrompt
+    : agentPrompt;
+  const bytes = Buffer.byteLength(body, 'utf8');
+  const promptPath = writeDispatchPrompt(projectRoot, taskId, body);
   const warmSuffix = warmCached ? ' — warm-cached (skills) + live task' : '';
   const marker = `[skills section elided: see ${promptPath}, ${bytes} bytes${warmSuffix} — READ this file and pass its CONTENTS verbatim as the Agent(prompt: ...) value. Do NOT pass the path string.]`;
   return { elided: true, promptPath, marker, bytes };
@@ -692,7 +704,7 @@ export async function handleDispatchSingle(
     // Spec §1 iron rule: strict opt-in elision. When prompt_format='elided',
     // write the prompt body to disk and emit a marker in Item 1; OMIT Item 2.
     // When undefined/'inline': behavior is byte-identical to pre-PR dispatch.
-    const elision = elidePromptIfRequested(process.cwd(), taskId, agentPrompt, prompt_format, singleWarm);
+    const elision = elidePromptIfRequested(process.cwd(), taskId, agentPrompt, prompt_format, singleWarm, write_mode);
     if (elision.elided) {
       const info = ctx.nativeTaskMap.get(taskId);
       if (info) info.promptPath = elision.promptPath;
@@ -700,11 +712,21 @@ export async function handleDispatchSingle(
     // Persist after elision so promptPath is durable across /mcp reconnect.
     persistNativeTaskMap();
 
+    // Spec 2026-05-22: when useWorktree, emit Agent() as a multi-line structurally
+    // separated template so the orchestrator LLM cannot drop isolation:"worktree"
+    // as a mid-tuple paraphrase. Non-worktree dispatches keep the single-line shape.
+    const promptRef = elision.elided ? '<file contents>' : `<AGENT_PROMPT:${taskId} below>`;
+    const agentCall = useWorktree
+      ? `Agent(\n` +
+        `  model: "${nativeConfig.model}",\n` +
+        `  prompt: ${promptRef},\n` +
+        `  isolation: "worktree",           // REQUIRED — do not omit\n` +
+        `  run_in_background: true\n` +
+        `)`
+      : `Agent(model: "${nativeConfig.model}", prompt: ${promptRef}, run_in_background: true)`;
     const promptInstruction = (elision.elided
-      ? `Step 1 — ${elision.marker}\n` +
-        `Agent(model: "${nativeConfig.model}", prompt: <file contents>${useWorktree ? ', isolation: "worktree"' : ''}, run_in_background: true)\n\n`
-      : `Step 1 — Pass the AGENT_PROMPT:${taskId} content item below verbatim to Agent(prompt: ...):\n` +
-        `Agent(model: "${nativeConfig.model}", prompt: <AGENT_PROMPT:${taskId} below>${useWorktree ? ', isolation: "worktree"' : ''}, run_in_background: true)\n\n`);
+      ? `Step 1 — ${elision.marker}\n${agentCall}\n\n`
+      : `Step 1 — Pass the AGENT_PROMPT:${taskId} content item below verbatim to Agent(prompt: ...):\n${agentCall}\n\n`);
 
     // Split into two content items so relay_token stays in orchestrator-only text
     // and AGENT_PROMPT is passed verbatim to Agent(prompt: ...).
@@ -715,7 +737,8 @@ export async function handleDispatchSingle(
         `NATIVE_DISPATCH: Execute this via Claude Code Agent tool, then relay the result.\n\n` +
         `Task ID: ${taskId}\n` +
         `Agent: ${agent_id}\n` +
-        `Model: ${nativeConfig.model}\n\n` +
+        `Model: ${nativeConfig.model}\n` +
+        (useWorktree ? `Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"\n\n` : `\n`) +
         promptInstruction +
         `Step 2 — REQUIRED after agent completes:\n` +
         `gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<agent output>")\n` +
@@ -1060,7 +1083,7 @@ export async function handleDispatchParallel(
 
     // Spec §1 strict opt-in. When elided: write prompt body to disk, omit
     // AGENT_PROMPT content item, embed marker in the instructions block.
-    const parallelElision = elidePromptIfRequested(process.cwd(), taskId, agentPrompt, prompt_format, parallelWarm);
+    const parallelElision = elidePromptIfRequested(process.cwd(), taskId, agentPrompt, prompt_format, parallelWarm, def.write_mode);
     if (parallelElision.elided) {
       const info = ctx.nativeTaskMap.get(taskId);
       if (info) info.promptPath = parallelElision.promptPath;
@@ -1069,9 +1092,22 @@ export async function handleDispatchParallel(
       ? parallelElision.marker
       : `<AGENT_PROMPT:${taskId} below>`;
 
+    const parallelUseWorktree = def.write_mode === 'worktree';
+    const parallelWorktreeBanner = parallelUseWorktree
+      ? `\n  Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"`
+      : '';
+    const parallelAgentCall = parallelUseWorktree
+      ? `Agent(\n` +
+        `    model: "${nativeConfig.model}",\n` +
+        `    prompt: ${parallelPromptRef},\n` +
+        `    isolation: "worktree",           // REQUIRED — do not omit\n` +
+        `    run_in_background: true\n` +
+        `  )`
+      : `Agent(model: "${nativeConfig.model}", prompt: ${parallelPromptRef}, run_in_background: true)`;
+
     lines.push(`  ${taskId} → ${def.agent_id} (native — dispatch via Agent tool)`);
     nativeInstructions.push(
-      `[${taskId}] Agent(model: "${nativeConfig.model}", prompt: ${parallelPromptRef}${def.write_mode === 'worktree' ? ', isolation: "worktree"' : ''}, run_in_background: true)` +
+      `[${taskId}] ${parallelAgentCall}${parallelWorktreeBanner}` +
       `\n  → then: gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<output>")`
     );
     // Item 2 ABSENT under elision — orchestrator MUST Read the cited path.
@@ -1349,7 +1385,7 @@ export async function handleDispatchConsensus(
 
     // Spec §1 strict opt-in. When 'elided', the per-task AGENT_PROMPT item is
     // omitted and the on-disk path is cited inline in the Agent() instruction.
-    const consensusElision = elidePromptIfRequested(process.cwd(), taskId, agentPrompt, prompt_format, consensusWarm);
+    const consensusElision = elidePromptIfRequested(process.cwd(), taskId, agentPrompt, prompt_format, consensusWarm, def.write_mode);
     if (consensusElision.elided) {
       const info = ctx.nativeTaskMap.get(taskId);
       if (info) info.promptPath = consensusElision.promptPath;
@@ -1359,9 +1395,25 @@ export async function handleDispatchConsensus(
       ? consensusElision.marker
       : `<AGENT_PROMPT:${taskId} below>`;
 
+    // Spec 2026-05-22: this consensus-dispatch site previously did NOT emit
+    // isolation:"worktree" at all (latent gap from before write_mode existed in
+    // the consensus path). Closing the gap and applying multi-line hardening.
+    const consensusUseWorktree = def.write_mode === 'worktree';
+    const consensusWorktreeBanner = consensusUseWorktree
+      ? `\n  Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"`
+      : '';
+    const consensusAgentCall = consensusUseWorktree
+      ? `Agent(\n` +
+        `    model: "${nativeConfig.model}",\n` +
+        `    prompt: ${consensusPromptRef},\n` +
+        `    isolation: "worktree",           // REQUIRED — do not omit\n` +
+        `    run_in_background: true\n` +
+        `  )`
+      : `Agent(model: "${nativeConfig.model}", prompt: ${consensusPromptRef}, run_in_background: true)`;
+
     lines.push(`  ${taskId} → ${def.agent_id} (native — dispatch via Agent tool)`);
     nativeInstructions.push(
-      `[${taskId}] Agent(model: "${nativeConfig.model}", prompt: ${consensusPromptRef}, run_in_background: true)` +
+      `[${taskId}] ${consensusAgentCall}${consensusWorktreeBanner}` +
       `\n  → then: gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<output>")`
     );
     // Item 2 ABSENT under elision (spec §2) — no skeleton/placeholder.

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -89,6 +89,9 @@ export function elidePromptIfRequested(
   agentPrompt: string,
   promptFormat: PromptFormat | undefined,
   warmCached: boolean = false,
+  // string instead of union: parallel/consensus pass through def.write_mode
+  // which is typed as `string` upstream. The actual gate is `=== 'worktree'`
+  // so any other value is treated as "no header" — fail-safe.
   writeMode?: string,
 ): { elided: true; promptPath: string; marker: string; bytes: number } | { elided: false } {
   if (promptFormat !== 'elided') return { elided: false };
@@ -704,7 +707,14 @@ export async function handleDispatchSingle(
     // Spec §1 iron rule: strict opt-in elision. When prompt_format='elided',
     // write the prompt body to disk and emit a marker in Item 1; OMIT Item 2.
     // When undefined/'inline': behavior is byte-identical to pre-PR dispatch.
-    const elision = elidePromptIfRequested(process.cwd(), taskId, agentPrompt, prompt_format, singleWarm, write_mode);
+    // Pre-merge consensus 2026-05-22: pass EFFECTIVE worktree mode (post
+    // git-repo downgrade at L685-692), not raw write_mode. Otherwise a non-git
+    // dispatch with write_mode='worktree' produces a contradictory packet:
+    // on-disk header demands isolation while the banner+Agent() call omit it.
+    const elision = elidePromptIfRequested(
+      process.cwd(), taskId, agentPrompt, prompt_format, singleWarm,
+      useWorktree ? 'worktree' : undefined,
+    );
     if (elision.elided) {
       const info = ctx.nativeTaskMap.get(taskId);
       if (info) info.promptPath = elision.promptPath;
@@ -1098,11 +1108,11 @@ export async function handleDispatchParallel(
       : '';
     const parallelAgentCall = parallelUseWorktree
       ? `Agent(\n` +
-        `    model: "${nativeConfig.model}",\n` +
-        `    prompt: ${parallelPromptRef},\n` +
-        `    isolation: "worktree",           // REQUIRED — do not omit\n` +
-        `    run_in_background: true\n` +
-        `  )`
+        `  model: "${nativeConfig.model}",\n` +
+        `  prompt: ${parallelPromptRef},\n` +
+        `  isolation: "worktree",           // REQUIRED — do not omit\n` +
+        `  run_in_background: true\n` +
+        `)`
       : `Agent(model: "${nativeConfig.model}", prompt: ${parallelPromptRef}, run_in_background: true)`;
 
     lines.push(`  ${taskId} → ${def.agent_id} (native — dispatch via Agent tool)`);
@@ -1404,11 +1414,11 @@ export async function handleDispatchConsensus(
       : '';
     const consensusAgentCall = consensusUseWorktree
       ? `Agent(\n` +
-        `    model: "${nativeConfig.model}",\n` +
-        `    prompt: ${consensusPromptRef},\n` +
-        `    isolation: "worktree",           // REQUIRED — do not omit\n` +
-        `    run_in_background: true\n` +
-        `  )`
+        `  model: "${nativeConfig.model}",\n` +
+        `  prompt: ${consensusPromptRef},\n` +
+        `  isolation: "worktree",           // REQUIRED — do not omit\n` +
+        `  run_in_background: true\n` +
+        `)`
       : `Agent(model: "${nativeConfig.model}", prompt: ${consensusPromptRef}, run_in_background: true)`;
 
     lines.push(`  ${taskId} → ${def.agent_id} (native — dispatch via Agent tool)`);

--- a/tests/cli/dispatch-native-prompt.test.ts
+++ b/tests/cli/dispatch-native-prompt.test.ts
@@ -855,3 +855,99 @@ describe('handleDispatchConsensus — Option B isolation snapshot capture', () =
     expect(entries.every(e => e.isolationSnapshot === undefined)).toBe(true);
   });
 });
+
+/**
+ * Spec 2026-05-22 worktree-isolation-prompt-hardening: harden the dispatch
+ * banner so isolation:"worktree" cannot be silently dropped by the orchestrator
+ * LLM. Tests assert: (a) standalone "Worktree isolation: REQUIRED" banner line
+ * appears iff write_mode === 'worktree', across single/parallel/consensus
+ * paths; (b) when prompt_format === 'elided' AND write_mode === 'worktree',
+ * the on-disk prompt file begins with the // GOSSIP_ISOLATION header.
+ */
+describe('worktree-isolation prompt hardening (spec 2026-05-22)', () => {
+  let skillDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    skillDir = mkdtempSync(join(tmpdir(), 'gossip-wt-hardening-'));
+    mkdirSync(join(skillDir, '.gossip', 'skills'), { recursive: true });
+    // useWorktree only triggers inside a git repo. Init one so the banner path
+    // actually fires.
+    execSync('git init -q', { cwd: skillDir });
+    process.chdir(skillDir);
+    resetCtx();
+    ctx.nativeAgentConfigs.set('native-claude', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Native reviewer',
+      skills: [],
+    });
+  });
+
+  afterEach(() => {
+    restoreCtx();
+    process.chdir(prevCwd);
+    rmSync(skillDir, { recursive: true, force: true });
+  });
+
+  it('single-dispatch banner contains Worktree isolation: REQUIRED when write_mode=worktree', async () => {
+    const result = await handleDispatchSingle('native-claude', 'Audit x', 'worktree');
+    const orchestratorText = result.content[0].text;
+    expect(orchestratorText).toContain('Worktree isolation: REQUIRED');
+    expect(orchestratorText).toContain('isolation: "worktree",           // REQUIRED — do not omit');
+  });
+
+  it('single-dispatch banner does NOT contain Worktree isolation: REQUIRED when write_mode is absent', async () => {
+    const result = await handleDispatchSingle('native-claude', 'Audit x');
+    const orchestratorText = result.content[0].text;
+    expect(orchestratorText).not.toContain('Worktree isolation: REQUIRED');
+  });
+
+  it('parallel-dispatch banner contains Worktree isolation: REQUIRED per worktree task', async () => {
+    const result = await handleDispatchParallel([
+      { agent_id: 'native-claude', task: 'Audit A', write_mode: 'worktree' },
+      { agent_id: 'native-claude', task: 'Audit B' },
+    ], false);
+    const orchestratorText = result.content[0].text;
+    // Worktree task → banner present.
+    expect(orchestratorText).toContain('Worktree isolation: REQUIRED');
+    // Multi-line Agent() template fired for worktree task.
+    expect(orchestratorText).toContain('isolation: "worktree",           // REQUIRED — do not omit');
+  });
+
+  it('consensus-dispatch banner contains Worktree isolation: REQUIRED when write_mode=worktree (closes latent gap)', async () => {
+    const result = await handleDispatchConsensus([
+      { agent_id: 'native-claude', task: 'Audit consensus', write_mode: 'worktree' },
+    ]);
+    const orchestratorText = result.content[0].text;
+    expect(orchestratorText).toContain('Worktree isolation: REQUIRED');
+    expect(orchestratorText).toContain('isolation: "worktree",           // REQUIRED — do not omit');
+  });
+
+  it('elided prompt file begins with // GOSSIP_ISOLATION header when write_mode=worktree', async () => {
+    const result = await handleDispatchSingle(
+      'native-claude', 'Audit elided', 'worktree',
+      undefined, undefined, undefined, undefined, undefined, 'elided',
+    );
+    // Marker in Item 1 cites the on-disk file. Read that file and assert header.
+    const orchestratorText = result.content[0].text;
+    const pathMatch = orchestratorText.match(/see (\S+\.txt),/);
+    expect(pathMatch).not.toBeNull();
+    const promptFile = readFileSync(pathMatch![1], 'utf8');
+    expect(promptFile.startsWith('// GOSSIP_ISOLATION: worktree\n')).toBe(true);
+    expect(promptFile).toContain('// The orchestrator MUST invoke Agent() with isolation: "worktree".');
+  });
+
+  it('elided prompt file does NOT contain GOSSIP_ISOLATION header when write_mode is sequential', async () => {
+    const result = await handleDispatchSingle(
+      'native-claude', 'Audit elided seq', undefined,
+      undefined, undefined, undefined, undefined, undefined, 'elided',
+    );
+    const orchestratorText = result.content[0].text;
+    const pathMatch = orchestratorText.match(/see (\S+\.txt),/);
+    expect(pathMatch).not.toBeNull();
+    const promptFile = readFileSync(pathMatch![1], 'utf8');
+    expect(promptFile.startsWith('// GOSSIP_ISOLATION')).toBe(false);
+  });
+});

--- a/tests/cli/dispatch-native-prompt.test.ts
+++ b/tests/cli/dispatch-native-prompt.test.ts
@@ -939,6 +939,34 @@ describe('worktree-isolation prompt hardening (spec 2026-05-22)', () => {
     expect(promptFile).toContain('// The orchestrator MUST invoke Agent() with isolation: "worktree".');
   });
 
+  it('non-git-repo single dispatch with write_mode=worktree silently downgrades (no banner, no header)', async () => {
+    // Pre-merge consensus fix: dispatch.ts:685-692 downgrades useWorktree to
+    // false in non-git-repos. The elided header must also gate on the same
+    // effective state, otherwise the on-disk file contradicts the banner.
+    // Build a fresh dir WITHOUT git init.
+    const nonGitDir = mkdtempSync(join(tmpdir(), 'gossip-nogit-'));
+    mkdirSync(join(nonGitDir, '.gossip', 'skills'), { recursive: true });
+    const restoreCwd = process.cwd();
+    process.chdir(nonGitDir);
+    try {
+      const result = await handleDispatchSingle(
+        'native-claude', 'Audit nogit', 'worktree',
+        undefined, undefined, undefined, undefined, undefined, 'elided',
+      );
+      const orchestratorText = result.content[0].text;
+      // useWorktree downgraded → banner absent, Agent() single-line.
+      expect(orchestratorText).not.toContain('Worktree isolation: REQUIRED');
+      // On-disk header must also be absent (consistency with the banner).
+      const pathMatch = orchestratorText.match(/see (\S+\.txt),/);
+      expect(pathMatch).not.toBeNull();
+      const promptFile = readFileSync(pathMatch![1], 'utf8');
+      expect(promptFile.startsWith('// GOSSIP_ISOLATION')).toBe(false);
+    } finally {
+      process.chdir(restoreCwd);
+      rmSync(nonGitDir, { recursive: true, force: true });
+    }
+  });
+
   it('elided prompt file does NOT contain GOSSIP_ISOLATION header when write_mode is sequential', async () => {
     const result = await handleDispatchSingle(
       'native-claude', 'Audit elided seq', undefined,


### PR DESCRIPTION
## Summary

The orchestrator LLM sometimes silently drops `isolation: "worktree"` when paraphrasing the dispatch banner — it was emitted mid-tuple as a conditional string fragment, exactly where LLMs drop keyword args under load. Subagent then runs in `cwd=project-root` and writes leak to master.

This PR makes the param structurally undroppable via three changes to `apps/cli/src/handlers/dispatch.ts`:

1. **Standalone `Worktree isolation: REQUIRED` banner line** below the existing Task ID/Agent/Model fields when `write_mode=worktree`.
2. **Multi-line `Agent()` template** with `isolation: "worktree"` on its own line (instead of mid-tuple string interpolation) when useWorktree. Non-worktree dispatches keep the single-line shape.
3. **`// GOSSIP_ISOLATION:` header** prepended to the elided prompt file when `write_mode=worktree` — header travels with the prompt body so the contract survives even if Item 1 gets mangled.

Also closes a **latent gap** in `handleDispatchConsensus`: previously the consensus path did not emit `isolation: "worktree"` at all when `write_mode=worktree`.

## Background

Three-agent consensus session 2026-05-22 (sonnet-reviewer, opus-implementer, haiku-researcher) converged on this approach after rejecting two prior designs:

- **Inverted Gate** (PreToolUse hook denying writes outside authorized worktree paths) — rejected because the hook's `IS_SUBAGENT` check exits early when `cwd=project-root` (the exact failure case), and the hook payload has no subagent identity.
- **Dispatch-Time Probe** (new MCP tool probing `.claude/worktrees/agent-<hash>/`) — rejected because the path is non-computable (gossipcat-managed worktrees use `mkdtemp(tmpdir(), 'gossip-wt-')`; Claude Code's native worktree hash is opaque), and adding an orchestrator-LLM tool on top of an LLM-compliance bug compounds the failure mode.

Three reviewers independently identified the prompt emission at dispatch.ts:705,707 as the actual root cause.

Option B post-relay detection (`worktree-isolation-detection.ts`) and PR #436 concurrent-worktree-taint stay unchanged as the safety net.

## Test plan

- [x] `npm run build` — clean across types/client/tools/orchestrator/relay
- [x] `npx jest tests/cli/dispatch-native-prompt.test.ts` — 21 passed, 8 pre-existing skipped (rg-gated)
- [x] 6 new test assertions covering all three dispatch paths (single/parallel/consensus) plus the elided header on both positive and negative cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)