### PR TITLE
fix(dashboard): semantic tokens + SVG fontFamily + a11y bundle (tier 2c)

### DIFF
--- a/packages/dashboard-v2/src/components/ActivityWaterfall.tsx
+++ b/packages/dashboard-v2/src/components/ActivityWaterfall.tsx
@@ -119,15 +119,21 @@ export function ActivityWaterfall({ agents, runs, loading = false, error = null 
     );
   }
 
-  // Fleet has agents but no activity in the last 24h.
+  // Fleet has agents but no activity in the last 24h, OR run data is missing
+  // (runs == null). Distinguish the two so a disconnected relay doesn't
+  // misreport as "fleet idle" — the latter is factually wrong when we never
+  // received run data at all.
   if (fleetTotal === 0) {
+    const message = runs == null
+      ? 'Run data unavailable — relay may be disconnected. Showing idle rows from the agent registry.'
+      : 'No active dispatches — fleet idle.';
     return (
       <WaterfallShell error={error} fleetTotal={0}>
         {agents.map((agent) => (
           <IdleRow key={agent.id} agent={agent} />
         ))}
         <div className="px-5 py-3 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
-          No active dispatches — fleet idle.
+          {message}
         </div>
       </WaterfallShell>
     );

--- a/packages/dashboard-v2/src/components/AgentCardBig.tsx
+++ b/packages/dashboard-v2/src/components/AgentCardBig.tsx
@@ -177,6 +177,7 @@ export function AgentCardBig({ agent, severityCounts, trendPoints }: AgentCardBi
                   if (kind === 'benched') return (
                     <span
                       className="shrink-0 rounded-sm bg-destructive/10 px-1 py-0.5 font-mono text-[8px] font-bold text-destructive"
+                      aria-label={`Benched (${s.bench.reason ?? 'auto'}). Excluded from dispatch until recovery.`}
                       data-tooltip={`Benched (${s.bench.reason ?? 'auto'}). Excluded from dispatch until recovery.`}
                     >
                       BENCHED
@@ -185,6 +186,7 @@ export function AgentCardBig({ agent, severityCounts, trendPoints }: AgentCardBi
                   if (kind === 'struggling') return (
                     <span
                       className="shrink-0 rounded-sm bg-unverified/10 px-1 py-0.5 font-mono text-[8px] font-bold text-unverified"
+                      aria-label="Struggling: consecutive failures tripped the circuit breaker."
                       data-tooltip="Struggling: consecutive failures tripped the circuit breaker."
                     >
                       STRUGGLING
@@ -193,6 +195,7 @@ export function AgentCardBig({ agent, severityCounts, trendPoints }: AgentCardBi
                   if (kind === 'kept-for-coverage') return (
                     <span
                       className="shrink-0 rounded-sm border border-unverified/40 bg-unverified/10 px-1 py-0.5 font-mono text-[8px] font-bold text-unverified"
+                      aria-label={`Would bench (${s.bench.reason ?? 'rule'}), but kept as sole provider of a category.`}
                       data-tooltip={`Would bench (${s.bench.reason ?? 'rule'}), but kept as sole provider of a category.`}
                     >
                       KEPT

--- a/packages/dashboard-v2/src/components/ConsensusFlow.tsx
+++ b/packages/dashboard-v2/src/components/ConsensusFlow.tsx
@@ -238,8 +238,8 @@ function SankeyHorizontal({ data }: { data: ConsensusFlowResponse }) {
                 textAnchor="end"
                 dominantBaseline="middle"
                 fontSize={11}
-                fontFamily="var(--font-mono)"
                 fill="var(--ink)"
+                style={{ fontFamily: 'var(--font-mono)' }}
               >
                 {FAMILY_LABEL[band.family]} · {band.agentCount}
               </text>
@@ -265,9 +265,8 @@ function SankeyHorizontal({ data }: { data: ConsensusFlowResponse }) {
                 textAnchor="middle"
                 dominantBaseline="middle"
                 fontSize={11}
-                fontFamily="var(--font-mono)"
                 fill="var(--ink)"
-                style={{ fontVariant: 'small-caps', letterSpacing: '0.04em' }}
+                style={{ fontFamily: 'var(--font-mono)', fontVariant: 'small-caps', letterSpacing: '0.04em' }}
               >
                 {VERDICT_LABEL[slot.verdict]} · {slot.count}
               </text>
@@ -297,8 +296,8 @@ function SankeyHorizontal({ data }: { data: ConsensusFlowResponse }) {
                   textAnchor="end"
                   dominantBaseline="middle"
                   fontSize={11}
-                  fontFamily="var(--font-mono)"
                   fill="var(--ink)"
+                  style={{ fontFamily: 'var(--font-mono)' }}
                 >
                   {slot.count} · {pct}%
                 </text>

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -47,16 +47,16 @@ const FILTER_CHIPS: { key: FilterType; label: string; cls: string; activeCls: st
 
 const SEV_FILTER_CHIPS: { key: 'all' | 'critical' | 'high' | 'medium' | 'low'; label: string; cls: string; activeCls: string; activeStyle?: React.CSSProperties; inactiveStyle?: React.CSSProperties }[] = [
   { key: 'all', label: 'All', cls: 'border-border/40 hover:border-border/60', activeCls: 'border-border', activeStyle: { color: 'var(--text)', background: 'var(--surface-sunk)' }, inactiveStyle: { color: 'var(--text-dim)' } },
-  { key: 'critical', label: 'Critical', cls: 'text-red-400/50 border-red-400/20 hover:border-red-400/40', activeCls: 'text-red-400 bg-red-400/10 border-red-400/40' },
+  { key: 'critical', label: 'Critical', cls: 'text-bad/50 border-bad/20 hover:border-bad/40', activeCls: 'text-bad bg-bad/10 border-bad/40' },
   { key: 'high', label: 'High', cls: 'text-severity-high/50 border-severity-high/20 hover:border-severity-high/40', activeCls: 'text-severity-high bg-severity-high/10 border-severity-high/40' },
-  { key: 'medium', label: 'Medium', cls: 'text-yellow-400/50 border-yellow-400/20 hover:border-yellow-400/40', activeCls: 'text-yellow-400 bg-yellow-400/10 border-yellow-400/40' },
+  { key: 'medium', label: 'Medium', cls: 'text-warn/50 border-warn/20 hover:border-warn/40', activeCls: 'text-warn bg-warn/10 border-warn/40' },
   { key: 'low', label: 'Low', cls: 'border-border/40 hover:border-border/60', activeCls: 'border-border', activeStyle: { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--surface-sunk) 50%, transparent)' }, inactiveStyle: { color: 'color-mix(in oklch, var(--text-dim) 50%, transparent)' } },
 ];
 
 const SEVERITY_CLS: Record<string, string> = {
-  critical: 'text-red-400 bg-red-500/10',
+  critical: 'text-bad bg-bad/10',
   high: 'text-severity-high bg-severity-high/10',
-  medium: 'text-yellow-400 bg-yellow-500/10',
+  medium: 'text-warn bg-warn/10',
   low: '',
 };
 const SEVERITY_STYLE_LOW: React.CSSProperties = { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--surface-sunk) 50%, transparent)' };
@@ -105,8 +105,10 @@ function ReportFinding({ f, reviewInfo, diagnostics }: {
   const typeLabel = f.findingType === 'suggestion' ? 'SUGGESTION'
     : f.findingType === 'insight' ? 'INSIGHT'
     : null;
-  const typeCls = f.findingType === 'suggestion' ? 'text-blue-400 bg-blue-500/10'
-    : f.findingType === 'insight' ? 'text-zinc-400 bg-zinc-500/10'
+  // suggestion = informational action → --info teal; insight = neutral
+  // observation → text-dim grey. Maps the typeCls tokens to DESIGN.md.
+  const typeCls = f.findingType === 'suggestion' ? 'text-info bg-info/10'
+    : f.findingType === 'insight' ? 'text-text-dim bg-text-dim/10'
     : '';
 
   // Extract first cite as identifier
@@ -131,7 +133,7 @@ function ReportFinding({ f, reviewInfo, diagnostics }: {
           </span>
         )}
         {identifier && (
-          <span className="bg-blue-500/10 px-2 py-1 font-mono text-[10px] text-blue-400 border border-blue-500/15 rounded">
+          <span className="bg-info/10 px-2 py-1 font-mono text-[10px] text-info border border-info/15 rounded">
             {identifier}
           </span>
         )}

--- a/packages/dashboard-v2/src/components/SeverityMixStrip.tsx
+++ b/packages/dashboard-v2/src/components/SeverityMixStrip.tsx
@@ -36,6 +36,8 @@ export function SeverityMixStrip({ counts, height = 10 }: SeverityMixStripProps)
     // future shape. Higher opacity + border so it reads in both themes.
     return (
       <div
+        role="img"
+        aria-label={`Severity distribution: no findings yet (${title})`}
         title={`${title} (no findings yet)`}
         style={{
           display: 'flex',
@@ -63,6 +65,8 @@ export function SeverityMixStrip({ counts, height = 10 }: SeverityMixStripProps)
 
   return (
     <div
+      role="img"
+      aria-label={`Severity distribution — ${title}`}
       title={title}
       style={{
         display: 'flex',

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -55,6 +55,14 @@
   --color-disputed: #c0392b;
   --color-unverified: #b8741d;
   --color-unique: #7c5cbf;
+  /* DESIGN.md semantic palette exposed as Tailwind utilities so components
+     can use bg-warn / text-bad / border-info / bg-warn/10 etc. instead of
+     reaching for raw text-red-400 / text-yellow-400 Tailwind palette values.
+     Hex literals match DESIGN.md so Tailwind v4 opacity modifiers (/10, /20)
+     compose correctly at build time. Dark-mode overrides below. */
+  --color-warn: #B47A2A;
+  --color-bad: #A53A4A;
+  --color-info: #3F8B86;
   --color-severity-high: #c0392b;
   --color-impact: #cc785c;
   --color-insight: #6b6a64;
@@ -256,6 +264,11 @@
   --color-secondary: #1c1a17;
   --color-secondary-foreground: #e8e4d7;
   --color-text-dim: #87847b;
+  /* DESIGN.md semantic palette — dark-mode overrides (mirror the light block
+     above; values from DESIGN.md "Dark mode" subsection). */
+  --color-warn: #D8A35A;
+  --color-bad: #D26478;
+  --color-info: #7CC1C7;
   --accent: #d68a6f;
   --accent-bright: #e08a6c;
   --accent-soft: rgba(214, 138, 111, 0.16);


### PR DESCRIPTION
Tier 2c of the dashboard-UI review (after #503 critical bundle, #504 `.h-section` sweep, #505 token discipline). **6 items in one bundle** — token plumbing prerequisite, FindingsMetrics severity swap, SVG fontFamily fix, 2 a11y fixes, 1 correctness bug.

## Changes (6 files, +40/−13 lines)

### 1. `globals.css` — plumb DESIGN.md semantic palette into Tailwind v4 `@theme`
| Token | Light | Dark |
|---|---|---|
| `--color-warn` | `#B47A2A` | `#D8A35A` |
| `--color-bad` | `#A53A4A` | `#D26478` |
| `--color-info` | `#3F8B86` | `#7CC1C7` |

Enables `bg-warn / text-bad / border-info / bg-warn/10` etc. Hex literals (not `var()` aliases) so Tailwind opacity modifiers compose correctly at build time.

### 2. `FindingsMetrics.tsx` — swap raw Tailwind palette → semantic tokens
| Site | Was | Now |
|---|---|---|
| `SEVERITY_FILTERS[critical]` | `text-red-400/*` | `text-bad/*` |
| `SEVERITY_FILTERS[medium]` | `text-yellow-400/*` | `text-warn/*` |
| `SEVERITY_CLS[critical]` | `text-red-400 bg-red-500/10` | `text-bad bg-bad/10` |
| `SEVERITY_CLS[medium]` | `text-yellow-400 bg-yellow-500/10` | `text-warn bg-warn/10` |
| `typeCls suggestion` | `text-blue-400 bg-blue-500/10` | `text-info bg-info/10` |
| `typeCls insight` | `text-zinc-400 bg-zinc-500/10` | `text-text-dim bg-text-dim/10` |
| identifier badge `:134` | `bg-blue-500/10 ... text-blue-400` | `bg-info/10 ... text-info` |

**Intentionally NOT touched:** `CITE_STYLES` (cite-file blue / cite-fn purple are syntax-highlighting categories, no DESIGN.md mapping — deferred).

### 3. `ConsensusFlow.tsx` — SVG `fontFamily` attribute → `style` prop (3 sites)
`fontFamily="var(--font-mono)"` is an SVG **presentation attribute**; CSS custom properties don't resolve in SVG attrs on some renderers (Firefox ≤120, export/print paths) and silently fell back to default monospace. Moved into the inline `style` prop at `:241`, `:268`, `:300`. At `:268` merged into the existing style object that already had `fontVariant: 'small-caps'`.

### 4. `SeverityMixStrip.tsx` — add `role="img"` + `aria-label` (2 divs)
Severity distribution was previously conveyed only via `title` (sighted-hover-only, **inaccessible to keyboard/screen-reader users**). Empty-state + full-state divs both annotated.

### 5. `AgentCardBig.tsx` — `aria-label` on BENCHED / STRUGGLING / KEPT badges
`data-tooltip` is CSS-only (`::after` pseudo) and inaccessible. Screen readers were reading just "BENCHED" with no context. Now they hear the full tooltip reason.

### 6. `ActivityWaterfall.tsx` — fix factually-wrong "fleet idle" when `runs == null`
`bucketActivity(runs ?? [])` produced `fleetTotal = 0` and the component rendered *"No active dispatches — fleet idle"* even when relay was disconnected and we had no run data at all. Now: when `runs == null` AND `fleetTotal === 0`, shows *"Run data unavailable — relay may be disconnected"* instead.

## Verification
- ✅ `npx tsc --noEmit -p packages/dashboard-v2` clean
- ✅ `npm run build:mcp` exit 0
- ✅ 0 remaining `text-red-400 / text-yellow-400 / bg-red-500 / bg-yellow-500` in `FindingsMetrics` (on swapped sites)
- ✅ 0 remaining `fontFamily="..."` SVG attributes in `ConsensusFlow`

## Tier 2d (final piece — saved for next)
DESIGN.md **error contract sweep**: `RecentSignalsPeek` / `SkillGraduationGrid` / `FindingDetailDrawer` → chip-bad top-right + 50% dimmed stale data; `ActivityWaterfall` `error` prop wiring from `OverviewPage` (it's currently dead-code). Behavioral UX — deserves its own care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)