### PR TITLE
fix(dashboard): UI critical bundle — accent dilution, drop shadow, tooltip font, a11y

### DIFF
--- a/packages/dashboard-v2/src/components/AgentRow.tsx
+++ b/packages/dashboard-v2/src/components/AgentRow.tsx
@@ -16,7 +16,7 @@ export function AgentRow({ agent }: AgentRowProps) {
     <button
       onClick={() => { navigate('/agent/' + encodeURIComponent(agent.id)); }}
       className="group flex min-w-0 flex-1 flex-col items-center rounded-lg border [border-color:var(--border)] p-4 text-center transition hover:[border-color:color-mix(in_oklch,var(--accent)_30%,transparent)] hover:bg-accent/10"
-      style={{ background: 'var(--surface-elev)', boxShadow: 'var(--shadow-card)' }}
+      style={{ background: 'var(--surface-elev)' }}
     >
       {/* Avatar with portal glow */}
       <div className="relative mb-3">

--- a/packages/dashboard-v2/src/components/CitationSnippet.tsx
+++ b/packages/dashboard-v2/src/components/CitationSnippet.tsx
@@ -13,7 +13,7 @@ export function CitationSnippet({ citation }: { citation: CS }) {
         className="overflow-x-auto"
         style={{
           background: 'var(--surface-sunk)',
-          borderLeft: '3px solid var(--accent)',
+          borderLeft: '3px solid var(--border-strong)',
           padding: '12px 16px',
           borderRadius: '6px',
           fontFamily: 'var(--font-mono)',

--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -326,6 +326,12 @@ export function SignalsPage() {
                       key={`${r.timestamp}-${r.agentId}-${i}`}
                       className={`border-b border-border/30 ${canOpen ? 'cursor-pointer transition-colors' : ''}`}
                       style={canOpen ? { ['--row-hover-bg' as string]: 'color-mix(in oklch, var(--surface-sunk) 40%, transparent)' } : undefined}
+                      // Keyboard-accessible activation: when canOpen, treat the row as
+                      // an interactive button (Enter/Space → openDrawer). Without this,
+                      // keyboard/SR users couldn't reach the drawer.
+                      role={canOpen ? 'button' : undefined}
+                      tabIndex={canOpen ? 0 : undefined}
+                      aria-label={canOpen ? `View finding ${r.findingId ?? ''}` : undefined}
                       onMouseEnter={(e) => {
                         if (canOpen) e.currentTarget.style.background = 'color-mix(in oklch, var(--surface-sunk) 40%, transparent)';
                       }}
@@ -333,6 +339,12 @@ export function SignalsPage() {
                         if (canOpen) e.currentTarget.style.background = '';
                       }}
                       onClick={() => canOpen && openDrawer(r.consensusId, r.findingId)}
+                      onKeyDown={(e) => {
+                        if (canOpen && (e.key === 'Enter' || e.key === ' ')) {
+                          e.preventDefault();
+                          openDrawer(r.consensusId, r.findingId);
+                        }
+                      }}
                     >
                       {/* Severity tick — full-bleed left bar, semantic color */}
                       <td

--- a/packages/dashboard-v2/src/components/SkillCard.tsx
+++ b/packages/dashboard-v2/src/components/SkillCard.tsx
@@ -23,7 +23,10 @@ const STATUS_CLS: Record<SkillStatus, string> = {
   failed: 'border-disputed/40 bg-disputed/10 text-disputed',
   silent_skill: 'border-unverified/40 bg-unverified/10 text-unverified',
   insufficient_evidence: 'border-unverified/40 bg-unverified/10 text-unverified',
-  inconclusive: 'border-orange-400/40 bg-orange-500/10 text-orange-400',
+  // Match SkillGraduationGrid: inconclusive → --warn (DESIGN.md amber).
+  // Raw orange-400 was a different hue, theme-baked, inconsistent with the
+  // overview grid showing the same skill data.
+  inconclusive: 'border-[color:var(--warn)]/40 bg-[color:var(--warn)]/10 text-[color:var(--warn)]',
   flagged_for_manual_review: 'border-disputed/40 bg-disputed/10 text-disputed',
 };
 

--- a/packages/dashboard-v2/src/components/TemporalScrubber.tsx
+++ b/packages/dashboard-v2/src/components/TemporalScrubber.tsx
@@ -62,10 +62,13 @@ export function TemporalScrubber({ runs, range, onRangeChange, height = 52 }: Te
                 aria-pressed={active}
                 className="rounded px-2 py-0.5 font-mono text-[10px] transition"
                 style={{
-                  background: active ? 'color-mix(in oklch, var(--accent) 10%, transparent)' : 'transparent',
-                  color: active ? 'var(--accent)' : 'var(--text-dim)',
+                  // Filter chips are interactive chrome, not CTAs — DESIGN.md
+                  // reserves --accent for brand mark / primary CTA / active nav.
+                  // Selected state uses weight + surface, not the brand hue.
+                  background: active ? 'var(--surface-sunk)' : 'transparent',
+                  color: active ? 'var(--text)' : 'var(--text-dim)',
                   border: '1px solid',
-                  borderColor: active ? 'color-mix(in oklch, var(--accent) 30%, transparent)' : 'transparent',
+                  borderColor: active ? 'var(--border-strong)' : 'transparent',
                 }}
               >
                 {r}

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -80,7 +80,9 @@
   --accent-bright: #e08a6c;
   --accent-soft: rgba(204, 120, 92, 0.12);
   --success: #1a7e5e;
-  --warn: #b8741d;
+  /* --warn declared below in the DESIGN.md alias block (#B47A2A).
+     Legacy #b8741d removed to prevent a future merge from regressing the
+     spec'd value via cascade ordering. */
   --danger: #c0392b;
   --beat: 1.6s;
   /* Phase 1b graph-stage tokens — cream stage in light mode. */
@@ -258,7 +260,8 @@
   --accent-bright: #e08a6c;
   --accent-soft: rgba(214, 138, 111, 0.16);
   --success: #57b289;
-  --warn: #c89a55;
+  /* --warn declared below in the DESIGN.md dark-mode alias block (#D8A35A).
+     Legacy #c89a55 removed to prevent cascade-order regressions. */
   --danger: #d68a7e;
   --shadow-overlay: 0 24px 64px -16px rgba(0, 0, 0, 0.65), 0 0 0 1px rgba(255, 255, 255, 0.06);
   --shadow-overlay-hairline: 0 0 0 1px rgba(255, 255, 255, 0.04);
@@ -467,7 +470,7 @@ html[data-theme="dark"]::after {
   background: var(--surface-sunk);
   border: 1px solid var(--border-strong);
   border-radius: 6px;
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-sans);
   font-size: 11px;
   font-weight: 500;
   line-height: 1.45;


### PR DESCRIPTION
Bundles 7 high-value fixes from the multi-agent dashboard review (sonnet-designer + sonnet-reviewer + haiku-researcher). **Every file:line was verified against actual source before editing** (haiku's `components/OverviewPage.tsx` path was a hallucination — the real path is `pages/OverviewPage.tsx` and is out of scope here).

## Changes

### Accent dilution (DESIGN.md: terracotta = brand mark / primary CTA / active nav only)
| File | Was | Now |
|---|---|---|
| `CitationSnippet.tsx:16` | `borderLeft: '3px solid var(--accent)'` on every code citation (rendered in every `FindingDetailDrawer`) | `var(--border-strong)` |
| `TemporalScrubber.tsx:65-68` | Active range chip painted in terracotta — it's a filter toggle, not a CTA | `var(--surface-sunk)` + `var(--border-strong)`; weight conveys "selected" |
| `SkillCard.tsx:26` | `inconclusive` used raw `text-orange-400 / bg-orange-500/10` — theme-baked, **inconsistent with `SkillGraduationGrid` which already uses `var(--warn)`** | `var(--warn)` so the same skill data shows the same amber on overview grid and agent page |

### Chrome (DESIGN.md: cards are hairline border only)
- **`AgentRow.tsx:19`** — removed `boxShadow: var(--shadow-card)` on every team-card. The hairline border on the parent class already provides separation.

### Token dedup (regression-proof the DESIGN.md palette)
- **`globals.css:83` + `:261`** — removed duplicate legacy `--warn` declarations (`#b8741d` light / `#c89a55` dark). Cascade was keeping the DESIGN.md aliases (`#B47A2A` / `#D8A35A`) live, but **a single misordered merge would have silently reverted the spec'd amber**.

### Global tooltip regression
- **`globals.css:470`** — `[data-tooltip]::after` hardcoded `font-family: 'Inter'`. Every tooltip across the dashboard was falling back off the Geist stack. Now `var(--font-sans)` (Geist-first).

### A11y
- **`SignalsPage.tsx:325`** — clickable `<tr>` rows that open the finding drawer had no `tabIndex`, no `role`, no `onKeyDown`. **Keyboard + screen-reader users couldn't open the drawer at all.** Added `role="button"`, `tabIndex={0}` (when `canOpen`), `aria-label`, and Enter/Space handling.

## Verification
- ✅ `npx tsc --noEmit -p packages/dashboard-v2/tsconfig.json` clean on touched files
- ✅ `npm run build:mcp` exit 0
- ✅ Each cited `file:line` independently grep-confirmed against `master` before editing

## Out of scope (tracked, not fixed in this PR)
The review surfaced ~30 findings total. This PR bundles only the bite-sized + load-bearing ones. Deferred:
- `.h-section` migration sweep — `SystemPulse` (5 sites), `AgentPage`, `ActivityBars`, `ConsensusFlow` header still use the Risk #4-killed `font-mono uppercase tracking-wider` pattern
- `ActivityWaterfall` local `agentColor()` with hardcoded hex (will drift from `globals.css` identity colors)
- Error-contract sweep — `RecentSignalsPeek`, `SkillGraduationGrid`, `FindingDetailDrawer` all miss the DESIGN.md "chip-bad + 50% stale data" contract; `ActivityWaterfall` renders "fleet idle" when `runs===null` (relay disconnected)
- `GraphRail` fixed `width: 320` doesn't stack under 1024px
- `FindingsMetrics` raw `text-red-400 / text-yellow-400` severity classes (shared by `FindingDetailDrawer`)
- `MemoryFolders` backlog folder type uses `var(--accent)` across 9 elements
- `ConsensusFlow` SVG `fontFamily` as presentation attribute (CSS vars don't resolve in some renderers)
- `SeverityMixStrip` / `AgentCardBig` badge `aria-label`s
- Pre-existing `--color-unverified` hue inconsistency vs DESIGN.md `--info` teal

Happy to bundle the next tier as a follow-up if the direction's right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)