### PR TITLE
feat(relay): chatbot SSE seam — /api/chat + ChatConversationStore (P2a)

### DIFF
--- a/packages/relay/src/dashboard/api-chat.ts
+++ b/packages/relay/src/dashboard/api-chat.ts
@@ -1,0 +1,152 @@
+/**
+ * api-chat.ts — SSE seam for the dashboard chatbot (MVP-0, P2a).
+ *
+ * `handleChat` is reached only after the dashboard router has verified auth
+ * (cookie or Bearer) — same contract as handleEventsSSE. It opens a
+ * text/event-stream (mirroring api-events.ts headers), then drives the
+ * injected `ChatbotAgent.turnStream` and forwards each event as an SSE frame.
+ *
+ * Invariants:
+ *  - The `message` and `conversationId` in `body` are UNTRUSTED HTTP input.
+ *    `message` must be a non-empty string or we 400 BEFORE opening the stream.
+ *  - `chatbot == null` (no LLM provider configured) is a graceful-degrade path:
+ *    emit an `error` event + `done`, then end. Never a 5xx.
+ *  - The handler NEVER throws: the whole turn is wrapped so any failure becomes
+ *    an `error` SSE event followed by stream close.
+ *  - `req.on('close')` stops iteration cooperatively (a flag the loop checks),
+ *    so a disconnecting client doesn't keep the generator (and its tool calls)
+ *    running unbounded.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'http';
+import type { ChatbotAgent } from '@gossip/orchestrator';
+import type { LLMMessage } from '@gossip/types';
+import type { ChatConversationStore } from './chat-session-store';
+
+export interface ChatRequestBody {
+  conversationId?: string | null;
+  message: string;
+}
+
+/** Upper bound on a client-supplied conversationId (UUIDs are 36 chars). */
+const MAX_CONVERSATION_ID_LENGTH = 128;
+
+export interface HandleChatDeps {
+  chatbot: ChatbotAgent | null;
+  store: ChatConversationStore;
+}
+
+/** SSE headers — identical posture to api-events.ts handleEventsSSE. */
+function writeSseHead(res: ServerResponse): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive',
+    'X-Accel-Buffering': 'no',
+  });
+}
+
+/** Serialize one event as an SSE `data:` frame. */
+function sse(res: ServerResponse, payload: unknown): void {
+  res.write(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+export async function handleChat(
+  req: IncomingMessage,
+  res: ServerResponse,
+  body: unknown,
+  deps: HandleChatDeps,
+): Promise<void> {
+  // Trust boundary: validate untrusted body BEFORE opening the SSE stream so an
+  // invalid request gets a plain 400 JSON response (no half-open event-stream).
+  const b = (body ?? {}) as Partial<ChatRequestBody>;
+  const message = b.message;
+  if (typeof message !== 'string' || message.trim().length === 0) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'message must be a non-empty string' }));
+    return;
+  }
+  // conversationId is optional; coerce anything non-string to null so the store
+  // mints a fresh id rather than keying off attacker-controlled junk. A string
+  // id is bounded — an over-long id is rejected (400) BEFORE opening the stream
+  // so it can't be used to bloat the store's keyspace.
+  const rawConvId = b.conversationId;
+  if (typeof rawConvId === 'string' && rawConvId.length > MAX_CONVERSATION_ID_LENGTH) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'conversationId too long' }));
+    return;
+  }
+  const conversationId = typeof rawConvId === 'string' && rawConvId.length > 0 ? rawConvId : null;
+
+  // Cooperative cancellation: flip on client disconnect, checked in the loop.
+  let clientGone = false;
+  req.on('close', () => { clientGone = true; });
+
+  writeSseHead(res);
+
+  // Single getOrCreate: capture both the (possibly minted) id and the existing
+  // history in one lookup. A second call would redundantly stamp lastTouched and
+  // re-run eviction.
+  const { id, messages: history } = deps.store.getOrCreate(conversationId);
+  // First frame always tells the client which conversation this turn belongs to
+  // (especially important when the server minted a new id).
+  sse(res, { type: 'conversation', conversationId: id });
+
+  // Graceful degrade: no provider configured.
+  if (!deps.chatbot) {
+    sse(res, { type: 'error', message: 'Chat unavailable — no LLM provider configured' });
+    sse(res, { type: 'done', text: '' });
+    res.end();
+    return;
+  }
+
+  try {
+    let assistantText = '';
+    // Track terminal state so we only persist a turn that actually completed.
+    // A yielded `error` event (vs a thrown error) ends the for-await normally,
+    // so without these flags we'd persist an empty assistant message.
+    let sawDone = false;
+    let sawError = false;
+
+    for await (const ev of deps.chatbot.turnStream(message, history)) {
+      if (clientGone) break;
+      if (ev.type === 'done') {
+        // Capture the final assistant text so we can persist the turn.
+        sawDone = true;
+        assistantText = ev.text;
+      } else if (ev.type === 'error') {
+        sawError = true;
+      }
+      sse(res, ev);
+    }
+
+    // A stream that yielded `error` but never `done` left the client without a
+    // terminal frame. Emit one so the client's stream state machine always ends
+    // cleanly (mirrors the throw path in the catch below). Skip if the client
+    // already disconnected.
+    if (sawError && !sawDone && !clientGone) {
+      sse(res, { type: 'done', text: '' });
+    }
+
+    // Persist the turn (user + assistant) only on a clean completion: the client
+    // is still attached AND the stream reached `done` without an `error`. A
+    // disconnected client (partial/aborted turn) or an error stream must NOT
+    // poison history — in particular, an error-only stream would otherwise
+    // append an empty assistant message.
+    if (sawDone && !sawError && !clientGone) {
+      const userMsg: LLMMessage = { role: 'user', content: message };
+      const assistantMsg: LLMMessage = { role: 'assistant', content: assistantText };
+      deps.store.append(id, [userMsg, assistantMsg]);
+    }
+  } catch (err) {
+    // NEVER throw out of the handler — surface as a terminal error event, then a
+    // terminal `done` so the client's stream state machine always sees an end
+    // frame (the yielded-error path emits its own done; this is the throw path).
+    try {
+      sse(res, { type: 'error', message: String(err) });
+      sse(res, { type: 'done', text: '' });
+    } catch { /* socket already gone */ }
+  } finally {
+    try { res.end(); } catch { /* already ended */ }
+  }
+}

