### PR TITLE
feat(relay): per-agent keychain credentials (key_ref) + first-class provider:"deepseek" (#522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to gossipcat are documented here. The format is loosely base
 ### Added
 
 - **Orchestrator-owned path exclusion for isolation detection** (issue #437). Built-in `.gossip/`/`.claude/` prefixes — plus an opt-in `consensus.orchestratorOwnedGlobs` allowlist — are excluded from leak attribution, so routine orchestrator/infra writes during a dispatch are no longer flagged or reverted. `git status --porcelain` head-drift remains a hard violation regardless.
+- **Per-agent credentials via `key_ref`** (issue #522). An agent config may set `key_ref` — the name of the keychain **service** to read its API key from — defaulting to `provider`. Two OpenAI-compatible agents (e.g. OpenAI + DeepSeek) can now use different keys. `key_ref` is a service name in `.gossip/config.json`, never the key itself; the key stays in the OS keychain.
+- **First-class `provider: "deepseek"`** (issue #522). DeepSeek (OpenAI-wire-compatible) is now a built-in provider: `base_url` defaults to `https://api.deepseek.com/v1`, auth errors name DeepSeek, and `deepseek-reasoner` responses (which return their answer in `reasoning_content`) are read correctly.
+
+### Fixed
+
+- **OpenAI-compatible custom agents no longer crash the MCP server** (issue #522). A provider error (e.g. a 401 from a misconfigured DeepSeek agent) on a single dispatch previously became an unhandled rejection that crash-looped the server. The task now fails cleanly. The agent's `base_url` is also no longer dropped on config load (it previously defaulted to `api.openai.com`), and auth failures give a clear, provider-named message instead of misdirecting to `platform.openai.com`.
 
 ## [0.5.3] — 2026-06-04
 

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -251,8 +251,13 @@ export function validateConfig(raw: any): GossipConfig {
       // always resolvable. Two non-fatal warnings catch common operator mistakes.
       if (agent.key_ref !== undefined) {
         if (typeof agent.key_ref !== 'string' || !KEY_REF_PATTERN.test(agent.key_ref)) {
+          // Do NOT echo the raw value: if an operator pasted an actual API key
+          // (which fails the pattern), printing it verbatim would leak the
+          // secret into logs / crash reporters. Show only a short masked prefix.
+          const masked =
+            typeof agent.key_ref === 'string' ? `${agent.key_ref.slice(0, 4)}…(${agent.key_ref.length} chars)` : typeof agent.key_ref;
           throw new Error(
-            `Agent "${id}" has invalid key_ref "${agent.key_ref}". A key_ref is a keychain ` +
+            `Agent "${id}" has invalid key_ref [${masked}]. A key_ref is a keychain ` +
             `service NAME and must match /^[a-zA-Z0-9_-]{1,32}$/ (never the key itself).`
           );
         }

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -62,6 +62,11 @@ export interface GossipConfig {
     /** Custom API base URL for OpenAI-compatible endpoints (e.g. DeepSeek).
      *  Validated in validateConfig; carried through configToAgentConfigs. #522 */
     base_url?: string;
+    /** Keychain SERVICE NAME this agent resolves its API key from. Defaults to
+     *  `provider` when omitted. A service NAME, never the key itself — the key
+     *  stays in the OS keychain. Validated against /^[a-zA-Z0-9_-]{1,32}$/ in
+     *  validateConfig; carried through configToAgentConfigs. #522 */
+    key_ref?: string;
   }>;
 }
 
@@ -100,7 +105,20 @@ export function loadConfig(configPath: string): GossipConfig {
 // enabled". Drift between these two lists means some values pass schema but
 // fail validateConfig (or vice versa) — that is a hard-to-diagnose user-facing
 // bug. If you change one, change the other.
-export const VALID_PROVIDERS = ['anthropic', 'openai', 'openclaw', 'google', 'local', 'native', 'none'];
+export const VALID_PROVIDERS = ['anthropic', 'openai', 'deepseek', 'openclaw', 'google', 'local', 'native', 'none'];
+
+// Keychain SERVICE-NAME allowlist for `agent.key_ref`. Mirrors the
+// VALID_PROVIDERS regex in apps/cli/src/keychain.ts:8 — a key_ref is read by
+// Keychain.getKey(service) and MUST pass the same validateProvider gate, so a
+// config that validates here can always be resolved by the keychain. A positive
+// allowlist (NOT a blocklist of bad chars). #522.
+const KEY_REF_PATTERN = /^[a-zA-Z0-9_-]{1,32}$/;
+
+// Well-known provider service names. A key_ref naming one of these that differs
+// from the agent's own provider is very likely an operator typo (the agent would
+// authenticate with the wrong key), so validateConfig WARNS — not a hard error,
+// because a shared custom service name across providers is a legitimate use. #522
+const WELL_KNOWN_KEY_SERVICES = ['anthropic', 'openai', 'deepseek', 'openclaw', 'google'];
 
 // Subset for `main_agent.provider`: 'native' is excluded because the main
 // agent must be able to invoke a real LLM (the orchestrator that dispatches
@@ -228,6 +246,44 @@ export function validateConfig(raw: any): GossipConfig {
           throw new Error(`Agent "${id}" has invalid base_url: ${agent.base_url}`);
         }
       }
+      // #522: key_ref is a keychain SERVICE NAME, never a key. It must pass the
+      // same allowlist the keychain enforces on reads, so a validated config is
+      // always resolvable. Two non-fatal warnings catch common operator mistakes.
+      if (agent.key_ref !== undefined) {
+        if (typeof agent.key_ref !== 'string' || !KEY_REF_PATTERN.test(agent.key_ref)) {
+          throw new Error(
+            `Agent "${id}" has invalid key_ref "${agent.key_ref}". A key_ref is a keychain ` +
+            `service NAME and must match /^[a-zA-Z0-9_-]{1,32}$/ (never the key itself).`
+          );
+        }
+        // Cross-provider WARNING: a key_ref that names a different well-known
+        // provider than the agent's own is probably a typo — the agent would
+        // read the wrong key. Legitimate for a shared custom service, hence warn.
+        if (
+          WELL_KNOWN_KEY_SERVICES.includes(agent.key_ref) &&
+          agent.key_ref !== agent.provider
+        ) {
+          process.stderr.write(
+            `[gossipcat] warning: agent "${id}" key_ref "${agent.key_ref}" names a known ` +
+            `provider different from its provider "${agent.provider}" — it will authenticate ` +
+            `with the "${agent.key_ref}" keychain key. Set key_ref to "${agent.provider}" if unintended.\n`
+          );
+        }
+        // Secret-looking WARNING: catches an operator pasting the raw key into
+        // the service-name field. (The regex above already blocks spaces and
+        // 'sk-...' lengths >32, but warn on the borderline cases that pass it.)
+        if (
+          agent.key_ref.length > 40 ||
+          /\s/.test(agent.key_ref) ||
+          agent.key_ref.startsWith('sk-')
+        ) {
+          process.stderr.write(
+            `[gossipcat] warning: agent "${id}" key_ref looks like a secret, not a service ` +
+            `name. key_ref must be a keychain SERVICE NAME; store the key via the keychain ` +
+            `and reference its service name here.\n`
+          );
+        }
+      }
     }
   }
 
@@ -245,6 +301,9 @@ export function configToAgentConfigs(config: GossipConfig): AgentConfig[] {
     // #522: carry base_url through so DeepSeek / OpenAI-compatible agents reach
     // their configured endpoint instead of defaulting to api.openai.com.
     base_url: agent.base_url,
+    // #522: carry the keychain service name through so the resolver reads the
+    // per-agent key (key_ref ?? provider) at both resolution sites.
+    key_ref: agent.key_ref,
   }));
 }
 

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -620,12 +620,16 @@ async function doBoot() {
     mainKey = await ctx.keychain.getKey(config.main_agent.provider);
     if (!mainKey) {
       for (const ac of agentConfigs) {
-        const key = await ctx.keychain.getKey(ac.provider);
+        // #522: resolve from the per-agent keychain SERVICE (key_ref ?? provider)
+        // so an agent whose key is stored under a custom key_ref is visible to
+        // the orchestrator-LLM fallback, not just provider-named ones.
+        const keyService = (ac as any).key_ref ?? ac.provider;
+        const key = await ctx.keychain.getKey(keyService);
         if (key) {
           mainProvider = ac.provider;
           mainModel = ac.model;
           mainKey = key;
-          process.stderr.write(`[gossipcat] ⚠️  Main agent key unavailable, using ${ac.provider}/${ac.model} for orchestration\n`);
+          process.stderr.write(`[gossipcat] ⚠️  Main agent key unavailable, using ${ac.provider}/${ac.model} (keychain "${keyService}") for orchestration\n`);
           break;
         }
       }

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -318,6 +318,7 @@ async function getModules() {
     MainAgent: (await import('@gossip/orchestrator')).MainAgent,
     WorkerAgent: (await import('@gossip/orchestrator')).WorkerAgent,
     createProvider: (await import('@gossip/orchestrator')).createProvider,
+    createProviderForAgent: (await import('@gossip/orchestrator')).createProviderForAgent,
     PerformanceWriter: (await import('@gossip/orchestrator')).PerformanceWriter,
     SkillEngine: (await import('@gossip/orchestrator')).SkillEngine,
     MemorySearcher: (await import('@gossip/orchestrator')).MemorySearcher,
@@ -553,8 +554,15 @@ async function doBoot() {
       process.stderr.write(`[gossipcat] 🤖 ${ac.id}: native agent (${modelTier})\n`);
       continue;
     }
-    const key = await ctx.keychain.getKey(ac.provider);
-    const llm = m.createProvider(ac.provider, ac.model, key ?? undefined, undefined, (ac as any).base_url);
+    // #522: resolve from the per-agent keychain SERVICE (key_ref ?? provider)
+    // and build via createProviderForAgent so this MCP-boot worker honors the
+    // DegradedProvider pre-flight + base_url, mirroring main-agent.ts. Without
+    // key_ref here, an MCP-booted key_ref agent would read the provider key.
+    const keyService = (ac as any).key_ref ?? ac.provider;
+    const key = await ctx.keychain.getKey(keyService);
+    const llm = m.createProviderForAgent(
+      ac.id, ac.provider, ac.model, key ?? undefined, (ac as any).base_url, undefined, (ac as any).key_ref,
+    );
     const { existsSync, readFileSync } = require('fs');
     const { join } = require('path');
     const instructionsPath = join(process.cwd(), '.gossip', 'agents', ac.id, 'instructions.md');
@@ -1233,7 +1241,8 @@ export function createMcpServer(): McpServer {
         } else {
           // Fallback: use the first agent that has a working key
           for (const ac of agentConfigs) {
-            const key = await ctx.keychain.getKey(ac.provider);
+            // #522: honor the per-agent keychain service (key_ref ?? provider).
+            const key = await ctx.keychain.getKey((ac as any).key_ref ?? ac.provider);
             if (key) {
               llm = createProvider(ac.provider, ac.model, key, undefined, (ac as any).base_url);
               process.stderr.write(`[gossipcat] gossip_plan: main agent key unavailable, using ${ac.provider}/${ac.model} for planning\n`);
@@ -1943,7 +1952,7 @@ export function createMcpServer(): McpServer {
       // lens generator, gossip publisher all call createProvider on this value),
       // and createProvider has no 'native' branch. 'native' remains valid for
       // utility_model and per-agent overrides.
-      main_provider: z.enum(['anthropic', 'openai', 'openclaw', 'google', 'local', 'none']).default('google')
+      main_provider: z.enum(['anthropic', 'openai', 'deepseek', 'openclaw', 'google', 'local', 'none']).default('google')
         .describe('Provider for the orchestrator LLM. Use "none" when no API key is available — features degrade gracefully to profile-based. Note: "native" is not valid here (use it only for utility_model or per-agent overrides).'),
       main_model: z.string().default('gemini-2.5-pro')
         .describe('Model ID for orchestrator (e.g. gemini-2.5-pro, claude-sonnet-4-6, gpt-4o)'),
@@ -1966,7 +1975,7 @@ export function createMcpServer(): McpServer {
         instructions: z.string().optional()
           .describe('For native agents: full instructions (markdown body of .claude/agents/*.md)'),
         // Custom agent fields
-        provider: z.enum(['anthropic', 'openai', 'openclaw', 'google', 'local']).optional()
+        provider: z.enum(['anthropic', 'openai', 'deepseek', 'openclaw', 'google', 'local']).optional()
           .describe('For custom agents: LLM provider'),
         custom_model: z.string().optional()
           .describe('For custom agents: model ID (e.g. gemini-2.5-pro, gpt-4o, claude-sonnet-4-6)'),

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -319,6 +319,7 @@ async function getModules() {
     WorkerAgent: (await import('@gossip/orchestrator')).WorkerAgent,
     createProvider: (await import('@gossip/orchestrator')).createProvider,
     createProviderForAgent: (await import('@gossip/orchestrator')).createProviderForAgent,
+    resolveAgentProvider: (await import('@gossip/orchestrator')).resolveAgentProvider,
     PerformanceWriter: (await import('@gossip/orchestrator')).PerformanceWriter,
     SkillEngine: (await import('@gossip/orchestrator')).SkillEngine,
     MemorySearcher: (await import('@gossip/orchestrator')).MemorySearcher,
@@ -555,13 +556,12 @@ async function doBoot() {
       continue;
     }
     // #522: resolve from the per-agent keychain SERVICE (key_ref ?? provider)
-    // and build via createProviderForAgent so this MCP-boot worker honors the
-    // DegradedProvider pre-flight + base_url, mirroring main-agent.ts. Without
-    // key_ref here, an MCP-booted key_ref agent would read the provider key.
-    const keyService = (ac as any).key_ref ?? ac.provider;
-    const key = await ctx.keychain.getKey(keyService);
-    const llm = m.createProviderForAgent(
-      ac.id, ac.provider, ac.model, key ?? undefined, (ac as any).base_url, undefined, (ac as any).key_ref,
+    // and build via resolveAgentProvider — the pure extracted helper that
+    // mirrors the same logic as main-agent.ts syncWorkers/start() without
+    // needing the full ctx. Behavior is byte-identical to the prior inline block.
+    const llm = await m.resolveAgentProvider(
+      { id: ac.id, provider: ac.provider, model: ac.model, base_url: (ac as any).base_url, key_ref: (ac as any).key_ref },
+      (s: string) => ctx.keychain.getKey(s),
     );
     const { existsSync, readFileSync } = require('fs');
     const { join } = require('path');

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -14,6 +14,7 @@ export { TaskDispatcher } from './task-dispatcher';
 export {
   createProvider,
   createProviderForAgent,
+  resolveAgentProvider,
   KEY_REQUIRING_PROVIDERS,
   AnthropicProvider,
   OpenAIProvider,

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -353,6 +353,7 @@ export class OpenAIProvider implements ILLMProvider {
   private quota: QuotaTracker;
   private baseUrl: string;
   private timeoutMs: number;
+  private providerLabel: string;
   constructor(
     private apiKey: string,
     private model: string,
@@ -366,10 +367,17 @@ export class OpenAIProvider implements ILLMProvider {
      * — pass 600_000 or higher when instantiating for those providers.
      */
     timeoutMs?: number,
+    /**
+     * Human-readable provider name used in the 401/403 auth-error message so a
+     * first-class OpenAI-compatible provider (e.g. DeepSeek) names itself rather
+     * than the generic "OpenAI-compatible". Defaults to "OpenAI-compatible". #522
+     */
+    providerLabel?: string,
   ) {
     this.baseUrl = (baseUrl ?? process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/$/, '');
     this.quota = new QuotaTracker(quotaSlot ?? 'openai', projectRoot);
     this.timeoutMs = timeoutMs ?? 120_000;
+    this.providerLabel = providerLabel ?? 'OpenAI-compatible';
   }
 
   async generate(messages: LLMMessage[], options?: LLMGenerateOptions): Promise<LLMResponse> {
@@ -407,7 +415,7 @@ export class OpenAIProvider implements ILLMProvider {
       // rate-limit semantics; a wrong key won't fix itself by waiting, so a
       // clear, fail-fast message is the correct behavior here (issue #522).
       if (res.status === 401 || res.status === 403) {
-        throw new Error(authErrorMessage('OpenAI-compatible', res.status, this.baseUrl, body));
+        throw new Error(authErrorMessage(this.providerLabel, res.status, this.baseUrl, body));
       }
       throw new Error(`OpenAI API error (${res.status}): ${body}`);
     }
@@ -456,7 +464,11 @@ export class OpenAIProvider implements ILLMProvider {
     }
     const usage = data.usage as Record<string, number> | undefined;
     return {
-      text: (msg.content as string) || '',
+      // #522: deepseek-reasoner returns its answer in `reasoning_content`,
+      // sometimes alongside an empty-string `content`. Use `||` (NOT `??`) so an
+      // empty-string content falls through to reasoning_content — `"" ?? x` keeps
+      // the empty string and drops the answer.
+      text: (msg.content || msg.reasoning_content || '') as string,
       toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
       usage: usage ? { inputTokens: usage.prompt_tokens, outputTokens: usage.completion_tokens } : undefined,
     };
@@ -695,7 +707,7 @@ class DegradedProvider implements ILLMProvider {
  * (NullProvider) do not. Exported for the pre-flight key check at the worker
  * construction site (main-agent.ts).
  */
-export const KEY_REQUIRING_PROVIDERS = ['anthropic', 'openai', 'openclaw', 'google'] as const;
+export const KEY_REQUIRING_PROVIDERS = ['anthropic', 'openai', 'deepseek', 'openclaw', 'google'] as const;
 
 /**
  * Build a provider for an agent, downgrading to a {@link DegradedProvider} when
@@ -711,11 +723,16 @@ export function createProviderForAgent(
   apiKey: string | undefined,
   baseUrl?: string,
   projectRoot?: string,
+  keyRef?: string,
 ): ILLMProvider {
   if ((KEY_REQUIRING_PROVIDERS as readonly string[]).includes(provider) && !apiKey) {
+    // Name the keychain SERVICE the resolver tried (key_ref ?? provider) so a
+    // missing per-agent key is actionable — the operator knows exactly which
+    // service to store. Service names are safe to log; never the key value. #522
+    const service = keyRef ?? provider;
     return new DegradedProvider(
       `no API key configured for agent "${agentId}" (provider ${provider}, ` +
-      `base_url ${baseUrl ?? 'default'}); set its key via the keychain`,
+      `base_url ${baseUrl ?? 'default'}); set the key for keychain service "${service}"`,
     );
   }
   return createProvider(provider, model, apiKey, projectRoot, baseUrl);
@@ -728,12 +745,21 @@ export function createProviderForAgent(
 // tests/cli/config.test.ts asserts this matches VALID_MAIN_PROVIDERS in
 // apps/cli/src/config.ts so a provider can never pass schema validation but
 // fail at runtime (or vice versa).
-export const CREATE_PROVIDER_CASES = ['anthropic', 'openai', 'openclaw', 'google', 'local', 'none'] as const;
+export const CREATE_PROVIDER_CASES = ['anthropic', 'openai', 'deepseek', 'openclaw', 'google', 'local', 'none'] as const;
 
 export function createProvider(provider: string, model: string, apiKey?: string, projectRoot?: string, baseUrl?: string): ILLMProvider {
   switch (provider) {
     case 'anthropic': return new AnthropicProvider(apiKey!, model, projectRoot);
     case 'openai': return new OpenAIProvider(apiKey ?? '', model, projectRoot, baseUrl, baseUrl ? `openai:${baseUrl}` : undefined);
+    // DeepSeek is OpenAI-wire-compatible — reuse OpenAIProvider. Default the
+    // base_url to api.deepseek.com/v1 (an explicit base_url still overrides),
+    // give it a 'deepseek' quota slot, and a 'DeepSeek' label so 401/403 auth
+    // errors name DeepSeek instead of the generic "OpenAI-compatible". #522
+    case 'deepseek': return new OpenAIProvider(
+      apiKey ?? '', model, projectRoot,
+      baseUrl ?? 'https://api.deepseek.com/v1',
+      'deepseek', undefined, 'DeepSeek',
+    );
     // OpenClaw is a remote agentic LLM with its own server-side tool chain
     // (web_fetch, exec, browser, etc.). Its wallclock regularly exceeds the
     // 120s default because it's doing Claude-like agentic work per request

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -738,6 +738,26 @@ export function createProviderForAgent(
   return createProvider(provider, model, apiKey, projectRoot, baseUrl);
 }
 
+/**
+ * Pure async helper: resolves the per-agent keychain service (key_ref ?? provider),
+ * fetches the key via the injected `getKey` callback, then delegates to
+ * {@link createProviderForAgent}. Extracted from the doBoot inline block so the
+ * key-resolution + provider-construction path can be unit-tested without a
+ * full MCP-boot harness. #522
+ *
+ * @param ac  Minimal agent config shape — same fields used at every construction site.
+ * @param getKey  Injected key lookup (e.g. `(s) => ctx.keychain.getKey(s)`); returns
+ *                `null` when the service has no stored key.
+ */
+export async function resolveAgentProvider(
+  ac: { id: string; provider: string; model: string; base_url?: string; key_ref?: string },
+  getKey: (service: string) => Promise<string | null>,
+): Promise<ILLMProvider> {
+  const keyService = ac.key_ref ?? ac.provider;
+  const key = await getKey(keyService);
+  return createProviderForAgent(ac.id, ac.provider, ac.model, key ?? undefined, ac.base_url, undefined, ac.key_ref);
+}
+
 // ─── Factory ────────────────────────────────────────────────────────────────
 
 // Runtime-side mirror of the providers the switch below knows how to build.

--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -80,7 +80,7 @@ export interface MainAgentConfig {
   relayUrl: string;
   relayApiKey?: string;  // shared secret for relay auth — passed to all workers
   agents: AgentConfig[];
-  apiKeys?: Record<string, string>;  // provider → key
+  apiKeys?: Record<string, string>;  // keychain service name (key_ref ?? provider) → key
   projectRoot?: string;  // defaults to process.cwd()
   llm?: ILLMProvider;  // override for testing
   bootstrapPrompt?: string;  // NEW — injected by BootstrapGenerator

--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -189,12 +189,20 @@ export class MainAgent {
     for (const config of this.registry.getAll()) {
       if (config.native) continue; // native agents use host's Agent tool, not relay
       if (this.workers.has(config.id)) continue; // skip if already set externally
-      // Try apiKeys map first, then keyProvider callback
-      let apiKey: string | undefined = this.apiKeys[config.provider];
+      // Try apiKeys map first, then keyProvider callback.
+      // #522: resolve from the per-agent keychain SERVICE (key_ref ?? provider),
+      // and build via createProviderForAgent so this MCP-boot path honors
+      // base_url and the DegradedProvider pre-flight — mirroring syncWorkers.
+      // Previously it used raw createProvider(config.provider, ...), which
+      // dropped base_url and bypassed the pre-flight (a latent #523 gap here).
+      const keyService = config.key_ref ?? config.provider;
+      let apiKey: string | undefined = this.apiKeys[keyService];
       if (!apiKey && this.keyProviderFn) {
-        apiKey = (await this.keyProviderFn(config.provider)) ?? undefined;
+        apiKey = (await this.keyProviderFn(keyService)) ?? undefined;
       }
-      const llm = createProvider(config.provider, config.model, apiKey);
+      const llm = createProviderForAgent(
+        config.id, config.provider, config.model, apiKey, config.base_url, undefined, config.key_ref,
+      );
 
       // Load per-agent instructions if available
       const instructionsPath = join(this.projectRoot, '.gossip', 'agents', config.id, 'instructions.md');
@@ -354,7 +362,9 @@ export class MainAgent {
       // worker (and its live relay connection) alone — this kills the disconnect
       // burst observed on every dispatch (see relay logs showing 4 workers
       // RELAY DISCONNECTED + reconnected within 30ms per dispatch).
-      const key = await keyProvider(ac.provider);
+      // #522: resolve the key from the per-agent keychain SERVICE (key_ref),
+      // defaulting to the provider name — byte-identical to pre-#522 when absent.
+      const key = await keyProvider(ac.key_ref ?? ac.provider);
       const existing = this.workers.get(ac.id);
       const hadKeySnapshot = this.lastKeyByAgent.has(ac.id);
       const prevKey = this.lastKeyByAgent.get(ac.id) ?? null;
@@ -381,7 +391,7 @@ export class MainAgent {
       // configured key gets a DegradedProvider that fails the TASK with a clear
       // diagnostic, instead of issuing an empty-Bearer request that returns a
       // misleading 401. base_url is now a typed field on AgentConfig.
-      const llm = createProviderForAgent(ac.id, ac.provider, ac.model, key ?? undefined, ac.base_url);
+      const llm = createProviderForAgent(ac.id, ac.provider, ac.model, key ?? undefined, ac.base_url, undefined, ac.key_ref);
 
       const instructionsPath = join(this.projectRoot, '.gossip', 'agents', ac.id, 'instructions.md');
       const instructions = existsSync(instructionsPath)

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -5,12 +5,18 @@
 /** Configuration for a worker agent */
 export interface AgentConfig {
   id: string;
-  provider: 'anthropic' | 'openai' | 'google' | 'local';
+  provider: 'anthropic' | 'openai' | 'deepseek' | 'google' | 'local';
   model: string;
   /** Custom API base URL for OpenAI-compatible endpoints (e.g. DeepSeek).
    *  When omitted, OpenAIProvider defaults to https://api.openai.com/v1.
    *  Carried from config through configToAgentConfigs (issue #522). */
   base_url?: string;
+  /** Keychain SERVICE NAME to resolve this agent's API key from. Defaults to
+   *  `provider` when omitted — byte-identical to pre-#522 behavior. Lets two
+   *  OpenAI-compatible agents read different keychain entries. This is a service
+   *  NAME, never the key itself (the key stays in the OS keychain). Validated
+   *  against /^[a-zA-Z0-9_-]{1,32}$/ in validateConfig (issue #522). */
+  key_ref?: string;
   /** Freeform role description — replaces preset. e.g. "ui-architect", "security-auditor" */
   role?: string;
   /** @deprecated Use role instead */

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -158,6 +158,97 @@ describe('configToAgentConfigs (issue #522 — base_url carry-through)', () => {
   });
 });
 
+describe('key_ref — per-agent keychain service (issue #522)', () => {
+  let stderrSpy: jest.SpyInstance;
+  beforeEach(() => {
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  it('configToAgentConfigs carries key_ref through to AgentConfig', () => {
+    const config = validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: {
+        ds: { provider: 'deepseek', model: 'deepseek-chat', skills: ['typescript'], key_ref: 'deepseek' },
+      },
+    });
+    const [ac] = configToAgentConfigs(config);
+    expect(ac.key_ref).toBe('deepseek');
+  });
+
+  it('leaves key_ref undefined when not configured (byte-identical default)', () => {
+    const config = validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: { a: { provider: 'openai', model: 'gpt-4', skills: ['x'] } },
+    });
+    const [ac] = configToAgentConfigs(config);
+    expect(ac.key_ref).toBeUndefined();
+  });
+
+  it('accepts a valid custom key_ref service name', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude' },
+      agents: { a: { provider: 'openai', model: 'gpt-4', skills: ['x'], key_ref: 'my-custom-key_1' } },
+    })).not.toThrow();
+  });
+
+  it('rejects a key_ref that fails the service-name allowlist regex', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude' },
+      agents: { a: { provider: 'openai', model: 'gpt-4', skills: ['x'], key_ref: 'has spaces!' } },
+    })).toThrow('invalid key_ref');
+  });
+
+  it('rejects a key_ref longer than 32 chars (regex cap)', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude' },
+      agents: { a: { provider: 'openai', model: 'gpt-4', skills: ['x'], key_ref: 'a'.repeat(33) } },
+    })).toThrow('invalid key_ref');
+  });
+
+  it('WARNS (does not throw) when key_ref names a different well-known provider', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude' },
+      agents: { a: { provider: 'openai', model: 'gpt-4', skills: ['x'], key_ref: 'anthropic' } },
+    })).not.toThrow();
+    const out = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+    expect(out).toMatch(/key_ref "anthropic" names a known provider/);
+  });
+
+  it('does NOT warn when key_ref equals the agent provider', () => {
+    validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude' },
+      agents: { a: { provider: 'openai', model: 'gpt-4', skills: ['x'], key_ref: 'openai' } },
+    });
+    const out = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+    expect(out).not.toMatch(/names a known provider/);
+  });
+
+  it('WARNS (does not throw) when key_ref looks like a secret (sk- prefix)', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude' },
+      agents: { a: { provider: 'openai', model: 'gpt-4', skills: ['x'], key_ref: 'sk-abc123' } },
+    })).not.toThrow();
+    const out = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+    expect(out).toMatch(/looks like a secret/);
+  });
+
+  it('accepts provider:"deepseek" as a first-class provider', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude' },
+      agents: { a: { provider: 'deepseek', model: 'deepseek-chat', skills: ['x'] } },
+    })).not.toThrow();
+  });
+
+  it('accepts main_agent.provider:"deepseek"', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'deepseek', model: 'deepseek-chat' },
+    })).not.toThrow();
+  });
+});
+
 describe('findConfigPath', () => {
   let tmpDir: string;
 

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -208,6 +208,24 @@ describe('key_ref — per-agent keychain service (issue #522)', () => {
     })).toThrow('invalid key_ref');
   });
 
