### PR TITLE
fix(dashboard-v2): SkillEffectivenessSparkline — bump MIN_VISIBLE_POINTS 3 → 5

### DIFF
--- a/packages/dashboard-v2/src/components/SkillEffectivenessSparkline.tsx
+++ b/packages/dashboard-v2/src/components/SkillEffectivenessSparkline.tsx
@@ -26,8 +26,10 @@ interface Props {
 const PADDING_X = 1;
 const PADDING_Y = 2;
 /** Minimum non-null buckets before the curve renders. Below this the
- *  threshold-only placeholder shows — N + verdict label carry the info. */
-const MIN_VISIBLE_POINTS = 3;
+ *  threshold-only placeholder shows — N + verdict label carry the info.
+ *  Set to 5 (half of the 10-bucket window) so sparse data with big gaps
+ *  collapses to the clean dashed line instead of fragmented stubs. */
+const MIN_VISIBLE_POINTS = 5;
 
 export function SkillEffectivenessSparkline({
   curve,


### PR DESCRIPTION
Threshold-of-3 (#484) still left low-N cards (N=9/N=13/N=18) rendering as fragmented dots + 1-2-point stubs — gap-splitting fires inside the same chart when buckets have nulls between them.

Bumping the floor to 5 (half of the 10-bucket window) makes sparse skills collapse to the clean dashed threshold placeholder; only skills with sufficient density show the curve.

PASSED cards (N=80+) still render their curves; PENDING low-N cards now show just the dashed threshold + verdict label + N count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)