--- a/packages/relay/src/dashboard/chat-session-store.ts
+++ b/packages/relay/src/dashboard/chat-session-store.ts
@@ -1,0 +1,108 @@
+/**
+ * ChatConversationStore — in-memory, bounded conversation history for the
+ * dashboard chatbot (MVP-0, P2). Conversation state is process-local only; a
+ * cold restart clears it (spec §5).
+ *
+ * Bounded + TTL'd like dashboard/auth.ts: capped at MAX_CONVERSATIONS entries
+ * with a CONVERSATION_TTL_MS idle window. Eviction runs opportunistically on
+ * access (getOrCreate) — expired entries are dropped, and if the map is still
+ * at capacity the oldest-touched conversation is evicted. There is no
+ * background timer; this is a request-driven structure.
+ */
+
+import { randomUUID } from 'crypto';
+import type { LLMMessage } from '@gossip/types';
+
+const MAX_CONVERSATIONS = 20;
+const CONVERSATION_TTL_MS = 2 * 60 * 60 * 1000; // 2 hours idle
+// Per-conversation history cap. Without this, a single long-lived conversation
+// grows unbounded; we keep only the most-recent turns.
+const MAX_MESSAGES_PER_CONVERSATION = 100;
+
+interface ConversationEntry {
+  messages: LLMMessage[];
+  lastTouched: number;
+}
+
+export class ChatConversationStore {
+  private conversations = new Map<string, ConversationEntry>();
+
+  /**
+   * Return the existing history for `id`, or create a fresh empty conversation.
+   * A null/empty id mints a new UUID. Eviction (expired-first, then
+   * oldest-touched if still over cap) runs before insertion so the map never
+   * exceeds MAX_CONVERSATIONS.
+   */
+  getOrCreate(id: string | null | undefined): { id: string; messages: LLMMessage[] } {
+    const now = Date.now();
+    this.evict(now);
+
+    const key = id && id.length > 0 ? id : randomUUID();
+    const existing = this.conversations.get(key);
+    if (existing) {
+      existing.lastTouched = now;
+      return { id: key, messages: existing.messages };
+    }
+
+    // New conversation. If we're at capacity after expiry eviction, drop the
+    // oldest-touched entry to make room.
+    if (this.conversations.size >= MAX_CONVERSATIONS) {
+      this.evictOldest();
+    }
+    const entry: ConversationEntry = { messages: [], lastTouched: now };
+    this.conversations.set(key, entry);
+    return { id: key, messages: entry.messages };
+  }
+
+  /** Append messages (e.g. [userMsg, assistantMsg]) to a conversation's history. */
+  append(id: string, msgs: LLMMessage[]): void {
+    const now = Date.now();
+    const entry = this.conversations.get(id);
+    if (!entry) {
+      // The conversation was evicted between turn start and append (rare under
+      // load). Recreate it so the turn isn't silently lost, respecting the cap.
+      if (this.conversations.size >= MAX_CONVERSATIONS) this.evictOldest();
+      const fresh: ConversationEntry = { messages: [...msgs], lastTouched: now };
+      this.trimHistory(fresh);
+      this.conversations.set(id, fresh);
+      return;
+    }
+    entry.messages.push(...msgs);
+    entry.lastTouched = now;
+    this.trimHistory(entry);
+  }
+
+  /**
+   * Drop the oldest messages from the front so history never exceeds
+   * MAX_MESSAGES_PER_CONVERSATION (keep the most-recent N).
+   */
+  private trimHistory(entry: ConversationEntry): void {
+    const overflow = entry.messages.length - MAX_MESSAGES_PER_CONVERSATION;
+    if (overflow > 0) entry.messages.splice(0, overflow);
+  }
+
+  /** Drop conversations whose idle window elapsed. */
+  private evict(now: number): void {
+    for (const [k, v] of this.conversations) {
+      if (now - v.lastTouched > CONVERSATION_TTL_MS) this.conversations.delete(k);
+    }
+  }
+
+  /** Evict the single oldest-touched conversation (capacity pressure). */
+  private evictOldest(): void {
+    let oldestKey: string | null = null;
+    let oldestTouched = Infinity;
+    for (const [k, v] of this.conversations) {
+      if (v.lastTouched < oldestTouched) {
+        oldestTouched = v.lastTouched;
+        oldestKey = k;
+      }
+    }
+    if (oldestKey !== null) this.conversations.delete(oldestKey);
+  }
+
+  /** Test/introspection helper. */
+  size(): number {
+    return this.conversations.size;
+  }
+}

