### PR TITLE
fix(dashboard): token discipline — backlog→warn, raw-orange link, agentColor dedup (tier 2b)

### DIFF
--- a/packages/dashboard-v2/src/components/ActivityWaterfall.tsx
+++ b/packages/dashboard-v2/src/components/ActivityWaterfall.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import type { AgentData, ConsensusRun } from '@/lib/types';
+import { agentColor } from '@/lib/utils';
 
 /** 24h activity waterfall — per-agent heatmap of signal volume by hour.
  *
@@ -65,19 +66,10 @@ const LEVEL_OPACITY: Record<0 | 1 | 2 | 3 | 4, number> = {
   4: 1.0,
 };
 
-/** Per-agent identity color — same mapping as the cosmic graph stage. */
-function agentColor(id: string): string {
-  switch (id) {
-    case 'sonnet-reviewer': return '#8C5E97';
-    case 'sonnet-designer': return '#C8A45A';
-    case 'sonnet-implementer': return '#A53A4A';
-    case 'opus-implementer': return '#C97056';
-    case 'gemini-reviewer': return '#3F8B86';
-    case 'gemini-tester': return '#2F7D5B';
-    case 'haiku-researcher': return '#6B7A85';
-    default: return '#6B6862';
-  }
-}
+// Per-agent identity color imported from @/lib/utils — canonical source
+// (AGENT_IDENTITY_TABLE, sourced from DESIGN.md §Per-agent identity). The
+// previous local switch duplicated the 7-agent table and hardcoded a fallback
+// hex, risking silent drift if globals.css identity tokens changed.
 
 export function ActivityWaterfall({ agents, runs, loading = false, error = null }: ActivityWaterfallProps) {
   const nowMs = Date.now();

--- a/packages/dashboard-v2/src/components/MemoryFolders.tsx
+++ b/packages/dashboard-v2/src/components/MemoryFolders.tsx
@@ -42,7 +42,9 @@ const TYPE_ACCENT_CLASS: Record<DisplayType, string> = {
 };
 
 const TYPE_ACCENT_STYLE: Record<DisplayType, React.CSSProperties | undefined> = {
-  backlog: { color: 'var(--accent)' },
+  // backlog = "open, needs action" → semantic --warn amber, not the brand
+  // terracotta (DESIGN.md: --accent is brand mark / primary CTA / active nav only).
+  backlog: { color: 'var(--warn)' },
   record: undefined,
   session: undefined,
   rule: undefined,
@@ -53,7 +55,7 @@ const TYPE_ACCENT_STYLE: Record<DisplayType, React.CSSProperties | undefined> = 
  * the same hue at low alpha to mimic mockup line 152 (`0 0 8px primary-soft`).
  */
 const TYPE_DOT: Record<DisplayType, { bg: string; glow: string }> = {
-  backlog: { bg: 'bg-accent', glow: 'var(--accent)' },
+  backlog: { bg: 'bg-[color:var(--warn)]', glow: 'var(--warn)' },
   record: { bg: 'bg-text-dim', glow: 'rgba(102, 102, 116, 0.55)' },
   session: { bg: 'bg-confirmed', glow: 'rgba(52, 211, 153, 0.55)' },
   rule: { bg: 'bg-unverified', glow: 'rgba(251, 191, 36, 0.55)' },
@@ -72,7 +74,7 @@ const TYPE_ICON_BOX_CLASS: Record<DisplayType, string> = {
 };
 
 const TYPE_ICON_BOX_STYLE: Record<DisplayType, React.CSSProperties | undefined> = {
-  backlog: { background: 'color-mix(in oklch, var(--accent) 6%, transparent)' },
+  backlog: { background: 'color-mix(in oklch, var(--warn) 6%, transparent)' },
   record: undefined,
   session: undefined,
   rule: undefined,

--- a/packages/dashboard-v2/src/pages/OverviewPage.tsx
+++ b/packages/dashboard-v2/src/pages/OverviewPage.tsx
@@ -110,7 +110,8 @@ export function OverviewPage({
             {actionable > 0 && (
               <a
                 href={href('/signals?signal=disagreement&signal=hallucination_caught&signal=new_finding')}
-                className="font-mono text-[11px] text-orange-400 transition hover:underline"
+                className="font-mono text-[11px] transition hover:underline"
+                style={{ color: 'var(--warn)' }}
                 data-tooltip="Findings open for operator review"
               >
                 {actionable} actionable →


### PR DESCRIPTION
Tier 2b of the dashboard-UI review (after #503 critical bundle, #504 `.h-section` sweep). Token discipline: replace raw Tailwind palette values + non-CTA accent uses with semantic CSS tokens, consolidate the duplicated per-agent color mapping.

## Changes (3 files, +12/−17 lines)

### 1. `ActivityWaterfall.tsx` — drop local `agentColor()` duplicate
The component had its own switch with hardcoded hex (`'#8C5E97'` etc.) that would silently drift if `globals.css` identity tokens changed. **Verified hex-identical** to the canonical `AGENT_IDENTITY_TABLE` in `@/lib/utils` for all 7 named agents (sonnet-reviewer/designer/implementer, opus-implementer, gemini-reviewer/tester, haiku-researcher). Canonical also handles unknown agents via deterministic hash, replacing the local's hardcoded `#6B6862` fallback. No visual regression; eliminates a real drift risk.

### 2. `pages/OverviewPage.tsx:113` — actionable-findings link `text-orange-400` → `var(--warn)`
Raw Tailwind color was theme-baked and not a DESIGN.md token. Semantically: actionable = warning / needs review → amber.

### 3. `MemoryFolders.tsx` — backlog folder-type 3 entries `--accent` → `--warn`
Designer flagged this as the highest-impact MemoryFolders fix: backlog = "open, needs action" → semantic `--warn`, not the brand terracotta. Surgical:
| Line | Was | Now |
|---|---|---|
| `:45` `TYPE_ACCENT_STYLE.backlog.color` | `var(--accent)` | `var(--warn)` |
| `:56` `TYPE_DOT.backlog.{bg,glow}` | `bg-accent` / `var(--accent)` | `bg-[color:var(--warn)]` / `var(--warn)` |
| `:75` `TYPE_ICON_BOX_STYLE.backlog.background` | `var(--accent) at 6%` | `var(--warn) at 6%` |

## Scope discipline
**Out of scope (tracked for tier 2c or a follow-up):**
- `FindingsMetrics` `SEVERITY_FILTERS / SEVERITY_CLS / CITE_STYLES` (raw `text-red-400 / yellow-400 / blue-400 / purple-400`) — needs `--color-warn / --color-bad / --color-info` aliases wired into `globals.css` `@theme` first to enable clean Tailwind utilities. Bundling into 2c.
- General `MemoryFolders` accent uses on **active-tab state** (`:191`, `:207`, `:328`) and **hover** (`:234`, `:341`) — those affect ALL folder types, not just backlog, and are about active-state design rather than the backlog-specific palette violation. Backlog-vs-others consistency is the narrow fix this PR makes.

## Verification
- ✅ `npx tsc --noEmit -p packages/dashboard-v2` clean
- ✅ `npm run build:mcp` exit 0
- ✅ Canonical `agentColor` hex-identical to dropped local (7/7 named agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)