### PR TITLE
feat(dashboard-v2): Step 9.5 — SkillGraduationGrid card layout + post-bind effectiveness sparklines

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -496,7 +496,7 @@ function FindingsPage({
 
 function Dashboard() {
   const route = useRoute();
-  const { overview, agents, tasks, consensus, consensusReports, fleetTrend, loading, refresh } = useDashboardData();
+  const { overview, agents, tasks, consensus, consensusReports, fleetTrend, skills, loading, refresh } = useDashboardData();
   const [activeTaskCount, setActiveTaskCount] = useState(0);
 
   const handleWsEvent = useCallback((event: DashboardEvent) => {
@@ -546,6 +546,7 @@ function Dashboard() {
         consensus={consensus}
         consensusReports={consensusReports}
         fleetTrend={fleetTrend}
+        skills={skills}
         activeTaskCount={activeTaskCount}
         setActiveTaskCount={setActiveTaskCount}
       />

--- a/packages/dashboard-v2/src/components/SkillEffectivenessSparkline.tsx
+++ b/packages/dashboard-v2/src/components/SkillEffectivenessSparkline.tsx
@@ -1,0 +1,153 @@
+import { useMemo } from 'react';
+import type { SkillCurvePoint } from '@/lib/types';
+
+/**
+ * DESIGN.md Step 9.5 — per-skill post-bind effectiveness sparkline.
+ *
+ * Single stroke path + dashed horizontal threshold line. No fill.
+ * Gaps (windows with no signals → value === null) split the path so the line
+ * doesn't lie about coverage. The verdict color (--ok / --info / --bad / etc.)
+ * is supplied by the parent so we never bake a palette decision in here.
+ *
+ * Sizing: defaults to 140×30 (matches the mockup density). Caller can override
+ * via props but the dashed threshold and gap-splitting logic don't care.
+ */
+
+interface Props {
+  curve: SkillCurvePoint[];
+  /** [0, 1] horizontal line. Default 0.7 (HANDBOOK invariant). */
+  threshold: number;
+  /** Stroke color for the curve. Should be the verdict color. */
+  stroke: string;
+  width?: number;
+  height?: number;
+}
+
+const PADDING_X = 1;
+const PADDING_Y = 2;
+
+export function SkillEffectivenessSparkline({
+  curve,
+  threshold,
+  stroke,
+  width = 140,
+  height = 30,
+}: Props) {
+  // Split the curve into contiguous defined-value runs so SVG `M ... L ...`
+  // segments don't visually bridge gaps. Each run becomes one <path>.
+  const segments = useMemo(() => splitSegments(curve), [curve]);
+
+  if (curve.length === 0) {
+    return <EmptySparkline width={width} height={height} />;
+  }
+
+  const innerW = width - PADDING_X * 2;
+  const innerH = height - PADDING_Y * 2;
+  const thresholdY = PADDING_Y + (1 - clamp01(threshold)) * innerH;
+
+  const xFor = (i: number): number => {
+    if (curve.length <= 1) return PADDING_X + innerW / 2;
+    return PADDING_X + (i / (curve.length - 1)) * innerW;
+  };
+  const yFor = (v: number): number => PADDING_Y + (1 - clamp01(v)) * innerH;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-hidden
+      style={{ display: 'block' }}
+    >
+      {/* Threshold line — dashed, ink-4 stroke. */}
+      <line
+        x1={PADDING_X}
+        x2={width - PADDING_X}
+        y1={thresholdY}
+        y2={thresholdY}
+        stroke="var(--ink-4)"
+        strokeWidth={1}
+        strokeDasharray="2 3"
+        opacity={0.7}
+      />
+      {/* One stroke path per contiguous segment of non-null values. */}
+      {segments.map((seg, i) => {
+        if (seg.length === 1) {
+          // Single point: draw a tiny circle so it's visible.
+          const { idx, value } = seg[0];
+          return (
+            <circle
+              key={i}
+              cx={xFor(idx)}
+              cy={yFor(value)}
+              r={1.4}
+              fill={stroke}
+            />
+          );
+        }
+        const d = seg
+          .map((p, j) => `${j === 0 ? 'M' : 'L'} ${xFor(p.idx).toFixed(2)} ${yFor(p.value).toFixed(2)}`)
+          .join(' ');
+        return (
+          <path
+            key={i}
+            d={d}
+            fill="none"
+            stroke={stroke}
+            strokeWidth={1.5}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+function EmptySparkline({ width, height }: { width: number; height: number }) {
+  // Render the threshold dashed line only — keeps the row height stable while
+  // signaling "no post-bind signals yet."
+  const thresholdY = height / 2;
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-hidden
+      style={{ display: 'block' }}
+    >
+      <line
+        x1={PADDING_X}
+        x2={width - PADDING_X}
+        y1={thresholdY}
+        y2={thresholdY}
+        stroke="var(--ink-4)"
+        strokeWidth={1}
+        strokeDasharray="2 3"
+        opacity={0.5}
+      />
+    </svg>
+  );
+}
+
+function splitSegments(curve: SkillCurvePoint[]): Array<Array<{ idx: number; value: number }>> {
+  const out: Array<Array<{ idx: number; value: number }>> = [];
+  let cur: Array<{ idx: number; value: number }> = [];
+  for (let i = 0; i < curve.length; i++) {
+    const v = curve[i].value;
+    if (v == null || !Number.isFinite(v)) {
+      if (cur.length > 0) { out.push(cur); cur = []; }
+      continue;
+    }
+    cur.push({ idx: i, value: v });
+  }
+  if (cur.length > 0) out.push(cur);
+  return out;
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}

--- a/packages/dashboard-v2/src/components/SkillGraduationGrid.tsx
+++ b/packages/dashboard-v2/src/components/SkillGraduationGrid.tsx
@@ -1,28 +1,26 @@
 import { useMemo } from 'react';
-import type { AgentData, SkillStatus, SkillSlot } from '@/lib/types';
-import { agentColor, timeAgo } from '@/lib/utils';
+import type { SkillsApiResponse, SkillEffectivenessEntry, SkillStatus } from '@/lib/types';
+import { SkillEffectivenessSparkline } from './SkillEffectivenessSparkline';
+import { href } from '@/lib/router';
 
 /**
- * DESIGN.md Step 9 — Skill graduation grid.
+ * DESIGN.md Step 9.5 — SkillGraduationGrid as a flat card grid.
  *
- * Renders every live skill across the fleet with a defined verdict color.
- * Detailed companion to `SkillVerdictsSnapshot` (which is just the bar-chart
- * summary). Source: `agents[].skillSlots[]` — already fetched by
- * `OverviewPage`, so no extra request.
+ * Replaces the verdict-grouped layout (Step 9). Each cell shows a post-bind
+ * effectiveness sparkline with a dashed graduation threshold line, plus the
+ * skill name on top and the small-caps verdict + signal count on the bottom.
  *
- * Verdict palette mirrors `SkillVerdictsSnapshot` (single source of truth).
+ * Source: GET /dashboard/api/skills `effectiveness` array — derived from
+ * agent-performance.jsonl bucketed by skill into 10 equal-time post-bind
+ * windows. UNKNOWN-verdict skills go into a native <details> collapsible
+ * below the main grid.
  *
- * Drift note from spec: spec says "reading the existing skill state JSON" via
- * the `SkillsGetResponse` endpoint. That payload only carries the bind index
- * (agent → skill → { enabled, source, mode, version, boundAt }) — there is no
- * per-skill `status` field on `SkillsGetResponse`. The verdict lives on
- * `AgentData.skillSlots[].status`, sourced from skill frontmatter inside
- * `api-agents.ts`. We use `agents` to satisfy the gate without backend
- * changes. If a future spec requires this grid to render before agents load,
- * `SkillsGetResponse` should be extended to inline per-slot status.
+ * Verdict palette mirrors SkillVerdictsSnapshot (single source of truth).
  */
 
-// Subset of SkillStatus that the spec calls out — the 6 graduation verdicts.
+// 6 graduation verdicts that get their own sparkline color. The 7th
+// (flagged_for_manual_review) plus any unknown string fall through to the
+// UNKNOWN collapsible bucket below.
 type GraduationVerdict =
   | 'passed'
   | 'pending'
@@ -31,11 +29,6 @@ type GraduationVerdict =
   | 'silent_skill'
   | 'failed';
 
-/**
- * Gate: every live skill renders with a defined color. `Record<...>` keyed by
- * literal status string means a missing key fails at TS compile, not at
- * render with `undefined` fallthrough.
- */
 const VERDICT_COLOR: Record<GraduationVerdict, string> = {
   passed: 'var(--ok)',
   pending: 'var(--info)',
@@ -54,313 +47,256 @@ const VERDICT_LABEL: Record<GraduationVerdict, string> = {
   failed: 'failed',
 };
 
-// Display order: success → in-flight → degraded → failed. Operator scans
-// top-to-bottom looking for problems, so failed lives at the bottom.
-const VERDICT_ORDER: GraduationVerdict[] = [
-  'passed',
-  'pending',
-  'inconclusive',
-  'insufficient_evidence',
-  'silent_skill',
-  'failed',
-];
-
-// Fallback colors for unexpected status strings or missing status. Render
-// defensively — don't crash, don't blank.
 const UNKNOWN_COLOR = 'var(--ink-4)';
-const UNKNOWN_LABEL = 'unknown';
 
-function isGraduationVerdict(s: string | undefined): s is GraduationVerdict {
-  return s !== undefined && s in VERDICT_COLOR;
-}
-
-interface Row {
-  agentId: string;
-  slot: SkillSlot;
-  verdict: GraduationVerdict | null; // null = unknown / missing status
+function isGraduationVerdict(s: SkillStatus | null | undefined): s is GraduationVerdict {
+  return s !== undefined && s !== null && s in VERDICT_COLOR;
 }
 
 interface Props {
-  agents: AgentData[] | null;
+  skills: SkillsApiResponse | null;
   loading?: boolean;
   error?: string | null;
 }
 
-export function SkillGraduationGrid({ agents, loading, error }: Props) {
-  const groups = useMemo(() => groupByVerdict(agents), [agents]);
+export function SkillGraduationGrid({ skills, loading, error }: Props) {
+  const { known, unknown, total, transitions } = useMemo(
+    () => partition(skills?.effectiveness),
+    [skills],
+  );
+
+  const skillCount = total;
 
   return (
-    <section
-      className="rounded-lg border border-border p-4"
-      style={{ background: 'var(--surface-elev)' }}
-    >
-      <header className="mb-3 flex items-baseline justify-between">
-        <h3 className="h-section">Skill Graduation</h3>
-        <div className="flex items-center gap-2">
-          {error && (
-            <span
-              className="rounded-sm px-1.5 py-0.5 font-mono text-[10px]"
-              style={{
-                color: 'var(--bad)',
-                background: 'color-mix(in oklch, var(--bad) 12%, transparent)',
-                border: '1px solid color-mix(in oklch, var(--bad) 30%, transparent)',
-              }}
-              title={error}
-            >
-              error
-            </span>
-          )}
+    <section className="space-y-2">
+      {/* Section header row — outside the card per the mockup. */}
+      <header className="flex items-baseline justify-between">
+        <div className="flex items-baseline gap-2">
+          <h3 className="h-section">Skill Graduation</h3>
           <span
-            className="font-mono text-[10px]"
-            style={{ color: 'color-mix(in oklch, var(--text-dim) 70%, transparent)' }}
+            className="font-mono text-[11px] tabular-nums"
+            style={{ color: 'var(--accent)' }}
           >
-            {groups.total} live
+            {skillCount}
+          </span>
+          <span
+            className="font-mono text-[11px]"
+            style={{ color: 'var(--ink-3)' }}
+          >
+            skills · {transitions} transitions /24h
           </span>
         </div>
+        <a
+          href={href('/')}
+          className="font-mono text-[11px] transition hover:underline"
+          style={{ color: 'var(--ink-3)' }}
+        >
+          skill detail →
+        </a>
       </header>
 
-      {loading && <GridSkeleton />}
-      {!loading && groups.total === 0 && !error && (
-        <p
-          className="text-[12px]"
-          style={{ color: 'color-mix(in oklch, var(--text-dim) 80%, transparent)' }}
-        >
-          No skills graduated yet — agents need more dispatches.
+      <div
+        className="rounded-lg border border-border p-4"
+        style={{ background: 'var(--surface-elev)' }}
+      >
+        <p className="mb-3 text-[11px]" style={{ color: 'var(--ink-3)' }}>
+          Each cell shows the post-bind effectiveness curve. Dashed line = graduation threshold.
+          Verdict is from the latest evidence window.
         </p>
-      )}
-      {!loading && groups.total > 0 && (
-        <div className="space-y-4">
-          {VERDICT_ORDER.map((v) => {
-            const rows = groups.byVerdict.get(v);
-            if (!rows || rows.length === 0) return null;
-            return (
-              <VerdictGroup key={v} verdict={v} rows={rows} />
-            );
-          })}
-          {groups.unknown.length > 0 && (
-            <UnknownGroup rows={groups.unknown} />
-          )}
-        </div>
-      )}
+
+        {error && <ErrorBanner message={error} />}
+        {loading && !skills && <GridSkeleton />}
+        {!loading && total === 0 && !error && (
+          <p className="text-[12px]" style={{ color: 'var(--ink-3)' }}>
+            No skills bound yet — agents need at least one dispatch with a skill match.
+          </p>
+        )}
+        {total > 0 && (
+          <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6">
+            {known.map((entry) => (
+              <SkillCard key={cellKey(entry)} entry={entry} />
+            ))}
+          </ul>
+        )}
+
+        {unknown.length > 0 && (
+          <details className="mt-4 group">
+            <summary
+              className="flex cursor-pointer list-none items-center gap-2 select-none"
+              style={{ color: 'var(--ink-3)' }}
+            >
+              <span
+                aria-hidden
+                className="chevron inline-block transition-transform"
+                style={{ fontSize: '10px', lineHeight: 1 }}
+              >
+                ▶
+              </span>
+              <span
+                className="text-[11px]"
+                style={{ fontVariant: 'small-caps', letterSpacing: '0.04em' }}
+              >
+                {unknown.length} unknown
+              </span>
+            </summary>
+            <ul className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6">
+              {unknown.map((entry) => (
+                <SkillCard key={cellKey(entry)} entry={entry} />
+              ))}
+            </ul>
+            <style>{`
+              details[open] > summary > .chevron { transform: rotate(90deg); }
+            `}</style>
+          </details>
+        )}
+      </div>
     </section>
   );
 }
 
-/* ── grouping ───────────────────────────────────────────────────────── */
-
-function groupByVerdict(agents: AgentData[] | null): {
-  byVerdict: Map<GraduationVerdict, Row[]>;
-  unknown: Row[];
-  total: number;
-} {
-  const byVerdict = new Map<GraduationVerdict, Row[]>();
-  const unknown: Row[] = [];
-  let total = 0;
-  if (!agents) return { byVerdict, unknown, total };
-
-  for (const agent of agents) {
-    for (const slot of agent.skillSlots) {
-      if (!slot.enabled) continue;
-      total++;
-      const s = slot.status as SkillStatus | undefined;
-      // flagged_for_manual_review (7th status from SkillStatus union) and any
-      // unknown string both fall through to the defensive "unknown" bucket so
-      // they get a defined color (UNKNOWN_COLOR) instead of blank chrome.
-      if (isGraduationVerdict(s)) {
-        const arr = byVerdict.get(s) ?? [];
-        arr.push({ agentId: agent.id, slot, verdict: s });
-        byVerdict.set(s, arr);
-      } else {
-        unknown.push({ agentId: agent.id, slot, verdict: null });
-      }
-    }
-  }
-
-  // Within each verdict, sort by most-recently-bound first so freshly-changed
-  // verdicts surface at the top of the column.
-  const sortFn = (a: Row, b: Row) =>
-    (b.slot.boundAt ?? '').localeCompare(a.slot.boundAt ?? '');
-  for (const arr of byVerdict.values()) arr.sort(sortFn);
-  unknown.sort(sortFn);
-
-  return { byVerdict, unknown, total };
+function cellKey(e: SkillEffectivenessEntry): string {
+  return `${e.agentId}::${e.skill}`;
 }
 
-/* ── verdict group header + grid ────────────────────────────────────── */
+/* ── partition ─────────────────────────────────────────────────────────── */
 
-function VerdictGroup({ verdict, rows }: { verdict: GraduationVerdict; rows: Row[] }) {
-  const color = VERDICT_COLOR[verdict];
-  const label = VERDICT_LABEL[verdict];
+function partition(
+  list: SkillEffectivenessEntry[] | undefined,
+): {
+  known: SkillEffectivenessEntry[];
+  unknown: SkillEffectivenessEntry[];
+  total: number;
+  transitions: number;
+} {
+  if (!list) return { known: [], unknown: [], total: 0, transitions: 0 };
+  const known: SkillEffectivenessEntry[] = [];
+  const unknown: SkillEffectivenessEntry[] = [];
+  // Transitions /24h proxy: skills whose curve has BOTH a passing and a failing
+  // window inside the last 24h slice. Approximated by checking the last two
+  // bucket values straddle the threshold (one above, one below). The backend
+  // doesn't expose drift_strike_at / regressed_from_passed_at directly yet, so
+  // this is a curve-shape heuristic, not a state-machine read. Documented drift
+  // from spec — easy to upgrade once those fields surface in the API.
+  let transitions = 0;
+  for (const e of list) {
+    if (isGraduationVerdict(e.status)) known.push(e);
+    else unknown.push(e);
+    if (e.curve.length >= 2) {
+      const tail = e.curve.slice(-2);
+      const above = tail.filter((p) => p.value != null && p.value >= e.threshold).length;
+      const below = tail.filter((p) => p.value != null && p.value < e.threshold).length;
+      if (above >= 1 && below >= 1) transitions++;
+    }
+  }
+  // Sort known: failing-first, then by name so operator eyes land on
+  // problems immediately within the flat grid.
+  const order: Record<GraduationVerdict, number> = {
+    failed: 0,
+    inconclusive: 1,
+    silent_skill: 2,
+    insufficient_evidence: 3,
+    pending: 4,
+    passed: 5,
+  };
+  known.sort((a, b) => {
+    const ra = isGraduationVerdict(a.status) ? order[a.status] : 99;
+    const rb = isGraduationVerdict(b.status) ? order[b.status] : 99;
+    if (ra !== rb) return ra - rb;
+    return a.skill.localeCompare(b.skill);
+  });
+  unknown.sort((a, b) => a.skill.localeCompare(b.skill));
+  return { known, unknown, total: known.length + unknown.length, transitions };
+}
+
+/* ── single skill card ─────────────────────────────────────────────────── */
+
+function SkillCard({ entry }: { entry: SkillEffectivenessEntry }) {
+  const verdict = isGraduationVerdict(entry.status) ? entry.status : null;
+  const color = verdict ? VERDICT_COLOR[verdict] : UNKNOWN_COLOR;
+  const label = verdict ? VERDICT_LABEL[verdict] : (entry.status ?? 'unknown');
+
   return (
-    <div>
-      <div className="mb-2 flex items-center gap-2">
+    <li
+      className="flex flex-col gap-1.5 rounded-sm border border-border p-2.5"
+      style={{ background: 'var(--surface)' }}
+      title={`${entry.agentId} · ${entry.skill} · ${label} · N=${entry.n}`}
+    >
+      {/* Top: skill name */}
+      <div className="truncate text-[13px]" style={{ color: 'var(--ink)' }}>
+        {entry.skill}
+      </div>
+      {/* Middle: sparkline */}
+      <SkillEffectivenessSparkline
+        curve={entry.curve}
+        threshold={entry.threshold}
+        stroke={color}
+      />
+      {/* Bottom: verdict label + N */}
+      <div className="flex items-baseline justify-between gap-2">
         <span
-          aria-hidden
-          className="h-1.5 w-1.5 rounded-full"
-          style={{ background: color }}
-        />
-        <span
-          className="h-section"
-          style={{ color: 'var(--text-dim)' }}
+          className="truncate text-[10px]"
+          style={{
+            color,
+            fontVariant: 'small-caps',
+            letterSpacing: '0.04em',
+          }}
         >
           {label}
         </span>
         <span
           className="font-mono text-[10px] tabular-nums"
-          style={{ color: 'color-mix(in oklch, var(--text-dim) 60%, transparent)' }}
+          style={{ color: 'var(--ink-3)' }}
         >
-          {rows.length}
+          N={entry.n}
         </span>
       </div>
-      <ul className="grid grid-cols-1 gap-1.5 sm:grid-cols-2 lg:grid-cols-3">
-        {rows.map((r) => (
-          <SkillCell key={`${r.agentId}::${r.slot.name}`} row={r} color={color} label={label} />
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-function UnknownGroup({ rows }: { rows: Row[] }) {
-  return (
-    <div>
-      <div className="mb-2 flex items-center gap-2">
-        <span
-          aria-hidden
-          className="h-1.5 w-1.5 rounded-full"
-          style={{ background: UNKNOWN_COLOR }}
-        />
-        <span className="h-section" style={{ color: 'var(--text-dim)' }}>
-          {UNKNOWN_LABEL}
-        </span>
-        <span
-          className="font-mono text-[10px] tabular-nums"
-          style={{ color: 'color-mix(in oklch, var(--text-dim) 60%, transparent)' }}
-        >
-          {rows.length}
-        </span>
-      </div>
-      <ul className="grid grid-cols-1 gap-1.5 sm:grid-cols-2 lg:grid-cols-3">
-        {rows.map((r) => (
-          <SkillCell
-            key={`${r.agentId}::${r.slot.name}`}
-            row={r}
-            color={UNKNOWN_COLOR}
-            label={r.slot.status ?? UNKNOWN_LABEL}
-          />
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-/* ── individual cell ────────────────────────────────────────────────── */
-
-function SkillCell({ row, color, label }: { row: Row; color: string; label: string }) {
-  const { agentId, slot } = row;
-  const metric = formatMetric(slot);
-
-  return (
-    <li
-      className="flex items-center gap-2 rounded-sm border border-border px-2.5 py-1.5"
-      style={{ background: 'var(--surface)' }}
-      title={`${agentId} · ${slot.name} · ${label}`}
-    >
-      {/* Per-agent identity dot — only place identity color lives (DESIGN.md). */}
-      <span
-        aria-hidden
-        className="h-2 w-2 shrink-0 rounded-full"
-        style={{ background: agentColor(agentId) }}
-      />
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-[12px]" style={{ color: 'var(--ink)' }}>
-          {slot.name}
-        </div>
-        <div
-          className="truncate text-[10px]"
-          style={{
-            color: 'color-mix(in oklch, var(--text-dim) 80%, transparent)',
-            fontVariant: 'small-caps',
-            letterSpacing: '0.04em',
-          }}
-        >
-          {agentId}
-        </div>
-      </div>
-      {metric && (
-        <span
-          className="shrink-0 font-mono text-[10px] tabular-nums"
-          style={{ color: 'color-mix(in oklch, var(--text-dim) 70%, transparent)' }}
-          title={metric.title}
-        >
-          {metric.text}
-        </span>
-      )}
-      <span
-        className="shrink-0 rounded-sm px-1.5 py-0.5 text-[10px]"
-        style={{
-          color,
-          background: `color-mix(in oklch, ${color} 14%, transparent)`,
-          border: `1px solid color-mix(in oklch, ${color} 30%, transparent)`,
-          fontVariant: 'small-caps',
-          letterSpacing: '0.04em',
-        }}
-      >
-        {label}
-      </span>
     </li>
   );
 }
 
-function formatMetric(slot: SkillSlot): { text: string; title: string } | null {
-  // Prefer evidence-progress when MIN_EVIDENCE gate info is present.
-  if (typeof slot.postBindSignals === 'number' && typeof slot.minEvidence === 'number') {
-    return {
-      text: `${slot.postBindSignals}/${slot.minEvidence}`,
-      title: `post-bind signals / MIN_EVIDENCE gate`,
-    };
-  }
-  if (typeof slot.effectiveness === 'number') {
-    return {
-      text: `${Math.round(slot.effectiveness * 100)}%`,
-      title: 'effectiveness',
-    };
-  }
-  if (slot.boundAt) {
-    return { text: timeAgo(slot.boundAt), title: `bound ${slot.boundAt}` };
-  }
-  return null;
+/* ── states ────────────────────────────────────────────────────────────── */
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div
+      className="mb-3 rounded-sm px-2 py-1 font-mono text-[10px]"
+      style={{
+        color: 'var(--bad)',
+        background: 'color-mix(in oklch, var(--bad) 12%, transparent)',
+        border: '1px solid color-mix(in oklch, var(--bad) 30%, transparent)',
+      }}
+    >
+      error · {message}
+    </div>
+  );
 }
 
-/* ── loading skeleton ───────────────────────────────────────────────── */
-
 function GridSkeleton() {
-  // Two pseudo-groups, three cells each.
   return (
-    <div className="space-y-4" aria-hidden>
-      {[0, 1].map((g) => (
-        <div key={g}>
-          <div className="mb-2 flex items-center gap-2">
-            <span
-              className="h-1.5 w-1.5 rounded-full"
-              style={{ background: 'color-mix(in oklch, var(--text-dim) 30%, transparent)' }}
-            />
-            <span
-              className="h-3 w-20 rounded-sm"
-              style={{ background: 'color-mix(in oklch, var(--text-dim) 18%, transparent)' }}
-            />
-          </div>
-          <ul className="grid grid-cols-1 gap-1.5 sm:grid-cols-2 lg:grid-cols-3">
-            {[0, 1, 2].map((c) => (
-              <li
-                key={c}
-                className="h-10 rounded-sm border border-border"
-                style={{ background: 'var(--surface)' }}
-              />
-            ))}
-          </ul>
-        </div>
+    <ul
+      className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6"
+      aria-hidden
+    >
+      {Array.from({ length: 6 }).map((_, i) => (
+        <li
+          key={i}
+          className="flex h-[88px] flex-col gap-1.5 rounded-sm border border-border p-2.5"
+          style={{ background: 'var(--surface)' }}
+        >
+          <span
+            className="h-3 w-3/4 rounded-sm"
+            style={{ background: 'color-mix(in oklch, var(--text-dim) 18%, transparent)' }}
+          />
+          <span
+            className="h-[30px] w-full rounded-sm"
+            style={{ background: 'color-mix(in oklch, var(--text-dim) 10%, transparent)' }}
+          />
+          <span
+            className="h-3 w-1/2 rounded-sm"
+            style={{ background: 'color-mix(in oklch, var(--text-dim) 14%, transparent)' }}
+          />
+        </li>
       ))}
-    </div>
+    </ul>
   );
 }

--- a/packages/dashboard-v2/src/hooks/useDashboardData.ts
+++ b/packages/dashboard-v2/src/hooks/useDashboardData.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { api } from '@/lib/api';
-import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, MemoryFile, FleetTrendResponse } from '@/lib/types';
+import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, MemoryFile, FleetTrendResponse, SkillsApiResponse } from '@/lib/types';
 
 /**
  * Polling interval for /api/agents and friends. Backs the "Team page updates
@@ -21,6 +21,12 @@ export interface DashboardState {
   consensus: ConsensusData | null;
   consensusReports: ConsensusReportsData | null;
   fleetTrend: FleetTrendResponse | null;
+  /**
+   * Step 9.5 — per-skill post-bind effectiveness curves. Drives the
+   * SkillGraduationGrid sparklines + skill-count subtitle. Null while
+   * the first poll is in flight.
+   */
+  skills: SkillsApiResponse | null;
   /**
    * Claude Code auto-memory (`~/.claude/projects/-<cwd>/memory/`). Flat list,
    * no 4-folder taxonomy. Separate from gossipMemories — callers MUST NOT merge
@@ -46,6 +52,7 @@ export function useDashboardData() {
   const [state, setState] = useState<DashboardState>({
     overview: null, agents: null, tasks: null, consensus: null, consensusReports: null,
     fleetTrend: null,
+    skills: null,
     nativeMemories: null, gossipMemories: null, memories: null,
     loading: true, error: null,
   });
@@ -59,7 +66,7 @@ export function useDashboardData() {
     if (inFlight.current) return;
     inFlight.current = true;
     try {
-      const [overview, agents, tasks, consensus, consensusReports, fleetTrend, nativeResp, gossipResp] = await Promise.all([
+      const [overview, agents, tasks, consensus, consensusReports, fleetTrend, skills, nativeResp, gossipResp] = await Promise.all([
         api<OverviewData>('overview'),
         api<AgentData[]>('agents'),
         api<TasksData>('tasks?limit=2000'),
@@ -72,6 +79,10 @@ export function useDashboardData() {
         api<ConsensusReportsData>('consensus-reports?page=1&pageSize=200').catch(() => ({ reports: [] })),
         // Fleet trend — 7-day window for AreaSparkline in AgentCardBig.
         api<FleetTrendResponse>('fleet-trend?days=7').catch(() => ({ days: 7, points: [] })),
+        // Step 9.5 — per-skill effectiveness curves for SkillGraduationGrid.
+        // Server-side 60s cache keyed on agent-performance.jsonl mtime — the
+        // 5s poll just refreshes the cache stamp, not the curve derivation.
+        api<SkillsApiResponse>('skills').catch(() => ({ index: {}, suggestions: [], effectiveness: [] })),
         // Native + gossip stores are fetched in parallel and kept SEPARATE. The
         // taxonomy/status split only applies to gossip memories. Native memories
         // render flat. Spec: docs/specs/2026-04-15-session-save-native-vs-gossip-memory.md
@@ -92,6 +103,7 @@ export function useDashboardData() {
       setState({
         overview, agents, tasks, consensus, consensusReports,
         fleetTrend,
+        skills,
         nativeMemories,
         gossipMemories,
         memories: nativeMemories, // deprecated legacy alias

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -36,6 +36,38 @@ export interface FleetTrendResponse {
   points: FleetTrendPoint[];
 }
 
+/* ── Step 9.5 — skills + post-bind effectiveness curves ───────────────── */
+
+export interface SkillCurvePoint {
+  /** Window-end timestamp (ms epoch). */
+  t: number;
+  /** Accuracy = correct/(correct+halluc) in window. null when window empty. */
+  value: number | null;
+}
+
+export interface SkillEffectivenessEntry {
+  agentId: string;
+  skill: string;
+  status: SkillStatus | null;
+  /** 10 equal-time windows from boundAt → now. */
+  curve: SkillCurvePoint[];
+  /** Graduation threshold — passed_baseline_rate from frontmatter, fallback 0.7. */
+  threshold: number;
+  /** Total post-bind signals across the full curve window. */
+  n: number;
+  /** ISO. Anchor for the curve. */
+  boundAt: string;
+}
+
+export interface SkillsApiResponse {
+  /** Raw skill-index passthrough (agent → skill → slot). Unused by the
+   *  dashboard today but kept for compatibility with the bind UI. */
+  index: Record<string, Record<string, unknown>>;
+  suggestions: string[];
+  /** Per-agent+skill effectiveness curves. Drives SkillGraduationGrid. */
+  effectiveness: SkillEffectivenessEntry[];
+}
+
 export interface ForcedDevelopEntry {
   timestamp: string;
   reason?: string;

--- a/packages/dashboard-v2/src/pages/OverviewPage.tsx
+++ b/packages/dashboard-v2/src/pages/OverviewPage.tsx
@@ -18,7 +18,7 @@ import { useUrlRangeParam } from '@/hooks/useUrlRangeParam';
 import { useGlobalAgentKeys } from '@/hooks/useGlobalAgentKeys';
 import { isGraphHidden } from '@/lib/feature-flags';
 import { href } from '@/lib/router';
-import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, FleetTrendResponse, FleetTrendPoint } from '@/lib/types';
+import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, FleetTrendResponse, FleetTrendPoint, SkillsApiResponse } from '@/lib/types';
 
 interface OverviewPageProps {
   overview: OverviewData;
@@ -30,6 +30,8 @@ interface OverviewPageProps {
   consensusReports?: ConsensusReportsData | null;
   /** Optional — Step 6: supplies 7d sparkline data for AgentCardBig. */
   fleetTrend?: FleetTrendResponse | null;
+  /** Optional — Step 9.5: per-skill post-bind effectiveness curves. */
+  skills?: SkillsApiResponse | null;
   activeTaskCount: number;
   setActiveTaskCount: (n: number) => void;
 }
@@ -48,6 +50,7 @@ export function OverviewPage({
   consensus,
   consensusReports,
   fleetTrend,
+  skills,
   activeTaskCount,
   setActiveTaskCount,
 }: OverviewPageProps) {
@@ -185,7 +188,7 @@ export function OverviewPage({
           summary; grid is the per-skill breakdown across all live bindings.
           Both render from already-fetched overview + agents data. */}
       <SkillVerdictsSnapshot overview={overview} />
-      <SkillGraduationGrid agents={agents} />
+      <SkillGraduationGrid skills={skills ?? null} />
     </div>
   );
 }

--- a/packages/relay/src/dashboard/api-skills.ts
+++ b/packages/relay/src/dashboard/api-skills.ts
@@ -1,23 +1,326 @@
 import { SkillIndex, SkillIndexData } from '@gossip/orchestrator/skill-index';
-import { existsSync } from 'fs';
+import { readJsonlWithRotated, normalizeSkillName } from '@gossip/orchestrator';
+import { existsSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
 
-export interface SkillsGetResponse { index: SkillIndexData; suggestions: string[]; }
+/**
+ * Verdict tags inlined from `check-effectiveness.ts` SkillStatus union. We keep
+ * this as a string-literal union (not a re-import) so the relay package
+ * doesn't widen its public surface with internal orchestrator types — the
+ * verdict is just a tag for the dashboard, not a state machine input.
+ */
+export type SkillVerdict =
+  | 'pending'
+  | 'passed'
+  | 'failed'
+  | 'silent_skill'
+  | 'insufficient_evidence'
+  | 'inconclusive'
+  | 'flagged_for_manual_review';
+
+/** One point on the post-bind effectiveness curve for a single skill. */
+export interface SkillCurvePoint {
+  /** Window-end timestamp (ms epoch). */
+  t: number;
+  /** Accuracy in window = correct / (correct + hallucinated). null when window empty. */
+  value: number | null;
+}
+
+/** Per-agent+skill effectiveness curve plus metadata. */
+export interface SkillEffectivenessEntry {
+  agentId: string;
+  skill: string;
+  status: SkillVerdict | null;
+  /** 10 equal-time windows from boundAt → now. */
+  curve: SkillCurvePoint[];
+  /** Graduation threshold — passed_baseline_rate from frontmatter, fallback 0.7. */
+  threshold: number;
+  /** Total post-bind signals across the full curve window. */
+  n: number;
+  /** ISO. Anchor for the curve. From frontmatter bound_at if present, else slot.boundAt. */
+  boundAt: string;
+}
+
+export interface SkillsGetResponse {
+  index: SkillIndexData;
+  suggestions: string[];
+  /**
+   * Per-skill post-bind effectiveness curves. One entry per enabled skill
+   * binding across the fleet. Empty array when no skills are bound.
+   *
+   * Derivation: signals from agent-performance.jsonl where
+   *   signal.agentId === agent && normalizeSkillName(signal.category) === skill
+   *   && signal.timestamp >= boundAt
+   * are bucketed into NUM_BUCKETS equal-time windows over [boundAt, now] and
+   * each bucket reports accuracy = correct/(correct+hallucinated). Cached
+   * for CACHE_TTL_MS keyed on the jsonl mtime.
+   */
+  effectiveness: SkillEffectivenessEntry[];
+}
+
 export interface SkillsBindRequest { agent_id: string; skill: string; enabled: boolean; }
 export interface SkillsBindResponse { success: boolean; error?: string; }
 
 const AGENT_ID_RE = /^[a-zA-Z0-9_-]{1,64}$/;
 
+/** Curve resolution. Spec-default 10 windows; held in a constant for clarity. */
+const NUM_BUCKETS = 10;
+/** Fallback threshold when frontmatter has no `passed_baseline_rate`. */
+const DEFAULT_THRESHOLD = 0.7;
+/** Cache TTL — short enough to stay live during a session, long enough to
+ *  amortize the jsonl scan across the 5s dashboard poll. */
+const CACHE_TTL_MS = 60_000;
+
 function isCorrupt(projectRoot: string, index: SkillIndex): boolean {
   return existsSync(join(projectRoot, '.gossip', 'skill-index.json')) && !index.exists();
 }
 
+/* ── frontmatter (status + bound_at + passed_baseline_rate) ────────────── */
+
+interface SkillFrontmatter {
+  status?: string;
+  bound_at?: string;
+  passed_baseline_rate?: number;
+}
+
+function readSkillFrontmatter(
+  projectRoot: string,
+  agentId: string,
+  skillName: string,
+): SkillFrontmatter | null {
+  try {
+    const path = join(projectRoot, '.gossip', 'agents', agentId, 'skills', `${skillName}.md`);
+    if (!existsSync(path)) return null;
+    const raw = readFileSync(path, 'utf-8');
+    if (!raw.startsWith('---')) return null;
+    const end = raw.indexOf('\n---', 3);
+    if (end === -1) return null;
+    const block = raw.slice(3, end);
+    const out: SkillFrontmatter = {};
+    for (const line of block.split('\n')) {
+      const m = line.match(/^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.+?)\s*$/);
+      if (!m) continue;
+      const key = m[1];
+      let value: string = m[2];
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      if (key === 'status') out.status = value;
+      else if (key === 'bound_at') out.bound_at = value;
+      else if (key === 'passed_baseline_rate') {
+        const n = Number(value);
+        if (Number.isFinite(n)) out.passed_baseline_rate = n;
+      }
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/* ── signal index (per-agent, per-normalized-skill) ────────────────────── */
+
+interface SignalEvent {
+  ts: number;
+  signal: string;
+}
+
+interface SignalIndex {
+  /** agentId → normalizedSkill → events (chronological order). */
+  byAgentSkill: Map<string, Map<string, SignalEvent[]>>;
+}
+
+const CORRECT_SIGNALS = new Set([
+  'agreement',
+  'category_confirmed',
+  'consensus_verified',
+  'unique_confirmed',
+]);
+const HALLUC_SIGNALS = new Set(['disagreement', 'hallucination_caught']);
+
+function buildSignalIndex(projectRoot: string): SignalIndex {
+  const idx: SignalIndex = { byAgentSkill: new Map() };
+  const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+  if (!existsSync(perfPath)) return idx;
+  let raw: string;
+  try { raw = readJsonlWithRotated(perfPath); } catch { return idx; }
+  if (!raw) return idx;
+
+  // Track scoped + wildcard retractions on the same pass, then re-filter.
+  const retracted = new Set<string>();
+  const retractedConsensusIds = new Set<string>();
+  const rows: Array<Record<string, unknown>> = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try { rows.push(JSON.parse(line)); } catch { /* skip */ }
+  }
+  for (const r of rows) {
+    if (r.signal === 'consensus_round_retracted') {
+      const cid = (r as { consensus_id?: unknown }).consensus_id;
+      if (typeof cid === 'string' && cid.length > 0) retractedConsensusIds.add(cid);
+      continue;
+    }
+    if (r.signal === 'signal_retracted') {
+      const agentId = r.agentId as string | undefined;
+      const taskKey = (r.taskId ?? r.timestamp) as string | undefined;
+      const retractedSignal = (r as { retractedSignal?: unknown }).retractedSignal;
+      if (!agentId || !taskKey) continue;
+      if (typeof retractedSignal === 'string') {
+        retracted.add(`${agentId}:${taskKey}:${retractedSignal}`);
+      } else {
+        retracted.add(`${agentId}:${taskKey}:*`);
+      }
+    }
+  }
+
+  for (const r of rows) {
+    if (r.type !== 'consensus') continue;
+    const signal = r.signal as string | undefined;
+    if (!signal) continue;
+    if (!CORRECT_SIGNALS.has(signal) && !HALLUC_SIGNALS.has(signal)) continue;
+    const agentId = r.agentId as string | undefined;
+    const category = r.category as string | undefined;
+    const tsStr = r.timestamp as string | undefined;
+    if (!agentId || !category || !tsStr) continue;
+    const ts = new Date(tsStr).getTime();
+    if (!Number.isFinite(ts) || ts === 0) continue;
+
+    // Retraction filter
+    const taskKey = (r.taskId ?? tsStr) as string;
+    if (retracted.has(`${agentId}:${taskKey}:${signal}`)) continue;
+    if (retracted.has(`${agentId}:${taskKey}:*`)) continue;
+    const findingId = (r as { findingId?: unknown }).findingId;
+    if (typeof findingId === 'string') {
+      let drop = false;
+      for (const cid of retractedConsensusIds) {
+        if (findingId.startsWith(cid + ':')) { drop = true; break; }
+      }
+      if (drop) continue;
+    }
+
+    const skillKey = normalizeSkillName(category);
+    if (!skillKey) continue;
+    let perAgent = idx.byAgentSkill.get(agentId);
+    if (!perAgent) { perAgent = new Map(); idx.byAgentSkill.set(agentId, perAgent); }
+    let arr = perAgent.get(skillKey);
+    if (!arr) { arr = []; perAgent.set(skillKey, arr); }
+    arr.push({ ts, signal });
+  }
+
+  // Sort each bucket chronologically.
+  for (const perAgent of idx.byAgentSkill.values()) {
+    for (const arr of perAgent.values()) arr.sort((a, b) => a.ts - b.ts);
+  }
+  return idx;
+}
+
+/* ── effectiveness derivation ──────────────────────────────────────────── */
+
+function deriveEffectiveness(
+  projectRoot: string,
+  index: SkillIndex,
+  signalIdx: SignalIndex,
+  nowMs: number,
+): SkillEffectivenessEntry[] {
+  const out: SkillEffectivenessEntry[] = [];
+  for (const agentId of index.getAgentIds()) {
+    for (const slot of index.getAgentSlots(agentId)) {
+      if (!slot.enabled) continue;
+      const fm = readSkillFrontmatter(projectRoot, agentId, slot.skill);
+      const boundAtIso = fm?.bound_at ?? slot.boundAt;
+      const boundAtMs = new Date(boundAtIso).getTime();
+      if (!Number.isFinite(boundAtMs) || boundAtMs <= 0) continue;
+      // Bucket span: divide [boundAt, now] into NUM_BUCKETS windows. When the
+      // skill was just bound (span < NUM_BUCKETS ms), clamp to a 1ms-per-bucket
+      // floor so the math doesn't degenerate. The curve will just be empty.
+      const totalSpan = Math.max(nowMs - boundAtMs, NUM_BUCKETS);
+      const bucketMs = totalSpan / NUM_BUCKETS;
+      const events = signalIdx.byAgentSkill.get(agentId)?.get(normalizeSkillName(slot.skill)) ?? [];
+      const buckets: Array<{ c: number; h: number }> = Array.from(
+        { length: NUM_BUCKETS },
+        () => ({ c: 0, h: 0 }),
+      );
+      let n = 0;
+      for (const ev of events) {
+        if (ev.ts < boundAtMs) continue;
+        const rel = ev.ts - boundAtMs;
+        let i = Math.floor(rel / bucketMs);
+        if (i < 0) i = 0;
+        if (i >= NUM_BUCKETS) i = NUM_BUCKETS - 1;
+        if (CORRECT_SIGNALS.has(ev.signal)) buckets[i].c++;
+        else if (HALLUC_SIGNALS.has(ev.signal)) buckets[i].h++;
+        n++;
+      }
+      const curve: SkillCurvePoint[] = buckets.map((b, i) => {
+        const total = b.c + b.h;
+        const t = boundAtMs + (i + 1) * bucketMs;
+        return { t, value: total > 0 ? b.c / total : null };
+      });
+      const threshold = fm?.passed_baseline_rate ?? DEFAULT_THRESHOLD;
+      const status = (fm?.status as SkillVerdict | undefined) ?? null;
+      out.push({
+        agentId,
+        skill: slot.skill,
+        status,
+        curve,
+        threshold,
+        n,
+        boundAt: boundAtIso,
+      });
+    }
+  }
+  return out;
+}
+
+/* ── cache ─────────────────────────────────────────────────────────────── */
+
+interface CacheEntry {
+  payload: SkillsGetResponse;
+  builtAtMs: number;
+  jsonlMtimeMs: number;
+}
+const cache = new Map<string, CacheEntry>();
+
+function jsonlMtime(projectRoot: string): number {
+  try {
+    return statSync(join(projectRoot, '.gossip', 'agent-performance.jsonl')).mtimeMs;
+  } catch { return 0; }
+}
+
+function cacheHit(projectRoot: string, nowMs: number): SkillsGetResponse | null {
+  const entry = cache.get(projectRoot);
+  if (!entry) return null;
+  if (nowMs - entry.builtAtMs > CACHE_TTL_MS) return null;
+  if (entry.jsonlMtimeMs !== jsonlMtime(projectRoot)) return null;
+  return entry.payload;
+}
+
+/* ── handlers ──────────────────────────────────────────────────────────── */
+
 export async function skillsGetHandler(projectRoot: string): Promise<SkillsGetResponse> {
+  const nowMs = Date.now();
+  const cached = cacheHit(projectRoot, nowMs);
+  if (cached) return cached;
   try {
     const index = new SkillIndex(projectRoot);
-    return { index: index.getIndex(), suggestions: [] };
+    let effectiveness: SkillEffectivenessEntry[] = [];
+    try {
+      const signalIdx = buildSignalIndex(projectRoot);
+      effectiveness = deriveEffectiveness(projectRoot, index, signalIdx, nowMs);
+    } catch { /* leave empty on derivation failure */ }
+    const payload: SkillsGetResponse = {
+      index: index.getIndex(),
+      suggestions: [],
+      effectiveness,
+    };
+    cache.set(projectRoot, {
+      payload,
+      builtAtMs: nowMs,
+      jsonlMtimeMs: jsonlMtime(projectRoot),
+    });
+    return payload;
   } catch {
-    return { index: {}, suggestions: [] };
+    return { index: {}, suggestions: [], effectiveness: [] };
   }
 }
 
@@ -35,6 +338,8 @@ export async function skillsBindHandler(projectRoot: string, body: SkillsBindReq
       const changed = index.disable(body.agent_id, body.skill);
       if (!changed) return { success: false, error: 'Skill not bound to agent' };
     }
+    // Bust the effectiveness cache so the next GET reflects the new binding.
+    cache.delete(projectRoot);
     return { success: true };
   } catch (err) {
     return { success: false, error: err instanceof Error ? err.message : 'Unknown error' };


### PR DESCRIPTION
## Summary

Step 9 (PR #474) shipped a verdict-grouped grid as foundation. Operator pivoted to the mockup's flat card-grid with per-skill effectiveness sparklines + dashed graduation threshold. This PR replaces the grid layout AND adds the backend data to support it.

### Backend (\`packages/relay/src/dashboard/\`)

- **\`api-skills.ts\`** (+313 / -38) — extends \`SkillsGetResponse\` with \`effectiveness: SkillEffectivenessEntry[]\`. New \`buildSignalIndex\` + \`deriveEffectiveness\` derive 10-bucket post-bind accuracy curves from \`agent-performance.jsonl\`. In-memory cache keyed on jsonl mtime, 60s TTL. Skill-bind handler busts the cache.

### Frontend (\`packages/dashboard-v2/src/\`)

- **\`components/SkillGraduationGrid.tsx\`** (rewritten, +~340 / -488) — flat card grid per mockup; section header \`{N} skills · {transitions} transitions /24h\`; UNKNOWN bucket as native \`<details>\` collapsible (closed by default; chevron rotates via CSS \`[open]\`).
- **\`components/SkillEffectivenessSparkline.tsx\`** (NEW, +153) — gap-splitting SVG sparkline (140×30) + dashed threshold line. Stroke color = verdict semantic.
- **\`lib/types.ts\`** (+32) — \`SkillCurvePoint\`, \`SkillEffectivenessEntry\`, \`SkillsApiResponse\`.
- **\`hooks/useDashboardData.ts\`** (+16 / -3) — adds \`skills\` to dashboard state via parallel fetch.
- **\`pages/OverviewPage.tsx\`** (+5 / -2) — accepts \`skills\` prop, passes to grid.
- **\`App.tsx\`** (+2 / -1) — wires \`skills\` through.

**Total:** +727 / -285 across 7 files. \`tsc -b && vite build\` clean across all 5 workspaces (96 modules, 437.74 kB JS / 75.37 kB CSS).

## Sample endpoint response

\`\`\`jsonc
{
  "index": { "<agentId>": { "<skill>": { "skill", "enabled", ... } } },
  "suggestions": [],
  "effectiveness": [
    {
      "agentId": "sonnet-reviewer",
      "skill": "trust-boundaries-provenance-tracing",
      "status": "passed",
      "curve": [
        { "t": 1715000000000, "value": 0.83 },
        { "t": 1715100000000, "value": null },
        { "t": 1715200000000, "value": 0.91 }
        // ... 10 buckets total
      ],
      "threshold": 0.75,
      "n": 124,
      "boundAt": "2026-04-12T00:00:00.000Z"
    }
  ]
}
\`\`\`

## DESIGN.md gate compliance

- [x] All 6 verdict states render via TypeScript \`Record<SkillStatus, string>\` + defensive UNKNOWN bucket
- [x] No \`--accent\` on chart/chrome (only the skill-count emphasis number in section header, allowed per DESIGN.md rule for "key count emphasis")
- [x] Hairline \`--border\` only — no shadows
- [x] All 4 states render (data / loading skeleton / empty / error banner)
- [x] UNKNOWN collapsible (native \`<details>\`, closed by default)
- [x] \`npm run build\` clean

## Drift from spec

1. **\`transitions /24h\` heuristic** — uses curve-shape (last-2-bucket tail straddles threshold) instead of \`drift_strike_at\` / \`regressed_from_passed_at\` directly, because those fields aren't exposed on the API yet. Documented inline in \`partition()\`. Easy upgrade once those fields surface.
2. **Live curl skipped** — standalone Node can't resolve \`@gossip/orchestrator/skill-index\` outside the relay process (pre-existing limitation, not introduced here). Build passes are the validation signal; relay server resolves these imports correctly at runtime.

## Test plan

- [x] \`tsc -b && vite build\` clean
- [x] Type-level gate: \`Record<GraduationVerdict, string>\` enforces 6-key completeness
- [x] Runtime defensive: unknown status string falls into UNKNOWN bucket (collapsible)
- [ ] Visual smoke after merge + relay restart (live effectiveness curves require relay binary rebuild)
- [ ] Verify cache invalidation on skill bind (60s TTL + mtime key)

## Related

- Master at \`6959ca2\` (post-Step-9 merge — verdict-grouped foundation)
- Mockup reference: operator screenshot showing 12-card grid with sparklines
- Spec: \`DESIGN.md:432\` (Step 9 application checklist entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)