### PR TITLE
fix(dispatch): hard-block parallel native write-intent dispatch (#434)

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -73,6 +73,25 @@ export function stampConcurrencyTaint(
 }
 
 /**
+ * [issue #434] A native parallel task carries branch-race write-intent if it
+ * will `git checkout -b` + commit in the SHARED process.cwd(): either an
+ * explicit `write_mode: 'sequential'`, or an implementer (by the load-bearing
+ * `-implementer` suffix, invariant #10) with no explicit write_mode. Two+ such
+ * tasks dispatched concurrently clobber the shared `.git/HEAD`.
+ * `worktree` (own .git) and `scoped` (no agent git) are safe and excluded.
+ * Read-only reviewers omit write_mode and don't end in `-implementer`, so they
+ * return false — parallel review/consensus dispatch is unaffected.
+ */
+export function isParallelHeadRaceWriteIntent(
+  t: { agent_id: string; write_mode?: string },
+): boolean {
+  return (
+    t.write_mode === 'sequential' ||
+    (t.write_mode === undefined && t.agent_id.endsWith('-implementer'))
+  );
+}
+
+/**
  * Common helper used at all three native dispatch sites. When `promptFormat`
  * is 'elided':
  *   - writes `agentPrompt` to .gossip/dispatch-prompts/<taskId>.txt
@@ -917,6 +936,22 @@ export async function handleDispatchParallel(
     } else {
       relayTasks.push(def);
     }
+  }
+
+  // [issue #434 / consensus 974a1bb2-de854fb4] HARD pre-dispatch guard.
+  // Two+ native write-intent tasks in mode:'parallel' run concurrently in the
+  // SAME process.cwd(), so their `git checkout -b` calls clobber the shared
+  // .git/HEAD and commits land on the wrong branch. A warning is useless here
+  // because it ships in the same response packet as the execute-now directive,
+  // so we block before any native task is emitted/spawned. worktree isolates
+  // (own .git), scoped does no agent git — both safe and excluded.
+  const writeIntentNative = nativeTasks.filter(isParallelHeadRaceWriteIntent);
+  if (writeIntentNative.length >= 2) {
+    return { content: [{ type: 'text' as const, text:
+      `Error: ${writeIntentNative.length} native implementer tasks dispatched in mode:'parallel' without write_mode:'worktree'. ` +
+      `They run concurrently in the same process.cwd() and share .git/HEAD, so their branch checkouts will clobber each other and commits will land on the wrong branch. ` +
+      `Pass write_mode:'worktree' per task (or 'scoped' with a scope path) so each task gets an isolated working tree. ` +
+      `See issue #434 and HANDBOOK invariant #13.` }] };
   }
 
   const lines: string[] = [];

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -148,6 +148,19 @@ When the orchestrator calls `gossip_relay(task_id, result)` after a native agent
 
 **Related:** invariant #8 (`FINDING_TAG_SCHEMA` — parsers are strict). Consensus: `edbf8675-87b24107`.
 
+### 13. Parallel native write-intent dispatch must use `worktree` — the dispatcher rejects it otherwise
+
+Two or more native **write-intent** tasks dispatched in `mode: "parallel"` run concurrently (`run_in_background: true`) in the **same** `process.cwd()`. Each implementer typically runs `git checkout -b <branch>`; `.git/HEAD` is a single file, so the last checkout wins (POSIX write semantics) and a later `git commit` from another agent lands on the wrong branch. The relay cannot see this — the race is inside the agent's Bash, not a `gossip_*` call (issue #434).
+
+A **warning is useless** here: it ships in the *same* MCP response packet as the `NATIVE_DISPATCH: Execute these N Agent calls` directive, so the orchestrator cannot interpose before the Agent() calls fire. Therefore `handleDispatchParallel` (`apps/cli/src/handlers/dispatch.ts`) **hard-rejects** the dispatch before any task is spawned when **≥2 native tasks** satisfy the exported `isParallelHeadRaceWriteIntent` predicate (`dispatch.ts`, unit-tested in `tests/cli/dispatch-parallel-head-race-guard.test.ts`) — i.e. `write_mode === 'sequential'` OR (`write_mode === undefined` AND `agent_id` ends in `-implementer`).
+
+**Safe modes (excluded, never trigger the error):**
+- `write_mode: "worktree"` — each task gets an isolated working tree with its own `.git` (`git branch X HEAD` only *reads* HEAD; `git worktree add` writes the worktree's own HEAD, not the shared one).
+- `write_mode: "scoped"` — scoped agents do no git; the orchestrator commits (invariant #5).
+- Read-only **reviewers** (no `-implementer` suffix, `write_mode` omitted) — parallel review/consensus dispatch is unaffected.
+
+**Do NOT** "fix" this by auto-promoting `sequential` → `worktree`: worktree always forks a fresh branch from the base, which silently discards prior work when the task is a *revision to an existing branch* (see `feedback_worktree_dispatch_branch_divergence`). The caller must choose `worktree` (fresh isolation) or `scoped` (orchestrator-committed) explicitly. The predicate gates on the `-implementer` suffix for the same reason as invariant #10. Consensus: `974a1bb2-de854fb4`.
+
 ---
 
 ## Operator playbook (for orchestrator LLMs)

--- a/tests/cli/dispatch-parallel-head-race-guard.test.ts
+++ b/tests/cli/dispatch-parallel-head-race-guard.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for isParallelHeadRaceWriteIntent — the predicate behind the
+ * issue #434 hard guard that blocks two+ native write-intent tasks in
+ * mode:'parallel' (they share .git/HEAD in process.cwd() and clobber each
+ * other's branch). Design consensus 974a1bb2-de854fb4.
+ *
+ * The predicate is what makes the guard safe to ship: it must catch the
+ * dangerous implementer/sequential case WITHOUT firing on legitimate parallel
+ * review/consensus dispatch (reviewers omit write_mode and don't end in
+ * `-implementer`), and must exclude the safe modes (worktree isolates, scoped
+ * does no agent git).
+ */
+
+import { isParallelHeadRaceWriteIntent } from '../../apps/cli/src/handlers/dispatch';
+
+describe('isParallelHeadRaceWriteIntent', () => {
+  it('matches explicit write_mode:"sequential" (any agent)', () => {
+    expect(isParallelHeadRaceWriteIntent({ agent_id: 'sonnet-implementer', write_mode: 'sequential' })).toBe(true);
+    expect(isParallelHeadRaceWriteIntent({ agent_id: 'some-custom-writer', write_mode: 'sequential' })).toBe(true);
+  });
+
+  it('matches an implementer (by -implementer suffix) with omitted write_mode', () => {
+    expect(isParallelHeadRaceWriteIntent({ agent_id: 'opus-implementer' })).toBe(true);
+    expect(isParallelHeadRaceWriteIntent({ agent_id: 'sonnet-implementer', write_mode: undefined })).toBe(true);
+  });
+
+  it('does NOT match read-only reviewers with omitted write_mode (parallel review is safe)', () => {
+    expect(isParallelHeadRaceWriteIntent({ agent_id: 'sonnet-reviewer' })).toBe(false);
+    expect(isParallelHeadRaceWriteIntent({ agent_id: 'haiku-researcher', write_mode: undefined })).toBe(false);
+    expect(isParallelHeadRaceWriteIntent({ agent_id: 'gemini-tester' })).toBe(false);
+  });
+
+  it('does NOT match safe write modes: worktree (own .git) and scoped (no agent git)', () => {
+    expect(isParallelHeadRaceWriteIntent({ agent_id: 'opus-implementer', write_mode: 'worktree' })).toBe(false);
+    expect(isParallelHeadRaceWriteIntent({ agent_id: 'opus-implementer', write_mode: 'scoped' })).toBe(false);
+  });
+
+  it('suffix match is exact: a non-suffixed implementer-ish name with omitted write_mode does NOT match', () => {
+    // invariant #10 is suffix-only; a name that merely contains "implementer"
+    // mid-string is not gated (consistent with IMPLEMENTER_PERMANENT_DEFAULTS).
+    expect(isParallelHeadRaceWriteIntent({ agent_id: 'implementer-helper' })).toBe(false);
+    expect(isParallelHeadRaceWriteIntent({ agent_id: 'my-impl' })).toBe(false);
+  });
+
+  it('guard threshold semantics: a mixed batch counts only write-intent natives', () => {
+    // Mirrors the handler's `nativeTasks.filter(isParallelHeadRaceWriteIntent).length >= 2`.
+    const batch = [
+      { agent_id: 'opus-implementer' },                          // write-intent (default impl)
+      { agent_id: 'sonnet-implementer', write_mode: 'sequential' }, // write-intent (explicit)
+      { agent_id: 'sonnet-reviewer' },                            // not (reviewer)
+      { agent_id: 'opus-implementer', write_mode: 'worktree' },   // not (safe)
+    ];
+    expect(batch.filter(isParallelHeadRaceWriteIntent).length).toBe(2);
+
+    const safeBatch = [
+      { agent_id: 'sonnet-reviewer' },
+      { agent_id: 'haiku-researcher' },
+      { agent_id: 'opus-implementer', write_mode: 'worktree' },
+    ];
+    expect(safeBatch.filter(isParallelHeadRaceWriteIntent).length).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #434.

## Problem

`gossip_dispatch(mode:'parallel')` with two+ native **write-intent** tasks (`write_mode:'sequential'` or omitted on an implementer) launches them concurrently (`run_in_background`) in the **same** `process.cwd()`. Their `git checkout -b` calls clobber the shared `.git/HEAD`, so a later `git commit` from one agent lands on another's branch. The relay can't see it (the race is inside the agent's Bash). The existing isolation detector (`dispatch.ts:1016/1023`) only covers `write_mode:'worktree'`, and a dispatch-time **warning is useless** — it ships in the same MCP response packet as the `NATIVE_DISPATCH: execute these N Agent calls` directive, so the orchestrator can't interpose before the race fires.

## Fix

`handleDispatchParallel` now **hard-rejects** (blocks, before any task is spawned) when ≥2 native tasks satisfy the exported `isParallelHeadRaceWriteIntent` predicate:

```
write_mode === 'sequential'  OR  (write_mode === undefined AND agent_id ends in '-implementer')
```

The error tells the caller to pass `write_mode:'worktree'` per task (or `'scoped'` with a scope path).

**Excluded (safe, never trigger):**
- `worktree` — own `.git`; `git branch X HEAD` only *reads* HEAD, `git worktree add` writes the worktree's own HEAD (not the shared one).
- `scoped` — no agent git; orchestrator commits (invariant #5).
- read-only **reviewers** (no `-implementer` suffix, `write_mode` omitted) — parallel review/consensus dispatch is unaffected (the load-bearing narrowing; gates on the `-implementer` convention from invariant #10).

**Not auto-promoted** to worktree: worktree forks fresh from base, which discards prior work on revision-to-existing-branch dispatches (`feedback_worktree_dispatch_branch_divergence`). The caller chooses explicitly.

Predicate extracted as exported `isParallelHeadRaceWriteIntent` + unit tests; HANDBOOK invariant #13 added.

## Two consensus rounds (anthropic-only; gemini quota-capped)
- **Design** `974a1bb2-de854fb4`: validated hard-error over warning (warning is unactionable), refuted a worktree-HEAD-race claim, narrowed the predicate to spare reviewers, rejected auto-promote.
- **Code** `4b29e99d-29384054`: 9 confirmed, 0 disputed — guard placement (zero side effects before early return), error shape match, predicate exclusions, **zero regression** (no existing test dispatches ≥2 implementers in parallel without worktree). Two LOW nits (error-message scope hint, HANDBOOK predicate xref) applied.

## Test plan
- [x] `tests/cli/dispatch-parallel-head-race-guard.test.ts` — 6/6 (predicate: sequential→block, implementer-default→block, reviewer→pass, worktree/scoped→pass, suffix-exact, mixed-batch count)
- [x] `npx tsc --noEmit` clean on touched files; `npm run build:mcp` exit 0
- [x] implemented by opus-implementer (scoped); predicate extraction + tests + HANDBOOK by orchestrator

consensus-id: 4b29e99d-29384054

🤖 Generated with [Claude Code](https://claude.com/claude-code)