+  it('does NOT echo the raw key_ref value in the throw (no secret leak)', () => {
+    // If an operator pastes an actual API key (which fails the regex), the
+    // error must mask it — never print the secret verbatim. #522 consensus a5953983.
+    const secret = 'sk-proj-' + 'A1b2C3d4'.repeat(6); // realistic, fails the regex
+    let msg = '';
+    try {
+      validateConfig({
+        main_agent: { provider: 'anthropic', model: 'claude' },
+        agents: { a: { provider: 'openai', model: 'gpt-4', skills: ['x'], key_ref: secret } },
+      });
+    } catch (e) {
+      msg = (e as Error).message;
+    }
+    expect(msg).toContain('invalid key_ref');
+    expect(msg).not.toContain(secret);
+    expect(msg).toContain(`(${secret.length} chars)`); // masked form names the length only
+  });
+
   it('WARNS (does not throw) when key_ref names a different well-known provider', () => {
     expect(() => validateConfig({
       main_agent: { provider: 'anthropic', model: 'claude' },

--- a/tests/orchestrator/llm-client.test.ts
+++ b/tests/orchestrator/llm-client.test.ts
@@ -1,4 +1,4 @@
-import { createProvider, createProviderForAgent, AnthropicProvider, OpenAIProvider, GeminiProvider, OllamaProvider } from '@gossip/orchestrator';
+import { createProvider, createProviderForAgent, resolveAgentProvider, AnthropicProvider, OpenAIProvider, GeminiProvider, OllamaProvider } from '@gossip/orchestrator';
 
 describe('LLM Client', () => {
   describe('createProvider', () => {
@@ -426,6 +426,72 @@ describe('LLM Client', () => {
       expect(caught!.message).toContain('keychain service "deepseek"');
       expect(fetchSpy).not.toHaveBeenCalled();
       fetchSpy.mockRestore();
+    });
+  });
+
+  describe('resolveAgentProvider — extracted pure helper (issue #522)', () => {
+    it('key_ref set: getKey called with key_ref service (not provider)', async () => {
+      const getKey = jest.fn().mockResolvedValue('sk-custom');
+      const provider = await resolveAgentProvider(
+        { id: 'a1', provider: 'openai', model: 'gpt-4', key_ref: 'my-custom-key' },
+        getKey,
+      );
+      expect(getKey).toHaveBeenCalledWith('my-custom-key');
+      expect(getKey).not.toHaveBeenCalledWith('openai');
+      expect(provider).toBeInstanceOf(OpenAIProvider);
+    });
+
+    it('key_ref absent: getKey called with provider name (byte-identical fallback)', async () => {
+      const getKey = jest.fn().mockResolvedValue('sk-provider');
+      const provider = await resolveAgentProvider(
+        { id: 'a2', provider: 'openai', model: 'gpt-4' },
+        getKey,
+      );
+      expect(getKey).toHaveBeenCalledWith('openai');
+      expect(provider).toBeInstanceOf(OpenAIProvider);
+    });
+
+    it('key missing for key-requiring provider → DegradedProvider whose generate() rejects naming the key_ref service', async () => {
+      const getKey = jest.fn().mockResolvedValue(null);
+      const provider = await resolveAgentProvider(
+        { id: 'ds-agent', provider: 'deepseek', model: 'deepseek-chat', key_ref: 'my-deepseek-key' },
+        getKey,
+      );
+      const fetchSpy = jest.spyOn(global, 'fetch');
+      await expect(provider.generate([{ role: 'user', content: 'hi' }]))
+        .rejects.toThrow(/my-deepseek-key/);
+      // DegradedProvider must not make a network call.
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+
+    it('key missing, no key_ref → DegradedProvider names the provider as the keychain service', async () => {
+      const getKey = jest.fn().mockResolvedValue(null);
+      const provider = await resolveAgentProvider(
+        { id: 'a3', provider: 'anthropic', model: 'claude-3' },
+        getKey,
+      );
+      await expect(provider.generate([{ role: 'user', content: 'hi' }]))
+        .rejects.toThrow(/keychain service "anthropic"/);
+    });
+
+    it('base_url threaded: deepseek with custom base_url builds provider without throwing', async () => {
+      const getKey = jest.fn().mockResolvedValue('sk-ds');
+      const provider = await resolveAgentProvider(
+        { id: 'ds2', provider: 'deepseek', model: 'deepseek-chat', base_url: 'https://my-proxy.example.com/v1' },
+        getKey,
+      );
+      expect(provider).toBeInstanceOf(OpenAIProvider);
+      // Verify base_url is threaded: a 401 error should reference the custom base_url.
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false, status: 401, text: async () => 'bad key',
+      }) as unknown as typeof fetch;
+      let caught: Error | undefined;
+      try { await provider.generate([{ role: 'user', content: 'hi' }]); } catch (e) { caught = e as Error; }
+      expect(caught).toBeDefined();
+      expect(caught!.message).toContain('https://my-proxy.example.com/v1');
+      global.fetch = originalFetch;
     });
   });
 

--- a/tests/orchestrator/llm-client.test.ts
+++ b/tests/orchestrator/llm-client.test.ts
@@ -357,6 +357,105 @@ describe('LLM Client', () => {
       const nullp = createProviderForAgent('a5', 'none', 'x', undefined);
       return expect(nullp.generate([{ role: 'user', content: 'hi' }])).resolves.toEqual({ text: '' });
     });
+
+    it('DegradedProvider names the keychain SERVICE from key_ref, not the provider (issue #522)', async () => {
+      // key_ref:"my-custom-key" on an openai agent → message names that service.
+      const provider = createProviderForAgent('cust', 'openai', 'gpt-4', undefined, 'https://api.example.com/v1', undefined, 'my-custom-key');
+      let caught: Error | undefined;
+      try { await provider.generate([{ role: 'user', content: 'hi' }]); } catch (e) { caught = e as Error; }
+      expect(caught).toBeDefined();
+      expect(caught!.message).toContain('no API key configured for agent "cust"');
+      expect(caught!.message).toContain('keychain service "my-custom-key"');
+    });
+
+    it('DegradedProvider falls back to provider name when key_ref absent', async () => {
+      const provider = createProviderForAgent('a6', 'openai', 'gpt-4', undefined);
+      let caught: Error | undefined;
+      try { await provider.generate([{ role: 'user', content: 'hi' }]); } catch (e) { caught = e as Error; }
+      expect(caught!.message).toContain('keychain service "openai"');
+    });
+  });
+
+  describe('provider:"deepseek" — first-class OpenAI-compatible provider (issue #522)', () => {
+    it('createProvider("deepseek") → OpenAIProvider', () => {
+      const provider = createProvider('deepseek', 'deepseek-chat', 'sk-ds-key');
+      expect(provider).toBeInstanceOf(OpenAIProvider);
+    });
+
+    it('defaults base_url to https://api.deepseek.com/v1 (named in the auth error)', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false, status: 401, text: async () => 'bad key',
+      }) as unknown as typeof fetch;
+
+      const provider = createProvider('deepseek', 'deepseek-chat', 'bad-key');
+      let caught: Error | undefined;
+      try { await provider.generate([{ role: 'user', content: 'hi' }]); } catch (e) { caught = e as Error; }
+      expect(caught!.message).toContain('https://api.deepseek.com/v1');
+      // Provider label names DeepSeek, not the generic "OpenAI-compatible".
+      expect(caught!.message).toMatch(/^DeepSeek authentication failed/);
+      expect(caught!.message).not.toContain('platform.openai.com');
+
+      global.fetch = originalFetch;
+    });
+
+    it('explicit base_url overrides the deepseek default', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false, status: 401, text: async () => 'bad key',
+      }) as unknown as typeof fetch;
+
+      const provider = createProvider('deepseek', 'deepseek-chat', 'bad-key', undefined, 'https://my-proxy.example.com/v1');
+      let caught: Error | undefined;
+      try { await provider.generate([{ role: 'user', content: 'hi' }]); } catch (e) { caught = e as Error; }
+      expect(caught!.message).toContain('https://my-proxy.example.com/v1');
+      expect(caught!.message).not.toContain('api.deepseek.com');
+
+      global.fetch = originalFetch;
+    });
+
+    it('deepseek is key-requiring: no key → DegradedProvider naming the deepseek service', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch');
+      // key_ref defaults to the provider "deepseek" when absent.
+      const provider = createProviderForAgent('ds-agent', 'deepseek', 'deepseek-reasoner', undefined, undefined, undefined, undefined);
+      let caught: Error | undefined;
+      try { await provider.generate([{ role: 'user', content: 'hi' }]); } catch (e) { caught = e as Error; }
+      expect(caught).toBeDefined();
+      expect(caught!.message).toContain('no API key configured for agent "ds-agent"');
+      expect(caught!.message).toContain('provider deepseek');
+      expect(caught!.message).toContain('keychain service "deepseek"');
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+  });
+
+  describe('reasoning_content fallback (deepseek-reasoner, issue #522)', () => {
+    async function generateWith(message: Record<string, unknown>): Promise<string> {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ choices: [{ message }], usage: { prompt_tokens: 1, completion_tokens: 1 } }),
+      }) as unknown as typeof fetch;
+      try {
+        const provider = createProvider('deepseek', 'deepseek-reasoner', 'sk-ds');
+        const res = await provider.generate([{ role: 'user', content: 'q' }]);
+        return res.text;
+      } finally {
+        global.fetch = originalFetch;
+      }
+    }
+
+    it('empty-string content falls through to reasoning_content (|| not ??)', async () => {
+      expect(await generateWith({ content: '', reasoning_content: 'answer', tool_calls: null })).toBe('answer');
+    });
+
+    it('non-empty content is preferred over reasoning_content', async () => {
+      expect(await generateWith({ content: 'x', reasoning_content: 'should-not-win', tool_calls: null })).toBe('x');
+    });
+
+    it('null content with no reasoning_content yields empty string', async () => {
+      expect(await generateWith({ content: null, tool_calls: null })).toBe('');
+    });
   });
 });
 

