### PR TITLE
fix(dashboard-v2+relay): LOW bundle — Sparkline threshold, AGENT_ID_RE dots, stable ribbon keys, drop shadow

### DIFF
--- a/packages/dashboard-v2/src/components/ActivityWaterfall.tsx
+++ b/packages/dashboard-v2/src/components/ActivityWaterfall.tsx
@@ -159,7 +159,7 @@ export function ActivityWaterfall({ agents, runs, loading = false, error = null 
             <div className="flex items-center gap-2 font-mono text-[12px]" style={{ color: 'var(--ink)' }}>
               <span
                 className="inline-block h-2 w-2 flex-shrink-0 rounded-full"
-                style={{ background: color, boxShadow: `0 0 4px ${color}80` }}
+                style={{ background: color }}
               />
               <span className="truncate">{agent.id}</span>
             </div>

--- a/packages/dashboard-v2/src/components/ConsensusFlow.tsx
+++ b/packages/dashboard-v2/src/components/ConsensusFlow.tsx
@@ -205,7 +205,7 @@ function SankeyHorizontal({ data }: { data: ConsensusFlowResponse }) {
         <g>
           {ribbons.map((r, i) => (
             <path
-              key={i}
+              key={`${r.fromFamily}-${r.toVerdict}`}
               d={r.path}
               fill={r.color}
               fillOpacity={0.55}
@@ -327,6 +327,8 @@ interface RibbonRender {
   path: string;
   color: string;
   tooltip: string;
+  fromFamily: ConsensusFlowFamily;
+  toVerdict: ConsensusFlowVerdict;
 }
 
 interface SankeyLayout {
@@ -430,6 +432,8 @@ function computeSankeyLayout(data: ConsensusFlowResponse): SankeyLayout {
       path,
       color: VERDICT_COLOR[e.to.verdict],
       tooltip: `${famCount} ${FAMILY_LABEL[e.from.family]} agent${famCount === 1 ? '' : 's'} → ${e.to.count} ${VERDICT_LABEL[e.to.verdict]} finding${e.to.count === 1 ? '' : 's'} (${Math.round(e.weight * 100)}%)`,
+      fromFamily: e.from.family,
+      toVerdict: e.to.verdict,
     });
   }
 

--- a/packages/dashboard-v2/src/components/SkillEffectivenessSparkline.tsx
+++ b/packages/dashboard-v2/src/components/SkillEffectivenessSparkline.tsx
@@ -47,7 +47,7 @@ export function SkillEffectivenessSparkline({
   // rather than "early signal." Fall back to the threshold-only placeholder.
   const definedCount = segments.reduce((n, s) => n + s.length, 0);
   if (curve.length === 0 || definedCount < MIN_VISIBLE_POINTS) {
-    return <EmptySparkline width={width} height={height} />;
+    return <EmptySparkline width={width} height={height} threshold={threshold} />;
   }
 
   const innerW = width - PADDING_X * 2;
@@ -113,10 +113,16 @@ export function SkillEffectivenessSparkline({
   );
 }
 
-function EmptySparkline({ width, height }: { width: number; height: number }) {
+function EmptySparkline({ width, height, threshold }: { width: number; height: number; threshold?: number }) {
   // Render the threshold dashed line only — keeps the row height stable while
   // signaling "no post-bind signals yet."
-  const thresholdY = height / 2;
+  // When threshold is defined, position the line at the correct ratio so it
+  // matches where the live sparkline would draw its dashed reference.
+  const innerH = height - PADDING_Y * 2;
+  const thresholdY =
+    threshold !== undefined
+      ? PADDING_Y + (1 - clamp01(threshold)) * innerH
+      : height / 2;
   return (
     <svg
       width={width}
@@ -130,10 +136,10 @@ function EmptySparkline({ width, height }: { width: number; height: number }) {
         x2={width - PADDING_X}
         y1={thresholdY}
         y2={thresholdY}
-        stroke="var(--ink-4)"
+        stroke="var(--ok)"
         strokeWidth={1}
-        strokeDasharray="2 3"
-        opacity={0.5}
+        strokeDasharray="2 2"
+        opacity={0.4}
       />
     </svg>
   );

--- a/packages/relay/src/dashboard/api-memory.ts
+++ b/packages/relay/src/dashboard/api-memory.ts
@@ -1,7 +1,7 @@
 import { readFileSync, readdirSync, existsSync } from 'fs';
 import { join } from 'path';
 
-const AGENT_ID_RE = /^[a-zA-Z0-9_-]{1,64}$/;
+const AGENT_ID_RE = /^[a-zA-Z0-9_.-]{1,64}$/;
 const DANGEROUS_IDS = new Set(['__proto__', 'constructor', 'prototype']);
 
 interface KnowledgeFile { filename: string; frontmatter: Record<string, string>; content: string; }

--- a/packages/relay/src/dashboard/api-skills.ts
+++ b/packages/relay/src/dashboard/api-skills.ts
@@ -61,7 +61,7 @@ export interface SkillsGetResponse {
 export interface SkillsBindRequest { agent_id: string; skill: string; enabled: boolean; }
 export interface SkillsBindResponse { success: boolean; error?: string; }
 
-const AGENT_ID_RE = /^[a-zA-Z0-9_-]{1,64}$/;
+const AGENT_ID_RE = /^[a-zA-Z0-9_.-]{1,64}$/;
 
 /** Curve resolution. Spec-default 10 windows; held in a constant for clarity. */
 const NUM_BUCKETS = 10;


### PR DESCRIPTION
## Summary

Closes 4 LOWs + 1 NEW from the consensus \`eee614bd-31ba4209\` [PROSE-ONLY] backlog:

- **EmptySparkline** now respects the \`threshold\` prop — renders a dashed \`var(--ok)\` line at the same y-coordinate as the live sparkline's threshold, opacity 0.4. Closes both the dashed-line gap (LOW) and the 0.5/0.7 opacity jump (NEW) in one change.
- **AGENT_ID_RE** in \`api-memory.ts\` and \`api-skills.ts\` now permits dots in agent IDs / skill names (\`gemini.flash\`, \`sonnet-implementer.v2\`) while preserving the underscore + length-cap contract used by \`_utility\`.
- **ConsensusFlow ribbons** keyed by stable \`\${fromFamily}-\${toVerdict}\` composite — fixes React reconciliation when ribbons reorder.
- **ActivityWaterfall identity dot** drops the glow \`boxShadow\` per DESIGN.md §Visual rules ("no drop shadows by default").

## Notes
Orchestrator-applied fix on top of sonnet-implementer output: the original patch had narrowed \`AGENT_ID_RE\` to \`/^[a-z][a-z0-9.-]*$/i\` which rejected \`_utility\`. Restored to original char class + length cap with dot added.

Worktree isolation failed for this dispatch (writes hit master, recurring per \`feedback_agent_isolation_worktree_sandbox_gap\`). Recovered by stash + branch + pop.

## Test plan
- [x] \`grep -n 'boxShadow' ActivityWaterfall.tsx\` → empty
- [x] ConsensusFlow ribbon key is composite, not index
- [x] \`AGENT_ID_RE\` accepts both \`_utility\` and \`gemini.flash\`
- [x] \`npm run build\` exits 0
- [ ] Visual verify Sparkline dashed threshold + identity dot before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)