### PR TITLE
feat(status): cached upgrade-available notice in gossip_status (#452)

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -10,6 +10,7 @@ import { createWriteStream, mkdirSync } from 'fs';
 import { join } from 'path';
 import { runHook } from './hook-run';
 import { parseHookSubcommand } from './hook-argv';
+import { getLastKnownLatest, checkForUpgrade, isUpgradeAvailable } from './upgrade-check';
 
 // ── Argv dispatch shim ──────────────────────────────────────────────────
 //
@@ -1546,6 +1547,22 @@ export function createMcpServer(): McpServer {
       }
       if (ctx.httpMcpPort) {
         lines.push(`  HTTP MCP: :${ctx.httpMcpPort}/mcp${ctx.httpMcpPortSource === 'sticky' ? ' (sticky)' : ''}`);
+      }
+
+      // Upgrade-available notice. The synchronous status path makes NO network
+      // call — it only reads the cached latest version. The actual registry
+      // refresh is fire-and-forget (void checkForUpgrade()). The env opt-out
+      // gates BOTH the network refresh and the banner emit, and every step is
+      // wrapped so an upgrade check can never break gossip_status.
+      if (process.env.GOSSIP_DISABLE_UPGRADE_CHECK !== '1') {
+        try {
+          const latest = getLastKnownLatest();
+          const current = getGossipcatVersion();
+          if (isUpgradeAvailable(current, latest)) {
+            lines.push(`⬆ Upgrade available: gossipcat v${latest} (you have v${current}). Run: npm update -g gossipcat`);
+          }
+          void checkForUpgrade();
+        } catch { /* fail-silent — status must always return valid output */ }
       }
 
       // Skill graduation heartbeat — surfaces whether the post-collect runner

--- a/apps/cli/src/upgrade-check.ts
+++ b/apps/cli/src/upgrade-check.ts
@@ -1,0 +1,125 @@
+import { readFileSync, writeFileSync, renameSync, mkdirSync, unlinkSync } from 'fs';
+import { join, dirname } from 'path';
+
+// Shape of the on-disk upgrade-check cache.
+interface UpgradeCache {
+  checkedAt: string; // ISO timestamp of the last successful registry fetch
+  latestVersion: string; // version string reported by the npm registry
+}
+
+const CACHE_REL = join('.gossip', 'upgrade-check.json');
+const TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+function cachePath(cwd: string): string {
+  // Always derived from cwd — no external path input is accepted.
+  return join(cwd, CACHE_REL);
+}
+
+/**
+ * Dumb synchronous cache reader. Returns the last-known latest version string
+ * from `.gossip/upgrade-check.json` under `cwd`, or null on any
+ * missing-file / read / parse error. Makes NO network call and applies NO env
+ * gating — the env opt-out lives in checkForUpgrade + the emit site.
+ */
+export function getLastKnownLatest(cwd: string = process.cwd()): string | null {
+  try {
+    const raw = readFileSync(cachePath(cwd), 'utf8');
+    const data = JSON.parse(raw) as Partial<UpgradeCache>;
+    return typeof data.latestVersion === 'string' && data.latestVersion.length > 0
+      ? data.latestVersion
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fire-and-forget background refresh of the upgrade-check cache. Never throws
+ * and never returns a meaningful value — callers should `void` it.
+ *
+ * - Returns immediately (no network) when GOSSIP_DISABLE_UPGRADE_CHECK === '1'.
+ * - Returns immediately (no network) when a fresh (< 24h) cache already exists.
+ * - Otherwise fetches the latest version from the npm registry and writes the
+ *   cache atomically (temp file + rename). Every error path is swallowed.
+ */
+export async function checkForUpgrade(cwd: string = process.cwd()): Promise<void> {
+  try {
+    if (process.env.GOSSIP_DISABLE_UPGRADE_CHECK === '1') return;
+
+    const path = cachePath(cwd);
+
+    // Skip the network when a fresh cache is present.
+    try {
+      const raw = readFileSync(path, 'utf8');
+      const data = JSON.parse(raw) as Partial<UpgradeCache>;
+      if (typeof data.checkedAt === 'string') {
+        const checkedMs = new Date(data.checkedAt).getTime();
+        if (Number.isFinite(checkedMs) && Date.now() - checkedMs < TTL_MS) return;
+      }
+    } catch {
+      // No cache / unreadable / unparseable → fall through to refresh.
+    }
+
+    // Same fetch shape as getLatestVersion in handlers/gossip-update.ts.
+    const res = await fetch('https://registry.npmjs.org/gossipcat/latest');
+    if (!res.ok) return;
+    const json = (await res.json()) as { version?: unknown };
+    if (typeof json.version !== 'string' || json.version.length === 0) return;
+
+    const cache: UpgradeCache = {
+      checkedAt: new Date().toISOString(),
+      latestVersion: json.version,
+    };
+
+    // Atomic write: temp file in the same dir + rename.
+    try {
+      mkdirSync(dirname(path), { recursive: true });
+    } catch {
+      // Directory may already exist or be uncreatable; the write below will
+      // simply fail-silent if the dir is missing.
+    }
+    const tmp = `${path}.${process.pid}.tmp`;
+    writeFileSync(tmp, JSON.stringify(cache), 'utf8');
+    try {
+      renameSync(tmp, path);
+    } catch (err) {
+      // Clean up the temp file so a failed rename (cross-device link, race)
+      // doesn't leave .gossip/upgrade-check.json.<pid>.tmp residue accumulating.
+      try { unlinkSync(tmp); } catch { /* best-effort */ }
+      throw err; // re-throw into the outer fail-silent catch
+    }
+  } catch {
+    // Fail-silent: a background upgrade check must never break the caller.
+  }
+}
+
+function parseSemver(v: string): [number, number, number] | null {
+  // Strip leading 'v', drop prerelease (-) and build (+) metadata.
+  const core = v.trim().replace(/^v/, '').split('-')[0].split('+')[0];
+  const parts = core.split('.');
+  if (parts.length < 3) return null;
+  const seg = parts.slice(0, 3);
+  // Each of the first three segments must be all-digits. Without this,
+  // Number('') coerces to 0, so a malformed '1.2..9' would parse as [1,2,0]
+  // instead of being rejected (consensus 11e1156e-febd4304 f3).
+  if (!seg.every((p) => /^\d+$/.test(p))) return null;
+  const nums = seg.map((p) => Number(p));
+  return [nums[0], nums[1], nums[2]];
+}
+
+/**
+ * Pure semver compare. Returns true iff `latest` is a strictly-greater x.y.z
+ * than `current`. Returns false when latest is null or either side fails to
+ * parse. Hand-rolled — no new dependency.
+ */
+export function isUpgradeAvailable(current: string, latest: string | null): boolean {
+  if (!latest) return false;
+  const c = parseSemver(current);
+  const l = parseSemver(latest);
+  if (!c || !l) return false;
+  for (let i = 0; i < 3; i++) {
+    if (l[i] > c[i]) return true;
+    if (l[i] < c[i]) return false;
+  }
+  return false;
+}

--- a/tests/cli/upgrade-check.test.ts
+++ b/tests/cli/upgrade-check.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the issue #452 upgrade-available check
+ * (apps/cli/src/upgrade-check.ts): cached, opt-out, fail-silent npm-version
+ * notice. Covers the pure semver compare, the sync cache reader, and the
+ * fire-and-forget refresh (env opt-out, 24h freshness skip, fetch→write,
+ * fail-silent on network error). Network is mocked — no real registry calls.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  getLastKnownLatest,
+  checkForUpgrade,
+  isUpgradeAvailable,
+} from '../../apps/cli/src/upgrade-check';
+
+const CACHE_REL = path.join('.gossip', 'upgrade-check.json');
+
+function writeCache(dir: string, checkedAt: string, latestVersion: string): void {
+  const p = path.join(dir, CACHE_REL);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify({ checkedAt, latestVersion }), 'utf8');
+}
+
+describe('isUpgradeAvailable', () => {
+  it('true when latest is a strictly-greater major/minor/patch', () => {
+    expect(isUpgradeAvailable('0.5.2', '0.5.3')).toBe(true);
+    expect(isUpgradeAvailable('0.5.2', '0.6.0')).toBe(true);
+    expect(isUpgradeAvailable('0.5.2', '1.0.0')).toBe(true);
+  });
+
+  it('false when equal or older', () => {
+    expect(isUpgradeAvailable('0.5.2', '0.5.2')).toBe(false);
+    expect(isUpgradeAvailable('0.5.2', '0.5.1')).toBe(false);
+    expect(isUpgradeAvailable('1.0.0', '0.9.9')).toBe(false);
+  });
+
+  it('false when latest is null (cache miss)', () => {
+    expect(isUpgradeAvailable('0.5.2', null)).toBe(false);
+  });
+
+  it("strips a leading 'v' on either side", () => {
+    expect(isUpgradeAvailable('v0.5.2', '0.5.3')).toBe(true);
+    expect(isUpgradeAvailable('0.5.2', 'v0.5.3')).toBe(true);
+    expect(isUpgradeAvailable('v0.5.2', 'v0.5.2')).toBe(false);
+  });
+
+  it('ignores prerelease/build metadata when comparing the core x.y.z', () => {
+    expect(isUpgradeAvailable('0.5.2', '0.5.2-beta.1')).toBe(false); // same core
+    expect(isUpgradeAvailable('0.5.2-rc.1', '0.5.3')).toBe(true);
+    expect(isUpgradeAvailable('0.5.2', '0.6.0+build.7')).toBe(true);
+  });
+
+  it('false on unparseable input (fewer than 3 numeric parts or non-numeric)', () => {
+    expect(isUpgradeAvailable('0.5.2', '0.6')).toBe(false);
+    expect(isUpgradeAvailable('garbage', '9.9.9')).toBe(false);
+    expect(isUpgradeAvailable('0.5.2', 'latest')).toBe(false);
+    expect(isUpgradeAvailable('0.5.2', '0.5.x')).toBe(false);
+  });
+
+  it('rejects empty version segments rather than coercing them to 0 (11e1156e f3)', () => {
+    // Number('') === 0; without the strict /^\d+$/ guard, '1.2..9' would parse
+    // as [1,2,0] and suppress a real upgrade. It must be rejected → false.
+    expect(isUpgradeAvailable('0.5.2', '1.2..9')).toBe(false);
+    expect(isUpgradeAvailable('0.5.2', '1..0')).toBe(false);
+    expect(isUpgradeAvailable('0.5.2', '..')).toBe(false);
+  });
+});
+
+describe('getLastKnownLatest', () => {
+  let dir: string;
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'upgrade-cache-')); });
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+  it('returns the cached latestVersion when present', () => {
+    writeCache(dir, new Date().toISOString(), '0.6.0');
+    expect(getLastKnownLatest(dir)).toBe('0.6.0');
+  });
+
+  it('returns null when the cache file is missing', () => {
+    expect(getLastKnownLatest(dir)).toBeNull();
+  });
+
+  it('returns null on malformed JSON', () => {
+    const p = path.join(dir, CACHE_REL);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, '{not json', 'utf8');
+    expect(getLastKnownLatest(dir)).toBeNull();
+  });
+
+  it('returns null when latestVersion is empty or missing', () => {
+    writeCache(dir, new Date().toISOString(), '');
+    expect(getLastKnownLatest(dir)).toBeNull();
+  });
+});
+
+describe('checkForUpgrade', () => {
+  let dir: string;
+  const realFetch = global.fetch;
+  const realEnv = process.env.GOSSIP_DISABLE_UPGRADE_CHECK;
+
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'upgrade-refresh-')); });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    global.fetch = realFetch;
+    if (realEnv === undefined) delete process.env.GOSSIP_DISABLE_UPGRADE_CHECK;
+    else process.env.GOSSIP_DISABLE_UPGRADE_CHECK = realEnv;
+  });
+
+  function mockFetch(impl: () => unknown): jest.Mock {
+    const m = jest.fn(impl);
+    (global as { fetch: unknown }).fetch = m;
+    return m;
+  }
+
+  it('opt-out: GOSSIP_DISABLE_UPGRADE_CHECK=1 makes no network call and writes no cache', async () => {
+    process.env.GOSSIP_DISABLE_UPGRADE_CHECK = '1';
+    const m = mockFetch(() => { throw new Error('fetch should not be called'); });
+    await checkForUpgrade(dir);
+    expect(m).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(dir, CACHE_REL))).toBe(false);
+  });
+
+  it('fresh cache (< 24h) skips the network', async () => {
+    writeCache(dir, new Date().toISOString(), '0.6.0');
+    const m = mockFetch(() => { throw new Error('fetch should not be called'); });
+    await checkForUpgrade(dir);
+    expect(m).not.toHaveBeenCalled();
+    expect(getLastKnownLatest(dir)).toBe('0.6.0'); // unchanged
+  });
+
+  it('stale cache (> 24h) refreshes from the registry and writes the new version', async () => {
+    const stale = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    writeCache(dir, stale, '0.5.0');
+    const m = mockFetch(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ version: '0.7.0' }) }));
+    await checkForUpgrade(dir);
+    expect(m).toHaveBeenCalledTimes(1);
+    expect(getLastKnownLatest(dir)).toBe('0.7.0');
+  });
+
+  it('missing cache refreshes and creates the cache file', async () => {
+    mockFetch(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ version: '0.7.1' }) }));
+    await checkForUpgrade(dir);
+    expect(getLastKnownLatest(dir)).toBe('0.7.1');
+  });
+
+  it('fail-silent: a rejected fetch does not throw and writes no cache', async () => {
+    mockFetch(() => Promise.reject(new Error('network down')));
+    await expect(checkForUpgrade(dir)).resolves.toBeUndefined();
+    expect(fs.existsSync(path.join(dir, CACHE_REL))).toBe(false);
+  });
+
+  it('fail-silent: a non-OK registry response does not write the cache', async () => {
+    mockFetch(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) }));
+    await checkForUpgrade(dir);
+    expect(fs.existsSync(path.join(dir, CACHE_REL))).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #452.

