### PR TITLE
fix(dashboard-v2): SkillEffectivenessSparkline — hide curve below 3 non-null buckets

### DIFF
--- a/packages/dashboard-v2/src/components/SkillEffectivenessSparkline.tsx
+++ b/packages/dashboard-v2/src/components/SkillEffectivenessSparkline.tsx
@@ -25,6 +25,9 @@ interface Props {
 
 const PADDING_X = 1;
 const PADDING_Y = 2;
+/** Minimum non-null buckets before the curve renders. Below this the
+ *  threshold-only placeholder shows — N + verdict label carry the info. */
+const MIN_VISIBLE_POINTS = 3;
 
 export function SkillEffectivenessSparkline({
   curve,
@@ -37,7 +40,11 @@ export function SkillEffectivenessSparkline({
   // segments don't visually bridge gaps. Each run becomes one <path>.
   const segments = useMemo(() => splitSegments(curve), [curve]);
 
-  if (curve.length === 0) {
+  // Total non-null buckets across all segments. Below MIN_VISIBLE_POINTS the
+  // curve renders as floating dots/short stubs, which reads as broken noise
+  // rather than "early signal." Fall back to the threshold-only placeholder.
+  const definedCount = segments.reduce((n, s) => n + s.length, 0);
+  if (curve.length === 0 || definedCount < MIN_VISIBLE_POINTS) {
     return <EmptySparkline width={width} height={height} />;
   }
 


### PR DESCRIPTION
After v0.5.0 reinstall the SkillGraduationGrid finally renders real effectiveness data, but skills with low N (mostly N<10) show only 1-2 non-null buckets across 10 windows. The gap-splitting renderer correctly draws those as floating dots / 1px stubs, but visually it reads as broken noise instead of 'early signal.'

Fix: introduce `MIN_VISIBLE_POINTS = 3`. Below that, fall back to the existing threshold-only placeholder (dashed line, same vertical real estate). The `N=X` count + verdict label in the parent cell already carry the 'gathering evidence' semantics for low-N skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)