### PR TITLE
feat(dashboard): FindingDetailDrawer loading skeleton

### DIFF
--- a/packages/dashboard-v2/src/components/FindingDetailDrawer.tsx
+++ b/packages/dashboard-v2/src/components/FindingDetailDrawer.tsx
@@ -41,6 +41,45 @@ const drawerStyle: CSSProperties = {
   fontFamily: 'var(--font-sans)',
 };
 
+function FindingDetailSkeleton() {
+  const cell = (h: string, w: string) => (
+    <div className={`${h} ${w} rounded`} style={{ background: 'var(--border)', opacity: 0.4 }} />
+  );
+  return (
+    <div className="mt-4 space-y-4" aria-busy="true">
+      {/* Chip row: tag + severity + "by agent" */}
+      <div className="flex items-center gap-2">
+        {cell('h-3.5', 'w-12')}
+        {cell('h-3.5', 'w-14')}
+        {cell('h-3.5', 'w-16')}
+      </div>
+      {/* Finding text: 3 stacked bars */}
+      <div className="space-y-2">
+        {cell('h-2', 'w-full')}
+        {cell('h-2', 'w-[92%]')}
+        {cell('h-2', 'w-[70%]')}
+      </div>
+      {/* Citations: label + block */}
+      <div className="space-y-2">
+        {cell('h-2', 'w-16')}
+        {cell('h-12', 'w-full')}
+      </div>
+      {/* Coverage: label + 2 rows */}
+      <div className="space-y-2">
+        {cell('h-2', 'w-16')}
+        {cell('h-2', 'w-[60%]')}
+        {cell('h-2', 'w-[45%]')}
+      </div>
+      {/* Signals: label + 2 rows */}
+      <div className="space-y-2">
+        {cell('h-2', 'w-20')}
+        {cell('h-2', 'w-full')}
+        {cell('h-2', 'w-[80%]')}
+      </div>
+    </div>
+  );
+}
+
 export function FindingDetailDrawer({ open, onOpenChange, consensusId, findingId }: Props) {
   const [detail, setDetail] = useState<FindingDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -62,7 +101,7 @@ export function FindingDetailDrawer({ open, onOpenChange, consensusId, findingId
         </SheetHeader>
 
         {error && <div className="mt-4"><ErrorChip message={error} /></div>}
-        {!error && !detail && <div className="mt-4 text-[11px]" style={{ color: 'var(--text-dim)' }}>Loading…</div>}
+        {!error && !detail && <FindingDetailSkeleton />}
 
         {detail && (
           <div className="mt-4 space-y-4">


### PR DESCRIPTION
Closes the last actionable next-session ledger item: *"`packages/dashboard-v2` FindingDetailDrawer loading skeleton not started."*

## Problem
`FindingDetailDrawer` showed a bare `Loading…` text label while fetching finding data — violating DESIGN.md **State Coverage** (line 282): *"Loading — skeleton shimmer using `--border` opacity 0.4 cells matching the full-state grid density. NO spinners. Skeletons should be the same shape as the full state so the layout doesn't shift on load."*

## Fix
Adds `FindingDetailSkeleton` — a static skeleton that mirrors the loaded layout section-for-section:
- chip row (3 cells) · finding-text (3 bars: full / 92% / 70%) · Citations (label + block) · Coverage (label + 2 rows) · Signals (label + 2 rows)

Built inside the **same `mt-4 space-y-4` container** as the loaded content, so data arrival causes **zero layout shift**. Cells use `var(--border)` at `opacity: 0.4` via a local `cell(h, w)` helper, **static (no `animate-pulse`)** following the `RecentSignalsPeek`/`ActivityWaterfall` precedent (which sidesteps the `prefers-reduced-motion` guard `ConsensusFlowSkeleton` needs). Root carries `aria-busy="true"`. No new tokens or hexes.

## Verification
- Dashboard `tsc --noEmit` clean; production `vite build` clean (97 modules)
- Injected-markup screenshots in **both light and dark themes** confirm a shape-matched, calm, legible skeleton with no spinner (renders the `--border` cells correctly in both themes)

`+40 / -1`, single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)