### PR TITLE
Phase 1c: hub-and-spoke graph redesign (drop d3-force)

### DIFF
--- a/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
+++ b/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
@@ -1,12 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import {
-  forceCenter, forceCollide, forceLink, forceManyBody, forceSimulation,
-  type Simulation, type SimulationLinkDatum, type SimulationNodeDatum,
-} from 'd3-force';
 import { NeuralAvatar } from './NeuralAvatar';
-import { subscribe } from '@/lib/animation-scheduler';
 import { classifyPeerRelationship, edgeWidthFor } from '@/lib/edge-classification';
-import type { AgentData, PeerRelationshipMap } from '@/lib/types';
+import { peerKey } from '@/lib/peer-relationships';
+import type { AgentData, PeerRelationship, PeerRelationshipMap } from '@/lib/types';
 
 interface AgentNetworkGraphProps {
   agents: AgentData[];
@@ -14,22 +10,6 @@ interface AgentNetworkGraphProps {
   selectedAgentId: string | null;
   onSelectAgent: (id: string | null) => void;
   height?: number;
-}
-
-interface GraphNode extends SimulationNodeDatum {
-  id: string;
-  agent: AgentData;
-}
-
-interface GraphLink extends SimulationLinkDatum<GraphNode> {
-  // We always construct links with resolved GraphNode references, never string
-  // ids, so d3-force's mutation path (string→object) is never taken. Tightening
-  // the union here lets the SVG render path drop its `as GraphNode` cast.
-  source: GraphNode;
-  target: GraphNode;
-  cls: 'trust' | 'mixed' | 'catch';
-  width: number;
-  rounds: number;
 }
 
 /** NeuralAvatar size bucket from signal count. */
@@ -40,10 +20,96 @@ function sizeFor(signals: number): number {
   return 48;
 }
 
+/** Layout position for a single agent in the stage. */
+interface Position {
+  x: number;
+  y: number;
+  /** 'center' = focused agent, 'peer' = peer of focused, 'fleet' = resting orbit, 'hidden' = non-peer when focused. */
+  role: 'center' | 'peer' | 'fleet' | 'hidden';
+}
+
+/**
+ * Resting layout: agents arranged on a single ring, sorted by id for stable
+ * angles. No edges drawn in this state — the ring itself is the visual.
+ */
+function restingLayout(agentIds: string[], width: number, height: number): Map<string, Position> {
+  const center = { x: width / 2, y: height / 2 };
+  const radius = Math.max(80, Math.min(width, height) / 2 - 100);
+  const out = new Map<string, Position>();
+  const sorted = [...agentIds].sort();
+  const N = sorted.length;
+  for (let i = 0; i < N; i++) {
+    // Start the first agent at the top (-π/2) and go clockwise.
+    const angle = (i / N) * Math.PI * 2 - Math.PI / 2;
+    out.set(sorted[i], {
+      x: center.x + radius * Math.cos(angle),
+      y: center.y + radius * Math.sin(angle),
+      role: 'fleet',
+    });
+  }
+  return out;
+}
+
+/**
+ * Focus layout: selected agent at center; peers placed on an inner orbit
+ * with distance inversely proportional to relationship strength (more rounds
+ * = closer to center). Non-peers are positioned off-stage and tagged
+ * 'hidden' so the renderer can fade them out.
+ */
+function focusLayout(
+  selectedId: string,
+  agentIds: string[],
+  peerRelationships: PeerRelationshipMap,
+  width: number,
+  height: number,
+): Map<string, Position> {
+  const center = { x: width / 2, y: height / 2 };
+  const out = new Map<string, Position>();
+  out.set(selectedId, { x: center.x, y: center.y, role: 'center' });
+
+  // Collect peers (anyone with a relationship entry to selectedId).
+  const peers: Array<{ id: string; rel: PeerRelationship }> = [];
+  for (const id of agentIds) {
+    if (id === selectedId) continue;
+    const rel = peerRelationships.get(peerKey(selectedId, id));
+    if (rel) peers.push({ id, rel });
+  }
+
+  // Distance encoding: more rounds = closer to center. Normalize rounds
+  // across the visible peer set so the strongest peer is always at maxRounds → 1.
+  const maxRounds = Math.max(1, ...peers.map((p) => p.rel.rounds));
+  const minOrbit = Math.max(120, Math.min(width, height) * 0.20);
+  const maxOrbit = Math.min(width, height) * 0.42;
+
+  // Stable angle: sort peers by id so positions don't shuffle between renders.
+  const sortedPeers = peers.slice().sort((a, b) => a.id.localeCompare(b.id));
+  const N = sortedPeers.length;
+  for (let i = 0; i < N; i++) {
+    const { id, rel } = sortedPeers[i];
+    const angle = (i / Math.max(1, N)) * Math.PI * 2 - Math.PI / 2;
+    const norm = rel.rounds / maxRounds; // 0..1, 1 = strongest
+    const distance = maxOrbit - norm * (maxOrbit - minOrbit);
+    out.set(id, {
+      x: center.x + distance * Math.cos(angle),
+      y: center.y + distance * Math.sin(angle),
+      role: 'peer',
+    });
+  }
+
+  // Non-peer agents (selected has no relationship with them) get a hidden
+  // off-stage position so the CSS transition fades them out.
+  for (const id of agentIds) {
+    if (out.has(id)) continue;
+    out.set(id, { x: center.x, y: center.y, role: 'hidden' });
+  }
+
+  return out;
+}
+
 export function AgentNetworkGraph({
   agents, peerRelationships, selectedAgentId, onSelectAgent, height = 420,
 }: AgentNetworkGraphProps) {
-  // Empty states — return early to avoid running force on zero/one nodes.
+  // Empty / single-agent states.
   if (agents.length === 0) {
     return (
       <div
@@ -78,19 +144,24 @@ export function AgentNetworkGraph({
     );
   }
 
-  // Force-layout + rendering branch — see ForceGraphInner below.
-  return <ForceGraphInner agents={agents} peerRelationships={peerRelationships} selectedAgentId={selectedAgentId} onSelectAgent={onSelectAgent} height={height} sizeFor={sizeFor} />;
+  return (
+    <HubSpokeGraph
+      agents={agents}
+      peerRelationships={peerRelationships}
+      selectedAgentId={selectedAgentId}
+      onSelectAgent={onSelectAgent}
+      height={height}
+    />
+  );
 }
 
-function ForceGraphInner({
-  agents, peerRelationships, selectedAgentId, onSelectAgent, height = 420, sizeFor,
-}: AgentNetworkGraphProps & { sizeFor: (signals: number) => number }) {
+function HubSpokeGraph({
+  agents, peerRelationships, selectedAgentId, onSelectAgent, height = 420,
+}: AgentNetworkGraphProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const simRef = useRef<Simulation<GraphNode, GraphLink> | null>(null);
   const [width, setWidth] = useState(800);
-  const [, forceRender] = useState(0); // bump to re-render on tick
 
-  // Resize observer to pick up container width.
+  // Resize observer keeps layout responsive.
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
@@ -102,68 +173,46 @@ function ForceGraphInner({
     return () => ro.disconnect();
   }, []);
 
-  // Build nodes + links from props. Re-runs when agents/relationships change.
-  const { nodes, links } = useMemo(() => {
-    const nodes: GraphNode[] = agents.map((agent) => ({ id: agent.id, agent }));
-    const nodeById = new Map(nodes.map((n) => [n.id, n]));
-    const links: GraphLink[] = [];
-    for (const [key, rel] of peerRelationships.entries()) {
-      const [a, b] = key.split('::');
-      const sourceNode = nodeById.get(a);
-      const targetNode = nodeById.get(b);
-      if (!sourceNode || !targetNode) continue;
+  // Deterministic positions — no force simulation. Recomputed on selection /
+  // size change. Each render returns the SAME Map structure when inputs match
+  // (memoized below), so CSS transitions animate left/top smoothly.
+  const positions = useMemo(() => {
+    const ids = agents.map((a) => a.id);
+    if (selectedAgentId && ids.includes(selectedAgentId)) {
+      return focusLayout(selectedAgentId, ids, peerRelationships, width, height);
+    }
+    return restingLayout(ids, width, height);
+  }, [agents, peerRelationships, selectedAgentId, width, height]);
+
+  // Spokes (only drawn in focus mode) — straight lines from center to each peer.
+  const spokes = useMemo(() => {
+    if (!selectedAgentId) return [];
+    const selectedPos = positions.get(selectedAgentId);
+    if (!selectedPos) return [];
+    type Spoke = { peerId: string; x1: number; y1: number; x2: number; y2: number; cls: 'trust' | 'mixed' | 'catch'; width: number; rounds: number };
+    const out: Spoke[] = [];
+    for (const a of agents) {
+      if (a.id === selectedAgentId) continue;
+      const pos = positions.get(a.id);
+      if (!pos || pos.role !== 'peer') continue;
+      const rel = peerRelationships.get(peerKey(selectedAgentId, a.id));
+      if (!rel) continue;
       const cls = classifyPeerRelationship(rel);
       if (!cls) continue;
-      links.push({ source: sourceNode, target: targetNode, cls, width: edgeWidthFor(rel.rounds), rounds: rel.rounds });
+      out.push({
+        peerId: a.id, x1: selectedPos.x, y1: selectedPos.y, x2: pos.x, y2: pos.y,
+        cls, width: edgeWidthFor(rel.rounds), rounds: rel.rounds,
+      });
     }
-    // Render order: mixed (background) → trust → catch (foreground). SVG paints in
-    // array order, so later entries sit on top. Meaningful signals (catch + trust)
-    // are now drawn over the visually-dominant "mixed" edges instead of being
-    // buried under them.
-    const ORDER: Record<GraphLink['cls'], number> = { mixed: 0, trust: 1, catch: 2 };
-    links.sort((a, b) => ORDER[a.cls] - ORDER[b.cls]);
-    return { nodes, links };
-  }, [agents, peerRelationships]);
+    // Mixed behind trust behind catch.
+    const ORDER: Record<Spoke['cls'], number> = { mixed: 0, trust: 1, catch: 2 };
+    out.sort((a, b) => ORDER[a.cls] - ORDER[b.cls]);
+    return out;
+  }, [agents, peerRelationships, selectedAgentId, positions]);
 
-  // (Re-)build force simulation on width/nodes/links change.
-  useEffect(() => {
-    // Wider link distance + stronger charge = more spread, less clumping
-    // for dense graphs (Phase 1b.1 polish — was 120/-400, felt cramped at 7+ agents).
-    // forceCollide uses each node's visual radius (from sizeFor) + 6px gutter so
-    // large-signal avatars (84px) never visually overlap. alphaDecay calmed from
-    // 0.05 to 0.028 (just above d3 default 0.0228) so the wider layout has time
-    // to actually settle — at 0.05 the simulation cooled in ~56 ticks, often
-    // stranding nodes in a local minimum.
-    const sim = forceSimulation<GraphNode, GraphLink>(nodes)
-      .force('link', forceLink<GraphNode, GraphLink>(links).id((d) => d.id).distance(200).strength(0.35))
-      .force('charge', forceManyBody<GraphNode>().strength(-700))
-      .force('collide', forceCollide<GraphNode>((d) => sizeFor(d.agent.scores.signals) / 2 + 6))
-      .force('center', forceCenter(width / 2, height / 2))
-      .alpha(1).alphaMin(0.01).alphaDecay(0.028);
-    simRef.current = sim;
-    sim.stop();
-    // Manual ticking via the shared scheduler — keeps frame budget unified.
-    // Clamping x/y after each tick keeps nodes inside the overflow-hidden
-    // container — without this, narrow viewports + the 800px width fallback
-    // can strand nodes off-screen with their click target unreachable.
-    const pad = 50;
-    const unsubscribe = subscribe(() => {
-      if (sim.alpha() < sim.alphaMin()) return;
-      sim.tick();
-      for (const n of nodes) {
-        if (n.x != null) n.x = Math.max(pad, Math.min(width - pad, n.x));
-        if (n.y != null) n.y = Math.max(pad, Math.min(height - pad, n.y));
-      }
-      forceRender((v) => v + 1);
-    });
-    return () => {
-      unsubscribe();
-      sim.stop();
-      simRef.current = null;
-    };
-  }, [nodes, links, width, height]);
+  // Count summary for the header.
+  const peerCount = selectedAgentId ? spokes.length : 0;
 
-  // Render nodes as absolutely-positioned divs + edges as one SVG overlay.
   return (
     <div
       ref={containerRef}
@@ -171,132 +220,153 @@ function ForceGraphInner({
       style={{ height, background: 'var(--stage-bg)', borderColor: 'var(--border)' }}
       onClick={() => onSelectAgent(null)}
     >
-      {/* Header label — gives the stage context for a first-time viewer. */}
+      {/* Header label — adapts to mode. */}
       <div
         className="absolute z-10 flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-widest"
         style={{ top: 10, left: 12, color: 'var(--stage-text-dim)', pointerEvents: 'none' }}
       >
-        <span>Agent Network</span>
-        <span style={{ opacity: 0.5 }}>·</span>
-        <span style={{ color: 'var(--text)' }}>{agents.length}</span>
-        <span style={{ opacity: 0.7 }}>agents</span>
-        <span style={{ opacity: 0.5 }}>·</span>
-        <span style={{ color: 'var(--text)' }}>{links.length}</span>
-        <span style={{ opacity: 0.7 }}>edges</span>
+        {selectedAgentId ? (
+          <>
+            <span>Focus</span>
+            <span style={{ opacity: 0.5 }}>·</span>
+            <span style={{ color: 'var(--text)' }}>{selectedAgentId}</span>
+            <span style={{ opacity: 0.5 }}>·</span>
+            <span style={{ color: 'var(--text)' }}>{peerCount}</span>
+            <span style={{ opacity: 0.7 }}>peer{peerCount === 1 ? '' : 's'}</span>
+          </>
+        ) : (
+          <>
+            <span>Fleet</span>
+            <span style={{ opacity: 0.5 }}>·</span>
+            <span style={{ color: 'var(--text)' }}>{agents.length}</span>
+            <span style={{ opacity: 0.7 }}>agents</span>
+            <span style={{ opacity: 0.5 }}>·</span>
+            <span style={{ opacity: 0.7 }}>click an avatar to focus</span>
+          </>
+        )}
       </div>
+
+      {/* Spokes in focus mode only. SVG layer sits above the background. */}
       <svg width="100%" height={height} style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
-        {links.map((l) => {
-          const s = l.source;
-          const t = l.target;
-          if (s.x == null || s.y == null || t.x == null || t.y == null) return null;
-          // Offset endpoints by node radius so edges meet the avatar circumference,
-          // not the center — avoids the "arrow stabbing through the icon" look.
-          const dx = t.x - s.x;
-          const dy = t.y - s.y;
+        {spokes.map((s) => {
+          // Trim line endpoints to avatar radius so spokes meet the circumference.
+          const selectedAgent = agents.find((a) => a.id === selectedAgentId);
+          const peerAgent = agents.find((a) => a.id === s.peerId);
+          if (!selectedAgent || !peerAgent) return null;
+          const sr = sizeFor(selectedAgent.scores.signals) / 2;
+          const pr = sizeFor(peerAgent.scores.signals) / 2;
+          const dx = s.x2 - s.x1;
+          const dy = s.y2 - s.y1;
           const len = Math.max(1, Math.hypot(dx, dy));
           const ux = dx / len;
           const uy = dy / len;
-          const sr = sizeFor(s.agent.scores.signals) / 2;
-          const tr = sizeFor(t.agent.scores.signals) / 2;
-          const sx = s.x + ux * sr;
-          const sy = s.y + uy * sr;
-          const tx = t.x - ux * tr;
-          const ty = t.y - uy * tr;
-          // Mid-perpendicular Bezier control point — 20px offset (Phase 1b.1 polish,
-          // was 40px; tightened to reduce the parallel-arc fishbowl effect on dense graphs).
-          const mx = (sx + tx) / 2;
-          const my = (sy + ty) / 2;
-          // Clockwise normal: rotate unit vector by -90°.
-          const nx = uy;
-          const ny = -ux;
-          const cx = mx + nx * 20;
-          const cy = my + ny * 20;
-          const d = `M ${sx},${sy} Q ${cx},${cy} ${tx},${ty}`;
-          const stroke = l.cls === 'trust' ? 'var(--success)' : l.cls === 'mixed' ? 'var(--warn)' : 'var(--danger)';
-          // Catch (red) is now solid — the strong --danger color carries the
-          // signal on its own, and dropping the dash makes it visually distinct
-          // from mixed (amber dashed). Previous "5,3 vs 8,2" dash pattern read
-          // as the same broken line at the eye-level distances users actually
-          // scan from.
-          const dash = l.cls === 'mixed' ? '8,2' : undefined;
-          // Edge opacity is theme-aware via --edge-opacity-* tokens — light
-          // mode needs a higher floor (0.70) than dark (0.55) to clear WCAG
-          // 1.4.11 for the deeper cream-mode stroke colors. Tokens override
-          // in [data-theme="dark"] in globals.css.
-          const isAdjacent = selectedAgentId == null || s.id === selectedAgentId || t.id === selectedAgentId;
-          const opacityVar = selectedAgentId == null
-            ? 'var(--edge-opacity-base)'
-            : isAdjacent
-              ? 'var(--edge-opacity-selected)'
-              : 'var(--edge-opacity-dim)';
+          const sx = s.x1 + ux * sr;
+          const sy = s.y1 + uy * sr;
+          const tx = s.x2 - ux * pr;
+          const ty = s.y2 - uy * pr;
+          const stroke = s.cls === 'trust' ? 'var(--success)' : s.cls === 'mixed' ? 'var(--warn)' : 'var(--danger)';
+          const dash = s.cls === 'mixed' ? '8,2' : undefined;
           return (
-            <path
-              key={`${s.id}::${t.id}`}
-              d={d}
+            <line
+              key={s.peerId}
+              x1={sx} y1={sy} x2={tx} y2={ty}
               stroke={stroke}
-              strokeWidth={l.width}
+              strokeWidth={s.width}
               strokeDasharray={dash}
-              fill="none"
-              style={{ opacity: opacityVar, transition: 'opacity 200ms cubic-bezier(0.4,0,0.2,1)' }}
+              strokeLinecap="round"
+              style={{
+                opacity: 'var(--edge-opacity-selected)',
+                transition: 'opacity 200ms cubic-bezier(0.4,0,0.2,1)',
+              }}
             />
           );
         })}
       </svg>
-      {/* Edge legend — three rows in the bottom-left, anchored over the stage. */}
-      <div
-        className="absolute z-10 flex flex-col gap-1 rounded font-mono text-[10px]"
-        style={{ bottom: 10, left: 12, color: 'var(--stage-text-dim)', pointerEvents: 'none' }}
-      >
-        <LegendRow stroke="var(--success)" label="Trust" />
-        <LegendRow stroke="var(--warn)" label="Mixed" dash="8,2" />
-        <LegendRow stroke="var(--danger)" label="Caught" />
-      </div>
-      {nodes.map((n) => {
-        if (n.x == null || n.y == null) return null;
-        const size = sizeFor(n.agent.scores.signals);
-        const isSelected = n.id === selectedAgentId;
-        const isDimmed = selectedAgentId != null && !isSelected;
-        const label = n.agent.id;
+
+      {/* Legend only in focus mode — resting state has no edges to legend. */}
+      {selectedAgentId && (
+        <div
+          className="absolute z-10 flex flex-col gap-1 rounded font-mono text-[10px]"
+          style={{ bottom: 10, left: 12, color: 'var(--stage-text-dim)', pointerEvents: 'none' }}
+        >
+          <LegendRow stroke="var(--success)" label="Trust" />
+          <LegendRow stroke="var(--warn)" label="Mixed" dash="8,2" />
+          <LegendRow stroke="var(--danger)" label="Caught" />
+        </div>
+      )}
+
+      {/* Agent nodes — absolutely positioned, transition-animated. */}
+      {agents.map((a) => {
+        const pos = positions.get(a.id);
+        if (!pos) return null;
+        const size = sizeFor(a.scores.signals);
+        const isCenter = pos.role === 'center';
+        const isHidden = pos.role === 'hidden';
+        const isPeer = pos.role === 'peer';
+        // Resting: full opacity. Center: full + glow ring. Peer: full. Hidden: 0.
+        const opacity = isHidden ? 0 : 1;
+        const labelColor = isCenter ? 'var(--text)' : 'var(--stage-text-dim)';
         return (
           <button
-            key={n.id}
+            key={a.id}
             type="button"
-            onClick={(ev) => { ev.stopPropagation(); onSelectAgent(n.id); }}
-            className="absolute -translate-x-1/2 -translate-y-1/2 transition"
+            onClick={(ev) => { ev.stopPropagation(); onSelectAgent(a.id); }}
+            className="absolute -translate-x-1/2 -translate-y-1/2"
             style={{
-              left: n.x, top: n.y,
-              opacity: isDimmed ? 0.4 : 1,
+              left: pos.x, top: pos.y,
+              opacity,
+              pointerEvents: isHidden ? 'none' : 'auto',
               border: 'none', background: 'transparent', padding: 0, cursor: 'pointer',
+              transition: 'left 320ms cubic-bezier(0.4,0,0.2,1), top 320ms cubic-bezier(0.4,0,0.2,1), opacity 200ms cubic-bezier(0.4,0,0.2,1)',
             }}
-            aria-label={`Select agent ${n.agent.id}`}
-            title={n.agent.id}
+            aria-label={`Select agent ${a.id}`}
+            title={a.id}
           >
             <div
               className="rounded-full"
               style={{
                 width: size, height: size,
-                boxShadow: isSelected ? `0 0 0 3px var(--accent)` : undefined,
+                boxShadow: isCenter ? `0 0 0 3px var(--accent), 0 8px 32px -8px var(--accent-soft)` : undefined,
+                transition: 'box-shadow 200ms cubic-bezier(0.4,0,0.2,1)',
               }}
             >
               <NeuralAvatar
-                agentId={n.agent.id}
-                signals={n.agent.scores.signals}
-                accuracy={n.agent.scores.accuracy}
-                uniqueness={n.agent.scores.uniqueness}
-                impact={n.agent.scores.impactScore}
+                agentId={a.id}
+                signals={a.scores.signals}
+                accuracy={a.scores.accuracy}
+                uniqueness={a.scores.uniqueness}
+                impact={a.scores.impactScore}
                 size={size}
               />
             </div>
             <div
               className="mt-1 font-mono text-[10px] font-bold uppercase tracking-wider"
               style={{
-                color: isSelected ? 'var(--text)' : 'var(--stage-text-dim)',
+                color: labelColor,
                 textAlign: 'center',
                 whiteSpace: 'nowrap',
+                transition: 'color 200ms cubic-bezier(0.4,0,0.2,1)',
               }}
             >
-              {label}
+              {a.id}
             </div>
+            {/* Round count under peer name in focus mode — quick relationship-strength signal. */}
+            {isPeer && (
+              <div
+                className="font-mono text-[9px]"
+                style={{
+                  color: 'var(--stage-text-dim)',
+                  textAlign: 'center',
+                  whiteSpace: 'nowrap',
+                  marginTop: 2,
+                }}
+              >
+                {(() => {
+                  const rel = peerRelationships.get(peerKey(selectedAgentId ?? '', a.id));
+                  return rel ? `${rel.rounds} round${rel.rounds === 1 ? '' : 's'}` : '';
+                })()}
+              </div>
+            )}
           </button>
         );
       })}
@@ -304,7 +374,7 @@ function ForceGraphInner({
   );
 }
 
-/** Bottom-left legend swatch — short stroke sample + label. */
+/** Edge legend swatch — short stroke sample + label. */
 function LegendRow({ stroke, label, dash }: { stroke: string; label: string; dash?: string }) {
   return (
     <div className="flex items-center gap-1.5">


### PR DESCRIPTION
## Summary

Replaces the BloodHound-style force-directed cloud with a **deterministic hub-and-spoke layout**. User feedback after Phase 1b.1/1b.2: even after polish (calmer curves, theme-aware opacity, render-order sort, force tuning), the force-directed graph still felt chaotic because positions had no meaning.

The new design moves to a **focus-mode interaction** where positions actively encode information.

## Two modes

**Resting (no selection):**
- All agents arranged on a single ring, sorted by id for stable angles
- No edges — the ring itself is the calm baseline
- Header: "Fleet · N agents · click an avatar to focus"

**Focus (agent selected):**
- Selected agent slides to center; peers animate to an inner orbit around it
- Distance from center = relationship strength (more rounds = closer)
- Non-peers fade to opacity 0
- Spokes draw from center to each peer (trust solid green, mixed dashed amber, catch solid red)
- Each peer shows its round count beneath its label
- Header: "Focus · <agent-id> · K peers"
- Click outside to release

## Implementation

- **Pure math, no physics.** `restingLayout` and `focusLayout` are pure functions; React's `useMemo` recomputes positions on selection or resize.
- **d3-force removed entirely** — no more `forceSimulation`, `forceLink`, `forceManyBody`, `forceCollide`, `forceCenter`. Bundle: **414KB → 401KB** (-13KB, -5KB gzipped).
- **CSS transitions** on `left`/`top` (320ms cubic-bezier) animate the rest→focus transition smoothly.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vite build` clean (bundle delta: -13KB JS)
- [x] `jest tests/dashboard/peer-relationships.test.ts tests/dashboard/edge-classification.test.ts` — 28/28 pass
- [ ] Visual smoke at `/dashboard/`:
  - Resting state shows agents on a clean ring
  - Click an avatar → smooth slide to center + peers orbit around
  - Click outside → smooth return to ring
  - Spokes color-code correctly; round counts visible under peer labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)