### PR TITLE
polish(dashboard-v2): hero graph organization + cosmic coherence + easter egg

### DIFF
--- a/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
+++ b/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
@@ -435,14 +435,22 @@ function HubSpokeGraph({
 }: AgentNetworkGraphProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(800);
+  // measuredHeight tracks the ACTUAL rendered card height (which stretches via
+  // the equal-height flex row), separately from the `height` prop (which is
+  // just the minimum floor). Centering the rings + stars + agents in the real
+  // canvas requires this — otherwise the system lives in the top `height` px
+  // and the bottom of the stretched card is empty.
+  const [measuredHeight, setMeasuredHeight] = useState(height);
 
-  // Resize observer keeps layout responsive.
+  // Resize observer keeps layout responsive in both dimensions.
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
     const ro = new ResizeObserver(([entry]) => {
       const w = entry.contentRect.width;
+      const h = entry.contentRect.height;
       if (w > 0) setWidth(w);
+      if (h > 0) setMeasuredHeight(h);
     });
     ro.observe(el);
     return () => ro.disconnect();
@@ -454,10 +462,10 @@ function HubSpokeGraph({
   const positions = useMemo(() => {
     const ids = agents.map((a) => a.id);
     if (selectedAgentId && ids.includes(selectedAgentId)) {
-      return focusLayout(selectedAgentId, ids, peerRelationships, width, height);
+      return focusLayout(selectedAgentId, ids, peerRelationships, width, measuredHeight);
     }
-    return restingLayout(agents, width, height);
-  }, [agents, peerRelationships, selectedAgentId, width, height]);
+    return restingLayout(agents, width, measuredHeight);
+  }, [agents, peerRelationships, selectedAgentId, width, measuredHeight]);
 
   // Spokes (only drawn in focus mode) — straight lines from center to each peer.
   const spokes = useMemo(() => {
@@ -523,11 +531,11 @@ function HubSpokeGraph({
     >
       {/* Starfield: observatory backdrop with eat-the-stars animation.
           Stars within ~60px of an agent drift in, shrink, fade, then respawn. */}
-      <Starfield width={width} height={height} agentPositions={agentPositionsForStars} />
+      <Starfield width={width} height={measuredHeight} agentPositions={agentPositionsForStars} />
       {/* Accuracy rings — rendered second (behind spokes/avatars, above stars).
           Hide labels in focus mode: positions are then driven by peer-
           distance, not accuracy, so the accuracy ticks would mislead. */}
-      <RingBands width={width} height={height} hideLabels={!!selectedAgentId} />
+      <RingBands width={width} height={measuredHeight} hideLabels={!!selectedAgentId} />
 
       {/* Header label — adapts to mode. */}
       <div
@@ -586,7 +594,7 @@ function HubSpokeGraph({
       )}
 
       {/* Spokes in focus mode only. SVG layer sits above the background. */}
-      <svg width="100%" height={height} style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+      <svg width="100%" height={measuredHeight} style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
         {spokes.map((s) => {
           // Trim line endpoints to avatar radius so spokes meet the circumference.
           const selectedAgent = agents.find((a) => a.id === selectedAgentId);

--- a/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
+++ b/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
@@ -59,19 +59,27 @@ function restingLayout(agents: AgentData[], width: number, height: number): Map<
   });
   const N = sorted.length;
 
+  // Golden-angle stride (phyllotaxis). 137.50776° ≈ 2.39996 rad.
+  // Equal-spaced angles (2π/N per step) put adjacent ranks at adjacent
+  // angles — when two agents share a similar accuracy they also land at
+  // similar radii, and the combination CLUSTERS them visually. The golden
+  // angle guarantees that for any N, consecutive items in the walk land
+  // far apart on the circle. So two agents with neighboring accuracies
+  // (e.g. sonnet-reviewer 63% + haiku-researcher 64% — same radius band)
+  // are placed on opposite sides of the chart instead of next to each
+  // other. The result spreads the fleet evenly regardless of how the
+  // accuracy distribution clumps.
+  const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
   for (let i = 0; i < N; i++) {
     const agent = sorted[i];
     // 0 = at center (perfect accuracy), 1 = at maxRadius (zero accuracy).
-    // Inner floor raised from 0.1 → 0.22 of maxRadius so the highest-accuracy
-    // agent (e.g. opus at 76%) doesn't visually merge with the center bloom.
+    // Inner floor at 0.22*maxRadius so the highest-accuracy agent doesn't
+    // visually merge with the orchestrator blackhole at the center.
     const acc = clamp(agent.scores?.accuracy ?? 0, 0, 1);
     const radius = Math.max(maxRadius * 0.22, (1 - acc) * maxRadius);
 
-    // Angle: evenly distribute around the perimeter, top start, clockwise.
-    // Walking the sorted-by-accuracy array gives a natural visual spread —
-    // adjacent ranks land at adjacent angles, not adjacent radii, so labels
-    // and avatars never share a column.
-    const angle = (i / N) * Math.PI * 2 - Math.PI / 2;
+    // Anchor at -π/2 (top) for the first agent, then step by golden angle.
+    const angle = -Math.PI / 2 + i * GOLDEN_ANGLE;
 
     out.set(agent.id, {
       x: center.x + radius * Math.cos(angle),

--- a/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
+++ b/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
@@ -277,6 +277,85 @@ function Starfield({ width, height, agentPositions }: StarfieldProps) {
   );
 }
 
+/** Smile face overlay shown on the orchestrator blackhole when clicked.
+ *  Pops in with a brief scale-bounce + fade, then fades out at ~900ms.
+ *  Four variants cycle through clicks so repeated clicks vary the reaction:
+ *    0 — normal smile
+ *    1 — winky face
+ *    2 — big grin (open mouth)
+ *    3 — cat smile ( :3 ) */
+function OrchestratorSmile({ variant }: { variant: number }) {
+  const face = (() => {
+    switch (variant) {
+      case 1: // wink
+        return (
+          <>
+            <path d="M 19 24 L 25 24" stroke="#F2EDE3" strokeWidth="1.5" strokeLinecap="round" />
+            <circle cx="34" cy="24" r="1.5" fill="#F2EDE3" />
+            <path d="M 20 31 Q 28 36 36 31" stroke="#F2EDE3" strokeWidth="1.5" strokeLinecap="round" fill="none" />
+          </>
+        );
+      case 2: // big grin
+        return (
+          <>
+            <circle cx="22" cy="23" r="1.6" fill="#F2EDE3" />
+            <circle cx="34" cy="23" r="1.6" fill="#F2EDE3" />
+            <path d="M 19 30 Q 28 38 37 30 Q 28 33 19 30 Z" fill="#F2EDE3" opacity="0.92" />
+          </>
+        );
+      case 3: // cat :3
+        return (
+          <>
+            <circle cx="22" cy="24" r="1.4" fill="#F2EDE3" />
+            <circle cx="34" cy="24" r="1.4" fill="#F2EDE3" />
+            <path d="M 22 30 Q 26 33 28 30 Q 30 33 34 30" stroke="#F2EDE3" strokeWidth="1.4" strokeLinecap="round" fill="none" />
+          </>
+        );
+      default: // normal smile
+        return (
+          <>
+            <circle cx="22" cy="24" r="1.5" fill="#F2EDE3" />
+            <circle cx="34" cy="24" r="1.5" fill="#F2EDE3" />
+            <path d="M 20 31 Q 28 36 36 31" stroke="#F2EDE3" strokeWidth="1.5" strokeLinecap="round" fill="none" />
+          </>
+        );
+    }
+  })();
+  return (
+    <svg
+      width="56" height="56" viewBox="0 0 56 56"
+      style={{
+        position: 'absolute',
+        top: 0, left: 0,
+        animation: 'orch-smile-pop 900ms ease-out forwards',
+        pointerEvents: 'none',
+      }}
+      aria-hidden
+    >
+      {face}
+    </svg>
+  );
+}
+
+/** Expanding ripple wave emitted from the orchestrator on click. Visual
+ *  confirmation the click landed even before the smile finishes pop-in. */
+function OrchestratorRipple() {
+  return (
+    <svg
+      width="56" height="56" viewBox="0 0 56 56"
+      style={{
+        position: 'absolute',
+        top: 0, left: 0,
+        animation: 'orch-ripple 700ms ease-out forwards',
+        pointerEvents: 'none',
+      }}
+      aria-hidden
+    >
+      <circle cx="28" cy="28" r="9" fill="none" stroke="var(--accent)" strokeWidth="1.2" />
+    </svg>
+  );
+}
+
 interface RingBandsProps {
   width: number;
   height: number;
@@ -464,6 +543,9 @@ function HubSpokeGraph({
   // canvas requires this — otherwise the system lives in the top `height` px
   // and the bottom of the stretched card is empty.
   const [measuredHeight, setMeasuredHeight] = useState(height);
+  // Easter egg: click the orchestrator blackhole. Count drives a smile face
+  // pop + ripple, and unlocks playful label reactions past certain thresholds.
+  const [orchestratorClicks, setOrchestratorClicks] = useState(0);
 
   // Resize observer keeps layout responsive in both dimensions.
   useEffect(() => {
@@ -681,10 +763,15 @@ function HubSpokeGraph({
           style={{
             left: width / 2,
             top: measuredHeight / 2,
-            pointerEvents: 'none',
+            cursor: 'pointer',
           }}
+          onClick={(ev) => {
+            ev.stopPropagation();
+            setOrchestratorClicks((c) => c + 1);
+          }}
+          title={orchestratorClicks >= 10 ? '♥' : orchestratorClicks >= 5 ? 'ok ok' : 'orchestrator'}
         >
-          <svg width="56" height="56" viewBox="0 0 56 56" style={{ display: 'block' }} aria-hidden>
+          <svg width="56" height="56" viewBox="0 0 56 56" style={{ display: 'block', pointerEvents: 'none' }} aria-hidden>
             {/* Outer accretion halo — terracotta glow */}
             <circle cx="28" cy="28" r="26" fill="none" stroke="var(--accent)" strokeWidth="0.6" opacity="0.35" />
             <circle cx="28" cy="28" r="22" fill="none" stroke="var(--accent)" strokeWidth="0.4" opacity="0.25" />
@@ -695,6 +782,17 @@ function HubSpokeGraph({
             {/* Inner accretion glow rim */}
             <circle cx="28" cy="28" r="9" fill="none" stroke="var(--accent)" strokeWidth="0.5" opacity="0.6" />
           </svg>
+          {/* Easter egg: smile face pops in on every click. The `key` prop
+              changes per click so React remounts the SVG and the CSS
+              animation restarts. Variant cycles 4 faces. */}
+          {orchestratorClicks > 0 && (
+            <OrchestratorSmile key={orchestratorClicks} variant={(orchestratorClicks - 1) % 4} />
+          )}
+          {/* Ripple wave — concentric expanding circle that fades out, hinting
+              the click registered even before the smile finishes pop-in. */}
+          {orchestratorClicks > 0 && (
+            <OrchestratorRipple key={`ripple-${orchestratorClicks}`} />
+          )}
           <div
             className="font-mono"
             style={{
@@ -705,12 +803,14 @@ function HubSpokeGraph({
               fontSize: '9px',
               letterSpacing: '0.18em',
               textTransform: 'uppercase',
-              color: 'var(--stage-text-dim)',
+              color: orchestratorClicks >= 10 ? 'var(--accent)' : 'var(--stage-text-dim)',
               whiteSpace: 'nowrap',
               opacity: 0.7,
+              pointerEvents: 'none',
+              transition: 'color 400ms ease-out',
             }}
           >
-            orchestrator
+            {orchestratorClicks >= 10 ? '♥ orchestrator ♥' : 'orchestrator'}
           </div>
         </div>
       )}

--- a/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
+++ b/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
@@ -676,16 +676,16 @@ function HubSpokeGraph({
         )}
       </div>
 
-      {/* Accuracy-scope legend — explains the radial encoding. Sits just below
-          the fleet-name overlay at the top-left. Per Step 4 review feedback,
-          the legend must be in the attention path (top-left, not bottom-left).
+      {/* Accuracy-scope legend — explains the radial encoding.
+          Per user feedback, positioned at the bottom-right to keep the
+          top-left clean (FLEET label + click-to-focus hint live there).
           Only shown in resting mode — focus mode has its own edge legend. */}
       {!selectedAgentId && (
         <div
           className="absolute z-10 h-section"
           style={{
-            top: 36,
-            left: 12,
+            bottom: 12,
+            right: 12,
             fontSize: '10px',
             color: 'var(--stage-text-dim)',
             background: 'color-mix(in oklch, var(--stage-bg) 70%, transparent)',

--- a/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
+++ b/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
@@ -694,7 +694,7 @@ function HubSpokeGraph({
             pointerEvents: 'none',
           }}
         >
-          closer to center = higher accuracy · spoke color = agent identity
+          closer to center = higher accuracy
         </div>
       )}
 

--- a/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
+++ b/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
@@ -27,6 +27,10 @@ interface Position {
   y: number;
   /** 'center' = focused agent, 'peer' = peer of focused, 'fleet' = resting orbit, 'hidden' = non-peer when focused. */
   role: 'center' | 'peer' | 'fleet' | 'hidden';
+  /** Angle from center in radians (-π/2 = top, 0 = right, π/2 = bottom, π = left).
+   *  Used by the renderer to position the agent's name label radially OUTWARD
+   *  from the avatar so labels never collide with avatars at smaller radii. */
+  angle?: number;
 }
 
 /**
@@ -36,33 +40,44 @@ interface Position {
  */
 function restingLayout(agents: AgentData[], width: number, height: number): Map<string, Position> {
   const center = { x: width / 2, y: height / 2 };
-  // maxRadius = 100% accuracy band (outermost ring). innerCushion keeps the 100% ring
-  // off the canvas edge.
-  const innerCushion = 40;
+  // Tighter cushion (was 40) lets the chart fill more of the available canvas.
+  const innerCushion = 24;
   const maxRadius = Math.max(80, Math.min(width, height) / 2 - innerCushion);
 
   const out = new Map<string, Position>();
   if (agents.length === 0) return out;
 
-  // Group agents by accuracy band so that agents with similar accuracy don't pile on top
-  // of each other. Use alphabetical order within a band as a stable angular offset.
-  const sorted = [...agents].sort((a, b) => a.id.localeCompare(b.id));
+  // Sort by accuracy DESCENDING so the alphabetical-around-perimeter degenerate
+  // case is replaced by a smarter walk: agents at similar radii get distributed
+  // around the chart, not clumped at the same angle. Stable secondary sort by id
+  // keeps the layout deterministic.
+  const sorted = [...agents].sort((a, b) => {
+    const da = b.scores?.accuracy ?? 0;
+    const dc = a.scores?.accuracy ?? 0;
+    if (da !== dc) return dc - da;
+    return a.id.localeCompare(b.id);
+  });
   const N = sorted.length;
 
   for (let i = 0; i < N; i++) {
     const agent = sorted[i];
     // 0 = at center (perfect accuracy), 1 = at maxRadius (zero accuracy).
-    // Floor at 0.1 of maxRadius so 100%-accuracy agents don't stack on the center bloom.
+    // Inner floor raised from 0.1 → 0.22 of maxRadius so the highest-accuracy
+    // agent (e.g. opus at 76%) doesn't visually merge with the center bloom.
     const acc = clamp(agent.scores?.accuracy ?? 0, 0, 1);
-    const radius = Math.max(maxRadius * 0.1, (1 - acc) * maxRadius);
+    const radius = Math.max(maxRadius * 0.22, (1 - acc) * maxRadius);
 
-    // Angle: alphabetical around the perimeter, top start, clockwise.
+    // Angle: evenly distribute around the perimeter, top start, clockwise.
+    // Walking the sorted-by-accuracy array gives a natural visual spread —
+    // adjacent ranks land at adjacent angles, not adjacent radii, so labels
+    // and avatars never share a column.
     const angle = (i / N) * Math.PI * 2 - Math.PI / 2;
 
     out.set(agent.id, {
       x: center.x + radius * Math.cos(angle),
       y: center.y + radius * Math.sin(angle),
       role: 'fleet',
+      angle,
     });
   }
   return out;
@@ -629,7 +644,23 @@ function HubSpokeGraph({
         const isPeer = pos.role === 'peer';
         // Resting: full opacity. Center: full + glow ring. Peer: full. Hidden: 0.
         const opacity = isHidden ? 0 : 1;
-        const labelColor = isCenter ? 'var(--text)' : 'var(--stage-text-dim)';
+        const labelColor = isCenter ? '#F2EDE3' : 'var(--stage-text-dim)';
+        // Position label RADIALLY OUTWARD from the avatar based on the layout
+        // angle. This prevents the universal "label below avatar" collision
+        // where two stacked agents have the upper agent's label landing on
+        // top of the lower agent. Top-half agents (angle in [-π, 0]) get the
+        // label above; bottom-half get it below; left/right shift inline.
+        const angle = pos.angle ?? Math.PI / 2; // default: below (no angle = center)
+        const labelDist = size / 2 + 14; // gap between avatar edge and label baseline
+        const labelDx = Math.cos(angle) * labelDist;
+        const labelDy = Math.sin(angle) * labelDist;
+        // Anchor the label so its inner edge (toward the center) lines up with
+        // the avatar — horizontal labels read left-or-right of avatar; vertical
+        // labels (top/bottom) stay center-anchored.
+        const labelAnchor: 'left' | 'right' | 'center' =
+          Math.abs(Math.cos(angle)) > 0.7
+            ? Math.cos(angle) > 0 ? 'left' : 'right'
+            : 'center';
         return (
           <button
             key={a.id}
@@ -664,12 +695,20 @@ function HubSpokeGraph({
               />
             </div>
             <div
-              className="mt-1 font-mono text-[10px] font-bold uppercase tracking-wider"
+              className="absolute font-mono text-[10px] font-bold uppercase tracking-wider"
               style={{
+                left: '50%',
+                top: '50%',
+                transform: `translate(calc(-50% + ${labelDx}px), calc(-50% + ${labelDy}px))${
+                  labelAnchor === 'left' ? ' translateX(calc(50% + 4px))'
+                  : labelAnchor === 'right' ? ' translateX(calc(-50% - 4px))'
+                  : ''
+                }`,
                 color: labelColor,
-                textAlign: 'center',
+                textAlign: labelAnchor === 'right' ? 'right' : labelAnchor === 'left' ? 'left' : 'center',
                 whiteSpace: 'nowrap',
-                transition: 'color 200ms cubic-bezier(0.4,0,0.2,1)',
+                pointerEvents: 'none',
+                transition: 'color 200ms cubic-bezier(0.4,0,0.2,1), transform 320ms cubic-bezier(0.4,0,0.2,1)',
               }}
             >
               {a.id}

--- a/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
+++ b/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
@@ -637,7 +637,10 @@ function HubSpokeGraph({
               strokeDasharray={dash}
               strokeLinecap="round"
               style={{
-                opacity: 'var(--edge-opacity-selected)',
+                // Dimmer spokes on the cosmic dark canvas — bright stroke
+                // saturates against the starfield. 0.55 reads as energy flow,
+                // 0.9 read as neon.
+                opacity: 0.55,
                 transition: 'opacity 200ms cubic-bezier(0.4,0,0.2,1)',
               }}
             />
@@ -654,6 +657,53 @@ function HubSpokeGraph({
           <LegendRow stroke="var(--success)" label="Trust" />
           <LegendRow stroke="var(--warn)" label="Mixed" dash="8,2" />
           <LegendRow stroke="var(--danger)" label="Caught" />
+        </div>
+      )}
+
+      {/* Center black hole — the gravitational locus of the fleet.
+          Represents the orchestrator: every agent is in orbit around it,
+          stars get pulled toward it (via the agent-eat animation), the
+          consensus locus collapses here. Visual: dark disc + accretion-
+          disk glow + outer halo, all on the center of the measured canvas.
+          Resting mode only; in focus mode the selected agent becomes the
+          gravitational center via the existing center glow ring. */}
+      {!selectedAgentId && measuredHeight > 0 && (
+        <div
+          className="absolute z-[1] -translate-x-1/2 -translate-y-1/2"
+          style={{
+            left: width / 2,
+            top: measuredHeight / 2,
+            pointerEvents: 'none',
+          }}
+        >
+          <svg width="56" height="56" viewBox="0 0 56 56" style={{ display: 'block' }} aria-hidden>
+            {/* Outer accretion halo — terracotta glow */}
+            <circle cx="28" cy="28" r="26" fill="none" stroke="var(--accent)" strokeWidth="0.6" opacity="0.35" />
+            <circle cx="28" cy="28" r="22" fill="none" stroke="var(--accent)" strokeWidth="0.4" opacity="0.25" />
+            {/* Event horizon — cream ring on the edge of the disc */}
+            <circle cx="28" cy="28" r="12" fill="none" stroke="#F2EDE3" strokeWidth="1.1" opacity="0.75" />
+            {/* The disc itself — actual blackhole, swallows whatever the rest is */}
+            <circle cx="28" cy="28" r="9" fill="#000" />
+            {/* Inner accretion glow rim */}
+            <circle cx="28" cy="28" r="9" fill="none" stroke="var(--accent)" strokeWidth="0.5" opacity="0.6" />
+          </svg>
+          <div
+            className="font-mono"
+            style={{
+              position: 'absolute',
+              top: 'calc(100% + 4px)',
+              left: '50%',
+              transform: 'translateX(-50%)',
+              fontSize: '9px',
+              letterSpacing: '0.18em',
+              textTransform: 'uppercase',
+              color: 'var(--stage-text-dim)',
+              whiteSpace: 'nowrap',
+              opacity: 0.7,
+            }}
+          >
+            orchestrator
+          </div>
         </div>
       )}
 
@@ -704,7 +754,12 @@ function HubSpokeGraph({
               className="rounded-full"
               style={{
                 width: size, height: size,
-                boxShadow: isCenter ? `0 0 0 3px var(--accent), 0 8px 32px -8px var(--accent-soft)` : undefined,
+                // Focus-mode center: blackhole-style accretion halo (cream
+                // event horizon + soft accent glow), not a bright terracotta
+                // ring. Coherent with the resting-mode orchestrator blackhole.
+                boxShadow: isCenter
+                  ? `0 0 0 1.5px rgba(242, 237, 227, 0.45), 0 0 0 6px rgba(201, 112, 86, 0.18), 0 0 28px -4px rgba(201, 112, 86, 0.35)`
+                  : undefined,
                 transition: 'box-shadow 200ms cubic-bezier(0.4,0,0.2,1)',
               }}
             >

--- a/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
+++ b/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
@@ -112,9 +112,11 @@ type Star = {
   x: number; y: number;
   baseR: number;   // born radius
   r: number;       // current radius (shrinks when consumed)
-  baseO: number;   // born opacity
-  o: number;       // current opacity
+  baseO: number;   // born opacity (target when idle, before twinkle modulation)
+  o: number;       // current opacity (after twinkle + consume effects)
   consumed: number | null; // index of agent consuming this star, or null
+  phase: number;    // 0..2π — initial twinkle phase so each star blinks independently
+  twinkleHz: number; // 0.2..1.2 cycles per second
 };
 
 /** Observatory-style starfield rendered behind the rings.
@@ -143,6 +145,8 @@ function Starfield({ width, height, agentPositions }: StarfieldProps) {
         baseO,
         o: baseO,
         consumed: null,
+        phase: rand() * Math.PI * 2,
+        twinkleHz: 0.2 + rand() * 1.0,
       };
     });
   }, [width, height]);
@@ -156,8 +160,12 @@ function Starfield({ width, height, agentPositions }: StarfieldProps) {
     const fadeRate = 1.5;     // opacity units per second when consumed
     const shrinkRate = 1.8;   // radius units per second when consumed
 
+    // Wall-clock-ish elapsed time for twinkle phase. Accumulates deltas so
+    // we don't depend on performance.now() (kept self-contained inside loop).
+    let elapsedS = 0;
     const tick = (deltaMs: number) => {
       const dt = deltaMs / 1000;
+      elapsedS += dt;
       const stars = starsRef.current;
       const circles = circlesRef.current;
       for (let i = 0; i < stars.length; i++) {
@@ -175,6 +183,13 @@ function Starfield({ width, height, agentPositions }: StarfieldProps) {
               break;
             }
           }
+        }
+
+        // Twinkle: idle stars softly modulate between 50% and 100% of baseO.
+        // Consumed stars skip twinkle so the fade-to-zero reads cleanly.
+        if (star.consumed === null) {
+          const mod = 0.75 + 0.25 * Math.sin(elapsedS * star.twinkleHz * Math.PI * 2 + star.phase);
+          star.o = star.baseO * mod;
         }
 
         if (star.consumed !== null) {

--- a/packages/dashboard-v2/src/components/GraphRail.tsx
+++ b/packages/dashboard-v2/src/components/GraphRail.tsx
@@ -131,12 +131,18 @@ function timeAgo(iso: string): string {
 }
 
 function AgentDetail({ agent, peerRelationships, agents }: { agent: AgentData; peerRelationships: PeerRelationshipMap; agents: AgentData[] }) {
-  // Status pill: benched > offline > online (highest-severity status wins).
+  // Status pill: benched > native (always ready) > offline > online.
+  // Native (Claude Code subagent) agents don't have a relay WebSocket and
+  // therefore no meaningful online/offline state — they're dispatched on
+  // demand by the orchestrator and are always available. Showing "OFFLINE"
+  // for them was misleading (a false signal that the agent was unhealthy).
   const status: { label: string; color: string } = agent.scores.bench.state === 'benched'
     ? { label: 'BENCHED', color: 'var(--danger)' }
-    : !agent.online
-      ? { label: 'OFFLINE', color: 'var(--text-dim)' }
-      : { label: 'ONLINE', color: 'var(--success)' };
+    : agent.native
+      ? { label: 'READY', color: 'var(--success)' }
+      : !agent.online
+        ? { label: 'OFFLINE', color: 'var(--ink-3)' }
+        : { label: 'ONLINE', color: 'var(--success)' };
 
   // Top 3 peers by total interaction count.
   const peers: Array<{ other: string; rel: PeerRelationship; total: number }> = [];
@@ -154,7 +160,7 @@ function AgentDetail({ agent, peerRelationships, agents }: { agent: AgentData; p
     <div className="flex h-full flex-col">
       {/* Status pill — top gradient strip */}
       <div
-        className="flex items-center gap-1.5 px-4 py-2 font-mono text-[9px] font-bold uppercase tracking-widest"
+        className="flex items-center gap-1.5 px-4 py-2 h-section"
         style={{ color: status.color, borderBottom: '1px solid var(--border)', background: `color-mix(in oklch, ${status.color} 6%, transparent)` }}
       >
         <span style={{ width: 6, height: 6, borderRadius: '50%', background: status.color, display: 'inline-block' }} />
@@ -165,8 +171,8 @@ function AgentDetail({ agent, peerRelationships, agents }: { agent: AgentData; p
       <div className="flex items-center gap-3 px-4 pt-4">
         <NeuralAvatar agentId={agent.id} signals={agent.scores.signals} accuracy={agent.scores.accuracy} uniqueness={agent.scores.uniqueness} impact={agent.scores.impactScore} size={48} />
         <div className="min-w-0 flex-1">
-          <div className="truncate font-mono text-[13px] font-semibold" style={{ color: 'var(--text)' }}>{agent.id}</div>
-          <div className="truncate font-mono text-[10px]" style={{ color: 'var(--text-dim)' }}>{agent.model}</div>
+          <div className="truncate font-mono text-[13px] font-semibold" style={{ color: 'var(--ink)' }}>{agent.id}</div>
+          <div className="truncate font-mono text-[10px]" style={{ color: 'var(--ink-3)' }}>{agent.model}</div>
         </div>
       </div>
 
@@ -180,7 +186,7 @@ function AgentDetail({ agent, peerRelationships, agents }: { agent: AgentData; p
 
       {/* Top peer relationships */}
       <div className="mt-4 px-4">
-        <div className="mb-1.5 font-mono text-[9px] font-bold uppercase tracking-widest" style={{ color: 'var(--text-faint)' }}>
+        <div className="mb-1.5 h-section">
           Top peers
         </div>
         {topPeers.length === 0 ? (
@@ -189,8 +195,8 @@ function AgentDetail({ agent, peerRelationships, agents }: { agent: AgentData; p
           <div className="space-y-1">
             {topPeers.map(({ other, rel }) => (
               <div key={other} className="rounded px-2 py-1.5" style={{ background: 'color-mix(in oklch, var(--surface) 50%, transparent)' }}>
-                <div className="truncate font-mono text-[11px]" style={{ color: 'var(--text)' }}>{other}</div>
-                <div className="mt-0.5 flex items-center gap-2 font-mono text-[10px]" style={{ color: 'var(--text-dim)' }}>
+                <div className="truncate font-mono text-[11px]" style={{ color: 'var(--ink)' }}>{other}</div>
+                <div className="mt-0.5 flex items-center gap-2 font-mono text-[10px]" style={{ color: 'var(--ink-3)' }}>
                   {rel.confirmed > 0 && <span><span style={{ color: 'var(--success)' }}>✓</span> {rel.confirmed}</span>}
                   {rel.disputed > 0 && <span><span style={{ color: 'var(--warn)' }}>≠</span> {rel.disputed}</span>}
                   {rel.hallucinationsCaught > 0 && <span><span style={{ color: 'var(--danger)' }}>◆</span> {rel.hallucinationsCaught}</span>}
@@ -205,12 +211,12 @@ function AgentDetail({ agent, peerRelationships, agents }: { agent: AgentData; p
       {/* Skills */}
       {agent.skills.length > 0 && (
         <div className="mt-4 px-4">
-          <div className="mb-1.5 font-mono text-[9px] font-bold uppercase tracking-widest" style={{ color: 'var(--text-faint)' }}>
+          <div className="mb-1.5 h-section">
             Skills <span style={{ color: 'var(--accent)' }}>{agent.skills.length}</span>
           </div>
           <div className="flex flex-wrap gap-1">
             {agent.skills.slice(0, 6).map((s) => (
-              <span key={s} className="rounded-sm border px-1.5 py-0.5 font-mono text-[10px]" style={{ borderColor: 'var(--border)', color: 'var(--text-dim)' }}>{s}</span>
+              <span key={s} className="rounded-sm border px-1.5 py-0.5 font-mono text-[10px]" style={{ borderColor: 'var(--border)', color: 'var(--ink-3)' }}>{s}</span>
             ))}
           </div>
         </div>

--- a/packages/dashboard-v2/src/components/TemporalScrubber.tsx
+++ b/packages/dashboard-v2/src/components/TemporalScrubber.tsx
@@ -48,10 +48,10 @@ export function TemporalScrubber({ runs, range, onRangeChange, height = 52 }: Te
       className="flex items-center gap-3 rounded-md border px-3 py-2"
       style={{ background: 'var(--surface-elev)', borderColor: 'var(--border)' }}
     >
-      <div className="font-mono text-[9px] font-bold uppercase tracking-widest" style={{ color: 'var(--text-faint)' }}>
+      <div className="h-section">
         Signal volume
       </div>
-      <span className="font-mono text-[9px] tabular-nums" style={{ color: 'var(--text-faint)' }}>{RANGE_AGO_LABEL[range]}</span>
+      <span className="font-mono text-[10px] tabular-nums" style={{ color: 'var(--ink-3)' }}>{RANGE_AGO_LABEL[range]}</span>
       <svg
         viewBox={`0 0 ${BUCKET_COUNT} 1`}
         preserveAspectRatio="none"
@@ -73,7 +73,7 @@ export function TemporalScrubber({ runs, range, onRangeChange, height = 52 }: Te
           );
         })}
       </svg>
-      <span className="font-mono text-[9px] tabular-nums" style={{ color: 'var(--text-faint)' }}>now</span>
+      <span className="font-mono text-[10px] tabular-nums" style={{ color: 'var(--ink-3)' }}>now</span>
       <div className="flex gap-1">
         {RANGES.map((r) => {
           const active = r === range;

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -169,6 +169,24 @@
   --s-8: 64px;
 }
 
+/* Orchestrator easter egg — click the center blackhole.
+   Smile pops in with a quick bounce + fade out; ripple expands + fades. */
+@keyframes orch-smile-pop {
+  0%   { opacity: 0; transform: scale(0.4); }
+  20%  { opacity: 1; transform: scale(1.25); }
+  45%  { opacity: 1; transform: scale(0.95); }
+  60%  { opacity: 1; transform: scale(1); }
+  100% { opacity: 0; transform: scale(1); }
+}
+@keyframes orch-ripple {
+  0%   { opacity: 0.7; transform: scale(0.9); }
+  100% { opacity: 0; transform: scale(3.4); }
+}
+@media (prefers-reduced-motion: reduce) {
+  /* Respect motion sensitivity: easter egg still fires but instantly. */
+  [style*="orch-smile-pop"], [style*="orch-ripple"] { animation: none !important; opacity: 0; }
+}
+
 /* DESIGN.md section header signature (small-caps Geist).
    Replaces the legacy `font-mono text-[11px] font-bold uppercase tracking-widest` pattern.
    Step 2 of the application checklist rolls this out across every existing header.


### PR DESCRIPTION
## Summary

9-commit polish pass on the AgentNetworkGraph after Step 4 shipped. Picks up direct user feedback through the session — distribution, panel consistency, native-agent status correctness, focus-mode aesthetic coherence, fun.

## What changed (chronological by commit)

| # | Commit | What |
|---|---|---|
| 1 | `414fc8f` | Radial outward labels + accuracy-rank distribution + tighter cushion (24px) + inner-radius floor (0.22*maxR) |
| 2 | `335a722` | ResizeObserver measures actual canvas height — rings/stars/agents center in the stretched stage, no orphan whitespace |
| 3 | `7fcd6fd` | Per-star twinkle (sine modulation, independent phases 0.2–1.2 Hz) |
| 4 | `6fde7cb` | Orchestrator blackhole at center (resting mode) + focus-mode cosmic coherence (soft cream halo on selected agent, dimmer 0.55 opacity spokes) |
| 5 | `f33d502` | **Correctness fix**: native agents show `● READY` in green instead of falsifying `● OFFLINE` grey. Plus panel consistency sweep — TOP PEERS / SKILLS / SIGNAL VOLUME labels all on `.h-section` |
| 6 | `c455aea` | Golden-angle distribution (phyllotaxis) — breaks adjacency clustering when accuracies are similar |
| 7 | `30b7bcc` | **Easter egg**: click the orchestrator blackhole — it smiles back (4 cycling face variants + ripple + label hearts at 10+ clicks) |
| 8 | `e6029cc` | Move accuracy-scope legend to bottom-right (was top-left) |
| 9 | `914b55d` | Drop the misleading `spoke color = agent identity` half of the legend (spokes only render in focus mode) |

## Correctness fix flagged in commit 5

The previous status logic showed `OFFLINE` for any agent with `!agent.online`. Native Claude Code subagents don't connect via the relay WebSocket — they're dispatched on demand and are always available. Showing them as OFFLINE was a false signal that read as "agent is broken / unreachable". Fixed to a four-state hierarchy: `benched (danger) > native (READY, success) > offline (idle) > online (success)`.

## Visual results

- Agents distributed evenly around the chart via phyllotaxis (no more clumping at adjacent angles)
- Orchestrator represented as a small blackhole at the gravitational center (dark disc + accretion halo)
- Cosmic stage always dark regardless of light/dark theme; 120 twinkling stars; agents passively eat nearby stars
- Focus mode preserves the cosmic language: soft cream halo on selected agent (matching blackhole accretion), dimmer energy-flow spokes
- Right rail + bottom signal-volume strip now share label vocabulary (`.h-section`) and color tokens (`--ink` / `--ink-3`) with the rest of the dashboard
- Click the orchestrator — it smiles back

## Test plan

- [x] `npm run build` clean across all 9 commits
- [x] Visual verify in light + dark theme — graph stage stays cosmic dark, rest follows theme
- [x] `sonnet-reviewer` native agent renders `● READY` in green (was `● OFFLINE`)
- [x] Click the orchestrator blackhole — smile pops in, ripple expands, cycles through 4 face variants
- [x] Past 10 clicks, label transforms to `♥ orchestrator ♥`
- [x] `prefers-reduced-motion: reduce` → animations clear (verified via the CSS media query in globals.css)
- [x] focusLayout untouched — `git diff` shows the click-to-focus mode behavior unchanged
- [x] No new dependencies

## Backlog noted (saved to memory, not in this PR)

- "Gravity" button easter egg — toggle in the graph top-right that runs an n-body physics sim on the agent vortexes with mass derived from signals/accuracy and the orchestrator blackhole as anchor mass. Velocity-Verlet integrator, URL persistence via `?gravity=1`. Saved at `~/.claude/projects/.../project_dashboard_gravity_button_easter_egg.md`.

## Process

- Plan: implicit (iterative user feedback driven)
- Previous related PRs: #463 (DESIGN.md), #464 (Steps 0+1), #465 (Step 2), #466 (Step 3), #467 (Step 4 base)
- This PR sits on top of Step 4 — sharpens the graph that PR introduced without changing its semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)