--- a/packages/relay/src/dashboard/index.ts
+++ b/packages/relay/src/dashboard/index.ts
@@ -2,3 +2,5 @@ export { DashboardAuth } from './auth';
 export { DashboardRouter } from './routes';
 export { DashboardWs, type DashboardEvent } from './ws';
 export { emitDashboardEvent, type DashboardEventEntry } from './api-events';
+export { ChatConversationStore } from './chat-session-store';
+export { handleChat, type ChatRequestBody, type HandleChatDeps } from './api-chat';

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -19,6 +19,9 @@ import { tasksHandler } from './api-tasks';
 import { activeTasksHandler } from './api-active-tasks';
 import { logsHandler } from './api-logs';
 import { violationsHandler } from './api-violations';
+import { handleChat } from './api-chat';
+import { ChatConversationStore } from './chat-session-store';
+import type { ChatbotAgent } from '@gossip/orchestrator';
 import { readFileSync, existsSync, realpathSync } from 'fs';
 import { join, resolve } from 'path';
 import { createHash, timingSafeEqual } from 'crypto';
@@ -40,6 +43,17 @@ interface DashboardContext {
 
 const AUTH_MAX_ATTEMPTS = 10;
 const AUTH_LOCKOUT_MS = 60_000; // 1 minute lockout after max attempts
+
+// Per-route body cap for POST /dashboard/api/chat. Larger than the shared
+// MAX_BODY_SIZE (8 KB) because a chat message can be a reasonable paragraph,
+// but still tightly bounded as a DoS guard (CORRECTION #6 — parametrize
+// readBody, don't bump the shared cap).
+const CHAT_MAX_BODY = 64 * 1024; // 64 KB
+
+// Minimum interval between chat turns from one IP — a simple per-IP throttle so
+// a single client can't fan out concurrent/rapid turns (each turn can run up to
+// maxToolCallsPerTurn tool executions). Mirrors the isIpLockedOut style.
+const CHAT_MIN_INTERVAL_MS = 1_000;
 
 /**
  * Resolve the bundled dashboard asset root. Same multi-candidate pattern as
@@ -63,6 +77,13 @@ function resolveDashboardRoot(projectRoot: string): string | null {
 export class DashboardRouter {
   private authAttempts = new Map<string, { count: number; lockedUntil: number }>();
   private dashboardRoot: string | null;
+  // Chatbot seam (P2). Null until the app layer injects an agent via
+  // setChatbot; a null agent is the graceful-degrade path (handleChat emits an
+  // error event rather than 5xx).
+  private chatbot: ChatbotAgent | null = null;
+  private chatStore = new ChatConversationStore();
+  // Per-IP last-chat-turn timestamp for the min-interval throttle.
+  private chatLastTurn = new Map<string, number>();
 
   constructor(
     private auth: DashboardAuth,
@@ -70,6 +91,15 @@ export class DashboardRouter {
     private ctx: DashboardContext,
   ) {
     this.dashboardRoot = resolveDashboardRoot(projectRoot);
+  }
+
+  /**
+   * Inject (or clear) the read-only chatbot agent. Called by the app layer
+   * after boot via RelayServer.setChatbot. Passing null disables chat with a
+   * graceful-degrade SSE error rather than a hard failure.
+   */
+  setChatbot(agent: ChatbotAgent | null): void {
+    this.chatbot = agent;
   }
 
   /** Update live context (call when agents connect/disconnect) */
@@ -202,6 +232,32 @@ export class DashboardRouter {
     }
     const attempt = this.authAttempts.get(ip);
     return !!(attempt && attempt.lockedUntil > now);
+  }
+
+  /**
+   * Per-IP min-interval throttle for chat turns. Returns true (and records the
+   * new turn timestamp) when the caller is allowed to proceed; false when the
+   * previous turn was too recent. Opportunistic pruning caps the map under
+   * abusive scans, same posture as isIpLockedOut.
+   */
+  private allowChatTurn(ip: string): boolean {
+    const now = Date.now();
+    if (this.chatLastTurn.size > 100) {
+      // Prune entries idle for longer than the throttle window can possibly
+      // matter (10x the interval). Pruning at exactly CHAT_MIN_INTERVAL_MS was
+      // too aggressive to reap under a fast scan — by the time the map crosses
+      // 100, the freshest 100 entries are all within one interval and nothing
+      // gets dropped, so the guard never actually reaps. A 10x window keeps the
+      // throttle decision intact while letting stale IPs fall out.
+      const staleBefore = CHAT_MIN_INTERVAL_MS * 10;
+      for (const [k, v] of this.chatLastTurn) {
+        if (now - v > staleBefore) this.chatLastTurn.delete(k);
+      }
+    }
+    const last = this.chatLastTurn.get(ip);
+    if (last !== undefined && now - last < CHAT_MIN_INTERVAL_MS) return false;
+    this.chatLastTurn.set(ip, now);
+    return true;
   }
 
   /**
@@ -427,6 +483,27 @@ export class DashboardRouter {
         return true;
       }
 
+      // Chatbot turn — /dashboard/api/chat. Auth already verified above.
+      // Streams SSE (handleChat takes over the response — do NOT go through
+      // json()). Read the body with a per-route cap (NOT the shared
+      // MAX_BODY_SIZE), then a per-IP min-interval throttle, then hand off.
+      if (url === '/dashboard/api/chat' && req.method === 'POST') {
+        const ip = req.socket?.remoteAddress || 'unknown';
+        if (!this.allowChatTurn(ip)) {
+          this.json(res, 429, { error: 'Too many chat requests. Slow down.' });
+          return true;
+        }
+        let body: unknown;
+        try {
+          body = JSON.parse(await readBody(req, CHAT_MAX_BODY));
+        } catch {
+          this.json(res, 400, { error: 'Invalid JSON body' });
+          return true;
+        }
+        await handleChat(req, res, body, { chatbot: this.chatbot, store: this.chatStore });
+        return true;
+      }
+
       this.json(res, 404, { error: 'Unknown API endpoint' });
     } catch (err) {
       this.json(res, 500, { error: 'Internal server error' });
@@ -603,14 +680,14 @@ export class DashboardRouter {
 
 const MAX_BODY_SIZE = 8 * 1024; // 8 KB — ample for auth key and skill bind payloads
 
-function readBody(req: IncomingMessage): Promise<string> {
+function readBody(req: IncomingMessage, maxBytes: number = MAX_BODY_SIZE): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     let size = 0;
     let tooLarge = false;
     req.on('data', (chunk: Buffer) => {
       size += chunk.length;
-      if (size > MAX_BODY_SIZE) {
+      if (size > maxBytes) {
         tooLarge = true;
         req.destroy();
         reject(new Error('Request body too large'));

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -15,6 +15,7 @@ import { AgentConnection, livenessMap } from './agent-connection';
 import { DashboardAuth } from './dashboard/auth';
 import { DashboardRouter } from './dashboard/routes';
 import { DashboardWs } from './dashboard/ws';
+import type { ChatbotAgent } from '@gossip/orchestrator';
 
 export interface DashboardConfig {
   projectRoot: string;
@@ -454,5 +455,15 @@ export class RelayServer {
    */
   setAgentConfigs(configs: Array<{ id: string; provider: string; model: string; preset?: string; skills: string[]; native?: boolean }>): void {
     this.dashboardRouter?.updateContext({ agentConfigs: configs });
+  }
+
+  /**
+   * Inject the read-only dashboard chatbot agent (or null to disable). Called
+   * by the app layer (mcp-server-sdk.ts) after boot once the chat provider/key
+   * are resolved. dashboardRouter is private, so this public forwarder is the
+   * only seam (spec §3.6, CORRECTION #1). No-op if the dashboard is disabled.
+   */
+  setChatbot(agent: ChatbotAgent | null): void {
+    this.dashboardRouter?.setChatbot(agent);
   }
 }