--- a/tests/orchestrator/main-agent-start-keyref.test.ts
+++ b/tests/orchestrator/main-agent-start-keyref.test.ts
@@ -1,0 +1,130 @@
+/**
+ * MainAgent.start() — the MCP-boot worker path (issue #522).
+ *
+ * start() is the SECOND key-resolution site (alongside syncWorkers). Before
+ * #522 it resolved keyProviderFn(config.provider), built via raw
+ * createProvider(...) — which dropped base_url and bypassed the DegradedProvider
+ * pre-flight — and cached the provider-resolved key in lastKeyByAgent (forcing a
+ * spurious first-syncWorkers teardown).
+ *
+ * These tests assert the post-#522 behavior at the boot path:
+ *   1. Key is resolved from the per-agent keychain SERVICE (key_ref ?? provider).
+ *   2. The worker is built via createProviderForAgent, so a missing key yields a
+ *      DegradedProvider (pre-flight) rather than a live empty-Bearer provider.
+ *   3. base_url is honored on the boot path (no longer dropped).
+ *   4. key_ref + base_url are orthogonal (different fields, both respected).
+ */
+
+// Capture the llm handed to each WorkerAgent so we can probe its behavior.
+const builtWorkers: Array<{ agentId: string; llm: any }> = [];
+jest.mock('../../packages/orchestrator/src/worker-agent', () => {
+  class FakeWorkerAgent {
+    constructor(public readonly agentId: string, public readonly llm: any) {
+      builtWorkers.push({ agentId, llm });
+    }
+    async start() { /* no relay */ }
+    async stop() { /* no relay */ }
+  }
+  return { WorkerAgent: FakeWorkerAgent };
+});
+
+// Stub the relay client so start()'s orchestrator connection is a no-op.
+jest.mock('@gossip/client', () => ({
+  GossipAgent: class {
+    on() { /* noop */ }
+    async connect() { /* noop */ }
+  },
+}));
+
+jest.mock('@gossip/tools', () => ({ ALL_TOOLS: [] }), { virtual: false });
+
+import { MainAgent, ILLMProvider } from '@gossip/orchestrator';
+
+const mockLLM: ILLMProvider = { async generate() { return { text: '' }; } };
+
+function workerFor(id: string) {
+  const w = builtWorkers.find(b => b.agentId === id);
+  if (!w) throw new Error(`worker ${id} not built`);
+  return w;
+}
+
+beforeEach(() => { builtWorkers.length = 0; });
+
+describe('MainAgent.start() — key_ref + base_url on the MCP-boot path (#522)', () => {
+  it('resolves the boot key from the per-agent service (key_ref ?? provider)', async () => {
+    const keyProvider = jest.fn(async (service: string) => `key-for-${service}`);
+    const agent = new MainAgent({
+      provider: 'local', model: 'mock', relayUrl: 'ws://localhost:0',
+      keyProvider,
+      agents: [
+        { id: 'a-ref', provider: 'openai', model: 'gpt', skills: [], key_ref: 'shared-key' },
+        { id: 'b-noref', provider: 'anthropic', model: 'claude', skills: [] },
+      ],
+      llm: mockLLM,
+    });
+
+    await agent.start();
+
+    const services = keyProvider.mock.calls.map(c => c[0]);
+    expect(services).toContain('shared-key'); // a-ref → key_ref
+    expect(services).toContain('anthropic');  // b-noref → provider
+    expect(services).not.toContain('openai'); // never the provider when key_ref is set
+  });
+
+  it('builds via createProviderForAgent: a missing key yields a DegradedProvider naming the key_ref service + base_url', async () => {
+    // No key in the keychain → pre-flight should degrade.
+    const keyProvider = jest.fn(async () => null);
+    const agent = new MainAgent({
+      provider: 'local', model: 'mock', relayUrl: 'ws://localhost:0',
+      keyProvider,
+      agents: [
+        { id: 'ds', provider: 'deepseek', model: 'deepseek-chat', skills: [], key_ref: 'deepseek', base_url: 'https://api.deepseek.com/v1' },
+      ],
+      llm: mockLLM,
+    });
+
+    await agent.start();
+
+    const { llm } = workerFor('ds');
+    // The DegradedProvider fails the task with a clear, key_ref-naming message —
+    // proving createProviderForAgent (not raw createProvider) was used on boot.
+    let caught: Error | undefined;
+    try { await llm.generate([{ role: 'user', content: 'hi' }]); } catch (e) { caught = e as Error; }
+    expect(caught).toBeDefined();
+    expect(caught!.message).toContain('no API key configured for agent "ds"');
+    expect(caught!.message).toContain('keychain service "deepseek"');
+    // base_url is honored on the boot path (no longer dropped).
+    expect(caught!.message).toContain('https://api.deepseek.com/v1');
+  });
+
+  it('orthogonality: key_ref names the key service while base_url targets a different endpoint', async () => {
+    const keyProvider = jest.fn(async (service: string) =>
+      service === 'my-custom-key' ? 'sk-real-custom' : null,
+    );
+    const agent = new MainAgent({
+      provider: 'local', model: 'mock', relayUrl: 'ws://localhost:0',
+      keyProvider,
+      agents: [
+        { id: 'ortho', provider: 'openai', model: 'gpt-4', skills: [], key_ref: 'my-custom-key', base_url: 'https://api.example.com/v1' },
+      ],
+      llm: mockLLM,
+    });
+
+    await agent.start();
+
+    // The key was resolved from the custom service, NOT 'openai'.
+    expect(keyProvider).toHaveBeenCalledWith('my-custom-key');
+    expect(keyProvider).not.toHaveBeenCalledWith('openai');
+
+    // With a real key present, a live (non-degraded) provider is built. Drive a
+    // 401 to confirm it targets the base_url, proving the two fields are independent.
+    const { llm } = workerFor('ortho');
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 401, text: async () => 'bad' }) as unknown as typeof fetch;
+    let caught: Error | undefined;
+    try { await llm.generate([{ role: 'user', content: 'hi' }]); } catch (e) { caught = e as Error; }
+    global.fetch = originalFetch;
+    expect(caught!.message).toContain('https://api.example.com/v1');
+    expect(caught!.message).not.toContain('api.openai.com');
+  });
+});

