### PR TITLE
fix(relay): OpenAI-compatible/DeepSeek custom agents — stop crash-loop, carry base_url, clear auth errors (#522)

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -38,6 +38,9 @@ export interface GossipConfig {
     preset?: string;
     skills: string[];
     native?: boolean;
+    /** Custom API base URL for OpenAI-compatible endpoints (e.g. DeepSeek).
+     *  Validated in validateConfig; carried through configToAgentConfigs. #522 */
+    base_url?: string;
   }>;
 }
 
@@ -187,6 +190,9 @@ export function configToAgentConfigs(config: GossipConfig): AgentConfig[] {
     preset: agent.preset,
     skills: agent.skills,
     native: agent.native,
+    // #522: carry base_url through so DeepSeek / OpenAI-compatible agents reach
+    // their configured endpoint instead of defaulting to api.openai.com.
+    base_url: agent.base_url,
   }));
 }
 

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -782,7 +782,13 @@ export async function handleDispatchSingle(
   }
 
   try {
-    const { taskId } = ctx.mainAgent.dispatch(agent_id, task, dispatchOptions as any);
+    const { taskId, finalResultPromise } = ctx.mainAgent.dispatch(agent_id, task, dispatchOptions as any);
+    // #522 SEV-1: a worker provider error (e.g. OpenAI 401) rejects this
+    // background promise. Without a catch it becomes an unhandledRejection and
+    // crash-loops the MCP server. Swallow it here — task errors still surface to
+    // the caller via gossip_collect / gossip_progress (the parallel/consensus
+    // path already does the same at dispatch-pipeline.ts ~747).
+    finalResultPromise?.catch(() => {});
     // For relay worktree dispatch the path is filled in by the async
     // runTask() inside dispatch-pipeline after WorktreeManager.create().
     // Record undefined here; the callback side (gossip_run completion or

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -185,6 +185,36 @@ import { isReservedAgentId } from './reserved-ids';
 let booted = false;
 let bootPromise: Promise<void> | null = null;
 
+// #522 SEV-1: install ONCE per process. main() runs on every connect (boot AND
+// reconnect), so guard the handler registration to avoid stacking duplicate
+// listeners across reconnects.
+let runtimeGuardsInstalled = false;
+
+/**
+ * Install process-level last-resort handlers for background task rejections.
+ *
+ * A worker provider error (e.g. an OpenAI 401 from a misconfigured DeepSeek
+ * agent) rejects a detached task promise. Before #522 there was no handler, so
+ * Node's default unhandledRejection behavior tore down the MCP server, which
+ * the host then respawned — a crash-loop. These handlers LOG to stderr (the
+ * .gossip/mcp.log sink) and CONTINUE; they must NOT process.exit, because a
+ * single background task failing is not a reason to kill the long-lived server.
+ *
+ * The boot-failure path keeps its own `main().catch(... process.exit(1))` — that
+ * is a genuine fatal and is intentionally left untouched.
+ */
+function installRuntimeRejectionGuards(): void {
+  if (runtimeGuardsInstalled) return;
+  runtimeGuardsInstalled = true;
+  process.on('unhandledRejection', (reason: unknown) => {
+    const msg = reason instanceof Error ? (reason.stack ?? reason.message) : String(reason);
+    process.stderr.write(`[gossipcat] ⚠️ unhandledRejection (background task; server continues): ${msg}\n`);
+  });
+  process.on('uncaughtException', (err: Error) => {
+    process.stderr.write(`[gossipcat] ⚠️ uncaughtException (server continues): ${err.stack ?? err.message}\n`);
+  });
+}
+
 // Re-entrant guard: prevents gossip_plan from being called inside a plan step
 let planExecutionDepth = 0;
 // Stash gathered session data between utility dispatch and re-entry (keyed by task ID)
@@ -5066,6 +5096,9 @@ async function main() {
   // so one McpServer instance is sufficient here. The HTTP path constructs a
   // fresh McpServer per inbound session (see issue #405 and the new-session
   // branch in startHttpMcpTransport).
+  // #522: arm last-resort guards before anything can dispatch a background task,
+  // so a rejecting task promise logs-and-continues instead of crash-looping.
+  installRuntimeRejectionGuards();
   const server = createMcpServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -13,6 +13,8 @@ export type { FindBestMatchOptions } from './agent-registry';
 export { TaskDispatcher } from './task-dispatcher';
 export {
   createProvider,
+  createProviderForAgent,
+  KEY_REQUIRING_PROVIDERS,
   AnthropicProvider,
   OpenAIProvider,
   GeminiProvider,

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -209,6 +209,23 @@ class QuotaTracker {
   }
 }
 
+/**
+ * Build a clear, non-misleading error message for a 401/403 from an LLM
+ * endpoint. Provider auth failures (bad/expired/missing key, wrong base_url)
+ * previously fell through to a generic `<Provider> API error (401): ...` which
+ * sent users to platform.openai.com even when the request targeted a
+ * DeepSeek / OpenAI-compatible base_url. This names the provider + endpoint and
+ * points at gossipcat's key source (the OS keychain, not env vars). Issue #522.
+ */
+function authErrorMessage(provider: string, status: number, endpoint: string, body: string): string {
+  return (
+    `${provider} authentication failed (HTTP ${status}) for ${endpoint}: ` +
+    `the API key was rejected. Verify the key for this provider/base_url — ` +
+    `gossipcat resolves provider keys from the OS keychain (not environment ` +
+    `variables). Response: ${body}`
+  );
+}
+
 export interface LLMGenerateOptions {
   tools?: ToolDefinition[];
   temperature?: number;
@@ -266,6 +283,9 @@ export class AnthropicProvider implements ILLMProvider {
       const body = (await res.text()).slice(0, 200);
       if (res.status === 429) this.quota.handle429(res, body);
       if (res.status === 503) this.quota.handle503(res, body);
+      if (res.status === 401 || res.status === 403) {
+        throw new Error(authErrorMessage('Anthropic', res.status, 'https://api.anthropic.com/v1', body));
+      }
       throw new Error(`Anthropic API error (${res.status}): ${body}`);
     }
     this.quota.onSuccess();
@@ -380,6 +400,15 @@ export class OpenAIProvider implements ILLMProvider {
       const body = (await res.text()).slice(0, 200);
       if (res.status === 429) this.quota.handle429(res, body);
       if (res.status === 503) this.quota.handle503(res, body);
+      // 401/403: auth/key failure for THIS endpoint. Surface a clear message
+      // that names the configured base_url rather than the generic OpenAI host,
+      // so DeepSeek / OpenAI-compatible users aren't sent to platform.openai.com.
+      // Cooldown is deferred — handle429's quota state machine is keyed to
+      // rate-limit semantics; a wrong key won't fix itself by waiting, so a
+      // clear, fail-fast message is the correct behavior here (issue #522).
+      if (res.status === 401 || res.status === 403) {
+        throw new Error(authErrorMessage('OpenAI-compatible', res.status, this.baseUrl, body));
+      }
       throw new Error(`OpenAI API error (${res.status}): ${body}`);
     }
     this.quota.onSuccess();
@@ -488,6 +517,9 @@ export class GeminiProvider implements ILLMProvider {
       const errBody = (await res.text()).slice(0, 200);
       if (res.status === 429) this.quota.handle429(res, errBody);
       if (res.status === 503) this.quota.handle503(res, errBody);
+      if (res.status === 401 || res.status === 403) {
+        throw new Error(authErrorMessage('Google Gemini', res.status, 'https://generativelanguage.googleapis.com/v1beta', errBody));
+      }
       throw new Error(`Gemini API error (${res.status}): ${errBody}`);
     }
     this.quota.onSuccess();
@@ -642,6 +674,51 @@ class NullProvider implements ILLMProvider {
   async generate(): Promise<LLMResponse> {
     return { text: '' };
   }
+}
+
+/**
+ * A provider that rejects every generate() call with a fixed diagnostic. Used
+ * for the pre-flight missing-key case (issue #522): a key-requiring agent built
+ * with no configured key gets one of these instead of crashing construction or
+ * issuing an empty-Bearer request that returns a misleading 401. The rejection
+ * surfaces as a normal task failure via gossip_collect / gossip_progress.
+ */
+class DegradedProvider implements ILLMProvider {
+  constructor(private readonly reason: string) {}
+  async generate(): Promise<LLMResponse> {
+    throw new Error(this.reason);
+  }
+}
+
+/**
+ * Providers that require an API key to function. `local` (Ollama) and `none`
+ * (NullProvider) do not. Exported for the pre-flight key check at the worker
+ * construction site (main-agent.ts).
+ */
+export const KEY_REQUIRING_PROVIDERS = ['anthropic', 'openai', 'openclaw', 'google'] as const;
+
+/**
+ * Build a provider for an agent, downgrading to a {@link DegradedProvider} when
+ * a key-requiring provider has no key configured. Prefer this over
+ * `createProvider` at agent-construction sites so a missing key fails the TASK
+ * with a clear message rather than crashing construction or sending an
+ * empty-Bearer request. Issue #522.
+ */
+export function createProviderForAgent(
+  agentId: string,
+  provider: string,
+  model: string,
+  apiKey: string | undefined,
+  baseUrl?: string,
+  projectRoot?: string,
+): ILLMProvider {
+  if ((KEY_REQUIRING_PROVIDERS as readonly string[]).includes(provider) && !apiKey) {
+    return new DegradedProvider(
+      `no API key configured for agent "${agentId}" (provider ${provider}, ` +
+      `base_url ${baseUrl ?? 'default'}); set its key via the keychain`,
+    );
+  }
+  return createProvider(provider, model, apiKey, projectRoot, baseUrl);
 }
 
 // ─── Factory ────────────────────────────────────────────────────────────────

--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -5,7 +5,7 @@
  * fans out to WorkerAgents, and synthesizes results.
  */
 
-import { ILLMProvider, createProvider } from './llm-client';
+import { ILLMProvider, createProvider, createProviderForAgent } from './llm-client';
 import { AgentRegistry } from './agent-registry';
 import { TaskDispatcher } from './task-dispatcher';
 import { WorkerAgent } from './worker-agent';
@@ -377,7 +377,11 @@ export class MainAgent {
         this.workers.delete(ac.id);
       }
 
-      const llm = createProvider(ac.provider, ac.model, key ?? undefined, undefined, (ac as any).base_url);
+      // Pre-flight key check (issue #522): a key-requiring provider with no
+      // configured key gets a DegradedProvider that fails the TASK with a clear
+      // diagnostic, instead of issuing an empty-Bearer request that returns a
+      // misleading 401. base_url is now a typed field on AgentConfig.
+      const llm = createProviderForAgent(ac.id, ac.provider, ac.model, key ?? undefined, ac.base_url);
 
       const instructionsPath = join(this.projectRoot, '.gossip', 'agents', ac.id, 'instructions.md');
       const instructions = existsSync(instructionsPath)

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -7,6 +7,10 @@ export interface AgentConfig {
   id: string;
   provider: 'anthropic' | 'openai' | 'google' | 'local';
   model: string;
+  /** Custom API base URL for OpenAI-compatible endpoints (e.g. DeepSeek).
+   *  When omitted, OpenAIProvider defaults to https://api.openai.com/v1.
+   *  Carried from config through configToAgentConfigs (issue #522). */
+  base_url?: string;
   /** Freeform role description — replaces preset. e.g. "ui-architect", "security-auditor" */
   role?: string;
   /** @deprecated Use role instead */

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { validateConfig, findConfigPath, VALID_MAIN_PROVIDERS } from '../../apps/cli/src/config';
+import { validateConfig, findConfigPath, configToAgentConfigs, VALID_MAIN_PROVIDERS } from '../../apps/cli/src/config';
 import { CREATE_PROVIDER_CASES } from '../../packages/orchestrator/src/llm-client';
 
 describe('Config Validation', () => {
@@ -112,6 +112,49 @@ describe('Config Validation', () => {
       const config = validateConfig({ main_agent: { provider: p, model: 'x' } });
       expect(config.main_agent.provider).toBe(p);
     }
+  });
+});
+
+describe('configToAgentConfigs (issue #522 — base_url carry-through)', () => {
+  it('carries base_url from config through to AgentConfig', () => {
+    const config = validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: {
+        deepseek: {
+          provider: 'openai',
+          model: 'deepseek-chat',
+          skills: ['typescript'],
+          base_url: 'https://api.deepseek.com/v1',
+        },
+      },
+    });
+    const [ac] = configToAgentConfigs(config);
+    expect(ac.id).toBe('deepseek');
+    expect(ac.provider).toBe('openai');
+    expect(ac.base_url).toBe('https://api.deepseek.com/v1');
+  });
+
+  it('leaves base_url undefined when not configured (defaults preserved)', () => {
+    const config = validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: { a: { provider: 'openai', model: 'gpt-4', skills: ['x'] } },
+    });
+    const [ac] = configToAgentConfigs(config);
+    expect(ac.base_url).toBeUndefined();
+  });
+
+  it('validateConfig accepts a valid https base_url', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude' },
+      agents: { a: { provider: 'openai', model: 'gpt-4', skills: ['x'], base_url: 'https://api.deepseek.com/v1' } },
+    })).not.toThrow();
+  });
+
+  it('validateConfig rejects a non-http(s) base_url scheme', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude' },
+      agents: { a: { provider: 'openai', model: 'gpt-4', skills: ['x'], base_url: 'ftp://nope' } },
+    })).toThrow('base_url must use http or https');
   });
 });
 

