### PR TITLE
fix(dashboard): DESIGN.md error contract sweep — ErrorChip + 50% stale data (tier 2d)

### DIFF
--- a/packages/dashboard-v2/src/components/ErrorChip.tsx
+++ b/packages/dashboard-v2/src/components/ErrorChip.tsx
@@ -1,0 +1,37 @@
+/**
+ * DESIGN.md "Error" state contract — full-card chip in mono small with the
+ * error reason. Sits next to the section header (top-right of the card) so
+ * stale cached data underneath can render at 50% opacity, signaling
+ * "we know this is potentially out of date" without destroying the user's
+ * context.
+ *
+ * Used by RecentSignalsPeek / SkillGraduationGrid / FindingDetailDrawer.
+ * Consumers are responsible for the opacity dim on the cached data; this
+ * component only provides the chip itself.
+ *
+ * Pairs with role="alert" so screen readers announce the error inline; the
+ * leading `!` is decorative (aria-hidden) to keep the SR text clean.
+ */
+
+interface ErrorChipProps {
+  message: string;
+  /** Tailwind classes appended to the chip — e.g. ml-auto / mt-1 for positioning. */
+  className?: string;
+}
+
+export function ErrorChip({ message, className }: ErrorChipProps) {
+  return (
+    <span
+      role="alert"
+      className={`inline-flex items-center gap-1 rounded-sm px-2 py-0.5 font-mono text-[10px] ${className ?? ''}`}
+      style={{
+        color: 'var(--bad)',
+        background: 'color-mix(in oklch, var(--bad) 12%, transparent)',
+        border: '1px solid color-mix(in oklch, var(--bad) 30%, transparent)',
+      }}
+    >
+      <span aria-hidden style={{ fontWeight: 700 }}>!</span>
+      <span>error · {message}</span>
+    </span>
+  );
+}

--- a/packages/dashboard-v2/src/components/FindingDetailDrawer.tsx
+++ b/packages/dashboard-v2/src/components/FindingDetailDrawer.tsx
@@ -3,6 +3,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sh
 import { api } from '@/lib/api';
 import { timeAgo } from '@/lib/utils';
 import { CitationSnippet } from './CitationSnippet';
+import { ErrorChip } from './ErrorChip';
 import type { FindingDetail } from '@/lib/types';
 import { href } from '@/lib/router';
 