--- a/tests/orchestrator/sync-workers.test.ts
+++ b/tests/orchestrator/sync-workers.test.ts
@@ -144,3 +144,32 @@ describe('MainAgent.syncWorkers — keychain short-circuit', () => {
     expect(alphaAfter.stopCalls).toBe(0);
   });
 });
+
+describe('MainAgent.syncWorkers — key_ref keychain-service resolution (issue #522)', () => {
+  function makeKeyRefAgent() {
+    return new MainAgent({
+      provider: 'local',
+      model: 'mock',
+      relayUrl: 'ws://localhost:0',
+      agents: [
+        // key_ref present → resolver reads service 'shared-key', NOT 'openai'.
+        { id: 'a-ref', provider: 'openai', model: 'gpt', skills: [], key_ref: 'shared-key' },
+        // key_ref absent → resolver reads the provider name 'anthropic'.
+        { id: 'b-noref', provider: 'anthropic', model: 'claude', skills: [] },
+      ],
+      llm: mockLLM,
+    });
+  }
+
+  it('resolves the key from key_ref when present, and from provider when absent', async () => {
+    const agent = makeKeyRefAgent();
+    const keyProvider = jest.fn(async (service: string) => `key-for-${service}`);
+
+    await agent.syncWorkers(keyProvider);
+
+    const services = keyProvider.mock.calls.map(c => c[0]);
+    expect(services).toContain('shared-key');   // a-ref → key_ref
+    expect(services).toContain('anthropic');     // b-noref → provider
+    expect(services).not.toContain('openai');    // never the provider when key_ref is set
+  });
+});


