### PR TITLE
fix(cli): set emptyDiff on all benign no-preserve early returns

### DIFF
--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -994,6 +994,9 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
           // to .gossip/recovery/<taskId>.patch BEFORE cleaning master, so an
           // isolation escape no longer destroys the agent's changes.
           const preserveResult = preserveLeakedPaths(revertRoot, isolationDiff.dirtyPathsAdded, task_id);
+          // NB: preserveOk is also false on the benign `emptyDiff` path (no patchPath) — that
+          // is fine: the `if (preserveResult.emptyDiff)` branch below is checked FIRST, so
+          // preserveOk only ever gates the genuine-failure vs. success decision. (47dbe3f5-504247c9 f5)
           const preserveOk = !preserveResult.error && !!preserveResult.patchPath;
 
           if (preserveResult.emptyDiff) {
@@ -1010,7 +1013,7 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
               suspectedReason: 'isolation_recovery_noop_empty_diff',
               timestamp: new Date().toISOString(),
             });
-            responseText += `\n  → isolation diff empty (leaked paths already match HEAD); nothing to preserve or revert.`;
+            responseText += `\n  → nothing to preserve or revert (leaked paths already match HEAD, or are no longer present).`;
           } else if (!preserveOk) {
             // Spec §3.1 option (b): the safety net failed — do NOT run the
             // destructive revert. Leave master dirty and surface a hard receipt

--- a/apps/cli/src/handlers/worktree-isolation-detection.ts
+++ b/apps/cli/src/handlers/worktree-isolation-detection.ts
@@ -200,11 +200,15 @@ export interface IsolationPreserveResult {
   /** Set on any git/IO failure — caller must NOT proceed to destructive revert. */
   error?: string;
   /**
-   * Set `true` when `git diff` produced no output (the present paths already
-   * match HEAD). Distinguishes "nothing to preserve, nothing to revert" from a
-   * genuine preserve failure: both leave `patchPath` unset and `error` unset,
-   * but only the latter warrants the operator-facing recovery alarm.
-   * See consensus 9abe6f5a-6db14a27 f2.
+   * Set `true` when there is benignly nothing to preserve — the patch we would
+   * have written is empty. Three cases set it: no input paths; no present paths
+   * to diff (all rejected by the safety filter, or vanished from disk before the
+   * diff ran); or `git diff` produced zero bytes (present paths already match
+   * HEAD). Distinguishes "nothing to preserve, nothing to revert" from a genuine
+   * preserve failure (`error`): both leave `patchPath` unset, but only `error`
+   * warrants the operator-facing recovery alarm. The taskId-validation failure
+   * is an `error`, NOT an emptyDiff. See consensus 9abe6f5a-6db14a27 f2 and
+   * 72981222-c54b4c11 f5.
    */
   emptyDiff?: boolean;
 }
@@ -236,7 +240,12 @@ export function preserveLeakedPaths(
   taskId: string,
 ): IsolationPreserveResult {
   const result: IsolationPreserveResult = { preserved: [], skipped: [], rejected: [] };
-  if (!paths || paths.length === 0) return result;
+  // No input paths → benignly nothing to preserve. Mark emptyDiff so the caller
+  // treats it as a no-op (not a preserve failure). 72981222-c54b4c11 f5.
+  if (!paths || paths.length === 0) {
+    result.emptyDiff = true;
+    return result;
+  }
 
   // Validate taskId before it touches the filesystem as a filename. Same guard
   // contract as .gossip/dispatch-prompts/<taskId>.txt (dispatch-prompt-storage.ts).
@@ -267,7 +276,15 @@ export function preserveLeakedPaths(
     }
   }
 
-  if (present.length === 0) return result;
+  // No present paths to diff (all rejected by the safety filter, or all vanished
+  // from disk before this ran). Benignly nothing to preserve AND nothing for the
+  // subsequent revert to restore — mark emptyDiff so the caller skips the revert
+  // calmly instead of raising the false "could NOT preserve" alarm. The skipped/
+  // rejected paths remain on `result` for audit. 72981222-c54b4c11 f5.
+  if (present.length === 0) {
+    result.emptyDiff = true;
+    return result;
+  }
 
   try {
     // 1. intent-to-add so untracked-new files surface in the diff as additions

--- a/tests/cli/worktree-isolation-recovery.test.ts
+++ b/tests/cli/worktree-isolation-recovery.test.ts
@@ -89,9 +89,9 @@ describe('preserveLeakedPaths — real git repo', () => {
     fs.rmSync(repo, { recursive: true, force: true });
   });
 
-  it('empty paths → no-op, no patch, no error', () => {
+  it('empty paths → no-op, no patch, no error, emptyDiff sentinel set', () => {
     const r = preserveLeakedPaths(repo, [], 'task-abc');
-    expect(r).toEqual({ preserved: [], skipped: [], rejected: [] });
+    expect(r).toEqual({ preserved: [], skipped: [], rejected: [], emptyDiff: true });
     expect(fs.existsSync(path.join(repo, '.gossip', 'recovery'))).toBe(false);
   });
 
@@ -114,12 +114,32 @@ describe('preserveLeakedPaths — real git repo', () => {
     expect(fs.existsSync(path.join(repo, '.gossip', 'recovery', 'task-emptydiff.patch'))).toBe(false);
   });
 
-  it('emptyDiff sentinel is NOT set when there is no work at all (empty / all-rejected input)', () => {
-    // The early returns that precede the git-diff step (empty input, all paths
-    // missing/rejected) must leave emptyDiff undefined — it specifically means
-    // "git diff ran and produced nothing", not "we never reached the diff".
-    expect(preserveLeakedPaths(repo, [], 'task-none').emptyDiff).toBeUndefined();
-    expect(preserveLeakedPaths(repo, ['/etc/passwd', '--force'], 'task-rej').emptyDiff).toBeUndefined();
+  it('benign no-patch early returns all set emptyDiff (empty input, all-rejected, all-vanished)', () => {
+    // 72981222-c54b4c11 f5: every benign "nothing to preserve" early return must
+    // set emptyDiff so the caller skips the destructive revert calmly instead of
+    // raising the false "could NOT preserve leaked work" alarm.
+    // (a) empty input
+    expect(preserveLeakedPaths(repo, [], 'task-none').emptyDiff).toBe(true);
+    // (b) all paths rejected by the safety filter → present.length === 0
+    const rej = preserveLeakedPaths(repo, ['/etc/passwd', '--force'], 'task-rej');
+    expect(rej.emptyDiff).toBe(true);
+    expect(rej.rejected).toEqual(['/etc/passwd', '--force']);
+    expect(rej.patchPath).toBeUndefined();
+    // (c) safe paths that no longer exist on disk → all skipped, present.length === 0
+    const gone = preserveLeakedPaths(repo, ['apps/cli/vanished.ts', 'also-gone.ts'], 'task-gone');
+    expect(gone.emptyDiff).toBe(true);
+    expect(gone.skipped.sort()).toEqual(['also-gone.ts', 'apps/cli/vanished.ts']);
+    expect(gone.preserved).toEqual([]);
+    expect(gone.patchPath).toBeUndefined();
+    expect(fs.existsSync(path.join(repo, '.gossip', 'recovery'))).toBe(false);
+  });
+
+  it('taskId validation failure sets error, NOT emptyDiff (genuine failure keeps the alarm)', () => {
+    // The taskId-validation early return is a real error and must remain
+    // distinguishable from the benign emptyDiff no-ops.
+    const r = preserveLeakedPaths(repo, ['apps/cli/src/leaked.ts'], '../escape');
+    expect(r.error).toMatch(/SAFE_NAME/);
+    expect(r.emptyDiff).toBeUndefined();
   });
 
   it('leaked NEW untracked file → patch captures it; tree byte-identical; git apply reproduces', () => {


### PR DESCRIPTION
## Summary

Closes the LOW follow-up tracked in PR #496's round-2 consensus (`72981222-c54b4c11` f5). The `emptyDiff` sentinel landed in #496 was only set on the `diff.length===0` path, so the two *other* benign no-patch early returns in `preserveLeakedPaths` still returned bare and routed to the false **"could NOT preserve leaked work; master left dirty; recover manually"** alarm:

- **`paths.length===0`** (empty input) — unreachable via the sole caller, but defensive.
- **`present.length===0`** — all paths rejected by the safety filter, OR all vanished from disk before the diff ran. **Reachable** via a rename/delete race.

Both now set `result.emptyDiff = true` so the call site treats them as a calm no-op (skip the destructive revert, no alarm). The **taskId-validation failure stays an `error`** (genuine failure → keeps the alarm) — not an `emptyDiff`.

Also broadened the call-site receipt message (no longer asserts "already match HEAD", inaccurate for the vanished/rejected cases), expanded the field doc to name all three benign triggers, and added a clarifying comment on `preserveOk` (consensus f5).

## Consensus

Pre-merge round **47dbe3f5-504247c9** (sonnet-reviewer + haiku-researcher; gemini 429-capped) — **6 confirmed, 0 disputed**. Verified: both benign returns set emptyDiff and the taskId path stays error-only; call site checks emptyDiff before `!preserveOk`; `skipped[]`/`rejected[]` audit arrays populated before the `present.length===0` return; no genuine-error path converted to emptyDiff; tests assert all four cases.

## Test plan
- [x] `tests/cli/worktree-isolation-recovery.test.ts` — empty-input / all-rejected / all-vanished assert `emptyDiff===true`; taskId-error asserts `emptyDiff` undefined
- [x] worktree-isolation-detection + relay-isolation-warning suites — 55/55
- [x] `npx tsc --noEmit` clean on touched files; `npm run build:mcp` exit 0

consensus-id: 47dbe3f5-504247c9

🤖 Generated with [Claude Code](https://claude.com/claude-code)