### PR TITLE
fix(dashboard): DESIGN.md token discipline — unverified-color bug + accent/shadow sweep

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -56,8 +56,11 @@ Restrained, semantic-strict. **One accent.** Every other color carries meaning.
 | `--ok` | `#2A6E4F` | `#DCEBE2` | confirmed, healthy, passed, positive delta (darkened from #2F7D5B to clear 4.5:1 for 11px chip text) |
 | `--warn` | `#B47A2A` | `#F2E4CC` | needs skills, drift, low confidence |
 | `--bad` | `#A53A4A` | `#EFD4D8` | disputed, hallucination, failed, critical |
-| `--info` | `#3F8B86` | `#D5E6E4` | unverified, neutral data viz default |
+| `--info` | `#3F8B86` | `#D5E6E4` | unverified status, neutral data viz default |
 | `--idle` | `#6B6862` | `#E5E0D7` | offline, dormant, silent skill |
+| `--severity-medium` | `#3E6DA8` | — | **medium** severity only (cool blue, NOT --info teal — see Decisions Log 2026-06-04) |
+
+Severity ramp (finding/signal lists, severity-mix strip): `--bad` critical → `--warn` high → `--severity-medium` low-blue → `--idle` low. `--info` teal is **status only** (unverified) and must never double as a severity color.
 
 ### Chart palette (multi-series ONLY)
 
@@ -442,3 +445,5 @@ Each PR ships a Lighthouse + axe-core report demonstrating WCAG AA compliance ma
 | 2026-05-24 | Revised v0 → v1 after design review (consensus 144335b4, sonnet-designer) | 10 findings + 1 suggestion + 1 insight. Critical: F1 token namespace collision (fixed via alias migration), F2 Geist not on Google Fonts (fixed by Step 0 + npm install). High: F3 added State Coverage subsection, F4 darkened `--ink-3` to #6B6862 / `--ok` to #2A6E4F / restricted `--ink-4` to non-text use, F5 added Responsive breakpoints. F9 expanded skill graduation to 6 states. F6/F7/F8/F10 folded into the revised application checklist (Steps 0/2/4/5/6/7 gates). S1 added prefers-reduced-motion rule. I1 acknowledged via new Step 2 (.h-section retroactive sweep) |
 | 2026-05-24 | v1.1 — Step 6 sub-bar / gauge / sparkline colors reverted from chart palette (`--c1/--c2/--c3`) to per-agent identity color (`agentColor(id)`) | The chart-palette mapping was a misreading of the original infographic-vocabulary intent. Per-agent identity flooding the data viz is what was shown in the approved Option C preview; only card chrome stays neutral. Status chip stays semantic. Caught during PR #471 visual review |
 | 2026-05-24 | v1.1 clarification — Fraunces is allowed for the gauge center % inside AgentCardBig | Strict reading of §Typography reserves Fraunces for routes/heroes; gauge center % is an explicit editorial-accent carve-out inside an otherwise Geist card. Caught and documented during PR #471 pre-merge consensus |
+| 2026-06-04 | Unified `unverified` status to `--info` teal everywhere (was rendering ochre `#b8741d` via `bg-unverified` utilities, teal via `var(--info)`) | Same status showed two colors across views; DESIGN.md row 59 defines unverified = `--info`. `--color-unverified` re-pointed to the `--info` hex in both themes (PR #509) |
+| 2026-06-04 | Introduced `--severity-medium` blue (`#3E6DA8` / `#6E9BD4`); moved `medium` severity off `--info` teal | The unverified-status unification made `medium` severity (also `--info` teal) collide with unverified status — one teal, two meanings, violating "status is always semantic." The warm ramp (rose/amber/gold) is fully consumed by critical/high + identity hues, and `--warn`'s dark value is already gold; a cool blue is the only non-colliding slot that preserves the original "medium = calm severity" intent. Updated `SeverityMixStrip`, `RecentSignalsPeek`, `SignalsPage`. `--info` is now status-only. Deferred follow-up: pre-existing `hover:bg-accent/30-40` washes (convention is `/10`) in `AgentActivityTimeline`/`AgentPage`/`TaskRow`/`SystemPulse` |

--- a/packages/dashboard-v2/src/components/AgentActivityTimeline.tsx
+++ b/packages/dashboard-v2/src/components/AgentActivityTimeline.tsx
@@ -112,7 +112,7 @@ export function AgentActivityTimeline({ agentId }: Props) {
                   key={i}
                   type="button"
                   onClick={() => setDrawer({ consensusId: s.consensusId!, findingId: s.findingId! })}
-                  className="w-full rounded-sm text-left transition hover:bg-accent/40"
+                  className="w-full rounded-sm text-left transition hover:bg-accent/10"
                 >
                   {row}
                 </button>

--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -485,7 +485,7 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
                                 key={j}
                                 type="button"
                                 onClick={() => setDrawerFinding({ consensusId: run.taskId, findingId: sig.findingId! })}
-                                className="block w-full rounded-sm text-left transition hover:bg-accent/40"
+                                className="block w-full rounded-sm text-left transition hover:bg-accent/10"
                               >{row}</button>
                             );
                           }

--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -281,7 +281,7 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
         {/* Left: Metrics — bars + compact stat strip */}
         <div>
           <h2 className="mb-3 h-section">Metrics</h2>
-          <div className="rounded-lg border border-border/40 p-4 shadow-[inset_0_1px_3px_rgba(0,0,0,0.35)]" style={{ background: 'color-mix(in oklch, var(--surface-elev) 80%, transparent)' }}>
+          <div className="rounded-lg border border-border/40 p-4" style={{ background: 'color-mix(in oklch, var(--surface-elev) 80%, transparent)' }}>
             <div className="space-y-2.5">
               {metricBars.map(m => (
                 <div key={m.label} className="grid grid-cols-[72px_1fr_44px] items-center gap-3">
@@ -558,7 +558,7 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
                     onClick={() => setExpandedMem(isOpen ? null : mem.filename)}
                     className="flex w-full items-center gap-2 p-3 text-left transition hover:bg-accent/10"
                   >
-                    <span className="font-mono text-xs" style={{ color: isOpen ? 'var(--accent)' : 'var(--text-dim)' }}>
+                    <span className="font-mono text-xs" style={{ color: isOpen ? 'var(--text)' : 'var(--text-dim)' }}>
                       {isOpen ? '\u25BE' : '\u25B8'}
                     </span>
                     <span className="shrink-0 rounded-sm px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase" style={{ background: 'var(--surface-sunk)', color: 'var(--text-dim)' }}>

--- a/packages/dashboard-v2/src/components/CircuitAlerts.tsx
+++ b/packages/dashboard-v2/src/components/CircuitAlerts.tsx
@@ -64,7 +64,10 @@ export function CircuitAlerts({ agents }: CircuitAlertsProps) {
               }`}
             >
               <div className="mb-1 flex items-center gap-2.5">
-                <span className={`h-1.5 w-1.5 rounded-full ${isBenched ? 'bg-destructive shadow-[0_0_6px_rgba(248,113,113,0.6)]' : 'bg-unverified'}`} />
+                <span
+                  className={`h-1.5 w-1.5 rounded-full ${isBenched ? 'bg-destructive' : 'bg-unverified'}`}
+                  style={isBenched ? { boxShadow: '0 0 6px color-mix(in oklch, var(--bad) 60%, transparent)' } : undefined}
+                />
                 <span className="text-sm font-semibold" style={{ color: 'var(--text)' }}>{agent.id}</span>
                 {r.label && (
                   <span className={`shrink-0 rounded-sm px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase ${r.cls}`}>

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -475,7 +475,7 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
                   ${isRetracted ? 'opacity-60 line-through decoration-disputed/40' : ''}
                   ${isExpanded
                     ? 'border-r-border/60 border-t-border/60 border-b-border/60'
-                    : 'hover:border-r-border/60 hover:border-t-border/60 hover:border-b-border/60 hover:shadow-sm hover:shadow-black/20 hover:-translate-y-px'
+                    : 'hover:border-r-border/60 hover:border-t-border/60 hover:border-b-border/60 hover:-translate-y-px'
                   }`}
                 style={{ background: isExpanded ? 'var(--surface-elev)' : 'color-mix(in oklch, var(--surface-elev) 50%, transparent)' }}
                 data-retracted={isRetracted ? 'true' : undefined}

--- a/packages/dashboard-v2/src/components/LogsPage.tsx
+++ b/packages/dashboard-v2/src/components/LogsPage.tsx
@@ -26,7 +26,7 @@ interface LogsResponse {
 // @theme build-time resolution and remain theme-switchable at runtime.
 const CATEGORY_STYLES: Record<string, React.CSSProperties> = {
   dispatch: { color: 'color-mix(in oklch, var(--text-dim) 80%, transparent)' },
-  consensus: { color: 'color-mix(in oklch, var(--accent) 70%, transparent)' },
+  consensus: { color: 'color-mix(in oklch, var(--info) 80%, transparent)' },
   error: {},   // uses text-disputed class, no override
   timeout: {}, // uses text-unverified class, no override
   worker: { color: 'color-mix(in oklch, var(--text-dim) 70%, transparent)' },
@@ -203,7 +203,7 @@ export function LogsPage() {
             onClick={() => setAutoScroll(!autoScroll)}
             className="rounded-sm px-2.5 py-1 font-mono text-[10px] font-semibold transition"
             style={autoScroll
-              ? { color: 'var(--accent)', background: 'color-mix(in oklch, var(--accent) 10%, transparent)' }
+              ? { color: 'var(--ok)', background: 'color-mix(in oklch, var(--ok) 10%, transparent)' }
               : { color: 'var(--text-dim)' }}
           >
             {autoScroll ? '⤓ Auto' : '⤓ Scroll'}

--- a/packages/dashboard-v2/src/components/MemoryDialog.tsx
+++ b/packages/dashboard-v2/src/components/MemoryDialog.tsx
@@ -15,14 +15,25 @@ interface MemoryDialogProps {
  *
  * Visual shell mirrors docs/designs/memory-brain-v3.html lines 235-292:
  *   - Narrow (~576px), vertically centered
- *   - Primary-faint ring shadow for the "floating card" feel
+ *   - Hairline overlay elevation (--shadow-overlay) for the "floating card" feel
  *   - Close glyph inline with tag + title in a single header row
  *   - Section headers colored primary, not muted
  */
+// Per-type chip token — source of truth is MemoryFolders TYPE_ACCENT_STYLE
+// (backlog = "open, needs action" → --warn amber, NOT the brand accent; there
+// is no DESIGN.md carve-out granting --accent to backlog). Every type uses a
+// neutral/semantic token so the chip never dilutes the brand accent.
+const CHIP_COLOR: Record<string, string> = {
+  backlog: 'var(--warn)',
+  record: 'var(--text-dim)',
+  session: 'var(--success)',
+  rule: 'var(--warn)',
+};
+
 const dialogStyle: CSSProperties = {
   background: 'var(--surface-elev)',
   borderRadius: '16px',
-  boxShadow: 'var(--shadow-overlay), 0 0 0 3px var(--accent-soft)',
+  boxShadow: 'var(--shadow-overlay)',
   border: '1px solid var(--border)',
   color: 'var(--text)',
   fontFamily: 'var(--font-sans)',
@@ -45,6 +56,7 @@ export function MemoryDialog({ memory, onClose }: MemoryDialogProps) {
   if (!memory) return null;
 
   const display = toDisplayType(memory);
+  const chipColor = CHIP_COLOR[display] ?? 'var(--text-dim)';
   const owner = memory.agentId === '_project' ? 'project' : memory.agentId || 'unknown';
   const path = `.gossip/agents/${memory.agentId || '_project'}/memory/knowledge/${memory.filename}`;
   const ts = pickTimestamp(memory.frontmatter);
@@ -72,8 +84,12 @@ export function MemoryDialog({ memory, onClose }: MemoryDialogProps) {
           </div>
           <div className="flex items-center gap-2.5">
           <span
-            className="shrink-0 rounded-sm border border-primary/30 px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase tracking-[0.14em]"
-            style={{ background: 'color-mix(in oklch, var(--accent) 6%, transparent)', color: 'var(--accent)' }}
+            className="shrink-0 rounded-sm border px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase tracking-[0.14em]"
+            style={{
+              background: `color-mix(in oklch, ${chipColor} 6%, transparent)`,
+              borderColor: `color-mix(in oklch, ${chipColor} 30%, transparent)`,
+              color: chipColor,
+            }}
           >
             {display}
           </span>

--- a/packages/dashboard-v2/src/components/MemoryFolders.tsx
+++ b/packages/dashboard-v2/src/components/MemoryFolders.tsx
@@ -233,7 +233,7 @@ export function MemoryFolders({ memories, heading = 'Memory', statusFilter = fal
               className={`group relative grid grid-cols-[auto_1fr_auto] grid-rows-[auto_auto] items-center gap-x-3 gap-y-1 rounded-md border p-3.5 text-left transition ${
                 empty
                   ? 'cursor-default border-border/20 opacity-55'
-                  : 'border-border/40 hover:border-primary/30 hover:bg-accent/40'
+                  : 'border-border/40 hover:border-primary/30 hover:bg-accent/10'
               }`}
               style={{ background: 'var(--surface-sunk)' }}
             >
@@ -340,14 +340,14 @@ export function NativeMemories({ memories }: { memories: MemoryFile[] }) {
               <li key={m.filename}>
                 <button
                   onClick={() => setOpen(m)}
-                  className="flex w-full items-center justify-between gap-3 rounded-sm border border-border/20 px-3 py-2 text-left transition hover:border-primary/30 hover:bg-accent/40"
+                  className="flex w-full items-center justify-between gap-3 rounded-sm border border-border/20 px-3 py-2 text-left transition hover:border-primary/30 hover:bg-accent/10"
                   style={{ background: 'color-mix(in oklch, var(--surface-sunk) 40%, transparent)' }}
                 >
                   <span className="flex min-w-0 items-center gap-2">
                     {recent && (
                       <span
                         className="h-1.5 w-1.5 shrink-0 rounded-full"
-                        style={{ background: 'var(--accent)', boxShadow: '0 0 8px var(--accent)' }}
+                        style={{ background: 'var(--ok)', boxShadow: '0 0 6px color-mix(in oklch, var(--ok) 60%, transparent)' }}
                         aria-label="Activity in the last 24h"
                       />
                     )}

--- a/packages/dashboard-v2/src/components/MemoryTileGrid.tsx
+++ b/packages/dashboard-v2/src/components/MemoryTileGrid.tsx
@@ -13,14 +13,16 @@ interface MemoryTileGridProps {
 }
 
 const TYPE_ACCENT_STYLE: Record<DisplayType, React.CSSProperties> = {
-  backlog: { color: 'var(--accent)' },
+  // backlog = "open, needs action" → --warn amber (matches MemoryFolders);
+  // brand accent is reserved for brand/CTA/active-nav, not data classification.
+  backlog: { color: 'var(--warn)' },
   record: { color: 'var(--text-dim)' },
   session: { color: 'var(--success)' },
   rule: { color: 'var(--warn)' },
 };
 
 const TYPE_TAG_RING: Record<DisplayType, string> = {
-  backlog: 'border-[color-mix(in_oklch,var(--accent)_30%,transparent)] bg-[color-mix(in_oklch,var(--accent)_6%,transparent)]',
+  backlog: 'border-[color-mix(in_oklch,var(--warn)_30%,transparent)] bg-[color-mix(in_oklch,var(--warn)_6%,transparent)]',
   record: 'border-text-dim/30 bg-text-dim/[0.08]',
   session: 'border-confirmed/30 bg-confirmed/[0.06]',
   rule: 'border-unverified/30 bg-unverified/[0.06]',
@@ -77,7 +79,7 @@ export function MemoryTileGrid({ folder, memories, onBack, onOpen }: MemoryTileG
               <button
                 key={`${mem.agentId || ''}/${mem.filename}`}
                 onClick={() => onOpen(mem)}
-                className="group flex flex-col gap-1.5 rounded-md border [border-color:color-mix(in_oklch,var(--border)_40%,transparent)] p-3 text-left transition hover:[border-color:color-mix(in_oklch,var(--accent)_30%,transparent)] hover:bg-accent/40"
+                className="group flex flex-col gap-1.5 rounded-md border [border-color:color-mix(in_oklch,var(--border)_40%,transparent)] p-3 text-left transition hover:[border-color:color-mix(in_oklch,var(--accent)_30%,transparent)] hover:bg-accent/10"
                 style={{ background: 'var(--surface-sunk)' }}
               >
                 <span

--- a/packages/dashboard-v2/src/components/NotificationStack.tsx
+++ b/packages/dashboard-v2/src/components/NotificationStack.tsx
@@ -73,7 +73,7 @@ function ToastItem({
   return (
     <div
       className={[
-        'pointer-events-auto border rounded shadow-sm px-4 py-3 max-w-sm cursor-pointer',
+        'pointer-events-auto border rounded px-4 py-3 max-w-sm cursor-pointer',
         'transition-all duration-200',
         'motion-reduce:transition-none motion-reduce:transform-none',
         'hover:border-border',
@@ -81,7 +81,7 @@ function ToastItem({
           ? 'opacity-0 scale-95 opacity-0 translate-y-2'
           : 'opacity-100 scale-100 translate-x-0',
       ].join(' ')}
-      style={{ background: 'var(--surface-elev)' }}
+      style={{ background: 'var(--surface-elev)', boxShadow: 'var(--shadow-card)' }}
       onClick={handleClick}
       onMouseEnter={clearTimer}
       onMouseLeave={startTimer}

--- a/packages/dashboard-v2/src/components/RecentSignalsPeek.tsx
+++ b/packages/dashboard-v2/src/components/RecentSignalsPeek.tsx
@@ -38,7 +38,7 @@ const VERDICT_COLOR: Record<string, string> = {
 const SEVERITY_TICK_COLOR: Record<string, string> = {
   critical: 'var(--bad)',
   high: 'var(--warn)',
-  medium: 'var(--info)',
+  medium: 'var(--severity-medium)',
   low: 'var(--ink-3)',
 };
 

--- a/packages/dashboard-v2/src/components/SeverityMixStrip.tsx
+++ b/packages/dashboard-v2/src/components/SeverityMixStrip.tsx
@@ -20,7 +20,7 @@ interface SeverityMixStripProps {
 const SEGMENT_COLORS: Record<keyof SeverityCount, string> = {
   critical: 'var(--bad)',
   high: 'var(--warn)',
-  medium: 'var(--info)',
+  medium: 'var(--severity-medium)',
   low: 'var(--idle)',
 };
 

--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -85,7 +85,7 @@ const VERDICT_COLOR: Record<string, string> = {
 const SEVERITY_TICK_COLOR: Record<string, string> = {
   critical: 'var(--bad)',
   high: 'var(--warn)',
-  medium: 'var(--info)',
+  medium: 'var(--severity-medium)',
   low: 'var(--ink-3)',
 };
 

--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -172,7 +172,7 @@ export function SystemPulse({ overview, activeTasks, mode = 'dense', showActivit
           </div>
           <a
             href={href('/signals?signal=disagreement&signal=hallucination_caught&signal=new_finding')}
-            className="block cursor-pointer border-t border-border transition-colors hover:bg-accent/30"
+            className="block cursor-pointer border-t border-border transition-colors hover:bg-accent/10"
             aria-label="View actionable findings on Signals page"
           >
             <BigStat

--- a/packages/dashboard-v2/src/components/TaskDetailModal.tsx
+++ b/packages/dashboard-v2/src/components/TaskDetailModal.tsx
@@ -41,8 +41,8 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
       onClick={onClose}
     >
       <div
-        className="relative mt-12 w-full max-w-3xl rounded-lg border border-border shadow-2xl"
-        style={{ background: 'var(--surface-elev)' }}
+        className="relative mt-12 w-full max-w-3xl rounded-lg border border-border"
+        style={{ background: 'var(--surface-elev)', boxShadow: 'var(--shadow-overlay)' }}
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/packages/dashboard-v2/src/components/TaskRow.tsx
+++ b/packages/dashboard-v2/src/components/TaskRow.tsx
@@ -130,7 +130,7 @@ export function TaskRow({ task, onClick }: TaskRowProps) {
 
   return (
     <tr
-      className={`border-b border-border hover:bg-accent/30 transition-colors ${onClick ? 'cursor-pointer' : ''}`}
+      className={`border-b border-border hover:bg-accent/10 transition-colors ${onClick ? 'cursor-pointer' : ''}`}
       onClick={onClick ? (e) => {
         if ((e.target as HTMLElement).closest('a')) return;
         onClick(task);

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -142,6 +142,12 @@
   --bad-soft: #EFD4D8;
   --info: #3F8B86;
   --info-soft: #D5E6E4;
+  /* Medium severity. Was mapped to --info teal, which collided with the
+     unverified STATUS token (both teal) once --color-unverified was unified to
+     --info. A distinct cool blue keeps "medium = the calm severity" while
+     freeing --info to mean only unverified/info. Severity ramp: --bad rose
+     (critical) → --warn amber (high) → --severity-medium blue → --idle slate (low). */
+  --severity-medium: #3E6DA8;
   --idle: #6B6862;
   --idle-soft: #E5E0D7;
   /* Chart palette (multi-series ONLY — never for status) */
@@ -312,6 +318,7 @@
   --bad-soft: #3A1C22;
   --info: #7CC1C7;
   --info-soft: #1A2729;
+  --severity-medium: #6E9BD4;
   --idle: #807A71;
   --idle-soft: #2A2722;
   /* Chart palette stays identical across themes (semantically same hues). */

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -53,7 +53,11 @@
 
   --color-confirmed: #1a7e5e;
   --color-disputed: #c0392b;
-  --color-unverified: #b8741d;
+  /* unverified = --info teal per DESIGN.md:59 (status palette). Hex-literal
+     (not var(--color-info)) so Tailwind v4 opacity modifiers compose at build.
+     Was #b8741d ochre, which collided with --warn and rendered unverified two
+     different colors across the dashboard. Dark override below mirrors --color-info. */
+  --color-unverified: #3F8B86;
   --color-unique: #7c5cbf;
   /* DESIGN.md semantic palette exposed as Tailwind utilities so components
      can use bg-warn / text-bad / border-info / bg-warn/10 etc. instead of
@@ -269,6 +273,7 @@
   --color-warn: #D8A35A;
   --color-bad: #D26478;
   --color-info: #7CC1C7;
+  --color-unverified: #7CC1C7;
   --accent: #d68a6f;
   --accent-bright: #e08a6c;
   --accent-soft: rgba(214, 138, 111, 0.16);


### PR DESCRIPTION
DESIGN.md token-discipline sweep across the dashboard, in three parts.

## 1. Unverified status rendered two different colors (real bug)

`bg-unverified` / `text-unverified` resolved to `--color-unverified: #b8741d` (ochre), but every `var(--info)` usage rendered teal. So the **same "unverified" status** showed **orange** in `FindingsMetrics`/`AgentPage`/`SignalTimeline` and **teal** in `RecentSignalsPeek`/`ConsensusFlow`/`SignalsPage`. DESIGN.md:59 defines unverified = `--info` teal.

Fix: re-point `--color-unverified` to `#3F8B86` (light) / `#7CC1C7` (dark — no dark override existed before), exactly matching `--color-info`.

## 2. Accent dilution + raw drop shadows

DESIGN.md reserves terracotta `--accent` for brand/CTA/active-nav and forbids default drop shadows. Swept:

| Component | Change |
|-----------|--------|
| TaskDetailModal | `shadow-2xl` → `var(--shadow-overlay)` |
| AgentPage | inset card shadow removed; memory chevron open-state `--accent` → `--text` |
| FindingsMetrics | `hover:shadow-sm` removed |
| MemoryDialog | accent ring removed; type chip `--accent` → per-type semantic token |
| MemoryTileGrid | backlog token + tag-ring `--accent` → `--warn`; `hover:bg-accent/40` → `/10` |
| MemoryFolders | activity dot `--accent` → `--ok`; folder-card + list hover `/40` → `/10` |
| LogsPage | consensus category `--accent` → `--info`; auto-scroll active → `--ok` |
| NotificationStack | raw `shadow-sm` → `var(--shadow-card)` |
| CircuitAlerts | raw `rgba()` glow → `color-mix(var(--bad))` (theme-aware) |

## 3. medium-severity ↔ unverified teal collision (follow-on from part 1)

Unifying unverified→`--info` teal made `medium` severity (also `--info` teal) collide with unverified status — one teal, two meanings, violating "status is always semantic." The warm severity zone (rose/amber/gold) is fully consumed by critical/high + per-agent identity hues, and `--warn`'s **dark** value (#D8A35A) is already gold (so gold collides with `high` in dark mode). A cool **blue** is the only non-colliding slot and preserves the original "medium = calm severity" intent.

Added `--severity-medium` (`#3E6DA8` / `#6E9BD4`); moved `medium` off `var(--info)` in `SeverityMixStrip`, `RecentSignalsPeek`, `SignalsPage`. Ramp is now `--bad` → `--warn` → `--severity-medium` → `--idle`; `--info` is status-only. DESIGN.md palette row + Decisions Log entries added.

## Review

Two rounds of `sonnet-designer` review (consensus `0b782ad7` + a re-confirm). The re-confirm **corrected a false premise**: there is no DESIGN.md carve-out granting `--accent` to the backlog category — `MemoryFolders`' `backlog → --warn` is the intended source of truth — and it caught a **missed** `MemoryFolders` folder-card hover. Both fixed here. (Note: the designer's `--c2` plum suggestion for medium was rejected — `--c2` is `sonnet-reviewer`'s identity hue; blue chosen instead.)

**Deferred follow-up:** pre-existing `hover:bg-accent/30-40` washes (convention is `/10`) in `AgentActivityTimeline`/`AgentPage`/`TaskRow`/`SystemPulse` — a small normalization pass, not introduced here.

**Gates:** `tsc` clean · `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)