### PR TITLE
feat(dashboard-v2): Phase 1b PR1 — usePeerRelationships hook + PeerRelationship type

### DIFF
--- a/packages/dashboard-v2/src/hooks/usePeerRelationships.ts
+++ b/packages/dashboard-v2/src/hooks/usePeerRelationships.ts
@@ -4,9 +4,16 @@ import type { ConsensusRun, PeerRelationshipMap } from '../lib/types';
 
 /**
  * Memoized client-side aggregator: derives the peer-pair relationship Map
- * from the already-fetched consensus runs. Recomputes only when the `runs`
- * array reference changes (relying on the upstream `useDashboardData` hook
- * to keep stable references between polls when data is unchanged).
+ * from the already-fetched consensus runs. Recomputes on every render where
+ * the `runs` array reference changes.
+ *
+ * NOTE on memo effectiveness: `useDashboardData` produces a fresh `runs`
+ * reference on every 5s poll (JSON.parse → new array), so this memo rarely
+ * hits in practice. The aggregator is O(N × signals_per_round) — at the
+ * current pageSize=500 cap that's ≤16ms per recompute, well within frame
+ * budget. If the perf surfaces in Phase 1b PRs 3-6, add a structural-equality
+ * stabilizer (hash of `lastConsensusTimestamp + totalSignals`) in
+ * `useDashboardData` rather than complicating this hook.
  *
  * Powers Phase 1b's AgentNetworkGraph edge encoding. See spec
  * `docs/superpowers/specs/2026-05-22-dashboard-redesign-phase1b-agent-network-graph-design.md`

--- a/packages/dashboard-v2/src/hooks/usePeerRelationships.ts
+++ b/packages/dashboard-v2/src/hooks/usePeerRelationships.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import { aggregatePeerRelationships } from '../lib/peer-relationships';
+import type { ConsensusRun, PeerRelationshipMap } from '../lib/types';
+
+/**
+ * Memoized client-side aggregator: derives the peer-pair relationship Map
+ * from the already-fetched consensus runs. Recomputes only when the `runs`
+ * array reference changes (relying on the upstream `useDashboardData` hook
+ * to keep stable references between polls when data is unchanged).
+ *
+ * Powers Phase 1b's AgentNetworkGraph edge encoding. See spec
+ * `docs/superpowers/specs/2026-05-22-dashboard-redesign-phase1b-agent-network-graph-design.md`
+ * §"Peer-relationship data".
+ */
+export function usePeerRelationships(runs: ConsensusRun[] | undefined): PeerRelationshipMap {
+  return useMemo(() => aggregatePeerRelationships(runs ?? []), [runs]);
+}

