### PR TITLE
feat(dashboard-v2): Phase 1b PR4 — GraphRail + ?agent= URL selection

### DIFF
--- a/packages/dashboard-v2/src/components/GraphRail.tsx
+++ b/packages/dashboard-v2/src/components/GraphRail.tsx
@@ -41,7 +41,9 @@ function FleetSummary({ agents, peerRelationships }: { agents: AgentData[]; peer
       recentCatches.push({ pair: [a, b], catches: rel.hallucinationsCaught, ts: rel.lastInteraction });
     }
   }
-  recentCatches.sort((a, b) => b.ts.localeCompare(a.ts));
+  // Sort by parsed timestamp, not lexicographic. Defense-in-depth in case
+  // `lastInteraction` ever ships a non-ISO format.
+  recentCatches.sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime());
   const top5Catches = recentCatches.slice(0, 5);
 
   return (
@@ -62,28 +64,30 @@ function FleetSummary({ agents, peerRelationships }: { agents: AgentData[]; peer
               key={a.id}
               type="button"
               onClick={() => setAgentParam(a.id)}
-              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition hover:[background:color-mix(in_oklch,var(--accent)_8%,transparent)]"
+              className="group flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition hover:[background:color-mix(in_oklch,var(--accent)_8%,transparent)]"
+              style={{ cursor: 'pointer' }}
             >
               <NeuralAvatar agentId={a.id} signals={a.scores.signals} accuracy={a.scores.accuracy} uniqueness={a.scores.uniqueness} impact={a.scores.impactScore} size={28} />
               <div className="min-w-0 flex-1">
                 <div className="truncate font-mono text-[11px] font-semibold" style={{ color: 'var(--text)' }}>{a.id}</div>
                 <div className="font-mono text-[10px]" style={{ color: 'var(--text-dim)' }}>{Math.round(a.scores.accuracy * 100)}% accuracy · {a.scores.signals} signals</div>
               </div>
+              <span className="opacity-0 transition group-hover:opacity-100 font-mono text-[10px]" style={{ color: 'var(--accent)' }}>→</span>
             </button>
           ))
         )}
       </Section>
 
