### PR TITLE
feat(cli): keychain doctor — flag stale/placeholder API keys in gossip_status

### DIFF
--- a/apps/cli/src/keychain-doctor.ts
+++ b/apps/cli/src/keychain-doctor.ts
@@ -1,0 +1,56 @@
+/**
+ * Keychain doctor — detects stale/placeholder API-key entries that may linger
+ * in a user's real keychain (e.g. from an OLD test that wrote test placeholders
+ * to the real 'gossip-mesh' service). Pure + dependency-light: it receives a
+ * getKey accessor so it is backend-agnostic and trivially unit-testable.
+ */
+
+export interface KeychainDoctorWarning {
+  service: string;
+  reason: string;
+  redactedValue: string;
+}
+
+const KNOWN_PLACEHOLDERS = new Set([
+  'okey-xyz',
+  'gkey-abc',
+  'test-key-123',
+  'old-key',
+  'new-key',
+  'gossip-mesh-test',
+]);
+
+const MIN_PLAUSIBLE_LENGTH = 16;
+
+/** Show at most the first 4 chars, never the full secret. */
+function redact(value: string): string {
+  if (value.length === 0) return '<empty>';
+  if (value.length <= 4) return '<short>';
+  return `${value.slice(0, 4)}…`;
+}
+
+function staleReason(value: string): string | null {
+  if (KNOWN_PLACEHOLDERS.has(value) || value.startsWith('test-')) {
+    return 'matches known test placeholder';
+  }
+  if (value.length < MIN_PLAUSIBLE_LENGTH) {
+    return `implausibly short (${value.length} chars) for a real key`;
+  }
+  return null;
+}
+
+export async function detectStaleKeychainEntries(
+  getKey: (service: string) => Promise<string | null>,
+  services: string[],
+): Promise<KeychainDoctorWarning[]> {
+  const warnings: KeychainDoctorWarning[] = [];
+  for (const service of services) {
+    const value = await getKey(service);
+    if (value == null || value.length === 0) continue; // missing keys handled elsewhere
+    const reason = staleReason(value);
+    if (reason) {
+      warnings.push({ service, reason, redactedValue: redact(value) });
+    }
+  }
+  return warnings;
+}

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1630,6 +1630,34 @@ export function createMcpServer(): McpServer {
         }
       } catch { /* quota-state.json not present — skip */ }
 
+      // Keychain doctor — surface stale/placeholder API-key entries that may
+      // linger in the user's real keychain (e.g. from an OLD test that wrote
+      // test placeholders to the real service). Backend-agnostic: goes only
+      // through ctx.keychain.getKey. Wrapped so a failure never breaks status.
+      try {
+        const { detectStaleKeychainEntries } = await import('./keychain-doctor');
+        const configPath = findConfigPath();
+        if (configPath) {
+          const doctorConfig = loadConfig(configPath);
+          const doctorAgents = configToAgentConfigs(doctorConfig);
+          const services = Array.from(
+            new Set([
+              ...doctorAgents.map((ac) => ac.key_ref ?? ac.provider),
+              doctorConfig.main_agent.provider,
+            ]),
+          );
+          const warnings = await detectStaleKeychainEntries(
+            (s: string) => ctx.keychain.getKey(s),
+            services,
+          );
+          for (const w of warnings) {
+            lines.push(
+              `  ⚠️ Keychain: "${w.service}" looks stale — ${w.reason} (${w.redactedValue}); re-run key setup`,
+            );
+          }
+        }
+      } catch { /* keychain doctor failure must never break status — skip */ }
+
       // Signals pending — recent consensus rounds with no manually-recorded signals.
       // Surfaces the back-search gap (per consensus 4c88bcd3, haiku:f17) so the
       // orchestrator can SEE which rounds it skipped without having to remember.

