### PR TITLE
fix(dashboard-v2): TopBar — normalize glossary button to match theme toggle

### DIFF
--- a/packages/dashboard-v2/src/components/TopBar.tsx
+++ b/packages/dashboard-v2/src/components/TopBar.tsx
@@ -107,13 +107,25 @@ export function TopBar() {
           {theme === 'light' ? '◐' : '◑'}
         </button>
         <button
+          type="button"
           onClick={() => setGlossaryOpen(true)}
           aria-label="Open glossary"
           title="Glossary"
-          className="flex items-center justify-center rounded-md border border-border/60 px-2 py-1 transition hover:border-border"
-          style={{ background: 'var(--surface-elev)', color: 'var(--ink)' }}
+          style={{
+            width: '32px',
+            height: '32px',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'var(--surface-elev)',
+            border: '1px solid var(--border)',
+            borderRadius: '8px',
+            color: 'var(--ink)',
+            cursor: 'pointer',
+            lineHeight: 1,
+          }}
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
             <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
             <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
           </svg>


### PR DESCRIPTION
Normalize the glossary (book icon) button to the same 32×32 / 8px-rounded square style as the adjacent dark-mode toggle. The previous Tailwind-utility-sized button (rounded-md / px-2 py-1) had different corner radius and pixel dimensions vs the inline-styled theme toggle, reading as a small disorientation between two adjacent controls.

SVG bumped 14→16px to match the theme glyph's optical weight.

(An initial commit also tried centering the logo + brand, but operator preferred the original left placement — reverted in d11a... while keeping the button polish.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)