### PR TITLE
chore(hooks): activate Layer-2 worktree sandbox + refresh gossipcat hooks

### DIFF
--- a/.claude/hooks/discipline/posttool-collect-reminder.sh
+++ b/.claude/hooks/discipline/posttool-collect-reminder.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# gossipcat discipline hook — PostToolUse signal-recording reminder for gossip_collect
+#
+# Reads stdin JSON: { tool_name, tool_input, tool_response, ... }
+# If tool_input.consensus === true, outputs a strict-order reminder to stdout.
+# Claude Code injects PostToolUse stdout as system context after the tool call.
+
+set -euo pipefail
+
+input="$(cat)"
+
+is_consensus="$(printf '%s' "$input" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    ti = d.get('tool_input', {})
+    print('yes' if ti.get('consensus') == True else 'no')
+except Exception:
+    print('no')
+" 2>/dev/null || echo 'no')"
+
+if [ "$is_consensus" = "yes" ]; then
+  echo "[gossipcat] EXECUTE NOW — record signals via gossip_signals before synthesizing or responding to user. Strict order: verify → signal → synthesize."
+fi
+
+exit 0

--- a/.claude/hooks/discipline/pretool-signals-validate.sh
+++ b/.claude/hooks/discipline/pretool-signals-validate.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# gossipcat discipline hook — PreToolUse finding_id validator for gossip_signals
+#
+# Reads stdin JSON: { tool_name, tool_input, ... }
+# If action === "record" AND a consensus_id is present (directly or on any
+# signal), warns on stderr for every signal missing finding_id.
+#
+# NEVER blocks — always exits 0.
+
+set -euo pipefail
+
+input="$(cat)"
+
+# Only act on record actions
+action="$(printf '%s' "$input" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    ti = d.get('tool_input', {})
+    print(ti.get('action', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)"
+
+if [ "$action" != "record" ]; then
+  exit 0
+fi
+
+# Check if any consensus_id is present (top-level or on any signal)
+has_consensus_id="$(printf '%s' "$input" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    ti = d.get('tool_input', {})
+    # Top-level consensus_id field
+    if ti.get('consensus_id'):
+        print('yes')
+        sys.exit(0)
+    # Any signal in signals[] has consensus_id
+    for sig in ti.get('signals', []):
+        if sig.get('consensus_id'):
+            print('yes')
+            sys.exit(0)
+    print('no')
+except Exception:
+    print('no')
+" 2>/dev/null || echo 'no')"
+
+if [ "$has_consensus_id" != "yes" ]; then
+  # Parallel-mode dispatch (no consensus_id) — no warning needed
+  exit 0
+fi
+
+# Warn for each signal that lacks finding_id (python writes directly to fd 2)
+printf '%s' "$input" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    ti = d.get('tool_input', {})
+    signals = ti.get('signals', [])
+    for i, sig in enumerate(signals):
+        if not sig.get('finding_id'):
+            print(f'[gossipcat] WARNING: signal #{i+1} is missing finding_id; consensus signals require it for dashboard back-trace', file=sys.stderr)
+except Exception:
+    pass
+" || true
+
+exit 0

--- a/.claude/hooks/discipline/session-start-bootstrap.sh
+++ b/.claude/hooks/discipline/session-start-bootstrap.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# gossipcat discipline hook — SessionStart bootstrap reminder
+#
+# Outputs a system reminder to stdout telling the orchestrator to call
+# gossip_status() if it has not yet bootstrapped. Claude Code injects
+# stdout from SessionStart hooks as system context at conversation start.
+
+cat <<'REMINDER'
+[gossipcat] BOOTSTRAP REQUIRED — call gossip_status() before dispatching any agents or acting on backlog items. This loads your operator playbook, agent roster, dispatch rules, and signal pipeline state. Without it you are operating blind. If you have already called gossip_status() this session, ignore this message.
+REMINDER

--- a/.claude/hooks/worktree-sandbox.sh
+++ b/.claude/hooks/worktree-sandbox.sh
@@ -180,6 +180,26 @@ if [ -z "$cwd" ]; then
   exit 0
 fi
 
+# Env-based orchestrator exemption (issue #162 problem 1).
+#
+# When the orchestrator shell cd's into a worktree to inspect/commit a
+# subagent's work (which is a legitimate operation), the cwd-glob logic
+# below pins it as if it were the subagent. Set
+# GOSSIPCAT_ORCHESTRATOR_ROLE=1 on the top-level orchestrator session to
+# short-circuit the gate.
+#
+# NOTE: gossip_setup (issue #176) now auto-creates a marker file at
+# $CLAUDE_PROJECT_DIR/.gossip/orchestrator-role so this env var no longer
+# needs to be set manually. The marker-file check below fires after
+# IS_SUBAGENT=1 is determined and is safe because each session's
+# CLAUDE_PROJECT_DIR points to its own project root (worktree sessions
+# point to the worktree, not the parent project), so subagents cannot
+# accidentally resolve the orchestrator's marker file.
+# The env var check is kept for backward compatibility (manual opt-in).
+case "$GOSSIPCAT_ORCHESTRATOR_ROLE" in
+  1|true|TRUE|yes|YES) exit 0 ;;
+esac
+
 # Distinguish orchestrator from subagent using $CLAUDE_PROJECT_DIR as anchor.
 # The orchestrator runs with its project dir as cwd; subagents run inside a
 # gossipcat worktree. We only gate subagents.
