### PR TITLE
test: drain KNOWN_BROKEN_SUITES to empty — fix 3 parked suites

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -9,6 +9,9 @@ const GEMINI_E2E_SUITES = [
   'tests/orchestrator/project-init-e2e\\.test\\.ts$',
   'tests/orchestrator/cognitive-e2e\\.test\\.ts$',
   'tests/orchestrator/interactive-session-e2e\\.test\\.ts$',
+  // Real-LLM consensus e2e: needs a local .gossip/config.json + a google key in
+  // keychain/env. Not broken — env-gated like the other e2e suites above.
+  'tests/orchestrator/consensus-e2e\\.test\\.ts$',
 ];
 
 // Known-broken test suites, excluded from the default run so CI can ship a
@@ -19,11 +22,7 @@ const GEMINI_E2E_SUITES = [
 // burndown.
 //
 // Set RUN_KNOWN_BROKEN=1 locally when actively fixing one of them.
-const KNOWN_BROKEN_SUITES = [
-  'tests/cli/mcp-signals-validation\\.test\\.ts$', // signal schema edge cases
-  'tests/orchestrator/consensus-e2e\\.test\\.ts$', // requires local .gossip/config.json fixture
-  'tests/relay/dashboard-edge-cases\\.test\\.ts$', // dashboard API edges
-];
+const KNOWN_BROKEN_SUITES = [];
 
 module.exports = {
   testEnvironment: 'node',

--- a/tests/cli/mcp-signals-validation.test.ts
+++ b/tests/cli/mcp-signals-validation.test.ts
@@ -326,11 +326,12 @@ describe('hallucination → gap pipeline — no keyword match skips suggestion',
     const gapTracker = new SkillGapTracker(testDir);
     const category = runGapPipeline(gapTracker, {
       agentId: 'sonnet-reviewer',
-      evidence: 'The finding was completely fabricated with no recognizable pattern.',
+      evidence: 'The reviewer felt the change looked acceptable overall.',
       taskId: 'task-none-001',
     });
 
-    // 'pattern' and 'fabricated' are not in DEFAULT_KEYWORDS
+    // Evidence deliberately matches no CATEGORY_PATTERNS keyword (category-extractor.ts).
+    // (Avoids "fabricated"/"verify"/etc. which now map to citation_grounding.)
     expect(category).toBe('');
     const entries = readGapLog(testDir);
     expect(entries).toHaveLength(0);
@@ -568,7 +569,7 @@ describe('bulk_from_consensus — category assignment via bulkInferCategory', ()
     try {
       const writer = new PerformanceWriter(testDir);
       // Simulate what addSignal does when category is undefined
-      writer.appendSignals([{
+      writer[WRITER_INTERNAL].appendSignals([{
         type: 'consensus' as const,
         signal: 'agreement',
         agentId: 'agent-a',
@@ -683,7 +684,7 @@ describe('gossip_signals retraction validation', () => {
       const agent_id = 'haiku-researcher';
       const reason = 'Verified the finding was fabricated.';
 
-      writer.appendSignals([{
+      writer[WRITER_INTERNAL].appendSignals([{
         type: 'consensus' as const,
         taskId: task_id,
         signal: 'signal_retracted',

--- a/tests/orchestrator/consensus-e2e.test.ts
+++ b/tests/orchestrator/consensus-e2e.test.ts
@@ -8,6 +8,9 @@ import { createProvider } from '../../packages/orchestrator/src/llm-client';
 import { existsSync, readFileSync, unlinkSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { execFileSync } from 'child_process';
+// Static import preserves the `unique symbol` type so it can index PerformanceWriter
+// (a dynamic `await import` widens it to plain `symbol`, breaking the index access).
+import { WRITER_INTERNAL } from '../../packages/orchestrator/src/_writer-internal';
 
 const PROJECT_ROOT = process.cwd();
 // Use a temp directory for performance signals to avoid destroying production data
@@ -55,7 +58,6 @@ describe('Consensus Protocol E2E', () => {
     // the consensus engine directly with synthetic Phase 1 results
     const { ConsensusEngine } = await import('../../packages/orchestrator/src/consensus-engine');
     const { PerformanceWriter } = await import('../../packages/orchestrator/src/performance-writer');
-    const { WRITER_INTERNAL } = await import('../../packages/orchestrator/src/_writer-internal');
 
     // Use google provider for cross-review (same as agents)
     const apiKey = getKeyFromKeychain('google');

--- a/tests/relay/dashboard-edge-cases.test.ts
+++ b/tests/relay/dashboard-edge-cases.test.ts
@@ -21,29 +21,43 @@ describe('Dashboard API: Edge Cases', () => {
 
   describe('api-overview', () => {
     it('should count consensus runs from agent-performance signals', async () => {
+      // consensusRuns uses the "real consensus run" definition (api-overview.ts:278,
+      // mirrors api-consensus.ts:98): a run needs >=2 distinct agents AND >=3 signals.
+      // Two runs, each 3 signals across 3 agents, both qualify.
+      const ts = new Date().toISOString();
+      const sig = (taskId: string, signal: string, agentId: string) =>
+        JSON.stringify({ type: 'consensus', taskId, signal, agentId, timestamp: ts });
       const signals = [
-        JSON.stringify({ type: 'consensus', taskId: 'task-1', signal: 'agreement', agentId: 'a', timestamp: new Date().toISOString() }),
-        JSON.stringify({ type: 'consensus', taskId: 'task-1', signal: 'unique_confirmed', agentId: 'b', timestamp: new Date().toISOString() }),
-        JSON.stringify({ type: 'consensus', taskId: 'task-2', signal: 'disagreement', agentId: 'a', timestamp: new Date().toISOString() }),
+        sig('task-1', 'agreement', 'a'),
+        sig('task-1', 'unique_confirmed', 'b'),
+        sig('task-1', 'agreement', 'c'),
+        sig('task-2', 'agreement', 'a'),
+        sig('task-2', 'unique_confirmed', 'b'),
+        sig('task-2', 'disagreement', 'c'),
       ].join('\n');
       writeFileSync(join(projectRoot, '.gossip', 'agent-performance.jsonl'), signals);
       const data = await overviewHandler(projectRoot, { agentConfigs: [], relayConnections: 0, connectedAgentIds: [] });
-      expect(data.consensusRuns).toBe(2); // 2 unique taskIds
-      expect(data.totalSignals).toBe(3);
-      expect(data.confirmedFindings).toBe(2); // agreement + unique_confirmed
-      expect(data.totalFindings).toBe(3);
+      expect(data.consensusRuns).toBe(2); // 2 runs, each >=2 agents and >=3 signals
+      expect(data.totalSignals).toBe(6);
+      expect(data.confirmedFindings).toBe(5); // agreement + unique_confirmed signals (3 in run-1, 2 in run-2)
+      expect(data.totalFindings).toBe(6); // every signal here is a finding-bearing type
     });
 
     it('should not throw on malformed agent-performance.jsonl', async () => {
-      writeFileSync(join(projectRoot, '.gossip', 'agent-performance.jsonl'), '{"foo":\nnot json\n{"bar": 1}');
+      // totalSignals counts only well-formed `type:"consensus"` signal rows. Two
+      // malformed lines plus one valid consensus signal -> resilient skip, count 1.
+      const valid = JSON.stringify({ type: 'consensus', taskId: 't', signal: 'agreement', agentId: 'a', timestamp: new Date().toISOString() });
+      writeFileSync(join(projectRoot, '.gossip', 'agent-performance.jsonl'), `{"foo":\nnot json\n${valid}`);
       const data = await overviewHandler(projectRoot, { agentConfigs: [], relayConnections: 0, connectedAgentIds: [] });
-      // Resilient: skips invalid lines, counts valid ones ({"bar": 1} parses OK)
       expect(data.totalSignals).toBe(1);
     });
 
     it('should handle very large agent-performance file without crashing', async () => {
       // NOTE: This is synchronous and will block. A better implementation would stream.
-      const largeFileContent = Array.from({ length: 10000 }, (_, i) => JSON.stringify({ i })).join('\n');
+      const ts = new Date().toISOString();
+      const largeFileContent = Array.from({ length: 10000 }, (_, i) =>
+        JSON.stringify({ type: 'consensus', taskId: `t${i}`, signal: 'agreement', agentId: 'a', timestamp: ts }),
+      ).join('\n');
       writeFileSync(join(projectRoot, '.gossip', 'agent-performance.jsonl'), largeFileContent);
       const data = await overviewHandler(projectRoot, { agentConfigs: [], relayConnections: 0, connectedAgentIds: [] });
       expect(data.totalSignals).toBe(10000);


### PR DESCRIPTION
Closes the final ledger item: clean up the 3 remaining `KNOWN_BROKEN_SUITES`. All three were **TEST-DRIFT or miscategorized** — no production code changed. `KNOWN_BROKEN_SUITES` is now `[]`.

## 1. `tests/cli/mcp-signals-validation.test.ts` — failed to compile
Two straggler `writer.appendSignals(...)` calls (`:571`, `:686`) weren't migrated to the symbol-gated `writer[WRITER_INTERNAL].appendSignals(...)` accessor the rest of the file already uses (TS2339 blocked the whole suite). Compiling then surfaced one stale assertion: `"fabricated"` is now a `citation_grounding` keyword (`category-extractor.ts:22`), so the "no keyword match" test needed evidence matching zero `CATEGORY_PATTERNS`. → **56/56**

## 2. `tests/orchestrator/consensus-e2e.test.ts` — miscategorized
This is a **real-LLM e2e test**: it needs a local `.gossip/config.json`, a Google API key from keychain/env, and a 600s timeout. It's not "broken tech debt" — it was misfiled. Its dynamic `await import` of `WRITER_INTERNAL` widened the type to plain `symbol` (TS7053 on the index access); switched to a static import (preserves `unique symbol`). **Moved from `KNOWN_BROKEN_SUITES` → `GEMINI_E2E_SUITES`**, so it's env-gated by `RUN_GEMINI_E2E=1` like its sibling e2e suites. Compiles clean; skipped by default.

## 3. `tests/relay/dashboard-edge-cases.test.ts` — 3 stale fixtures
`overviewHandler` semantics were intentionally tightened (documented in `api-overview.ts`): `totalSignals` counts only `type:"consensus"` rows, and `consensusRuns` requires **≥2 agents AND ≥3 signals** per run (mirrors `api-consensus.ts:98`). The fixtures asserted the old loose semantics. Rewrote all 3 to match current behavior while preserving each test's intent (run-counting / malformed-resilience / large-file). → **11/11**

## Verification
- Full **default** suite green: **279 suites, 3766 passed, 0 failed**, 29 skipped (the env-gated e2e suites)
- `tsc --noEmit` clean across all 3 touched files (incl. the now-gated consensus-e2e)
- `KNOWN_BROKEN_SUITES = []` — burndown complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)