### PR TITLE
feat(skills): implementation-discipline skill for implementer agents

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -754,7 +754,7 @@ async function doBoot() {
     // Implementer-only permanent defaults — bound to any agent whose id ends
     // in `-implementer`. Convention documented in .claude/rules/gossipcat.md.
     // Spec: docs/specs/2026-04-22-premise-verification.md (Component C).
-    const IMPLEMENTER_PERMANENT_DEFAULTS = ['verify-the-premise'];
+    const IMPLEMENTER_PERMANENT_DEFAULTS = ['verify-the-premise', 'implementation-discipline'];
     // Researcher/Reviewer permanent defaults — bound to any agent whose id
     // ends in `-researcher` or `-reviewer`. Disjoint from the implementer
     // filter: hybrid ids like `foo-researcher-implementer` match BOTH filters

--- a/packages/orchestrator/src/default-skills/implementation-discipline.md
+++ b/packages/orchestrator/src/default-skills/implementation-discipline.md
@@ -41,7 +41,10 @@ review — wins over the clever one.
 
 ## 3. Surgical changes
 - Edit only what the task requires. Do NOT "improve" adjacent code, comments, or
-  formatting, and do NOT refactor things that aren't broken.
+  formatting, and do NOT refactor things that aren't broken. (Exception: a minimal
+  refactor strictly necessary to land your change cleanly — e.g. extracting a
+  function you must call — is in scope, as long as it preserves existing behavior
+  and stays the minimum needed.)
 - Match the surrounding style even if you'd personally write it differently.
 - Remove imports / variables / functions that YOUR change orphaned. Do NOT
   delete pre-existing dead code unless the task asked for it.
@@ -68,5 +71,7 @@ review — wins over the clever one.
   review and inflate blast radius.
 - "I added config/an interface in case we need it later." You don't; delete it.
 - Dropping input validation at a boundary because the state "is impossible."
-- Self-certifying ("tests pass, done") in place of stating checkable criteria and
-  letting cross-review verify.
+- Self-certifying ("tests pass, done") as a substitute for stating checkable
+  criteria and letting cross-review verify. (This does NOT mean ignore a red test
+  — a failing test still blocks; cross-review is an added gate, not a replacement
+  for green tests.)

--- a/packages/orchestrator/src/default-skills/implementation-discipline.md
+++ b/packages/orchestrator/src/default-skills/implementation-discipline.md
@@ -1,0 +1,72 @@
+---
+name: implementation-discipline
+description: Coding-time discipline for implementer agents — think first, simplest change, surgical edits, stated success criteria.
+keywords: []
+category: implementation
+mode: permanent
+status: active
+---
+
+## When this skill activates
+Always — this is a permanent-mode skill for implementer agents. It governs HOW
+you write code, not WHAT to build. Premise-checking is a separate skill
+(`verify-the-premise`); run that first, then apply this.
+
+## Iron law
+Every line you change must trace to the dispatched task. Touch nothing else.
+The simplest change that satisfies the task — and survives a trust-boundary
+review — wins over the clever one.
+
+## 1. Think before coding
+- State the assumptions your implementation depends on. If an assumption is
+  load-bearing and unverified, check it (see `verify-the-premise`) or flag it.
+- If the task has more than one reasonable interpretation, do NOT pick silently.
+  Implement the most defensible one and name the alternative in your result so
+  the orchestrator can redirect cheaply.
+- If a materially simpler approach exists than the one implied by the task, say
+  so before building the complex one. Pushing back early is cheaper than a
+  rewrite after consensus.
+
+## 2. Simplicity first — with a trust-boundary carve-out
+- Minimum code that solves the task. No features, abstractions, config, or
+  "flexibility" that the task did not ask for. No abstraction for single-use code.
+- If 200 lines could be 50, rewrite before you submit.
+- **CARVE-OUT (do not skip):** "no error handling for impossible scenarios" does
+  NOT apply at trust boundaries. Any value that crossed an untrusted edge — MCP
+  tool input, an LLM/agent output, a file path or citation from a finding, a
+  parsed persisted record — must be validated even when the bad state "can't
+  happen." In this project, attackers (and buggy upstreams) make impossible
+  states real. Validate-and-fail-closed at the boundary is required simplicity,
+  not speculative complexity. (See the `trust-boundaries` skill.)
+
+## 3. Surgical changes
+- Edit only what the task requires. Do NOT "improve" adjacent code, comments, or
+  formatting, and do NOT refactor things that aren't broken.
+- Match the surrounding style even if you'd personally write it differently.
+- Remove imports / variables / functions that YOUR change orphaned. Do NOT
+  delete pre-existing dead code unless the task asked for it.
+- Spotting an adjacent bug or smell is valuable — but **cite it, don't fix it**.
+  Note it in your result (or as a finding) so the orchestrator can scope a
+  follow-up. Fixing it in this change is scope creep; reporting it is not.
+
+## 4. Stated success criteria
+- Before editing, restate the task as a verifiable goal and a brief numbered
+  plan with a per-step check. Example:
+  ```
+  1. Add the validator    → verify: npx tsc passes
+  2. Wire the call site    → verify: new unit test for invalid input is red→green
+  3. Cover the edge case   → verify: jest <path> all green
+  ```
+- "Add validation" becomes "write tests for invalid inputs, then make them pass."
+  Strong, checkable criteria let you finish without round-trips.
+- Do NOT treat self-passing tests as final sign-off — your output is verified by
+  peer cross-review against the actual code, not by your own green run. State the
+  criteria, meet them, then report; the consensus loop confirms.
+
+## Anti-patterns
+- Drive-by refactors bundled into a feature change — they hide the real diff from
+  review and inflate blast radius.
+- "I added config/an interface in case we need it later." You don't; delete it.
+- Dropping input validation at a boundary because the state "is impossible."
+- Self-certifying ("tests pass, done") in place of stating checkable criteria and
+  letting cross-review verify.