## Summary

`gossip_status` now surfaces a one-line notice when a newer `gossipcat` is published, so users on stale installs get an in-band upgrade signal instead of silently missing correctness/security fixes (the original motivation: v0.4.31's worktree-isolation hardening sat unused on stale installs).

**New `apps/cli/src/upgrade-check.ts`:**
- `getLastKnownLatest(cwd?)` — SYNC, dumb cache reader of `.gossip/upgrade-check.json` `{checkedAt, latestVersion}`; fail-silent → `null`.
- `checkForUpgrade(cwd?)` — ASYNC fire-and-forget: env opt-out first → 24h freshness skip → else fetch registry + atomic temp+rename write (unlinks the temp on rename failure). Fail-silent throughout; never throws.
- `isUpgradeAvailable(current, latest)` — pure hand-rolled semver compare (strips leading `v`, drops prerelease/build, strict-greater, **rejects empty/non-digit segments**); no new dependency.

**`gossip_status` handler** (`mcp-server-sdk.ts` ~1557): synchronously reads the cache and emits the banner when newer, then fires `void checkForUpgrade()` to refresh for next call. **The sync status path makes no network call.** The whole block is env-gated (`GOSSIP_DISABLE_UPGRADE_CHECK=1`) and try/catch-wrapped so it can never break status. Distinct from the dist-mcp bundle-staleness warning (mtime-based, dev-repo only).

## Consensus

Code round **`11e1156e-febd4304`** (sonnet-reviewer + haiku-researcher; gemini quota-capped) — **8 confirmed, 0 disputed**: sync path makes no network call, env opt-out gates both refresh + emit, cwd-only path, all error paths fail-silent, tests match logic, exact banner string, zero snapshot-test regression. Two LOW nits applied (orphaned-tmp cleanup on rename failure; strict `parseSemver` digit validation).

## Test plan
- [x] `tests/cli/upgrade-check.test.ts` — 17/17 (semver incl. v-prefix/prerelease/malformed/empty-segment; cache reader missing/malformed/empty; refresh env-opt-out / fresh-skip / stale-refresh / missing-refresh / fail-silent rejected + non-OK)
- [x] `npx tsc --noEmit` clean; `npm run build:mcp` exit 0
- [x] implemented by opus-implementer (scoped); tests + LOW-nit fixes + commit by orchestrator

consensus-id: 11e1156e-febd4304

🤖 Generated with [Claude Code](https://claude.com/claude-code)