-      <Section label="Weekly trends" tone="muted">
-        <EmptyRow text="Historical delta data lands in Phase 1b PR5." />
-      </Section>
+      {/* Weekly trends section deferred — historical-delta data lands in Phase 1b PR5.
+          Hidden rather than rendered-as-placeholder so the fleet summary doesn't
+          carry a visible "unfinished" hole in production UI. */}
 
       <Section label="Recent hallucination catches" tone="danger">
         {top5Catches.length === 0 ? (
           <EmptyRow text="No catches in the active window." />
         ) : (
-          top5Catches.map((c, i) => (
-            <div key={i} className="rounded px-2 py-1.5">
+          top5Catches.map((c) => (
+            <div key={`${c.pair[0]}::${c.pair[1]}`} className="rounded px-2 py-1.5">
               <div className="font-mono text-[11px]" style={{ color: 'var(--text)' }}>
                 <span style={{ color: 'var(--danger)' }}>◆</span> {c.pair[0]} ↔ {c.pair[1]}
               </div>
@@ -215,7 +219,7 @@ function AgentDetail({ agent, peerRelationships, agents }: { agent: AgentData; p
       {/* Action footer — sticky bottom. Keyboard hints visual-only this PR. */}
       <div className="mt-auto flex flex-col gap-1.5 border-t p-3" style={{ borderColor: 'var(--border)' }}>
         <ActionButton label="Open dispatch log" kbd="⏎" href={`/agent/${encodeURIComponent(agent.id)}`} />
-        <ActionButton label="View skill graph" kbd="G" href={`/agent/${encodeURIComponent(agent.id)}#skills`} />
+        <ActionButton label="View skill graph" kbd="G" href={`/agent/${encodeURIComponent(agent.id)}#skills`} disabled={agent.skills.length === 0} />
         <ActionButton label="Dispatch consensus" kbd="⌘D" href="#" disabled />
       </div>
     </div>
@@ -236,6 +240,7 @@ function ActionButton({ label, kbd, href, disabled }: { label: string; kbd: stri
     <a
       href={disabled ? undefined : `/dashboard${href}`}
       aria-disabled={disabled}
+      tabIndex={disabled ? -1 : undefined}
       className="flex items-center justify-between rounded px-2 py-1.5 font-mono text-[11px] transition"
       style={{ background: disabled ? 'transparent' : 'color-mix(in oklch, var(--surface) 50%, transparent)', color: disabled ? 'var(--text-faint)' : 'var(--text)', pointerEvents: disabled ? 'none' : 'auto', opacity: disabled ? 0.5 : 1 }}
     >

--- a/packages/dashboard-v2/src/components/GraphRail.tsx
+++ b/packages/dashboard-v2/src/components/GraphRail.tsx
@@ -1,0 +1,246 @@
+import type { AgentData, PeerRelationship, PeerRelationshipMap } from '@/lib/types';
+import { NeuralAvatar } from './NeuralAvatar';
+import { peerKey } from '@/lib/peer-relationships';
+import { setAgentParam } from '@/lib/url-agent-param';
+
+interface GraphRailProps {
+  selectedAgent: AgentData | null;
+  agents: AgentData[];
+  peerRelationships: PeerRelationshipMap;
+  height?: number; // matches the AgentNetworkGraph stage height (default 420)
+}
+
+export function GraphRail({ selectedAgent, agents, peerRelationships, height = 420 }: GraphRailProps) {
+  return (
+    <aside
+      className="flex-shrink-0 overflow-y-auto rounded-lg border"
+      style={{ width: 320, height, background: 'var(--surface-elev)', borderColor: 'var(--border)' }}
+      aria-label={selectedAgent ? `Agent detail: ${selectedAgent.id}` : 'Fleet summary'}
+    >
+      {selectedAgent ? (
+        <AgentDetail agent={selectedAgent} peerRelationships={peerRelationships} agents={agents} />
+      ) : (
+        <FleetSummary agents={agents} peerRelationships={peerRelationships} />
+      )}
+    </aside>
+  );
+}
+
+function FleetSummary({ agents, peerRelationships }: { agents: AgentData[]; peerRelationships: PeerRelationshipMap }) {
+  // Top 3 by accuracy (signals > 0 to exclude no-data agents).
+  const topPerformers = [...agents]
+    .filter((a) => a.scores.signals > 0)
+    .sort((a, b) => b.scores.accuracy - a.scores.accuracy)
+    .slice(0, 3);
+
+  // Recent 5 hallucination catches across the fleet (from peer relationships).
+  const recentCatches: Array<{ pair: [string, string]; catches: number; ts: string }> = [];
+  for (const [k, rel] of peerRelationships.entries()) {
+    if (rel.hallucinationsCaught > 0) {
+      const [a, b] = k.split('::');
+      recentCatches.push({ pair: [a, b], catches: rel.hallucinationsCaught, ts: rel.lastInteraction });
+    }
+  }
+  recentCatches.sort((a, b) => b.ts.localeCompare(a.ts));
+  const top5Catches = recentCatches.slice(0, 5);
+
+  return (
+    <div className="flex h-full flex-col p-4">
+      <div className="mb-2 font-mono text-[10px] font-bold uppercase tracking-widest" style={{ color: 'var(--text-dim)' }}>
+        Fleet at a glance
+      </div>
+      <p className="mb-4 font-mono text-[11px]" style={{ color: 'var(--text-faint)' }}>
+        Click a node to see detail.
+      </p>
+
+      <Section label="Top performers" tone="success">
+        {topPerformers.length === 0 ? (
+          <EmptyRow text="No agent has logged a signal yet." />
+        ) : (
+          topPerformers.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              onClick={() => setAgentParam(a.id)}
+              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition hover:[background:color-mix(in_oklch,var(--accent)_8%,transparent)]"
+            >
+              <NeuralAvatar agentId={a.id} signals={a.scores.signals} accuracy={a.scores.accuracy} uniqueness={a.scores.uniqueness} impact={a.scores.impactScore} size={28} />
+              <div className="min-w-0 flex-1">
+                <div className="truncate font-mono text-[11px] font-semibold" style={{ color: 'var(--text)' }}>{a.id}</div>
+                <div className="font-mono text-[10px]" style={{ color: 'var(--text-dim)' }}>{Math.round(a.scores.accuracy * 100)}% accuracy · {a.scores.signals} signals</div>
+              </div>
+            </button>
+          ))
+        )}
+      </Section>
+
+      <Section label="Weekly trends" tone="muted">
+        <EmptyRow text="Historical delta data lands in Phase 1b PR5." />
+      </Section>
+
+      <Section label="Recent hallucination catches" tone="danger">
+        {top5Catches.length === 0 ? (
+          <EmptyRow text="No catches in the active window." />
+        ) : (
+          top5Catches.map((c, i) => (
+            <div key={i} className="rounded px-2 py-1.5">
+              <div className="font-mono text-[11px]" style={{ color: 'var(--text)' }}>
+                <span style={{ color: 'var(--danger)' }}>◆</span> {c.pair[0]} ↔ {c.pair[1]}
+              </div>
+              <div className="font-mono text-[10px]" style={{ color: 'var(--text-dim)' }}>
+                {c.catches} caught · {timeAgo(c.ts)}
+              </div>
+            </div>
+          ))
+        )}
+      </Section>
+    </div>
+  );
+}
+
+function Section({ label, tone, children }: { label: string; tone: 'success' | 'muted' | 'danger'; children: React.ReactNode }) {
+  const toneColor = tone === 'success' ? 'var(--success)' : tone === 'danger' ? 'var(--danger)' : 'var(--text-faint)';
+  return (
+    <section className="mb-4">
+      <div className="mb-1.5 flex items-center gap-1.5 font-mono text-[9px] font-bold uppercase tracking-widest" style={{ color: toneColor }}>
+        <span style={{ width: 4, height: 4, borderRadius: '50%', background: toneColor, display: 'inline-block' }} />
+        {label}
+      </div>
+      <div className="space-y-1">{children}</div>
+    </section>
+  );
+}
+
+function EmptyRow({ text }: { text: string }) {
+  return <div className="px-2 py-1.5 font-mono text-[10px]" style={{ color: 'var(--text-faint)' }}>{text}</div>;
+}
+
+/** Naive time-ago for the rail. ISO timestamp → "3h ago" / "2d ago". */
+function timeAgo(iso: string): string {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const diffSec = Math.max(0, Math.floor((now - then) / 1000));
+  if (diffSec < 60) return `${diffSec}s ago`;
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`;
+  return `${Math.floor(diffSec / 86400)}d ago`;
+}
+
+function AgentDetail({ agent, peerRelationships, agents }: { agent: AgentData; peerRelationships: PeerRelationshipMap; agents: AgentData[] }) {
+  // Status pill: benched > offline > online (highest-severity status wins).
+  const status: { label: string; color: string } = agent.scores.bench.state === 'benched'
+    ? { label: 'BENCHED', color: 'var(--danger)' }
+    : !agent.online
+      ? { label: 'OFFLINE', color: 'var(--text-dim)' }
+      : { label: 'ONLINE', color: 'var(--success)' };
+
+  // Top 3 peers by total interaction count.
+  const peers: Array<{ other: string; rel: PeerRelationship; total: number }> = [];
+  for (const other of agents) {
+    if (other.id === agent.id) continue;
+    const rel = peerRelationships.get(peerKey(agent.id, other.id));
+    if (!rel) continue;
+    const total = rel.confirmed + rel.disputed + rel.hallucinationsCaught;
+    peers.push({ other: other.id, rel, total });
+  }
+  peers.sort((a, b) => b.total - a.total);
+  const topPeers = peers.slice(0, 3);
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Status pill — top gradient strip */}
+      <div
+        className="flex items-center gap-1.5 px-4 py-2 font-mono text-[9px] font-bold uppercase tracking-widest"
+        style={{ color: status.color, borderBottom: '1px solid var(--border)', background: `color-mix(in oklch, ${status.color} 6%, transparent)` }}
+      >
+        <span style={{ width: 6, height: 6, borderRadius: '50%', background: status.color, display: 'inline-block' }} />
+        {status.label}
+      </div>
+
+      {/* Identity */}
+      <div className="flex items-center gap-3 px-4 pt-4">
+        <NeuralAvatar agentId={agent.id} signals={agent.scores.signals} accuracy={agent.scores.accuracy} uniqueness={agent.scores.uniqueness} impact={agent.scores.impactScore} size={48} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-mono text-[13px] font-semibold" style={{ color: 'var(--text)' }}>{agent.id}</div>
+          <div className="truncate font-mono text-[10px]" style={{ color: 'var(--text-dim)' }}>{agent.model}</div>
+        </div>
+      </div>
+
+      {/* Mini stats grid */}
+      <div className="mx-4 mt-4 grid grid-cols-2 gap-2">
+        <Stat label="Accuracy" value={`${Math.round(agent.scores.accuracy * 100)}%`} />
+        <Stat label="Reliability" value={agent.scores.taskCompletionRate == null ? '—' : `${Math.round(agent.scores.taskCompletionRate * 100)}%`} />
+        <Stat label="Signals" value={agent.scores.signals.toLocaleString()} />
+        <Stat label="Impact" value={`${Math.round(agent.scores.impactScore * 100)}%`} />
+      </div>
+
+      {/* Top peer relationships */}
+      <div className="mt-4 px-4">
+        <div className="mb-1.5 font-mono text-[9px] font-bold uppercase tracking-widest" style={{ color: 'var(--text-faint)' }}>
+          Top peers
+        </div>
+        {topPeers.length === 0 ? (
+          <EmptyRow text="No cross-review history yet." />
+        ) : (
+          <div className="space-y-1">
+            {topPeers.map(({ other, rel }) => (
+              <div key={other} className="rounded px-2 py-1.5" style={{ background: 'color-mix(in oklch, var(--surface) 50%, transparent)' }}>
+                <div className="truncate font-mono text-[11px]" style={{ color: 'var(--text)' }}>{other}</div>
+                <div className="mt-0.5 flex items-center gap-2 font-mono text-[10px]" style={{ color: 'var(--text-dim)' }}>
+                  {rel.confirmed > 0 && <span><span style={{ color: 'var(--success)' }}>✓</span> {rel.confirmed}</span>}
+                  {rel.disputed > 0 && <span><span style={{ color: 'var(--warn)' }}>≠</span> {rel.disputed}</span>}
+                  {rel.hallucinationsCaught > 0 && <span><span style={{ color: 'var(--danger)' }}>◆</span> {rel.hallucinationsCaught}</span>}
+                  <span style={{ opacity: 0.6 }}>· {rel.rounds} rounds</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Skills */}
+      {agent.skills.length > 0 && (
+        <div className="mt-4 px-4">
+          <div className="mb-1.5 font-mono text-[9px] font-bold uppercase tracking-widest" style={{ color: 'var(--text-faint)' }}>
+            Skills <span style={{ color: 'var(--accent)' }}>{agent.skills.length}</span>
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {agent.skills.slice(0, 6).map((s) => (
+              <span key={s} className="rounded-sm border px-1.5 py-0.5 font-mono text-[10px]" style={{ borderColor: 'var(--border)', color: 'var(--text-dim)' }}>{s}</span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Action footer — sticky bottom. Keyboard hints visual-only this PR. */}
+      <div className="mt-auto flex flex-col gap-1.5 border-t p-3" style={{ borderColor: 'var(--border)' }}>
+        <ActionButton label="Open dispatch log" kbd="⏎" href={`/agent/${encodeURIComponent(agent.id)}`} />
+        <ActionButton label="View skill graph" kbd="G" href={`/agent/${encodeURIComponent(agent.id)}#skills`} />
+        <ActionButton label="Dispatch consensus" kbd="⌘D" href="#" disabled />
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded px-2 py-1.5" style={{ background: 'color-mix(in oklch, var(--surface) 50%, transparent)' }}>
+      <div className="font-mono text-[9px] uppercase tracking-widest" style={{ color: 'var(--text-faint)' }}>{label}</div>
+      <div className="mt-0.5 font-mono text-[15px] font-medium tabular-nums" style={{ color: 'var(--text)' }}>{value}</div>
+    </div>
+  );
+}
+
+function ActionButton({ label, kbd, href, disabled }: { label: string; kbd: string; href: string; disabled?: boolean }) {
+  return (
+    <a
+      href={disabled ? undefined : `/dashboard${href}`}
+      aria-disabled={disabled}
+      className="flex items-center justify-between rounded px-2 py-1.5 font-mono text-[11px] transition"
+      style={{ background: disabled ? 'transparent' : 'color-mix(in oklch, var(--surface) 50%, transparent)', color: disabled ? 'var(--text-faint)' : 'var(--text)', pointerEvents: disabled ? 'none' : 'auto', opacity: disabled ? 0.5 : 1 }}
+    >
+      <span>{label}</span>
+      <kbd className="rounded border px-1 py-0.5 font-mono text-[9px]" style={{ borderColor: 'var(--border)', background: 'var(--surface-sunk)', color: 'var(--text-dim)' }}>{kbd}</kbd>
+    </a>
+  );
+}

--- a/packages/dashboard-v2/src/hooks/useUrlAgentParam.ts
+++ b/packages/dashboard-v2/src/hooks/useUrlAgentParam.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { getAgentParam, setAgentParam } from '../lib/url-agent-param';
+
+/**
+ * React hook bridging the ?agent= URL param to component state.
+ * Mirrors the pattern of useRoute (lib/router.ts): subscribe to the
+ * existing `dashboard:navigate` event for re-render triggers.
+ *
+ * Returns [selectedAgentId, setSelectedAgentId]. Setting null clears
+ * the param. Back/forward browser navigation works because pushState
+ * is paired with the popstate-derived `dashboard:navigate` event.
+ */
+export function useUrlAgentParam(): [string | null, (id: string | null) => void] {
+  const [id, setId] = useState<string | null>(() =>
+    typeof window === 'undefined' ? null : getAgentParam(window.location.search),
+  );
+
+  useEffect(() => {
+    const sync = () => {
+      const next = typeof window === 'undefined' ? null : getAgentParam(window.location.search);
+      setId((prev) => (prev === next ? prev : next));
+    };
+    window.addEventListener('dashboard:navigate', sync as EventListener);
+    return () => {
+      window.removeEventListener('dashboard:navigate', sync as EventListener);
+    };
+  }, []);
+
+  return [id, setAgentParam];
+}

--- a/packages/dashboard-v2/src/hooks/useUrlAgentParam.ts
+++ b/packages/dashboard-v2/src/hooks/useUrlAgentParam.ts
@@ -26,5 +26,8 @@ export function useUrlAgentParam(): [string | null, (id: string | null) => void]
     };
   }, []);
 
-  return [id, setAgentParam];
+  // `as const` preserves the tuple shape; without it, TypeScript widens the
+  // return type to (string | null | setter)[], which makes destructured
+  // call-site inference unsafe.
+  return [id, setAgentParam] as const;
 }

--- a/packages/dashboard-v2/src/lib/url-agent-param.ts
+++ b/packages/dashboard-v2/src/lib/url-agent-param.ts
@@ -1,0 +1,50 @@
+/**
+ * URL `?agent=ID` selection state for the AgentNetworkGraph + GraphRail
+ * (Phase 1b PR4). Lives in the query string (NOT the hash) so it round-trips
+ * cleanly through the existing dashboard:navigate dispatch — no extra
+ * event plumbing needed.
+ *
+ * Pure helpers + a thin write that does the side-effect. React-facing
+ * code uses the hook at hooks/useUrlAgentParam.ts.
+ */
+
+export function getAgentParam(search: string): string | null {
+  const v = new URLSearchParams(search).get('agent');
+  return v && v.length > 0 ? v : null;
+}
+
+/**
+ * Build the new URL with `agent` set/removed, preserving every other param
+ * and the pathname. Pure — does not mutate `window.location`.
+ */
+export function buildUrlWithAgent(pathname: string, search: string, agentId: string | null): string {
+  const params = new URLSearchParams(search);
+  if (agentId === null) {
+    params.delete('agent');
+  } else {
+    params.set('agent', agentId);
+  }
+  const qs = params.toString();
+  return qs.length > 0 ? `${pathname}?${qs}` : pathname;
+}
+
+/**
+ * Side-effecting setter: pushes a new history entry with the new `agent`
+ * param and fires `dashboard:navigate` so the router's useRoute hook
+ * re-renders. SSR-safe (no-op when window is undefined).
+ *
+ * Uses `globalThis` cast to avoid DOM-lib dependency at the root tsconfig
+ * level (which uses ES2022-only lib). The dashboard-v2 tsconfig includes DOM.
+ */
+export function setAgentParam(agentId: string | null): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = globalThis as any;
+  if (typeof w.window === 'undefined') return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const win: any = w.window;
+  const url = buildUrlWithAgent(win.location.pathname, win.location.search, agentId);
+  if (url !== win.location.pathname + win.location.search) {
+    win.history.pushState({}, '', url);
+    win.dispatchEvent(new Event('dashboard:navigate'));
+  }
+}

--- a/packages/dashboard-v2/src/pages/OverviewPage.tsx
+++ b/packages/dashboard-v2/src/pages/OverviewPage.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react';
 import { SystemPulse } from '@/components/SystemPulse';
 import { ActiveTasksBanner } from '@/components/ActiveTasksBanner';
 import { TeamHero } from '@/components/TeamHero';
 import { TasksSection } from '@/components/TasksSection';
 import { RecentSignalsPeek } from '@/components/RecentSignalsPeek';
 import { AgentNetworkGraph } from '@/components/AgentNetworkGraph';
+import { GraphRail } from '@/components/GraphRail';
 import { usePeerRelationships } from '@/hooks/usePeerRelationships';
+import { useUrlAgentParam } from '@/hooks/useUrlAgentParam';
 import { isGraphBeta } from '@/lib/feature-flags';
 import { href } from '@/lib/router';
 import type { OverviewData, AgentData, TasksData, ConsensusData } from '@/lib/types';
@@ -38,18 +39,31 @@ export function OverviewPage({
   const actionable = overview.actionableFindings;
   const showGraph = isGraphBeta();
   const peerRelationships = usePeerRelationships(consensus?.runs);
-  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  // Phase 1b PR4 — selection state moved to ?agent= URL param for deep-linking.
+  const [selectedAgentId, setSelectedAgentId] = useUrlAgentParam();
+  const selectedAgent = agents && selectedAgentId
+    ? agents.find((a) => a.id === selectedAgentId) ?? null
+    : null;
 
   return (
     <div className="mx-auto max-w-5xl space-y-8">
-      {/* Phase 1b PR3 — AgentNetworkGraph behind ?graph=1 flag, ABOVE existing widgets. */}
+      {/* Phase 1b PR3+PR4 — AgentNetworkGraph + GraphRail side-by-side behind ?graph=1. */}
       {showGraph && agents && (
-        <AgentNetworkGraph
-          agents={agents}
-          peerRelationships={peerRelationships}
-          selectedAgentId={selectedAgentId}
-          onSelectAgent={setSelectedAgentId}
-        />
+        <div className="flex gap-3">
+          <div className="min-w-0 flex-1">
+            <AgentNetworkGraph
+              agents={agents}
+              peerRelationships={peerRelationships}
+              selectedAgentId={selectedAgentId}
+              onSelectAgent={setSelectedAgentId}
+            />
+          </div>
+          <GraphRail
+            selectedAgent={selectedAgent}
+            agents={agents}
+            peerRelationships={peerRelationships}
+          />
+        </div>
       )}
       {/* Page header */}
       <header>

--- a/tests/dashboard/url-agent-param.test.ts
+++ b/tests/dashboard/url-agent-param.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure helpers for the ?agent= URL query param. The setter side has a
+ * side-effect (history.pushState + dispatchEvent) which we stub.
+ */
+
+import {
+  getAgentParam,
+  buildUrlWithAgent,
+} from '../../packages/dashboard-v2/src/lib/url-agent-param';
+
+describe('getAgentParam', () => {
+  it('returns null when ?agent= is absent', () => {
+    expect(getAgentParam('')).toBeNull();
+    expect(getAgentParam('?')).toBeNull();
+    expect(getAgentParam('?other=x')).toBeNull();
+    expect(getAgentParam('?graph=1')).toBeNull();
+  });
+  it('returns the agent id when present', () => {
+    expect(getAgentParam('?agent=opus-implementer')).toBe('opus-implementer');
+    expect(getAgentParam('?graph=1&agent=sonnet-reviewer')).toBe('sonnet-reviewer');
+    expect(getAgentParam('?agent=foo&other=bar')).toBe('foo');
+  });
+  it('returns null for an empty value', () => {
+    expect(getAgentParam('?agent=')).toBeNull();
+  });
+});
+
+describe('buildUrlWithAgent', () => {
+  it('adds ?agent=ID when none present', () => {
+    expect(buildUrlWithAgent('/dashboard/', '', 'opus-implementer'))
+      .toBe('/dashboard/?agent=opus-implementer');
+  });
+  it('preserves existing other params', () => {
+    expect(buildUrlWithAgent('/dashboard/', '?graph=1', 'opus-implementer'))
+      .toBe('/dashboard/?graph=1&agent=opus-implementer');
+  });
+  it('replaces an existing agent param', () => {
+    expect(buildUrlWithAgent('/dashboard/', '?agent=old&graph=1', 'new'))
+      .toBe('/dashboard/?agent=new&graph=1');
+  });
+  it('removes the param when id is null', () => {
+    expect(buildUrlWithAgent('/dashboard/', '?agent=opus-implementer&graph=1', null))
+      .toBe('/dashboard/?graph=1');
+  });
+  it('returns the pathname alone when removing the last param', () => {
+    expect(buildUrlWithAgent('/dashboard/', '?agent=opus-implementer', null))
+      .toBe('/dashboard/');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1b PR 4 of 6 — adds the 320px companion rail to the AgentNetworkGraph (PR3), closing the navigational loop spec Direction C calls for. Selection state lives in `?agent=<id>` URL params so it deep-links + survives reload. The rail switches between two states: empty (fleet summary card stack) and selected (detail card with peer relationships and action buttons).

**Spec:** `docs/superpowers/specs/2026-05-22-dashboard-redesign-phase1b-agent-network-graph-design.md` §"Components — GraphRail" + §"4. Selection + scrubber state" + §"5. Empty states"
**Plan:** `docs/superpowers/plans/2026-05-23-dashboard-phase1b-pr4-graph-rail.md`

## How to view

`http://localhost:63007/dashboard/?graph=1` — graph on left, rail on right. Click a node → URL becomes `?graph=1&agent=<id>` and the rail switches to detail. Refresh — selection survives. Click empty stage → param drops, rail returns to fleet summary.

## What changed

4 commits, 4 files, ~280 LOC:

| Commit | Files | What |
|---|---|---|
| `5f65594` | `lib/url-agent-param.ts` (new) + test (8 tests) | Pure `getAgentParam` / `buildUrlWithAgent` / `setAgentParam` (the last fires `dashboard:navigate` after pushState) |
| `3ec33f2` | `hooks/useUrlAgentParam.ts` (new) | React hook bridging URL ↔ component state via the existing route-sync event |
| `e68abe9` | `components/GraphRail.tsx` (new, ~280 LOC) | 320px rail with two branches: `AgentDetail` (status pill / identity / stats / peers / skills / actions) and `FleetSummary` (top performers / weekly trends placeholder / recent catches) |
| `1c142e0` | `OverviewPage.tsx` | Swap local `useState` for `useUrlAgentParam`; flex layout when `?graph=1` to put graph + rail side-by-side |

## Spec deviation noted

Spec says "selectedAgentId stored in URL hash (`#/overview?agent=…`)." This PR uses the **query string** (`?agent=…`) instead because the existing `lib/router.ts` already dispatches `dashboard:navigate` on `pushState` + `popstate`; hash routing would need a parallel listener with no behavioral benefit. Deep-linking, browser back/forward, and reload-survival are all preserved.

## Bundle delta

`397.66 KB → 406.94 KB` (+9.3 KB raw / +1.9 KB gzipped) — GraphRail component.

## Test plan

- [x] `npx jest tests/dashboard/url-agent-param.test.ts` — `Tests: 8 passed, 8 total`
- [x] All dashboard tests still green (132 total across 12 suites)
- [x] `cd packages/dashboard-v2 && npx tsc --noEmit -p tsconfig.json` — zero errors
- [x] `npx vite build` — clean, 733ms
- [x] Live smoke at `http://localhost:63007/dashboard/?graph=1` — empty rail (fleet summary), click node → detail rail + URL `?graph=1&agent=<id>`, reload → selection preserved
- [x] Flag-off path (`/dashboard/`) byte-identical to post-PR3 Overview
- [ ] **Reviewer:** URL-state correctness — pushState + dispatchEvent pattern, popstate handling, back/forward
- [ ] **Reviewer:** GraphRail doesn't re-fetch — purely derives from props
- [ ] **Designer:** does the rail close the navigational loop? 320px width right? Hierarchy readable?

## Out of scope (later PRs)

- Global keyboard shortcuts (⏎/G/⌘D) — `<kbd>` hints render now; actual handlers land in PR5
- Historical-trend data for "Biggest deltas this week" — currently a placeholder ("Trend data coming Phase 1b PR5")
- `NarrativeStripe` + `TemporalScrubber` (PR5)
- Flag-flip + default-layout replacement (PR6)

## Phase 1b PR series

| PR | Focus | Status |
|---|---|---|
| 1 | `usePeerRelationships` + `PeerRelationship` type | ✅ Merged (`a4db0e3`) |
| 2 | Shared `AnimationScheduler` + NeuralAvatar migration | ✅ Merged (`3b2ca4d`) |
| 3 | `AgentNetworkGraph` (feature-flagged) | ✅ Merged (`1556fe9`) |
| 4 (this) | `GraphRail` + URL-hash selection | **In review** |
| 5 | `NarrativeStripe` + `TemporalScrubber` + key handlers | — |
| 6 | Flag flip — replace default Overview | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)