--- a/tests/relay/api-chat.test.ts
+++ b/tests/relay/api-chat.test.ts
@@ -1,0 +1,556 @@
+import { EventEmitter } from 'events';
+import { handleChat } from '../../packages/relay/src/dashboard/api-chat';
+import { ChatConversationStore } from '../../packages/relay/src/dashboard/chat-session-store';
+import { DashboardRouter } from '../../packages/relay/src/dashboard/routes';
+import { DashboardAuth } from '../../packages/relay/src/dashboard/auth';
+import { mkdtempSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { ChatStreamEvent } from '@gossip/orchestrator';
+import type { LLMMessage } from '@gossip/types';
+
+// --- Mock req/res ------------------------------------------------------------
+
+/** Minimal IncomingMessage stand-in — only `socket` + the 'close' event matter. */
+function mockReq(): EventEmitter & { socket: { remoteAddress: string } } {
+  const req = new EventEmitter() as EventEmitter & { socket: { remoteAddress: string } };
+  req.socket = { remoteAddress: '127.0.0.1' };
+  return req;
+}
+
+interface MockRes {
+  statusCode: number | null;
+  headers: Record<string, unknown> | null;
+  chunks: string[];
+  ended: boolean;
+  endData: string | null;
+  writeHead(status: number, headers?: Record<string, unknown>): void;
+  write(chunk: string): boolean;
+  end(data?: string): void;
+}
+
+function mockRes(): MockRes {
+  return {
+    statusCode: null,
+    headers: null,
+    chunks: [],
+    ended: false,
+    endData: null,
+    writeHead(status, headers) { this.statusCode = status; this.headers = headers ?? null; },
+    write(chunk) { this.chunks.push(chunk); return true; },
+    end(data) { this.ended = true; this.endData = data ?? null; },
+  };
+}
+
+/** Parse the SSE `data: {...}` frames the handler wrote into objects. */
+function parseEvents(res: MockRes): any[] {
+  return res.chunks
+    .map(c => c.trim())
+    .filter(c => c.startsWith('data:'))
+    .map(c => JSON.parse(c.slice('data:'.length).trim()));
+}
+
+/** A stub ChatbotAgent — only `turnStream` is exercised by handleChat. */
+function stubAgent(events: ChatStreamEvent[]): any {
+  return {
+    async *turnStream(_message: string, _history: LLMMessage[]) {
+      for (const ev of events) yield ev;
+    },
+  };
+}
+
+// --- Tests -------------------------------------------------------------------
+
+describe('handleChat — SSE seam', () => {
+  it('(1) happy path: streams conversation + token + done, ends, persists turn', async () => {
+    const store = new ChatConversationStore();
+    const chatbot = stubAgent([
+      { type: 'token', text: 'hi' },
+      { type: 'done', text: 'hi' },
+    ]);
+    const req = mockReq();
+    const res = mockRes();
+
+    await handleChat(req as any, res as any, { conversationId: null, message: 'hello' }, { chatbot, store });
+
+    const events = parseEvents(res);
+    const types = events.map(e => e.type);
+    expect(types).toContain('conversation');
+    expect(types).toContain('token');
+    expect(types).toContain('done');
+
+    const conv = events.find(e => e.type === 'conversation');
+    expect(typeof conv.conversationId).toBe('string');
+    expect(conv.conversationId.length).toBeGreaterThan(0);
+
+    // (f6) SSE was opened with the event-stream content type.
+    expect(res.statusCode).toBe(200);
+    expect(res.headers).toMatchObject({ 'Content-Type': 'text/event-stream' });
+
+    expect(res.ended).toBe(true);
+
+    // The turn (user + assistant) was appended to the minted conversation.
+    const history = store.getOrCreate(conv.conversationId).messages;
+    expect(history).toEqual([
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi' },
+    ]);
+  });
+
+  it('(2) graceful degrade: chatbot=null emits error + done + end, no throw', async () => {
+    const store = new ChatConversationStore();
+    const req = mockReq();
+    const res = mockRes();
+
+    await expect(
+      handleChat(req as any, res as any, { message: 'hello' }, { chatbot: null, store }),
+    ).resolves.toBeUndefined();
+
+    const events = parseEvents(res);
+    const types = events.map(e => e.type);
+    expect(types).toEqual(['conversation', 'error', 'done']);
+    const err = events.find(e => e.type === 'error');
+    expect(err.message).toMatch(/no LLM provider/i);
+    expect(res.ended).toBe(true);
+    expect(res.statusCode).toBe(200); // SSE opened, not a 4xx/5xx
+  });
+
+  it('(3) invalid message (empty) → 400 JSON, no SSE opened', async () => {
+    const store = new ChatConversationStore();
+    const req = mockReq();
+    const res = mockRes();
+
+    await handleChat(req as any, res as any, { message: '   ' }, { chatbot: stubAgent([]), store });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    // No SSE frames were written.
+    expect(parseEvents(res)).toEqual([]);
+    expect(res.ended).toBe(true);
+  });
+
+  it('(3b) invalid message (non-string) → 400 JSON', async () => {
+    const store = new ChatConversationStore();
+    const req = mockReq();
+    const res = mockRes();
+
+    await handleChat(req as any, res as any, { message: 123 as any }, { chatbot: stubAgent([]), store });
+    expect(res.statusCode).toBe(400);
+    expect(parseEvents(res)).toEqual([]);
+  });
+
+  it('error during iteration becomes a terminal error event, never throws', async () => {
+    const store = new ChatConversationStore();
+    const boom: any = {
+      async *turnStream() {
+        yield { type: 'token', text: 'partial' };
+        throw new Error('kaboom');
+      },
+    };
+    const req = mockReq();
+    const res = mockRes();
+
+    await expect(
+      handleChat(req as any, res as any, { message: 'hi' }, { chatbot: boom, store }),
+    ).resolves.toBeUndefined();
+
+    const events = parseEvents(res);
+    const types = events.map(e => e.type);
+    expect(types).toContain('error');
+    // (f5) The throw path now also emits a terminal `done` so the client always
+    // sees an end frame.
+    expect(types).toContain('done');
+    expect(res.ended).toBe(true);
+
+    // (f5) A thrown turn must NOT be persisted — no partial/empty assistant msg
+    // poisons the conversation history.
+    const conv = events.find(e => e.type === 'conversation');
+    expect(store.getOrCreate(conv.conversationId).messages).toEqual([]);
+  });
+
+  it('(f7) yielded error event emits error + done and does NOT persist an empty turn', async () => {
+    const store = new ChatConversationStore();
+    // turnStream YIELDS an error (vs throwing) then returns normally — the
+    // for-await ends cleanly, so the handler must not append an empty assistant.
+    const yieldsError: any = {
+      async *turnStream() {
+        yield { type: 'error', message: 'provider exploded' };
+        // returns without a `done`
+      },
+    };
+    const req = mockReq();
+    const res = mockRes();
+
+    await expect(
+      handleChat(req as any, res as any, { message: 'hi' }, { chatbot: yieldsError, store }),
+    ).resolves.toBeUndefined();
+
+    const events = parseEvents(res);
+    const types = events.map(e => e.type);
+    // The yielded error is forwarded; a terminal done frame closes the stream.
+    expect(types).toContain('error');
+    expect(types).toContain('done');
+    expect(res.ended).toBe(true);
+
+    // Critically: nothing was persisted — no empty assistant message.
+    const conv = events.find(e => e.type === 'conversation');
+    expect(store.getOrCreate(conv.conversationId).messages).toEqual([]);
+  });
+
+  it('(f2) client disconnect mid-stream stops writes and does NOT persist the turn', async () => {
+    const store = new ChatConversationStore();
+    // A deferred promise the stub awaits forever after its first yield — the
+    // generator is parked mid-turn until we resolve it (which we never do
+    // before disconnect). This models a long-running tool call.
+    let releaseHang!: () => void;
+    const hang = new Promise<void>(resolve => { releaseHang = resolve; });
+
+    const writesAfterClose: string[] = [];
+    const req = mockReq();
+    const res = mockRes();
+    // Record any writes that happen after the client closes.
+    const origWrite = res.write.bind(res);
+    let closed = false;
+    res.write = (chunk: string) => {
+      if (closed) writesAfterClose.push(chunk);
+      return origWrite(chunk);
+    };
+
+    const parked: any = {
+      async *turnStream() {
+        yield { type: 'tool_use', name: 'search', args: {} };
+        // Park here; while parked, the client disconnects.
+        await hang;
+        // If the loop ever resumes it would try to emit more — but clientGone
+        // should have been flipped, so the loop breaks before writing.
+        yield { type: 'token', text: 'late' };
+        yield { type: 'done', text: 'late' };
+      },
+    };
+
+    const handled = handleChat(
+      req as any, res as any, { message: 'hi' }, { chatbot: parked, store },
+    );
+
+    // Let the generator advance to the first yield + park on `hang`.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Client disconnects mid-stream, then the parked turn is released.
+    closed = true;
+    req.emit('close');
+    releaseHang();
+
+    await handled;
+
+    // No frames were written after the disconnect (the loop broke on clientGone).
+    expect(writesAfterClose).toEqual([]);
+    // And the aborted turn was NOT persisted.
+    const conv = parseEvents(res).find(e => e.type === 'conversation');
+    expect(store.getOrCreate(conv.conversationId).messages).toEqual([]);
+  });
+
+  it('(f3) conversation continuity: turn2 receives turn1 user+assistant history', async () => {
+    const store = new ChatConversationStore();
+
+    // Turn 1: mint a new conversation, persist user+assistant.
+    const agent1 = stubAgent([
+      { type: 'token', text: 'first-reply' },
+      { type: 'done', text: 'first-reply' },
+    ]);
+    const req1 = mockReq();
+    const res1 = mockRes();
+    await handleChat(
+      req1 as any, res1 as any,
+      { conversationId: null, message: 'first-msg' },
+      { chatbot: agent1, store },
+    );
+    const conv = parseEvents(res1).find(e => e.type === 'conversation');
+    const convId: string = conv.conversationId;
+
+    // Turn 2: reuse the id; the stub records the history arg it was handed.
+    let receivedHistory: LLMMessage[] | null = null;
+    const recordingAgent: any = {
+      async *turnStream(_message: string, history: LLMMessage[]) {
+        // Snapshot the history AT CALL TIME — the store hands back the live
+        // array, which the handler later mutates via append(). We assert on what
+        // turn2 was actually given, not the post-append state.
+        receivedHistory = history.map(m => ({ ...m }));
+        yield { type: 'done', text: 'second-reply' };
+      },
+    };
+    const req2 = mockReq();
+    const res2 = mockRes();
+    await handleChat(
+      req2 as any, res2 as any,
+      { conversationId: convId, message: 'second-msg' },
+      { chatbot: recordingAgent, store },
+    );
+
+    expect(receivedHistory).toEqual([
+      { role: 'user', content: 'first-msg' },
+      { role: 'assistant', content: 'first-reply' },
+    ]);
+  });
+
+  it('(f10) over-long conversationId → 400 JSON, no SSE opened', async () => {
+    const store = new ChatConversationStore();
+    const req = mockReq();
+    const res = mockRes();
+
+    await handleChat(
+      req as any, res as any,
+      { conversationId: 'x'.repeat(129), message: 'hi' },
+      { chatbot: stubAgent([]), store },
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    expect(parseEvents(res)).toEqual([]);
+  });
+});
+
+describe('ChatConversationStore', () => {
+  it('(4) getOrCreate returns [] for a new id; append accumulates', () => {
+    const store = new ChatConversationStore();
+    const { id, messages } = store.getOrCreate(null);
+    expect(messages).toEqual([]);
+
+    store.append(id, [{ role: 'user', content: 'a' }]);
+    store.append(id, [{ role: 'assistant', content: 'b' }]);
+    expect(store.getOrCreate(id).messages).toEqual([
+      { role: 'user', content: 'a' },
+      { role: 'assistant', content: 'b' },
+    ]);
+  });
+
+  it('(4b) getOrCreate is stable for an explicit id', () => {
+    const store = new ChatConversationStore();
+    store.getOrCreate('conv-1');
+    store.append('conv-1', [{ role: 'user', content: 'x' }]);
+    const second = store.getOrCreate('conv-1');
+    expect(second.id).toBe('conv-1');
+    expect(second.messages).toEqual([{ role: 'user', content: 'x' }]);
+  });
+
+  it('(4c) eviction caps at MAX_CONVERSATIONS (add 21 → oldest gone, size ≤ 20)', () => {
+    const store = new ChatConversationStore();
+    const ids: string[] = [];
+    for (let i = 0; i < 21; i++) {
+      const { id } = store.getOrCreate(`c-${i}`);
+      ids.push(id);
+    }
+    expect(store.size()).toBeLessThanOrEqual(20);
+    // The very first conversation (oldest-touched) should have been evicted:
+    // re-getting it yields a fresh empty history rather than its original.
+    // (We didn't append anything, so assert membership via size invariant +
+    // that a re-create of c-0 doesn't push us over the cap.)
+    const sizeBefore = store.size();
+    store.getOrCreate('c-0');
+    expect(store.size()).toBeLessThanOrEqual(20);
+    expect(sizeBefore).toBeLessThanOrEqual(20);
+  });
+
+  it('(4d) eviction drops the oldest-touched entry first', () => {
+    const store = new ChatConversationStore();
+    // Fill to capacity, tracking that c-0 is the oldest.
+    for (let i = 0; i < 20; i++) store.getOrCreate(`k-${i}`);
+    store.append('k-0', [{ role: 'user', content: 'oldest' }]);
+    // Touch k-0 is NOT done after; adding a 21st new conv must evict the
+    // oldest-touched, which — since getOrCreate stamps lastTouched on access —
+    // is whichever was touched longest ago. Force k-0 to be oldest by touching
+    // every other key after it.
+    for (let i = 1; i < 20; i++) store.getOrCreate(`k-${i}`);
+    store.getOrCreate('k-new'); // 21st distinct → triggers evictOldest
+    expect(store.size()).toBeLessThanOrEqual(20);
+    // k-0 was the least-recently-touched and should be gone: re-getting it is a
+    // fresh empty conversation, not the one holding 'oldest'.
+    expect(store.getOrCreate('k-0').messages).toEqual([]);
+  });
+
+  it('(f8) append caps per-conversation history at 100, keeping the most recent', () => {
+    const store = new ChatConversationStore();
+    store.getOrCreate('cap');
+    // Append 150 messages one at a time.
+    for (let i = 0; i < 150; i++) {
+      store.append('cap', [{ role: 'user', content: `m-${i}` }]);
+    }
+    const msgs = store.getOrCreate('cap').messages;
+    expect(msgs.length).toBe(100);
+    // The oldest 50 were trimmed from the front; the window is m-50 .. m-149.
+    expect(msgs[0]).toEqual({ role: 'user', content: 'm-50' });
+    expect(msgs[msgs.length - 1]).toEqual({ role: 'user', content: 'm-149' });
+  });
+
+  it('(f8b) a single over-cap append batch is trimmed to the most recent 100', () => {
+    const store = new ChatConversationStore();
+    // Append a 120-message batch into a fresh (recreated) entry in one call.
+    const batch: LLMMessage[] = [];
+    for (let i = 0; i < 120; i++) batch.push({ role: 'user', content: `b-${i}` });
+    store.append('batch', batch);
+    const msgs = store.getOrCreate('batch').messages;
+    expect(msgs.length).toBe(100);
+    expect(msgs[0]).toEqual({ role: 'user', content: 'b-20' });
+    expect(msgs[msgs.length - 1]).toEqual({ role: 'user', content: 'b-119' });
+  });
+
+  it('(f4) a conversation idle past CONVERSATION_TTL_MS is evicted on next access', () => {
+    jest.useFakeTimers();
+    try {
+      const store = new ChatConversationStore();
+      store.getOrCreate('stale');
+      store.append('stale', [{ role: 'user', content: 'keep-me?' }]);
+      expect(store.size()).toBe(1);
+
+      // Advance past the 2-hour idle window, then touch a DIFFERENT id —
+      // getOrCreate runs eviction, so the stale entry is dropped.
+      jest.advanceTimersByTime(2 * 60 * 60 * 1000 + 1);
+      store.getOrCreate('fresh');
+
+      // The stale conversation was evicted; re-getting it is a fresh empty one.
+      expect(store.getOrCreate('stale').messages).toEqual([]);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+// --- readBody backward-compat (parametrized cap) -----------------------------
+//
+// readBody is module-private, so it's exercised through the public router:
+//   - the default-cap call sites (e.g. POST /dashboard/api/auth at the shared
+//     MAX_BODY_SIZE=8KB) must reject an over-8KB body exactly as before, AND
+//   - the chat route uses readBody(req, CHAT_MAX_BODY=64KB), so a body between
+//     8KB and 64KB is accepted (proves the per-route cap is wired AND the
+//     default is unchanged for existing sites).
+
+function routerReq(method: string, url: string, headers: Record<string, string> = {}): any {
+  const req = new EventEmitter() as any;
+  req.method = method;
+  req.url = url;
+  req.headers = headers;
+  req.socket = { remoteAddress: '127.0.0.1' };
+  req.destroy = () => { req.emit('error', new Error('destroyed')); };
+  return req;
+}
+
+function routerRes(): any {
+  const res = new EventEmitter() as any;
+  res._status = 200;
+  res._headers = {};
+  res._body = '';
+  res.writeHead = (code: number, headers?: Record<string, string>) => {
+    res._status = code;
+    if (headers) Object.assign(res._headers, headers);
+    return res;
+  };
+  res.write = (chunk: string) => { res._body += chunk; return true; };
+  res.end = (body?: string) => { if (body !== undefined) res._body += body; };
+  return res;
+}
+
+function freshRouter(): { router: DashboardRouter; auth: DashboardAuth } {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'gossip-chat-'));
+  mkdirSync(join(projectRoot, '.gossip'), { recursive: true });
+  const auth = new DashboardAuth();
+  auth.init();
+  const router = new DashboardRouter(auth, projectRoot, {
+    agentConfigs: [], relayConnections: 0, connectedAgentIds: [],
+  });
+  return { router, auth };
+}
+
+describe('readBody backward-compat (per-route cap parametrization)', () => {
+  it('(5) default call sites still enforce the shared 8KB cap', async () => {
+    const { router } = freshRouter();
+    // POST /api/auth reads with the DEFAULT cap (MAX_BODY_SIZE = 8KB) — proving
+    // the parametrization left existing call sites unchanged. readBody rejects
+    // an over-8KB body exactly as before this change.
+    const req = routerReq('POST', '/dashboard/api/auth');
+    const res = routerRes();
+    const handled = router.handle(req, res);
+    // 9KB body — over the 8KB default cap → readBody destroys req + rejects.
+    req.emit('data', Buffer.alloc(9 * 1024, 0x61));
+    req.emit('end');
+    await expect(handled).rejects.toThrow(/too large/i);
+  });
+
+  it('(5a) a normal sub-8KB auth body still parses under the default cap', async () => {
+    const { router, auth } = freshRouter();
+    // A normal small auth body still flows (default cap unaffected at the low end).
+    const req = routerReq('POST', '/dashboard/api/auth');
+    const res = routerRes();
+    const handled = router.handle(req, res);
+    req.emit('data', Buffer.from(JSON.stringify({ key: auth.getKey() })));
+    req.emit('end');
+    await handled;
+    expect(res._status).toBe(200);
+  });
+
+  it('(5b) chat route accepts a body that exceeds the default 8KB cap (up to 64KB)', async () => {
+    const { router, auth } = freshRouter();
+    router.setChatbot(null); // graceful-degrade so the SSE path completes
+    // A ~16KB message — over the 8KB default but under CHAT_MAX_BODY (64KB).
+    const bigMessage = 'x'.repeat(16 * 1024);
+    const body = JSON.stringify({ message: bigMessage });
+    const req = routerReq('POST', '/dashboard/api/chat', {
+      authorization: `Bearer ${auth.getKey()}`,
+    });
+    const res = routerRes();
+    const handled = router.handle(req, res);
+    req.emit('data', Buffer.from(body));
+    req.emit('end');
+    await handled;
+    // Not a 413/400 from the cap — the SSE stream opened (200) and the
+    // graceful-degrade error/done frames were written.
+    expect(res._status).toBe(200);
+    expect(res._body).toContain('"type":"conversation"');
+    expect(res._body).toContain('no LLM provider');
+  });
+
+  it('(5c) chat route rejects a body over the 64KB per-route cap', async () => {
+    const { router, auth } = freshRouter();
+    router.setChatbot(null);
+    const req = routerReq('POST', '/dashboard/api/chat', {
+      authorization: `Bearer ${auth.getKey()}`,
+    });
+    const res = routerRes();
+    const handled = router.handle(req, res);
+    // 65KB — over CHAT_MAX_BODY. readBody destroys + rejects → 400 JSON.
+    req.emit('data', Buffer.alloc(65 * 1024, 0x61));
+    req.emit('end');
+    await handled;
+    expect(res._status).toBe(400);
+  });
+});
+
+describe('chat route — per-IP rate limit', () => {
+  it('(f1) two rapid chat turns from one IP → second is 429', async () => {
+    const { router, auth } = freshRouter();
+    router.setChatbot(null); // graceful-degrade so the first turn completes fast
+
+    const headers = { authorization: `Bearer ${auth.getKey()}` };
+    const body = JSON.stringify({ message: 'hi' });
+
+    // First turn: allowed → SSE opens (200) and graceful-degrade frames flow.
+    const req1 = routerReq('POST', '/dashboard/api/chat', headers);
+    const res1 = routerRes();
+    const handled1 = router.handle(req1, res1);
+    req1.emit('data', Buffer.from(body));
+    req1.emit('end');
+    await handled1;
+    expect(res1._status).toBe(200);
+    expect(res1._body).toContain('"type":"conversation"');
+
+    // Second turn from the SAME IP within CHAT_MIN_INTERVAL_MS → throttled 429.
+    const req2 = routerReq('POST', '/dashboard/api/chat', headers);
+    const res2 = routerRes();
+    const handled2 = router.handle(req2, res2);
+    req2.emit('data', Buffer.from(body));
+    req2.emit('end');
+    await handled2;
+    expect(res2._status).toBe(429);
+    // The throttle short-circuits before the SSE stream opens.
+    expect(res2._body).not.toContain('"type":"conversation"');
+  });
+});


### PR DESCRIPTION
P2a of the dashboard chatbot — the **relay-side HTTP/SSE seam** that drives the `ChatbotAgent` engine ([P1, #518](https://github.com/gossipcat-ai/gossipcat-ai/pull/518)). Self-contained in `@gossip/relay`; tool wrappers + app-layer wiring are P2b. Spec: `docs/specs/2026-06-04-dashboard-chatbot-mvp0-v2-final.md` (§3.6).

## What it adds
- **`POST /dashboard/api/chat`** (auth-gated) — reads the body with a per-route cap, opens an SSE stream, drives `ChatbotAgent.turnStream`, forwards each event (`conversation`/`tool_use`/`tool_result`/`token`/`done`/`error`) as an SSE frame.
- **`RelayServer.setChatbot(agent|null)` → `DashboardRouter.setChatbot`** — the injection seam (`dashboardRouter` is private; the app layer injects in P2b). `chatbot=null` is graceful-degrade (no crash).
- **`ChatConversationStore`** — bounded (20) + 2h TTL + **per-conversation 100-message cap**; mirrors `auth.ts` eviction.
- Per-IP chat **rate-limit (429)**; per-route `readBody(req, 64KB)` via a **backward-compatible** `readBody` signature.

## Consensus-gated (caught real bugs)
A two-phase consensus gate (`5b8269fe`) caught two MEDIUMs the initial 13 tests missed:
1. An **error-event path that persisted an empty assistant message** (history poisoning) and omitted the terminal `done` (clients hang / `EventSource` auto-reconnect loops).
2. **Unbounded per-conversation history** (memory + LLM-cost growth).

Both fixed: turns persist **only on a clean completed stream** (`sawDone && !sawError && !clientGone`); **every** termination path (success / yield-error / throw / graceful-degrade) ends with a `done` frame.

Confirmed sound by the gate: trust boundaries (message/conversationId validated *before* SSE opens; SSE JSON-framed so error strings can't escape; `socket.remoteAddress` not spoofable `X-Forwarded-For`), auth gate, client-disconnect cooperative-cancel + non-persist.

## Tests
**21 api-chat tests** (13 original + 8 new): route-level 429, client-disconnect non-persist, multi-turn continuity (turn1 history reaches turn2), TTL expiry (fake timers), yield-error & throw non-persistence, SSE `Content-Type`, per-conversation 100-cap. Full relay suite **218 passed**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)