### PR TITLE
fix(dashboard): re-source Overview 24h activity from flat signal log (heatmap idle-while-signals-exist bug)

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -502,7 +502,7 @@ function FindingsPage({
 
 function Dashboard() {
   const route = useRoute();
-  const { overview, agents, tasks, consensus, consensusReports, fleetTrend, skills, loading, refresh } = useDashboardData();
+  const { overview, agents, tasks, consensus, consensusReports, fleetTrend, signalActivity, skills, loading, refresh } = useDashboardData();
   const [activeTaskCount, setActiveTaskCount] = useState(0);
 
   const handleWsEvent = useCallback((event: DashboardEvent) => {
@@ -552,6 +552,7 @@ function Dashboard() {
         consensus={consensus}
         consensusReports={consensusReports}
         fleetTrend={fleetTrend}
+        signalActivity={signalActivity}
         skills={skills}
         activeTaskCount={activeTaskCount}
         setActiveTaskCount={setActiveTaskCount}

--- a/packages/dashboard-v2/src/components/ActivityWaterfall.tsx
+++ b/packages/dashboard-v2/src/components/ActivityWaterfall.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { AgentData, ConsensusRun } from '@/lib/types';
+import type { AgentData, SignalActivityResponse } from '@/lib/types';
 import { agentColor } from '@/lib/utils';
 
 /** 24h activity waterfall — per-agent heatmap of signal volume by hour.
@@ -8,6 +8,13 @@ import { agentColor } from '@/lib/utils';
  *  empty state. Each agent gets a row of 24 cells (one per hour of the
  *  rolling 24h window ending now). Cell intensity = signal volume in that
  *  hour relative to the row's max.
+ *
+ *  Data source: the flat per-agent signal histogram from
+ *  /api/signal-activity (server-bucketed from agent-performance.jsonl over a
+ *  rolling 24h window). This reflects ALL signal activity — manual
+ *  gossip_signals(record) and single-dispatch signals included — NOT just
+ *  gated consensus runs (the consensus-runs feed requires ≥2 agents & ≥3
+ *  signals, so it dropped manual/solo activity to zero here previously).
  *
  *  State coverage per DESIGN.md "State coverage" subsection:
  *    - Full:    matrix rendered with shaded cells
@@ -19,30 +26,28 @@ import { agentColor } from '@/lib/utils';
  */
 interface ActivityWaterfallProps {
   agents: AgentData[];
-  runs: ConsensusRun[] | null | undefined;
+  activity: SignalActivityResponse | null | undefined;
   loading?: boolean;
   error?: string | null;
 }
 
 const HOURS = 24;
-const NOW_OFFSET_MS = 60 * 60 * 1000;
-const WINDOW_MS = HOURS * NOW_OFFSET_MS;
 
-/** Compute a per-agent 24-hour signal-count matrix from consensus runs.
- *  Bucket index 0 = oldest (24h ago), HOURS-1 = current hour. */
-function bucketActivity(runs: ConsensusRun[], agents: AgentData[], nowMs: number): Map<string, number[]> {
+/** Build a per-agent 24-hour signal-count matrix from the server-bucketed
+ *  signal-activity histogram. Bucket index 0 = oldest hour, HOURS-1 = current.
+ *  Every agent in `agents` is zero-filled; server buckets are copied in,
+ *  clamped/padded to exactly HOURS so a malformed row can't break the grid. */
+function bucketActivity(
+  activity: SignalActivityResponse | null | undefined,
+  agents: AgentData[],
+): Map<string, number[]> {
   const out = new Map<string, number[]>();
   for (const a of agents) out.set(a.id, new Array(HOURS).fill(0));
-  const cutoffMs = nowMs - WINDOW_MS;
-  for (const run of runs) {
-    if (run.retracted) continue;
-    const ts = Date.parse(run.timestamp);
-    if (isNaN(ts) || ts < cutoffMs || ts > nowMs) continue;
-    const bucket = Math.min(HOURS - 1, Math.floor((ts - cutoffMs) / NOW_OFFSET_MS));
-    for (const sig of run.signals ?? []) {
-      const row = out.get(sig.agentId);
-      if (row) row[bucket] += 1;
-    }
+  for (const entry of activity?.agents ?? []) {
+    const row = out.get(entry.id);
+    if (!row) continue;
+    const src = entry.buckets ?? [];
+    for (let i = 0; i < HOURS; i++) row[i] = src[i] ?? 0;
   }
   return out;
 }
@@ -71,16 +76,13 @@ const LEVEL_OPACITY: Record<0 | 1 | 2 | 3 | 4, number> = {
 // previous local switch duplicated the 7-agent table and hardcoded a fallback
 // hex, risking silent drift if globals.css identity tokens changed.
 
-export function ActivityWaterfall({ agents, runs, loading = false, error = null }: ActivityWaterfallProps) {
-  const nowMs = Date.now();
+export function ActivityWaterfall({ agents, activity, loading = false, error = null }: ActivityWaterfallProps) {
   // Memoize the bucket computation — re-runs only when the underlying data
-  // changes, not on every parent re-render.
+  // changes, not on every parent re-render. The 24h window is computed
+  // server-side, so this is a pure copy/zero-fill (no Date math here).
   const buckets = useMemo(
-    () => bucketActivity(runs ?? [], agents, nowMs),
-    // nowMs intentionally excluded — bucketing is recomputed on data changes,
-    // not wall-clock ticks (each hour boundary would re-render but that's fine).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [runs, agents],
+    () => bucketActivity(activity, agents),
+    [activity, agents],
   );
 
   // Per-row totals for the right-side count column.
@@ -119,13 +121,13 @@ export function ActivityWaterfall({ agents, runs, loading = false, error = null 
     );
   }
 
-  // Fleet has agents but no activity in the last 24h, OR run data is missing
-  // (runs == null). Distinguish the two so a disconnected relay doesn't
-  // misreport as "fleet idle" — the latter is factually wrong when we never
-  // received run data at all.
+  // Fleet has agents but no activity in the last 24h, OR activity data is
+  // missing (activity == null). Distinguish the two so a disconnected relay
+  // doesn't misreport as "fleet idle" — the latter is factually wrong when we
+  // never received activity data at all.
   if (fleetTotal === 0) {
-    const message = runs == null
-      ? 'Run data unavailable — relay may be disconnected. Showing idle rows from the agent registry.'
+    const message = activity == null
+      ? 'Activity data unavailable — relay may be disconnected. Showing idle rows from the agent registry.'
       : 'No active dispatches — fleet idle.';
     return (
       <WaterfallShell error={error} fleetTotal={0}>

--- a/packages/dashboard-v2/src/hooks/useDashboardData.ts
+++ b/packages/dashboard-v2/src/hooks/useDashboardData.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { api } from '@/lib/api';
-import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, MemoryFile, FleetTrendResponse } from '@/lib/types';
+import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, MemoryFile, FleetTrendResponse, SignalActivityResponse } from '@/lib/types';
 import type { SkillsApiResponse } from '@gossip/types';
 
 /**
@@ -22,6 +22,13 @@ export interface DashboardState {
   consensus: ConsensusData | null;
   consensusReports: ConsensusReportsData | null;
   fleetTrend: FleetTrendResponse | null;
+  /**
+   * 24h per-agent signal-activity histogram from the flat signal log. Backs
+   * the Overview ActivityWaterfall heatmap + "Signals · 24h" counter, which
+   * previously under-reported because they were sourced from gated consensus
+   * runs. Null while the first poll is in flight.
+   */
+  signalActivity: SignalActivityResponse | null;
   /**
    * Step 9.5 — per-skill post-bind effectiveness curves. Drives the
    * SkillGraduationGrid sparklines + skill-count subtitle. Null while
@@ -53,6 +60,7 @@ export function useDashboardData() {
   const [state, setState] = useState<DashboardState>({
     overview: null, agents: null, tasks: null, consensus: null, consensusReports: null,
     fleetTrend: null,
+    signalActivity: null,
     skills: null,
     nativeMemories: null, gossipMemories: null, memories: null,
     loading: true, error: null,
@@ -67,7 +75,7 @@ export function useDashboardData() {
     if (inFlight.current) return;
     inFlight.current = true;
     try {
-      const [overview, agents, tasks, consensus, consensusReports, fleetTrend, skills, nativeResp, gossipResp] = await Promise.all([
+      const [overview, agents, tasks, consensus, consensusReports, fleetTrend, signalActivity, skills, nativeResp, gossipResp] = await Promise.all([
         api<OverviewData>('overview'),
         api<AgentData[]>('agents'),
         api<TasksData>('tasks?limit=2000'),
@@ -80,6 +88,10 @@ export function useDashboardData() {
         api<ConsensusReportsData>('consensus-reports?page=1&pageSize=200').catch(() => ({ reports: [] })),
         // Fleet trend — 7-day window for AreaSparkline in AgentCardBig.
         api<FleetTrendResponse>('fleet-trend?days=7').catch(() => ({ days: 7, points: [] })),
+        // 24h per-agent signal-activity histogram from the flat signal log —
+        // backs the ActivityWaterfall heatmap so manual/single-dispatch signals
+        // appear (consensus-runs feed is gated to ≥2 agents & ≥3 signals).
+        api<SignalActivityResponse>('signal-activity').catch(() => ({ agents: [], total: 0, generatedAt: '' })),
         // Step 9.5 — per-skill effectiveness curves for SkillGraduationGrid.
         // Server-side 60s cache keyed on agent-performance.jsonl mtime — the
         // 5s poll just refreshes the cache stamp, not the curve derivation.
@@ -104,6 +116,7 @@ export function useDashboardData() {
       setState({
         overview, agents, tasks, consensus, consensusReports,
         fleetTrend,
+        signalActivity,
         skills,
         nativeMemories,
         gossipMemories,

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -36,6 +36,13 @@ export interface FleetTrendResponse {
   points: FleetTrendPoint[];
 }
 
+/* ── 24h signal-activity histogram (flat signal log, not consensus runs) ── */
+export interface SignalActivityResponse {
+  agents: { id: string; buckets: number[] }[];
+  total: number;
+  generatedAt: string;
+}
+
 /* ── Step 9.5 — skills + post-bind effectiveness curves ───────────────── */
 // SkillCurvePoint, SkillEffectivenessEntry, SkillsApiResponse, SkillVerdict,
 // and SkillStatus are canonical in @gossip/types/skills. Re-exported here for

--- a/packages/dashboard-v2/src/pages/OverviewPage.tsx
+++ b/packages/dashboard-v2/src/pages/OverviewPage.tsx
@@ -18,7 +18,7 @@ import { useUrlRangeParam } from '@/hooks/useUrlRangeParam';
 import { useGlobalAgentKeys } from '@/hooks/useGlobalAgentKeys';
 import { isGraphHidden } from '@/lib/feature-flags';
 import { href } from '@/lib/router';
-import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, FleetTrendResponse, FleetTrendPoint } from '@/lib/types';
+import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, FleetTrendResponse, FleetTrendPoint, SignalActivityResponse } from '@/lib/types';
 import type { SkillsApiResponse } from '@gossip/types';
 
 interface OverviewPageProps {
@@ -31,6 +31,8 @@ interface OverviewPageProps {
   consensusReports?: ConsensusReportsData | null;
   /** Optional — Step 6: supplies 7d sparkline data for AgentCardBig. */
   fleetTrend?: FleetTrendResponse | null;
+  /** Optional — 24h per-agent signal histogram for the ActivityWaterfall heatmap. */
+  signalActivity?: SignalActivityResponse | null;
   /** Optional — Step 9.5: per-skill post-bind effectiveness curves. */
   skills?: SkillsApiResponse | null;
   activeTaskCount: number;
@@ -51,6 +53,7 @@ export function OverviewPage({
   consensus,
   consensusReports,
   fleetTrend,
+  signalActivity,
   skills,
   activeTaskCount,
   setActiveTaskCount,
@@ -178,7 +181,7 @@ export function OverviewPage({
       {agents && (
         <ActivityWaterfall
           agents={agents}
-          runs={consensus?.runs}
+          activity={signalActivity}
         />
       )}
 

--- a/packages/relay/src/dashboard/api-signal-activity.ts
+++ b/packages/relay/src/dashboard/api-signal-activity.ts
@@ -1,0 +1,74 @@
+import { join } from 'path';
+import { readJsonlWithRotated } from '@gossip/orchestrator';
+
+/**
+ * Per-agent 24h signal-activity histogram, sourced from the FLAT signal log
+ * (`.gossip/agent-performance.jsonl`) rather than from gated consensus runs.
+ *
+ * Why this exists: the Overview waterfall previously derived its heatmap from
+ * the /api/consensus runs feed, which is gated to ≥2 agents & ≥3 signals
+ * (api-consensus.ts). Manually-recorded signals and single-dispatch signals
+ * never reach that feed, so the heatmap + "Signals · 24h" counter under-reported
+ * to zero while the Signal stream (api-signals.ts) showed activity. This handler
+ * mirrors the api-signals inclusion rules so the numbers agree.
+ */
+export interface SignalActivityResponse {
+  agents: { id: string; buckets: number[] }[];
+  total: number;
+  generatedAt: string;
+}
+
+const HOURS = 24;
+const HOUR_MS = 3600_000;
+
+export async function signalActivityHandler(projectRoot: string): Promise<SignalActivityResponse> {
+  const now = Date.now();
+  const cutoff = now - HOURS * HOUR_MS;
+  const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+
+  // Per-agent length-24 bucket arrays, lazily created on first sighting.
+  const byAgent = new Map<string, number[]>();
+
+  try {
+    const raw = readJsonlWithRotated(perfPath);
+    // readJsonlWithRotated returns '' (never null) when both the live and
+    // rotated logs are absent/unreadable; '' is falsy so this also covers an
+    // existing-but-empty file. Either way there is nothing to bucket.
+    if (!raw) return { agents: [], total: 0, generatedAt: new Date(now).toISOString() };
+    const lines = raw.trim().split('\n').filter(Boolean);
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line);
+        // Same inclusion rules as the Signal stream (api-signals.ts) so the
+        // counters agree: only consensus-type rows, drop round-retraction
+        // tombstones and the `_system` sentinel.
+        if (entry.type !== 'consensus') continue;
+        if (entry.signal === 'consensus_round_retracted' || entry.agentId === '_system') continue;
+        if (typeof entry.agentId !== 'string' || !entry.agentId) continue;
+
+        const ts = Date.parse(entry.timestamp);
+        if (Number.isNaN(ts) || ts < cutoff || ts > now) continue;
+
+        // 0 = oldest hour in the window, 23 = current hour.
+        const idx = Math.min(HOURS - 1, Math.floor((ts - cutoff) / HOUR_MS));
+        let row = byAgent.get(entry.agentId);
+        if (!row) {
+          row = new Array(HOURS).fill(0);
+          byAgent.set(entry.agentId, row);
+        }
+        row[idx] += 1;
+      } catch { /* skip malformed */ }
+    }
+  } catch {
+    return { agents: [], total: 0, generatedAt: new Date().toISOString() };
+  }
+
+  let total = 0;
+  const agents: { id: string; buckets: number[] }[] = [];
+  for (const [id, buckets] of byAgent) {
+    for (const c of buckets) total += c;
+    agents.push({ id, buckets });
+  }
+
+  return { agents, total, generatedAt: new Date(now).toISOString() };
+}

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -11,6 +11,7 @@ import { gossipMemoryHandler } from './api-gossip-memory';
 import { consensusHandler } from './api-consensus';
 import { consensusFlowHandler, isValidConsensusId } from './api-consensus-flow';
 import { signalsHandler } from './api-signals';
+import { signalActivityHandler } from './api-signal-activity';
 import { findingHandler } from './api-finding';
 import { openFindingsHandler } from './api-open-findings';
 import { learningsHandler } from './api-learnings';
@@ -341,6 +342,12 @@ export class DashboardRouter {
 
       if (url === '/dashboard/api/signals' && req.method === 'GET') {
         const data = await signalsHandler(this.projectRoot, query ?? undefined);
+        this.json(res, 200, data);
+        return true;
+      }
+
+      if (url === '/dashboard/api/signal-activity' && req.method === 'GET') {
+        const data = await signalActivityHandler(this.projectRoot);
         this.json(res, 200, data);
         return true;
       }

--- a/tests/relay/api-signal-activity.test.ts
+++ b/tests/relay/api-signal-activity.test.ts
@@ -1,0 +1,154 @@
+import { signalActivityHandler } from '../../packages/relay/src/dashboard/api-signal-activity';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+interface SeedRec {
+  type?: string;
+  signal: string;
+  agentId: string;
+  counterpartId?: string;
+  source?: string;
+  timestamp: string;
+}
+
+function seed(recs: SeedRec[]): string {
+  const root = mkdtempSync(join(tmpdir(), 'gossip-test-sig-activity-'));
+  mkdirSync(join(root, '.gossip'), { recursive: true });
+  const lines = recs
+    .map((r) => JSON.stringify({ type: 'consensus', ...r }))
+    .join('\n') + '\n';
+  writeFileSync(join(root, '.gossip', 'agent-performance.jsonl'), lines);
+  return root;
+}
+
+// Writes raw lines verbatim (no JSON wrapping) so tests can inject malformed
+// JSONL, blank lines, or records with an explicit non-consensus `type`.
+function seedRaw(rawLines: string[]): string {
+  const root = mkdtempSync(join(tmpdir(), 'gossip-test-sig-activity-raw-'));
+  mkdirSync(join(root, '.gossip'), { recursive: true });
+  writeFileSync(join(root, '.gossip', 'agent-performance.jsonl'), rawLines.join('\n') + '\n');
+  return root;
+}
+
+const HOUR_MS = 3600_000;
+const iso = (msAgo: number) => new Date(Date.now() - msAgo).toISOString();
+
+function totalFor(res: { agents: { id: string; buckets: number[] }[] }, id: string): number {
+  const a = res.agents.find((x) => x.id === id);
+  return a ? a.buckets.reduce((s, n) => s + n, 0) : 0;
+}
+
+describe('signalActivityHandler — flat signal log 24h histogram', () => {
+  it('counts a MANUAL single-agent signal (the regression)', async () => {
+    // A manually-recorded signal: source:"manual", one agentId, no consensus
+    // round. The old consensus-runs path (≥2 agents & ≥3 signals) would drop
+    // this to zero — it MUST appear here.
+    const root = seed([
+      { signal: 'unique_confirmed', agentId: 'solo-agent', source: 'manual', timestamp: iso(2 * HOUR_MS) },
+    ]);
+    const res = await signalActivityHandler(root);
+    expect(res.total).toBe(1);
+    expect(totalFor(res, 'solo-agent')).toBe(1);
+    expect(res.agents.find((a) => a.id === 'solo-agent')?.buckets).toHaveLength(24);
+  });
+
+  it('skips _system sentinel and consensus_round_retracted rows', async () => {
+    const root = seed([
+      { signal: 'agreement', agentId: 'real-agent', timestamp: iso(1 * HOUR_MS) },
+      { signal: 'consensus_round_retracted', agentId: '_system', timestamp: iso(1 * HOUR_MS) },
+      { signal: 'some_round_signal', agentId: '_system', timestamp: iso(1 * HOUR_MS) },
+    ]);
+    const res = await signalActivityHandler(root);
+    expect(res.total).toBe(1);
+    expect(res.agents.map((a) => a.id)).toEqual(['real-agent']);
+  });
+
+  it('excludes entries older than the 24h window', async () => {
+    const root = seed([
+      { signal: 'agreement', agentId: 'old-agent', timestamp: iso(25 * HOUR_MS) },
+      { signal: 'agreement', agentId: 'recent-agent', timestamp: iso(1 * HOUR_MS) },
+    ]);
+    const res = await signalActivityHandler(root);
+    expect(res.total).toBe(1);
+    expect(res.agents.map((a) => a.id)).toEqual(['recent-agent']);
+  });
+
+  it('lands a recent signal in the last bucket (index 23)', async () => {
+    // A signal within the current hour falls into the newest bucket.
+    const root = seed([
+      { signal: 'agreement', agentId: 'now-agent', timestamp: iso(60_000) },
+    ]);
+    const res = await signalActivityHandler(root);
+    const buckets = res.agents.find((a) => a.id === 'now-agent')?.buckets ?? [];
+    expect(buckets).toHaveLength(24);
+    expect(buckets[23]).toBe(1);
+    expect(buckets.slice(0, 23).every((n) => n === 0)).toBe(true);
+  });
+
+  it('returns empty shape when the log is absent', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossip-test-sig-activity-empty-'));
+    const res = await signalActivityHandler(root);
+    expect(res.agents).toEqual([]);
+    expect(res.total).toBe(0);
+    expect(typeof res.generatedAt).toBe('string');
+  });
+
+  it('excludes non-consensus type rows (only type==="consensus" counts)', async () => {
+    const root = seedRaw([
+      JSON.stringify({ type: 'state', signal: 'agreement', agentId: 'state-agent', timestamp: iso(1 * HOUR_MS) }),
+      JSON.stringify({ type: 'consensus', signal: 'agreement', agentId: 'real-agent', timestamp: iso(1 * HOUR_MS) }),
+    ]);
+    const res = await signalActivityHandler(root);
+    expect(res.total).toBe(1);
+    expect(res.agents.map((a) => a.id)).toEqual(['real-agent']);
+  });
+
+  it('skips malformed JSONL lines without throwing', async () => {
+    const root = seedRaw([
+      '{ this is not valid json',
+      '',
+      JSON.stringify({ type: 'consensus', signal: 'agreement', agentId: 'good-agent', timestamp: iso(1 * HOUR_MS) }),
+    ]);
+    const res = await signalActivityHandler(root);
+    expect(res.total).toBe(1);
+    expect(totalFor(res, 'good-agent')).toBe(1);
+  });
+
+  it('excludes future-dated entries (ts > now)', async () => {
+    const root = seed([
+      // iso(-HOUR_MS) → timestamp one hour in the future.
+      { signal: 'agreement', agentId: 'future-agent', timestamp: iso(-1 * HOUR_MS) },
+      { signal: 'agreement', agentId: 'recent-agent', timestamp: iso(1 * HOUR_MS) },
+    ]);
+    const res = await signalActivityHandler(root);
+    expect(res.total).toBe(1);
+    expect(res.agents.map((a) => a.id)).toEqual(['recent-agent']);
+  });
+
+  it('aggregates multiple agents into independent per-agent buckets', async () => {
+    const root = seed([
+      { signal: 'agreement', agentId: 'agent-a', timestamp: iso(60_000) },       // ~now → bucket 23
+      { signal: 'agreement', agentId: 'agent-a', timestamp: iso(60_000) },       // second hit, same bucket
+      { signal: 'agreement', agentId: 'agent-b', timestamp: iso(12 * HOUR_MS) }, // ~12h ago → middle bucket
+    ]);
+    const res = await signalActivityHandler(root);
+    expect(res.total).toBe(3);
+    expect(totalFor(res, 'agent-a')).toBe(2);
+    expect(totalFor(res, 'agent-b')).toBe(1);
+    // agent-a concentrated in the newest bucket; agent-b nowhere near it.
+    expect(res.agents.find((a) => a.id === 'agent-a')?.buckets[23]).toBe(2);
+    expect(res.agents.find((a) => a.id === 'agent-b')?.buckets[23]).toBe(0);
+  });
+
+  it('counts a record with counterpartId once (by agentId only — no double count)', async () => {
+    const root = seed([
+      { signal: 'agreement', agentId: 'primary', counterpartId: 'other', timestamp: iso(1 * HOUR_MS) },
+    ]);
+    const res = await signalActivityHandler(root);
+    expect(res.total).toBe(1);
+    expect(totalFor(res, 'primary')).toBe(1);
+    // counterpartId must NOT get its own row.
+    expect(res.agents.find((a) => a.id === 'other')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem (user-reported)

The Overview **"Agent · 24h activity"** heatmap + **"Signals · 24h"** counter render all-empty / zero even while signals are actively being recorded (the Signal-stream widget shows them, e.g. "+7 in last hour"). Two widgets, two data sources:

| Widget | Source |
|--------|--------|
| Signal stream | flat signal log — `api('signals')`, ungated (`RecentSignalsPeek.tsx`) |
| 24h activity heatmap + counter | `consensus?.runs` — **consensus rounds only** (`ActivityWaterfall` ← `OverviewPage`) |

`/consensus` builds runs by grouping `agent-performance.jsonl` then **gating to `agents.size >= 2 && taskSignals.length >= 3`** (`api-consensus.ts:121`). So manual `gossip_signals(record)` and single `gossip_run` dispatches — which never form a ≥2-agent/≥3-signal round — are dropped from the heatmap entirely. A workflow built on single dispatches + manual signals shows the waterfall as permanently idle while the stream shows live activity.

## Fix

Re-source the waterfall from the flat signal log so it reflects **all** signal activity, matching the stream.

- **New** `GET /dashboard/api/signal-activity` → `{ agents: [{ id, buckets: number[24] }], total, generatedAt }`. Reads `agent-performance.jsonl` with the **same inclusion rules as `api-signals.ts`** (`type==='consensus'`, skip `consensus_round_retracted` + `_system`), so heatmap total == stream reality. Rolling 24h, bucket idx 0 = oldest hour, 23 = current.
- **Re-wire** `ActivityWaterfall`: `runs` prop → `activity` histogram prop. Bucketing moves server-side; client zero-fills registry agents and clamps to 24 buckets. Header labels unchanged (now accurate).
- `useDashboardData` fetches the new endpoint with a `.catch` fallback; `App` → `OverviewPage` thread it through.

## Review & tests

3-agent consensus `81d9851a-9eeb4fcf` (sonnet-reviewer + gemini-reviewer + gemini-tester): **17 confirmed, 1 disputed, 0 hallucinations.** Bucket math verified off-by-one-free (`ts===cutoff`→idx 0, `ts===now`→idx 23 after `Math.min` clamp); fail-soft paths complete; server/client `SignalActivityResponse` shape-identical; no orphaned `runs` dependency. The one disputed finding (`Promise.all` `.catch` asymmetry) was verified **pre-existing**, not introduced here.

Test suite: **10 cases** — manual-signal regression, `_system`/retracted skip, non-consensus `type` exclusion, malformed JSONL, future-ts exclusion, 24h window, per-agent bucket isolation, `counterpartId`-not-double-counted.

**Gates:** `tsc` (relay + dashboard) clean · `vite build` clean · `jest` 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)