### PR DESCRIPTION
## Summary

Implements the per-agent-credential feature deferred from #522 (the bug-fixes shipped in #523). **Operator decision: keychain-per-agent**, not env-based — the codebase resolves every key from the OS keychain, so a `key_ref` names a keychain **service**, never a secret. Spec (local): `docs/specs/2026-06-09-per-agent-credentials-deepseek.md`, spec-consensus `653a3078`.

## What it does

- **`key_ref` on agent config** — optional; names the keychain service to read. Defaults to `provider` (byte-identical to today). `validateConfig` enforces the keychain service-name allowlist `/^[a-zA-Z0-9_-]{1,32}$/` and warns (stderr, non-fatal) on a cross-provider `key_ref` or a secret-looking value. Two OpenAI-compatible agents can now use different keys.
- **Resolution at every live worker-construction site** — `getKey(key_ref ?? provider)` at `MainAgent.syncWorkers`, `MainAgent.start()` (which previously also **dropped `base_url`** and bypassed the `DegradedProvider` pre-flight on the MCP-boot path), and — found via premise-check **beyond the spec's two sites** — the `mcp-server-sdk` `doBoot` live worker (`:554`) and the `gossip_plan` key fallback. `createProviderForAgent` gains a `keyRef` param so its missing-key message names the exact keychain service to set.
- **First-class `provider:"deepseek"`** — registered in all four lists (`VALID_PROVIDERS`, both `gossip_setup` `z.enum`s, `KEY_REQUIRING_PROVIDERS`); routes to `OpenAIProvider` with `base_url` default `https://api.deepseek.com/v1`, a `deepseek` quota slot, and a `DeepSeek` auth-error label. The `openai`+`base_url` path is unchanged.
- **`deepseek-reasoner` parsing** — `parseOpenAIResponse` reads `content || reasoning_content || ''` (`||`, so an empty-string `content` falls through to the answer).

## Verification

- `tsc` clean on both packages (the orchestrator `dist/` was stale — missing #523's `createProviderForAgent` export — and was rebuilt; CI's `npm run build` covers this).
- **158/158** across config, llm-client, sync-workers, main-agent, keychain, mcp-handlers + new `tests/orchestrator/main-agent-start-keyref.test.ts`.

## Notes / scope
- Per §7 v1: `gossip_setup` stays secret-free (hint-only) — operators set `key_ref` by editing `.gossip/config.json` (validated). Only the four-enum `deepseek` registration is in `gossip_setup`.
- `create-team.ts` provider-availability prompt left unchanged (a UX probe, not a validation gate).
- This touches credential resolution + a trust boundary — the spec's §6 gates it on a pre-merge code-consensus round (running now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
