### PR TITLE
fix(relay): stop false-positive worktree-isolation auto-restore of orchestrator writes (#437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ## [Unreleased]
 
+### Changed
+
+- **Worktree-isolation auto-restore is now OFF by default** (issue #437). Previously, when the isolation detector flagged a leak into the parent checkout, it would `git restore` the affected paths automatically after preserving them to `.gossip/recovery/<taskId>.patch`. Because the detector attributes *any* path dirtied during a dispatch window to the agent, in an orchestrated session it could misfire on the orchestrator's own concurrent writes (e.g. journaling to `.claude/`) and destroy them. The destructive revert is now gated behind `GOSSIP_WORKTREE_AUTO_REVERT` (or `consensus.worktreeAutoRevert: true`); the new default preserves the patch and reports, leaving the working tree untouched. **To restore the previous auto-clean behavior, set `GOSSIP_WORKTREE_AUTO_REVERT=1`.**
+
+### Added
+
+- **Orchestrator-owned path exclusion for isolation detection** (issue #437). Built-in `.gossip/`/`.claude/` prefixes — plus an opt-in `consensus.orchestratorOwnedGlobs` allowlist — are excluded from leak attribution, so routine orchestrator/infra writes during a dispatch are no longer flagged or reverted. `git status --porcelain` head-drift remains a hard violation regardless.
+
 ## [0.5.3] — 2026-06-04
 
 Dashboard correctness plus a broad DESIGN.md token-discipline pass, with worktree-isolation reliability fixes underneath in the CLI.

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -31,6 +31,27 @@ export interface GossipConfig {
      * false (no behavior change for default installs).
      */
     autoDiscoverWorktrees?: boolean;
+    /**
+     * When false, the round-close open-findings auto-resolver is skipped.
+     * Read directly in collect.ts; absent ⇒ enabled (default-on).
+     */
+    autoResolveOnRoundClose?: boolean;
+    /**
+     * Layer B opt-in (issue #437, spec 2026-06-09). Seeds the
+     * GOSSIP_WORKTREE_AUTO_REVERT runtime-flag default on load; the env var
+     * overrides (env → config → registry default '0'). When the effective flag
+     * is OFF (the default), a detected isolation leak is preserved + reported
+     * but NOT destructively reverted from the parent checkout.
+     */
+    worktreeAutoRevert?: boolean;
+    /**
+     * Layer A extra exclusions (issue #437, spec 2026-06-09). Operator-supplied
+     * STRING globs matched against repo-relative dirty paths, UNIONED with the
+     * built-in `.gossip/`/`.claude/` prefixes (which are never removable).
+     * Wildcard-only (`**`/`*`) and traversal (`../`) entries are rejected by
+     * validateConfig.
+     */
+    orchestratorOwnedGlobs?: string[];
   };
   agents?: Record<string, {
     provider: string;
@@ -123,6 +144,37 @@ export function validateConfig(raw: any): GossipConfig {
       typeof raw.consensus.autoResolveOnRoundClose !== 'boolean'
     ) {
       throw new Error('Config "consensus.autoResolveOnRoundClose" must be a boolean');
+    }
+    if (
+      raw.consensus.worktreeAutoRevert !== undefined &&
+      typeof raw.consensus.worktreeAutoRevert !== 'boolean'
+    ) {
+      throw new Error('Config "consensus.worktreeAutoRevert" must be a boolean');
+    }
+    if (raw.consensus.orchestratorOwnedGlobs !== undefined) {
+      const globs = raw.consensus.orchestratorOwnedGlobs;
+      if (!Array.isArray(globs)) {
+        throw new Error('Config "consensus.orchestratorOwnedGlobs" must be an array of strings');
+      }
+      for (const g of globs) {
+        if (typeof g !== 'string' || g.length === 0) {
+          throw new Error('Config "consensus.orchestratorOwnedGlobs" entries must be non-empty strings');
+        }
+        // Defense-in-depth on the pattern itself (spec §8.2 item 3): a
+        // wildcard-only entry would suppress ALL detection; a `../` entry is a
+        // traversal smell even though the match target is bounded to
+        // repo-relative strings.
+        if (g === '**' || g === '*') {
+          throw new Error(
+            `Config "consensus.orchestratorOwnedGlobs" entry "${g}" is wildcard-only and would suppress all isolation detection`,
+          );
+        }
+        if (g.includes('../')) {
+          throw new Error(
+            `Config "consensus.orchestratorOwnedGlobs" entry "${g}" contains a traversal segment ("../") and is rejected`,
+          );
+        }
+      }
     }
   }
 

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -164,34 +164,43 @@ function appendRelayWarning(
 
 /**
  * Resolve the effective GOSSIP_WORKTREE_AUTO_REVERT flag (spec 2026-06-09
- * Layer B, §8.2 item 4). Precedence: env → file → `consensus.worktreeAutoRevert`
+ * Layer B, §8.2 item 4). Precedence: env → flags-file → `consensus.worktreeAutoRevert`
  * config → registry default '0'.
  *
- * There is no standalone config→runtime-store seed seam today (the runtime store
- * has no boot-time config hydration; `consensus.autoResolveOnRoundClose` is read
- * the same direct way in collect.ts). So the config value is supplied as the
- * `defaultValue` to `getRuntimeFlagBool`, which already implements env→file→
- * defaultValue precedence — making the env/registry path authoritative while
- * letting the config file seed the default. TODO(§8.2-4): if a real config→store
- * hydration seam lands, move this seeding there.
+ * The config value is supplied as the STRING `defaultValue` to `getRuntimeFlag`,
+ * NOT to `getRuntimeFlagBool`. This matters: `getRuntimeFlagBool` forwards
+ * `undefined` (not its `defaultValue`) to `getRuntimeFlag`, which then returns
+ * the registry default `'0'` before any caller default applies — so a config
+ * seed passed to `getRuntimeFlagBool` is dead code (pre-merge consensus
+ * 9fe6d8db). `getRuntimeFlag`'s own precedence is env(non-empty) > flags-file >
+ * explicit defaultValue > registry default, so seeding it directly makes the
+ * config opt-in actually work while keeping env/flags-file authoritative.
+ *
+ * Empty-string env (`export GOSSIP_WORKTREE_AUTO_REVERT=`) is an explicit OFF,
+ * matching the bool-helper's force-off semantics for a destructive opt-in.
  *
  * Fail-open: any config read error falls back to the registry default ('0' → OFF).
+ * Exported for direct precedence testing (config seed honored without env).
  */
-function worktreeAutoRevertEnabled(projectRoot: string): boolean {
-  let configDefault: boolean | undefined;
+export function worktreeAutoRevertEnabled(projectRoot: string): boolean {
+  // Explicit empty-string env → force OFF regardless of file/config.
+  if (process.env.GOSSIP_WORKTREE_AUTO_REVERT === '') return false;
+
+  let configSeed: string | undefined;
   try {
     const { findConfigPath, loadConfig } = require('../config');
     const cfgP = findConfigPath(projectRoot);
     const cfg = cfgP ? loadConfig(cfgP) : null;
     const v = cfg?.consensus?.worktreeAutoRevert;
-    if (typeof v === 'boolean') configDefault = v;
+    if (typeof v === 'boolean') configSeed = v ? '1' : '0';
   } catch { /* fail-open — env/registry path stays authoritative */ }
   try {
-    const { getRuntimeFlagBool } = require('@gossip/orchestrator');
-    return getRuntimeFlagBool('GOSSIP_WORKTREE_AUTO_REVERT', configDefault);
+    const { getRuntimeFlag } = require('@gossip/orchestrator');
+    const raw = getRuntimeFlag('GOSSIP_WORKTREE_AUTO_REVERT', configSeed);
+    return raw === '1' || raw?.toLowerCase() === 'true';
   } catch {
     // Orchestrator import failed — honor config seed, else registry default OFF.
-    return configDefault ?? false;
+    return configSeed === '1';
   }
 }
 

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -199,8 +199,11 @@ export function worktreeAutoRevertEnabled(projectRoot: string): boolean {
     const raw = getRuntimeFlag('GOSSIP_WORKTREE_AUTO_REVERT', configSeed);
     return raw === '1' || raw?.toLowerCase() === 'true';
   } catch {
-    // Orchestrator import failed — honor config seed, else registry default OFF.
-    return configSeed === '1';
+    // Orchestrator import failed — a broken subsystem must NOT become the
+    // enabling condition for a destructive op. Fail OFF regardless of the config
+    // seed (pre-merge consensus 1bdcafc4 — "heuristic detector must not default
+    // to a destructive op"). The operator can still force it via env.
+    return false;
   }
 }
 
@@ -655,7 +658,12 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
       let orchestratorOwnedGlobs: string[] = [];
       try {
         const { findConfigPath, loadConfig } = require('../config');
-        const cfgP = findConfigPath(process.cwd());
+        // Resolve config from the project root (same basis as revertRoot below),
+        // not bare process.cwd() — the MCP server's cwd can differ from the
+        // project root, which would silently skip the operator globs (pre-merge
+        // consensus 1bdcafc4).
+        const cfgRoot = ctx.mainAgent?.projectRoot ?? process.cwd();
+        const cfgP = findConfigPath(cfgRoot);
         const cfg = cfgP ? loadConfig(cfgP) : null;
         const g = cfg?.consensus?.orchestratorOwnedGlobs;
         if (Array.isArray(g)) orchestratorOwnedGlobs = g;

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -163,6 +163,39 @@ function appendRelayWarning(
 }
 
 /**
+ * Resolve the effective GOSSIP_WORKTREE_AUTO_REVERT flag (spec 2026-06-09
+ * Layer B, §8.2 item 4). Precedence: env → file → `consensus.worktreeAutoRevert`
+ * config → registry default '0'.
+ *
+ * There is no standalone config→runtime-store seed seam today (the runtime store
+ * has no boot-time config hydration; `consensus.autoResolveOnRoundClose` is read
+ * the same direct way in collect.ts). So the config value is supplied as the
+ * `defaultValue` to `getRuntimeFlagBool`, which already implements env→file→
+ * defaultValue precedence — making the env/registry path authoritative while
+ * letting the config file seed the default. TODO(§8.2-4): if a real config→store
+ * hydration seam lands, move this seeding there.
+ *
+ * Fail-open: any config read error falls back to the registry default ('0' → OFF).
+ */
+function worktreeAutoRevertEnabled(projectRoot: string): boolean {
+  let configDefault: boolean | undefined;
+  try {
+    const { findConfigPath, loadConfig } = require('../config');
+    const cfgP = findConfigPath(projectRoot);
+    const cfg = cfgP ? loadConfig(cfgP) : null;
+    const v = cfg?.consensus?.worktreeAutoRevert;
+    if (typeof v === 'boolean') configDefault = v;
+  } catch { /* fail-open — env/registry path stays authoritative */ }
+  try {
+    const { getRuntimeFlagBool } = require('@gossip/orchestrator');
+    return getRuntimeFlagBool('GOSSIP_WORKTREE_AUTO_REVERT', configDefault);
+  } catch {
+    // Orchestrator import failed — honor config seed, else registry default OFF.
+    return configDefault ?? false;
+  }
+}
+
+/**
  * Spawn a timeout watcher for a native task.
  * INVARIANT: On timeout, writes timed_out to nativeResultMap. Does NOT delete from nativeTaskMap.
  * The collect polling loop depends on nativeTaskMap entries persisting until real relay or TTL eviction.
@@ -601,9 +634,24 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
   // emit worktree_isolation_failed if HEAD moved or new dirty paths appeared
   // that weren't in the dispatch-time snapshot. Spec:
   // docs/specs/2026-05-20-native-worktree-isolation-fix.md
-  let isolationDiff: { headChanged: boolean; dirtyPathsAdded: string[]; isViolation: boolean } | null = null;
+  let isolationDiff:
+    | { headChanged: boolean; dirtyPathsAdded: string[]; isViolation: boolean; excludedPaths?: string[] }
+    | null = null;
   if (taskInfo.writeMode === 'worktree' && taskInfo.isolationSnapshot) {
     try {
+      // Operator-configured extra orchestrator-owned globs (spec 2026-06-09
+      // Layer A, §3.4). Unioned with the built-in .gossip//.claude/ prefixes
+      // inside diffIsolationSnapshots. Read fail-open — a missing/corrupt config
+      // must never block relay completion.
+      let orchestratorOwnedGlobs: string[] = [];
+      try {
+        const { findConfigPath, loadConfig } = require('../config');
+        const cfgP = findConfigPath(process.cwd());
+        const cfg = cfgP ? loadConfig(cfgP) : null;
+        const g = cfg?.consensus?.orchestratorOwnedGlobs;
+        if (Array.isArray(g)) orchestratorOwnedGlobs = g;
+      } catch { /* fail-open — built-in prefixes still apply */ }
+
       const { checkIsolationViolation } = require('./worktree-isolation-detection');
       isolationDiff = checkIsolationViolation(
         taskInfo.agentId,
@@ -611,6 +659,7 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
         taskInfo.isolationSnapshot,
         process.cwd(),
         taskInfo.concurrentWorktreeTaint,
+        orchestratorOwnedGlobs,
       );
     } catch { /* best-effort — detector must not block relay completion */ }
   }
@@ -952,6 +1001,24 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
   if (relayLintFired) {
     responseText += `\n⚠ relay_findings_dropped: result has 0 <agent_finding> tags but task was a consensus dispatch — orchestrator may have paraphrased; original tagged findings are lost from the dashboard.`;
   }
+  // Base-rate audit (spec 2026-06-09 §3.1 / §8.2 item 5): record orchestrator-
+  // owned paths excluded from attribution BEFORE the violation/revert decision,
+  // even when no violation results — this is the measurement that tells us how
+  // often Layer A fires so the prefix list can be tuned. Fail-open.
+  if (isolationDiff && isolationDiff.excludedPaths && isolationDiff.excludedPaths.length > 0) {
+    try {
+      const excludedRoot = ctx.mainAgent?.projectRoot ?? process.cwd();
+      const exList = isolationDiff.excludedPaths.slice(0, 5).join(' ');
+      appendRelayWarning(excludedRoot, {
+        taskId: task_id,
+        agentId: taskInfo.agentId,
+        reason: 'isolation_excluded_orchestrator_paths',
+        resultLength: isolationDiff.excludedPaths.length,
+        suspectedReason: `excluded_orchestrator_owned count=${isolationDiff.excludedPaths.length} paths=${exList}`,
+        timestamp: new Date().toISOString(),
+      });
+    } catch { /* best-effort — appendRelayWarning is already fail-open internally */ }
+  }
   if (isolationDiff && isolationDiff.isViolation) {
     if (taskInfo?.concurrentWorktreeTaint === true) {
       responseText += `\n⚠ worktree_isolation_skipped: Agent(isolation:"worktree") violation detected but attribution is ambiguous — this task's lifetime overlapped with another worktree task at dispatch time (${isolationDiff.dirtyPathsAdded.length} new dirty path(s)).`;
@@ -1031,8 +1098,10 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
               timestamp: new Date().toISOString(),
             });
             responseText += `\n  → ⚠ could NOT preserve leaked work (${errMsg}); master left dirty to avoid data loss. Recover manually: git stash push -- ${pathList}.`;
-          } else {
-            // Preserve succeeded — safe to clean master via the destructive revert.
+          } else if (worktreeAutoRevertEnabled(revertRoot)) {
+            // Preserve succeeded AND auto-revert opted in (GOSSIP_WORKTREE_AUTO_REVERT
+            // / consensus.worktreeAutoRevert) — clean master via the destructive
+            // revert. Byte-for-byte the pre-#437 behaviour. Spec 2026-06-09 Layer B.
             const revertResult = revertLeakedPaths(revertRoot, isolationDiff.dirtyPathsAdded);
             const auditSuspectedReason =
               revertResult.error
@@ -1057,6 +1126,24 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
                 : '';
               responseText += `\n  → leaked work preserved at .gossip/recovery/${task_id}.patch; master restored (${revertResult.restored.length} path(s))${skippedPart}${rejectedPart}. Recover with: git apply .gossip/recovery/${task_id}.patch (onto a fresh branch).`;
             }
+          } else {
+            // DEFAULT (auto-revert OFF, spec 2026-06-09 Layer B): preserve + report,
+            // do NOT touch the working tree. A heuristic detector must not default
+            // to a destructive op (issue #437). Master is left exactly as-is.
+            appendRelayWarning(revertRoot, {
+              taskId: task_id,
+              agentId: taskInfo.agentId,
+              reason: 'isolation_recovery_preserved_no_revert',
+              resultLength: isolationDiff.dirtyPathsAdded.length,
+              suspectedReason: `auto_revert_disabled patch=${preserveResult.patchPath} preserved=${preserveResult.preserved.length}`,
+              timestamp: new Date().toISOString(),
+            });
+            responseText +=
+              `\n  → leaked work preserved at .gossip/recovery/${task_id}.patch; ` +
+              `master left as-is (auto-revert disabled). ` +
+              `If this was a real isolation leak, clean with: git restore <paths>. ` +
+              `Recover the work with: git apply .gossip/recovery/${task_id}.patch (onto a fresh branch). ` +
+              `Enable auto-revert with GOSSIP_WORKTREE_AUTO_REVERT=1.`;
           }
         } catch (err) {
           responseText += `\n  → auto-recovery FAILED: ${(err as Error).message}. Run 'git restore <paths>' manually.`;

--- a/apps/cli/src/handlers/worktree-isolation-detection.ts
+++ b/apps/cli/src/handlers/worktree-isolation-detection.ts
@@ -78,12 +78,18 @@ function globToRegExp(glob: string): RegExp {
     const c = glob[i];
     if (c === '*') {
       if (glob[i + 1] === '*') {
-        // `**` → any characters including path separators.
-        re += '.*';
-        i++;
-        // Consume a trailing slash after `**` so `docs/**` matches `docs/x`
-        // (the `**/` form) as well as `docs/a/b`.
-        if (glob[i + 1] === '/') i++;
+        i++; // consume the second '*'
+        if (glob[i + 1] === '/') {
+          // `**/` → zero or more COMPLETE path segments (each ending in `/`).
+          // Emitting `(?:.*/)?` (not `.*`) keeps a separator boundary, so
+          // `docs/**/foo` matches `docs/foo` and `docs/a/b/foo` but NOT
+          // `docs/xfoo` (issue #437 pre-merge consensus 9fe6d8db).
+          i++; // consume the '/'
+          re += '(?:.*/)?';
+        } else {
+          // Trailing `**` → any remaining characters including separators.
+          re += '.*';
+        }
       } else {
         // `*` → any characters except a path separator.
         re += '[^/]*';

--- a/apps/cli/src/handlers/worktree-isolation-detection.ts
+++ b/apps/cli/src/handlers/worktree-isolation-detection.ts
@@ -36,8 +36,104 @@ export interface IsolationSnapshot {
 /** Parsed diff between two snapshots. */
 export interface IsolationDiff {
   headChanged: boolean;
+  /**
+   * Agent-attributable added dirty paths, AFTER orchestrator-owned exclusion.
+   * Downstream preserve/revert only ever act on these — never on the infra
+   * paths the orchestrator owns. Spec 2026-06-09 §8.2 item 5.
+   */
   dirtyPathsAdded: string[];
   isViolation: boolean;
+  /**
+   * Added dirty paths filtered OUT as orchestrator/infra-owned (built-in
+   * `.gossip/`/`.claude/` prefixes or operator `excludeGlobs`). Carried for the
+   * audit (`isolation_excluded_orchestrator_paths`) and base-rate measurement.
+   * Omitted/empty when nothing was excluded.
+   */
+  excludedPaths?: string[];
+}
+
+/**
+ * Paths the orchestrator / main session and gossipcat infra routinely write
+ * during a dispatch window. A native code-writing agent's legitimate output
+ * lands in source dirs (packages/, apps/, src/, tests/) — never in these.
+ * Attributing these to an agent is a false positive by construction. These
+ * prefixes are ALWAYS excluded and are not operator-removable (infra invariants).
+ * Spec 2026-06-09 §3.1 / §8.
+ */
+const ORCHESTRATOR_OWNED_PREFIXES = [
+  '.gossip/', // operational state: signals, recovery, dispatch-prompts, session
+  '.claude/', // Claude Code session state: knowledge-nominations.md, worktrees, agents
+];
+
+/**
+ * Translate a single glob pattern into a RegExp matched against repo-relative
+ * porcelain path STRINGS (never a filesystem glob engine — spec §8.2 item 1).
+ * Supports the subset we need: `**` (any chars incl. `/`), `*` (any chars
+ * except `/`), `?` (single non-`/` char). All other regex metacharacters are
+ * escaped literally. Anchored at both ends so a pattern matches the whole path.
+ */
+function globToRegExp(glob: string): RegExp {
+  let re = '';
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        // `**` → any characters including path separators.
+        re += '.*';
+        i++;
+        // Consume a trailing slash after `**` so `docs/**` matches `docs/x`
+        // (the `**/` form) as well as `docs/a/b`.
+        if (glob[i + 1] === '/') i++;
+      } else {
+        // `*` → any characters except a path separator.
+        re += '[^/]*';
+      }
+    } else if (c === '?') {
+      re += '[^/]';
+    } else {
+      // Escape every regex metacharacter so the pattern is matched literally.
+      re += c.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+/**
+ * Partition repo-relative dirty paths into agent-attributable vs.
+ * orchestrator/infra-owned. A path is EXCLUDED if it starts with any built-in
+ * `ORCHESTRATOR_OWNED_PREFIXES` entry OR matches any operator `extraGlobs`.
+ *
+ * Pure (no FS access). `extraGlobs` are matched as STRING globs against the
+ * path text — NEVER via a filesystem glob engine (`glob.sync`/`fast-glob`),
+ * which would resolve against cwd and let `**` suppress all detection
+ * (spec §8.2 item 1). The built-in prefixes are unioned with `extraGlobs`,
+ * never replaced (spec §8.3 "union, not replace").
+ */
+export function filterOrchestratorOwned(
+  paths: string[],
+  extraGlobs: string[] = [],
+): { agentAttributable: string[]; excluded: string[] } {
+  const agentAttributable: string[] = [];
+  const excluded: string[] = [];
+  if (!paths || paths.length === 0) return { agentAttributable, excluded };
+
+  // Compile operator globs once. Skip non-string / empty entries defensively —
+  // validateConfig already rejects them, but this keeps the matcher fail-safe.
+  const globMatchers = (extraGlobs || [])
+    .filter((g): g is string => typeof g === 'string' && g.length > 0)
+    .map(globToRegExp);
+
+  for (const p of paths) {
+    if (typeof p !== 'string' || p.length === 0) continue;
+    const isBuiltIn = ORCHESTRATOR_OWNED_PREFIXES.some(prefix => p.startsWith(prefix));
+    const isGlobbed = !isBuiltIn && globMatchers.some(re => re.test(p));
+    if (isBuiltIn || isGlobbed) {
+      excluded.push(p);
+    } else {
+      agentAttributable.push(p);
+    }
+  }
+  return { agentAttributable, excluded };
 }
 
 /** Read `git rev-parse HEAD` from `cwd`. Returns null on any failure. */
@@ -385,29 +481,43 @@ export function captureIsolationSnapshot(cwd: string = process.cwd()): Isolation
 }
 
 /**
- * Diff two snapshots. Violation if HEAD moved OR new dirty paths appeared
- * that weren't in the `before` set.
+ * Diff two snapshots. Violation if HEAD moved OR new AGENT-ATTRIBUTABLE dirty
+ * paths appeared that weren't in the `before` set.
  *
  * `before.head === null` short-circuits the HEAD comparison — we can't claim
  * drift if we never read the baseline. The dirty-path diff still runs and is
  * sufficient to catch the PR #422 pattern (HEAD untouched, files written
  * directly to parent checkout).
+ *
+ * Orchestrator/infra-owned paths (built-in `.gossip/`/`.claude/` prefixes plus
+ * operator `excludeGlobs`) are subtracted from the added-path set BEFORE the
+ * violation decision (spec 2026-06-09 §3.1, placement §8.1 option b — all three
+ * dispatch paths route through here on relay, so the consensus path inherits the
+ * filter with no special-case code). `dirtyPathsAdded` therefore means
+ * "agent-attributable added paths"; the filtered-out infra paths ride along on
+ * `excludedPaths`. `headChanged` is NEVER excludable — HEAD drift stays a hard
+ * violation regardless of exclusions (§8.1).
  */
 export function diffIsolationSnapshots(
   before: IsolationSnapshot,
   after: IsolationSnapshot,
+  excludeGlobs: string[] = [],
 ): IsolationDiff {
   const headChanged =
     before.head !== null && after.head !== null && before.head !== after.head;
 
   const beforeSet = new Set(before.dirty);
-  const dirtyPathsAdded = after.dirty.filter(p => !beforeSet.has(p));
+  const addedPaths = after.dirty.filter(p => !beforeSet.has(p));
 
-  return {
+  const { agentAttributable, excluded } = filterOrchestratorOwned(addedPaths, excludeGlobs);
+
+  const diff: IsolationDiff = {
     headChanged,
-    dirtyPathsAdded,
-    isViolation: headChanged || dirtyPathsAdded.length > 0,
+    dirtyPathsAdded: agentAttributable,
+    isViolation: headChanged || agentAttributable.length > 0,
   };
+  if (excluded.length > 0) diff.excludedPaths = excluded;
+  return diff;
 }
 
 /** Build the operational-signal payload for a detected isolation failure. */
@@ -427,6 +537,7 @@ export function buildIsolationSignal(args: {
   head_before: string | null;
   head_after: string | null;
   dirty_paths_added: string[];
+  excluded_paths: string[];
 } {
   const { agentId, taskId, before, after, diff } = args;
   const headSummary = diff.headChanged
@@ -445,6 +556,7 @@ export function buildIsolationSignal(args: {
     head_before: before.head,
     head_after: after.head,
     dirty_paths_added: diff.dirtyPathsAdded,
+    excluded_paths: diff.excludedPaths ?? [],
   };
 }
 
@@ -458,6 +570,9 @@ export function buildIsolationSignal(args: {
  *   with at least one other worktree-mode task at dispatch time. Attribution
  *   is ambiguous — skip emitConsensusSignals and emit a skipped breadcrumb
  *   instead. `false` or `undefined` preserves existing emit behaviour.
+ * @param excludeGlobs - Operator-configured extra orchestrator-owned globs
+ *   (`consensus.orchestratorOwnedGlobs`), unioned with the built-in
+ *   `.gossip/`/`.claude/` prefixes and subtracted from the attributable set.
  *
  * Fail-open: any throw is swallowed; returns a no-violation diff.
  */
@@ -467,10 +582,11 @@ export function checkIsolationViolation(
   before: IsolationSnapshot,
   cwd: string = process.cwd(),
   concurrencyTainted?: boolean,
+  excludeGlobs: string[] = [],
 ): IsolationDiff {
   try {
     const after = captureIsolationSnapshot(cwd);
-    const diff = diffIsolationSnapshots(before, after);
+    const diff = diffIsolationSnapshots(before, after, excludeGlobs);
     if (diff.isViolation) {
       if (concurrencyTainted === true) {
         // Lifetime overlapped with another worktree task — attribution is

--- a/packages/orchestrator/src/runtime-config-schema.ts
+++ b/packages/orchestrator/src/runtime-config-schema.ts
@@ -38,6 +38,14 @@ export const RUNTIME_FLAG_REGISTRY = {
     default: '',
     description: 'Operator override agent_id for consensus auto-verify discovery.',
   },
+  /**
+   * When '1', a detected worktree-isolation leak whose work was successfully
+   * preserved to .gossip/recovery/<taskId>.patch is ALSO destructively
+   * reverted from the parent checkout (git restore --source=HEAD). Default '0'
+   * (preserve + report only) — a heuristic detector must not default to a
+   * destructive op (issue #437, round 251e5ef6-d4d44ba2).
+   */
+  GOSSIP_WORKTREE_AUTO_REVERT: { type: 'boolean', default: '0', description: 'Destructively revert preserved isolation-leak paths from the parent checkout' },
 } as const;
 
 export type RuntimeFlagKey = keyof typeof RUNTIME_FLAG_REGISTRY;

--- a/tests/cli/relay-isolation-warning.test.ts
+++ b/tests/cli/relay-isolation-warning.test.ts
@@ -64,11 +64,19 @@ function makeMainAgent(projectRoot: string): any {
 let testDir: string;
 let originalCwd: string;
 let stderrSpy: jest.SpyInstance;
+let prevAutoRevert: string | undefined;
 
 beforeEach(() => {
   testDir = mkdtempSync(join(tmpdir(), 'gossip-relay-iso-test-'));
   originalCwd = process.cwd();
   process.chdir(testDir);
+
+  // These tests assert the destructive preserve-then-revert behaviour, which
+  // post-#437 (spec 2026-06-09 Layer B) is OPT-IN — default OFF. Enable it via
+  // env so the carry-forward revert assertions stay green. The no-revert default
+  // is covered separately in worktree-isolation-false-positive.test.ts.
+  prevAutoRevert = process.env.GOSSIP_WORKTREE_AUTO_REVERT;
+  process.env.GOSSIP_WORKTREE_AUTO_REVERT = '1';
 
   ctx.nativeTaskMap = new Map();
   ctx.nativeResultMap = new Map();
@@ -101,6 +109,8 @@ afterEach(() => {
   stderrSpy.mockRestore();
   process.chdir(originalCwd);
   rmSync(testDir, { recursive: true, force: true });
+  if (prevAutoRevert === undefined) delete process.env.GOSSIP_WORKTREE_AUTO_REVERT;
+  else process.env.GOSSIP_WORKTREE_AUTO_REVERT = prevAutoRevert;
 });
 
 function seedWorktreeTask(

--- a/tests/cli/worktree-isolation-false-positive.test.ts
+++ b/tests/cli/worktree-isolation-false-positive.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Tests for the worktree-isolation false-positive-attribution fix (issue #437).
+ * Spec: docs/specs/2026-06-09-worktree-isolation-false-positive-attribution.md
+ *       (incl. §8 consensus revisions).
+ *
+ * Two independent layers:
+ *  - Layer A: orchestrator-owned path exclusion inside diffIsolationSnapshots.
+ *    Built-in `.gossip/`/`.claude/` prefixes (never removable) + operator
+ *    `orchestratorOwnedGlobs`, matched as STRING globs against repo-relative
+ *    porcelain paths. `headChanged` stays a hard violation regardless.
+ *  - Layer B: auto-restore becomes opt-in (GOSSIP_WORKTREE_AUTO_REVERT, default
+ *    OFF). When OFF a detected leak is preserved + reported but master is left
+ *    as-is; when ON the pre-#437 preserve-then-revert behaviour is byte-for-byte.
+ *
+ * Layer A / config are tested as pure functions; Layer B is tested through
+ * handleNativeRelay with the same mock harness as relay-isolation-warning.test.ts.
+ */
+import { mkdtempSync, rmSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import {
+  filterOrchestratorOwned,
+  diffIsolationSnapshots,
+  type IsolationSnapshot,
+} from '../../apps/cli/src/handlers/worktree-isolation-detection';
+import { validateConfig } from '../../apps/cli/src/config';
+
+function snap(dirty: string[], head: string | null = 'a'.repeat(40)): IsolationSnapshot {
+  return { head, dirty: [...dirty].sort(), takenAt: new Date().toISOString() };
+}
+
+// ─── Layer A — filterOrchestratorOwned (pure) ────────────────────────────────
+
+describe('filterOrchestratorOwned', () => {
+  it('excludes built-in .claude/ prefix paths', () => {
+    const r = filterOrchestratorOwned(['.claude/knowledge-nominations.md']);
+    expect(r.agentAttributable).toEqual([]);
+    expect(r.excluded).toEqual(['.claude/knowledge-nominations.md']);
+  });
+
+  it('excludes built-in .gossip/ prefix paths', () => {
+    const r = filterOrchestratorOwned(['.gossip/session-gossip.jsonl']);
+    expect(r.agentAttributable).toEqual([]);
+    expect(r.excluded).toEqual(['.gossip/session-gossip.jsonl']);
+  });
+
+  it('keeps source paths attributable while excluding infra paths', () => {
+    const r = filterOrchestratorOwned([
+      'packages/orchestrator/src/foo.ts',
+      '.claude/notes.md',
+    ]);
+    expect(r.agentAttributable).toEqual(['packages/orchestrator/src/foo.ts']);
+    expect(r.excluded).toEqual(['.claude/notes.md']);
+  });
+
+  it('honors operator extraGlobs (docs/journal/**) but not un-globbed siblings', () => {
+    const r = filterOrchestratorOwned(
+      ['docs/journal/x.md', 'docs/other.md'],
+      ['docs/journal/**'],
+    );
+    expect(r.agentAttributable).toEqual(['docs/other.md']);
+    expect(r.excluded).toEqual(['docs/journal/x.md']);
+  });
+
+  it('source-dir-overlap footgun: packages/tools/** excludes a real source file', () => {
+    // §8.3 — asserts the footgun is real, justifying the config-validation warning.
+    const r = filterOrchestratorOwned(
+      ['packages/tools/src/index.ts'],
+      ['packages/tools/**'],
+    );
+    expect(r.agentAttributable).toEqual([]);
+    expect(r.excluded).toEqual(['packages/tools/src/index.ts']);
+  });
+
+  it('union, not replace: a custom glob does NOT remove built-in exclusions', () => {
+    const r = filterOrchestratorOwned(
+      ['.gossip/x.jsonl', '.claude/y.md', 'docs/journal/z.md', 'apps/cli/src/a.ts'],
+      ['docs/journal/**'],
+    );
+    expect(r.agentAttributable).toEqual(['apps/cli/src/a.ts']);
+    expect(r.excluded.sort()).toEqual(
+      ['.claude/y.md', '.gossip/x.jsonl', 'docs/journal/z.md'].sort(),
+    );
+  });
+
+  it('empty input → both empty; no extraGlobs is a no-op exclusion of source paths', () => {
+    expect(filterOrchestratorOwned([])).toEqual({ agentAttributable: [], excluded: [] });
+    const r = filterOrchestratorOwned(['apps/cli/src/foo.ts']);
+    expect(r.agentAttributable).toEqual(['apps/cli/src/foo.ts']);
+    expect(r.excluded).toEqual([]);
+  });
+
+  it('single-star glob does not cross a path separator', () => {
+    const r = filterOrchestratorOwned(
+      ['logs/a.log', 'logs/sub/b.log'],
+      ['logs/*'],
+    );
+    // `logs/*` matches the top-level file only, not the nested one.
+    expect(r.excluded).toEqual(['logs/a.log']);
+    expect(r.agentAttributable).toEqual(['logs/sub/b.log']);
+  });
+});
+
+// ─── Layer A — diffIsolationSnapshots integration ────────────────────────────
+
+describe('diffIsolationSnapshots — orchestrator-owned exclusion', () => {
+  it('dirty .claude/knowledge-nominations.md only → no violation (6-07 13996c4c regression)', () => {
+    const before = snap([]);
+    const after = snap(['.claude/knowledge-nominations.md']);
+    const diff = diffIsolationSnapshots(before, after);
+    expect(diff.isViolation).toBe(false);
+    expect(diff.dirtyPathsAdded).toEqual([]);
+    expect(diff.excludedPaths).toEqual(['.claude/knowledge-nominations.md']);
+  });
+
+  it('dirty .gossip/session-gossip.jsonl only → excluded, no violation', () => {
+    const diff = diffIsolationSnapshots(snap([]), snap(['.gossip/session-gossip.jsonl']));
+    expect(diff.isViolation).toBe(false);
+    expect(diff.excludedPaths).toEqual(['.gossip/session-gossip.jsonl']);
+  });
+
+  it('source file + .claude/notes.md → only source attributable; notes.md excluded', () => {
+    const diff = diffIsolationSnapshots(
+      snap([]),
+      snap(['packages/orchestrator/src/foo.ts', '.claude/notes.md']),
+    );
+    expect(diff.isViolation).toBe(true);
+    expect(diff.dirtyPathsAdded).toEqual(['packages/orchestrator/src/foo.ts']);
+    expect(diff.excludedPaths).toEqual(['.claude/notes.md']);
+  });
+
+  it('operator glob docs/journal/** excludes journal write but not docs/other.md', () => {
+    const diff = diffIsolationSnapshots(
+      snap([]),
+      snap(['docs/journal/x.md', 'docs/other.md']),
+      ['docs/journal/**'],
+    );
+    expect(diff.isViolation).toBe(true);
+    expect(diff.dirtyPathsAdded).toEqual(['docs/other.md']);
+    expect(diff.excludedPaths).toEqual(['docs/journal/x.md']);
+  });
+
+  it('headChanged=true with only excluded dirty paths → STILL a violation', () => {
+    const before = snap([], 'a'.repeat(40));
+    const after = snap(['.claude/knowledge-nominations.md'], 'b'.repeat(40));
+    const diff = diffIsolationSnapshots(before, after);
+    expect(diff.headChanged).toBe(true);
+    expect(diff.isViolation).toBe(true);
+    expect(diff.dirtyPathsAdded).toEqual([]); // attribution still empty
+    expect(diff.excludedPaths).toEqual(['.claude/knowledge-nominations.md']);
+  });
+
+  it('source-dir-overlap: orchestratorOwnedGlobs packages/tools/** suppresses a real leak', () => {
+    const diff = diffIsolationSnapshots(
+      snap([]),
+      snap(['packages/tools/src/index.ts']),
+      ['packages/tools/**'],
+    );
+    expect(diff.isViolation).toBe(false);
+    expect(diff.excludedPaths).toEqual(['packages/tools/src/index.ts']);
+  });
+
+  it('no excluded paths → excludedPaths omitted (undefined)', () => {
+    const diff = diffIsolationSnapshots(snap([]), snap(['apps/cli/src/foo.ts']));
+    expect(diff.isViolation).toBe(true);
+    expect(diff.dirtyPathsAdded).toEqual(['apps/cli/src/foo.ts']);
+    expect(diff.excludedPaths).toBeUndefined();
+  });
+});
+
+// ─── Config validation ───────────────────────────────────────────────────────
+
+describe('validateConfig — orchestratorOwnedGlobs / worktreeAutoRevert', () => {
+  const base = { main_agent: { provider: 'anthropic', model: 'claude-opus-4-6' } };
+
+  it('accepts valid orchestratorOwnedGlobs + worktreeAutoRevert', () => {
+    const cfg = validateConfig({
+      ...base,
+      consensus: { worktreeAutoRevert: true, orchestratorOwnedGlobs: ['docs/journal/**'] },
+    });
+    expect(cfg.consensus?.worktreeAutoRevert).toBe(true);
+    expect(cfg.consensus?.orchestratorOwnedGlobs).toEqual(['docs/journal/**']);
+  });
+
+  it('rejects wildcard-only entry **', () => {
+    expect(() =>
+      validateConfig({ ...base, consensus: { orchestratorOwnedGlobs: ['**'] } }),
+    ).toThrow(/wildcard-only/);
+  });
+
+  it('rejects wildcard-only entry *', () => {
+    expect(() =>
+      validateConfig({ ...base, consensus: { orchestratorOwnedGlobs: ['*'] } }),
+    ).toThrow(/wildcard-only/);
+  });
+
+  it('rejects traversal entry ../../*', () => {
+    expect(() =>
+      validateConfig({ ...base, consensus: { orchestratorOwnedGlobs: ['../../*'] } }),
+    ).toThrow(/traversal/);
+  });
+
+  it('rejects non-string / empty members', () => {
+    expect(() =>
+      validateConfig({ ...base, consensus: { orchestratorOwnedGlobs: [123] } }),
+    ).toThrow(/non-empty strings/);
+    expect(() =>
+      validateConfig({ ...base, consensus: { orchestratorOwnedGlobs: [''] } }),
+    ).toThrow(/non-empty strings/);
+  });
+
+  it('rejects non-array orchestratorOwnedGlobs', () => {
+    expect(() =>
+      validateConfig({ ...base, consensus: { orchestratorOwnedGlobs: 'docs/**' } }),
+    ).toThrow(/array of strings/);
+  });
+
+  it('rejects non-boolean worktreeAutoRevert', () => {
+    expect(() =>
+      validateConfig({ ...base, consensus: { worktreeAutoRevert: 'yes' } }),
+    ).toThrow(/must be a boolean/);
+  });
+});
+
+// ─── Layer B — auto-restore opt-in through handleNativeRelay ─────────────────
+
+// Mock the detector module so we can deterministically return a violation diff
+// without standing up a real git working tree (mirrors relay-isolation-warning).
+const mockCheck = jest.fn();
+const mockRevert = jest.fn();
+const mockPreserve = jest.fn();
+jest.mock('../../apps/cli/src/handlers/worktree-isolation-detection', () => {
+  const actual = jest.requireActual('../../apps/cli/src/handlers/worktree-isolation-detection');
+  return {
+    __esModule: true,
+    ...actual,
+    checkIsolationViolation: (...args: any[]) => mockCheck(...args),
+    revertLeakedPaths: (...args: any[]) => mockRevert(...args),
+    preserveLeakedPaths: (...args: any[]) => mockPreserve(...args),
+  };
+});
+
+import { handleNativeRelay } from '../../apps/cli/src/handlers/native-tasks';
+import { ctx } from '../../apps/cli/src/mcp-context';
+
+const AGENT_ID = 'sonnet-implementer';
+const TASK_ID = 'iso-fp-task-1';
+
+function makeMainAgent(projectRoot: string): any {
+  return {
+    dispatch: jest.fn().mockReturnValue({ taskId: 'mock' }),
+    collect: jest.fn().mockResolvedValue({ results: [] }),
+    getAgentConfig: jest.fn().mockReturnValue(null),
+    getLLM: jest.fn().mockReturnValue(null),
+    getAgentList: jest.fn().mockReturnValue([]),
+    getSessionGossip: jest.fn().mockReturnValue([]),
+    getPerfReader: jest.fn().mockReturnValue(undefined),
+    recordNativeTask: jest.fn(),
+    recordNativeTaskCompleted: jest.fn(),
+    recordPlanStepResult: jest.fn(),
+    publishNativeGossip: jest.fn().mockResolvedValue(undefined),
+    scopeTracker: { release: jest.fn() },
+    getWorktreeManager: jest.fn().mockReturnValue({
+      cleanup: jest.fn().mockResolvedValue(undefined),
+      pruneOrphans: jest.fn().mockResolvedValue(undefined),
+    }),
+    projectRoot,
+  };
+}
+
+function seedWorktreeTask(taskId: string, agentId: string): void {
+  ctx.nativeTaskMap.set(taskId, {
+    agentId,
+    task: 'implement thing in worktree',
+    startedAt: Date.now() - 1000,
+    timeoutMs: 120_000,
+    writeMode: 'worktree',
+    isolationSnapshot: {
+      head: 'a'.repeat(40),
+      dirty: [],
+      takenAt: new Date(Date.now() - 1000).toISOString(),
+    },
+  } as any);
+}
+
+function readWarnings(dir: string): any[] {
+  try {
+    const raw = readFileSync(join(dir, '.gossip', 'relay-warnings.jsonl'), 'utf8').trim();
+    return raw.split('\n').filter(Boolean).map((l) => JSON.parse(l));
+  } catch {
+    return [];
+  }
+}
+
+describe('handleNativeRelay — Layer B auto-restore opt-in', () => {
+  let testDir: string;
+  let originalCwd: string;
+  let stderrSpy: jest.SpyInstance;
+  let prevAutoRevert: string | undefined;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'gossip-iso-fp-test-'));
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+
+    ctx.nativeTaskMap = new Map();
+    ctx.nativeResultMap = new Map();
+    ctx.pendingConsensusRounds = new Map();
+    ctx.recentConsensusTaskIds = new Map();
+    ctx.recentConsensusAgentIds = new Map();
+    ctx.mainAgent = makeMainAgent(testDir);
+    ctx.nativeUtilityConfig = null;
+    ctx.booted = true;
+    ctx.boot = jest.fn().mockResolvedValue(undefined) as any;
+
+    mockCheck.mockReset();
+    mockRevert.mockReset();
+    mockPreserve.mockReset();
+    mockRevert.mockReturnValue({ restored: [], skipped: [], rejected: [] });
+    mockPreserve.mockReturnValue({
+      preserved: ['apps/cli/src/leaked.ts'],
+      skipped: [],
+      rejected: [],
+      patchPath: join(testDir, '.gossip', 'recovery', `${TASK_ID}.patch`),
+    });
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    prevAutoRevert = process.env.GOSSIP_WORKTREE_AUTO_REVERT;
+    delete process.env.GOSSIP_WORKTREE_AUTO_REVERT;
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    process.chdir(originalCwd);
+    rmSync(testDir, { recursive: true, force: true });
+    if (prevAutoRevert === undefined) delete process.env.GOSSIP_WORKTREE_AUTO_REVERT;
+    else process.env.GOSSIP_WORKTREE_AUTO_REVERT = prevAutoRevert;
+  });
+
+  it('DEFAULT (flag unset): real source leak → patch preserved, NO revert, working tree untouched', async () => {
+    seedWorktreeTask(TASK_ID, AGENT_ID);
+    mockCheck.mockReturnValue({
+      headChanged: false,
+      dirtyPathsAdded: ['apps/cli/src/leaked.ts'],
+      isViolation: true,
+    });
+
+    const res = await handleNativeRelay(
+      TASK_ID,
+      '<agent_finding type="finding" severity="LOW">x</agent_finding>',
+    );
+
+    // The destructive revert must NOT run under the default-OFF posture.
+    expect(mockRevert).not.toHaveBeenCalled();
+
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain('worktree_isolation_failed');
+    expect(text).toContain('leaked work preserved at .gossip/recovery/iso-fp-task-1.patch');
+    expect(text).toContain('master left as-is (auto-revert disabled)');
+    expect(text).toContain('git restore <paths>');
+    expect(text).toContain('GOSSIP_WORKTREE_AUTO_REVERT=1');
+
+    const warnings = readWarnings(testDir);
+    const entry = warnings.find((e) => e.reason === 'isolation_recovery_preserved_no_revert');
+    expect(entry).toBeDefined();
+    expect(entry.taskId).toBe(TASK_ID);
+    expect(entry.suspectedReason).toContain('auto_revert_disabled');
+  });
+
+  it('flag=1 (env): same leak → preserve THEN revert, master cleaned (pre-#437 behaviour)', async () => {
+    process.env.GOSSIP_WORKTREE_AUTO_REVERT = '1';
+    seedWorktreeTask(TASK_ID, AGENT_ID);
+    mockCheck.mockReturnValue({
+      headChanged: false,
+      dirtyPathsAdded: ['apps/cli/src/leaked.ts'],
+      isViolation: true,
+    });
+    mockRevert.mockReturnValue({ restored: ['apps/cli/src/leaked.ts'], skipped: [], rejected: [] });
+
+    const res = await handleNativeRelay(
+      TASK_ID,
+      '<agent_finding type="finding" severity="LOW">x</agent_finding>',
+    );
+
+    expect(mockRevert).toHaveBeenCalledTimes(1);
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain('master restored (1 path(s))');
+    expect(text).not.toContain('auto-revert disabled');
+
+    const warnings = readWarnings(testDir);
+    expect(warnings.find((e) => e.reason === 'isolation_recovery_preserved')).toBeDefined();
+    expect(warnings.find((e) => e.reason === 'isolation_recovery_preserved_no_revert')).toBeUndefined();
+  });
+
+  it('emits isolation_excluded_orchestrator_paths audit when excludedPaths present', async () => {
+    seedWorktreeTask(TASK_ID, AGENT_ID);
+    // No violation, but the detector reports excluded orchestrator-owned paths.
+    mockCheck.mockReturnValue({
+      headChanged: false,
+      dirtyPathsAdded: [],
+      isViolation: false,
+      excludedPaths: ['.claude/knowledge-nominations.md', '.gossip/x.jsonl'],
+    });
+
+    await handleNativeRelay(
+      TASK_ID,
+      '<agent_finding type="finding" severity="LOW">x</agent_finding>',
+    );
+
+    const warnings = readWarnings(testDir);
+    const excludedEntry = warnings.find((e) => e.reason === 'isolation_excluded_orchestrator_paths');
+    expect(excludedEntry).toBeDefined();
+    expect(excludedEntry.taskId).toBe(TASK_ID);
+    expect(excludedEntry.resultLength).toBe(2);
+    expect(excludedEntry.suspectedReason).toContain('.claude/knowledge-nominations.md');
+  });
+});

--- a/tests/cli/worktree-isolation-false-positive.test.ts
+++ b/tests/cli/worktree-isolation-false-positive.test.ts
@@ -100,6 +100,17 @@ describe('filterOrchestratorOwned', () => {
     expect(r.excluded).toEqual(['logs/a.log']);
     expect(r.agentAttributable).toEqual(['logs/sub/b.log']);
   });
+
+  it('** before a literal segment enforces a path-separator boundary (consensus 9fe6d8db)', () => {
+    // Regression for the globToRegExp `**/foo` boundary bug: `docs/**/foo` must
+    // match `docs/foo` and `docs/a/b/foo` but NOT `docs/xfoo` (suffix match).
+    const r = filterOrchestratorOwned(
+      ['docs/xfoo', 'docs/foo', 'docs/a/b/foo'],
+      ['docs/**/foo'],
+    );
+    expect(r.excluded.sort()).toEqual(['docs/a/b/foo', 'docs/foo'].sort());
+    expect(r.agentAttributable).toEqual(['docs/xfoo']); // NOT silenced
+  });
 });
 
 // ─── Layer A — diffIsolationSnapshots integration ────────────────────────────
@@ -241,8 +252,9 @@ jest.mock('../../apps/cli/src/handlers/worktree-isolation-detection', () => {
   };
 });
 
-import { handleNativeRelay } from '../../apps/cli/src/handlers/native-tasks';
+import { handleNativeRelay, worktreeAutoRevertEnabled } from '../../apps/cli/src/handlers/native-tasks';
 import { ctx } from '../../apps/cli/src/mcp-context';
+import { writeFileSync, mkdirSync } from 'fs';
 
 const AGENT_ID = 'sonnet-implementer';
 const TASK_ID = 'iso-fp-task-1';
@@ -414,5 +426,65 @@ describe('handleNativeRelay — Layer B auto-restore opt-in', () => {
     expect(excludedEntry.taskId).toBe(TASK_ID);
     expect(excludedEntry.resultLength).toBe(2);
     expect(excludedEntry.suspectedReason).toContain('.claude/knowledge-nominations.md');
+  });
+});
+
+// ─── Layer B — worktreeAutoRevertEnabled config→flag precedence ──────────────
+// Regression for the consensus 9fe6d8db HIGH finding: consensus.worktreeAutoRevert
+// in .gossip/config.json must actually seed the flag when no env override is set.
+// (The original impl passed the seed to getRuntimeFlagBool's defaultValue, which
+// is dead code because the registry default '0' pre-empts it.)
+describe('worktreeAutoRevertEnabled — config→flag seeding precedence', () => {
+  let root: string;
+  let prevEnv: string | undefined;
+
+  function writeConfig(worktreeAutoRevert?: boolean): void {
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+    const cfg: any = { main_agent: { provider: 'anthropic', model: 'claude-opus-4-6' } };
+    if (worktreeAutoRevert !== undefined) cfg.consensus = { worktreeAutoRevert };
+    writeFileSync(join(root, '.gossip', 'config.json'), JSON.stringify(cfg));
+  }
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'iso-fp-cfg-'));
+    prevEnv = process.env.GOSSIP_WORKTREE_AUTO_REVERT;
+    delete process.env.GOSSIP_WORKTREE_AUTO_REVERT;
+  });
+
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.GOSSIP_WORKTREE_AUTO_REVERT;
+    else process.env.GOSSIP_WORKTREE_AUTO_REVERT = prevEnv;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('config worktreeAutoRevert:true with NO env → enabled (the dead-config bug)', () => {
+    writeConfig(true);
+    expect(worktreeAutoRevertEnabled(root)).toBe(true);
+  });
+
+  it('config worktreeAutoRevert:false → disabled', () => {
+    writeConfig(false);
+    expect(worktreeAutoRevertEnabled(root)).toBe(false);
+  });
+
+  it('config absent / no consensus block → registry default OFF', () => {
+    writeConfig(undefined);
+    expect(worktreeAutoRevertEnabled(root)).toBe(false);
+  });
+
+  it('no config file at all → registry default OFF (fail-open)', () => {
+    expect(worktreeAutoRevertEnabled(root)).toBe(false);
+  });
+
+  it('env=1 overrides config false', () => {
+    writeConfig(false);
+    process.env.GOSSIP_WORKTREE_AUTO_REVERT = '1';
+    expect(worktreeAutoRevertEnabled(root)).toBe(true);
+  });
+
+  it('explicit empty-string env forces OFF even with config true', () => {
+    writeConfig(true);
+    process.env.GOSSIP_WORKTREE_AUTO_REVERT = '';
+    expect(worktreeAutoRevertEnabled(root)).toBe(false);
   });
 });

--- a/tests/cli/worktree-isolation-realworld.integration.test.ts
+++ b/tests/cli/worktree-isolation-realworld.integration.test.ts
@@ -1,0 +1,187 @@
+/**
+ * REAL-WORLD end-to-end validation of the #437 false-positive fix.
+ * Spec: docs/specs/2026-06-09-worktree-isolation-false-positive-attribution.md
+ *
+ * Unlike worktree-isolation-false-positive.test.ts — which drives
+ * `diffIsolationSnapshots` with synthetic snapshots and mocks git for Layer B —
+ * these tests stand up a REAL git repo in a temp dir and reproduce each of
+ * @GravyaDev's three reported incidents end-to-end through the REAL exported
+ * functions (`captureIsolationSnapshot`, `checkIsolationViolation`,
+ * `preserveLeakedPaths`, `revertLeakedPaths`) against real `git status` /
+ * `git restore`. The assertions are on the ACTUAL on-disk file contents — the
+ * thing that was being destroyed in production.
+ *
+ * Incident map (issue #437):
+ *   S1  6-07  (task 13996c4c) orchestrator appended to .claude/knowledge-nominations.md
+ *             during an in-flight worktree dispatch → detector attributed it to
+ *             the agent and git-restore'd it. MUST now be excluded → no violation
+ *             → the orchestrator's journal line survives on disk.
+ *   S2  Regression proof: the PRE-FIX attribution (after.dirty − before.dirty,
+ *             no exclusion) DID flag that path, and `revertLeakedPaths` on it
+ *             really does wipe the orchestrator's line. Proves the bug was real
+ *             and that S1's no-violation is what prevents reaching the revert.
+ *   S3  6-06 i1 default-OFF: a real source-file leak → violation, but the relay
+ *             default branch preserves WITHOUT reverting → leaked work stays on
+ *             disk + a recovery patch exists. No data loss by default.
+ *   S4  flag=1 opt-in: same leak, relay opt-in branch preserves THEN reverts →
+ *             master is cleaned (pre-#437 behaviour) and the work is recoverable
+ *             via the patch.
+ *   S5  operator glob: a write under an operator `orchestratorOwnedGlobs` entry
+ *             is excluded just like the built-ins → no violation → survives.
+ */
+
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  captureIsolationSnapshot,
+  checkIsolationViolation,
+  preserveLeakedPaths,
+  revertLeakedPaths,
+} from '../../apps/cli/src/handlers/worktree-isolation-detection';
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, stdio: ['ignore', 'pipe', 'ignore'] }).toString();
+}
+
+describe('worktree-isolation #437 — real git repo, end-to-end incident reproduction', () => {
+  let repo: string;
+
+  function writeFile(rel: string, content: string): void {
+    const abs = path.join(repo, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+
+  function read(rel: string): string {
+    return fs.readFileSync(path.join(repo, rel), 'utf8');
+  }
+
+  beforeEach(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'rw437-'));
+    git(repo, ['init', '-q']);
+    git(repo, ['config', 'user.email', 'test@example.com']);
+    git(repo, ['config', 'user.name', 'Test']);
+    git(repo, ['config', 'commit.gpgsign', 'false']);
+    // `.gossip/` is gitignored exactly as in the real project root so recovery
+    // artifacts never appear in porcelain.
+    writeFile('.gitignore', '.gossip/\n');
+    // Baseline tracked files: the orchestrator journal (S1/S2) and a source
+    // file that an agent will later leak into (S3/S4). Both committed so
+    // `git restore --source=HEAD` has a clean version to revert to.
+    writeFile('.claude/knowledge-nominations.md', '# nominations\n');
+    writeFile('packages/x/leaked.ts', 'export const ok = 1;\n');
+    // A journal dir the operator excludes via orchestratorOwnedGlobs (S5).
+    // Tracked at baseline because `git status --porcelain` COLLAPSES a wholly-
+    // untracked directory to `docs/` (one entry) — a deep glob would miss that.
+    // Real journaling dirs are already in the repo, so a new file in them shows
+    // its full path. (Built-in .gossip//.claude/ prefixes are immune: a
+    // collapsed `?? .claude/` still startsWith('.claude/').)
+    writeFile('docs/journal/.gitkeep', '');
+    git(repo, ['add', '-A']);
+    git(repo, ['commit', '-q', '-m', 'baseline']);
+  });
+
+  afterEach(() => {
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  // ── S1: the exact 6-07 incident is now a non-event ────────────────────────
+  it('S1 (6-07): orchestrator journaling to .claude/ during dispatch → no violation, line survives', () => {
+    const before = captureIsolationSnapshot(repo); // dispatch-time snapshot
+
+    // Orchestrator appends a journal line WHILE the agent task is "in flight".
+    const journalLine = 'nominated: real-world-check\n';
+    fs.appendFileSync(path.join(repo, '.claude/knowledge-nominations.md'), journalLine);
+
+    const diff = checkIsolationViolation('opus-implementer', '13996c4c', before, repo, false, []);
+
+    expect(diff.isViolation).toBe(false);
+    expect(diff.dirtyPathsAdded).toEqual([]); // nothing attributed to the agent
+    expect(diff.excludedPaths).toContain('.claude/knowledge-nominations.md');
+    // The decisive real-world assertion: the orchestrator's line is STILL on disk.
+    expect(read('.claude/knowledge-nominations.md')).toContain(journalLine.trim());
+  });
+
+  // ── S2: regression proof — pre-fix attribution really did destroy it ───────
+  it('S2 (regression proof): the OLD attribution flags the .claude/ write and revert WIPES it', () => {
+    const before = captureIsolationSnapshot(repo);
+    const journalLine = 'nominated: would-have-been-lost\n';
+    fs.appendFileSync(path.join(repo, '.claude/knowledge-nominations.md'), journalLine);
+    const after = captureIsolationSnapshot(repo);
+
+    // Reconstruct the pre-#437 attribution: every added dirty path is a "leak",
+    // with no orchestrator-owned exclusion (the exact bug).
+    const beforeSet = new Set(before.dirty);
+    const oldDirtyPathsAdded = after.dirty.filter(p => !beforeSet.has(p));
+    expect(oldDirtyPathsAdded).toContain('.claude/knowledge-nominations.md'); // OLD isViolation=true
+
+    // And the old destructive default really does wipe the orchestrator's work.
+    revertLeakedPaths(repo, oldDirtyPathsAdded);
+    expect(read('.claude/knowledge-nominations.md')).not.toContain(journalLine.trim());
+
+    // Contrast: the fixed detector never reaches that revert for this input.
+    const fixed = checkIsolationViolation('opus-implementer', '13996c4c', before, repo, false, []);
+    expect(fixed.isViolation).toBe(false);
+  });
+
+  // ── S3: real source leak, default-OFF → preserved, NOT reverted ────────────
+  it('S3 (6-06 i1, default-OFF): real source leak → violation, relay default preserves without revert', () => {
+    const before = captureIsolationSnapshot(repo);
+
+    // Agent leaks: appends to a real tracked source file in the parent checkout.
+    const leak = 'export const leaked = 2;\n';
+    fs.appendFileSync(path.join(repo, 'packages/x/leaked.ts'), leak);
+
+    const diff = checkIsolationViolation('opus-implementer', 'task-s3', before, repo, false, []);
+    expect(diff.isViolation).toBe(true);
+    expect(diff.dirtyPathsAdded).toContain('packages/x/leaked.ts'); // genuinely attributable
+
+    // Reproduce the relay's DEFAULT (flag OFF) branch: preserve, do NOT revert.
+    const preserve = preserveLeakedPaths(repo, diff.dirtyPathsAdded, 'task-s3');
+    expect(preserve.patchPath).toBeTruthy();
+    expect(fs.existsSync(path.join(repo, '.gossip/recovery/task-s3.patch'))).toBe(true);
+    // No revertLeakedPaths call on the default path → the leaked work stays put.
+    expect(read('packages/x/leaked.ts')).toContain(leak.trim());
+  });
+
+  // ── S4: opt-in flag → preserve THEN revert (pre-#437 behaviour, recoverable)
+  it('S4 (flag=1 opt-in): same leak → relay opt-in preserves then reverts; work recoverable via patch', () => {
+    const before = captureIsolationSnapshot(repo);
+    const leak = 'export const leaked = 3;\n';
+    fs.appendFileSync(path.join(repo, 'packages/x/leaked.ts'), leak);
+
+    const diff = checkIsolationViolation('opus-implementer', 'task-s4', before, repo, false, []);
+    expect(diff.isViolation).toBe(true);
+
+    // Reproduce the relay's OPT-IN branch: preserve THEN revert.
+    const preserve = preserveLeakedPaths(repo, diff.dirtyPathsAdded, 'task-s4');
+    expect(preserve.patchPath).toBeTruthy();
+    revertLeakedPaths(repo, diff.dirtyPathsAdded);
+
+    // Master is cleaned …
+    expect(read('packages/x/leaked.ts')).not.toContain(leak.trim());
+    // … but the work is recoverable: applying the patch restores it.
+    git(repo, ['apply', path.join(repo, '.gossip/recovery/task-s4.patch')]);
+    expect(read('packages/x/leaked.ts')).toContain(leak.trim());
+  });
+
+  // ── S5: operator-configured glob is excluded just like the built-ins ───────
+  it('S5 (operator glob): a write under orchestratorOwnedGlobs is excluded → no violation, survives', () => {
+    const before = captureIsolationSnapshot(repo);
+
+    const note = '# session journal\n';
+    writeFile('docs/journal/today.md', note); // new untracked file during dispatch
+
+    const diff = checkIsolationViolation('opus-implementer', 'task-s5', before, repo, false, [
+      'docs/journal/**',
+    ]);
+
+    expect(diff.isViolation).toBe(false);
+    expect(diff.excludedPaths).toContain('docs/journal/today.md');
+    expect(fs.existsSync(path.join(repo, 'docs/journal/today.md'))).toBe(true);
+    expect(read('docs/journal/today.md')).toBe(note);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the **false-positive destructive auto-restore** class in the worktree-isolation detector reported by @GravyaDev on #437 (3 instances, 1 real data loss). The detector attributed **any** path dirtied between dispatch and relay to the agent, then `git restore`'d it by default — so in an orchestrated session the routine dirtying of `.claude/`/`.gossip/` state while a dispatch is in flight got misattributed and reverted, destroying orchestrator-owned work.

Closes the engage-gap's most urgent symptom. Does **not** revisit managed worktrees (Option A, proven dead — CC resets cwd between tool calls).

## Consensus

This PR touches an impact-adjacent file (`worktree-isolation-detection.ts`). Multi-agent consensus was run on the implementation diff:

consensus-id: 9fe6d8db-8b6543bd

(Spec design round: `251e5ef6-d4d44ba2`. The pre-merge code round above caught two real bugs — a dead config opt-in channel (HIGH) and a glob `**/` boundary bug (MEDIUM) — both fixed in `106e650e` with +7 regression tests.)

## What changed — two layers, shipping together

**Layer A — orchestrator-owned path exclusion** (`worktree-isolation-detection.ts`)
- `filterOrchestratorOwned` subtracts built-in `.gossip/`/`.claude/` prefixes + operator `consensus.orchestratorOwnedGlobs` from the added-path set **inside `diffIsolationSnapshots`**, so all three dispatch paths inherit it with no special-case code.
- Globs matched as **string patterns** against repo-relative porcelain paths via a small inline matcher — never a filesystem glob engine (a `**` could otherwise suppress all detection).
- `headChanged` stays a hard violation. Excluded paths ride on `IsolationDiff.excludedPaths` + an `isolation_excluded_orchestrator_paths` base-rate audit.

**Layer B — auto-restore becomes opt-in** (`native-tasks.ts`)
- The destructive `revertLeakedPaths` is gated behind `GOSSIP_WORKTREE_AUTO_REVERT`, **default OFF**. New default: preserve the patch + report, never touch the working tree. A heuristic detector misfire is now non-destructive by construction.
- Opt back in via `GOSSIP_WORKTREE_AUTO_REVERT=1` or `consensus.worktreeAutoRevert: true`.

Config validation rejects wildcard-only (`**`/`*`) and traversal (`../`) glob entries.

## Verification

- **Real-git end-to-end reproduction** (`worktree-isolation-realworld.integration.test.ts`): drives the actual functions against a temp git repo and asserts on-disk outcomes — S1 reproduces the exact 6-07 `.claude/knowledge-nominations.md` incident (line survives); **S2 is a regression-proof** showing the *pre-fix* attribution flags the path and `revertLeakedPaths` really wipes it; S3/S4 prove default-OFF-preserves vs flag=1-reverts at the on-disk level.
- Unit suite covers Layer A filtering, config validation, and Layer B via `handleNativeRelay`.
- **92/92** isolation + **55/55** config/runtime-config green; both packages typecheck clean.

## Follow-ups (non-blocking)
- `validateConfig` accepts source-tree globs (`packages/**`) that suppress all attribution — a footgun warning is worth adding.
- Discoverability of accumulated `.gossip/recovery/*.patch` under default-OFF (dashboard/`gossip_watch`).
- Untracked-directory collapse: `git status --porcelain` collapses a wholly-untracked dir to one entry, so deep operator globs miss it; built-in prefixes are immune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
