### PR TITLE
Phase 1b.2: stop 5s reflow + full agent labels + edge legibility

### DIFF
--- a/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
+++ b/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
@@ -256,11 +256,7 @@ function ForceGraphInner({
         const size = sizeFor(n.agent.scores.signals);
         const isSelected = n.id === selectedAgentId;
         const isDimmed = selectedAgentId != null && !isSelected;
-        // Strip the redundant agent_type suffix from common ids (e.g.
-        // "sonnet-reviewer" → "reviewer") since the avatar color already
-        // encodes the provider. Falls through to the full id otherwise.
-        const labelParts = n.agent.id.split('-');
-        const label = labelParts.length > 1 ? labelParts.slice(1).join('-') : n.agent.id;
+        const label = n.agent.id;
         return (
           <button
             key={n.id}

--- a/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
+++ b/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
@@ -213,7 +213,12 @@ function ForceGraphInner({
           const cy = my + ny * 20;
           const d = `M ${sx},${sy} Q ${cx},${cy} ${tx},${ty}`;
           const stroke = l.cls === 'trust' ? 'var(--success)' : l.cls === 'mixed' ? 'var(--warn)' : 'var(--danger)';
-          const dash = l.cls === 'catch' ? '5,3' : l.cls === 'mixed' ? '8,2' : undefined;
+          // Catch (red) is now solid — the strong --danger color carries the
+          // signal on its own, and dropping the dash makes it visually distinct
+          // from mixed (amber dashed). Previous "5,3 vs 8,2" dash pattern read
+          // as the same broken line at the eye-level distances users actually
+          // scan from.
+          const dash = l.cls === 'mixed' ? '8,2' : undefined;
           // Edge opacity is theme-aware via --edge-opacity-* tokens — light
           // mode needs a higher floor (0.70) than dark (0.55) to clear WCAG
           // 1.4.11 for the deeper cream-mode stroke colors. Tokens override
@@ -244,36 +249,58 @@ function ForceGraphInner({
       >
         <LegendRow stroke="var(--success)" label="Trust" />
         <LegendRow stroke="var(--warn)" label="Mixed" dash="8,2" />
-        <LegendRow stroke="var(--danger)" label="Caught" dash="5,3" />
+        <LegendRow stroke="var(--danger)" label="Caught" />
       </div>
       {nodes.map((n) => {
         if (n.x == null || n.y == null) return null;
         const size = sizeFor(n.agent.scores.signals);
         const isSelected = n.id === selectedAgentId;
         const isDimmed = selectedAgentId != null && !isSelected;
+        // Strip the redundant agent_type suffix from common ids (e.g.
+        // "sonnet-reviewer" → "reviewer") since the avatar color already
+        // encodes the provider. Falls through to the full id otherwise.
+        const labelParts = n.agent.id.split('-');
+        const label = labelParts.length > 1 ? labelParts.slice(1).join('-') : n.agent.id;
         return (
           <button
             key={n.id}
             type="button"
             onClick={(ev) => { ev.stopPropagation(); onSelectAgent(n.id); }}
-            className="absolute -translate-x-1/2 -translate-y-1/2 rounded-full transition"
+            className="absolute -translate-x-1/2 -translate-y-1/2 transition"
             style={{
-              left: n.x, top: n.y, width: size, height: size,
+              left: n.x, top: n.y,
               opacity: isDimmed ? 0.4 : 1,
-              boxShadow: isSelected ? `0 0 0 3px var(--accent)` : undefined,
               border: 'none', background: 'transparent', padding: 0, cursor: 'pointer',
             }}
             aria-label={`Select agent ${n.agent.id}`}
             title={n.agent.id}
           >
-            <NeuralAvatar
-              agentId={n.agent.id}
-              signals={n.agent.scores.signals}
-              accuracy={n.agent.scores.accuracy}
-              uniqueness={n.agent.scores.uniqueness}
-              impact={n.agent.scores.impactScore}
-              size={size}
-            />
+            <div
+              className="rounded-full"
+              style={{
+                width: size, height: size,
+                boxShadow: isSelected ? `0 0 0 3px var(--accent)` : undefined,
+              }}
+            >
+              <NeuralAvatar
+                agentId={n.agent.id}
+                signals={n.agent.scores.signals}
+                accuracy={n.agent.scores.accuracy}
+                uniqueness={n.agent.scores.uniqueness}
+                impact={n.agent.scores.impactScore}
+                size={size}
+              />
+            </div>
+            <div
+              className="mt-1 font-mono text-[10px] font-bold uppercase tracking-wider"
+              style={{
+                color: isSelected ? 'var(--text)' : 'var(--stage-text-dim)',
+                textAlign: 'center',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {label}
+            </div>
           </button>
         );
       })}

--- a/packages/dashboard-v2/src/hooks/usePeerRelationships.ts
+++ b/packages/dashboard-v2/src/hooks/usePeerRelationships.ts
@@ -1,24 +1,43 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { aggregatePeerRelationships } from '../lib/peer-relationships';
 import type { ConsensusRun, PeerRelationshipMap } from '../lib/types';
 
 /**
- * Memoized client-side aggregator: derives the peer-pair relationship Map
- * from the already-fetched consensus runs. Recomputes on every render where
- * the `runs` array reference changes.
+ * Stable structural fingerprint of a PeerRelationshipMap — same content
+ * always hashes to the same string regardless of insertion order.
+ */
+function fingerprint(map: PeerRelationshipMap): string {
+  const parts: string[] = [];
+  for (const [k, v] of map.entries()) {
+    parts.push(`${k}:${v.rounds}:${v.confirmed}:${v.disputed}:${v.hallucinationsCaught}`);
+  }
+  parts.sort();
+  return parts.join('|');
+}
+
+/**
+ * Memoized client-side aggregator with *structural* stability: the returned
+ * Map reference only changes when aggregated content actually changes.
  *
- * NOTE on memo effectiveness: `useDashboardData` produces a fresh `runs`
- * reference on every 5s poll (JSON.parse → new array), so this memo rarely
- * hits in practice. The aggregator is O(N × signals_per_round) — at the
- * current pageSize=500 cap that's ≤16ms per recompute, well within frame
- * budget. If the perf surfaces in Phase 1b PRs 3-6, add a structural-equality
- * stabilizer (hash of `lastConsensusTimestamp + totalSignals`) in
- * `useDashboardData` rather than complicating this hook.
+ * Why: `useDashboardData` produces a fresh `runs` array reference on every
+ * 5s poll (JSON.parse → new array). Without the fingerprint cache, every
+ * poll yielded a new map reference even when no peer-relationship fact had
+ * changed — AgentNetworkGraph's force-simulation useEffect would tear down
+ * and rebuild on every poll, visible as nodes "jumping" every 5 seconds.
  *
  * Powers Phase 1b's AgentNetworkGraph edge encoding. See spec
  * `docs/superpowers/specs/2026-05-22-dashboard-redesign-phase1b-agent-network-graph-design.md`
  * §"Peer-relationship data".
  */
 export function usePeerRelationships(runs: ConsensusRun[] | undefined): PeerRelationshipMap {
-  return useMemo(() => aggregatePeerRelationships(runs ?? []), [runs]);
+  const lastFingerprint = useRef<string>('');
+  const lastMap = useRef<PeerRelationshipMap>(new Map());
+  return useMemo(() => {
+    const next = aggregatePeerRelationships(runs ?? []);
+    const fp = fingerprint(next);
+    if (fp === lastFingerprint.current) return lastMap.current;
+    lastFingerprint.current = fp;
+    lastMap.current = next;
+    return next;
+  }, [runs]);
 }


### PR DESCRIPTION
## Summary

Three small visual fixes to `AgentNetworkGraph` based on user feedback after Phase 1b.1 (#460) landed:

1. **Stop the 5s graph reflow.** `usePeerRelationships` returned a fresh `Map` reference on every `useDashboardData` 5s poll → AgentNetworkGraph's force-simulation `useEffect` tore down and rebuilt every poll → nodes "jumped" to new positions every 5 seconds (the unprofessional jitter). Added a structural fingerprint of the aggregated map + `useRef` cache: same Map reference is returned across polls unless a peer-relationship fact actually changed.

2. **Full agent name labels under avatars.** Each `NeuralAvatar` now shows the full agent id (`sonnet-reviewer`, `opus-implementer`) below it in monospace 10px. Selected nodes use `--text`; others use `--stage-text-dim` so labels recede until scanned.

3. **Mixed vs caught edge differentiation.** Previous `5,3` (catch) vs `8,2` (mixed) dash patterns read identically at eye-level. Catch is now solid red — strong `--danger` color carries the signal; mixed stays dashed amber. Legend updated.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vite build` clean (+~0.5KB JS for the label + fingerprint)
- [x] `jest tests/dashboard/usePeerRelationships.test.ts tests/dashboard/peer-relationships.test.ts` — 19/19 pass (fingerprint stabilizer doesn't alter aggregator output, just memoization)
- [ ] Visual smoke at `/dashboard/` — confirm graph no longer reflows on 5s tick
- [ ] Verify full agent id visible beneath each avatar
- [ ] Verify catch edges read as solid red, mixed as dashed amber

🤖 Generated with [Claude Code](https://claude.com/claude-code)