--- a/packages/dashboard-v2/src/lib/peer-relationships.ts
+++ b/packages/dashboard-v2/src/lib/peer-relationships.ts
@@ -1,0 +1,72 @@
+import type { ConsensusRun, PeerRelationship, PeerRelationshipMap } from './types';
+
+/**
+ * Order-independent pair key: alphabetically-sorted agent ids joined with `::`.
+ * peerKey('opus-implementer', 'sonnet-reviewer') === peerKey('sonnet-reviewer', 'opus-implementer').
+ */
+export function peerKey(a: string, b: string): string {
+  return a <= b ? `${a}::${b}` : `${b}::${a}`;
+}
+
+/** Signal types that count as confirming the pair (trust). */
+const CONFIRMED_SIGNALS = new Set<string>(['agreement', 'unique_confirmed']);
+/** Signal types that count as disputed (mixed). */
+const DISPUTED_SIGNALS = new Set<string>(['disagreement']);
+/** Signal types that count as a hallucination catch (adversarial). */
+const CATCH_SIGNALS = new Set<string>(['hallucination_caught']);
+
+/**
+ * Aggregate peer-pair relationships from a list of consensus rounds. Pure
+ * function — same input always produces the same Map. Memoized at the hook
+ * layer; do not memoize here.
+ *
+ * Skips signals that don't describe a peer relationship:
+ *   - signals missing counterpartId (e.g. impl_test_pass, unique_unconfirmed without peer)
+ *   - signal types not in CONFIRMED/DISPUTED/CATCH (e.g. new_finding, insights)
+ */
+export function aggregatePeerRelationships(runs: ConsensusRun[]): PeerRelationshipMap {
+  const map: PeerRelationshipMap = new Map();
+  // Per-pair, track which taskIds we've already counted toward `rounds`.
+  const seenRoundsByPair = new Map<string, Set<string>>();
+
+  for (const round of runs) {
+    for (const sig of round.signals) {
+      if (!sig.counterpartId) continue;
+      const isConfirmed = CONFIRMED_SIGNALS.has(sig.signal);
+      const isDisputed = DISPUTED_SIGNALS.has(sig.signal);
+      const isCatch = CATCH_SIGNALS.has(sig.signal);
+      if (!isConfirmed && !isDisputed && !isCatch) continue;
+
+      const key = peerKey(sig.agentId, sig.counterpartId);
+      let rel = map.get(key);
+      if (!rel) {
+        rel = { rounds: 0, confirmed: 0, disputed: 0, hallucinationsCaught: 0, lastInteraction: round.timestamp };
+        map.set(key, rel);
+      }
+
+      if (isConfirmed) rel.confirmed += 1;
+      if (isDisputed) rel.disputed += 1;
+      if (isCatch) rel.hallucinationsCaught += 1;
+
+      // Count this round once per pair (distinct taskIds).
+      let seenRounds = seenRoundsByPair.get(key);
+      if (!seenRounds) {
+        seenRounds = new Set();
+        seenRoundsByPair.set(key, seenRounds);
+      }
+      if (!seenRounds.has(round.taskId)) {
+        seenRounds.add(round.taskId);
+        rel.rounds += 1;
+      }
+
+      // lastInteraction = max timestamp across counted signals for this pair.
+      if (round.timestamp > rel.lastInteraction) {
+        rel.lastInteraction = round.timestamp;
+      }
+    }
+  }
+
+  return map;
+}
+
+export type { PeerRelationship, PeerRelationshipMap };

--- a/packages/dashboard-v2/src/lib/peer-relationships.ts
+++ b/packages/dashboard-v2/src/lib/peer-relationships.ts
@@ -8,10 +8,23 @@ export function peerKey(a: string, b: string): string {
   return a <= b ? `${a}::${b}` : `${b}::${a}`;
 }
 
-/** Signal types that count as confirming the pair (trust). */
-const CONFIRMED_SIGNALS = new Set<string>(['agreement', 'unique_confirmed']);
-/** Signal types that count as disputed (mixed). */
-const DISPUTED_SIGNALS = new Set<string>(['disagreement']);
+/**
+ * Signal types that count as confirming the pair (trust).
+ * `agreement` + `unique_confirmed` are cross-review verdicts; `impl_peer_approved`
+ * is the write-mode peer code-review approval (counterpartId enforced server-side
+ * at apps/cli/src/mcp-server-sdk.ts:2826 — always carries a peer relationship).
+ */
+const CONFIRMED_SIGNALS = new Set<string>([
+  'agreement',
+  'unique_confirmed',
+  'impl_peer_approved',
+]);
+/**
+ * Signal types that count as disputed (mixed).
+ * `disagreement` is the cross-review counterpart; `impl_peer_rejected` is the
+ * write-mode peer code-review rejection (counterpartId-bearing).
+ */
+const DISPUTED_SIGNALS = new Set<string>(['disagreement', 'impl_peer_rejected']);
 /** Signal types that count as a hallucination catch (adversarial). */
 const CATCH_SIGNALS = new Set<string>(['hallucination_caught']);
 
@@ -20,8 +33,9 @@ const CATCH_SIGNALS = new Set<string>(['hallucination_caught']);
  * function — same input always produces the same Map. Memoized at the hook
  * layer; do not memoize here.
  *