@@ -60,7 +61,7 @@ export function FindingDetailDrawer({ open, onOpenChange, consensusId, findingId
           <SheetTitle className="font-mono text-sm" style={{ color: 'var(--text)' }}>Finding detail</SheetTitle>
         </SheetHeader>
 
-        {error && <div className="mt-4 text-[11px] text-disputed">{error}</div>}
+        {error && <div className="mt-4"><ErrorChip message={error} /></div>}
         {!error && !detail && <div className="mt-4 text-[11px]" style={{ color: 'var(--text-dim)' }}>Loading…</div>}
 
         {detail && (

--- a/packages/dashboard-v2/src/components/RecentSignalsPeek.tsx
+++ b/packages/dashboard-v2/src/components/RecentSignalsPeek.tsx
@@ -3,6 +3,7 @@ import type React from 'react';
 import { api } from '@/lib/api';
 import { timeAgo } from '@/lib/utils';
 import { navigate } from '@/lib/router';
+import { ErrorChip } from './ErrorChip';
 import type { SignalEntry } from '@/lib/types';
 
 interface SignalsResponse {
@@ -109,6 +110,7 @@ export function RecentSignalsPeek() {
         >
           all signals →
         </button>
+        {err && <ErrorChip message={err} className="ml-2" />}
       </header>
 
       <div className="rounded-lg border border-border" style={{ background: 'var(--surface-elev)' }}>
@@ -156,12 +158,18 @@ export function RecentSignalsPeek() {
             </table>
           </div>
         )}
-        {err && <p className="px-4 py-3 text-xs" style={{ color: 'var(--text-dim)' }}>unavailable</p>}
+        {/* DESIGN.md error contract — when err is set we render the cached
+            items (already preserved in state, since setItems is only called
+            on a successful fetch) dimmed at 50% so the operator still sees
+            their context. The full error reason lives in the header ErrorChip. */}
         {!err && items && items.length === 0 && (
           <p className="px-4 py-3 text-xs" style={{ color: 'var(--text-dim)' }}>no signals recorded</p>
         )}
-        {!err && items && items.length > 0 && (
-          <table className="w-full">
+        {err && (!items || items.length === 0) && (
+          <p className="px-4 py-3 text-xs" style={{ color: 'var(--text-dim)' }}>no cached signals to display</p>
+        )}
+        {items && items.length > 0 && (
+          <table className="w-full" style={err ? { opacity: 0.5 } : undefined}>
             <thead>
               <tr className="border-b border-border">
                 <th className="h-section py-2 pl-4 pr-3 text-left" style={{ fontSize: 10, width: 80 }}>time</th>

--- a/packages/dashboard-v2/src/components/SkillGraduationGrid.tsx
+++ b/packages/dashboard-v2/src/components/SkillGraduationGrid.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import type { SkillsApiResponse, SkillEffectivenessEntry, SkillStatus } from '@gossip/types';
 import { SkillEffectivenessSparkline } from './SkillEffectivenessSparkline';
+import { ErrorChip } from './ErrorChip';
 import { href } from '@/lib/router';
 import { agentColor } from '@/lib/utils';
 
@@ -94,6 +95,7 @@ export function SkillGraduationGrid({ skills, loading, error }: Props) {
         >
           skill detail →
         </a>
+        {error && <ErrorChip message={error} className="ml-2" />}
       </header>
 
       <div
@@ -105,7 +107,12 @@ export function SkillGraduationGrid({ skills, loading, error }: Props) {
           Verdict is from the latest evidence window.
         </p>
 
-        {error && <ErrorBanner message={error} />}
+        {/* DESIGN.md error contract — full error reason lives in the header
+            ErrorChip; here we render the cached grid dimmed at 50% so the
+            operator keeps their context instead of seeing a destructive
+            full-width banner that replaces the data. The legacy ErrorBanner
+            is no longer used; kept in the file for compatibility but
+            unreferenced. */}
         {loading && !skills && <GridSkeleton />}
         {!loading && total === 0 && !error && (
           <p className="text-[12px]" style={{ color: 'var(--ink-3)' }}>
@@ -113,7 +120,10 @@ export function SkillGraduationGrid({ skills, loading, error }: Props) {
           </p>
         )}
         {total > 0 && (
-          <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6">
+          <ul
+            className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6"
+            style={error ? { opacity: 0.5 } : undefined}
+          >
             {known.map((entry) => (
               <SkillCard key={cellKey(entry)} entry={entry} />
             ))}
@@ -331,20 +341,10 @@ function latestValue(curve: SkillEffectivenessEntry['curve']): number | null {
 
 /* ── states ────────────────────────────────────────────────────────────── */
 
-function ErrorBanner({ message }: { message: string }) {
-  return (
-    <div
-      className="mb-3 rounded-sm px-2 py-1 font-mono text-[10px]"
-      style={{
-        color: 'var(--bad)',
-        background: 'color-mix(in oklch, var(--bad) 12%, transparent)',
-        border: '1px solid color-mix(in oklch, var(--bad) 30%, transparent)',
-      }}
-    >
-      error · {message}
-    </div>
-  );
-}
+// Legacy ErrorBanner removed in favor of the shared ErrorChip in the header
+// per DESIGN.md error contract — the error reason lives top-right of the
+// card and the cached grid below dims to 50% so the operator keeps context
+// instead of seeing a full-width destructive banner replace the data.
 
 function GridSkeleton() {
   return (


### PR DESCRIPTION
Tier 2d of the dashboard-UI review (after #503 critical bundle, #504 `.h-section` sweep, #505 token discipline, #506 semantic tokens + SVG + a11y). The DESIGN.md "Error" state contract — **chip-bad at top-right with the error reason in mono small + cached data dimmed at 50% so the operator keeps context** — was missing across the dashboard. Three components either replaced the data with a destructive banner, or just showed plain dimmed text and let the data disappear.

## New file
**`components/ErrorChip.tsx`** — single source of truth for the chip.
- `role="alert"` so screen readers announce the error inline
- Leading `!` is `aria-hidden` decorative
- Small mono pill in `var(--bad)` with a soft tinted fill

## Sites swapped to `ErrorChip` + 50% data preservation

### 1. `RecentSignalsPeek.tsx`
- Header now renders `ErrorChip` on `err` (next to "all signals →").
- The standalone `"unavailable"` `<p>` is gone.
- **Signals table renders even when `err` is set** (items already preserved in state — `setItems` only fires on a successful `.then`), dimmed to `opacity: 0.5`. If there are genuinely no cached items, a *"no cached signals to display"* placeholder appears instead.

### 2. `SkillGraduationGrid.tsx`
- Header gets `ErrorChip` on error (next to "skill detail →").
- Inline full-width `ErrorBanner` (replacing the grid) is gone — including the now-dead local function.
- **Skill grid renders even when error is set**, dimmed to `opacity: 0.5`, so the operator keeps the latest-known skill cards on screen while investigating the fetch failure.

### 3. `FindingDetailDrawer.tsx`
- Replaced inline `text-disputed` text with `ErrorChip`.
- Drawer doesn't cache data across openings, so no dim is applied.
- Loading skeleton is **deferred** (structural drawer layout change; designer flagged but out of scope here).

## Scope discipline
- `ActivityWaterfall` `error`-prop wiring from `OverviewPage` is **not** in this PR. Requires exposing error state from the parent data hooks and is structurally upstream. The component's existing `error` prop will render correctly when callers eventually pass it (`WaterfallShell` already handles it).
- Loading skeleton in `FindingDetailDrawer` deferred.

## Verification
- ✅ `npx tsc --noEmit -p packages/dashboard-v2` clean
- ✅ `npm run build:mcp` exit 0
- ✅ `ErrorBanner` function + reference fully removed from `SkillGraduationGrid`

## Closes the tier-2 dashboard-UI review chain

| | Status |
|---|---|
| #503 (tier 1 critical bundle) | merged `33458c89` |
| #504 (tier 2a `.h-section` sweep) | merged `da0de31b` |
| #505 (tier 2b token discipline) | merged `0c8cc88d` |
| #506 (tier 2c semantic + SVG + a11y) | merged `1da134a8` |
| **#507 (tier 2d error contract)** | this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)