### PR TITLE
fix(dashboard): .h-section sweep — section labels small-caps Geist (tier 2a)

### DIFF
--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -285,7 +285,7 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
             <div className="space-y-2.5">
               {metricBars.map(m => (
                 <div key={m.label} className="grid grid-cols-[72px_1fr_44px] items-center gap-3">
-                  <span className="font-mono text-[10px] uppercase tracking-wider" style={{ color: 'var(--text-dim)' }}>{m.label}</span>
+                  <span className="h-section" style={{ color: 'var(--text-dim)', fontSize: '10px' }}>{m.label}</span>
                   <div className="h-1.5 overflow-hidden rounded-full" style={{ background: 'color-mix(in oklch, var(--surface) 80%, transparent)' }}>
                     <div className={`h-full rounded-full transition-all ${m.fill}`} style={{ width: `${Math.max(0, Math.min(100, m.value * 100))}%` }} />
                   </div>

--- a/packages/dashboard-v2/src/components/ConsensusFlow.tsx
+++ b/packages/dashboard-v2/src/components/ConsensusFlow.tsx
@@ -112,10 +112,7 @@ function ConsensusFlowChart({ data }: { data: ConsensusFlowResponse }) {
     >
       <header className="mb-4 flex items-start justify-between gap-3">
         <div>
-          <h2
-            className="font-mono text-[13px] font-semibold"
-            style={{ color: 'var(--ink)' }}
-          >
+          <h2 className="h-section" style={{ color: 'var(--ink)' }}>
             Consensus flow
           </h2>
           <p

--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -60,7 +60,7 @@ function BigStat({ value, unit, label, valueClass = '', valueColor, pulse, toolt
         </span>
         {unit && <span className="font-mono text-xs" style={{ color: 'var(--ink-3)' }}>{unit}</span>}
       </div>
-      <div className="mt-1.5 text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--ink-3)' }}>
+      <div className="h-section mt-1.5" style={{ color: 'var(--ink-3)', fontSize: '10px' }}>
         {label}
       </div>
     </div>
@@ -137,18 +137,18 @@ export function SystemPulse({ overview, activeTasks, mode = 'dense', showActivit
             {/* Three-row agent stat (stacked to fit narrow cell) */}
             <div className="flex flex-col items-stretch justify-center gap-1.5 px-4 py-3">
               <div className="flex items-baseline justify-between gap-2">
-                <span className="font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--ink-3)' }} data-tooltip="Agents currently executing a task">Dispatched</span>
+                <span className="h-section" style={{ color: 'var(--ink-3)', fontSize: '10px' }} data-tooltip="Agents currently executing a task">Dispatched</span>
                 <span
                   className="font-mono text-base font-bold leading-none"
                   style={{ color: overview.agentsOnline > 0 ? 'var(--ok)' : 'var(--text)' }}
                 >{overview.agentsOnline}</span>
               </div>
               <div className="flex items-baseline justify-between gap-2">
-                <span className="font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--ink-3)' }} data-tooltip="Relay agents with an active WebSocket connection">Connected</span>
+                <span className="h-section" style={{ color: 'var(--ink-3)', fontSize: '10px' }} data-tooltip="Relay agents with an active WebSocket connection">Connected</span>
                 <span className={`font-mono text-base font-bold leading-none ${overview.relayConnected > 0 ? 'text-confirmed' : ''}`} style={overview.relayConnected > 0 ? undefined : { color: 'var(--ink-3)' }}>{overview.relayConnected}</span>
               </div>
               <div className="flex items-baseline justify-between gap-2">
-                <span className="font-mono text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--ink-3)' }} data-tooltip="Total agents in gossipcat config">Registered</span>
+                <span className="h-section" style={{ color: 'var(--ink-3)', fontSize: '10px' }} data-tooltip="Total agents in gossipcat config">Registered</span>
                 <span className="font-mono text-base font-bold leading-none" style={{ color: 'var(--ink-3)' }}>{totalAgents}</span>
               </div>
             </div>
@@ -241,7 +241,7 @@ function ActivityBars({ hourly }: ActivityBarsProps) {
   const max = Math.max(1, ...bars);
   return (
     <div className="border-t border-border px-3.5 py-3" style={{ background: 'color-mix(in oklch, var(--surface-sunk) 30%, transparent)' }}>
-      <div className="mb-2 font-mono text-[9px] font-bold uppercase tracking-wider" style={{ color: 'color-mix(in oklch, var(--ink-3) 60%, transparent)' }}>
+      <div className="h-section mb-2" style={{ color: 'color-mix(in oklch, var(--ink-3) 60%, transparent)', fontSize: '11px' }}>
         Activity Last 12h
       </div>
       <div className="flex h-6 items-end gap-0.5">


### PR DESCRIPTION
Tier 2a of the dashboard-UI review follow-ups (after PR #503). DESIGN.md Risk #4 explicitly killed the `font-mono uppercase tracking-wider` pattern for **section labels** in favor of small-caps Geist (the `.h-section` utility). This PR is the focused sweep.

## Sites migrated (7 — across 3 files, +7/−10 lines)
| Site | Was | Now |
|---|---|---|
| `SystemPulse.tsx:63` | BigStat label (10px) | `h-section` + `fontSize: '10px'` |
| `SystemPulse.tsx:140` | "Dispatched" (dense agent-stat row, 10px) | `h-section` + 10px |
| `SystemPulse.tsx:147` | "Connected" | `h-section` + 10px |
| `SystemPulse.tsx:151` | "Registered" | `h-section` + 10px |
| `SystemPulse.tsx:244` | "Activity Last 12h" (**9px** — below the `--t-micro` 11px floor) | `h-section` + **lifted to 11px** (also closes the floor violation) |
| `AgentPage.tsx:288` | metric-bar labels ("Accuracy", "Uniqueness", ...) | `h-section` + 10px |
| `ConsensusFlow.tsx:116` | `<h2>` "Consensus flow" — `font-mono text-[13px]` (mono voice forbidden for section headers, Risk #4) | `h-section` (13px default) |

## Scope discipline (load-bearing)

This PR **only** touches section labels. Status chips, pills, and finding tags keep the mono-pill voice intentionally — they're state markers with semantic color, not section labels per DESIGN.md. Sites explicitly left as-is:
- `FindingDetailDrawer.tsx` finding-tag / severity / retracted chips
- `TaskRow.tsx` / `TasksSection.tsx` status pills
- `MemoryFolders.tsx:201` folder-type tag chip
- `CircuitAlerts.tsx:45` / `ViolationsCard.tsx:43` / `ViolationsPage.tsx:135` — destructive/warning chips with semantic color (borderline; leaving for a follow-up if they turn out to be section headers)
- `FindingsMetrics.tsx:184/586/794` — chip-shaped indicators
- `AgentPage.tsx:305` — `{st.label}` (likely a sub-label, 9px + `mt-0.5`; will inspect in a follow-up)

## Verification
- ✅ `npx tsc --noEmit -p packages/dashboard-v2` clean
- ✅ `npm run build:mcp` exit 0
- ✅ 3 touched files now have **0** `uppercase tracking-wider` matches
- ✅ Each cited `file:line` independently grep-confirmed before edit

## What's next in tier 2
- **2b — Token discipline:** raw `text-red-400 / yellow-400 / orange-400 / blue-400 / purple-400` → `--bad/--warn/--info`; `MemoryFolders` backlog accent flood (9 sites) → `--warn`; `ActivityWaterfall` local `agentColor()` divergence → canonical import
- **2c — Error contract + a11y:** `RecentSignalsPeek / SkillGraduationGrid / FindingDetailDrawer` error states → DESIGN.md chip-bad + stale data; `ActivityWaterfall` "fleet idle" wrong message on `runs===null`; `ConsensusFlow` SVG `fontFamily` attribute → `style`; `SeverityMixStrip` / `AgentCardBig` badge `aria-label`s

🤖 Generated with [Claude Code](https://claude.com/claude-code)