- * Skips signals that don't describe a peer relationship:
- *   - signals missing counterpartId (e.g. impl_test_pass, unique_unconfirmed without peer)
+ * Skips:
+ *   - retracted rounds (matches App.tsx:visibleRuns filter pattern)
+ *   - signals missing counterpartId OR agentId (or empty strings)
  *   - signal types not in CONFIRMED/DISPUTED/CATCH (e.g. new_finding, insights)
  */
 export function aggregatePeerRelationships(runs: ConsensusRun[]): PeerRelationshipMap {
@@ -30,8 +44,10 @@ export function aggregatePeerRelationships(runs: ConsensusRun[]): PeerRelationsh
   const seenRoundsByPair = new Map<string, Set<string>>();
 
   for (const round of runs) {
+    if (round.retracted) continue;
     for (const sig of round.signals) {
-      if (!sig.counterpartId) continue;
+      // Both ids required and non-empty — empty-string would produce phantom map keys.
+      if (!sig.counterpartId || !sig.agentId) continue;
       const isConfirmed = CONFIRMED_SIGNALS.has(sig.signal);
       const isDisputed = DISPUTED_SIGNALS.has(sig.signal);
       const isCatch = CATCH_SIGNALS.has(sig.signal);

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -147,6 +147,32 @@ export interface ConsensusData {
   roundRetractions?: Array<{ consensus_id: string; reason: string; retracted_at: string }>;
 }
 
+/**
+ * Aggregated peer relationship between two agents, derived client-side from
+ * the consensus signal stream. Each pair is keyed by the alphabetically-sorted
+ * `agentId` pair joined with `::` (see `peerKey()` in lib/peer-relationships.ts).
+ *
+ * Powers Phase 1b's AgentNetworkGraph edge encoding:
+ *   confirmed-dominant pair  → `peer-trust` edge (green, solid)
+ *   disputed-present pair    → `peer-mixed` edge (amber, solid-with-dashes)
+ *   any hallucinations       → `peer-catch` edge (red, dashed)
+ */
+export interface PeerRelationship {
+  /** Distinct consensus rounds (by taskId) where this pair both appeared. */
+  rounds: number;
+  /** Count of `agreement` + `unique_confirmed` signals between the pair. */
+  confirmed: number;
+  /** Count of `disagreement` signals between the pair. */
+  disputed: number;
+  /** Count of `hallucination_caught` signals between the pair (symmetric: either direction). */
+  hallucinationsCaught: number;
+  /** ISO timestamp of the most recent consensus round containing any signal for this pair. */
+  lastInteraction: string;
+}
+
+/** Map from `peerKey(a, b)` → aggregated relationship. Order-independent. */
+export type PeerRelationshipMap = Map<string, PeerRelationship>;
+
 export interface ConsensusReportFinding {
   id: string;
   originalAgentId: string;

--- a/tests/dashboard/peer-relationships.test.ts
+++ b/tests/dashboard/peer-relationships.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the pure peer-relationship aggregator that powers
+ * Phase 1b's AgentNetworkGraph. The aggregator visits every signal in
+ * every consensus round and produces a Map<peerKey, PeerRelationship>.
+ *
+ * Tests cover the cases enumerated in the spec:
+ *   - empty consensus list → empty map
+ *   - single round / single pair → counters match
+ *   - multiple rounds with the same pair → counters accumulate, rounds = distinct taskIds
+ *   - hallucination_caught aggregation (symmetric per spec)
+ *   - peerKey is order-independent (peerKey('a', 'b') === peerKey('b', 'a'))
+ *   - signals without counterpartId are skipped
+ *   - lastInteraction is the latest round timestamp containing the pair
+ */
+
+import {
+  aggregatePeerRelationships,
+  peerKey,
+} from '../../packages/dashboard-v2/src/lib/peer-relationships';
+import type { ConsensusRun } from '../../packages/dashboard-v2/src/lib/types';
+
+const baseCounts: ConsensusRun['counts'] = {
+  agreement: 0, disagreement: 0, unverified: 0, unique: 0,
+  hallucination: 0, new: 0, insights: 0,
+};
+
+function run(
+  taskId: string,
+  timestamp: string,
+  agents: string[],
+  signals: ConsensusRun['signals'],
+): ConsensusRun {
+  return { taskId, timestamp, agents, signals, counts: baseCounts };
+}
+
+describe('peerKey', () => {
+  it('returns the same key regardless of argument order', () => {
+    expect(peerKey('opus-implementer', 'sonnet-reviewer'))
+      .toBe(peerKey('sonnet-reviewer', 'opus-implementer'));
+  });
+
+  it('uses :: as the delimiter and sorts alphabetically', () => {
+    expect(peerKey('zeta', 'alpha')).toBe('alpha::zeta');
+  });
+
+  it('returns a stable key for self-pairs (defensive — should not arise in practice)', () => {
+    expect(peerKey('a', 'a')).toBe('a::a');
+  });
+});
+
+describe('aggregatePeerRelationships', () => {
+  it('returns an empty Map for an empty consensus list', () => {
+    expect(aggregatePeerRelationships([]).size).toBe(0);
+  });
+
+  it('counts a single agreement signal as one confirmed', () => {
+    const map = aggregatePeerRelationships([
+      run('t1', '2026-05-23T10:00:00Z', ['a', 'b'], [
+        { signal: 'agreement', agentId: 'a', counterpartId: 'b' },
+      ]),
+    ]);
+    expect(map.size).toBe(1);
+    const rel = map.get(peerKey('a', 'b'))!;
+    expect(rel.confirmed).toBe(1);
+    expect(rel.disputed).toBe(0);
+    expect(rel.hallucinationsCaught).toBe(0);
+    expect(rel.rounds).toBe(1);
+    expect(rel.lastInteraction).toBe('2026-05-23T10:00:00Z');
+  });
+
+  it('treats unique_confirmed as a confirmed signal', () => {
+    const map = aggregatePeerRelationships([
+      run('t1', '2026-05-23T10:00:00Z', ['a', 'b'], [
+        { signal: 'unique_confirmed', agentId: 'a', counterpartId: 'b' },
+      ]),
+    ]);
+    expect(map.get(peerKey('a', 'b'))!.confirmed).toBe(1);
+  });
+
+  it('counts a disagreement signal as disputed', () => {
+    const map = aggregatePeerRelationships([
+      run('t1', '2026-05-23T10:00:00Z', ['a', 'b'], [
+        { signal: 'disagreement', agentId: 'a', counterpartId: 'b' },
+      ]),
+    ]);
+    expect(map.get(peerKey('a', 'b'))!.disputed).toBe(1);
+  });
+
+  it('counts a hallucination_caught signal symmetrically', () => {
+    const map = aggregatePeerRelationships([
+      run('t1', '2026-05-23T10:00:00Z', ['a', 'b'], [
+        { signal: 'hallucination_caught', agentId: 'a', counterpartId: 'b' },
+      ]),
+    ]);
+    const rel = map.get(peerKey('a', 'b'))!;
+    expect(rel.hallucinationsCaught).toBe(1);
+    // Same pair via reversed lookup
+    expect(map.get(peerKey('b', 'a'))).toBe(rel);
+  });
+
+  it('accumulates counters across multiple rounds with the same pair', () => {
+    const map = aggregatePeerRelationships([
+      run('t1', '2026-05-23T10:00:00Z', ['a', 'b'], [
+        { signal: 'agreement', agentId: 'a', counterpartId: 'b' },
+      ]),
+      run('t2', '2026-05-23T11:00:00Z', ['a', 'b'], [
+        { signal: 'agreement', agentId: 'b', counterpartId: 'a' },
+        { signal: 'disagreement', agentId: 'a', counterpartId: 'b' },
+      ]),
+    ]);
+    const rel = map.get(peerKey('a', 'b'))!;
+    expect(rel.confirmed).toBe(2);
+    expect(rel.disputed).toBe(1);
+    expect(rel.rounds).toBe(2);
+    expect(rel.lastInteraction).toBe('2026-05-23T11:00:00Z');
+  });
+
+  it('counts rounds as distinct taskIds (not signal count)', () => {
+    const map = aggregatePeerRelationships([
+      run('t1', '2026-05-23T10:00:00Z', ['a', 'b'], [
+        { signal: 'agreement', agentId: 'a', counterpartId: 'b' },
+        { signal: 'agreement', agentId: 'b', counterpartId: 'a' },
+        { signal: 'disagreement', agentId: 'a', counterpartId: 'b' },
+      ]),
+    ]);
+    // Three signals, but all in one round.
+    expect(map.get(peerKey('a', 'b'))!.rounds).toBe(1);
+  });
+
+  it('skips signals with no counterpartId (no peer relationship implied)', () => {
+    const map = aggregatePeerRelationships([
+      run('t1', '2026-05-23T10:00:00Z', ['a'], [
+        { signal: 'impl_test_pass', agentId: 'a' },
+        { signal: 'unique_unconfirmed', agentId: 'a' },
+      ]),
+    ]);
+    expect(map.size).toBe(0);
+  });
+
+  it('skips new_finding and unverified signals (no pair relationship)', () => {
+    const map = aggregatePeerRelationships([
+      run('t1', '2026-05-23T10:00:00Z', ['a', 'b'], [
+        { signal: 'new_finding', agentId: 'a', counterpartId: 'b' },
+        { signal: 'unique_unconfirmed', agentId: 'a', counterpartId: 'b' },
+      ]),
+    ]);
+    expect(map.size).toBe(0);
+  });
+
+  it('handles three or more agents in a single round', () => {
+    const map = aggregatePeerRelationships([
+      run('t1', '2026-05-23T10:00:00Z', ['a', 'b', 'c'], [
+        { signal: 'agreement', agentId: 'a', counterpartId: 'b' },
+        { signal: 'disagreement', agentId: 'a', counterpartId: 'c' },
+        { signal: 'agreement', agentId: 'b', counterpartId: 'c' },
+      ]),
+    ]);
+    expect(map.size).toBe(3);
+    expect(map.get(peerKey('a', 'b'))!.confirmed).toBe(1);
+    expect(map.get(peerKey('a', 'c'))!.disputed).toBe(1);
+    expect(map.get(peerKey('b', 'c'))!.confirmed).toBe(1);
+  });
+
+  it('keeps lastInteraction as the latest timestamp even when later rounds add no new counter', () => {
+    const map = aggregatePeerRelationships([
+      run('t1', '2026-05-23T10:00:00Z', ['a', 'b'], [
+        { signal: 'agreement', agentId: 'a', counterpartId: 'b' },
+      ]),
+      run('t2', '2026-05-23T12:00:00Z', ['a', 'b'], [
+        { signal: 'new_finding', agentId: 'a', counterpartId: 'b' }, // skipped counter
+      ]),
+    ]);
+    // The pair appeared in t2 even though the signal didn't change counters;
+    // rounds should reflect distinct taskIds where the pair appeared.
+    // We deliberately do NOT bump lastInteraction for skipped signals — pair
+    // didn't have a counted interaction in t2.
+    const rel = map.get(peerKey('a', 'b'))!;
+    expect(rel.lastInteraction).toBe('2026-05-23T10:00:00Z');
+    expect(rel.rounds).toBe(1);
+  });
+});

--- a/tests/dashboard/peer-relationships.test.ts
+++ b/tests/dashboard/peer-relationships.test.ts
@@ -178,4 +178,58 @@ describe('aggregatePeerRelationships', () => {
     expect(rel.lastInteraction).toBe('2026-05-23T10:00:00Z');
     expect(rel.rounds).toBe(1);
   });
+
+  // --- Regressions from PR #454 sonnet-reviewer consensus (4ad05e8) ---
+
+  it('counts impl_peer_approved as confirmed (write-mode peer code-review verdict)', () => {
+    const map = aggregatePeerRelationships([
+      run('t1', '2026-05-23T10:00:00Z', ['reviewer', 'implementer'], [
+        { signal: 'impl_peer_approved', agentId: 'reviewer', counterpartId: 'implementer' },
+      ]),
+    ]);
+    expect(map.get(peerKey('reviewer', 'implementer'))!.confirmed).toBe(1);
+  });
+
+  it('counts impl_peer_rejected as disputed (write-mode peer code-review verdict)', () => {
+    const map = aggregatePeerRelationships([
+      run('t1', '2026-05-23T10:00:00Z', ['reviewer', 'implementer'], [
+        { signal: 'impl_peer_rejected', agentId: 'reviewer', counterpartId: 'implementer' },
+      ]),
+    ]);
+    expect(map.get(peerKey('reviewer', 'implementer'))!.disputed).toBe(1);
+  });
+
+  it('skips retracted rounds entirely (matches App.tsx visibleRuns filter)', () => {
+    const map = aggregatePeerRelationships([
+      { ...run('t1', '2026-05-23T10:00:00Z', ['a', 'b'], [
+        { signal: 'agreement', agentId: 'a', counterpartId: 'b' },
+      ]), retracted: true, retractedAt: '2026-05-23T10:30:00Z', retractionReason: 'test' },
+      run('t2', '2026-05-23T11:00:00Z', ['a', 'b'], [
+        { signal: 'agreement', agentId: 'a', counterpartId: 'b' },
+      ]),
+    ]);
+    // Retracted t1 must not contribute; only t2 counts.
+    const rel = map.get(peerKey('a', 'b'))!;
+    expect(rel.confirmed).toBe(1);
+    expect(rel.rounds).toBe(1);
+    expect(rel.lastInteraction).toBe('2026-05-23T11:00:00Z');
+  });
+
+  it('skips signals with empty-string counterpartId (would create phantom map keys)', () => {
+    const map = aggregatePeerRelationships([
+      run('t1', '2026-05-23T10:00:00Z', ['a'], [
+        { signal: 'agreement', agentId: 'a', counterpartId: '' },
+      ]),
+    ]);
+    expect(map.size).toBe(0);
+  });
+
+  it('skips signals with empty-string agentId (would create phantom map keys)', () => {
+    const map = aggregatePeerRelationships([
+      run('t1', '2026-05-23T10:00:00Z', ['', 'b'], [
+        { signal: 'agreement', agentId: '', counterpartId: 'b' },
+      ]),
+    ]);
+    expect(map.size).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Phase 1b's data foundation: a client-side aggregator hook that derives per-agent-pair relationship aggregates from the already-fetched `ConsensusRun[]`. Pure-client, memoized, no backend changes. **No UI yet** — this PR exists to validate the data layer before any rendering work (PRs 2-6 in the series will consume this hook).

**Spec:** `docs/superpowers/specs/2026-05-22-dashboard-redesign-phase1b-agent-network-graph-design.md` §"2. Peer-relationship data" + §"Implementation outline — PR 1"
**Plan:** `docs/superpowers/plans/2026-05-23-dashboard-phase1b-pr1-peer-relationships.md`

## What's in this PR

3 commits, 4 files, +296 LOC:

| Commit | File | What |
|---|---|---|
| `6f1866a` | `packages/dashboard-v2/src/lib/types.ts` (+26) | `PeerRelationship` interface + `PeerRelationshipMap` alias |
| `2638cb9` | `packages/dashboard-v2/src/lib/peer-relationships.ts` (new, 72 LOC) | `peerKey(a, b)` + pure `aggregatePeerRelationships(runs)` |
| `2638cb9` | `tests/dashboard/peer-relationships.test.ts` (new, 181 LOC) | 14 unit tests — 3 for `peerKey`, 11 for the aggregator |
| `f4fbe0a` | `packages/dashboard-v2/src/hooks/usePeerRelationships.ts` (new, 17 LOC) | React hook wrapping the pure aggregator in `useMemo` |

## Signal → relationship attribute mapping (the part reviewers should challenge)

The aggregator visits every signal in every consensus round and increments per-pair counters using this mapping:

| `signal` value | Counter | Notes |
|---|---|---|
| `agreement` | `confirmed++` | Both agents agreed — strong trust signal |
| `unique_confirmed` | `confirmed++` | Solo finding verified by a peer — trust |
| `disagreement` | `disputed++` | One agent disputed another's finding — mixed |
| `hallucination_caught` | `hallucinationsCaught++` | One agent caught a peer's fabrication — adversarial |
| `new_finding` | (skip) | No pair relationship implied |
| `unique_unconfirmed` | (skip) | Solo finding, no peer verification yet |
| any signal with no `counterpartId` | (skip) | E.g. `impl_test_pass` — not a peer relationship |

Pair identification: `signal.agentId` + `signal.counterpartId` → `peerKey(a, b)` (alphabetically sorted, joined with `::`).

`rounds` = distinct `taskId`s where the pair had a counted signal (per-pair `Set<string>` for dedup).
`lastInteraction` = max `round.timestamp` across counted signals.

## Live-data sanity check (run as plan Task 5)

Ran the aggregator against the current `/dashboard/api/consensus` output (10 recent rounds):

```
Unique peer pairs: 3
opus-implementer::sonnet-reviewer              total=  62  confirmed= 57  disputed=  5  catch=  0  rounds=  3
sonnet-designer::sonnet-reviewer               total=  17  confirmed= 17  disputed=  0  catch=  0  rounds=  1
haiku-researcher::sonnet-reviewer              total=  12  confirmed= 11  disputed=  1  catch=  0  rounds=  2
```

The sonnet-designer pair with 17 confirmed = PR #453 cross-review I just ran. The opus pair history matches prior sessions. Aggregator behaves correctly on live data.

**Observation worth flagging:** the first signal in each round (typically `agreement` on the originating agent's own finding) lacks `counterpartId` and is correctly skipped. Other signals in the same round carry `counterpartId` and ARE counted. This means the totals above represent **cross-agent agreements**, not self-confirmations — which is the intended semantic.

## Test plan

- [x] `npx jest tests/dashboard/peer-relationships.test.ts` — `Tests: 14 passed, 14 total`
- [x] `cd packages/dashboard-v2 && npx tsc --noEmit -p tsconfig.json` — zero errors
- [x] `npx vite build` — clean, 678ms
- [x] Live-data sanity check — 3 pairs detected, totals match known cross-review history
- [ ] **Reviewer:** challenge the signal-type → counter mapping. Are there signal types I'm under-counting (e.g. `impl_peer_approved` for write-mode tasks)? Are there signal types I'm over-counting that don't describe a peer relationship?
- [ ] **Reviewer:** spot-check 3 live consensus runs end-to-end — fetch `/dashboard/api/consensus`, count agreements/disputes manually, compare to aggregator output

## Phase 1b PR series — what's next

| PR | Focus | Status |
|---|---|---|
| PR 1 (this) | `usePeerRelationships` hook + `PeerRelationship` type | **In review** |
| PR 2 | Shared `AnimationScheduler` + NeuralAvatar migration | Not started |
| PR 3 | `AgentNetworkGraph` component (feature-flagged, dark-stage only) | Not started |
| PR 4 | `GraphRail` + selected-agent state via URL hash | Not started |
| PR 5 | `NarrativeStripe` + `TemporalScrubber` (histogram only) | Not started |
| PR 6 | Flip the feature flag, replace default Overview layout | Not started |

Each PR is independently mergeable behind a feature flag. This PR (data layer) has no flag because it adds no UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)