### PR TITLE
fix(dashboard-v2 + relay): DESIGN.md cleanup + task-graph rotation reader

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -121,17 +121,17 @@ function TeamPage({
           <h1 className="h-route">Team</h1>
           <span className="font-mono text-sm tabular-nums" style={{ color: 'var(--ink-3)' }}>{agents.length}</span>
         </div>
-        <p className="mt-0.5 font-mono text-[10px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 60%, transparent)' }}>Per-agent accuracy, signal counts, and dispatch weights.</p>
+        <p className="mt-0.5 text-[13px]" style={{ color: 'var(--ink-3)' }}>Per-agent accuracy, signal counts, and dispatch weights.</p>
         <div className="mt-2 grid grid-cols-2 gap-px overflow-hidden rounded-md [border-color:color-mix(in_oklch,var(--border)_40%,transparent)] border [background:color-mix(in_oklch,var(--border)_30%,transparent)] sm:grid-cols-4">
           {[
-            { label: 'Healthy', value: healthy, varColor: 'var(--success)' },
-            { label: 'Benched', value: circuitOpen, varColor: circuitOpen > 0 ? 'var(--danger)' : 'var(--text-dim)' },
-            { label: 'Total Signals', value: totalSignals.toLocaleString(), varColor: 'var(--text)' },
-            { label: 'Tokens Used', value: totalTokens.toLocaleString(), varColor: 'var(--text)' },
+            { label: 'Healthy', value: healthy, varColor: 'var(--ok)' },
+            { label: 'Benched', value: circuitOpen, varColor: circuitOpen > 0 ? 'var(--bad)' : 'var(--ink-3)' },
+            { label: 'Total Signals', value: totalSignals.toLocaleString(), varColor: 'var(--ink)' },
+            { label: 'Tokens Used', value: totalTokens.toLocaleString(), varColor: 'var(--ink)' },
           ].map((stat) => (
-            <div key={stat.label} style={{ background: 'color-mix(in oklch, var(--surface-elev) 80%, transparent)' }} className="px-4 py-3">
+            <div key={stat.label} style={{ background: 'var(--surface-elev)' }} className="px-4 py-3">
               <div className="font-mono text-lg font-bold tabular-nums" style={{ color: stat.varColor }}>{stat.value}</div>
-              <div className="mt-0.5 font-mono text-[10px] uppercase tracking-wider" style={{ color: 'color-mix(in oklch, var(--text-dim) 70%, transparent)' }}>{stat.label}</div>
+              <div className="h-section mt-0.5">{stat.label}</div>
             </div>
           ))}
         </div>
@@ -144,8 +144,8 @@ function TeamPage({
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search agents by id, provider, or model..."
-          className="w-full max-w-md rounded-md [border-color:color-mix(in_oklch,var(--border)_40%,transparent)] border px-3 py-1.5 font-mono text-xs focus:[border-color:color-mix(in_oklch,var(--accent)_40%,transparent)] focus:outline-none"
-          style={{ background: 'color-mix(in oklch, var(--surface-elev) 80%, transparent)', color: 'var(--text)' }}
+          className="w-full max-w-md rounded-md [border-color:color-mix(in_oklch,var(--border)_40%,transparent)] border px-3 py-1.5 font-mono text-xs focus:[border-color:var(--ink-3)] focus:outline-none"
+          style={{ background: 'color-mix(in oklch, var(--surface-elev) 80%, transparent)', color: 'var(--ink)' }}
         />
       </div>
 
@@ -162,38 +162,38 @@ function TeamPage({
             <col />
           </colgroup>
           <thead>
-            <tr className="border-b [border-color:color-mix(in_oklch,var(--border)_40%,transparent)] font-mono text-[10px] uppercase tracking-wider" style={{ background: 'color-mix(in oklch, var(--surface-sunk) 20%, transparent)', color: 'color-mix(in oklch, var(--text-dim) 80%, transparent)' }}>
-              <th className="py-2.5 pl-5 pr-2 text-center">#</th>
-              <th className="py-2.5 pr-3 text-left">Agent</th>
-              <th className="py-2.5 pr-4 text-right cursor-pointer select-none hover:[color:var(--text)]" onClick={() => toggleSort('weight')}>
+            <tr className="border-b [border-color:color-mix(in_oklch,var(--border)_40%,transparent)]" style={{ background: 'color-mix(in oklch, var(--surface-sunk) 20%, transparent)' }}>
+              <th className="h-section py-2.5 pl-5 pr-2 text-center">#</th>
+              <th className="h-section py-2.5 pr-3 text-left">Agent</th>
+              <th className="h-section py-2.5 pr-4 text-right cursor-pointer select-none hover:[color:var(--ink)]" onClick={() => toggleSort('weight')}>
                 Weight {arrow('weight')}
               </th>
-              <th className="py-2.5 pr-4 text-left align-top">
-                <div className="flex items-center gap-2 text-[10px]">
-                  <button onClick={() => toggleSort('accuracy')} className="flex items-center gap-1 hover:[color:var(--text)]" data-tooltip="Accuracy — fraction of findings confirmed by cross-review (with hallucination penalty)">
+              <th className="h-section py-2.5 pr-4 text-left align-top">
+                <div className="flex items-center gap-2">
+                  <button onClick={() => toggleSort('accuracy')} className="flex items-center gap-1 hover:[color:var(--ink)]" data-tooltip="Accuracy — fraction of findings confirmed by cross-review (with hallucination penalty)">
                     <span className="inline-block h-1.5 w-1.5 rounded-full bg-confirmed" />Acc{arrow('accuracy')}
                   </button>
-                  <span style={{ color: 'color-mix(in oklch, var(--text-dim) 30%, transparent)' }}>·</span>
-                  <button onClick={() => toggleSort('uniqueness')} className="flex items-center gap-1 hover:[color:var(--text)]" data-tooltip="Uniqueness — findings this agent surfaced that no peer found">
+                  <span style={{ color: 'color-mix(in oklch, var(--ink-3) 30%, transparent)' }}>·</span>
+                  <button onClick={() => toggleSort('uniqueness')} className="flex items-center gap-1 hover:[color:var(--ink)]" data-tooltip="Uniqueness — findings this agent surfaced that no peer found">
                     <span className="inline-block h-1.5 w-1.5 rounded-full bg-unique" />Unq{arrow('uniqueness')}
                   </button>
-                  <span style={{ color: 'color-mix(in oklch, var(--text-dim) 30%, transparent)' }}>·</span>
-                  <button onClick={() => toggleSort('impact')} className="flex items-center gap-1 hover:[color:var(--text)]" data-tooltip="Impact — severity-weighted finding score">
+                  <span style={{ color: 'color-mix(in oklch, var(--ink-3) 30%, transparent)' }}>·</span>
+                  <button onClick={() => toggleSort('impact')} className="flex items-center gap-1 hover:[color:var(--ink)]" data-tooltip="Impact — severity-weighted finding score">
                     <span className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--c8)]" />Imp{arrow('impact')}
                   </button>
                 </div>
               </th>
-              <th className="py-2.5 pr-4 text-right cursor-pointer select-none hover:[color:var(--text)]" onClick={() => toggleSort('signals')}>
+              <th className="h-section py-2.5 pr-4 text-right cursor-pointer select-none hover:[color:var(--ink)]" onClick={() => toggleSort('signals')}>
                 Signals {arrow('signals')}
               </th>
               <th
-                className="py-2.5 pr-4 text-right cursor-pointer select-none hover:[color:var(--text)]"
+                className="h-section py-2.5 pr-4 text-right cursor-pointer select-none hover:[color:var(--ink)]"
                 onClick={() => toggleSort('hallucinations')}
                 data-tooltip="Hallucinations — fabricated findings caught by cross-review"
               >
                 Halluc {arrow('hallucinations')}
               </th>
-              <th className="py-2.5 pr-5 text-left cursor-pointer select-none hover:[color:var(--text)]" onClick={() => toggleSort('lastTask')}>
+              <th className="h-section py-2.5 pr-5 text-left cursor-pointer select-none hover:[color:var(--ink)]" onClick={() => toggleSort('lastTask')}>
                 Last Task {arrow('lastTask')}
               </th>
             </tr>
@@ -202,7 +202,7 @@ function TeamPage({
             {sorted.map((agent, i) => {
               const s = agent.scores;
               const lt = lastTaskByAgent.get(agent.id);
-              const weightColor = s.dispatchWeight >= 1.2 ? 'var(--success)' : s.dispatchWeight >= 0.8 ? 'var(--text)' : 'var(--danger)';
+              const weightColor = s.dispatchWeight >= 1.2 ? 'var(--ok)' : s.dispatchWeight >= 0.8 ? 'var(--ink)' : 'var(--bad)';
               const rankDisplay = i + 1;
 
               return (
@@ -215,9 +215,9 @@ function TeamPage({
                     <span
                       className="font-mono text-[11px] tabular-nums"
                       style={{
-                        color: rankDisplay === 1 ? 'var(--accent)' :
-                               rankDisplay === 2 || rankDisplay === 3 ? 'color-mix(in oklch, var(--text) 80%, transparent)' :
-                               'color-mix(in oklch, var(--text-dim) 40%, transparent)',
+                        color: rankDisplay === 1 ? 'var(--ink)' :
+                               rankDisplay === 2 || rankDisplay === 3 ? 'color-mix(in oklch, var(--ink-2) 80%, transparent)' :
+                               'var(--ink-3)',
                         fontWeight: rankDisplay === 1 ? 'bold' : rankDisplay <= 3 ? 600 : undefined,
                       }}
                     >{rankDisplay}</span>
@@ -236,32 +236,34 @@ function TeamPage({
                       />
                       <div className="min-w-0">
                         <div className="flex items-center gap-1.5">
-                          <span className="truncate font-mono text-xs font-semibold group-hover:[color:var(--accent)]" style={{ color: 'var(--text)' }}>{agent.id}</span>
+                          <span className="truncate font-mono text-xs font-semibold group-hover:[color:var(--accent)]" style={{ color: 'var(--ink)' }}>{agent.id}</span>
                           {(() => {
                             const kind = getBenchBadgeKind(s);
                             if (kind === 'benched') return (
                               <span
-                                className="shrink-0 rounded px-1 font-mono text-[8px] font-bold uppercase tracking-wider"
-                                style={{ background: 'color-mix(in oklch, var(--danger) 15%, transparent)', color: 'var(--danger)' }}
+                                className="shrink-0 rounded px-1 text-[8px] font-bold"
+                                style={{ background: 'color-mix(in oklch, var(--bad) 15%, transparent)', color: 'var(--bad)', fontVariant: 'small-caps', letterSpacing: '0.04em' }}
                                 data-tooltip={`Benched (${s.bench.reason ?? 'auto'}). Excluded from dispatch until recovery.`}
                               >benched</span>
                             );
                             if (kind === 'struggling') return (
                               <span
-                                className="shrink-0 rounded bg-unverified/15 px-1 font-mono text-[8px] font-bold uppercase tracking-wider text-unverified"
+                                className="shrink-0 rounded bg-unverified/15 px-1 text-[8px] font-bold text-unverified"
+                                style={{ fontVariant: 'small-caps', letterSpacing: '0.04em' }}
                                 data-tooltip="Struggling: consecutive failures tripped the circuit breaker. Deprioritized until new clean signals recover the score."
                               >struggling</span>
                             );
                             if (kind === 'kept-for-coverage') return (
                               <span
-                                className="shrink-0 rounded border border-unverified/40 px-1 font-mono text-[8px] font-bold uppercase tracking-wider text-unverified"
+                                className="shrink-0 rounded border border-unverified/40 px-1 text-[8px] font-bold text-unverified"
+                                style={{ fontVariant: 'small-caps', letterSpacing: '0.04em' }}
                                 data-tooltip={`Would bench (${s.bench.reason ?? 'rule'}), but kept as sole provider of a category.`}
                               >kept for coverage</span>
                             );
                             return null;
                           })()}
                         </div>
-                        <div className="truncate font-mono text-[10px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 50%, transparent)' }}>
+                        <div className="truncate font-mono text-[10px]" style={{ color: 'var(--ink-3)' }}>
                           {agent.provider}/{agent.model}
                         </div>
                       </div>
@@ -273,7 +275,9 @@ function TeamPage({
                     <span className="font-mono text-sm font-bold tabular-nums" style={{ color: weightColor }}>{s.dispatchWeight.toFixed(2)}</span>
                   </td>
 
-                  {/* Metrics: four mini bars stacked — Acc / Rel / Unq / Imp */}
+                  {/* Metrics: three mini bars stacked — Acc / Unq / Imp.
+                      Reliability row removed pending backend taskCompletionRate
+                      wiring (consensus eee614bd-31ba4209 + task-graph emission). */}
                   <td className="py-3 pr-4 align-top">
                     <div className="space-y-1">
                       <MiniBar
@@ -282,21 +286,20 @@ function TeamPage({
                         fillClass={s.accuracy >= 0.7 ? 'bg-confirmed' : s.accuracy >= 0.4 ? 'bg-unverified' : 'bg-disputed'}
                         tooltip="Adjusted accuracy = raw signal ratio × 1/(1 + weighted hallucinations × 0.3). The penalty is recoverable via skill-gated multiplier in the same category."
                       />
-                      <MiniBar label="Rel" value={s.taskCompletionRate ?? 0} fillClass="bg-chart" tooltip="Reliability — fraction of dispatched tasks that finished without pipeline error or timeout" />
                       <MiniBar label="U" value={s.uniqueness} fillClass="bg-unique" tooltip="Uniqueness — findings this agent surfaced that no other agent found" />
                       <MiniBar label="I" value={s.impactScore} fillClass="bg-[var(--c8)]" tooltip="Impact — severity-weighted finding score; critical and high findings count more" />
                     </div>
                   </td>
 
                   {/* Signals */}
-                  <td className="py-3 pr-4 text-right align-top font-mono text-xs tabular-nums" style={{ color: 'var(--text)' }}>
+                  <td className="py-3 pr-4 text-right align-top font-mono text-xs tabular-nums" style={{ color: 'var(--ink)' }}>
                     {s.signals.toLocaleString()}
                   </td>
 
                   {/* Hallucinations */}
                   <td className="py-3 pr-4 text-right align-top font-mono text-xs tabular-nums">
                     <span
-                      style={{ color: s.hallucinations > 0 ? 'var(--danger)' : 'color-mix(in oklch, var(--text-dim) 40%, transparent)', fontWeight: s.hallucinations > 10 ? 'bold' : undefined }}
+                      style={{ color: s.hallucinations > 0 ? 'var(--bad)' : 'var(--ink-3)', fontWeight: s.hallucinations > 10 ? 'bold' : undefined }}
                       data-tooltip={`Agreements ${s.agreements} · Disagreements ${s.disagreements} · Hallucinations ${s.hallucinations}`}
                     >
                       {s.hallucinations}
@@ -310,13 +313,13 @@ function TeamPage({
                         <span className="warn-badge shrink-0 rounded px-1.5 py-0.5 font-mono text-[9px] font-semibold">
                           {lt.taskId.slice(0, 8)}
                         </span>
-                        <span className="truncate text-[11px]" style={{ maxWidth: 260, color: 'color-mix(in oklch, var(--text-dim) 80%, transparent)' }}>
+                        <span className="truncate text-[11px]" style={{ maxWidth: 260, color: 'var(--ink-2)' }}>
                           {lt.task}
                         </span>
-                        <span className="ml-auto shrink-0 font-mono text-[10px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 50%, transparent)' }}>{timeAgo(lt.timestamp)}</span>
+                        <span className="ml-auto shrink-0 font-mono text-[10px]" style={{ color: 'var(--ink-3)' }}>{timeAgo(lt.timestamp)}</span>
                       </div>
                     ) : (
-                      <span className="font-mono text-[10px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 30%, transparent)' }}>no tasks</span>
+                      <span className="font-mono text-[10px]" style={{ color: 'var(--ink-3)' }}>no tasks</span>
                     )}
                   </td>
                 </tr>
@@ -332,11 +335,11 @@ function TeamPage({
 function MiniBar({ label, value, fillClass, tooltip }: { label: string; value: number; fillClass: string; tooltip?: string }) {
   return (
     <div className="flex items-center gap-2" data-tooltip={tooltip} data-tooltip-pos="top">
-      <span className="w-6 font-mono text-[8px] uppercase" style={{ color: 'color-mix(in oklch, var(--text-dim) 50%, transparent)' }}>{label}</span>
+      <span className="w-6 text-[10px]" style={{ color: 'var(--ink-3)', fontVariant: 'small-caps', letterSpacing: '0.04em' }}>{label}</span>
       <div className="h-1 flex-1 overflow-hidden rounded-full" style={{ background: 'color-mix(in oklch, var(--surface) 60%, transparent)' }}>
         <div className={`h-full rounded-full ${fillClass}`} style={{ width: `${Math.max(0, Math.min(100, value * 100))}%` }} />
       </div>
-      <span className="w-8 text-right font-mono text-[10px] tabular-nums" style={{ color: 'color-mix(in oklch, var(--text) 80%, transparent)' }}>
+      <span className="w-8 text-right font-mono text-[10px] tabular-nums" style={{ color: 'var(--ink-2)' }}>
         {Math.round(value * 100)}%
       </span>
     </div>
@@ -374,10 +377,10 @@ function TasksPage({ tasks }: { tasks: import('@/lib/types').TasksData }) {
           <h1 className="h-route">Tasks</h1>
           <span className="font-mono text-sm tabular-nums" style={{ color: 'var(--ink-3)' }}>{tasks.total}</span>
         </div>
-        <p className="mt-0.5 font-mono text-[10px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 60%, transparent)' }}>Live dispatched tasks and their relay status.</p>
-        <div className="mt-2 flex gap-4 font-mono text-[11px]" style={{ color: 'var(--text-dim)' }}>
-          <span><span style={{ color: 'var(--success)' }}>{completed}</span> completed</span>
-          {failed > 0 && <span><span style={{ color: 'var(--danger)' }}>{failed}</span> failed</span>}
+        <p className="mt-0.5 text-[13px]" style={{ color: 'var(--ink-3)' }}>Live dispatched tasks and their relay status.</p>
+        <div className="mt-2 flex gap-4 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
+          <span><span style={{ color: 'var(--ok)' }}>{completed}</span> completed</span>
+          {failed > 0 && <span><span style={{ color: 'var(--bad)' }}>{failed}</span> failed</span>}
           {running > 0 && <span><span className="text-unverified">{running}</span> running</span>}
           <span>showing {paged.length} of {filtered.length}{q && ` (filtered from ${tasks.items.length})`}</span>
         </div>
@@ -390,9 +393,9 @@ function TasksPage({ tasks }: { tasks: import('@/lib/types').TasksData }) {
           onChange={(e) => { setQuery(e.target.value); setPage(0); }}
           placeholder="Search tasks by description, agent, id, status..."
           className="w-full max-w-md rounded-md [border-color:color-mix(in_oklch,var(--border)_40%,transparent)] border px-3 py-1.5 font-mono text-xs focus:[border-color:color-mix(in_oklch,var(--accent)_40%,transparent)] focus:outline-none"
-          style={{ background: 'color-mix(in oklch, var(--surface-elev) 80%, transparent)', color: 'var(--text)' }}
+          style={{ background: 'color-mix(in oklch, var(--surface-elev) 80%, transparent)', color: 'var(--ink)' }}
         />
-        <div className={`flex shrink-0 items-center gap-2 font-mono text-[11px] ${totalPages <= 1 ? 'invisible' : ''}`} style={{ color: 'var(--text-dim)' }}>
+        <div className={`flex shrink-0 items-center gap-2 font-mono text-[11px] ${totalPages <= 1 ? 'invisible' : ''}`} style={{ color: 'var(--ink-3)' }}>
             <button
               onClick={() => setPage((p) => Math.max(0, p - 1))}
               disabled={clampedPage === 0}
@@ -411,19 +414,19 @@ function TasksPage({ tasks }: { tasks: import('@/lib/types').TasksData }) {
 
       <div className="overflow-hidden rounded-md [border-color:color-mix(in_oklch,var(--border)_40%,transparent)] border" style={{ background: 'color-mix(in oklch, var(--surface-elev) 80%, transparent)' }}>
         {paged.length === 0 ? (
-          <div className="py-12 text-center text-sm" style={{ color: 'var(--text-dim)' }}>
+          <div className="py-12 text-center text-sm" style={{ color: 'var(--ink-3)' }}>
             {q ? 'No tasks match your search.' : 'No tasks yet.'}
           </div>
         ) : (
           <table className="w-full text-left">
             <thead>
               <tr className="border-b [border-color:color-mix(in_oklch,var(--border)_40%,transparent)]" style={{ background: 'color-mix(in oklch, var(--surface-sunk) 30%, transparent)' }}>
-                <th className="py-2.5 pl-4 pr-2 text-xs font-medium" style={{ width: 32, color: 'var(--text-dim)' }}></th>
-                <th className="py-2.5 pr-3 font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }}>ID</th>
-                <th className="py-2.5 pr-3 font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }}>Agent</th>
-                <th className="py-2.5 pr-3 font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }}>Description</th>
-                <th className="py-2.5 pr-3 font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }}>Duration</th>
-                <th className="py-2.5 pr-4 text-right font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }}>When</th>
+                <th className="py-2.5 pl-4 pr-2 h-section" style={{ width: 32 }}></th>
+                <th className="py-2.5 pr-3 h-section">ID</th>
+                <th className="py-2.5 pr-3 h-section">Agent</th>
+                <th className="py-2.5 pr-3 h-section">Description</th>
+                <th className="py-2.5 pr-3 h-section">Duration</th>
+                <th className="py-2.5 pr-4 text-right h-section">When</th>
               </tr>
             </thead>
             <tbody>
@@ -462,20 +465,20 @@ function FindingsPage({
           <h1 className="h-route">Consensus Rounds</h1>
           <span className="font-mono text-sm tabular-nums" style={{ color: 'var(--ink-3)' }}>{visibleRuns.length}</span>
           {!showRetracted && retractedCount > 0 && (
-            <span className="font-mono text-sm tabular-nums" style={{ color: 'color-mix(in oklch, var(--text-dim) 60%, transparent)' }}>
+            <span className="font-mono text-sm tabular-nums" style={{ color: 'var(--ink-3)' }}>
               / {consensus.totalRuns ?? consensus.runs.length} total
             </span>
           )}
         </div>
-        <p className="mt-0.5 font-mono text-[10px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 60%, transparent)' }}>Multi-agent review rounds — findings confirmed when ≥2 agents agree.</p>
-        <div className="mt-2 flex gap-4 font-mono text-[11px]" style={{ color: 'var(--text-dim)' }}>
-          <span><span style={{ color: 'var(--success)' }}>{confirmedTotal}</span> confirmed</span>
-          <span><span style={{ color: 'var(--danger)' }}>{disputedTotal}</span> disputed</span>
+        <p className="mt-0.5 text-[13px]" style={{ color: 'var(--ink-3)' }}>Multi-agent review rounds — findings confirmed when ≥2 agents agree.</p>
+        <div className="mt-2 flex gap-4 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
+          <span><span style={{ color: 'var(--ok)' }}>{confirmedTotal}</span> confirmed</span>
+          <span><span style={{ color: 'var(--bad)' }}>{disputedTotal}</span> disputed</span>
           {unverifiedTotal > 0 && <span><span className="text-unverified">{unverifiedTotal}</span> unverified</span>}
           <span>{consensus.totalSignals} total signals</span>
         </div>
         {retractedCount > 0 && (
-          <div className="mt-2 flex items-center gap-2 font-mono text-[11px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 70%, transparent)' }}>
+          <div className="mt-2 flex items-center gap-2 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
             <span>
               {showRetracted
                 ? `${retractedCount} retracted run${retractedCount === 1 ? '' : 's'} shown`
@@ -484,7 +487,7 @@ function FindingsPage({
             <button
               type="button"
               onClick={() => setShowRetracted(v => !v)}
-              className="rounded-sm [border-color:color-mix(in_oklch,var(--border)_40%,transparent)] border px-2 py-0.5 text-[10px] transition hover:bg-accent/10 hover:[color:var(--text)]"
+              className="rounded-sm [border-color:color-mix(in_oklch,var(--border)_40%,transparent)] border px-2 py-0.5 text-[10px] transition hover:bg-accent/10 hover:[color:var(--ink)]"
               style={{ background: 'var(--surface-elev)' }}
             >
               {showRetracted ? 'hide' : 'show'}
@@ -513,7 +516,7 @@ function Dashboard() {
     return (
       <div className="min-h-screen" style={{ background: 'var(--surface)' }}>
         <TopBar />
-        <div className="flex items-center justify-center py-20" style={{ color: 'var(--text-dim)' }}>Loading dashboard...</div>
+        <div className="flex items-center justify-center py-20" style={{ color: 'var(--ink-3)' }}>Loading dashboard...</div>
       </div>
     );
   }
@@ -578,7 +581,7 @@ export function App() {
   const { authed, login, error } = useAuth();
 
   if (authed === null) {
-    return <div className="flex min-h-screen items-center justify-center" style={{ color: 'var(--text-dim)' }}>Loading...</div>;
+    return <div className="flex min-h-screen items-center justify-center" style={{ color: 'var(--ink-3)' }}>Loading...</div>;
   }
 
   if (!authed) {

--- a/packages/dashboard-v2/src/components/AgentCardBig.tsx
+++ b/packages/dashboard-v2/src/components/AgentCardBig.tsx
@@ -210,12 +210,6 @@ export function AgentCardBig({ agent, severityCounts, trendPoints }: AgentCardBi
             style={{ background: 'color-mix(in oklch, var(--surface) 40%, transparent)' }}
           >
             <SubBar
-              label="reliability"
-              value={s.taskCompletionRate ?? 0}
-              color={ac}
-              tooltip={`Reliability ${pct(s.taskCompletionRate ?? 0)}\nTask completion rate.`}
-            />
-            <SubBar
               label="unique"
               value={s.uniqueness}
               color={ac}

--- a/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
+++ b/packages/dashboard-v2/src/components/AgentNetworkGraph.tsx
@@ -141,10 +141,27 @@ function Starfield({ width, height, agentPositions }: StarfieldProps) {
   useEffect(() => {
     if (width <= 0 || height <= 0) return;
     const rand = seededRandom(7311);
-    const count = 120;
+    const count = 170;
     starsRef.current = Array.from({ length: count }, () => {
-      const baseR = rand() < 0.82 ? 0.7 : 1.4;
-      const baseO = 0.20 + rand() * 0.40; // brighter in dark mode (canvas is always dark now)
+      // Three-tier size + brightness so the field reads like real sky:
+      // most are tiny dim background stars, some mid, and a few bright
+      // "named" stars pop. Brightness scales with size so big = bright.
+      const roll = rand();
+      let baseR: number;
+      let baseO: number;
+      if (roll < 0.07) {
+        // ~7% bright stars
+        baseR = 2.0 + rand() * 0.6;
+        baseO = 0.75 + rand() * 0.25;
+      } else if (roll < 0.32) {
+        // ~25% mid stars
+        baseR = 1.2 + rand() * 0.4;
+        baseO = 0.45 + rand() * 0.35;
+      } else {
+        // ~68% faint background stars
+        baseR = 0.5 + rand() * 0.4;
+        baseO = 0.25 + rand() * 0.30;
+      }
       return {
         x: rand() * width,
         y: rand() * height,
@@ -154,7 +171,9 @@ function Starfield({ width, height, agentPositions }: StarfieldProps) {
         o: baseO,
         consumed: null,
         phase: rand() * Math.PI * 2,
-        twinkleHz: 0.2 + rand() * 1.0,
+        // Slightly wider Hz range — brighter stars twinkle a touch faster
+        // so they read as more "alive" than the dim background.
+        twinkleHz: 0.25 + rand() * 1.4,
       };
     });
   }, [width, height]);
@@ -196,8 +215,10 @@ function Starfield({ width, height, agentPositions }: StarfieldProps) {
         // Twinkle: idle stars softly modulate between 50% and 100% of baseO.
         // Consumed stars skip twinkle so the fade-to-zero reads cleanly.
         if (star.consumed === null) {
-          const mod = 0.75 + 0.25 * Math.sin(elapsedS * star.twinkleHz * Math.PI * 2 + star.phase);
-          star.o = star.baseO * mod;
+          // Deeper twinkle swing (45% .. 115% of baseO) makes bright stars
+          // visibly pulse and dim background ones shimmer in/out.
+          const mod = 0.80 + 0.35 * Math.sin(elapsedS * star.twinkleHz * Math.PI * 2 + star.phase);
+          star.o = Math.min(1, star.baseO * mod);
         }
 
         if (star.consumed !== null) {

--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -89,7 +89,6 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
 
   const metricBars = [
     { label: 'accuracy', value: s.accuracy, fill: s.accuracy >= 0.7 ? 'bg-confirmed' : s.accuracy >= 0.4 ? 'bg-unverified' : 'bg-disputed' },
-    { label: 'reliability', value: s.taskCompletionRate ?? 0, fill: 'bg-chart', tooltip: 'Task completion rate — fraction of dispatched tasks that finished without pipeline error or timeout' },
     { label: 'unique', value: s.uniqueness, fill: 'bg-unique' },
     { label: 'impact', value: s.impactScore, fill: 'bg-[var(--c8)]' },
   ];
@@ -285,7 +284,7 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
           <div className="rounded-lg border border-border/40 p-4 shadow-[inset_0_1px_3px_rgba(0,0,0,0.35)]" style={{ background: 'color-mix(in oklch, var(--surface-elev) 80%, transparent)' }}>
             <div className="space-y-2.5">
               {metricBars.map(m => (
-                <div key={m.label} className="grid grid-cols-[72px_1fr_44px] items-center gap-3" {...(m.tooltip ? { 'data-tooltip': m.tooltip } : {})}>
+                <div key={m.label} className="grid grid-cols-[72px_1fr_44px] items-center gap-3">
                   <span className="font-mono text-[10px] uppercase tracking-wider" style={{ color: 'var(--text-dim)' }}>{m.label}</span>
                   <div className="h-1.5 overflow-hidden rounded-full" style={{ background: 'color-mix(in oklch, var(--surface) 80%, transparent)' }}>
                     <div className={`h-full rounded-full transition-all ${m.fill}`} style={{ width: `${Math.max(0, Math.min(100, m.value * 100))}%` }} />

--- a/packages/dashboard-v2/src/components/AuthGate.tsx
+++ b/packages/dashboard-v2/src/components/AuthGate.tsx
@@ -1,8 +1,9 @@
 import { useState, type FormEvent } from 'react';
+import type { AuthError } from '@/hooks/useAuth';
 
 interface AuthGateProps {
-  onLogin: (key: string) => void;
-  error: boolean;
+  onLogin: (key: string) => Promise<void>;
+  error: AuthError;
 }
 
 // The CRT glitch effect used to fire on a random 3-12s interval — but on an
@@ -13,15 +14,29 @@ interface AuthGateProps {
 
 export function AuthGate({ onLogin, error }: AuthGateProps) {
   const [key, setKey] = useState('');
+  const [pending, setPending] = useState(false);
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    if (key.trim()) onLogin(key.trim());
+    if (!key.trim() || pending) return;
+    setPending(true);
+    try {
+      await onLogin(key.trim());
+    } finally {
+      setPending(false);
+    }
   };
+
+  const errorMessage =
+    error === 'bad_key'
+      ? 'Invalid key. Check your terminal for the correct key.'
+      : error === 'network'
+      ? 'Connection error — relay may be offline.'
+      : null;
 
   return (
     <div className="min-h-screen flex items-center justify-center" style={{ background: 'var(--surface)' }}>
-      <div className="w-full max-w-sm rounded-xl border [border-color:var(--border)] p-8 text-center shadow-2xl" style={{ background: 'var(--surface-elev)' }}>
+      <div className="w-full max-w-sm rounded-xl border [border-color:var(--border)] p-8 text-center" style={{ background: 'var(--surface-elev)' }}>
         {/* Logo with CRT hover effect */}
         <div className="crt-logo mx-auto mb-4" style={{ width: 'fit-content' }}>
           <img
@@ -34,10 +49,8 @@ export function AuthGate({ onLogin, error }: AuthGateProps) {
 
         {/* Wordmark */}
         <p
-          className="mb-1 text-[30px] font-bold tracking-tight"
+          className="h-route mb-1"
           style={{
-            color: 'var(--text)',
-            fontFamily: 'var(--font-sans)',
             letterSpacing: '-0.02em',
             textShadow: '0 0 24px var(--accent)',
           }}
@@ -45,7 +58,7 @@ export function AuthGate({ onLogin, error }: AuthGateProps) {
           Gossipcat
         </p>
 
-        <p className="mb-6 text-sm" style={{ color: 'var(--text-dim)' }}>
+        <p className="mb-6 text-[13px]" style={{ color: 'var(--ink-3)' }}>
           Authenticate to access the dashboard
         </p>
 
@@ -56,21 +69,23 @@ export function AuthGate({ onLogin, error }: AuthGateProps) {
             onChange={(e) => setKey(e.target.value)}
             placeholder="Dashboard key"
             autoFocus
-            className="w-full rounded-lg border [border-color:var(--border)] px-4 py-3 font-mono text-sm outline-none focus:[border-color:var(--accent)] focus:ring-2 focus:[--tw-ring-color:color-mix(in_oklch,var(--accent)_20%,transparent)]"
-            style={{ background: 'var(--surface)', color: 'var(--text)' }}
+            disabled={pending}
+            className="w-full rounded-lg border [border-color:var(--border)] px-4 py-3 font-mono text-sm outline-none focus:[border-color:var(--ink-3)] focus:ring-2 focus:[--tw-ring-color:color-mix(in_oklch,var(--ink-3)_20%,transparent)] disabled:opacity-50"
+            style={{ background: 'var(--surface)', color: 'var(--ink)' }}
           />
           <button
             type="submit"
-            className="mt-4 w-full rounded-lg px-4 py-3 text-sm font-semibold transition hover:opacity-90"
+            disabled={pending}
+            className="mt-4 w-full rounded-lg px-4 py-3 text-sm font-semibold transition hover:opacity-90 disabled:opacity-60"
             style={{ background: 'var(--accent)', color: '#fff' }}
           >
-            Unlock
+            {pending ? 'Unlocking…' : 'Unlock'}
           </button>
         </form>
 
-        {error && (
-          <p className="mt-3 text-sm" style={{ color: 'var(--danger)' }}>
-            Invalid key. Check your terminal for the correct key.
+        {errorMessage && (
+          <p className="mt-3 text-sm" style={{ color: 'var(--bad)' }}>
+            {errorMessage}
           </p>
         )}
       </div>

--- a/packages/dashboard-v2/src/components/RecentSignalsPeek.tsx
+++ b/packages/dashboard-v2/src/components/RecentSignalsPeek.tsx
@@ -102,7 +102,7 @@ export function RecentSignalsPeek() {
         <div className="flex items-baseline gap-3">
           <h3 className="h-section">Signal stream</h3>
           {lastHour > 0 && (
-            <span className="font-mono text-[11px]" style={{ color: 'var(--accent)' }}>
+            <span className="font-mono text-[11px]" style={{ color: 'var(--info)' }}>
               +{lastHour} in last hour
             </span>
           )}
@@ -147,7 +147,8 @@ export function RecentSignalsPeek() {
                     <td className="py-2.5 pr-3 align-middle">
                       <div className="flex items-center gap-2">
                         <span
-                          aria-hidden="true"
+                          role="img"
+                          aria-label={s.severity ? `severity: ${s.severity}` : 'severity: unspecified'}
                           style={{ display: 'inline-block', width: 3, height: 14, background: tickColor, borderRadius: 1, flexShrink: 0 }}
                           title={s.severity ?? ''}
                         />

--- a/packages/dashboard-v2/src/components/SeverityMixStrip.tsx
+++ b/packages/dashboard-v2/src/components/SeverityMixStrip.tsx
@@ -16,15 +16,12 @@ interface SeverityMixStripProps {
   height?: number;
 }
 
-/** Monochrome opacity ramp — single rose hue ramping from dark
- *  (critical) to light (low) reads as "severity intensity" without
- *  collisions with the verdict/status semantic palette elsewhere. */
-const SEGMENT_COLOR = 'var(--bad)';
-const SEGMENT_OPACITY: Record<keyof SeverityCount, number> = {
-  critical: 1.0,
-  high: 0.7,
-  medium: 0.45,
-  low: 0.22,
+/** Per-severity semantic colors per DESIGN.md Step 6. */
+const SEGMENT_COLORS: Record<keyof SeverityCount, string> = {
+  critical: 'var(--bad)',
+  high: 'var(--warn)',
+  medium: 'var(--info)',
+  low: 'var(--idle)',
 };
 
 const SEVERITY_ORDER: Array<keyof SeverityCount> = ['critical', 'high', 'medium', 'low'];
@@ -55,8 +52,8 @@ export function SeverityMixStrip({ counts, height = 10 }: SeverityMixStripProps)
             key={sev}
             style={{
               flex: 1,
-              background: SEGMENT_COLOR,
-              opacity: SEGMENT_OPACITY[sev] * 0.5,
+              background: SEGMENT_COLORS[sev],
+              opacity: 0.4,
             }}
           />
         ))}
@@ -84,8 +81,7 @@ export function SeverityMixStrip({ counts, height = 10 }: SeverityMixStripProps)
             key={sev}
             style={{
               width: `${pct.toFixed(2)}%`,
-              background: SEGMENT_COLOR,
-              opacity: SEGMENT_OPACITY[sev],
+              background: SEGMENT_COLORS[sev],
               flexShrink: 0,
             }}
           />

--- a/packages/dashboard-v2/src/components/SkillGraduationGrid.tsx
+++ b/packages/dashboard-v2/src/components/SkillGraduationGrid.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import type { SkillsApiResponse, SkillEffectivenessEntry, SkillStatus } from '@/lib/types';
 import { SkillEffectivenessSparkline } from './SkillEffectivenessSparkline';
 import { href } from '@/lib/router';
+import { agentColor } from '@/lib/utils';
 
 /**
  * DESIGN.md Step 9.5 — SkillGraduationGrid as a flat card grid.
@@ -74,8 +75,8 @@ export function SkillGraduationGrid({ skills, loading, error }: Props) {
         <div className="flex items-baseline gap-2">
           <h3 className="h-section">Skill Graduation</h3>
           <span
-            className="font-mono text-[11px] tabular-nums"
-            style={{ color: 'var(--accent)' }}
+            className="font-mono text-[11px] tabular-nums font-bold"
+            style={{ color: 'var(--ink)' }}
           >
             {skillCount}
           </span>
@@ -214,6 +215,12 @@ function SkillCard({ entry }: { entry: SkillEffectivenessEntry }) {
   const verdict = isGraduationVerdict(entry.status) ? entry.status : null;
   const color = verdict ? VERDICT_COLOR[verdict] : UNKNOWN_COLOR;
   const label = verdict ? VERDICT_LABEL[verdict] : (entry.status ?? 'unknown');
+  // Delta only meaningful for skills that have actually graduated — for
+  // pending/failed/etc. the trend is noise, not progress.
+  const deltaPp = verdict === 'passed' ? computeDeltaPp(entry.curve) : null;
+  const currentValue = latestValue(entry.curve);
+  const currentStr = currentValue == null ? '—' : currentValue.toFixed(2);
+  const thresholdStr = entry.threshold.toFixed(2);
 
   return (
     <li
@@ -221,9 +228,33 @@ function SkillCard({ entry }: { entry: SkillEffectivenessEntry }) {
       style={{ background: 'var(--surface)' }}
       title={`${entry.agentId} · ${entry.skill} · ${label} · N=${entry.n}`}
     >
-      {/* Top: skill name */}
-      <div className="truncate text-[13px]" style={{ color: 'var(--ink)' }}>
-        {entry.skill}
+      {/* Top: skill name + 7d chip; agent identity below */}
+      <div className="flex flex-col gap-0.5">
+        <div className="flex items-baseline justify-between gap-2">
+          <div className="truncate text-[13px]" style={{ color: 'var(--ink)' }}>
+            {entry.skill}
+          </div>
+          <span
+            className="shrink-0 rounded-sm border border-border px-1 font-mono text-[9px] tabular-nums"
+            style={{ color: 'var(--ink-3)' }}
+            title="7-day effectiveness window"
+          >
+            7d
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span
+            aria-hidden
+            className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+            style={{ backgroundColor: agentColor(entry.agentId) }}
+          />
+          <span
+            className="truncate font-mono text-[10px]"
+            style={{ color: 'var(--ink-3)' }}
+          >
+            {entry.agentId}
+          </span>
+        </div>
       </div>
       {/* Middle: sparkline */}
       <SkillEffectivenessSparkline
@@ -231,7 +262,7 @@ function SkillCard({ entry }: { entry: SkillEffectivenessEntry }) {
         threshold={entry.threshold}
         stroke={color}
       />
-      {/* Bottom: verdict label + N */}
+      {/* Bottom: verdict label + delta-pp + N */}
       <div className="flex items-baseline justify-between gap-2">
         <span
           className="truncate text-[10px]"
@@ -243,15 +274,59 @@ function SkillCard({ entry }: { entry: SkillEffectivenessEntry }) {
         >
           {label}
         </span>
-        <span
-          className="font-mono text-[10px] tabular-nums"
-          style={{ color: 'var(--ink-3)' }}
-        >
-          N={entry.n}
-        </span>
+        <div className="flex items-baseline gap-2">
+          {deltaPp !== null && (
+            <span
+              className="font-mono text-[10px] tabular-nums"
+              style={{
+                color:
+                  deltaPp > 0 ? 'var(--ok)' : deltaPp < 0 ? 'var(--bad)' : 'var(--ink-3)',
+              }}
+              title={`Trend ${deltaPp > 0 ? 'up' : deltaPp < 0 ? 'down' : 'flat'} ${Math.abs(deltaPp)} percentage points across the 7d window`}
+              aria-label={`Trend ${deltaPp > 0 ? 'up' : deltaPp < 0 ? 'down' : 'flat'} ${Math.abs(deltaPp)} percentage points`}
+            >
+              {deltaPp > 0 ? '+' : ''}
+              {deltaPp}pp
+            </span>
+          )}
+          <span
+            className="font-mono text-[10px] tabular-nums"
+            style={{ color: 'var(--ink)' }}
+            title={`current ${currentStr} · threshold ${thresholdStr}`}
+          >
+            {currentStr}
+            <span style={{ color: 'var(--ink-3)' }}> / {thresholdStr}</span>
+          </span>
+          <span
+            className="font-mono text-[10px] tabular-nums"
+            style={{ color: 'var(--ink-3)' }}
+          >
+            N={entry.n}
+          </span>
+        </div>
       </div>
     </li>
   );
+}
+
+/** First→last non-null bucket delta, in percentage points (integer).
+ *  Returns null if fewer than 4 non-null buckets — with 2-3 sparse buckets
+ *  the delta swings to ±100pp from single signals, which is misleading
+ *  (consensus eee614bd-31ba4209 finding f17). */
+const DELTA_MIN_BUCKETS = 4;
+function computeDeltaPp(curve: SkillEffectivenessEntry['curve']): number | null {
+  const defined = curve.filter((p) => p.value != null && Number.isFinite(p.value)) as Array<{ value: number }>;
+  if (defined.length < DELTA_MIN_BUCKETS) return null;
+  return Math.round((defined[defined.length - 1].value - defined[0].value) * 100);
+}
+
+/** Most recent non-null bucket value, or null if all buckets are empty. */
+function latestValue(curve: SkillEffectivenessEntry['curve']): number | null {
+  for (let i = curve.length - 1; i >= 0; i--) {
+    const v = curve[i].value;
+    if (v != null && Number.isFinite(v)) return v;
+  }
+  return null;
 }
 
 /* ── states ────────────────────────────────────────────────────────────── */

--- a/packages/dashboard-v2/src/components/TopBar.tsx
+++ b/packages/dashboard-v2/src/components/TopBar.tsx
@@ -49,8 +49,7 @@ export function TopBar() {
       </div>
       <div className="flex items-center gap-2">
         <div
-          role="button"
-          tabIndex={-1}
+          aria-hidden="true"
           title="Search — coming soon"
           style={{
             display: 'inline-flex',

--- a/packages/dashboard-v2/src/hooks/useAuth.ts
+++ b/packages/dashboard-v2/src/hooks/useAuth.ts
@@ -1,21 +1,23 @@
 import { useState, useEffect, useCallback } from 'react';
 import { checkAuth, login as apiLogin } from '@/lib/api';
 
+export type AuthError = 'bad_key' | 'network' | null;
+
 export function useAuth() {
   const [authed, setAuthed] = useState<boolean | null>(null);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<AuthError>(null);
 
   useEffect(() => {
     checkAuth().then(setAuthed);
   }, []);
 
   const login = useCallback(async (key: string) => {
-    setError(false);
-    const ok = await apiLogin(key);
-    if (ok) {
+    setError(null);
+    const result = await apiLogin(key);
+    if (result.ok) {
       setAuthed(true);
     } else {
-      setError(true);
+      setError(result.kind);
     }
   }, []);
 

--- a/packages/dashboard-v2/src/lib/api.ts
+++ b/packages/dashboard-v2/src/lib/api.ts
@@ -10,14 +10,22 @@ export async function api<T>(path: string, options?: RequestInit): Promise<T> {
   return res.json();
 }
 
-export async function login(key: string): Promise<boolean> {
-  const res = await fetch(`${BASE}/auth`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ key }),
-  });
-  return res.ok;
+export type LoginResult = { ok: true } | { ok: false; kind: 'bad_key' | 'network' };
+
+export async function login(key: string): Promise<LoginResult> {
+  try {
+    const res = await fetch(`${BASE}/auth`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key }),
+    });
+    if (res.ok) return { ok: true };
+    if (res.status === 401 || res.status === 403) return { ok: false, kind: 'bad_key' };
+    return { ok: false, kind: 'network' };
+  } catch {
+    return { ok: false, kind: 'network' };
+  }
 }
 
 export async function checkAuth(): Promise<boolean> {

--- a/packages/relay/src/dashboard/api-agents.ts
+++ b/packages/relay/src/dashboard/api-agents.ts
@@ -219,13 +219,22 @@ interface AgentTaskData {
 
 function readTaskGraphByAgent(projectRoot: string): Map<string, AgentTaskData> {
   const taskGraphPath = join(projectRoot, '.gossip', 'task-graph.jsonl');
+  const archivePath = taskGraphPath + '.1';
   const result = new Map<string, AgentTaskData>();
 
-  if (!existsSync(taskGraphPath)) return result;
+  if (!existsSync(taskGraphPath) && !existsSync(archivePath)) return result;
 
-  let lines: string[];
+  // Read archive first (older events), then primary — same order as event log.
+  // Rotation puts old task.created in .jsonl.1 while task.completed lives in
+  // the primary; reading only the primary makes them orphans.
+  let lines: string[] = [];
   try {
-    lines = readFileSync(taskGraphPath, 'utf-8').trim().split('\n').filter(Boolean);
+    if (existsSync(archivePath)) {
+      lines.push(...readFileSync(archivePath, 'utf-8').split('\n').filter(Boolean));
+    }
+    if (existsSync(taskGraphPath)) {
+      lines.push(...readFileSync(taskGraphPath, 'utf-8').split('\n').filter(Boolean));
+    }
   } catch {
     return result;
   }

--- a/packages/relay/src/dashboard/api-overview.ts
+++ b/packages/relay/src/dashboard/api-overview.ts
@@ -140,13 +140,23 @@ export async function overviewHandler(projectRoot: string, ctx: OverviewContext)
   const now = Date.now();
   const hourMs = 60 * 60 * 1000;
 
-  // Single pass over task-graph.jsonl for active agents, task stats, and hourly buckets.
+  // Single pass over task-graph.jsonl (+ rotated .1) for active agents,
+  // task stats, and hourly buckets. Rotation puts pre-rotation task.created in
+  // .jsonl.1; reading only the primary makes long-lived tasks orphan-completion
+  // and underreports taskCompletionRate / reliability bars.
   const graphPath = join(projectRoot, '.gossip', 'task-graph.jsonl');
-  if (existsSync(graphPath)) {
+  const archivePath = graphPath + '.1';
+  if (existsSync(graphPath) || existsSync(archivePath)) {
     try {
       const created = new Map<string, { agentId: string; timestamp: string }>();
       const finished = new Set<string>();
-      const lines = readFileSync(graphPath, 'utf-8').trim().split('\n').filter(Boolean);
+      const lines: string[] = [];
+      if (existsSync(archivePath)) {
+        lines.push(...readFileSync(archivePath, 'utf-8').split('\n').filter(Boolean));
+      }
+      if (existsSync(graphPath)) {
+        lines.push(...readFileSync(graphPath, 'utf-8').split('\n').filter(Boolean));
+      }
       for (const line of lines) {
         try {
           const ev = JSON.parse(line);

--- a/packages/relay/src/dashboard/api-skills.ts
+++ b/packages/relay/src/dashboard/api-skills.ts
@@ -65,6 +65,7 @@ const AGENT_ID_RE = /^[a-zA-Z0-9_-]{1,64}$/;
 
 /** Curve resolution. Spec-default 10 windows; held in a constant for clarity. */
 const NUM_BUCKETS = 10;
+const WINDOW_MS = 7 * 24 * 60 * 60 * 1000; // 7d effectiveness window
 /** Fallback threshold when frontmatter has no `passed_baseline_rate`. */
 const DEFAULT_THRESHOLD = 0.7;
 /** Cache TTL — short enough to stay live during a session, long enough to
@@ -230,10 +231,11 @@ function deriveEffectiveness(
       const boundAtIso = fm?.bound_at ?? slot.boundAt;
       const boundAtMs = new Date(boundAtIso).getTime();
       if (!Number.isFinite(boundAtMs) || boundAtMs <= 0) continue;
-      // Bucket span: divide [boundAt, now] into NUM_BUCKETS windows. When the
-      // skill was just bound (span < NUM_BUCKETS ms), clamp to a 1ms-per-bucket
-      // floor so the math doesn't degenerate. The curve will just be empty.
-      const totalSpan = Math.max(nowMs - boundAtMs, NUM_BUCKETS);
+      // Bucket span: cap to a recent 7d window so dense recent activity fills
+      // all buckets instead of clustering into 2-3 of N. Skills bound long ago
+      // with no recent signals collapse to empty buckets (threshold-only render).
+      const windowStartMs = Math.max(boundAtMs, nowMs - WINDOW_MS);
+      const totalSpan = Math.max(nowMs - windowStartMs, NUM_BUCKETS);
       const bucketMs = totalSpan / NUM_BUCKETS;
       const events = signalIdx.byAgentSkill.get(agentId)?.get(normalizeSkillName(slot.skill)) ?? [];
       const buckets: Array<{ c: number; h: number }> = Array.from(
@@ -242,8 +244,8 @@ function deriveEffectiveness(
       );
       let n = 0;
       for (const ev of events) {
-        if (ev.ts < boundAtMs) continue;
-        const rel = ev.ts - boundAtMs;
+        if (ev.ts < windowStartMs) continue;
+        const rel = ev.ts - windowStartMs;
         let i = Math.floor(rel / bucketMs);
         if (i < 0) i = 0;
         if (i >= NUM_BUCKETS) i = NUM_BUCKETS - 1;
@@ -253,7 +255,7 @@ function deriveEffectiveness(
       }
       const curve: SkillCurvePoint[] = buckets.map((b, i) => {
         const total = b.c + b.h;
-        const t = boundAtMs + (i + 1) * bucketMs;
+        const t = windowStartMs + (i + 1) * bucketMs;
         return { t, value: total > 0 ? b.c / total : null };
       });
       const threshold = fm?.passed_baseline_rate ?? DEFAULT_THRESHOLD;

--- a/packages/relay/src/dashboard/api-tasks.ts
+++ b/packages/relay/src/dashboard/api-tasks.ts
@@ -2,6 +2,23 @@ import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { isUtilityAgent } from './utility-agents';
 
+/** Read task-graph.jsonl + its single rotated archive (.jsonl.1).
+ *  After single-slot rotation (5MB cap), task.created events from before the
+ *  rotation live in .1 while their task.completed lands in the new primary —
+ *  reading only the primary makes long-lived tasks appear as orphan completions
+ *  and disappear from the Tasks page entirely. */
+function readTaskGraphLines(graphPath: string): string[] {
+  const out: string[] = [];
+  const archive = graphPath + '.1';
+  if (existsSync(archive)) {
+    out.push(...readFileSync(archive, 'utf-8').split('\n').filter(Boolean));
+  }
+  if (existsSync(graphPath)) {
+    out.push(...readFileSync(graphPath, 'utf-8').split('\n').filter(Boolean));
+  }
+  return out;
+}
+
 interface TaskEntry {
   taskId: string;
   agentId: string;
@@ -28,13 +45,15 @@ export async function tasksHandler(projectRoot: string, query?: URLSearchParams)
   const offset = isNaN(rawOffset) || rawOffset < 0 ? 0 : rawOffset;
 
   const graphPath = join(projectRoot, '.gossip', 'task-graph.jsonl');
-  if (!existsSync(graphPath)) return { items: [], total: 0, offset, limit };
+  if (!existsSync(graphPath) && !existsSync(graphPath + '.1')) {
+    return { items: [], total: 0, offset, limit };
+  }
 
   const created = new Map<string, { agentId: string; task: string; timestamp: string }>();
   const completed = new Map<string, { duration?: number; timestamp: string; failed: boolean; cancelled?: boolean; inputTokens?: number; outputTokens?: number; result?: string }>();
 
   try {
-    const lines = readFileSync(graphPath, 'utf-8').trim().split('\n').filter(Boolean);
+    const lines = readTaskGraphLines(graphPath);
     for (const line of lines) {
       try {
         const entry = JSON.parse(line);


### PR DESCRIPTION
## Summary

Bundles three high-leverage fixes from this session into one PR:

1. **Consensus eee614bd-31ba4209 HIGH findings** — 7 fixes across SeverityMixStrip, RecentSignalsPeek, SkillGraduationGrid, TopBar, computeDeltaPp gate.
2. **Task-graph rotation reader bug** — the real reason the Tasks page was empty and Reliability bars showed 0%. Readers now load `task-graph.jsonl` + `.jsonl.1` archive in chronological order.
3. **TeamPage + AuthGate DESIGN.md compliance** — `.h-route` heading parity, `.h-section` small-caps labels, full token migration (`--text` → `--ink`, `--danger` → `--bad`, etc.), AuthGate loading state + distinguishable errors.

Plus polish: SkillGraduationGrid cards now show per-agent identity + 7d chip + current/threshold + ±pp delta; AgentNetworkGraph starfield is more alive (170 stars, three-tier brightness, deeper twinkle).

## Root cause: task-graph rotation
`performance-writer.ts` does single-slot 5MB rotation → renames the primary to `.jsonl.1`. The relay's three readers (`api-tasks`, `api-agents`, `api-overview`) only read the primary, so any task whose `task.created` fell into the archive appeared as an orphan completion and was filtered out. With 1,483 historical `task.created` entries in the archive and 3 in the primary, the Tasks page showed "0 of 0" and `taskCompletionRate` was always null.

Fix: readers now read archive first then primary, concatenated.

## Test plan
- [x] `npm run -w packages/dashboard-v2 build` passes
- [x] `npm run -w packages/relay build` passes
- [x] DESIGN.md gates: `grep "uppercase tracking-wider" packages/dashboard-v2/src/components/AuthGate.tsx packages/dashboard-v2/src/App.tsx` returns empty for TeamPage scope; `shadow-2xl` removed from AuthGate
- [x] Visual: TeamPage header now Fraunces, stat tiles small-caps, rank #1 ink not terracotta, LAST TASK column populated (was empty)
- [x] Visual: SkillGraduationGrid shows per-agent identity dot + 7d chip + cur/thr + ±pp on PASSED only
- [ ] Re-test login page in incognito after merge
- [ ] Verify Reliability bars stay hidden until taskCompletionRate backend wiring lands (separate PR)

## Out of scope
- TasksPage + ConsensusPage still use pre-migration tokens (tracked separately in consensus eee614bd-31ba4209 follow-ups)
- SystemPulse + GraphRail all-caps mono labels (next PR)
- Task-graph emission for native+relay `task.created` is already wired correctly; this PR fixes the reader half

🤖 Generated with [Claude Code](https://claude.com/claude-code)