### PR TITLE
fix(dashboard-v2): Tasks section + accent regressions (PR-C)

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -310,7 +310,7 @@ function TeamPage({
                         <span className="warn-badge shrink-0 rounded px-1.5 py-0.5 font-mono text-[9px] font-semibold">
                           {lt.taskId.slice(0, 8)}
                         </span>
-                        <span className="truncate font-inter text-[11px]" style={{ maxWidth: 260, color: 'color-mix(in oklch, var(--text-dim) 80%, transparent)' }}>
+                        <span className="truncate text-[11px]" style={{ maxWidth: 260, color: 'color-mix(in oklch, var(--text-dim) 80%, transparent)' }}>
                           {lt.task}
                         </span>
                         <span className="ml-auto shrink-0 font-mono text-[10px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 50%, transparent)' }}>{timeAgo(lt.timestamp)}</span>
@@ -421,7 +421,7 @@ function TasksPage({ tasks }: { tasks: import('@/lib/types').TasksData }) {
                 <th className="py-2.5 pl-4 pr-2 text-xs font-medium" style={{ width: 32, color: 'var(--text-dim)' }}></th>
                 <th className="py-2.5 pr-3 font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }}>ID</th>
                 <th className="py-2.5 pr-3 font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }}>Agent</th>
-                <th className="py-2.5 pr-3 text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }}>Description</th>
+                <th className="py-2.5 pr-3 font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }}>Description</th>
                 <th className="py-2.5 pr-3 font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }}>Duration</th>
                 <th className="py-2.5 pr-4 text-right font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }}>When</th>
               </tr>

--- a/packages/dashboard-v2/src/components/NarrativeStripe.tsx
+++ b/packages/dashboard-v2/src/components/NarrativeStripe.tsx
@@ -55,18 +55,18 @@ export function NarrativeStripe() {
       aria-live="polite"
       className="flex items-center gap-3 rounded-md border px-3 py-2 font-mono text-[11px]"
       style={{
-        background: 'color-mix(in oklch, var(--accent) 8%, transparent)',
-        borderColor: 'color-mix(in oklch, var(--accent) 30%, transparent)',
+        background: 'color-mix(in oklch, var(--info) 8%, transparent)',
+        borderColor: 'color-mix(in oklch, var(--info) 30%, transparent)',
         color: 'var(--text)',
         animation: 'beat-pulse-narrative calc(var(--beat) * 2) ease-in-out infinite',
       }}
     >
       <span
         className="inline-block h-2 w-2 rounded-full"
-        style={{ background: 'var(--accent)', boxShadow: '0 0 6px var(--accent)' }}
+        style={{ background: 'var(--info)', boxShadow: '0 0 6px var(--info)' }}
       />
       <span style={{ color: 'var(--text-dim)' }}>Round in flight</span>
-      <span className="font-bold" style={{ color: 'var(--accent)' }}>{shortId}</span>
+      <span className="font-bold" style={{ color: 'var(--info)' }}>{shortId}</span>
       {activeAgentId && (
         <span style={{ color: 'var(--text-dim)' }}>
           → <span style={{ color: 'var(--text)' }}>{activeAgentId}</span>
@@ -80,7 +80,7 @@ export function NarrativeStripe() {
           const el = document.getElementById('consensus-rounds-section');
           if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }}
-        className="ml-auto rounded px-1.5 py-0.5 font-mono text-[10px] transition hover:[background:color-mix(in_oklch,var(--accent)_12%,transparent)]"
+        className="ml-auto rounded px-1.5 py-0.5 font-mono text-[10px] transition hover:[background:color-mix(in_oklch,var(--info)_12%,transparent)]"
         style={{ color: 'var(--text-faint)', cursor: 'pointer' }}
       >
         watch ↓

--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -178,7 +178,7 @@ export function SystemPulse({ overview, activeTasks, mode = 'dense', showActivit
             <BigStat
               value={overview.actionableFindings}
               label="Actionable"
-              valueClass={overview.actionableFindings > 0 ? 'text-orange-400' : 'text-confirmed'}
+              valueClass={overview.actionableFindings > 0 ? 'text-orange-400' : ''}
               tooltip="Findings still open and need operator review (disagreements + hallucinations + new findings)"
             />
           </a>

--- a/packages/dashboard-v2/src/components/TaskRow.tsx
+++ b/packages/dashboard-v2/src/components/TaskRow.tsx
@@ -175,7 +175,7 @@ export function TaskRow({ task, onClick }: TaskRowProps) {
           {task.agentId}
         </a>
       </td>
-      <td className="py-2.5 pr-3 font-inter text-sm" style={{ color: 'color-mix(in oklch, var(--text) 80%, transparent)' }}>
+      <td className="py-2.5 pr-3 text-xs leading-snug" style={{ color: 'color-mix(in oklch, var(--text) 80%, transparent)' }}>
         {(() => { const line = task.task.replace(/\n.*/s, ''); return line.length > 100 ? line.slice(0, 100) + '…' : line; })()}
       </td>
       <td className="py-2.5 pr-3 font-mono text-xs" style={{ color: 'var(--text-dim)' }}>

--- a/packages/dashboard-v2/src/components/TasksSection.tsx
+++ b/packages/dashboard-v2/src/components/TasksSection.tsx
@@ -93,7 +93,7 @@ export function TasksSection({ tasks, limit = DEFAULT_PAGE_SIZE }: TasksSectionP
     <section className="flex h-full flex-col">
       <div className="mb-3 flex items-center justify-between">
         <h2 className="h-section">
-          Tasks <span style={{ color: 'var(--accent)' }}>{tasks.total}</span>
+          Tasks <span style={{ color: 'var(--ink)', fontWeight: 700 }}>{tasks.total}</span>
         </h2>
         {hasMore && (
           <a href="/dashboard/tasks" className="font-mono text-xs transition" style={{ color: 'var(--text-dim)' }}>


### PR DESCRIPTION
## Summary

PR-C from the post-Step-9 designer audit. Six fixes across 5 files, all CSS/token swaps. Closes out the audit-fix series.

### Tasks section
- \`App.tsx:424\` TasksPage "Description" \`<th>\` gets \`font-mono\` to match sibling column headers
- \`App.tsx:313\` Team leaderboard "Last Task" span drops \`font-inter\` (pre-Step-3 holdover; Geist resolves through the font stack automatically)
- \`TaskRow.tsx:178\` description \`<td>\`: \`font-inter text-sm\` → \`text-xs leading-snug\` — matches surrounding data-cell typography

### Regressions
- \`TasksSection.tsx:96\` section header count: \`var(--accent)\` → \`var(--ink)\` + \`fontWeight: 700\`. Matches TeamHero count pattern; DESIGN.md reserves accent for brand/CTA/nav only.
- \`NarrativeStripe.tsx\` (5 sites): \`var(--accent)\` → \`var(--info)\`. The pulsing in-flight indicator no longer competes with the TopBar's brand accent when both are visible.
- \`SystemPulse.tsx:181\` zero-state actionable: \`text-confirmed\` (green) → \`''\` (neutral inherit). Green = "confirmed finding" elsewhere; ambiguous for "0 actionable". Note: dense-mode only.

**Skipped** (per audit + verification): RecentSignalsPeek semantic colors — already shipped in Step 8 via the \`VERDICT_COLOR\` map. Designer audit was stale on this item.

**Total:** +10 / -10 across 5 files. \`tsc -b && vite build\` clean (96 modules, 706ms).

## Gate compliance

- [x] Build clean
- [x] No NEW \`--accent\` leaks (this PR removes them)
- [x] No regressions to other widgets

## Note on dispatch

First implementer dispatch had a worktree isolation failure (edits leaked into the parent checkout, relay auto-recovered via \`git restore\`). Re-applied the edits directly per CLAUDE.md exception for ≤10-line CSS-only changes. Same end state; clean diff scoped to the 5 files cited in the audit.

## Related

- Master at \`82a42f2\` (post-PR-B)
- Closes audit findings #2 (Tasks gaps) and #5 (regressions)
- All 14 findings from the post-Step-9 designer audit resolved across PR-A (#476) + PR-B (#478) + this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)