--- a/tests/cli/dispatch-single-crash-guard.test.ts
+++ b/tests/cli/dispatch-single-crash-guard.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Issue #522 SEV-1 crash guard.
+ *
+ * handleDispatchSingle's relay path used to destructure `{ taskId }` from
+ * mainAgent.dispatch() and DROP the returned finalResultPromise. When a worker
+ * provider errored (e.g. an OpenAI 401 from a misconfigured DeepSeek agent),
+ * that detached promise rejected with no .catch attached → Node emitted an
+ * unhandledRejection → the MCP server tore down and the host respawned it
+ * (crash-loop).
+ *
+ * The fix captures finalResultPromise and attaches `.catch(() => {})` so the
+ * background rejection is swallowed at the handler. Task errors still surface to
+ * the caller via gossip_collect / gossip_progress.
+ *
+ * These tests exercise the relay (non-native) path: the agent is intentionally
+ * NOT registered in ctx.nativeAgentConfigs, so the native short-circuit above
+ * line ~580 is skipped and execution reaches the dispatch() call at ~785.
+ */
+
+import { ctx } from '../../apps/cli/src/mcp-context';
+import { handleDispatchSingle } from '../../apps/cli/src/handlers/dispatch';
+
+function makeMainAgent(overrides: Record<string, any> = {}): any {
+  return {
+    dispatch: jest.fn().mockReturnValue({ taskId: 'default-task-id' }),
+    scopeTracker: {
+      hasOverlap: jest.fn().mockReturnValue({ overlaps: false }),
+      register: jest.fn(),
+      release: jest.fn(),
+    },
+    getSkillIndex: jest.fn().mockReturnValue(null),
+    projectRoot: '/tmp/gossip-test-project',
+    ...overrides,
+  };
+}
+
+const originalCtx = {
+  mainAgent: ctx.mainAgent,
+  nativeAgentConfigs: ctx.nativeAgentConfigs,
+  booted: ctx.booted,
+  boot: ctx.boot,
+  syncWorkersViaKeychain: ctx.syncWorkersViaKeychain,
+};
+
+function resetCtx(mainAgentOverrides: Record<string, any> = {}) {
+  ctx.mainAgent = makeMainAgent(mainAgentOverrides);
+  ctx.nativeAgentConfigs = new Map(); // relay path: agent is NOT native
+  ctx.booted = true;
+  ctx.boot = jest.fn().mockResolvedValue(undefined) as any;
+  ctx.syncWorkersViaKeychain = jest.fn().mockResolvedValue(undefined) as any;
+}
+
+describe('handleDispatchSingle — #522 background-rejection crash guard', () => {
+  afterEach(() => {
+    Object.assign(ctx, originalCtx);
+  });
+
+  it('attaches a catch so a rejecting finalResultPromise does not unhandled-reject', async () => {
+    // dispatch() returns a promise that rejects (simulating a worker provider
+    // 401). The handler must attach .catch so this never becomes an
+    // unhandledRejection. We register a one-shot listener that fails the test if
+    // the rejection escapes.
+    const rejecting = Promise.reject(new Error('OpenAI authentication failed (HTTP 401)'));
+    const dispatch = jest.fn().mockReturnValue({ taskId: 'tid-401', finalResultPromise: rejecting });
+
+    let escaped: unknown;
+    const onUnhandled = (reason: unknown) => { escaped = reason; };
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      resetCtx({ dispatch });
+      const result = await handleDispatchSingle('relay-agent', 'do work');
+      // The handler returns its normal "Dispatched" envelope even though the
+      // background task will reject.
+      expect(result.content[0].text).toContain('Dispatched to relay-agent');
+      expect(dispatch).toHaveBeenCalledTimes(1);
+
+      // Let microtasks + the rejection-detection turn flush.
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      expect(escaped).toBeUndefined();
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('returns the normal envelope when dispatch resolves (no regression)', async () => {
+    const dispatch = jest.fn().mockReturnValue({
+      taskId: 'tid-ok',
+      finalResultPromise: Promise.resolve({ result: 'ok' }),
+    });
+    resetCtx({ dispatch });
+
+    const result = await handleDispatchSingle('relay-agent', 'do work');
+    expect(result.content[0].text).toContain('Dispatched to relay-agent');
+  });
+
+  it('tolerates a dispatch() that returns no finalResultPromise (optional chaining)', async () => {
+    // Legacy/mock shape — handler must not throw on a missing finalResultPromise.
+    const dispatch = jest.fn().mockReturnValue({ taskId: 'tid-legacy' });
+    resetCtx({ dispatch });
+
+    const result = await handleDispatchSingle('relay-agent', 'do work');
+    expect(result.content[0].text).toContain('Dispatched to relay-agent');
+  });
+});

--- a/tests/orchestrator/llm-client.test.ts
+++ b/tests/orchestrator/llm-client.test.ts
@@ -1,4 +1,4 @@
-import { createProvider, AnthropicProvider, OpenAIProvider, GeminiProvider, OllamaProvider } from '@gossip/orchestrator';
+import { createProvider, createProviderForAgent, AnthropicProvider, OpenAIProvider, GeminiProvider, OllamaProvider } from '@gossip/orchestrator';
 
 describe('LLM Client', () => {
   describe('createProvider', () => {
@@ -65,8 +65,9 @@ describe('LLM Client', () => {
   });
 
   describe('AnthropicProvider', () => {
-    it('throws on API error', async () => {
-      // Mock fetch to return error
+    it('throws a clear AUTH error on 401 (issue #522)', async () => {
+      // 401/403 now produce a dedicated auth message that points at the
+      // keychain, NOT the generic `Anthropic API error (401)` fall-through.
       const originalFetch = global.fetch;
       global.fetch = jest.fn().mockResolvedValue({
         ok: false,
@@ -76,7 +77,22 @@ describe('LLM Client', () => {
 
       const provider = new AnthropicProvider('bad-key', 'claude-3');
       await expect(provider.generate([{ role: 'user', content: 'hello' }]))
-        .rejects.toThrow('Anthropic API error (401): Unauthorized');
+        .rejects.toThrow(/Anthropic authentication failed \(HTTP 401\).*keychain/s);
+
+      global.fetch = originalFetch;
+    });
+
+    it('throws on non-auth API error (e.g. 500) via the generic path', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal',
+      }) as unknown as typeof fetch;
+
+      const provider = new AnthropicProvider('test-key', 'claude-3');
+      await expect(provider.generate([{ role: 'user', content: 'hello' }]))
+        .rejects.toThrow('Anthropic API error (500): Internal');
 
       global.fetch = originalFetch;
     });
@@ -231,6 +247,115 @@ describe('LLM Client', () => {
       });
 
       global.fetch = originalFetch;
+    });
+
+    it('401 → clear AUTH error that names the keychain and NOT platform.openai.com (issue #522)', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: async () => 'Incorrect API key provided',
+      }) as unknown as typeof fetch;
+
+      // DeepSeek / OpenAI-compatible endpoint.
+      const provider = new OpenAIProvider('bad-key', 'deepseek-chat', undefined, 'https://api.deepseek.com/v1');
+      let caught: Error | undefined;
+      try {
+        await provider.generate([{ role: 'user', content: 'hi' }]);
+      } catch (e) {
+        caught = e as Error;
+      }
+      expect(caught).toBeDefined();
+      expect(caught!.message).toMatch(/authentication failed \(HTTP 401\)/);
+      expect(caught!.message).toMatch(/keychain/);
+      // Must reference the configured base_url, never the generic OpenAI host.
+      expect(caught!.message).toContain('https://api.deepseek.com/v1');
+      expect(caught!.message).not.toContain('platform.openai.com');
+
+      global.fetch = originalFetch;
+    });
+
+    it('403 → AUTH error, also avoids platform.openai.com (issue #522)', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: async () => 'Forbidden',
+      }) as unknown as typeof fetch;
+
+      const provider = new OpenAIProvider('bad-key', 'gpt-4');
+      let caught: Error | undefined;
+      try {
+        await provider.generate([{ role: 'user', content: 'hi' }]);
+      } catch (e) {
+        caught = e as Error;
+      }
+      expect(caught!.message).toMatch(/authentication failed \(HTTP 403\)/);
+      expect(caught!.message).not.toContain('platform.openai.com');
+
+      global.fetch = originalFetch;
+    });
+
+    it('non-auth 500 still uses the generic OpenAI error path', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => 'boom',
+      }) as unknown as typeof fetch;
+
+      const provider = new OpenAIProvider('test-key', 'gpt-4');
+      await expect(provider.generate([{ role: 'user', content: 'hi' }]))
+        .rejects.toThrow('OpenAI API error (500): boom');
+
+      global.fetch = originalFetch;
+    });
+  });
+
+  describe('createProviderForAgent — pre-flight key check (issue #522)', () => {
+    it('key-requiring provider with no key → DegradedProvider that fails the task with a clear message', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch');
+      const provider = createProviderForAgent('deepseek-agent', 'openai', 'deepseek-chat', undefined, 'https://api.deepseek.com/v1');
+
+      let caught: Error | undefined;
+      try {
+        await provider.generate([{ role: 'user', content: 'hi' }]);
+      } catch (e) {
+        caught = e as Error;
+      }
+      // Fails the TASK (rejects generate) without making an empty-Bearer request.
+      expect(caught).toBeDefined();
+      expect(caught!.message).toContain('no API key configured for agent "deepseek-agent"');
+      expect(caught!.message).toContain('provider openai');
+      expect(caught!.message).toContain('https://api.deepseek.com/v1');
+      expect(caught!.message).toMatch(/keychain/);
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      fetchSpy.mockRestore();
+    });
+
+    it('empty-string key is treated as missing', async () => {
+      const provider = createProviderForAgent('a1', 'anthropic', 'claude-3', '');
+      await expect(provider.generate([{ role: 'user', content: 'hi' }]))
+        .rejects.toThrow('no API key configured for agent "a1"');
+    });
+
+    it('default base_url is reported as \'default\' when none configured', async () => {
+      const provider = createProviderForAgent('a2', 'openai', 'gpt-4', undefined);
+      await expect(provider.generate([{ role: 'user', content: 'hi' }]))
+        .rejects.toThrow(/base_url default/);
+    });
+
+    it('key-requiring provider WITH a key builds a real provider (no DegradedProvider)', () => {
+      const provider = createProviderForAgent('a3', 'openai', 'gpt-4', 'sk-real', 'https://api.deepseek.com/v1');
+      expect(provider).toBeInstanceOf(OpenAIProvider);
+    });
+
+    it('non-key provider (local/none) builds normally even without a key', () => {
+      expect(createProviderForAgent('a4', 'local', 'llama3', undefined)).toBeInstanceOf(OllamaProvider);
+      // 'none' resolves to NullProvider which has no exported class; assert it does not throw + resolves empty.
+      const nullp = createProviderForAgent('a5', 'none', 'x', undefined);
+      return expect(nullp.generate([{ role: 'user', content: 'hi' }])).resolves.toEqual({ text: '' });
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes [#522](https://github.com/gossipcat-ai/gossipcat-ai/issues/522) — wiring an OpenAI-compatible custom agent (DeepSeek via `base_url`) crashed the MCP server repeatedly and failed with a 401 misdirecting to `platform.openai.com`. Root causes verified via multi-agent investigation, orchestrator-confirmed against code. **Scope: bug-fixes only** — per-agent credentials and a first-class `provider:"deepseek"` are deferred to a feature spec (the codebase is keychain-based, not env-based, so that's a design decision).

## Root causes & fixes

1. **SEV-1 crash-loop.** `handleDispatchSingle` dropped the task's `finalResultPromise` with no `.catch()` (`dispatch.ts:785`); a provider error (e.g. 401) became an unhandled rejection, and the MCP server had **no** process-level handler, so Node exited and the host respawned — a loop. (Only single dispatch was affected; parallel/consensus already `.catch()` at `dispatch-pipeline.ts:747`.)
   - `.catch(() => {})` the promise at the source (errors still surface via `gossip_collect`/`gossip_progress`).
   - Idempotent, log-and-continue `unhandledRejection`/`uncaughtException` guards in the MCP boot path — **never** `process.exit` on a background task error; the boot-failure `main().catch(...exit(1))` is untouched.

2. **`base_url` silently dropped.** `configToAgentConfigs` omitted `base_url`, so a DeepSeek agent defaulted to `api.openai.com` — which is why the 401 cited `platform.openai.com`. Now typed on `GossipConfig.agents` + `AgentConfig` and carried through.

3. **Misleading auth errors.** 401/403 fell through to a generic `<provider> API error`. A shared `authErrorMessage` now names the provider + configured endpoint and points at the OS keychain (gossipcat resolves keys from the keychain, **not** env) — applied to OpenAI/Anthropic/Gemini. Cooldown deferred (a wrong key won't self-heal by waiting; documented inline).

4. **Empty-Bearer on missing key.** `createProviderForAgent` + `DegradedProvider`: a key-requiring agent with no key fails the **task** with `no API key configured for agent <id> (provider, base_url)` via `gossip_collect`, instead of an empty-Bearer request → confusing upstream 401.

## Verification

- `tsc` clean on `apps/cli` and `packages/orchestrator`.
- **132 passed / 8 skipped / 0 failed** across llm-client, config, main-agent, dispatch, and the new `tests/cli/dispatch-single-crash-guard.test.ts` (asserts a rejecting `finalResultPromise` does not unhandled-reject).

## Review note

The `uncaughtException` log-and-continue guard is broader than strictly needed — Node warns about resuming after an uncaught exception. It's defensible for an availability-first long-lived server (the alternative is the crash-loop this fixes), and the actual bug is already fixed at the source (`dispatch.ts` `.catch()` + the `unhandledRejection` guard). Happy to drop the `uncaughtException` half if reviewers prefer a stricter posture.

## Deferred follow-ups (issue #522)
- Per-agent credentials + first-class `provider:"deepseek"` (design: keychain-per-agent vs. env-based).
- 401/403 session cooldown so a bad-key agent isn't repeatedly dispatched.
- DeepSeek `deepseek-reasoner` returns `reasoning_content`, which `parseOpenAIResponse` doesn't read yet (`deepseek-chat` works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
