### PR TITLE
test(cli): un-break mcp-handlers suite — reconcile 6 stale assertions

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -20,7 +20,6 @@ const GEMINI_E2E_SUITES = [
 //
 // Set RUN_KNOWN_BROKEN=1 locally when actively fixing one of them.
 const KNOWN_BROKEN_SUITES = [
-  'tests/cli/mcp-handlers\\.test\\.ts$',           // dispatch budget assertions
   'tests/cli/mcp-signals-validation\\.test\\.ts$', // signal schema edge cases
   'tests/orchestrator/consensus-e2e\\.test\\.ts$', // requires local .gossip/config.json fixture
   'tests/relay/dashboard-edge-cases\\.test\\.ts$', // dashboard API edges

--- a/tests/cli/mcp-handlers.test.ts
+++ b/tests/cli/mcp-handlers.test.ts
@@ -133,8 +133,11 @@ describe('PerformanceWriter — gossip_signals backing store', () => {
       },
     ]);
 
-    const raw = readFileSync(join(testDir, '.gossip', 'agent-performance.jsonl'), 'utf-8').trim();
-    const parsed = JSON.parse(raw);
+    // appendSignals with a consensusId also appends a `_meta`/`round_counter_bumped`
+    // line (round-counter.ts Option C), so the file is 2 lines — parse the signal row.
+    const lines = readFileSync(join(testDir, '.gossip', 'agent-performance.jsonl'), 'utf-8')
+      .trim().split('\n').filter(Boolean).map((l: string) => JSON.parse(l));
+    const parsed = lines.find((r: { type?: string }) => r.type !== '_meta');
     expect(parsed.findingId).toBe('4c88bcd3-00cf4810:gemini-reviewer:f1');
     expect(parsed.consensusId).toBe('4c88bcd3-00cf4810');
     expect(parsed.severity).toBe('high');
@@ -412,14 +415,20 @@ describe('handleCollect', () => {
 
 describe('handleNativeRelay', () => {
   let testDir: string;
+  let previousCwd: string;
 
   beforeEach(() => {
+    previousCwd = process.cwd();
     testDir = makeTmpDir('relay');
     resetCtx({}, testDir);
+    // emitCompletionSignals writes to process.cwd()/.gossip (native-tasks.ts:700);
+    // align cwd with testDir so signals land in the test sandbox, not the real repo.
+    process.chdir(testDir);
   });
 
   afterEach(() => {
     restoreCtx();
+    process.chdir(previousCwd);
     rmSync(testDir, { recursive: true, force: true });
   });
 
@@ -911,7 +920,7 @@ describe('persistNativeTaskMap + restore', () => {
     expect(data.tasks['t1'].agentId).toBe('claude-reviewer');
   });
 
-  it('persists result metadata but strips full result text (slim format)', () => {
+  it('persists result metadata, truncating full result text to 50k on disk (slim format)', () => {
     const now = Date.now();
     const longResult = 'x'.repeat(100_000);
     ctx.nativeResultMap.set('r1', {
@@ -925,8 +934,9 @@ describe('persistNativeTaskMap + restore', () => {
     const filePath = join(testDir, '.gossip', 'native-tasks.json');
     const data = JSON.parse(readFileSync(filePath, 'utf-8'));
     expect(data.results['r1']).toBeDefined();
-    // Full result text is not stored — only status metadata
-    expect(data.results['r1'].result).toBeUndefined();
+    // Disk copy is truncated to 50k chars (native-tasks.ts:320), not stripped entirely;
+    // the full result stays in memory.
+    expect(data.results['r1'].result).toBe('x'.repeat(50_000));
     expect(data.results['r1'].status).toBe('completed');
   });
 
@@ -1210,7 +1220,9 @@ describe('handleDispatchSingle — native skill injection', () => {
     });
 
     const result = await handleDispatchSingle('native-claude', 'Audit the memory system');
-    const text = result.content[0].text;
+    // Skills live in the AGENT_PROMPT content item, not the orchestrator-instructions
+    // item (content[0]) — two-item native dispatch split.
+    const text = result.content.find(c => c.text.startsWith('AGENT_PROMPT:'))?.text ?? '';
     expect(text).toContain('--- SKILLS ---');
     expect(text).toContain('memory-retrieval');
     expect(text).toContain('Recall past findings');
@@ -1250,7 +1262,7 @@ describe('handleDispatchSingle — native skill injection', () => {
     const result = await handleDispatchConsensus([
       { agent_id: 'native-claude', task: 'Audit memory' },
     ]);
-    const text = result.content[0].text;
+    const text = result.content.find(c => c.text.startsWith('AGENT_PROMPT:'))?.text ?? '';
     const skillsIdx = text.indexOf('--- SKILLS ---');
     const consensusIdx = text.indexOf('--- CONSENSUS OUTPUT FORMAT ---');
     expect(skillsIdx).toBeGreaterThan(-1);
@@ -1274,7 +1286,8 @@ describe('handleDispatchSingle — native skill injection', () => {
     });
 
     const result = await handleDispatchSingle('native-claude', 'Audit memory');
-    expect(result.content[0].text).toContain('[Context truncated to fit budget]');
+    const agentPrompt = result.content.find(c => c.text.startsWith('AGENT_PROMPT:'))?.text ?? '';
+    expect(agentPrompt).toContain('[Context truncated to fit budget]');
   });
 
   it('verify-the-premise skill appears in *-implementer agent prompt when bound', async () => {


### PR DESCRIPTION
Closes the next-session ledger item: *"`tests/cli/mcp-handlers.test.ts` — 6 skill-injection/fixture failures remain in KNOWN_BROKEN_SUITES; need targeted triage."*

A read-only triage (sonnet-reviewer) classified all 6 failures as **TEST-DRIFT** — production behavior is correct, the assertions were stale. **No production code changed**, so no consensus round was required. Each claim was independently verified against source before fixing.

## The 6 failures
| # | Test | Root cause | Fix |
|---|------|-----------|-----|
| 1 | preserves findingId/consensusId | `appendSignals` appends a 2nd `_meta`/`round_counter_bumped` JSONL line when `consensusId` present (round-counter.ts Option C) | parse the non-`_meta` signal row, not the whole file |
| 2 | emits format_compliance meta-signal | `emitCompletionSignals` writes to `process.cwd()/.gossip` (`native-tasks.ts:700`); test checked `testDir` (never written) — and was silently polluting the **real** repo's `agent-performance.jsonl` | `process.chdir(testDir)` in beforeEach/afterEach |
| 3 | strips full result text (slim) | `persistNativeTaskMap` truncates on-disk result to **50k chars** (`native-tasks.ts:320`), doesn't strip to `undefined` | expect the 50k truncation; title/comment corrected |
| 4–6 | skill-injection trio | after the two-item native-dispatch split (commit `ff237678`), the assembled prompt (SKILLS / CONSENSUS OUTPUT FORMAT / truncation sentinel) lives in the `AGENT_PROMPT` content item, not `content[0]` (the `REQUIRED_NEXT_ACTION` block) | switch to `content.find(c => c.text.startsWith('AGENT_PROMPT:'))` — the extraction the passing sibling tests already use |

Notably, **#2's fix also stops the test from polluting the real repo's signal log** on every run.

## Verification
- Suite **63/63 green by default** (no `RUN_KNOWN_BROKEN` flag) → removed from `KNOWN_BROKEN_SUITES` in `jest.config.base.js`
- Full `tests/cli`: **72 suites / 906 passed**, 8 skipped (remaining known-broken/e2e), no regressions
- Real `.gossip/agent-performance.jsonl` confirmed un-polluted after a test run

Remaining in `KNOWN_BROKEN_SUITES`: `mcp-signals-validation`, `consensus-e2e`, `dashboard-edge-cases` (separate items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)