### PR TITLE
fix(cli): close #495 follow-ups f1/f4/f5 + emptyDiff sentinel (isolation recovery)

### DIFF
--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -996,7 +996,22 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
           const preserveResult = preserveLeakedPaths(revertRoot, isolationDiff.dirtyPathsAdded, task_id);
           const preserveOk = !preserveResult.error && !!preserveResult.patchPath;
 
-          if (!preserveOk) {
+          if (preserveResult.emptyDiff) {
+            // Empty diff: the leaked paths already match HEAD (e.g. a zero-byte
+            // untracked file or a content-identical write). Nothing to preserve
+            // and nothing for the destructive revert to restore — skip both,
+            // calmly. This is NOT a preserve failure, so it must not emit the
+            // recovery alarm (consensus 9abe6f5a-6db14a27 f2).
+            appendRelayWarning(revertRoot, {
+              taskId: task_id,
+              agentId: taskInfo.agentId,
+              reason: 'isolation_recovery_preserved',
+              resultLength: isolationDiff.dirtyPathsAdded.length,
+              suspectedReason: 'isolation_recovery_noop_empty_diff',
+              timestamp: new Date().toISOString(),
+            });
+            responseText += `\n  → isolation diff empty (leaked paths already match HEAD); nothing to preserve or revert.`;
+          } else if (!preserveOk) {
             // Spec §3.1 option (b): the safety net failed — do NOT run the
             // destructive revert. Leave master dirty and surface a hard receipt
             // so the operator can recover manually before any work is lost.

--- a/apps/cli/src/handlers/worktree-isolation-detection.ts
+++ b/apps/cli/src/handlers/worktree-isolation-detection.ts
@@ -99,9 +99,13 @@ export function filterSafePaths(paths: string[]): { safe: string[]; rejected: st
   const rejected: string[] = [];
   if (!paths) return { safe, rejected };
   for (const p of paths) {
-    if (typeof p === 'string' && p.length > 0 && !p.startsWith('/') && !p.startsWith('-')) {
+    if (typeof p !== 'string') continue; // non-string entries aren't auditable as paths
+    if (p.length > 0 && !p.startsWith('/') && !p.startsWith('-')) {
       safe.push(p);
-    } else if (typeof p === 'string' && p.length > 0) {
+    } else {
+      // f4 (PR #495): empty-string AND unsafe (absolute / leading-dash) paths
+      // both land in rejected[] so they surface in the receipt rather than
+      // vanishing silently — consistent with this filter's audit purpose.
       rejected.push(p);
     }
   }
@@ -290,6 +294,16 @@ export function preserveLeakedPaths(
         // `git status`), recoverable with `git reset HEAD -- <paths>`. We do not
         // fail the preserve for this: the patch (the thing that matters) is intact.
       }
+    }
+
+    // f1 (PR #495): an empty diff means the present paths produced no content
+    // delta (e.g. a leaked path already matching HEAD). Writing a zero-byte
+    // patch and setting patchPath would falsely report "work preserved" in the
+    // receipt. Skip the write and leave patchPath unset so the caller treats it
+    // as "no patch written" — harmless here, since an empty diff means there is
+    // nothing for the subsequent revert to restore.
+    if (diff.length === 0) {
+      return result;
     }
 
     const recoveryDir = path.join(cwd, '.gossip', 'recovery');

--- a/apps/cli/src/handlers/worktree-isolation-detection.ts
+++ b/apps/cli/src/handlers/worktree-isolation-detection.ts
@@ -199,6 +199,14 @@ export interface IsolationPreserveResult {
   rejected: string[];
   /** Set on any git/IO failure — caller must NOT proceed to destructive revert. */
   error?: string;
+  /**
+   * Set `true` when `git diff` produced no output (the present paths already
+   * match HEAD). Distinguishes "nothing to preserve, nothing to revert" from a
+   * genuine preserve failure: both leave `patchPath` unset and `error` unset,
+   * but only the latter warrants the operator-facing recovery alarm.
+   * See consensus 9abe6f5a-6db14a27 f2.
+   */
+  emptyDiff?: boolean;
 }
 
 /**
@@ -298,11 +306,14 @@ export function preserveLeakedPaths(
 
     // f1 (PR #495): an empty diff means the present paths produced no content
     // delta (e.g. a leaked path already matching HEAD). Writing a zero-byte
-    // patch and setting patchPath would falsely report "work preserved" in the
-    // receipt. Skip the write and leave patchPath unset so the caller treats it
-    // as "no patch written" — harmless here, since an empty diff means there is
-    // nothing for the subsequent revert to restore.
+    // patch would falsely report "work preserved". Set the `emptyDiff` sentinel
+    // and return WITHOUT a patchPath: there is nothing to preserve AND nothing
+    // for the subsequent revert to restore. The caller uses `emptyDiff` to tell
+    // this "nothing to do" state apart from a genuine preserve failure — without
+    // it, an empty diff is mis-reported to the operator as "could NOT preserve
+    // leaked work" (consensus 9abe6f5a-6db14a27 f2).
     if (diff.length === 0) {
+      result.emptyDiff = true;
       return result;
     }
 

--- a/tests/cli/worktree-isolation-recovery.test.ts
+++ b/tests/cli/worktree-isolation-recovery.test.ts
@@ -95,11 +95,13 @@ describe('preserveLeakedPaths — real git repo', () => {
     expect(fs.existsSync(path.join(repo, '.gossip', 'recovery'))).toBe(false);
   });
 
-  it('empty diff (present path, no content delta) → no patch, patchPath unset, no error', () => {
+  it('empty diff (present path, no content delta) → no patch, emptyDiff sentinel set, no error', () => {
     // README.md is tracked and unmodified since the baseline commit: it exists
     // on disk (passes the present-file check) so git runs, but `git diff`
     // yields nothing. f1: no zero-byte patch is written and patchPath stays
-    // unset, so the caller does not falsely treat the work as preserved.
+    // unset. The `emptyDiff` sentinel lets the call site distinguish this
+    // "nothing to do" state from a genuine preserve failure
+    // (consensus 9abe6f5a-6db14a27 f2) so it does not emit the recovery alarm.
     const before = porcelain(repo);
     const r = preserveLeakedPaths(repo, ['README.md'], 'task-emptydiff');
     const after = porcelain(repo);
@@ -108,7 +110,16 @@ describe('preserveLeakedPaths — real git repo', () => {
     expect(r.error).toBeUndefined();
     expect(r.patchPath).toBeUndefined();
     expect(r.preserved).toEqual([]);
+    expect(r.emptyDiff).toBe(true);
     expect(fs.existsSync(path.join(repo, '.gossip', 'recovery', 'task-emptydiff.patch'))).toBe(false);
+  });
+
+  it('emptyDiff sentinel is NOT set when there is no work at all (empty / all-rejected input)', () => {
+    // The early returns that precede the git-diff step (empty input, all paths
+    // missing/rejected) must leave emptyDiff undefined — it specifically means
+    // "git diff ran and produced nothing", not "we never reached the diff".
+    expect(preserveLeakedPaths(repo, [], 'task-none').emptyDiff).toBeUndefined();
+    expect(preserveLeakedPaths(repo, ['/etc/passwd', '--force'], 'task-rej').emptyDiff).toBeUndefined();
   });
 
   it('leaked NEW untracked file → patch captures it; tree byte-identical; git apply reproduces', () => {

--- a/tests/cli/worktree-isolation-recovery.test.ts
+++ b/tests/cli/worktree-isolation-recovery.test.ts
@@ -39,10 +39,12 @@ function porcelain(cwd: string): string {
 }
 
 describe('filterSafePaths', () => {
-  it('passes repo-relative paths, rejects absolute and leading-dash', () => {
+  it('passes repo-relative paths, rejects absolute, leading-dash, and empty', () => {
     const r = filterSafePaths(['ok.ts', 'a/b/c.ts', '/etc/passwd', '--force', '']);
     expect(r.safe).toEqual(['ok.ts', 'a/b/c.ts']);
-    expect(r.rejected).toEqual(['/etc/passwd', '--force']);
+    // f4 (PR #495): empty-string paths now surface in rejected[] (in input
+    // order) instead of vanishing silently.
+    expect(r.rejected).toEqual(['/etc/passwd', '--force', '']);
   });
 
   it('empty input → both empty', () => {
@@ -91,6 +93,22 @@ describe('preserveLeakedPaths — real git repo', () => {
     const r = preserveLeakedPaths(repo, [], 'task-abc');
     expect(r).toEqual({ preserved: [], skipped: [], rejected: [] });
     expect(fs.existsSync(path.join(repo, '.gossip', 'recovery'))).toBe(false);
+  });
+
+  it('empty diff (present path, no content delta) → no patch, patchPath unset, no error', () => {
+    // README.md is tracked and unmodified since the baseline commit: it exists
+    // on disk (passes the present-file check) so git runs, but `git diff`
+    // yields nothing. f1: no zero-byte patch is written and patchPath stays
+    // unset, so the caller does not falsely treat the work as preserved.
+    const before = porcelain(repo);
+    const r = preserveLeakedPaths(repo, ['README.md'], 'task-emptydiff');
+    const after = porcelain(repo);
+
+    expect(after).toBe(before);
+    expect(r.error).toBeUndefined();
+    expect(r.patchPath).toBeUndefined();
+    expect(r.preserved).toEqual([]);
+    expect(fs.existsSync(path.join(repo, '.gossip', 'recovery', 'task-emptydiff.patch'))).toBe(false);
   });
 
   it('leaked NEW untracked file → patch captures it; tree byte-identical; git apply reproduces', () => {


### PR DESCRIPTION
## Summary

Closes the three deferred follow-ups from PR #495's consensus (`fec1d5aa-a5294239`), batched together because every edit to `worktree-isolation-detection.ts` re-triggers the impact-adjacency consensus gate.

- **f1 (MEDIUM)** — guard `preserveLeakedPaths` against an empty `git diff` so no zero-byte patch + false "work preserved" receipt is produced.
- **f4 (LOW)** — `filterSafePaths` now routes empty-string paths into `rejected[]` (in input order) instead of dropping them silently; non-string entries still dropped via an explicit `continue`.
- **f5** — empty-diff test + updated `filterSafePaths` unit test for the f4 contract.

## Pre-merge consensus caught a real follow-on bug

A 2-agent round (sonnet-reviewer + haiku-researcher; gemini quota-capped this month) on the f1/f4/f5 commit surfaced one **HIGH** that I'd introduced:

- The naive f1 guard returned with `patchPath` unset, which the call site (`native-tasks.ts:997` `preserveOk = !error && !!patchPath`) could **not** tell apart from a genuine preserve failure. An empty diff therefore fired the alarming *"could NOT preserve leaked work; master left dirty; recover manually"* receipt + `isolation_recovery_failed` warning — when there was nothing to preserve OR revert.

**Fix (second commit):** added `emptyDiff?: boolean` to `IsolationPreserveResult`, set on the `diff.length === 0` early return, and branched on it at the call site to emit a calm "nothing to preserve or revert" no-op (logged, not a failure) and skip the destructive revert. Genuine failures keep the hard receipt.

## Note for reviewers (signal-integrity)

The round produced 4 "disputed" entries that were **all** the artifact of sonnet-reviewer resolving its reads against a **stale sibling worktree** (`.claude/worktrees/agent-ada965f6`, the original #495 branch — pre-f1/f4) instead of this branch. Ground truth was verified against the live tree + `git show HEAD`: haiku-researcher was correct on every disputed point; signals were recorded accordingly (sonnet's stale-read finding = `hallucination_caught`, haiku's correct findings = `unique_confirmed`), while still crediting sonnet for the one real HIGH it uniquely caught.

## Test plan
- [x] `tests/cli/worktree-isolation-recovery.test.ts` + `worktree-isolation-detection.test.ts` + `relay-isolation-warning.test.ts` — 54/54
- [x] empty-diff test asserts `emptyDiff === true`; pre-diff early returns assert `emptyDiff` undefined
- [x] `npx tsc --noEmit` — no new errors in touched files
- [x] `npm run build:mcp` — exit 0

consensus-id: 9abe6f5a-6db14a27

🤖 Generated with [Claude Code](https://claude.com/claude-code)