@@ -225,6 +245,25 @@ fi
 
 # Orchestrator (or non-gossipcat cwd) → pass through without gating.
 [ "$IS_SUBAGENT" -eq 0 ] && exit 0
+
+# Marker-file orchestrator exemption (issue #176).
+#
+# gossip_setup writes $CLAUDE_PROJECT_DIR/.gossip/orchestrator-role at the
+# PROJECT ROOT. When the orchestrator cd's into a worktree, IS_SUBAGENT was
+# set to 1 above, but we can still detect the orchestrator because:
+#   - Orchestrator session: CLAUDE_PROJECT_DIR = <project root>
+#     → marker = <project root>/.gossip/orchestrator-role  ← exists
+#   - Subagent session:     CLAUDE_PROJECT_DIR = <worktree root>
+#     → marker = <worktree>/.gossip/orchestrator-role      ← does NOT exist
+# This is naturally self-policing: subagents cannot see the orchestrator's
+# marker file without explicitly reading outside their worktree.
+# Only check when CLAUDE_PROJECT_DIR is set; skip silently when absent.
+if [ -n "$CLAUDE_PROJECT_DIR" ]; then
+  if [ -f "${CLAUDE_PROJECT_DIR}/.gossip/orchestrator-role" ]; then
+    exit 0
+  fi
+fi
+
 # Subagent falls through to existing path-gating logic below (unchanged).
 
 # Case-insensitive tool-name match (portable: no bash 4+ ${var,,}).
@@ -268,7 +307,41 @@ ${edit_paths}"
     # absolute-path token `/etc/passwd` would be missed.
     cmd="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null)"
     if [ -n "$cmd" ]; then
-      candidates="$(printf '%s\n' "$cmd" \
+      # Quoted-string false-positive mitigation (issue #162 problem 2).
+      #
+      # The raw grep matches any /path token preceded by a shell metachar,
+      # including tokens inside single-quoted arg bodies like `git commit -m
+      # 'fixes /etc/config'` or `gh pr create --body '... see /etc/passwd
+      # ...'`. These never write to those paths, but they falsely trip the
+      # boundary check.
+      #
+      # Mitigation: if argv[0] (the first whitespace-separated token with
+      # any leading path stripped) is NOT a shell wrapper, strip single-
+      # quoted content before extraction. Shell wrappers (`bash -c`,
+      # `sh -c`, `eval`, `zsh -c`, `ksh -c`) may carry the REAL command
+      # inside single quotes, so we leave their bodies untouched.
+      #
+      # Known bypass: `env bash -c 'cp /wt /etc/x'` — argv[0] is `env`, so
+      # we strip the single-quoted body. The subagent prompt (Layer 1) and
+      # the git porcelain audit (Layer 3) still apply. Documented in
+      # docs/specs/2026-04-18-sandbox-hook-quoted-args.md (if/when we ship it).
+      argv0_raw="$(printf '%s' "$cmd" | awk '{print $1}')"
+      argv0_basename="${argv0_raw##*/}"
+      cmd_for_extraction="$cmd"
+      case "$argv0_basename" in
+        bash|sh|zsh|ksh|dash|eval|exec)
+          # Shell wrapper — keep quoted content for extraction.
+          ;;
+        *)
+          # Non-shell — strip balanced single-quoted spans. POSIX sed, no
+          # state. Caveats: ANSI-C `$'...'` quoting and `'\''` escaped
+          # apostrophe edges leak partial content; these are narrow cases
+          # and the downstream grep still catches any absolute-path token
+          # that survives the strip.
+          cmd_for_extraction="$(printf '%s' "$cmd" | sed "s/'[^']*'//g")"
+          ;;
+      esac
+      candidates="$(printf '%s\n' "$cmd_for_extraction" \
         | grep -oE '(^|[[:space:]=><;\|(){},&`])/[^[:space:]"'"'"'`;\|><(){},&]+' 2>/dev/null \
         | sed -E -e 's/^[[:space:]=><;\|(){},&`]//')"
     fi
