### PR TITLE
feat(cli): `gossipcat key set/list` — store API keys from the published binary

### DIFF
--- a/apps/cli/src/key-command.ts
+++ b/apps/cli/src/key-command.ts
@@ -1,0 +1,66 @@
+/**
+ * `gossipcat key` subcommand — store/list provider API keys from the PUBLISHED
+ * binary, without needing the source-repo setup wizard.
+ *
+ * PURE + DI: all side effects (keychain access, secret prompt, output) are
+ * injected via KeyCommandIO so the logic is trivially unit-testable and never
+ * touches a real keychain in tests. Mirrors the keychain-doctor.ts DI style.
+ *
+ * SECURITY: the secret key value is NEVER echoed/logged. Confirmations name the
+ * provider only. There is intentionally NO MCP tool for this — routing a secret
+ * through the LLM tool layer would be a trust-boundary violation.
+ */
+import { KEY_REQUIRING_PROVIDERS } from '@gossip/orchestrator';
+
+const VALID_PROVIDERS = /^[a-zA-Z0-9_-]{1,32}$/;
+
+export interface KeyCommandIO {
+  setKey(provider: string, key: string): Promise<void>;
+  getKey(provider: string): Promise<string | null>;
+  readSecret(): Promise<string>;
+  out(line: string): void;
+  err(line: string): void;
+}
+
+const USAGE =
+  'Usage:\n' +
+  '  gossipcat key set <provider>   Store an API key in the OS keychain (service: gossip-mesh)\n' +
+  '  gossipcat key list             Show which providers have a stored key';
+
+/** args = everything AFTER `key`. Returns exit code (0 ok, 2 usage/error). */
+export async function runKeyCommand(args: string[], io: KeyCommandIO): Promise<number> {
+  const sub = args[0];
+
+  if (sub === 'set') {
+    const provider = args[1];
+    if (!provider) {
+      io.err(USAGE);
+      return 2;
+    }
+    // Validate BEFORE reading the secret so a bad provider never prompts.
+    if (!VALID_PROVIDERS.test(provider)) {
+      io.err(`invalid provider name "${provider}" (allowed: letters, digits, _ and -, 1-32 chars)`);
+      return 2;
+    }
+    const key = (await io.readSecret()).trim();
+    if (key.length === 0) {
+      io.err('no key provided (stdin was empty)');
+      return 2;
+    }
+    await io.setKey(provider, key);
+    io.out(`stored key for "${provider}" in the gossip-mesh keychain`);
+    return 0;
+  }
+
+  if (sub === 'list') {
+    for (const provider of KEY_REQUIRING_PROVIDERS) {
+      const value = await io.getKey(provider);
+      const present = typeof value === 'string' && value.length > 0;
+      io.out(`  ${present ? '✓' : '·'} ${provider}`);
+    }
+    return 0;
+  }
+
+  io.err(USAGE);
+  return 2;
+}

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -38,7 +38,12 @@ import { getLastKnownLatest, checkForUpgrade, isUpgradeAvailable } from './upgra
 //
 // See memory `project_bootstrap_hook_command_dispatch_bug.md` for the
 // full diagnosis and the dist-mcp-only build context.
