### PR TITLE
fix(relay): redirect / → /dashboard

### DIFF
--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -145,6 +145,15 @@ export class DashboardRouter {
       return this.serveDashboard(res);
     }
 
+    // Root + bare host: redirect to /dashboard. The SPA at /dashboard
+    // handles its own auth gate (login form when no session cookie,
+    // overview when authed).
+    if (url === '/' || url === '') {
+      res.writeHead(302, { Location: '/dashboard' });
+      res.end();
+      return true;
+    }
+
     this.json(res, 404, { error: 'Not found' });
     return true;
   }


### PR DESCRIPTION
Bare host (http://localhost:63007/) returned a JSON 404. Now 302 → /dashboard, which already handles its own auth gate (login form when no session cookie, SPA when authed).

Note: ships in the bundled relay code. The globally-installed gossipcat binary won't pick this up until reinstalled from this repo (`npm install -g .`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)