### PR TITLE
fix(orchestrator): catalog entries for permanent-default skills + reconcile hybrid-suffix test

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -22,7 +22,6 @@ const GEMINI_E2E_SUITES = [
 const KNOWN_BROKEN_SUITES = [
   'tests/cli/mcp-handlers\\.test\\.ts$',           // dispatch budget assertions
   'tests/cli/mcp-signals-validation\\.test\\.ts$', // signal schema edge cases
-  'tests/orchestrator/skill-catalog\\.test\\.ts$', // catalog shape drift
   'tests/orchestrator/consensus-e2e\\.test\\.ts$', // requires local .gossip/config.json fixture
   'tests/relay/dashboard-edge-cases\\.test\\.ts$', // dashboard API edges
 ];

--- a/packages/orchestrator/src/default-skills/catalog.json
+++ b/packages/orchestrator/src/default-skills/catalog.json
@@ -96,6 +96,30 @@
       "description": "IaC, containers, networking, monitoring, alerting, scaling, disaster recovery",
       "keywords": ["infra", "terraform", "kubernetes", "docker", "monitoring", "cloud", "networking"],
       "categories": ["infrastructure"]
+    },
+    {
+      "name": "memory-retrieval",
+      "description": "Call gossip_remember BEFORE reviewing — recall prior findings on the same code so you don't re-discover or contradict yourself",
+      "keywords": [],
+      "categories": ["review"]
+    },
+    {
+      "name": "verify-the-premise",
+      "description": "Grep-verify quantitative claims in the dispatch task BEFORE writing code.",
+      "keywords": [],
+      "categories": ["verification"]
+    },
+    {
+      "name": "implementation-discipline",
+      "description": "Coding-time discipline for implementer agents — think first, simplest change, surgical edits, stated success criteria.",
+      "keywords": [],
+      "categories": ["implementation"]
+    },
+    {
+      "name": "emit-structured-claims",
+      "description": "Emit a structured premise-claims JSON block alongside prose findings so the orchestrator can grep-verify code-shape claims and close the four Stage-1 bypass classes.",
+      "keywords": [],
+      "categories": ["review", "research"]
     }
   ]
 }

--- a/tests/cli/mcp-handlers.test.ts
+++ b/tests/cli/mcp-handlers.test.ts
@@ -1376,20 +1376,22 @@ describe('handleDispatchSingle — native skill injection', () => {
     expect(prompt).not.toContain('emit-structured-claims');
   });
 
-  it('hybrid *-researcher-implementer agent inherits BOTH emit-structured-claims AND verify-the-premise', async () => {
-    // Load-bearing invariant: disjoint suffix sets mean a hybrid id matches
-    // both filters and gets each suffix's defaults once. Simulates the post-
-    // seed SkillIndex state by declaring both skills enabled.
+  it('hybrid *-researcher-implementer agent inherits implementer defaults ONLY, not emit-structured-claims', async () => {
+    // Disjoint-suffix routing (permanent-defaults.ts seedPermanentDefaults):
+    // an id ending in `-implementer` routes ONLY to IMPLEMENTER_PERMANENT_DEFAULTS
+    // (verify-the-premise + implementation-discipline). `foo-researcher-implementer`
+    // does NOT end in `-researcher`/`-reviewer`, so emit-structured-claims is never
+    // seeded. Simulates the post-seed SkillIndex state with implementer defaults only.
     ctx.mainAgent = makeMainAgent({
       getSkillIndex: jest
         .fn()
-        .mockReturnValue(makeSkillIndex(['emit-structured-claims', 'verify-the-premise'])),
+        .mockReturnValue(makeSkillIndex(['verify-the-premise', 'implementation-discipline'])),
     });
     ctx.nativeAgentConfigs.set('foo-researcher-implementer', {
       model: 'claude-sonnet-4-6',
       instructions: 'Hybrid researcher-implementer.',
       description: 'Hybrid native agent',
-      skills: ['emit-structured-claims', 'verify-the-premise'],
+      skills: ['verify-the-premise', 'implementation-discipline'],
     });
     const result = await handleDispatchSingle(
       'foo-researcher-implementer',
@@ -1397,9 +1399,10 @@ describe('handleDispatchSingle — native skill injection', () => {
     );
     const prompt = result.content.find(c => c.text.startsWith('AGENT_PROMPT:'))?.text ?? '';
     expect(prompt).toContain('--- SKILLS ---');
-    expect(prompt).toContain('emit-structured-claims');
     expect(prompt).toContain('verify-the-premise');
-    expect(prompt).toContain('premise-claims');
+    expect(prompt).toContain('implementation-discipline');
+    expect(prompt).not.toContain('emit-structured-claims');
+    expect(prompt).not.toContain('premise-claims');
     expect(prompt.toLowerCase()).toContain('iron law');
   });
 });


### PR DESCRIPTION
Closes two `[PROSE-ONLY]` next-session ledger items. Both are small reconciliations against the permanent-defaults work that landed in #512.

## Item A — `catalog.json` missing permanent-default skill entries
`SkillCatalog.validate()` asserts every `.md` in `default-skills/` has a catalog entry. Four permanent-default skill files had none:
- `memory-retrieval` (global default)
- `verify-the-premise`, `implementation-discipline` (implementer defaults)
- `emit-structured-claims` (researcher/reviewer default)

This was the **sole** failure in `tests/orchestrator/skill-catalog.test.ts` ("catalog shape drift"). Added the 4 entries with **empty `keywords`** — these skills are suffix-routed permanent defaults, never task-keyword-matched, so empty keywords keeps `matchTask` from spuriously suggesting them in coverage warnings. Descriptions are verbatim from each file's frontmatter.

The suite is now **12/12 green** and removed from `KNOWN_BROKEN_SUITES`.

> Note: the ledger said "3 skills" — the actual missing set is **4** (`validate()` scans all `.md` files, not just `IMPLEMENTER_PERMANENT_DEFAULTS`).

## Item C — reconcile the semantically-wrong hybrid-suffix test
The `mcp-handlers.test.ts` "hybrid both" test asserted an **impossible** post-seed state: that `foo-researcher-implementer` inherits *both* `emit-structured-claims` AND `verify-the-premise`. It passed only because it mocked the `SkillIndex` to force both skills on — documenting behavior that contradicts shipped disjoint-suffix routing (`permanent-defaults.ts`: an id ending in `-implementer` routes **only** to `IMPLEMENTER_PERMANENT_DEFAULTS`).

Rewrote it to assert implementer-only inheritance (`verify-the-premise` + `implementation-discipline`, **not** `emit-structured-claims`). The `.not.toContain('premise-claims')` assertion proves the disjoint boundary (`premise-claims` is unique to `emit-structured-claims.md`).

`mcp-handlers.test.ts` **stays** in `KNOWN_BROKEN_SUITES` — 6 unrelated skill-injection/fixture failures remain (separate scope).

## Verification
- `jest tests/orchestrator/skill-catalog.test.ts` → **12/12 passed**
- `RUN_KNOWN_BROKEN=1 jest tests/cli/mcp-handlers.test.ts -t "hybrid"` → **passes**
- Full `mcp-handlers.test.ts` → **6 failed / 57 passed**, identical to pre-change (no regression)
- `tsc --noEmit` → no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)