### PR DESCRIPTION
Adds a permanent-mode default skill, `implementation-discipline`, auto-bound to every `-implementer` agent. It codifies coding-time discipline distilled from a 3-agent consensus review of the external [`andrej-karpathy-skills`](https://github.com/forrestchang/andrej-karpathy-skills) rules — adopting the *ideas* (MIT, public) in our own words rather than importing the file, plugin, or fork.

## Why not just install the upstream repo

Consensus round `f2ad00f6-ad8b4f50` (sonnet-reviewer + haiku-researcher + gemini-reviewer) flagged:
- 🔴 **`curl -o CLAUDE.md` install method** would silently overwrite our load-bearing orchestrator `CLAUDE.md` — critical.
- 🟠 The link everyone shares (`multica-ai/...`) is a **fork** of canonical `forrestchang/...`; the borrowed "Karpathy" name (README admits it's unaffiliated) is a halo effect.
- 🟡 A generic root `CLAUDE.md` is the **wrong vehicle** — it competes with our layered `.claude/rules/gossipcat.md` + skill system.

The rules themselves are sound, but they're **coding-time** disciplines → they belong on the agents who *write* code, not the orchestrator (the pivotal cross-review finding that resolved an initial reviewer disagreement).

## What the skill contains (with consensus amendments)

| Part | Adaptation |
|------|-----------|
| **Think first** | Defers premise-grepping to the existing `verify-the-premise` skill (no duplication); keeps state-assumptions / name-the-alternative / push-back-simpler. |
| **Simplicity first** | **+ trust-boundary carve-out:** "no error handling for impossible scenarios" does NOT apply to values crossing an untrusted edge (MCP input, LLM/agent output, file citations, parsed records). Both reviewers flagged the unqualified rule as dangerous in a security-conscious project. |
| **Surgical changes** | **+ "cite, don't fix" nuance:** reporting an adjacent issue is encouraged; fixing it in-scope is scope creep. Resolves the false "rule penalizes citing findings" friction. |
| **Stated success criteria** | The verifiable-goal + numbered-plan prefix **only**; drops the orchestrator-TDD-self-loop framing and notes peer cross-review (not self-passing tests) is the real sign-off. |

## Wiring

`IMPLEMENTER_PERMANENT_DEFAULTS` (`apps/cli/src/mcp-server-sdk.ts`) gains `implementation-discipline` alongside `verify-the-premise` — auto-binds via the `-implementer` suffix (HANDBOOK invariant #10). Ships in the npm `default-skills` bundle (`build:mcp` copies it).

## Gates

- `tsc` (apps/cli) clean
- `build:mcp` bundles the skill into `dist-mcp/default-skills/`
- skill-loader tests 37/37 (frontmatter parses)
- Exclusivity test (`emit-structured-claims` must not leak to implementers) unaffected — it mocks the skill index directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)