-{
+//
+// Wrapped in an IIFE (not a bare block) so the `key` branch can `return` after
+// spawning its async handler — the async work keeps the event loop alive and
+// calls process.exit(code) when done, while the synchronous `return` prevents
+// fall-through to the MCP server boot below.
+const __argvShimHandled = (() => {
   const argv = process.argv.slice(2);
   const sub = argv[0];
   if (sub === 'hook') {
@@ -57,6 +62,8 @@ import { getLastKnownLatest, checkForUpgrade, isUpgradeAvailable } from './upgra
       'Usage:\n' +
       '  gossipcat                Start MCP server (for Claude Code / Cursor)\n' +
       '  gossipcat hook --run     Run UserPromptSubmit bootstrap hook (internal)\n' +
+      '  gossipcat key set <provider>   Store an API key in the OS keychain (service: gossip-mesh)\n' +
+      '  gossipcat key list             Show which providers have a stored key\n' +
       '  gossipcat help           Show this help\n' +
       '\n' +
       'The published binary is the MCP server bundle. The full CLI\n' +
@@ -64,6 +71,32 @@ import { getLastKnownLatest, checkForUpgrade, isUpgradeAvailable } from './upgra
       'and is available via `npm start` / `npx ts-node` in the source repo.\n'
     );
     process.exit(0);
+  }
+  if (sub === 'key') {
+    // Terminal-only credential bootstrap for the published binary. Deliberately
+    // NOT an MCP tool: a secret must never traverse the LLM tool layer.
+    void (async () => {
+      const { runKeyCommand } = await import('./key-command');
+      const { Keychain } = await import('./keychain');
+      const kc = new Keychain();
+      const io = {
+        setKey: (p: string, k: string) => kc.setKey(p, k),
+        getKey: (p: string) => kc.getKey(p),
+        readSecret: () => readSecretFromStdin(),
+        out: (l: string) => process.stdout.write(l + '\n'),
+        err: (l: string) => process.stderr.write(l + '\n'),
+      };
+      const code = await runKeyCommand(argv.slice(1), io);
+      process.exit(code);
+    })().catch((err: unknown) => {
+      // main() (which installs the unhandledRejection guard) never runs on the
+      // key path, so a keychain/import/stdin failure would otherwise crash with a
+      // raw stack trace. Surface a clean message and a non-zero exit instead.
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`gossipcat key: ${msg}\n`);
+      process.exit(1);
+    });
+    return true; // async handler owns the process; do NOT boot the MCP server
   }
   // `mcp` is a back-compat alias for no-args; legacy `.mcp.json` files written
   // by older `gossip_setup` invocations pass `"args": ["mcp"]`. Without this
@@ -74,12 +107,70 @@ import { getLastKnownLatest, checkForUpgrade, isUpgradeAvailable } from './upgra
     process.exit(2);
   }
   // No args (or `mcp` alias) → fall through; the MCP server boots below.
-}
+  return false;
+})();
 
+/**
+ * Read an API key secret from the terminal WITHOUT echoing it. Used only by the
+ * `gossipcat key set` shim branch above.
+ *   - TTY: prompt on STDERR (never stdout — stdout is the MCP channel), read one
+ *     line with echo disabled so the key is not displayed or left in scrollback.
+ *   - Piped (non-TTY): read all of stdin and return it verbatim (caller trims).
+ * The raw string is returned; the secret is never logged or printed here.
+ */
+function readSecretFromStdin(): Promise<string> {
+  const stdin = process.stdin;
+  if (!stdin.isTTY) {
+    return new Promise<string>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      stdin.on('data', (c: Buffer) => chunks.push(c));
+      stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+      // Without this, a broken pipe emits an unhandled 'error' → uncaughtException
+      // crash (no guard runs on the key path). Reject so the .catch surfaces it.
+      stdin.on('error', (e: Error) => reject(e));
+      stdin.resume();
+    });
+  }
+  return new Promise<string>((resolve) => {
+    process.stderr.write('Paste the API key, then Enter: ');
+    let buf = '';
+    const wasRaw = stdin.isRaw === true;
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding('utf8');
+    const onData = (ch: string) => {
+      for (const c of ch) {
+        const code = c.charCodeAt(0);
+        if (c === '\n' || c === '\r') {
+          stdin.setRawMode(wasRaw);
+          stdin.pause();
+          stdin.removeListener('data', onData);
+          process.stderr.write('\n');
+          resolve(buf);
+          return;
+        } else if (code === 3) { // Ctrl-C (ETX)
+          stdin.setRawMode(wasRaw);
+          stdin.pause();
+          stdin.removeListener('data', onData);
+          process.stderr.write('\n');
+          process.exit(130);
+        } else if (code === 127 || code === 8) { // DEL / backspace
+          buf = buf.slice(0, -1);
+        } else {
+          buf += c; // never echoed
+        }
+      }
+    };
+    stdin.on('data', onData);
+  });
+}
 // Redirect stderr to log file BEFORE any other imports.
 // Suppressed in test runs (GOSSIPCAT_MCP_NO_MAIN=1) so jest can surface assertion
 // failures on the real stderr stream — see tests/cli/http-mcp-second-connect.test.ts.