@@ -324,7 +397,7 @@ while IFS= read -r path_arg; do
   fi
 
   if ! path_is_inside "$cwd_norm" "$path_norm"; then
-    emit_deny "BOUNDARY ESCAPE: ${tool_name} targets '${path_arg}' (normalized: '${path_norm}') outside worktree cwd '${cwd_norm}'. Use a relative path (./...) inside the worktree."
+    emit_deny "BOUNDARY ESCAPE: ${tool_name} targets '${path_arg}' (normalized: '${path_norm}') outside worktree cwd '${cwd_norm}'. Use a relative path (./...) inside the worktree. If you are the orchestrator, re-run gossip_setup to auto-write the orchestrator-role marker (issue #176). Fallback: export GOSSIPCAT_ORCHESTRATOR_ROLE=1 and relaunch Claude Code."
   fi
 done <<EOF
 $candidates

--- a/.claude/rules/gossipcat.md
+++ b/.claude/rules/gossipcat.md
@@ -1,0 +1,214 @@
+<!-- Source of truth for .claude/rules/gossipcat.md. Auto-loaded at runtime via gossip_status(); also substituted via rules-content.ts at gossip_setup time. Edit here, both distribution paths inherit. -->
+# Gossipcat — Multi-Agent Orchestration
+
+## STEP 0 — LOAD TOOLS
+
+Gossipcat tools are deferred by Claude Code. Load the schema before calling any gossip tool:
+```
+ToolSearch(query: "select:mcp__gossipcat__gossip_status")
+```
+Then call `gossip_status()` to load fresh session context (triggers bootstrap regeneration).
+
+## Your Role
+
+You are the **orchestrator**. Dispatch tasks to agents, verify results, and record signals — do not implement code directly. Before writing implementation code, call `gossip_run(agent_id: "auto", task: "...")` to dispatch to the best agent. Exceptions: user says `(direct)`, change is docs/CSS/tests/log-strings only, or under 10 lines with no shared-state side effects.
+
+## Team Setup
+When the user asks to set up agents, review code with multiple agents, or build with a team, use the gossipcat MCP tools.
+
+### Creating agents
+Use `gossip_setup` with an agents array. Each agent can be:
+- **type: "native"** — Creates a Claude Code subagent (.claude/agents/*.md) that ALSO connects to the gossipcat relay. Works both as a native Agent() and via gossip_dispatch(). Supports consensus cross-review.
+- **type: "custom"** — Any provider (anthropic, openai, google, local). Only accessible via gossip_dispatch().
+
+**Native agent requirements:** Native agents need TWO files to work fully:
+1. `.gossip/config.json` entry — with explicit `skills` array and `"native": true`
+2. `.claude/agents/<id>.md` — with frontmatter (name, model, description, tools) and prompt
+
+`gossip_setup` creates both automatically. Mid-session agent changes require `/mcp` reconnect.
+
+### Dispatching work
+
+**Single-agent tasks** (default):
+```
+gossip_run(agent_id: "<id>", task: "Implement X")
+```
+`gossip_run` is the preferred dispatch. Do NOT use raw Agent() for gossipcat tasks.
+
+**Write modes:** `gossip_run(agent_id, task, write_mode: "scoped", scope: "./src")`
+**Parallel:** `gossip_dispatch(mode:"parallel", tasks) → gossip_collect(task_ids)`
+**Plan → Execute:** `gossip_plan(task) → gossip_dispatch(mode:"parallel", tasks) → gossip_collect(ids)`
+
+**After dispatching agents** — always print a visible dispatch summary (relay agents run invisibly):
+```
+┌─ gossipcat dispatch ────────────────────────┐
+│  task-id  → agent-name (relay 📡|native 🧠) │
+└─────────────────────────────────────────────┘
+```
+
+## Available Agents
+- sonnet-reviewer: anthropic/claude-sonnet-4-6 (custom) — native
+- haiku-researcher: anthropic/claude-haiku-4-5 (custom) — native
+- gemini-reviewer: google/gemini-2.5-pro (reviewer)
+- gemini-tester: google/gemini-2.5-pro (tester)
+- sonnet-implementer: anthropic/claude-sonnet-4-6 (custom) — native
+- opus-implementer: anthropic/claude-opus-4-6 (custom) — native
+- sonnet-designer: anthropic/claude-sonnet-4-6 (custom) — native
+
+### Implementer naming convention
+
+Implementer agents should be named with the `-implementer` suffix. The
+`verify-the-premise` skill (premise-verification Stage 1) auto-binds to any
+agent whose `id` ends in `-implementer`; custom implementer agents following
+this convention will inherit the skill automatically. An implementer named
+otherwise (e.g. `claude-writer`) will silently miss the skill — name it
+`claude-writer-implementer` to opt in.
+
+Investigation agents follow the same convention. The `emit-structured-claims`
+skill (premise-verification Stage 2) auto-binds to any agent whose `id` ends
+in `-researcher` or `-reviewer`. Name custom research / review agents with
+one of those suffixes (e.g. `foo-researcher`, `foo-reviewer`) so they inherit
+the skill automatically.
+
+Auto-bind bindings are disjoint by suffix — an agent id may match multiple
+suffixes and will inherit each suffix's defaults once. A hybrid id like
+`foo-researcher-implementer` receives BOTH the `-researcher` defaults
+(`emit-structured-claims`) AND the `-implementer` defaults
+(`verify-the-premise`).
+
+## When to Use Multi-Agent vs Single Agent
+
+**Use consensus (3+ agents) for:**
+| Task | Why | Split Strategy |
+|------|-----|----------------|
+| Security review | Different agents catch different vuln classes | Split by package/concern |
+| Code review | Cross-validation catches what single reviewers miss | Split by concern |
+| Bug investigation | Competing hypotheses tested in parallel | One hypothesis per agent |
+| Architecture review | Multiple perspectives on trade-offs | Split by dimension |
+| Pre-ship verification | Catch regressions before merge | Split by area changed |
+
+**Single agent is fine for:** quick lookups, running tests, file reads.
+
+## Consensus Workflow — The Complete Flow
+
+### Step 1: Dispatch
+```
+gossip_dispatch(mode: "consensus", tasks: [
+  { agent_id: "<reviewer>", task: "Review X for security" },
+  { agent_id: "<researcher>", task: "Review X for architecture" },
+  { agent_id: "<tester>", task: "Review X for test coverage" },
+])
+```
+
+### Step 2: Execute native agents, then relay results
+`gossip_relay(task_id: "<id>", result: "<agent output>")`
+
+### Step 3: Collect with cross-review
+`gossip_collect(task_ids, consensus: true, timeout_ms: 300000)`
+Returns: CONFIRMED, DISPUTED, UNIQUE, UNVERIFIED, NEW tagged findings.
+
+### Step 4: Verify and record signals IMMEDIATELY
+For EACH finding, read the actual code. Record signals AS YOU VERIFY:
+```
+gossip_signals(action: "record", signals: [
+  { signal: "unique_confirmed", agent_id: "reviewer", finding: "XSS in template", finding_id: "<consensus_id>:<agent:fN>" },
+  { signal: "hallucination_caught", agent_id: "reviewer", finding: "Claimed X but code shows Y", finding_id: "<consensus_id>:<agent:fN>" },
+  { signal: "agreement", agent_id: "reviewer", counterpart_id: "researcher", finding: "Both found it", finding_id: "<consensus_id>:<agent:fN>" },
+])
+```
+**CRITICAL:** Record `hallucination_caught` IMMEDIATELY when a finding is wrong. Don't batch — record inline as you verify. This keeps agent scores accurate.
+
+**finding_id is MANDATORY** on every signal. Format: `<consensus_id>:<agent_id>:fN` (e.g. `b81956b2-e0fa4ea4:sonnet-reviewer:f1`). Without it, signals are unauditable — you can't trace which finding caused a score change.
+
+### Step 5: Verify ALL UNVERIFIED findings.
+UNVERIFIED does not mean "skip." It means the cross-reviewer couldn't check it — YOU can.
+For each UNVERIFIED finding: grep/read the cited code or identifiers, then record the signal.
+Do NOT present raw consensus results with unverified findings to the user.
+
+### Step 6: Fix confirmed issues (only after all signals recorded).
+
+## Performance Signals & Agent Scores
+
+Call `gossip_scores()` to see: accuracy (0-1), uniqueness (0-1), dispatchWeight (0.5-1.5).
+- High-accuracy agents → solo tasks, primary reviewers
+- High-uniqueness, low-accuracy → always use in consensus, never solo
+- Check scores periodically to track improvement
+
+## gossip_verify_memory — Backlog Hygiene
+
+Before acting on any backlog item from memory, call `gossip_verify_memory(memory_path, claim)`:
+- **FRESH** — proceed, optionally cite `checked_at`.
+- **STALE** — do NOT use as-is. Read the actual code at paths in `evidence`, apply `rewrite_suggestion` to the memory file, then proceed.
+- **CONTRADICTED** — memory is wrong. Stop, read the code, rewrite the memory, reassess whether the original task still makes sense.
+- **INCONCLUSIVE** — fall back to manual audit via Read/Grep + `gossip_run(agent_id: "auto", task: "Audit <item>: ...")`. Do NOT treat as a pass.
+
+Backlog memories decay fast — an item described as "not shipped" may be 90% built. Never skip this check.
+
+## Agent Accuracy — Skill Development
+
+When an agent has repeated hallucinations, use the **skill system**, not instruction edits:
+1. `gossip_scores()` — identify low-accuracy agents
+2. `gossip_skills(action: "develop", agent_id: "<id>", category: "<category>")` — generates a skill from failure data
+   - Categories: `trust_boundaries`, `injection_vectors`, `input_validation`, `concurrency`, `resource_exhaustion`, `type_safety`, `error_handling`, `data_integrity`
+3. `gossip_skills(action: "bind", agent_id: "<id>", skill: "<name>")` — bind if not auto-bound
+4. `gossip_skills(action: "list")` — verify skill is enabled
+
+**Do NOT** edit `instructions.md` to fix accuracy. Instructions set the base contract; skills are the improvement mechanism.
+
+## Memory Hygiene — status Field
+
+Every `project_*` memory MUST include a `status` field in frontmatter:
+- `status: open` — active backlog, in-progress, or pending. Decays; verify before acting.
+- `status: shipped` — work has landed. Reference only; don't mutate.
+- `status: closed` — decided not to pursue. Archive semantics.
+
+**Do NOT trust the MEMORY.md index line.** The index snippet is frozen text; the linked file's frontmatter `status:` is the truth. Before dispatching work on any `project_*.md` backlog item: (1) open the file, (2) read the `status:` field, (3) if it's not obviously fresh, call `gossip_verify_memory(path, claim)` per "Backlog Hygiene" above. Skipping this re-dispatches shipped work, wastes agent quota, and pollutes scores.
+
+## Memory System
+
+Memory persists across sessions automatically:
+- `.gossip/agents/<id>/memory/knowledge/*.md` — cognitive summaries
+- `.gossip/agents/_project/memory/knowledge/` — shared cross-agent context
+- `.gossip/next-session.md` — session continuity priorities
+
+**Call `gossip_session_save()` before ending your session.** Without it, the next session starts cold.
+
+## Dashboard
+
+Use `gossip_status()` for URL and key. Tabs: Overview, Agents, Consensus, Skills, Memory.
+
+## Subagent Override (IMPORTANT)
+
+When ANY skill or workflow (including subagent-driven-development, executing-plans, or
+any custom skill) instructs you to dispatch work via the Agent() tool, use `gossip_run`
+instead. This ensures tasks appear in the dashboard, agent memory is written, and
+performance signals are recorded.
+
+**Flow:** `gossip_run(agent_id, task)` → returns Agent() instructions for native agents →
+execute the Agent() → `gossip_relay(task_id, result)` to close the loop.
+
+**Exception:** `gossip_dispatch(mode:"consensus")` already handles its own native Agent() calls —
+don't double-wrap those.
+
+**Why:** Raw Agent() bypasses the gossipcat pipeline. Tasks won't appear in the activity
+feed, no memory is written, no signals recorded. The agent effectively works off-grid.
+
+## Native Agent Relay Rule
+
+When dispatching native agents: gossip_dispatch → Agent() → gossip_relay. Never skip the relay call.
+
+## Implementation Tasks — Auto-Dispatch
+
+Check Tier 1/2 triggers first (see .claude/rules/gossipcat.md). If no match, call
+gossip_run(agent_id: "auto", task: "<description>") BEFORE writing any code.
+
+Exceptions: (direct) in user message, Tier 3 changes (docs, CSS, tests), or already
+executing inside a dispatched plan step.
+
+gossip_run auto classifies single vs multi and routes appropriately:
+- Single: selects best-fit agent by dispatch weight, dispatches directly
+- Multi: calls gossip_plan for decomposition, presents for approval, then dispatches
+
+## Permissions
+
+Auto-allow writes: `{ "permissions": { "allow": ["Edit", "Write", "Bash(npm *)"] } }`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,5 +30,18 @@
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
     "gossipcat"
-  ]
+  ],
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-sandbox.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,40 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat .gossip/bootstrap.md 2>/dev/null || echo '[gossipcat] No bootstrap yet. Load tools first: ToolSearch(query: \"select:mcp__gossipcat__gossip_status\") then call gossip_status()'"
+            "command": "gossipcat hook --run"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/discipline/session-start-bootstrap.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "mcp__gossipcat__gossip_signals",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/discipline/pretool-signals-validate.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "mcp__gossipcat__gossip_collect",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/discipline/posttool-collect-reminder.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

The Layer-2 worktree boundary-escape sandbox hook (`.claude/hooks/worktree-sandbox.sh`) was installed on disk but **never registered as a `PreToolUse` hook** — silently inert. This re-runs the installer (`gossip_setup`) to register it now that `settings.json` is valid, and folds in the rest of the installer's hook refresh.

Root cause + installer fix are tracked separately in **#500** (copy-before-register ordering skips registration when `settings.json` is malformed, as it was before #385's repair). This PR is the **data/config fix** for this repo; #500 is the **code fix** so it can't recur.

## Changes (all gossipcat-installer-generated, verified by diff — no hand-written logic)
- **`.claude/settings.json`** — register `worktree-sandbox.sh` as `PreToolUse` (matcher `Bash|Edit|Write|MultiEdit|NotebookEdit`). **Activates Layer-2.** Orchestrator is exempt at project root via the `.gossip/orchestrator-role` marker; only `.claude/worktrees/agent-*` subagent cwds are gated (verified against the hook's exemption logic).
- **`.claude/hooks/worktree-sandbox.sh`** — refresh stale installed copy (12KB → 16KB) to the current bundled version.
- **`.claude/settings.local.json`** — correct the bootstrap command (`cat .gossip/bootstrap.md` → `gossipcat hook --run`, per #443) + register the discipline hooks (SessionStart bootstrap, PreToolUse signals-validate, PostToolUse collect-reminder).
- **`.claude/hooks/discipline/*.sh`, `.claude/rules/gossipcat.md`** — installer artifacts.

## Why it matters
Plausibly a contributor to the **#437** native-worktree-isolation gap — a Layer-2 defense that had been silently off. Activating it restores the intended boundary-escape enforcement for subagent worktree dispatches.

## Test plan
- [x] `git diff` confirms changes are exactly the installer output (no manual edits)
- [x] Hook exemption verified: orchestrator (project-root cwd) + `.gossip/orchestrator-role` marker → allowed; only `agent-*` worktree cwds gated
- [ ] Reviewer: confirm activating the `PreToolUse` gate is desired now (it changes subagent dispatch behavior — boundary-escape writes will be denied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)