### PR TITLE
feat(dashboard-v2): Phase 1b PR6 — flag flip, graph as default Overview

### DIFF
--- a/packages/dashboard-v2/src/lib/feature-flags.ts
+++ b/packages/dashboard-v2/src/lib/feature-flags.ts
@@ -1,14 +1,18 @@
 /**
- * Feature flag util — Phase 1b PR3 ships the AgentNetworkGraph behind
- * `?graph=1`. No localStorage persistence: opt-in per session keeps the
- * blast radius small while the component is in beta.
+ * Feature flag util.
  *
+ * Phase 1b PR3 introduced `?graph=1` as opt-IN for the AgentNetworkGraph beta.
+ * Phase 1b PR6 flipped the default: the graph layout is now standard, and
+ * `?graph=0` is the opt-OUT escape hatch for anyone who wants only the legacy
+ * calm widgets.
+ *
+ * Returns true when the user has explicitly opted OUT of the graph.
  * Pass `window.location.search` as the argument (or omit to use it
  * automatically when called from a browser context).
  */
-export function isGraphBeta(search?: string): boolean {
+export function isGraphHidden(search?: string): boolean {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const win = (globalThis as any).window as { location: { search: string } } | undefined;
   const s = search ?? (win != null ? win.location.search : '');
-  return new URLSearchParams(s).get('graph') === '1';
+  return new URLSearchParams(s).get('graph') === '0';
 }

--- a/packages/dashboard-v2/src/pages/OverviewPage.tsx
+++ b/packages/dashboard-v2/src/pages/OverviewPage.tsx
@@ -11,7 +11,7 @@ import { usePeerRelationships } from '@/hooks/usePeerRelationships';
 import { useUrlAgentParam } from '@/hooks/useUrlAgentParam';
 import { useUrlRangeParam } from '@/hooks/useUrlRangeParam';
 import { useGlobalAgentKeys } from '@/hooks/useGlobalAgentKeys';
-import { isGraphBeta } from '@/lib/feature-flags';
+import { isGraphHidden } from '@/lib/feature-flags';
 import { href } from '@/lib/router';
 import type { OverviewData, AgentData, TasksData, ConsensusData } from '@/lib/types';
 
@@ -19,7 +19,7 @@ interface OverviewPageProps {
   overview: OverviewData;
   agents: AgentData[] | null;
   tasks: TasksData | null;
-  /** Optional — only consumed by the ?graph=1 beta to derive peer relationships. */
+  /** Optional — consumed by the graph layer to derive peer relationships. */
   consensus?: ConsensusData | null;
   activeTaskCount: number;
   setActiveTaskCount: (n: number) => void;
@@ -41,7 +41,7 @@ export function OverviewPage({
   setActiveTaskCount,
 }: OverviewPageProps) {
   const actionable = overview.actionableFindings;
-  const showGraph = isGraphBeta();
+  const hideGraph = isGraphHidden();
   const peerRelationships = usePeerRelationships(consensus?.runs);
   // Phase 1b PR4 — selection state moved to ?agent= URL param for deep-linking.
   const [selectedAgentId, setSelectedAgentId] = useUrlAgentParam();
@@ -54,8 +54,10 @@ export function OverviewPage({
 
   return (
     <div className="mx-auto max-w-5xl space-y-8">
-      {/* Phase 1b PR3+PR4+PR5 — Graph + Rail + NarrativeStripe + TemporalScrubber, all behind ?graph=1. */}
-      {showGraph && agents && (
+      {/* Phase 1b PRs 3-6 — Graph + Rail + NarrativeStripe + TemporalScrubber.
+          Shown by default; ?graph=0 opts out (escape hatch to the legacy
+          calm-widgets-only layout below). */}
+      {!hideGraph && agents && (
         <div className="space-y-3">
           <NarrativeStripe />
           <div className="flex gap-3">
@@ -124,7 +126,7 @@ export function OverviewPage({
       <ActiveTasksBanner onCountChange={setActiveTaskCount} />
 
       {/* Top-4 agents — echoes the AgentNetworkGraph selection when the graph is on */}
-      {agents && <TeamHero agents={agents} highlightedAgentId={showGraph ? selectedAgentId : null} />}
+      {agents && <TeamHero agents={agents} highlightedAgentId={!hideGraph ? selectedAgentId : null} />}
 
       {/* Recent dispatches — limit 3 (vs dense view's 5) */}
       {tasks && <TasksSection tasks={tasks} limit={3} />}

--- a/tests/dashboard/feature-flags.test.ts
+++ b/tests/dashboard/feature-flags.test.ts
@@ -1,16 +1,25 @@
-import { isGraphBeta } from '../../packages/dashboard-v2/src/lib/feature-flags';
+import { isGraphHidden } from '../../packages/dashboard-v2/src/lib/feature-flags';
 
-describe('isGraphBeta', () => {
-  it('returns true when ?graph=1 is in the search string', () => {
-    expect(isGraphBeta('?graph=1')).toBe(true);
-    expect(isGraphBeta('?graph=1&other=x')).toBe(true);
-    expect(isGraphBeta('?other=x&graph=1')).toBe(true);
+describe('isGraphHidden', () => {
+  it('returns true when ?graph=0 is in the search string (explicit opt-out)', () => {
+    expect(isGraphHidden('?graph=0')).toBe(true);
+    expect(isGraphHidden('?graph=0&other=x')).toBe(true);
+    expect(isGraphHidden('?other=x&graph=0')).toBe(true);
   });
-  it('returns false when ?graph= is absent or set to anything but 1', () => {
-    expect(isGraphBeta('')).toBe(false);
-    expect(isGraphBeta('?')).toBe(false);
-    expect(isGraphBeta('?graph=0')).toBe(false);
-    expect(isGraphBeta('?graph=true')).toBe(false);
-    expect(isGraphBeta('?other=x')).toBe(false);
+
+  it('returns false when ?graph= is absent (default: graph shown)', () => {
+    expect(isGraphHidden('')).toBe(false);
+    expect(isGraphHidden('?')).toBe(false);
+    expect(isGraphHidden('?other=x')).toBe(false);
+  });
+
+  it('returns false for legacy ?graph=1 bookmarks (still shows graph)', () => {
+    expect(isGraphHidden('?graph=1')).toBe(false);
+  });
+
+  it('returns false for any value other than 0', () => {
+    expect(isGraphHidden('?graph=true')).toBe(false);
+    expect(isGraphHidden('?graph=false')).toBe(false);
+    expect(isGraphHidden('?graph=')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

**The last PR of Phase 1b.** Flips the `?graph=` feature flag from opt-in to opt-out:

- **Before:** `?graph=1` shows the graph (opt-in beta, default off)
- **After:** default shows the graph; `?graph=0` hides it (opt-out escape hatch)

This is a single semantic flip — no new code, no deleted widgets, no migration. The legacy calm widgets continue to render below the graph in the default view. `?graph=0` hides the graph block and renders just the legacy widgets — byte-identical to the post-Phase-1a Overview.

**Spec:** `docs/superpowers/specs/2026-05-22-dashboard-redesign-phase1b-agent-network-graph-design.md` §"Implementation outline — PR 6"
**Plan:** `docs/superpowers/plans/2026-05-23-dashboard-phase1b-pr6-flag-flip.md`

## Spec deviation (documented)

Spec said "Old `SystemPulse` / `TeamHero` / etc. become available at `?expert=1` only." Phase 1a removed Expert View entirely, so we can't push the legacy widgets there. The chosen substitute: `?graph=0` becomes the calm-only escape hatch. Existing widgets stay visible below the graph in the default view (no widget was deleted).

## Legacy-URL compat

Anyone who bookmarked `?graph=1` during the beta still gets the graph — `isGraphHidden` checks for `"0"` specifically, not for "absence-or-non-1." No 404, no surprise.

## What changed

2 commits, 3 files, ~20 LOC:

| Commit | File | What |
|---|---|---|
| `<sha1>` | `lib/feature-flags.ts` + test | Rename + invert: `isGraphBeta` → `isGraphHidden` |
| `<sha2>` | `pages/OverviewPage.tsx` | `showGraph` → `hideGraph`, flip JSX guard, refresh comment |

## Bundle delta

`412.72 KB → 412.72 KB` (no change). Pure semantic flip.

## Test plan

- [x] `npx jest tests/dashboard/feature-flags.test.ts` — `Tests: 4 passed, 4 total`
- [x] All dashboard tests still green (155 total across 14 suites)
- [x] `cd packages/dashboard-v2 && npx tsc --noEmit -p tsconfig.json` — zero errors
- [x] `npx vite build` — clean, 715ms
- [x] Live smoke at `http://localhost:63007/dashboard/` — graph + rail + scrubber visible by default, URL has no `?graph=`
- [x] `http://localhost:63007/dashboard/?graph=0` — graph hidden, legacy widgets only
- [x] `http://localhost:63007/dashboard/?graph=1` — graph still shows (legacy bookmark compat)
- [ ] **Reviewer:** verify the inverted-flag semantics — `?graph=0` → hidden, any other state → shown
- [ ] **Designer:** at default load, is graph-first the right page weight? Or should we keep the calm widgets above for first-time visitors?

## Phase 1b PR series — COMPLETE

| PR | Focus | Status |
|---|---|---|
| 1 | `usePeerRelationships` + `PeerRelationship` type | ✅ Merged (`a4db0e3`) |
| 2 | Shared `AnimationScheduler` + NeuralAvatar migration | ✅ Merged (`3b2ca4d`) |
| 3 | `AgentNetworkGraph` (feature-flagged) | ✅ Merged (`1556fe9`) |
| 4 | `GraphRail` + `?agent=` URL selection | ✅ Merged (`fc2e02c`) |
| 5 | NarrativeStripe + TemporalScrubber + global keys | ✅ Merged (`19e3a62`) |
| 6 (this) | Flag flip — graph as default | **In review** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)