-if (process.env.GOSSIPCAT_MCP_NO_MAIN !== '1') {
+// Also suppressed when the argv shim handled a subcommand (`key`): that path owns
+// stdout/stderr for its prompt + result, and the MCP server must NOT boot or it
+// would steal stdin and redirect the key prompt into mcp.log.
+if (process.env.GOSSIPCAT_MCP_NO_MAIN !== '1' && !__argvShimHandled) {
   const gossipDir = join(process.cwd(), '.gossip');
   try { mkdirSync(gossipDir, { recursive: true }); } catch {}
   const logStream = createWriteStream(join(gossipDir, 'mcp.log'), { flags: 'a' });
@@ -5127,6 +5218,9 @@ async function main() {
 // Suppress automatic main() invocation when imported from tests. Tests set
 // GOSSIPCAT_MCP_NO_MAIN=1 so they can call createMcpServer() in isolation
 // without binding stdio. Issue #405 regression test relies on this.
-if (process.env.GOSSIPCAT_MCP_NO_MAIN !== '1') {
+// Also suppressed when the argv shim handled a subcommand (`key`): the async
+// key handler owns the process and calls process.exit(); booting the MCP server
+// here would race it for stdin.
+if (process.env.GOSSIPCAT_MCP_NO_MAIN !== '1' && !__argvShimHandled) {
   main().catch(err => { process.stderr.write(`[gossipcat] Fatal: ${err.message}\n`); process.exit(1); });
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -122,9 +122,9 @@ try {
 } catch (e) {
   // Soft-fail on write errors: global npm installs often target root-owned dirs
   // where EACCES is expected. Hard-exiting here would abort `npm install -g`
-  // for every user without sudo — users can re-run `gossipcat setup` after.
+  // for every user without sudo — users can run `gossipcat key set` after.
   // Regression guard: tests/cli/install-packaging.test.ts:133-140.
-  console.warn(`gossipcat: postinstall could not write .mcp.json (${e.code || e.message}). Run 'gossipcat setup' after install to configure.`);
+  console.warn(`gossipcat: postinstall could not write .mcp.json (${e.code || e.message}). Run 'gossipcat key set <provider>' after install to store your API keys.`);
 }
 
 // Staleness check: warn if dist-mcp/ is older than package.json

--- a/tests/cli/key-command.test.ts
+++ b/tests/cli/key-command.test.ts
@@ -1,0 +1,123 @@
+/**
+ * key-command.test.ts — unit tests for the `gossipcat key` subcommand logic.
+ *
+ * runKeyCommand is pure + DI: all I/O (keychain, secret prompt, stdout/stderr)
+ * is injected via a fake KeyCommandIO so these tests never touch a real OS
+ * keychain or stdin. The load-bearing security property — the secret key value
+ * must NEVER appear in any out()/err() line — is asserted explicitly.
+ */
+
+import { runKeyCommand, KeyCommandIO } from '../../apps/cli/src/key-command';
+
+interface FakeIO extends KeyCommandIO {
+  store: Map<string, string>;
+  outLines: string[];
+  errLines: string[];
+  readSecretCalls: number;
+}
+
+function makeIO(opts: {
+  secret?: string;
+  seed?: Record<string, string>;
+} = {}): FakeIO {
+  const store = new Map<string, string>(Object.entries(opts.seed ?? {}));
+  const outLines: string[] = [];
+  const errLines: string[] = [];
+  const io: FakeIO = {
+    store,
+    outLines,
+    errLines,
+    readSecretCalls: 0,
+    async setKey(provider, key) { store.set(provider, key); },
+    async getKey(provider) { return store.get(provider) ?? null; },
+    async readSecret() { io.readSecretCalls++; return opts.secret ?? ''; },
+    out(line) { outLines.push(line); },
+    err(line) { errLines.push(line); },
+  };
+  return io;
+}
+
+/** Assert a secret value never leaked into any captured output line. */
+function assertNoLeak(io: FakeIO, secret: string) {
+  for (const line of [...io.outLines, ...io.errLines]) {
+    expect(line).not.toContain(secret);
+  }
+}
+
+describe('runKeyCommand', () => {
+  describe('set', () => {
+    it('stores a key and confirms by provider name only (no secret leak)', async () => {
+      const secret = 'sk-realkey-abc123-do-not-print';
+      const io = makeIO({ secret });
+      const code = await runKeyCommand(['set', 'deepseek'], io);
+
+      expect(code).toBe(0);
+      expect(io.store.get('deepseek')).toBe(secret);
+      expect(io.outLines.join('\n')).toContain('deepseek');
+      assertNoLeak(io, secret);
+    });
+
+    it('returns 2 and does not store when the secret is empty/whitespace', async () => {
+      const io = makeIO({ secret: '   \n\t ' });
+      const code = await runKeyCommand(['set', 'deepseek'], io);
+
+      expect(code).toBe(2);
+      expect(io.store.has('deepseek')).toBe(false);
+      expect(io.errLines.join('\n').toLowerCase()).toContain('empty');
+    });
+
+    it('returns 2 with usage when no provider is given', async () => {
+      const io = makeIO({ secret: 'sk-whatever' });
+      const code = await runKeyCommand(['set'], io);
+
+      expect(code).toBe(2);
+      expect(io.errLines.join('\n')).toContain('key set <provider>');
+      // readSecret must not run without a provider
+      expect(io.readSecretCalls).toBe(0);
+    });
+
+    it('rejects an invalid provider name BEFORE reading the secret', async () => {
+      const io = makeIO({ secret: 'sk-should-never-be-read' });
+      const code = await runKeyCommand(['set', 'bad/provider!'], io);
+
+      expect(code).toBe(2);
+      expect(io.readSecretCalls).toBe(0); // validation gates the prompt
+      expect(io.errLines.join('\n').toLowerCase()).toContain('invalid');
+      expect(io.store.has('bad/provider!')).toBe(false);
+    });
+  });
+
+  describe('list', () => {
+    it('marks present providers with ✓ and absent with ·, never printing values', async () => {
+      const secret = 'sk-deepseek-secret-value';
+      const io = makeIO({ seed: { deepseek: secret } });
+      const code = await runKeyCommand(['list'], io);
+
+      expect(code).toBe(0);
+      const out = io.outLines.join('\n');
+      expect(out).toMatch(/✓\s+deepseek/);
+      expect(out).toMatch(/·\s+openai/);
+      assertNoLeak(io, secret);
+    });
+  });
+
+  describe('unknown', () => {
+    it('returns 2 with usage for an unknown subcommand', async () => {
+      const io = makeIO();
+      const code = await runKeyCommand(['frobnicate'], io);
+
+      expect(code).toBe(2);
+      const err = io.errLines.join('\n');
+      expect(err).toContain('key set <provider>');
+      expect(err).toContain('key list');
+    });
+
+    it('returns 2 with usage when no subcommand is given', async () => {
+      const io = makeIO();
+      const code = await runKeyCommand([], io);
+
+      expect(code).toBe(2);
+      expect(io.errLines.join('\n')).toContain('key list');
+    });
+  });
+});

--- a/tests/cli/key-shim-boot-gate.test.ts
+++ b/tests/cli/key-shim-boot-gate.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression guard — key-shim-boot-gate.test.ts
+ *
+ * The `gossipcat key` subcommand runs inside the argv shim of mcp-server-sdk.ts
+ * via a fire-and-forget async handler (top-level await is unavailable in the
+ * CommonJS bundle). That handler returns synchronously while its work is still
+ * pending, so module evaluation continues past the shim. If the MCP server boot
+ * (`main()`) and the stderr→mcp.log redirect are NOT gated on the shim's
+ * handled-flag, `gossipcat key set` would ALSO boot the MCP server, steal stdin
+ * from the secret prompt, and redirect the prompt into mcp.log — silently
+ * breaking the feature. These source-level assertions lock in the gate.
+ *
+ * Verified by reading source text only — no exec, no spawn.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '..', '..', 'apps', 'cli', 'src', 'mcp-server-sdk.ts'),
+  'utf-8',
+);
+
+describe('argv shim boot gate', () => {
+  it('declares the handled-flag from the argv shim IIFE', () => {
+    expect(SRC).toMatch(/const __argvShimHandled = \(\(\) =>/);
+  });
+
+  it('the `key` branch returns true so the async handler owns the process', () => {
+    // The key branch must signal "handled" so the boot below is suppressed.
+    expect(SRC).toMatch(/if \(sub === 'key'\)/);
+    expect(SRC).toMatch(/return true;.*async handler owns the process|async handler owns the process[\s\S]*return true;/);
+  });
+
+  it('gates main() invocation on !__argvShimHandled (no boot when key handled)', () => {
+    expect(SRC).toMatch(
+      /process\.env\.GOSSIPCAT_MCP_NO_MAIN !== '1' && !__argvShimHandled[\s\S]*main\(\)\.catch/,
+    );
+  });
+
+  it('gates the stderr→mcp.log redirect on !__argvShimHandled', () => {
+    // Two blocks guard on the same condition; assert it appears at least twice.
+    const matches = SRC.match(
+      /process\.env\.GOSSIPCAT_MCP_NO_MAIN !== '1' && !__argvShimHandled/g,
+    );
+    expect(matches && matches.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## What

Adds a terminal-only **`gossipcat key set <provider>` / `gossipcat key list`** subcommand to the published binary. Prerequisite for **#2** (relay auth hardening).

### Why
The published `gossipcat` binary is the MCP-server bundle; the setup wizard (`apps/cli/src/index.ts`) isn't packaged, and **no MCP tool stores keys**. A user who creates an `openai`/`deepseek`/`openclaw` agent via `gossip_setup` had **no in-product way to store its API key** — the agent failed at dispatch (a real report: DeepSeek key "never stored", `gossipcat setup` → "unknown subcommand"). This closes the credential-bootstrap dead-end across all backends (macOS Keychain / Linux secret-tool / encrypted-file fallback).

## Changes
- **`apps/cli/src/key-command.ts`** (new) — pure, DI-style `runKeyCommand(args, io)`. `set <provider>` validates the provider name **before** prompting, reads the secret, stores via `Keychain.setKey` (service `gossip-mesh`, account = provider), confirms by provider name only — **the secret is never echoed or logged**. `list` shows `✓`/`·` per `KEY_REQUIRING_PROVIDERS`, never values.
- **`apps/cli/src/mcp-server-sdk.ts`** — `key` branch in the argv shim + hidden-input `readSecretFromStdin` (TTY raw-mode no-echo; non-TTY pipe read). The shim is now an IIFE returning a handled-flag; **both** boot gates (stderr→`mcp.log` redirect and `main()`) are gated on `!__argvShimHandled` so `gossipcat key` does **not** boot the MCP server / steal stdin. The async handler has a `.catch`; the non-TTY read has an `'error'` listener.
- **`scripts/postinstall.js`** — post-install hint pointed at `gossipcat setup` (errors on the published binary) → now `gossipcat key set <provider>`.
- **tests** — `key-command.test.ts` (set/list/invalid/empty/unknown + no-secret-leak assertion); `key-shim-boot-gate.test.ts` (locks in both boot gates + the `key` branch contract).

> **Not an MCP tool** — routing a secret through the LLM tool layer would be a trust-boundary violation. Terminal-only by design.

Usage:
```bash
echo 'sk-...' | gossipcat key set deepseek    # or interactive hidden prompt on a TTY
gossipcat key list
```

## Verification
- `npx tsc --noEmit -p apps/cli/tsconfig.json` → exit 0
- `npx jest tests/cli/key-command.test.ts tests/cli/key-shim-boot-gate.test.ts tests/cli/install-packaging.test.ts` → 26/26 pass

## Consensus `5b0b53ff-1437473e` (gemini-reviewer + sonnet-reviewer): 10 confirmed, 0 disputed
- **Caught pre-review (orchestrator):** a **critical boot-fallthrough** — `main()` and the stderr redirect were ungated, so `gossipcat key set` would also boot the MCP server and contend for stdin. Fixed (both gates `&& !__argvShimHandled`) + source-level regression test, before consensus.
- **Consensus findings, all applied:** `.catch` on the async IIFE (no rejection guard runs on the key path); `'error'` listener on the non-TTY stdin read; Ctrl-C cleanup symmetry.
- Confirmed: secret never leaks, both boot gates guarded, TTY raw-mode restored on all exit paths, provider validated before prompt.

## Follow-up (out of scope)
- Spawn-level integration test for `gossipcat key` (currently guarded at source level).
- `help`/`-h` alias spawn coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)