### PR TITLE
feat(dashboard-v2): Phase 1b PR5 — NarrativeStripe + TemporalScrubber + global keys

### DIFF
--- a/packages/dashboard-v2/src/components/NarrativeStripe.tsx
+++ b/packages/dashboard-v2/src/components/NarrativeStripe.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from 'react';
+import { useWebSocket } from '@/hooks/useWebSocket';
+import type { DashboardEvent } from '@/lib/types';
+
+/** Auto-hide after 60s if consensus_complete never arrives. */
+const STRIPE_TIMEOUT_MS = 60_000;
+
+/**
+ * Thin live-update stripe — visible only when a consensus round is in
+ * flight. Pulses at 2×beat (3.2s). Subscribes to the existing dashboard
+ * WebSocket; tracks task_dispatched → consensus_complete pairs.
+ *
+ * Per Phase 1b spec §"NarrativeStripe": this is a presence indicator,
+ * not a detail view. Click "watch" scrolls the consensus rounds section
+ * into view (a real per-round drill-in is deferred).
+ */
+export function NarrativeStripe() {
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
+  const [activeAgentId, setActiveAgentId] = useState<string | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+
+  const clear = () => {
+    setActiveTaskId(null);
+    setActiveAgentId(null);
+    if (timeoutRef.current != null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  };
+
+  useWebSocket((event: DashboardEvent) => {
+    if (event.type === 'task_dispatched') {
+      setActiveTaskId(event.taskId);
+      setActiveAgentId(event.agentId);
+      if (timeoutRef.current != null) window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = window.setTimeout(clear, STRIPE_TIMEOUT_MS) as unknown as number;
+      return;
+    }
+    if (event.type === 'consensus_complete' || event.type === 'task_completed' || event.type === 'task_failed') {
+      if (event.type !== 'consensus_complete' && (event as { taskId?: string }).taskId !== activeTaskId) return;
+      clear();
+    }
+  });
+
+  useEffect(() => () => clear(), []);
+
+  if (activeTaskId === null) return null;
+  const shortId = activeTaskId.slice(0, 8);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center gap-3 rounded-md border px-3 py-2 font-mono text-[11px]"
+      style={{
+        background: 'color-mix(in oklch, var(--accent) 8%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--accent) 30%, transparent)',
+        color: 'var(--text)',
+        animation: 'beat-pulse-narrative calc(var(--beat) * 2) ease-in-out infinite',
+      }}
+    >
+      <span
+        className="inline-block h-2 w-2 rounded-full"
+        style={{ background: 'var(--accent)', boxShadow: '0 0 6px var(--accent)' }}
+      />
+      <span style={{ color: 'var(--text-dim)' }}>Round in flight</span>
+      <span className="font-bold" style={{ color: 'var(--accent)' }}>{shortId}</span>
+      {activeAgentId && (
+        <span style={{ color: 'var(--text-dim)' }}>
+          → <span style={{ color: 'var(--text)' }}>{activeAgentId}</span>
+        </span>
+      )}
+      <span className="ml-auto" style={{ color: 'var(--text-faint)' }}>live</span>
+
+      <style>{`
+        @keyframes beat-pulse-narrative {
+          0%, 100% { opacity: 1; }
+          50%      { opacity: 0.72; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/packages/dashboard-v2/src/components/NarrativeStripe.tsx
+++ b/packages/dashboard-v2/src/components/NarrativeStripe.tsx
@@ -36,8 +36,10 @@ export function NarrativeStripe() {
       timeoutRef.current = window.setTimeout(clear, STRIPE_TIMEOUT_MS) as unknown as number;
       return;
     }
+    // Narrow via discriminated union — all three terminal variants in
+    // DashboardEvent expose `taskId`, so no cast is needed.
     if (event.type === 'consensus_complete' || event.type === 'task_completed' || event.type === 'task_failed') {
-      if (event.type !== 'consensus_complete' && (event as { taskId?: string }).taskId !== activeTaskId) return;
+      if (event.taskId !== activeTaskId) return;
       clear();
     }
   });
@@ -70,14 +72,19 @@ export function NarrativeStripe() {
           → <span style={{ color: 'var(--text)' }}>{activeAgentId}</span>
         </span>
       )}
-      <span className="ml-auto" style={{ color: 'var(--text-faint)' }}>live</span>
-
-      <style>{`
-        @keyframes beat-pulse-narrative {
-          0%, 100% { opacity: 1; }
-          50%      { opacity: 0.72; }
-        }
-      `}</style>
+      <button
+        type="button"
+        onClick={() => {
+          // Scroll the consensus rounds section into view if it exists.
+          // The actual per-round drill-in is deferred to a future PR.
+          const el = document.getElementById('consensus-rounds-section');
+          if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }}
+        className="ml-auto rounded px-1.5 py-0.5 font-mono text-[10px] transition hover:[background:color-mix(in_oklch,var(--accent)_12%,transparent)]"
+        style={{ color: 'var(--text-faint)', cursor: 'pointer' }}
+      >
+        watch ↓
+      </button>
     </div>
   );
 }

--- a/packages/dashboard-v2/src/components/TemporalScrubber.tsx
+++ b/packages/dashboard-v2/src/components/TemporalScrubber.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from 'react';
-import { bucketize, BUCKET_COUNT } from '@/lib/histogram';
+import { useEffect, useMemo, useState } from 'react';
+import { bucketize, BUCKET_COUNT, rangeWindowMs } from '@/lib/histogram';
 import type { Range } from '@/lib/range-param';
 import type { ConsensusRun } from '@/lib/types';
 
@@ -12,7 +12,25 @@ interface TemporalScrubberProps {
 
 const RANGES: Range[] = ['1h', '24h', '7d', '30d'];
 
+/** Human label for the left flank — "1 hour ago" / "24 hours ago" / "7 days ago" / "30 days ago". */
+const RANGE_AGO_LABEL: Record<Range, string> = {
+  '1h': '1h ago',
+  '24h': '24h ago',
+  '7d': '7d ago',
+  '30d': '30d ago',
+};
+
 export function TemporalScrubber({ runs, range, onRangeChange, height = 52 }: TemporalScrubberProps) {
+  // `nowMs` ticks at the bucket interval so the histogram doesn't freeze
+  // while real time advances without new data. One bucket-width per tick
+  // is sufficient — finer resolution would re-render needlessly.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const bucketMs = rangeWindowMs(range) / BUCKET_COUNT;
+    const id = window.setInterval(() => setNowMs(Date.now()), bucketMs);
+    return () => window.clearInterval(id);
+  }, [range]);
+
   const buckets = useMemo(() => {
     // Each round contributes signals.length timestamps (using the round's ts).
     const timestamps: string[] = [];
@@ -20,8 +38,8 @@ export function TemporalScrubber({ runs, range, onRangeChange, height = 52 }: Te
       const n = r.signals?.length ?? 0;
       for (let i = 0; i < n; i++) timestamps.push(r.timestamp);
     }
-    return bucketize(timestamps, range, Date.now());
-  }, [runs, range]);
+    return bucketize(timestamps, range, nowMs);
+  }, [runs, range, nowMs]);
 
   const max = Math.max(1, ...buckets);
 
@@ -33,6 +51,7 @@ export function TemporalScrubber({ runs, range, onRangeChange, height = 52 }: Te
       <div className="font-mono text-[9px] font-bold uppercase tracking-widest" style={{ color: 'var(--text-faint)' }}>
         Signal volume
       </div>
+      <span className="font-mono text-[9px] tabular-nums" style={{ color: 'var(--text-faint)' }}>{RANGE_AGO_LABEL[range]}</span>
       <svg
         viewBox={`0 0 ${BUCKET_COUNT} 1`}
         preserveAspectRatio="none"
@@ -49,11 +68,12 @@ export function TemporalScrubber({ runs, range, onRangeChange, height = 52 }: Te
               width={0.8}
               height={Math.max(h, c > 0 ? 0.04 : 0)}
               fill="currentColor"
-              opacity={c === 0 ? 0.08 : 0.85}
+              opacity={c === 0 ? 0.15 : 0.85}
             />
           );
         })}
       </svg>
+      <span className="font-mono text-[9px] tabular-nums" style={{ color: 'var(--text-faint)' }}>now</span>
       <div className="flex gap-1">
         {RANGES.map((r) => {
           const active = r === range;
@@ -62,6 +82,7 @@ export function TemporalScrubber({ runs, range, onRangeChange, height = 52 }: Te
               key={r}
               type="button"
               onClick={() => onRangeChange(r)}
+              aria-pressed={active}
               className="rounded px-2 py-0.5 font-mono text-[10px] transition"
               style={{
                 background: active ? 'color-mix(in oklch, var(--accent) 10%, transparent)' : 'transparent',

--- a/packages/dashboard-v2/src/components/TemporalScrubber.tsx
+++ b/packages/dashboard-v2/src/components/TemporalScrubber.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from 'react';
+import { bucketize, BUCKET_COUNT } from '@/lib/histogram';
+import type { Range } from '@/lib/range-param';
+import type { ConsensusRun } from '@/lib/types';
+
+interface TemporalScrubberProps {
+  runs: ConsensusRun[];
+  range: Range;
+  onRangeChange: (r: Range) => void;
+  height?: number; // default 52, per spec
+}
+
+const RANGES: Range[] = ['1h', '24h', '7d', '30d'];
+
+export function TemporalScrubber({ runs, range, onRangeChange, height = 52 }: TemporalScrubberProps) {
+  const buckets = useMemo(() => {
+    // Each round contributes signals.length timestamps (using the round's ts).
+    const timestamps: string[] = [];
+    for (const r of runs) {
+      const n = r.signals?.length ?? 0;
+      for (let i = 0; i < n; i++) timestamps.push(r.timestamp);
+    }
+    return bucketize(timestamps, range, Date.now());
+  }, [runs, range]);
+
+  const max = Math.max(1, ...buckets);
+
+  return (
+    <div
+      className="flex items-center gap-3 rounded-md border px-3 py-2"
+      style={{ background: 'var(--surface-elev)', borderColor: 'var(--border)' }}
+    >
+      <div className="font-mono text-[9px] font-bold uppercase tracking-widest" style={{ color: 'var(--text-faint)' }}>
+        Signal volume
+      </div>
+      <svg
+        viewBox={`0 0 ${BUCKET_COUNT} 1`}
+        preserveAspectRatio="none"
+        style={{ flex: 1, height, color: 'var(--accent)' }}
+      >
+        {buckets.map((c, i) => {
+          const h = c === 0 ? 0 : (c / max);
+          const y = 1 - h;
+          return (
+            <rect
+              key={i}
+              x={i + 0.1}
+              y={y}
+              width={0.8}
+              height={Math.max(h, c > 0 ? 0.04 : 0)}
+              fill="currentColor"
+              opacity={c === 0 ? 0.08 : 0.85}
+            />
+          );
+        })}
+      </svg>
+      <div className="flex gap-1">
+        {RANGES.map((r) => {
+          const active = r === range;
+          return (
+            <button
+              key={r}
+              type="button"
+              onClick={() => onRangeChange(r)}
+              className="rounded px-2 py-0.5 font-mono text-[10px] transition"
+              style={{
+                background: active ? 'color-mix(in oklch, var(--accent) 10%, transparent)' : 'transparent',
+                color: active ? 'var(--accent)' : 'var(--text-dim)',
+                border: '1px solid',
+                borderColor: active ? 'color-mix(in oklch, var(--accent) 30%, transparent)' : 'transparent',
+              }}
+            >
+              {r}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -189,6 +189,12 @@ html[data-theme="dark"]::after {
   50%      { opacity: 0.55; transform: scale(0.9); }
 }
 
+/* Subtler pulse for NarrativeStripe — slower (2×beat), opacity-only, no scale. */
+@keyframes beat-pulse-narrative {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.72; }
+}
+
 /* Override Tailwind's animate-pulse on live-indicator elements to use the
    project-wide --beat cadence instead of the default 2s timing. */
 .animate-pulse {

--- a/packages/dashboard-v2/src/hooks/useGlobalAgentKeys.ts
+++ b/packages/dashboard-v2/src/hooks/useGlobalAgentKeys.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+import { navigate } from '@/lib/router';
+
+/**
+ * Global keyboard handler for the rail's currently-advertised shortcuts.
+ *   ⏎ — open dispatch log for the selected agent
+ *   G — view skill graph
+ *   ⌘D / Ctrl-D — dispatch consensus (no-op for now; visual hint only)
+ *
+ * Skips when focus is in an editable element so typing isn't hijacked.
+ */
+function isEditable(t: EventTarget | null): boolean {
+  if (!(t instanceof Element)) return false;
+  const tag = t.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  return (t as HTMLElement).isContentEditable === true;
+}
+
+export function useGlobalAgentKeys(selectedAgentId: string | null): void {
+  useEffect(() => {
+    if (!selectedAgentId) return;
+
+    function onKey(ev: KeyboardEvent) {
+      if (isEditable(ev.target)) return;
+
+      // ⌘D / Ctrl-D — claimed by browser bookmarks. Still hint for visual
+      // consistency with the rail's <kbd> label; the actual dispatch wiring
+      // is deferred (consensus dispatch needs a server-side hook).
+      if ((ev.metaKey || ev.ctrlKey) && (ev.key === 'd' || ev.key === 'D')) {
+        // Intentionally no preventDefault — let the browser keep bookmarks.
+        return;
+      }
+
+      // Bare key shortcuts — only act when no modifier is held.
+      if (ev.metaKey || ev.ctrlKey || ev.altKey) return;
+
+      if (ev.key === 'Enter') {
+        ev.preventDefault();
+        navigate('/agent/' + encodeURIComponent(selectedAgentId!));
+      } else if (ev.key === 'g' || ev.key === 'G') {
+        ev.preventDefault();
+        navigate('/agent/' + encodeURIComponent(selectedAgentId!) + '#skills');
+      }
+    }
+
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [selectedAgentId]);
+}

--- a/packages/dashboard-v2/src/hooks/useGlobalAgentKeys.ts
+++ b/packages/dashboard-v2/src/hooks/useGlobalAgentKeys.ts
@@ -9,11 +9,18 @@ import { navigate } from '@/lib/router';
  *
  * Skips when focus is in an editable element so typing isn't hijacked.
  */
+/** ARIA roles that imply text input on otherwise-non-editable elements. */
+const EDITABLE_ROLES = new Set(['textbox', 'combobox', 'listbox', 'spinbutton', 'searchbox']);
+
 function isEditable(t: EventTarget | null): boolean {
   if (!(t instanceof Element)) return false;
   const tag = t.tagName;
   if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
-  return (t as HTMLElement).isContentEditable === true;
+  if ((t as HTMLElement).isContentEditable === true) return true;
+  // Rich-text editors and custom widgets often render as <div role="textbox">
+  // with their own contenteditable management; respect their input contract.
+  const role = t.getAttribute('role');
+  return role !== null && EDITABLE_ROLES.has(role);
 }
 
 export function useGlobalAgentKeys(selectedAgentId: string | null): void {

--- a/packages/dashboard-v2/src/hooks/useUrlRangeParam.ts
+++ b/packages/dashboard-v2/src/hooks/useUrlRangeParam.ts
@@ -12,12 +12,20 @@ export function useUrlRangeParam(): readonly [Range, (r: Range | null) => void] 
   });
 
   useEffect(() => {
+    // Canonicalize on mount — write the default ?range=7d if absent so the
+    // URL is shareable from the first render (otherwise a freshly-loaded
+    // visitor's URL won't reflect their current range until they manually
+    // pick a different one).
+    if (typeof window !== 'undefined' && getRangeParam(window.location.search) === null) {
+      setRangeParam(r);
+    }
     const sync = () => {
       const next = typeof window === 'undefined' ? '7d' : (getRangeParam(window.location.search) ?? '7d');
       setR((prev) => (prev === next ? prev : next));
     };
     window.addEventListener('dashboard:navigate', sync as EventListener);
     return () => window.removeEventListener('dashboard:navigate', sync as EventListener);
+    // eslint-disable-next-line react-hooks/exhaustive-deps — `r` is captured intentionally on mount only
   }, []);
 
   return [r, setRangeParam] as const;

--- a/packages/dashboard-v2/src/hooks/useUrlRangeParam.ts
+++ b/packages/dashboard-v2/src/hooks/useUrlRangeParam.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { getRangeParam, setRangeParam, type Range } from '../lib/range-param';
+
+/**
+ * Mirror of useUrlAgentParam — bridges ?range= URL param to component state
+ * via the existing dashboard:navigate event. Default '7d' when param absent.
+ */
+export function useUrlRangeParam(): readonly [Range, (r: Range | null) => void] {
+  const [r, setR] = useState<Range>(() => {
+    if (typeof window === 'undefined') return '7d';
+    return getRangeParam(window.location.search) ?? '7d';
+  });
+
+  useEffect(() => {
+    const sync = () => {
+      const next = typeof window === 'undefined' ? '7d' : (getRangeParam(window.location.search) ?? '7d');
+      setR((prev) => (prev === next ? prev : next));
+    };
+    window.addEventListener('dashboard:navigate', sync as EventListener);
+    return () => window.removeEventListener('dashboard:navigate', sync as EventListener);
+  }, []);
+
+  return [r, setRangeParam] as const;
+}

--- a/packages/dashboard-v2/src/hooks/useWebSocket.ts
+++ b/packages/dashboard-v2/src/hooks/useWebSocket.ts
@@ -1,10 +1,24 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { connectWs, onEvent } from '@/lib/ws';
 import type { DashboardEvent } from '@/lib/types';
 
+/**
+ * Subscribe to dashboard WebSocket events. The handler is stored in a ref
+ * and called via a stable wrapper, so the underlying `onEvent` subscription
+ * is established ONCE per mount — not on every render. Callers can pass a
+ * fresh closure each render without causing subscription churn or stale-state
+ * races (e.g. event arriving in the window between setState and the next
+ * render). Reviewer-recommended pattern; replaces the previous `[handler]`
+ * dep array that thrashed the listener.
+ */
 export function useWebSocket(handler: (event: DashboardEvent) => void) {
+  const handlerRef = useRef(handler);
+  // Mirror the latest handler into the ref on every render. Cheap; no
+  // effect needed since this is a plain assignment.
+  handlerRef.current = handler;
+
   useEffect(() => {
     connectWs();
-    return onEvent(handler);
-  }, [handler]);
+    return onEvent((event) => handlerRef.current(event));
+  }, []);
 }

--- a/packages/dashboard-v2/src/lib/histogram.ts
+++ b/packages/dashboard-v2/src/lib/histogram.ts
@@ -1,0 +1,42 @@
+import type { Range } from './range-param';
+
+/** Number of buckets across the selected range. Locked by spec §TemporalScrubber. */
+export const BUCKET_COUNT = 24;
+
+const RANGE_MS: Record<Range, number> = {
+  '1h': 3600_000,
+  '24h': 24 * 3600_000,
+  '7d': 7 * 24 * 3600_000,
+  '30d': 30 * 24 * 3600_000,
+};
+
+export function rangeWindowMs(range: Range): number {
+  return RANGE_MS[range];
+}
+
+/**
+ * Bucketize a list of ISO timestamps into `BUCKET_COUNT` equal-width
+ * buckets ending at `now`. Returns counts per bucket, oldest first.
+ *
+ *   bucket[0]   = oldest slice (now - window  →  now - window + bucketMs)
+ *   bucket[23]  = newest slice (now - bucketMs → now)
+ *
+ * Pure function. Memoize at the caller.
+ */
+export function bucketize(timestamps: string[], range: Range, nowMs: number): number[] {
+  const window = rangeWindowMs(range);
+  const bucketMs = window / BUCKET_COUNT;
+  const start = nowMs - window;
+  const buckets = new Array<number>(BUCKET_COUNT).fill(0);
+
+  for (const iso of timestamps) {
+    const t = new Date(iso).getTime();
+    if (!Number.isFinite(t)) continue;
+    if (t < start || t > nowMs) continue;
+    const offset = t - start;
+    let idx = Math.floor(offset / bucketMs);
+    if (idx >= BUCKET_COUNT) idx = BUCKET_COUNT - 1; // include the boundary
+    buckets[idx] += 1;
+  }
+  return buckets;
+}

--- a/packages/dashboard-v2/src/lib/range-param.ts
+++ b/packages/dashboard-v2/src/lib/range-param.ts
@@ -1,0 +1,31 @@
+export type Range = '1h' | '24h' | '7d' | '30d';
+
+const VALID: ReadonlyArray<Range> = ['1h', '24h', '7d', '30d'];
+
+export function isRange(v: unknown): v is Range {
+  return typeof v === 'string' && (VALID as readonly string[]).includes(v);
+}
+
+export function getRangeParam(search: string): Range | null {
+  const raw = new URLSearchParams(search).get('range');
+  return isRange(raw) ? raw : null;
+}
+
+export function buildUrlWithRange(pathname: string, search: string, range: Range | null): string {
+  const params = new URLSearchParams(search);
+  if (range === null) params.delete('range');
+  else params.set('range', range);
+  const qs = params.toString();
+  return qs.length > 0 ? `${pathname}?${qs}` : pathname;
+}
+
+export function setRangeParam(range: Range | null): void {
+  const g = globalThis as unknown as { window?: { location: { pathname: string; search: string }; history: { pushState: (...a: unknown[]) => void }; dispatchEvent: (e: Event) => void } };
+  if (!g.window) return;
+  const w = g.window;
+  const url = buildUrlWithRange(w.location.pathname, w.location.search, range);
+  if (url !== w.location.pathname + w.location.search) {
+    w.history.pushState({}, '', url);
+    w.dispatchEvent(new Event('dashboard:navigate'));
+  }
+}

--- a/packages/dashboard-v2/src/pages/OverviewPage.tsx
+++ b/packages/dashboard-v2/src/pages/OverviewPage.tsx
@@ -5,8 +5,12 @@ import { TasksSection } from '@/components/TasksSection';
 import { RecentSignalsPeek } from '@/components/RecentSignalsPeek';
 import { AgentNetworkGraph } from '@/components/AgentNetworkGraph';
 import { GraphRail } from '@/components/GraphRail';
+import { NarrativeStripe } from '@/components/NarrativeStripe';
+import { TemporalScrubber } from '@/components/TemporalScrubber';
 import { usePeerRelationships } from '@/hooks/usePeerRelationships';
 import { useUrlAgentParam } from '@/hooks/useUrlAgentParam';
+import { useUrlRangeParam } from '@/hooks/useUrlRangeParam';
+import { useGlobalAgentKeys } from '@/hooks/useGlobalAgentKeys';
 import { isGraphBeta } from '@/lib/feature-flags';
 import { href } from '@/lib/router';
 import type { OverviewData, AgentData, TasksData, ConsensusData } from '@/lib/types';
@@ -41,28 +45,37 @@ export function OverviewPage({
   const peerRelationships = usePeerRelationships(consensus?.runs);
   // Phase 1b PR4 — selection state moved to ?agent= URL param for deep-linking.
   const [selectedAgentId, setSelectedAgentId] = useUrlAgentParam();
+  // Phase 1b PR5 — ?range= for TemporalScrubber + global ⏎/G shortcuts.
+  const [range, setRange] = useUrlRangeParam();
+  useGlobalAgentKeys(selectedAgentId);
   const selectedAgent = agents && selectedAgentId
     ? agents.find((a) => a.id === selectedAgentId) ?? null
     : null;
 
   return (
     <div className="mx-auto max-w-5xl space-y-8">
-      {/* Phase 1b PR3+PR4 — AgentNetworkGraph + GraphRail side-by-side behind ?graph=1. */}
+      {/* Phase 1b PR3+PR4+PR5 — Graph + Rail + NarrativeStripe + TemporalScrubber, all behind ?graph=1. */}
       {showGraph && agents && (
-        <div className="flex gap-3">
-          <div className="min-w-0 flex-1">
-            <AgentNetworkGraph
+        <div className="space-y-3">
+          <NarrativeStripe />
+          <div className="flex gap-3">
+            <div className="min-w-0 flex-1">
+              <AgentNetworkGraph
+                agents={agents}
+                peerRelationships={peerRelationships}
+                selectedAgentId={selectedAgentId}
+                onSelectAgent={setSelectedAgentId}
+              />
+            </div>
+            <GraphRail
+              selectedAgent={selectedAgent}
               agents={agents}
               peerRelationships={peerRelationships}
-              selectedAgentId={selectedAgentId}
-              onSelectAgent={setSelectedAgentId}
             />
           </div>
-          <GraphRail
-            selectedAgent={selectedAgent}
-            agents={agents}
-            peerRelationships={peerRelationships}
-          />
+          {consensus && (
+            <TemporalScrubber runs={consensus.runs} range={range} onRangeChange={setRange} />
+          )}
         </div>
       )}
       {/* Page header */}

--- a/tests/dashboard/histogram.test.ts
+++ b/tests/dashboard/histogram.test.ts
@@ -61,4 +61,34 @@ describe('bucketize', () => {
     const total = buckets.reduce((a, b) => a + b, 0);
     expect(total).toBeLessThanOrEqual(1);
   });
+
+  // --- Boundary cases added per PR #458 sonnet-reviewer consensus ---
+
+  it('includes a timestamp exactly at nowMs (right boundary, clamped to last bucket)', () => {
+    const now = new Date('2026-05-23T12:00:00Z').getTime();
+    const buckets = bucketize([new Date(now).toISOString()], '24h', now);
+    expect(buckets[23]).toBe(1);
+    expect(buckets.slice(0, 23).every((b) => b === 0)).toBe(true);
+  });
+
+  it('includes a timestamp exactly at start (oldest boundary, lands in bucket 0)', () => {
+    const now = new Date('2026-05-23T12:00:00Z').getTime();
+    const start = now - 24 * 3600_000;
+    const buckets = bucketize([new Date(start).toISOString()], '24h', now);
+    expect(buckets[0]).toBe(1);
+    expect(buckets.slice(1).every((b) => b === 0)).toBe(true);
+  });
+
+  it('excludes a timestamp one ms after nowMs', () => {
+    const now = new Date('2026-05-23T12:00:00Z').getTime();
+    const buckets = bucketize([new Date(now + 1).toISOString()], '24h', now);
+    expect(buckets.every((b) => b === 0)).toBe(true);
+  });
+
+  it('excludes a timestamp one ms before start', () => {
+    const now = new Date('2026-05-23T12:00:00Z').getTime();
+    const start = now - 24 * 3600_000;
+    const buckets = bucketize([new Date(start - 1).toISOString()], '24h', now);
+    expect(buckets.every((b) => b === 0)).toBe(true);
+  });
 });

--- a/tests/dashboard/histogram.test.ts
+++ b/tests/dashboard/histogram.test.ts
@@ -1,0 +1,64 @@
+import { bucketize, rangeWindowMs, BUCKET_COUNT } from '../../packages/dashboard-v2/src/lib/histogram';
+
+describe('rangeWindowMs', () => {
+  it('returns the window duration in ms for each range', () => {
+    expect(rangeWindowMs('1h')).toBe(3600_000);
+    expect(rangeWindowMs('24h')).toBe(24 * 3600_000);
+    expect(rangeWindowMs('7d')).toBe(7 * 24 * 3600_000);
+    expect(rangeWindowMs('30d')).toBe(30 * 24 * 3600_000);
+  });
+});
+
+describe('BUCKET_COUNT', () => {
+  it('is 24 (locked by spec)', () => {
+    expect(BUCKET_COUNT).toBe(24);
+  });
+});
+
+describe('bucketize', () => {
+  it('returns an array of length 24 even for empty input', () => {
+    const buckets = bucketize([], '1h', Date.now());
+    expect(buckets).toHaveLength(24);
+    expect(buckets.every((b) => b === 0)).toBe(true);
+  });
+
+  it('places a single timestamp in the correct bucket', () => {
+    const now = new Date('2026-05-23T12:00:00Z').getTime();
+    const oneHourAgo = new Date('2026-05-23T11:00:00Z').getTime();
+    // 1h range, 24 buckets = 2.5 min each. The timestamp at exactly 60 min ago
+    // belongs in bucket 0 (oldest), the timestamp at "now" is at the newest end.
+    const buckets = bucketize([new Date(oneHourAgo).toISOString()], '1h', now);
+    expect(buckets).toHaveLength(24);
+    expect(buckets[0]).toBe(1);
+    expect(buckets.slice(1).every((b) => b === 0)).toBe(true);
+  });
+
+  it('places a "now" timestamp in the last bucket', () => {
+    const now = Date.now();
+    const buckets = bucketize([new Date(now - 1).toISOString()], '24h', now);
+    expect(buckets[23]).toBe(1);
+  });
+
+  it('skips timestamps outside the window', () => {
+    const now = new Date('2026-05-23T12:00:00Z').getTime();
+    const twoDaysAgo = new Date('2026-05-21T12:00:00Z').getTime();
+    const buckets = bucketize([new Date(twoDaysAgo).toISOString()], '24h', now);
+    expect(buckets.every((b) => b === 0)).toBe(true);
+  });
+
+  it('accumulates multiple timestamps in the same bucket', () => {
+    const now = new Date('2026-05-23T12:00:00Z').getTime();
+    const t = new Date('2026-05-23T11:55:00Z').toISOString();
+    const buckets = bucketize([t, t, t], '1h', now);
+    const total = buckets.reduce((a, b) => a + b, 0);
+    expect(total).toBe(3);
+  });
+
+  it('ignores invalid timestamps without throwing', () => {
+    const now = Date.now();
+    const buckets = bucketize(['not-a-date', '', '2026-05-23T12:00:00Z'], '24h', now);
+    expect(buckets).toHaveLength(24);
+    const total = buckets.reduce((a, b) => a + b, 0);
+    expect(total).toBeLessThanOrEqual(1);
+  });
+});

--- a/tests/dashboard/range-param.test.ts
+++ b/tests/dashboard/range-param.test.ts
@@ -1,0 +1,49 @@
+import { getRangeParam, buildUrlWithRange, isRange } from '../../packages/dashboard-v2/src/lib/range-param';
+
+describe('isRange', () => {
+  it('accepts known values', () => {
+    expect(isRange('1h')).toBe(true);
+    expect(isRange('24h')).toBe(true);
+    expect(isRange('7d')).toBe(true);
+    expect(isRange('30d')).toBe(true);
+  });
+  it('rejects unknown values', () => {
+    expect(isRange('')).toBe(false);
+    expect(isRange('5h')).toBe(false);
+    expect(isRange('1d')).toBe(false);
+    expect(isRange(null as any)).toBe(false);
+  });
+});
+
+describe('getRangeParam', () => {
+  it('returns null when ?range= is absent', () => {
+    expect(getRangeParam('')).toBeNull();
+    expect(getRangeParam('?other=x')).toBeNull();
+  });
+  it('returns the value when present and valid', () => {
+    expect(getRangeParam('?range=24h')).toBe('24h');
+    expect(getRangeParam('?graph=1&range=30d')).toBe('30d');
+  });
+  it('returns null for an invalid value', () => {
+    expect(getRangeParam('?range=garbage')).toBeNull();
+    expect(getRangeParam('?range=5h')).toBeNull();
+  });
+});
+
+describe('buildUrlWithRange', () => {
+  it('adds ?range=… when none present', () => {
+    expect(buildUrlWithRange('/dashboard/', '', '24h')).toBe('/dashboard/?range=24h');
+  });
+  it('replaces existing range param', () => {
+    expect(buildUrlWithRange('/dashboard/', '?range=7d&graph=1', '24h'))
+      .toBe('/dashboard/?range=24h&graph=1');
+  });
+  it('removes the param when value is null (default range)', () => {
+    expect(buildUrlWithRange('/dashboard/', '?range=24h&graph=1', null))
+      .toBe('/dashboard/?graph=1');
+  });
+  it('preserves all other params', () => {
+    expect(buildUrlWithRange('/dashboard/', '?agent=opus&graph=1', '1h'))
+      .toBe('/dashboard/?agent=opus&graph=1&range=1h');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1b PR 5 of 6 — finishes the BloodHound-style Overview before PR6's flag flip. Three connected pieces, all behind `?graph=1`:

1. **NarrativeStripe** — thin live-update strip that appears when consensus rounds are in flight. Pulses at 2×beat (3.2s). Subscribes to existing `useWebSocket`. Auto-hides on `consensus_complete` for matching `taskId` or after a 60s safety timeout.
2. **TemporalScrubber** — static signal-volume histogram with 4 range pills (1h / 24h / 7d / 30d). Always 24 buckets across the range. State backed by `?range=` URL param (default `7d`). No replay, no playhead — deferred per spec §7.
3. **Global keyboard shortcuts** — `⏎` opens dispatch log, `G` opens skill graph for the selected agent. `⌘D` left as visual hint only (browser bookmarks own the chord; consensus dispatch wiring would need a server-side hook).

Combined with PR4 the URL is now fully deep-linkable: `?graph=1&agent=<id>&range=24h` round-trips through reload and back/forward.

**Spec:** `docs/superpowers/specs/2026-05-22-dashboard-redesign-phase1b-agent-network-graph-design.md` §"Components — NarrativeStripe", §"TemporalScrubber", §"4. Selection + scrubber state"
**Plan:** `docs/superpowers/plans/2026-05-23-dashboard-phase1b-pr5-narrative-scrubber-keys.md`

## What changed

7 commits, 8 files, ~440 LOC + 17 new tests:

| Commit | Files | What |
|---|---|---|
| `963bba6` | `lib/range-param.ts` (new) + test (9) | Pure `getRangeParam` / `buildUrlWithRange` / `setRangeParam` |
| `074d99d` | `hooks/useUrlRangeParam.ts` (new) | React hook mirror of `useUrlAgentParam`; default `'7d'` |
| `db513f5` | `lib/histogram.ts` (new) + test (8) | Pure `bucketize(timestamps, range, now)` → `number[24]` |
| `7a4be5d` | `components/NarrativeStripe.tsx` (new) | Live consensus-round indicator with 60s safety timeout |
| `cf4d080` | `components/TemporalScrubber.tsx` (new) | SVG histogram + range pills |
| `4607382` | `hooks/useGlobalAgentKeys.ts` (new) | `document` keydown listener; skips editable elements |
| `6f70db7` | `OverviewPage.tsx` | Wire all four pieces (stripe above graph, scrubber below, hook side-effect, range state) |

## Locked decisions (from spec)

- **24 buckets always** across the selected range (1h → 2.5min, 24h → 1h, 7d → 7h, 30d → 30h)
- **Pulse cadence:** 2 × `--beat` = 3.2s (spec rejected the original 1.5×beat as unlisted)
- **60s safety timeout** on NarrativeStripe so it auto-hides if `consensus_complete` never arrives (e.g., agent died)
- **⌘D no-op** — visual hint only; browser bookmarks own that chord
- **Skip editable focus** — `<input>`, `<textarea>`, `<select>`, `[contenteditable]` don't trigger global keys

## Bundle delta

`407.09 KB → 411.93 KB` (+4.8 KB raw / +1.3 KB gzipped) — 3 components + 2 hooks + 1 pure module.

## Test plan

- [x] `npx jest tests/dashboard/range-param.test.ts tests/dashboard/histogram.test.ts` — `Tests: 17 passed, 17 total`
- [x] All dashboard tests still green (149 total across 14 suites)
- [x] `cd packages/dashboard-v2 && npx tsc --noEmit -p tsconfig.json` — zero errors
- [x] `npx vite build` — clean, 676ms
- [x] Live smoke at `http://localhost:63007/dashboard/?graph=1` — stripe hidden (no active task), scrubber visible with bars + 4 range pills, default range `7d`
- [x] Click `24h` → URL becomes `?graph=1&range=24h`, scrubber updates
- [x] Select agent + press `⏎` → navigates to `/dashboard/agent/<id>`; browser back returns with full state preserved
- [x] Flag-off (`/dashboard/`) byte-identical to post-PR4 Overview
- [ ] **Reviewer:** NarrativeStripe lifecycle (websocket cleanup, 60s timeout cancellation on unmount, race on rapid `task_dispatched`)
- [ ] **Reviewer:** `useGlobalAgentKeys` cleanup, editable-focus skip behavior
- [ ] **Reviewer:** `bucketize` boundary precision (range edges, invalid timestamps)
- [ ] **Designer:** stripe pulse cadence + scrubber readability at all 4 ranges

## Out of scope (PR6 / future)

- Flag flip — replace default Overview layout (PR6)
- Per-round drill-in on NarrativeStripe click (deferred)
- Temporal replay / playhead (spec defers explicitly to Phase 2)
- `⌘D` consensus-dispatch wiring (needs server-side hook)
- "Weekly trends" historical-delta data in GraphRail (deferred from PR4)

## Phase 1b PR series

| PR | Focus | Status |
|---|---|---|
| 1 | `usePeerRelationships` + `PeerRelationship` type | ✅ Merged (`a4db0e3`) |
| 2 | Shared `AnimationScheduler` + NeuralAvatar migration | ✅ Merged (`3b2ca4d`) |
| 3 | `AgentNetworkGraph` (feature-flagged) | ✅ Merged (`1556fe9`) |
| 4 | `GraphRail` + URL-hash selection | ✅ Merged (`fc2e02c`) |
| 5 (this) | NarrativeStripe + TemporalScrubber + global keys | **In review** |
| 6 | Flag flip — replace default Overview | Next |

🤖 Generated with [Claude Code](https://claude.com/claude-code)