--- a/tests/cli/keychain-doctor.test.ts
+++ b/tests/cli/keychain-doctor.test.ts
@@ -1,0 +1,71 @@
+import { detectStaleKeychainEntries } from '../../apps/cli/src/keychain-doctor';
+
+function fakeGetKey(store: Map<string, string>) {
+  return async (service: string): Promise<string | null> => store.get(service) ?? null;
+}
+
+describe('detectStaleKeychainEntries', () => {
+  it('flags a known test placeholder with a placeholder reason', async () => {
+    const store = new Map([['openai', 'okey-xyz']]);
+    const warnings = await detectStaleKeychainEntries(fakeGetKey(store), ['openai']);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].service).toBe('openai');
+    expect(warnings[0].reason).toMatch(/placeholder/i);
+  });
+
+  it('does NOT flag a plausible real key', async () => {
+    const realKey = 'sk-' + 'a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8s9T0u1V2';
+    const store = new Map([['anthropic', realKey]]);
+    const warnings = await detectStaleKeychainEntries(fakeGetKey(store), ['anthropic']);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('flags an implausibly short key with a short reason', async () => {
+    const store = new Map([['google', 'shortkey']]); // 8 chars
+    const warnings = await detectStaleKeychainEntries(fakeGetKey(store), ['google']);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].reason).toMatch(/short/i);
+    expect(warnings[0].reason).toContain('8');
+  });
+
+  it('skips null/empty values (missing keys handled elsewhere)', async () => {
+    const store = new Map([['deepseek', '']]);
+    const warnings = await detectStaleKeychainEntries(fakeGetKey(store), [
+      'deepseek',
+      'openclaw', // not in store → getKey returns null
+    ]);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('never leaks the full secret in redactedValue', async () => {
+    // A long value that IS flagged (test- prefix) so we can assert redaction
+    // happens on a real warning, not on a skipped/clean key.
+    const longSecret = 'test-this-is-a-very-long-secret-value-1234567890abcdef';
+    const store = new Map([['openai', longSecret]]);
+    const warnings = await detectStaleKeychainEntries(fakeGetKey(store), ['openai']);
+    expect(warnings).toHaveLength(1);
+    // The full raw secret must NOT appear in the redacted value.
+    expect(warnings[0].redactedValue).not.toBe(longSecret);
+    expect(warnings[0].redactedValue.includes(longSecret)).toBe(false);
+    // Truncated to first 4 chars + ellipsis.
+    expect(warnings[0].redactedValue).toBe('test…');
+    expect(warnings[0].redactedValue.length).toBeLessThan(longSecret.length);
+  });
+
+  it('flags values starting with the test- prefix', async () => {
+    const store = new Map([['custom-ref', 'test-something-here-longer']]);
+    const warnings = await detectStaleKeychainEntries(fakeGetKey(store), ['custom-ref']);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].reason).toMatch(/placeholder/i);
+  });
+
+  it('redacts a flagged 1-4 char value to <short> without exposing it', async () => {
+    const store = new Map([['google', 'abc']]); // 3 chars → short reason + <short> redaction
+    const warnings = await detectStaleKeychainEntries(fakeGetKey(store), ['google']);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].reason).toMatch(/short/i);
+    // length <= 4 takes the <short> marker, never slice — no chars of the value leak.
+    expect(warnings[0].redactedValue).toBe('<short>');
+    expect(warnings[0].redactedValue.includes('abc')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a **backend-agnostic keychain doctor** that surfaces stale/placeholder API-key entries in `gossip_status` output. Closes backlog **#3**.

### Why
An old version of `keychain.test.ts` wrote test placeholders (`okey-xyz`, `gkey-abc`) to the **real** `gossip-mesh` keychain service, overwriting users' real API keys → `"API key not valid"` errors. The test is now isolated to `gossip-mesh-test`, but pre-existing pollution had **no detector**. This adds one — and it works across all backends (macOS `security`, Linux `secret-tool`, and the encrypted-file fallback on Windows / secret-tool-less Linux), since it only goes through `Keychain.getKey`.

## Changes
- **`apps/cli/src/keychain-doctor.ts`** (new) — pure `detectStaleKeychainEntries(getKey, services)`. Flags known placeholders, the `test-` prefix, and `< 16`-char keys. `redact()` never emits more than the first 4 chars of a secret (`<empty>` / `<short>` markers for very short values).
- **`apps/cli/src/mcp-server-sdk.ts`** — fail-soft `try/catch` block in the `gossip_status` handler (mirrors the Quota-health block). Services = `key_ref ?? provider` per agent + `main_agent.provider`, deduped. Emits nothing on a healthy install.
- **`tests/cli/keychain-doctor.test.ts`** (new) — 7 cases incl. redaction-leak assertion + `<short>` path.

## Verification
- `npx tsc --noEmit -p apps/cli/tsconfig.json` → exit 0
- `npx jest tests/cli/keychain-doctor.test.ts` → 7/7 pass

## Consensus
`48c43c59-adb047c0` (gemini-reviewer + sonnet-reviewer, 2 rounds): **6 confirmed, 0 hallucinations**. Applied review fixes:
- Removed dead `startsWith('test-key')` branch (subsumed by `test-`)
- Dropped unnecessary `(ac as {key_ref?})` cast — `key_ref` is a first-class `AgentConfig` field (`types.ts:19`)
- Added `<short>` / len-1–4 redaction test

## Follow-up (out of scope)
Pre-existing `(ac as any).key_ref` casts at `mcp-server-sdk.ts:563` and `:626` carry the same type-unsafety; not introduced here. Worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)