### PR TITLE
fix(relay): resolve skills across all 3 tiers in readSkillFrontmatter

### DIFF
--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -2,7 +2,7 @@ export { MainAgent } from './main-agent';
 export { seedMemoryHygiene } from './memory-hygiene-seed';
 export type { MemoryHygieneSeedResult } from './memory-hygiene-seed';
 export { detectFormatCompliance, MAX_COMPLIANCE_INPUT } from './dispatch-pipeline';
-export { loadSkills, DEFAULT_KEYWORDS, resolveSkillExists } from './skill-loader';
+export { loadSkills, DEFAULT_KEYWORDS, resolveSkillExists, resolveSkill } from './skill-loader';
 export type { LoadSkillsResult, DroppedSkill } from './skill-loader';
 export { SkillCounterTracker } from './skill-counters';
 export type { MainAgentConfig } from './main-agent';

--- a/packages/orchestrator/src/skill-loader.ts
+++ b/packages/orchestrator/src/skill-loader.ts
@@ -452,7 +452,7 @@ function getKeywords(content: string, skillName: string): string[] {
  * back to the non-realpath'd absolute path so a transient FS error never
  * fails the load.
  */
-function resolveSkill(
+export function resolveSkill(
   agentId: string,
   skill: string,
   projectRoot: string,

--- a/packages/relay/src/dashboard/api-skills.ts
+++ b/packages/relay/src/dashboard/api-skills.ts
@@ -1,6 +1,6 @@
 import { SkillIndex, SkillIndexData } from '@gossip/orchestrator/skill-index';
-import { readJsonlWithRotated, normalizeSkillName } from '@gossip/orchestrator';
-import { existsSync, readFileSync, statSync } from 'fs';
+import { readJsonlWithRotated, normalizeSkillName, resolveSkill } from '@gossip/orchestrator';
+import { existsSync, statSync } from 'fs';
 import { join } from 'path';
 import type { SkillVerdict, SkillCurvePoint, SkillEffectivenessEntry } from '@gossip/types';
 
@@ -56,19 +56,21 @@ function readSkillFrontmatter(
   skillName: string,
 ): SkillFrontmatter | null {
   try {
-    const path = join(projectRoot, '.gossip', 'agents', agentId, 'skills', `${skillName}.md`);
-    if (!existsSync(path)) return null;
-    const raw = readFileSync(path, 'utf-8');
+    const resolved = resolveSkill(agentId, skillName, projectRoot);
+    if (!resolved) return null;
+    const raw = resolved.content;
     if (!raw.startsWith('---')) return null;
     const end = raw.indexOf('\n---', 3);
     if (end === -1) return null;
     const block = raw.slice(3, end);
     const out: SkillFrontmatter = {};
     for (const line of block.split('\n')) {
-      const m = line.match(/^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.+?)\s*$/);
+      // Strip inline comments before matching to handle `key: value  # note`
+      const trimmed = line.replace(/#.*$/, '').trim();
+      const m = trimmed.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.+)$/);
       if (!m) continue;
       const key = m[1];
-      let value: string = m[2];
+      let value: string = m[2].trim();
       if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
         value = value.slice(1, -1);
       }
@@ -79,6 +81,8 @@ function readSkillFrontmatter(
         if (Number.isFinite(n)) out.passed_baseline_rate = n;
       }
     }
+    // Return null instead of empty object when no recognized fields were parsed
+    if (!out.status && !out.bound_at && out.passed_baseline_rate === undefined) return null;
     return out;
   } catch {
     return null;

--- a/tests/relay/skill-frontmatter-resolution.test.ts
+++ b/tests/relay/skill-frontmatter-resolution.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for 3-tier skill resolution in readSkillFrontmatter (api-skills.ts).
+ *
+ * readSkillFrontmatter is private — tested indirectly via skillsGetHandler
+ * which calls deriveEffectiveness → readSkillFrontmatter for each enabled slot.
+ * The skill-index drives which agents/skills are iterated.
+ */
+import { skillsGetHandler } from '../../packages/relay/src/dashboard/api-skills';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/** Writes a minimal skill-index.json binding one skill slot for an agent. */
+function writeSkillIndex(
+  root: string,
+  agentId: string,
+  skill: string,
+  boundAt = '2026-01-01T00:00:00Z',
+): void {
+  writeFileSync(
+    join(root, '.gossip', 'skill-index.json'),
+    JSON.stringify({
+      [agentId]: {
+        [skill]: {
+          skill,
+          enabled: true,
+          source: 'manual',
+          mode: 'permanent',
+          version: 1,
+          boundAt,
+        },
+      },
+    }),
+  );
+}
+
+describe('readSkillFrontmatter — 3-tier skill resolution via skillsGetHandler', () => {
+  it('reads status from a project-tier skill (.gossip/skills/) when agent-local is absent', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-skill-fm-'));
+    mkdirSync(join(root, '.gossip', 'skills'), { recursive: true });
+    mkdirSync(join(root, '.gossip', 'agents', 'test-agent', 'skills'), { recursive: true });
+
+    // Only project-tier skill file — no agent-local copy
+    writeFileSync(
+      join(root, '.gossip', 'skills', 'data-integrity.md'),
+      '---\nstatus: active\nbound_at: 2026-01-01T00:00:00Z\n---\n# Data Integrity\nProject-wide skill.\n',
+    );
+    writeSkillIndex(root, 'test-agent', 'data-integrity');
+
+    const resp = await skillsGetHandler(root);
+    const entry = resp.effectiveness.find(
+      (e) => e.agentId === 'test-agent' && e.skill === 'data-integrity',
+    );
+    expect(entry).toBeDefined();
+    // Before fix: status was null (agent-local not found, project-tier ignored)
+    // After fix: status should be 'active'
+    expect(entry!.status).toBe('active');
+  });
+
+  it('agent-local skill takes precedence over project-tier when both exist', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-skill-fm-'));
+    mkdirSync(join(root, '.gossip', 'skills'), { recursive: true });
+    mkdirSync(join(root, '.gossip', 'agents', 'test-agent', 'skills'), { recursive: true });
+
+    // Project-tier: status pending
+    writeFileSync(
+      join(root, '.gossip', 'skills', 'error-handling.md'),
+      '---\nstatus: pending\nbound_at: 2026-01-01T00:00:00Z\n---\n# Error Handling\n',
+    );
+    // Agent-local: status active (should win)
+    writeFileSync(
+      join(root, '.gossip', 'agents', 'test-agent', 'skills', 'error-handling.md'),
+      '---\nstatus: active\nbound_at: 2026-02-01T00:00:00Z\n---\n# Error Handling (local)\n',
+    );
+    writeSkillIndex(root, 'test-agent', 'error-handling');
+
+    const resp = await skillsGetHandler(root);
+    const entry = resp.effectiveness.find(
+      (e) => e.agentId === 'test-agent' && e.skill === 'error-handling',
+    );
+    expect(entry).toBeDefined();
+    // Agent-local wins: status must be 'active', not 'pending'
+    expect(entry!.status).toBe('active');
+  });
+
+  it('skill with NO frontmatter (just a heading) returns null status', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-skill-fm-'));
+    mkdirSync(join(root, '.gossip', 'skills'), { recursive: true });
+    mkdirSync(join(root, '.gossip', 'agents', 'test-agent', 'skills'), { recursive: true });
+
+    // Prose-only skill file, no frontmatter
+    writeFileSync(
+      join(root, '.gossip', 'skills', 'trust-boundaries.md'),
+      '# Trust Boundaries\nThis skill has no YAML frontmatter.\n',
+    );
+    writeSkillIndex(root, 'test-agent', 'trust-boundaries');
+
+    const resp = await skillsGetHandler(root);
+    const entry = resp.effectiveness.find(
+      (e) => e.agentId === 'test-agent' && e.skill === 'trust-boundaries',
+    );
+    // No frontmatter → no bound_at → deriveEffectiveness skips this entry
+    // (boundAtMs is NaN/0, so the entry is not emitted)
+    // The slot must NOT appear with a non-null status.
+    if (entry) {
+      expect(entry.status).toBeNull();
+    }
+    // If entry is undefined, that's also correct — no frontmatter, no bound_at parsed.
+  });
+
+  it('inline comment stripping: `status: pending  # note` parses as pending', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-skill-fm-'));
+    mkdirSync(join(root, '.gossip', 'skills'), { recursive: true });
+    mkdirSync(join(root, '.gossip', 'agents', 'test-agent', 'skills'), { recursive: true });
+
+    writeFileSync(
+      join(root, '.gossip', 'skills', 'input-validation.md'),
+      '---\nstatus: pending  # needs more data\nbound_at: 2026-01-01T00:00:00Z\n---\n# Input Validation\n',
+    );
+    writeSkillIndex(root, 'test-agent', 'input-validation');
+
+    const resp = await skillsGetHandler(root);
+    const entry = resp.effectiveness.find(
+      (e) => e.agentId === 'test-agent' && e.skill === 'input-validation',
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.status).toBe('pending');
+  });
+
+  it('nonexistent skill (no file in any tier) returns null status / no entry', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-skill-fm-'));
+    mkdirSync(join(root, '.gossip', 'skills'), { recursive: true });
+    mkdirSync(join(root, '.gossip', 'agents', 'test-agent', 'skills'), { recursive: true });
+
+    // No skill file written anywhere
+    writeSkillIndex(root, 'test-agent', 'nonexistent-skill', '2026-01-01T00:00:00Z');
+
+    const resp = await skillsGetHandler(root);
+    const entry = resp.effectiveness.find(
+      (e) => e.agentId === 'test-agent' && e.skill === 'nonexistent-skill',
+    );
+    // No file → resolveSkill returns null → readSkillFrontmatter returns null →
+    // boundAt falls back to slot.boundAt → entry may still exist but status is null
+    if (entry) {
+      expect(entry.status).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the dashboard skill graduation grid showing ~38 of 61 enabled skills as UNKNOWN (`status: null`).

**Root cause:** `readSkillFrontmatter` in `packages/relay/src/dashboard/api-skills.ts` only checked the agent-local tier (`.gossip/agents/<id>/skills/<skill>.md`). But skills resolve across **three** tiers (per `skill-loader.ts`):
1. `.gossip/agents/<id>/skills/` (agent-local)
2. `.gossip/skills/` (project-wide)
3. `<orchestrator>/default-skills/` (bundled defaults)

Project + bundled skills were invisible to the relay, so they read as `status: null` and rendered UNKNOWN.

**Fix:**
- Exported the existing 3-tier `resolveSkill()` resolver from `@gossip/orchestrator` (was private in `skill-loader.ts`; behavior unchanged, path-traversal guards intact).
- Refactored `readSkillFrontmatter` to route through `resolveSkill()` instead of a hardcoded tier-1 path.
- Hygiene: strip inline `# comments` before the frontmatter regex; return `null` instead of empty `{}` when no fields parse.

## Caveat (correct behavior)

Bundled-default skills (tier 3, e.g. `default-skills/security-audit.md`) are prose-only with no YAML frontmatter — they **still** return `status: null` after this fix. That is correct: a bundled default has no per-agent status until signals accrue. The fix specifically recovers **tier-2 project skills** that carry `status:` frontmatter (e.g. `.gossip/skills/data-integrity.md` → `status: active`).

## Test plan

- [x] New `tests/relay/skill-frontmatter-resolution.test.ts` — 5 cases (project-tier recovery, agent-local precedence, no-frontmatter→null, comment stripping, nonexistent→null)
- [x] 3564/3564 tests pass (1 pre-existing skip)
- [x] `npm run build` exits 0
- [x] `grep export function resolveSkill` present; relay imports + uses it
- [ ] Visual: confirm dashboard UNKNOWN count drops after merge + relay restart

## Note

This is the first of a 2-PR strategy. The separate **N=181 aggregation** question (stale counter; live API returns 61, not 181) is NOT addressed here and needs its own trace if it resurfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)