### PR TITLE
fix(dashboard-v2): DESIGN.md token sweep — SystemPulse + GraphRail + SkillsApiResponse hoist

### DIFF
--- a/packages/dashboard-v2/package.json
+++ b/packages/dashboard-v2/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@gossip/types": "*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "d3-force": "^3.0.0",

--- a/packages/dashboard-v2/src/components/GraphRail.tsx
+++ b/packages/dashboard-v2/src/components/GraphRail.tsx
@@ -51,7 +51,7 @@ function FleetSummary({ agents, peerRelationships }: { agents: AgentData[]; peer
       <div className="mb-2 h-section">
         Fleet at a glance
       </div>
-      <p className="mb-4 font-mono text-[12px]" style={{ color: 'var(--text-faint)' }}>
+      <p className="mb-4 font-mono text-[12px]" style={{ color: 'var(--ink-4)' }}>
         Click a node to see detail.
       </p>
 
@@ -69,7 +69,7 @@ function FleetSummary({ agents, peerRelationships }: { agents: AgentData[]; peer
             >
               <div className="min-w-0 flex-1">
                 <div className="truncate font-mono text-[12px] font-semibold" style={{ color: 'var(--text)' }}>{a.id}</div>
-                <div className="mt-0.5 font-mono text-[11px]" style={{ color: 'var(--text-dim)' }}>{Math.round(a.scores.accuracy * 100)}% accuracy · {a.scores.signals} signals</div>
+                <div className="mt-0.5 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>{Math.round(a.scores.accuracy * 100)}% accuracy · {a.scores.signals} signals</div>
               </div>
               <span className="opacity-0 transition group-hover:opacity-100 font-mono text-[11px]" style={{ color: 'var(--accent)' }}>→</span>
             </button>
@@ -90,7 +90,7 @@ function FleetSummary({ agents, peerRelationships }: { agents: AgentData[]; peer
               <div className="font-mono text-[12px]" style={{ color: 'var(--text)' }}>
                 <span style={{ color: 'var(--danger)' }}>◆</span> {c.pair[0]} ↔ {c.pair[1]}
               </div>
-              <div className="mt-0.5 font-mono text-[11px]" style={{ color: 'var(--text-dim)' }}>
+              <div className="mt-0.5 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
                 {c.catches} caught · {timeAgo(c.ts)}
               </div>
             </div>
@@ -102,11 +102,11 @@ function FleetSummary({ agents, peerRelationships }: { agents: AgentData[]; peer
 }
 
 function Section({ label, tone, children }: { label: string; tone: 'success' | 'muted' | 'danger'; children: React.ReactNode }) {
-  const toneColor = tone === 'success' ? 'var(--success)' : tone === 'danger' ? 'var(--danger)' : 'var(--text-faint)';
+  const toneColor = tone === 'success' ? 'var(--success)' : tone === 'danger' ? 'var(--danger)' : 'var(--ink-4)';
   return (
     <section className="mb-4">
-      <div className="mb-1.5 flex items-center gap-1.5 font-mono text-[11px] font-bold uppercase tracking-wider" style={{ color: toneColor }}>
-        <span style={{ width: 4, height: 4, borderRadius: '50%', background: toneColor, display: 'inline-block' }} />
+      <div className="mb-1.5 flex items-center gap-1.5 h-section">
+        <span style={{ width: 4, height: 4, borderRadius: '50%', background: toneColor, display: 'inline-block', flexShrink: 0 }} />
         {label}
       </div>
       <div className="space-y-1">{children}</div>
@@ -115,7 +115,7 @@ function Section({ label, tone, children }: { label: string; tone: 'success' | '
 }
 
 function EmptyRow({ text }: { text: string }) {
-  return <div className="px-2 py-1.5 font-mono text-[11px]" style={{ color: 'var(--text-faint)' }}>{text}</div>;
+  return <div className="px-2 py-1.5 font-mono text-[11px]" style={{ color: 'var(--ink-4)' }}>{text}</div>;
 }
 
 /** Naive time-ago for the rail. ISO timestamp → "3h ago" / "2d ago". */
@@ -234,7 +234,7 @@ function AgentDetail({ agent, peerRelationships, agents }: { agent: AgentData; p
 function Stat({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded px-2 py-1.5" style={{ background: 'color-mix(in oklch, var(--surface) 50%, transparent)' }}>
-      <div className="font-mono text-[10px] uppercase tracking-wider" style={{ color: 'var(--text-faint)' }}>{label}</div>
+      <div className="h-section">{label}</div>
       <div className="mt-0.5 font-mono text-[16px] font-medium tabular-nums" style={{ color: 'var(--text)' }}>{value}</div>
     </div>
   );
@@ -247,10 +247,10 @@ function ActionButton({ label, kbd, href, disabled }: { label: string; kbd: stri
       aria-disabled={disabled}
       tabIndex={disabled ? -1 : undefined}
       className="flex items-center justify-between rounded px-2 py-2 font-mono text-[12px] transition"
-      style={{ background: disabled ? 'transparent' : 'color-mix(in oklch, var(--surface) 50%, transparent)', color: disabled ? 'var(--text-faint)' : 'var(--text)', pointerEvents: disabled ? 'none' : 'auto', opacity: disabled ? 0.5 : 1 }}
+      style={{ background: disabled ? 'transparent' : 'color-mix(in oklch, var(--surface) 50%, transparent)', color: disabled ? 'var(--ink-4)' : 'var(--text)', pointerEvents: disabled ? 'none' : 'auto', opacity: disabled ? 0.5 : 1 }}
     >
       <span>{label}</span>
-      <kbd className="rounded border px-1 py-0.5 font-mono text-[10px]" style={{ borderColor: 'var(--border)', background: 'var(--surface-sunk)', color: 'var(--text-dim)' }}>{kbd}</kbd>
+      <kbd className="rounded border px-1 py-0.5 font-mono text-[10px]" style={{ borderColor: 'var(--border)', background: 'var(--surface-sunk)', color: 'var(--ink-3)' }}>{kbd}</kbd>
     </a>
   );
 }

--- a/packages/dashboard-v2/src/components/SkillGraduationGrid.tsx
+++ b/packages/dashboard-v2/src/components/SkillGraduationGrid.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { SkillsApiResponse, SkillEffectivenessEntry, SkillStatus } from '@/lib/types';
+import type { SkillsApiResponse, SkillEffectivenessEntry, SkillStatus } from '@gossip/types';
 import { SkillEffectivenessSparkline } from './SkillEffectivenessSparkline';
 import { href } from '@/lib/router';
 import { agentColor } from '@/lib/utils';

--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -32,7 +32,7 @@ interface BigStatProps {
   value: string | number;
   unit?: string;
   label: string;
-  /** Non-theme Tailwind class for the value (e.g. text-confirmed, text-unverified, text-orange-400).
+  /** Non-theme Tailwind class for the value (e.g. text-confirmed, text-unverified).
    *  Pass empty string to fall back to var(--text). Theme-sensitive colours
    *  are handled via valueColor instead. */
   valueClass?: string;
@@ -58,9 +58,9 @@ function BigStat({ value, unit, label, valueClass = '', valueColor, pulse, toolt
         >
           {value}
         </span>
-        {unit && <span className="font-mono text-xs" style={{ color: 'var(--text-dim)' }}>{unit}</span>}
+        {unit && <span className="font-mono text-xs" style={{ color: 'var(--ink-3)' }}>{unit}</span>}
       </div>
-      <div className="mt-1.5 text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }}>
+      <div className="mt-1.5 text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--ink-3)' }}>
         {label}
       </div>
     </div>
@@ -117,7 +117,7 @@ export function SystemPulse({ overview, activeTasks, mode = 'dense', showActivit
               value={activeTasks}
               label="Active Tasks"
               valueClass={activeTasks > 0 ? 'text-unverified' : ''}
-              valueColor={activeTasks > 0 ? undefined : 'var(--text-dim)'}
+              valueColor={activeTasks > 0 ? undefined : 'var(--ink-3)'}
               pulse={activeTasks > 0}
             />
           </div>
@@ -125,7 +125,7 @@ export function SystemPulse({ overview, activeTasks, mode = 'dense', showActivit
             value={`${confirmRate}%`}
             label="Confirmed"
             valueClass={confirmRate >= 50 ? 'text-confirmed' : confirmRate > 0 ? 'text-unverified' : ''}
-            valueColor={confirmRate === 0 ? 'var(--text-dim)' : undefined}
+            valueColor={confirmRate === 0 ? 'var(--ink-3)' : undefined}
           />
         </div>
       ) : (
@@ -137,26 +137,26 @@ export function SystemPulse({ overview, activeTasks, mode = 'dense', showActivit
             {/* Three-row agent stat (stacked to fit narrow cell) */}
             <div className="flex flex-col items-stretch justify-center gap-1.5 px-4 py-3">
               <div className="flex items-baseline justify-between gap-2">
-                <span className="font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }} data-tooltip="Agents currently executing a task">Dispatched</span>
+                <span className="font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--ink-3)' }} data-tooltip="Agents currently executing a task">Dispatched</span>
                 <span
                   className="font-mono text-base font-bold leading-none"
                   style={{ color: overview.agentsOnline > 0 ? 'var(--ok)' : 'var(--text)' }}
                 >{overview.agentsOnline}</span>
               </div>
               <div className="flex items-baseline justify-between gap-2">
-                <span className="font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }} data-tooltip="Relay agents with an active WebSocket connection">Connected</span>
-                <span className={`font-mono text-base font-bold leading-none ${overview.relayConnected > 0 ? 'text-confirmed' : ''}`} style={overview.relayConnected > 0 ? undefined : { color: 'var(--text-dim)' }}>{overview.relayConnected}</span>
+                <span className="font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--ink-3)' }} data-tooltip="Relay agents with an active WebSocket connection">Connected</span>
+                <span className={`font-mono text-base font-bold leading-none ${overview.relayConnected > 0 ? 'text-confirmed' : ''}`} style={overview.relayConnected > 0 ? undefined : { color: 'var(--ink-3)' }}>{overview.relayConnected}</span>
               </div>
               <div className="flex items-baseline justify-between gap-2">
-                <span className="font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-dim)' }} data-tooltip="Total agents in gossipcat config">Registered</span>
-                <span className="font-mono text-base font-bold leading-none" style={{ color: 'var(--text-dim)' }}>{totalAgents}</span>
+                <span className="font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--ink-3)' }} data-tooltip="Total agents in gossipcat config">Registered</span>
+                <span className="font-mono text-base font-bold leading-none" style={{ color: 'var(--ink-3)' }}>{totalAgents}</span>
               </div>
             </div>
             <BigStat
               value={activeTasks}
               label="Active Tasks"
               valueClass={activeTasks > 0 ? 'text-unverified' : ''}
-              valueColor={activeTasks > 0 ? undefined : 'var(--text-dim)'}
+              valueColor={activeTasks > 0 ? undefined : 'var(--ink-3)'}
               pulse={activeTasks > 0}
             />
             <BigStat
@@ -178,7 +178,7 @@ export function SystemPulse({ overview, activeTasks, mode = 'dense', showActivit
             <BigStat
               value={overview.actionableFindings}
               label="Actionable"
-              valueClass={overview.actionableFindings > 0 ? 'text-orange-400' : ''}
+              valueClass={overview.actionableFindings > 0 ? 'text-unverified' : ''}
               tooltip="Findings still open and need operator review (disagreements + hallucinations + new findings)"
             />
           </a>
@@ -189,28 +189,28 @@ export function SystemPulse({ overview, activeTasks, mode = 'dense', showActivit
       {!isCalm && (
         <div className="px-3.5 py-3">
           <div className="flex items-center justify-between py-1 font-mono text-[11px]">
-            <span style={{ color: 'var(--text-dim)' }}>tasks completed</span>
+            <span style={{ color: 'var(--ink-3)' }}>tasks completed</span>
             <span className="font-semibold tabular-nums" style={{ color: 'var(--text)' }}>{overview.tasksCompleted}</span>
           </div>
           <div className="flex items-center justify-between py-1 font-mono text-[11px]">
-            <span style={{ color: 'var(--text-dim)' }}>signals total</span>
+            <span style={{ color: 'var(--ink-3)' }}>signals total</span>
             <span className="font-semibold tabular-nums" style={{ color: 'var(--text)' }}>{overview.totalSignals}</span>
           </div>
           {overview.tasksFailed > 0 && (
             <div className="flex items-center justify-between py-1 font-mono text-[11px]">
-              <span style={{ color: 'var(--text-dim)' }}>tasks failed</span>
+              <span style={{ color: 'var(--ink-3)' }}>tasks failed</span>
               <span className="font-semibold text-destructive tabular-nums">{overview.tasksFailed}</span>
             </div>
           )}
           <div className="flex items-center justify-between py-1 font-mono text-[11px]">
-            <span style={{ color: 'var(--text-dim)' }}>avg duration</span>
+            <span style={{ color: 'var(--ink-3)' }}>avg duration</span>
             <span className="font-semibold tabular-nums" style={{ color: 'var(--text)' }}>{formatDuration(overview.avgDurationMs)}</span>
           </div>
           <div className="flex items-center justify-between py-1 font-mono text-[11px]">
-            <span style={{ color: 'var(--text-dim)' }}>success rate</span>
+            <span style={{ color: 'var(--ink-3)' }}>success rate</span>
             <span
               className={`font-semibold tabular-nums ${successRate !== null && successRate >= 95 ? 'text-confirmed' : successRate !== null && successRate >= 80 ? 'text-unverified' : successRate !== null ? 'text-destructive' : ''}`}
-              style={successRate === null ? { color: 'var(--text-dim)' } : undefined}
+              style={successRate === null ? { color: 'var(--ink-3)' } : undefined}
             >
               {successRate === null ? '—' : `${successRate}%`}
             </span>
@@ -223,7 +223,7 @@ export function SystemPulse({ overview, activeTasks, mode = 'dense', showActivit
 
       {/* Last consensus footer */}
       {overview.lastConsensusTimestamp && (
-        <div className="border-t border-border px-3.5 py-2 font-mono text-[10px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 60%, transparent)' }}>
+        <div className="border-t border-border px-3.5 py-2 font-mono text-[10px]" style={{ color: 'color-mix(in oklch, var(--ink-3) 60%, transparent)' }}>
           last consensus {timeAgo(overview.lastConsensusTimestamp)}
         </div>
       )}
@@ -241,7 +241,7 @@ function ActivityBars({ hourly }: ActivityBarsProps) {
   const max = Math.max(1, ...bars);
   return (
     <div className="border-t border-border px-3.5 py-3" style={{ background: 'color-mix(in oklch, var(--surface-sunk) 30%, transparent)' }}>
-      <div className="mb-2 font-mono text-[9px] font-bold uppercase tracking-wider" style={{ color: 'color-mix(in oklch, var(--text-dim) 60%, transparent)' }}>
+      <div className="mb-2 font-mono text-[9px] font-bold uppercase tracking-wider" style={{ color: 'color-mix(in oklch, var(--ink-3) 60%, transparent)' }}>
         Activity Last 12h
       </div>
       <div className="flex h-6 items-end gap-0.5">
@@ -263,7 +263,7 @@ function ActivityBars({ hourly }: ActivityBarsProps) {
           );
         })}
       </div>
-      <div className="mt-1 flex justify-between font-mono text-[9px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 40%, transparent)' }}>
+      <div className="mt-1 flex justify-between font-mono text-[9px]" style={{ color: 'color-mix(in oklch, var(--ink-3) 40%, transparent)' }}>
         <span>12h ago</span>
         <span>now</span>
       </div>

--- a/packages/dashboard-v2/src/hooks/useDashboardData.ts
+++ b/packages/dashboard-v2/src/hooks/useDashboardData.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { api } from '@/lib/api';
-import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, MemoryFile, FleetTrendResponse, SkillsApiResponse } from '@/lib/types';
+import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, MemoryFile, FleetTrendResponse } from '@/lib/types';
+import type { SkillsApiResponse } from '@gossip/types';
 
 /**
  * Polling interval for /api/agents and friends. Backs the "Team page updates

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -37,50 +37,19 @@ export interface FleetTrendResponse {
 }
 
 /* ── Step 9.5 — skills + post-bind effectiveness curves ───────────────── */
-
-export interface SkillCurvePoint {
-  /** Window-end timestamp (ms epoch). */
-  t: number;
-  /** Accuracy = correct/(correct+halluc) in window. null when window empty. */
-  value: number | null;
-}
-
-export interface SkillEffectivenessEntry {
-  agentId: string;
-  skill: string;
-  status: SkillStatus | null;
-  /** 10 equal-time windows from boundAt → now. */
-  curve: SkillCurvePoint[];
-  /** Graduation threshold — passed_baseline_rate from frontmatter, fallback 0.7. */
-  threshold: number;
-  /** Total post-bind signals across the full curve window. */
-  n: number;
-  /** ISO. Anchor for the curve. */
-  boundAt: string;
-}
-
-export interface SkillsApiResponse {
-  /** Raw skill-index passthrough (agent → skill → slot). Unused by the
-   *  dashboard today but kept for compatibility with the bind UI. */
-  index: Record<string, Record<string, unknown>>;
-  suggestions: string[];
-  /** Per-agent+skill effectiveness curves. Drives SkillGraduationGrid. */
-  effectiveness: SkillEffectivenessEntry[];
-}
+// SkillCurvePoint, SkillEffectivenessEntry, SkillsApiResponse, SkillVerdict,
+// and SkillStatus are canonical in @gossip/types/skills. Re-exported here for
+// backward compat so all existing `import type { ... } from '@/lib/types'`
+// call sites continue to compile without changes.
+import type { SkillStatus as _SkillStatus } from '@gossip/types';
+export type { SkillCurvePoint, SkillEffectivenessEntry, SkillsApiResponse, SkillVerdict, SkillStatus } from '@gossip/types';
+// Alias in local scope so SkillSlot.status below resolves correctly.
+type SkillStatus = _SkillStatus;
 
 export interface ForcedDevelopEntry {
   timestamp: string;
   reason?: string;
 }
-
-export type SkillStatus =
-  | 'pending'
-  | 'passed'
-  | 'failed'
-  | 'silent_skill'
-  | 'insufficient_evidence'
-  | 'inconclusive'
-  | 'flagged_for_manual_review';
 
 export interface SkillSlot {
   name: string;

--- a/packages/dashboard-v2/src/pages/OverviewPage.tsx
+++ b/packages/dashboard-v2/src/pages/OverviewPage.tsx
@@ -18,7 +18,8 @@ import { useUrlRangeParam } from '@/hooks/useUrlRangeParam';
 import { useGlobalAgentKeys } from '@/hooks/useGlobalAgentKeys';
 import { isGraphHidden } from '@/lib/feature-flags';
 import { href } from '@/lib/router';
-import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, FleetTrendResponse, FleetTrendPoint, SkillsApiResponse } from '@/lib/types';
+import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, FleetTrendResponse, FleetTrendPoint } from '@/lib/types';
+import type { SkillsApiResponse } from '@gossip/types';
 
 interface OverviewPageProps {
   overview: OverviewData;

--- a/packages/relay/src/dashboard/api-skills.ts
+++ b/packages/relay/src/dashboard/api-skills.ts
@@ -2,44 +2,10 @@ import { SkillIndex, SkillIndexData } from '@gossip/orchestrator/skill-index';
 import { readJsonlWithRotated, normalizeSkillName } from '@gossip/orchestrator';
 import { existsSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
+import type { SkillVerdict, SkillCurvePoint, SkillEffectivenessEntry } from '@gossip/types';
 
-/**
- * Verdict tags inlined from `check-effectiveness.ts` SkillStatus union. We keep
- * this as a string-literal union (not a re-import) so the relay package
- * doesn't widen its public surface with internal orchestrator types — the
- * verdict is just a tag for the dashboard, not a state machine input.
- */
-export type SkillVerdict =
-  | 'pending'
-  | 'passed'
-  | 'failed'
-  | 'silent_skill'
-  | 'insufficient_evidence'
-  | 'inconclusive'
-  | 'flagged_for_manual_review';
-
-/** One point on the post-bind effectiveness curve for a single skill. */
-export interface SkillCurvePoint {
-  /** Window-end timestamp (ms epoch). */
-  t: number;
-  /** Accuracy in window = correct / (correct + hallucinated). null when window empty. */
-  value: number | null;
-}
-
-/** Per-agent+skill effectiveness curve plus metadata. */
-export interface SkillEffectivenessEntry {
-  agentId: string;
-  skill: string;
-  status: SkillVerdict | null;
-  /** 10 equal-time windows from boundAt → now. */
-  curve: SkillCurvePoint[];
-  /** Graduation threshold — passed_baseline_rate from frontmatter, fallback 0.7. */
-  threshold: number;
-  /** Total post-bind signals across the full curve window. */
-  n: number;
-  /** ISO. Anchor for the curve. From frontmatter bound_at if present, else slot.boundAt. */
-  boundAt: string;
-}
+// Re-export from @gossip/types so relay consumers get the canonical types.
+export type { SkillVerdict, SkillCurvePoint, SkillEffectivenessEntry };
 
 export interface SkillsGetResponse {
   index: SkillIndexData;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,3 +4,4 @@ export * from './codec';
 export * from './tools';
 export * from './errors';
 export * from './orchestrator';
+export * from './skills';

--- a/packages/types/src/skills.ts
+++ b/packages/types/src/skills.ts
@@ -1,0 +1,63 @@
+/**
+ * Skills API shared types — used by both the relay (api-skills.ts) and the
+ * dashboard-v2 client. Canonical home is @gossip/types so both packages share
+ * one definition and avoid type drift.
+ */
+
+/** Effectiveness verdict for a bound skill — matches orchestrator SkillStatus union. */
+export type SkillVerdict =
+  | 'pending'
+  | 'passed'
+  | 'failed'
+  | 'silent_skill'
+  | 'insufficient_evidence'
+  | 'inconclusive'
+  | 'flagged_for_manual_review';
+
+/**
+ * Alias for SkillVerdict kept for dashboard-v2 backward compatibility.
+ * dashboard-v2/src/lib/types.ts re-exported this as SkillStatus before the hoist.
+ */
+export type SkillStatus = SkillVerdict;
+
+/** One point on the post-bind effectiveness curve for a single skill. */
+export interface SkillCurvePoint {
+  /** Window-end timestamp (ms epoch). */
+  t: number;
+  /** Accuracy in window = correct / (correct + hallucinated). null when window empty. */
+  value: number | null;
+}
+
+/** Per-agent+skill effectiveness curve plus graduation metadata. */
+export interface SkillEffectivenessEntry {
+  agentId: string;
+  skill: string;
+  status: SkillVerdict | null;
+  /** 10 equal-time windows from boundAt → now. */
+  curve: SkillCurvePoint[];
+  /** Graduation threshold — passed_baseline_rate from frontmatter, fallback 0.7. */
+  threshold: number;
+  /** Total post-bind signals across the full curve window. */
+  n: number;
+  /** ISO. Anchor for the curve. */
+  boundAt: string;
+}
+
+/**
+ * Response shape for GET /api/skills — served by relay, consumed by dashboard-v2.
+ * Renamed from SkillsGetResponse (relay) and SkillsApiResponse (dashboard) to
+ * a single canonical name.
+ */
+export interface SkillsApiResponse {
+  /** Raw skill-index passthrough (agent → skill → slot). */
+  index: Record<string, Record<string, unknown>>;
+  suggestions: string[];
+  /** Per-agent+skill effectiveness curves. Drives SkillGraduationGrid. */
+  effectiveness: SkillEffectivenessEntry[];
+}
+
+/**
+ * Alias kept for relay backward compat — relay's handler still returns SkillsGetResponse.
+ * @deprecated Use SkillsApiResponse directly.
+ */
+export type SkillsGetResponse = SkillsApiResponse;


### PR DESCRIPTION
## Summary

Closes **3 MEDIUM + 1 type-drift** findings carried over from consensus `eee614bd-31ba4209` ([PROSE-ONLY] backlog):

1. **GraphRail.tsx:108, 237** — section + stat label divs migrated to `.h-section` small-caps Geist signature (was `font-mono uppercase tracking-wider`) per `DESIGN.md` §Typography (lines 180–205).
2. **SystemPulse.tsx** (~19 sites) — `var(--text-dim)` → `var(--ink-3)` and `var(--text-faint)` → `var(--ink-4)` per `DESIGN.md` token map (lines 102–105).
3. **SystemPulse.tsx:181** — `text-orange-400` → `text-unverified` (semantic `--warn` amber) for the actionable-findings count.
4. **SkillsApiResponse type drift** — hoisted to `packages/types/src/skills.ts` as canonical home. dashboard-v2 + relay both consume from `@gossip/types`; dashboard-v2 re-exports for backward compat.

## Test plan

- [x] `grep -rn 'text-orange-400\|var(--text-dim)\|var(--text-faint)' packages/dashboard-v2/src/components/{SystemPulse,GraphRail}.tsx` → empty
- [x] `grep -rnE 'font-mono.*uppercase.*tracking-wider' packages/dashboard-v2/src/components/GraphRail.tsx` → empty
- [x] `grep -rn 'SkillsApiResponse\|SkillsGetResponse' packages/dashboard-v2/src/lib/types.ts` → only re-exports remain (no local definitions)
- [x] `npm run build` (full workspace) → exits 0
- [x] `npx tsc --noEmit` in `packages/dashboard-v2/` → exits 0
- [ ] Visual verify SystemPulse + GraphRail in browser before merge

## Notes

- 3 commits, kept logically separable (types hoist → consumer refactor → token sweep) for clean revert if needed.
- Implementer dispatched with `isolation: "worktree"` but writes hit master directly (recurring sandbox gap per `feedback_agent_isolation_worktree_sandbox_gap`). Recovered by branch-from-uncommitted-master + commit; no work lost.
- Did NOT bundle the additional findings sonnet-designer surfaced (CONF column removal, RecentSignalsPeek skeleton, `unique_unconfirmed` color) — those are semantic decisions and belong in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)