### PR TITLE
feat(orchestrator): auth-failure visibility in gossip_status (closes #2)

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1749,6 +1749,17 @@ export function createMcpServer(): McpServer {
         }
       } catch { /* keychain doctor failure must never break status — skip */ }
 
+      // Auth-failure visibility — surface any provider whose API key was rejected
+      // (HTTP 401/403) within the TTL window so the operator sees WHICH key to fix.
+      // Separate from quota health: a 401/403 is a manual-fix condition, not a
+      // wait-it-out cooldown. Self-heals on a later success + read-time TTL filter.
+      try {
+        const { readRecentAuthFailures } = await import('@gossip/orchestrator');
+        for (const f of readRecentAuthFailures(process.cwd())) {
+          lines.push(`  ⚠️ Auth: "${f.provider}" key rejected (HTTP ${f.status}) — run 'gossipcat key set ${f.provider}'`);
+        }
+      } catch { /* auth-state.json not present — skip */ }
+
       // Signals pending — recent consensus rounds with no manually-recorded signals.
       // Surfaces the back-search gap (per consensus 4c88bcd3, haiku:f17) so the
       // orchestrator can SEE which rounds it skipped without having to remember.

--- a/packages/orchestrator/src/auth-state.ts
+++ b/packages/orchestrator/src/auth-state.ts
@@ -1,0 +1,102 @@
+/**
+ * Auth-failure visibility surface (separate from QuotaTracker / quota-state.json).
+ *
+ * A 401/403 means a provider's API key was rejected — a "manual fix" condition,
+ * NOT the "retry later" semantics of a 429 (which QuotaTracker owns). Conflating
+ * the two in quota-state.json would be wrong: waiting never fixes a bad key.
+ *
+ * This module records auth rejections to `.gossip/auth-state.json` as a
+ * best-effort side-record (never throws), so `gossip_status` can surface which
+ * provider's key is bad. It is VISIBILITY ONLY — it adds no cooldown, gate, or
+ * control-flow change. The 401/403 still throws and fails fast exactly as before.
+ *
+ * Self-healing: a later success clears the entry (clearAuthFailure), and reads
+ * TTL-filter stale entries so a transient bad-key window can't wedge a session.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join } from 'path';
+
+export interface AuthFailure {
+  provider: string;
+  status: number;
+  at: number;
+}
+
+interface AuthStateFile {
+  [provider: string]: { status: number; at: number };
+}
+
+const PROVIDER_RE = /^[a-zA-Z0-9_-]{1,32}$/;
+
+function statePath(projectRoot: string): string {
+  return join(projectRoot, '.gossip', 'auth-state.json');
+}
+
+function readState(path: string): AuthStateFile {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as AuthStateFile;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Record a provider auth rejection (HTTP 401/403) as a best-effort side-record.
+ * No-op when projectRoot is missing or provider fails validation. Never throws.
+ * Merges into existing entries so other providers are preserved.
+ */
+export function recordAuthFailure(projectRoot: string | undefined, provider: string, status: number): void {
+  if (!projectRoot) return;
+  if (!PROVIDER_RE.test(provider)) return;
+  try {
+    const path = statePath(projectRoot);
+    const dir = join(path, '..');
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const existing = readState(path);
+    existing[provider] = { status, at: Date.now() };
+    writeFileSync(path, JSON.stringify(existing, null, 2));
+  } catch { /* best-effort, never throw */ }
+}
+
+/**
+ * Clear a provider's recorded auth failure (called on a later success).
+ * No-op when projectRoot is missing or the entry is absent. Never throws.
+ */
+export function clearAuthFailure(projectRoot: string | undefined, provider: string): void {
+  if (!projectRoot) return;
+  try {
+    const path = statePath(projectRoot);
+    if (!existsSync(path)) return;
+    const existing = readState(path);
+    if (!(provider in existing)) return;
+    delete existing[provider];
+    writeFileSync(path, JSON.stringify(existing, null, 2));
+  } catch { /* best-effort, never throw */ }
+}
+
+/**
+ * Read recent auth failures within the TTL window (default 6h), newest first.
+ * Returns [] on any error, missing file, or no projectRoot. TTL-filtering
+ * prevents a stale bad-key window from wedging across sessions.
+ */
+export function readRecentAuthFailures(
+  projectRoot: string | undefined,
+  ttlMs = 6 * 60 * 60 * 1000,
+): AuthFailure[] {
+  if (!projectRoot) return [];
+  try {
+    const path = statePath(projectRoot);
+    if (!existsSync(path)) return [];
+    const state = readState(path);
+    const now = Date.now();
+    const out: AuthFailure[] = [];
+    for (const [provider, entry] of Object.entries(state)) {
+      if (!entry || typeof entry.at !== 'number' || typeof entry.status !== 'number') continue;
+      if (now - entry.at <= ttlMs) out.push({ provider, status: entry.status, at: entry.at });
+    }
+    return out.sort((a, b) => b.at - a.at);
+  } catch {
+    return [];
+  }
+}

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -24,6 +24,8 @@ export {
   PROVIDER_PLACEHOLDER_RE,
 } from './llm-client';
 export type { ILLMProvider, LLMGenerateOptions } from './llm-client';
+export { recordAuthFailure, clearAuthFailure, readRecentAuthFailures } from './auth-state';
+export type { AuthFailure } from './auth-state';
 export * from './types';
 export * from './consensus-types';
 export type { ImplSignal, MetaSignal, PerformanceSignal } from './consensus-types';

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -14,6 +14,7 @@ import { join } from 'path';
 import { ToolDefinition, LLMMessage } from '@gossip/types';
 import { LLMResponse } from './types';
 import { log as _log } from './log';
+import { recordAuthFailure, clearAuthFailure } from './auth-state';
 
 // ─── 503 Retry Helper ───────────────────────────────────────────────────────
 
@@ -241,8 +242,12 @@ export interface ILLMProvider {
 
 export class AnthropicProvider implements ILLMProvider {
   private quota: QuotaTracker;
-  constructor(private apiKey: string, private model: string, projectRoot?: string) {
+  private projectRoot?: string;
+  private authSlot: string;
+  constructor(private apiKey: string, private model: string, projectRoot?: string, authSlot?: string) {
     this.quota = new QuotaTracker('anthropic', projectRoot);
+    this.projectRoot = projectRoot;
+    this.authSlot = authSlot ?? 'anthropic';
   }
 
   async generate(messages: LLMMessage[], options?: LLMGenerateOptions): Promise<LLMResponse> {
@@ -284,11 +289,13 @@ export class AnthropicProvider implements ILLMProvider {
       if (res.status === 429) this.quota.handle429(res, body);
       if (res.status === 503) this.quota.handle503(res, body);
       if (res.status === 401 || res.status === 403) {
+        recordAuthFailure(this.projectRoot, this.authSlot, res.status);
         throw new Error(authErrorMessage('Anthropic', res.status, 'https://api.anthropic.com/v1', body));
       }
       throw new Error(`Anthropic API error (${res.status}): ${body}`);
     }
     this.quota.onSuccess();
+    clearAuthFailure(this.projectRoot, this.authSlot);
     const data = await res.json() as Record<string, unknown>;
     return this.parseAnthropicResponse(data);
   }
@@ -354,6 +361,9 @@ export class OpenAIProvider implements ILLMProvider {
   private baseUrl: string;
   private timeoutMs: number;
   private providerLabel: string;
+  private projectRoot?: string;
+  /** Keychain provider slot (deepseek / openclaw / openai) — the key the operator must fix. */
+  private authProvider: string;
   constructor(
     private apiKey: string,
     private model: string,
@@ -373,11 +383,22 @@ export class OpenAIProvider implements ILLMProvider {
      * than the generic "OpenAI-compatible". Defaults to "OpenAI-compatible". #522
      */
     providerLabel?: string,
+    /**
+     * Keychain SERVICE name (key_ref ?? provider) to name in the auth-failure
+     * record, so gossip_status tells the operator the exact `gossipcat key set
+     * <service>` to run. Distinct from the quota slot: rate-limit quota is keyed
+     * per provider/endpoint (shared across agents on the same endpoint), while a
+     * rejected key is per-agent credential. Defaults to the quota slot. #522
+     */
+    authSlot?: string,
   ) {
     this.baseUrl = (baseUrl ?? process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/$/, '');
-    this.quota = new QuotaTracker(quotaSlot ?? 'openai', projectRoot);
+    const quotaSlotResolved = quotaSlot ?? 'openai';
+    this.quota = new QuotaTracker(quotaSlotResolved, projectRoot);
+    this.authProvider = authSlot ?? quotaSlotResolved;
     this.timeoutMs = timeoutMs ?? 120_000;
     this.providerLabel = providerLabel ?? 'OpenAI-compatible';
+    this.projectRoot = projectRoot;
   }
 
   async generate(messages: LLMMessage[], options?: LLMGenerateOptions): Promise<LLMResponse> {
@@ -415,11 +436,13 @@ export class OpenAIProvider implements ILLMProvider {
       // rate-limit semantics; a wrong key won't fix itself by waiting, so a
       // clear, fail-fast message is the correct behavior here (issue #522).
       if (res.status === 401 || res.status === 403) {
+        recordAuthFailure(this.projectRoot, this.authProvider, res.status);
         throw new Error(authErrorMessage(this.providerLabel, res.status, this.baseUrl, body));
       }
       throw new Error(`OpenAI API error (${res.status}): ${body}`);
     }
     this.quota.onSuccess();
+    clearAuthFailure(this.projectRoot, this.authProvider);
     const data = await res.json() as Record<string, unknown>;
     return this.parseOpenAIResponse(data);
   }
@@ -479,9 +502,13 @@ export class OpenAIProvider implements ILLMProvider {
 
 export class GeminiProvider implements ILLMProvider {
   private quota: QuotaTracker;
+  private projectRoot?: string;
+  private authSlot: string;
 
-  constructor(private apiKey: string, private model: string, projectRoot?: string) {
+  constructor(private apiKey: string, private model: string, projectRoot?: string, authSlot?: string) {
     this.quota = new QuotaTracker('google', projectRoot);
+    this.projectRoot = projectRoot;
+    this.authSlot = authSlot ?? 'google';
   }
 
   async generate(messages: LLMMessage[], options?: LLMGenerateOptions): Promise<LLMResponse> {
@@ -530,11 +557,13 @@ export class GeminiProvider implements ILLMProvider {
       if (res.status === 429) this.quota.handle429(res, errBody);
       if (res.status === 503) this.quota.handle503(res, errBody);
       if (res.status === 401 || res.status === 403) {
+        recordAuthFailure(this.projectRoot, this.authSlot, res.status);
         throw new Error(authErrorMessage('Google Gemini', res.status, 'https://generativelanguage.googleapis.com/v1beta', errBody));
       }
       throw new Error(`Gemini API error (${res.status}): ${errBody}`);
     }
     this.quota.onSuccess();
+    clearAuthFailure(this.projectRoot, this.authSlot);
     const data = await res.json() as Record<string, unknown>;
     const result = this.parseGeminiResponse(data);
     if (process.env.GOSSIP_DEBUG) _log('Gemini', `→ text=${result.text?.length ?? 0}chars, toolCalls=${result.toolCalls?.length ?? 0}${result.toolCalls?.length ? ` [${result.toolCalls.map(tc => tc.name).join(', ')}]` : ''}, tokens=${result.usage?.inputTokens ?? '?'}/${result.usage?.outputTokens ?? '?'}`);
@@ -735,7 +764,10 @@ export function createProviderForAgent(
       `base_url ${baseUrl ?? 'default'}); set the key for keychain service "${service}"`,
     );
   }
-  return createProvider(provider, model, apiKey, projectRoot, baseUrl);
+  // Auth-failure slot = the keychain SERVICE the operator must fix (key_ref ??
+  // provider), so gossip_status names the right `gossipcat key set <service>`.
+  // Distinct from the quota slot (per-endpoint rate-limit state). #522
+  return createProvider(provider, model, apiKey, projectRoot, baseUrl, keyRef ?? provider);
 }
 
 /**
@@ -767,10 +799,10 @@ export async function resolveAgentProvider(
 // fail at runtime (or vice versa).
 export const CREATE_PROVIDER_CASES = ['anthropic', 'openai', 'deepseek', 'openclaw', 'google', 'local', 'none'] as const;
 
-export function createProvider(provider: string, model: string, apiKey?: string, projectRoot?: string, baseUrl?: string): ILLMProvider {
+export function createProvider(provider: string, model: string, apiKey?: string, projectRoot?: string, baseUrl?: string, authSlot?: string): ILLMProvider {
   switch (provider) {
-    case 'anthropic': return new AnthropicProvider(apiKey!, model, projectRoot);
-    case 'openai': return new OpenAIProvider(apiKey ?? '', model, projectRoot, baseUrl, baseUrl ? `openai:${baseUrl}` : undefined);
+    case 'anthropic': return new AnthropicProvider(apiKey!, model, projectRoot, authSlot);
+    case 'openai': return new OpenAIProvider(apiKey ?? '', model, projectRoot, baseUrl, baseUrl ? `openai:${baseUrl}` : undefined, undefined, undefined, authSlot);
     // DeepSeek is OpenAI-wire-compatible — reuse OpenAIProvider. Default the
     // base_url to api.deepseek.com/v1 (an explicit base_url still overrides),
     // give it a 'deepseek' quota slot, and a 'DeepSeek' label so 401/403 auth
@@ -778,15 +810,15 @@ export function createProvider(provider: string, model: string, apiKey?: string,
     case 'deepseek': return new OpenAIProvider(
       apiKey ?? '', model, projectRoot,
       baseUrl ?? 'https://api.deepseek.com/v1',
-      'deepseek', undefined, 'DeepSeek',
+      'deepseek', undefined, 'DeepSeek', authSlot,
     );
     // OpenClaw is a remote agentic LLM with its own server-side tool chain
     // (web_fetch, exec, browser, etc.). Its wallclock regularly exceeds the
     // 120s default because it's doing Claude-like agentic work per request
     // — two timeouts this session (task 2b426ef6 at 100.9s, task 53005181
     // hit the 120s cap on a URL-fetching review). Give it 10 minutes.
-    case 'openclaw': return new OpenAIProvider(apiKey ?? '', model, projectRoot, baseUrl ?? 'http://127.0.0.1:18789/v1', 'openclaw', 600_000);
-    case 'google': return new GeminiProvider(apiKey!, model, projectRoot);
+    case 'openclaw': return new OpenAIProvider(apiKey ?? '', model, projectRoot, baseUrl ?? 'http://127.0.0.1:18789/v1', 'openclaw', 600_000, undefined, authSlot);
+    case 'google': return new GeminiProvider(apiKey!, model, projectRoot, authSlot);
     case 'local': return new OllamaProvider(model);
     case 'none': return new NullProvider();
     default: throw new Error(`Unknown provider: ${provider}`);

--- a/tests/orchestrator/auth-state.test.ts
+++ b/tests/orchestrator/auth-state.test.ts
@@ -1,0 +1,140 @@
+import { recordAuthFailure, clearAuthFailure, readRecentAuthFailures } from '@gossip/orchestrator';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('auth-state', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'gossip-auth-state-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('record → read returns the entry', () => {
+    recordAuthFailure(root, 'anthropic', 401);
+    const failures = readRecentAuthFailures(root);
+    expect(failures).toHaveLength(1);
+    expect(failures[0].provider).toBe('anthropic');
+    expect(failures[0].status).toBe(401);
+    expect(typeof failures[0].at).toBe('number');
+  });
+
+  it('records two providers, then clearing one leaves only the other', () => {
+    recordAuthFailure(root, 'anthropic', 401);
+    recordAuthFailure(root, 'google', 403);
+    expect(readRecentAuthFailures(root).map(f => f.provider).sort()).toEqual(['anthropic', 'google']);
+
+    clearAuthFailure(root, 'anthropic');
+    const remaining = readRecentAuthFailures(root);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].provider).toBe('google');
+    expect(remaining[0].status).toBe(403);
+  });
+
+  it('filters entries older than the 6h TTL', () => {
+    // Write a stale entry directly (at = 7h ago).
+    const dir = join(root, '.gossip');
+    mkdirSync(dir, { recursive: true });
+    const sevenHoursAgo = Date.now() - 7 * 60 * 60 * 1000;
+    writeFileSync(
+      join(dir, 'auth-state.json'),
+      JSON.stringify({ deepseek: { status: 401, at: sevenHoursAgo } }, null, 2),
+    );
+    expect(readRecentAuthFailures(root)).toEqual([]);
+
+    // A fresh entry alongside the stale one is still returned (stale filtered out).
+    recordAuthFailure(root, 'openai', 403);
+    const fresh = readRecentAuthFailures(root);
+    expect(fresh).toHaveLength(1);
+    expect(fresh[0].provider).toBe('openai');
+  });
+
+  it('returns [] for a missing file without throwing', () => {
+    expect(readRecentAuthFailures(root)).toEqual([]);
+  });
+
+  it('returns [] for a malformed file without throwing', () => {
+    const dir = join(root, '.gossip');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'auth-state.json'), '{ this is not: valid json');
+    expect(() => readRecentAuthFailures(root)).not.toThrow();
+    expect(readRecentAuthFailures(root)).toEqual([]);
+  });
+
+  it('writes nothing for an invalid provider name', () => {
+    recordAuthFailure(root, 'bad/name', 401);
+    expect(existsSync(join(root, '.gossip', 'auth-state.json'))).toBe(false);
+    expect(readRecentAuthFailures(root)).toEqual([]);
+  });
+
+  it('rejects an over-long provider name (>32 chars)', () => {
+    recordAuthFailure(root, 'a'.repeat(33), 401);
+    expect(readRecentAuthFailures(root)).toEqual([]);
+  });
+
+  it('is a safe no-op when projectRoot is undefined', () => {
+    expect(() => recordAuthFailure(undefined, 'anthropic', 401)).not.toThrow();
+    expect(() => clearAuthFailure(undefined, 'anthropic')).not.toThrow();
+    expect(readRecentAuthFailures(undefined)).toEqual([]);
+  });
+
+  it('preserves existing entries on merge-write', () => {
+    recordAuthFailure(root, 'anthropic', 401);
+    recordAuthFailure(root, 'google', 403);
+    const raw = JSON.parse(readFileSync(join(root, '.gossip', 'auth-state.json'), 'utf-8'));
+    expect(Object.keys(raw).sort()).toEqual(['anthropic', 'google']);
+  });
+
+  it('returns failures sorted newest-first', () => {
+    const dir = join(root, '.gossip');
+    mkdirSync(dir, { recursive: true });
+    const now = Date.now();
+    writeFileSync(
+      join(dir, 'auth-state.json'),
+      JSON.stringify({
+        older: { status: 401, at: now - 1000 },
+        newer: { status: 403, at: now - 10 },
+      }, null, 2),
+    );
+    const out = readRecentAuthFailures(root);
+    expect(out.map(f => f.provider)).toEqual(['newer', 'older']);
+  });
+
+  it('skips structurally-valid entries with non-numeric at/status', () => {
+    const dir = join(root, '.gossip');
+    mkdirSync(dir, { recursive: true });
+    const now = Date.now();
+    writeFileSync(
+      join(dir, 'auth-state.json'),
+      JSON.stringify({
+        good: { status: 401, at: now - 10 },
+        badAt: { status: 401, at: 'not-a-number' },
+        badStatus: { status: 'nope', at: now - 10 },
+      }),
+    );
+    const out = readRecentAuthFailures(root);
+    expect(out.map(f => f.provider)).toEqual(['good']);
+  });
+
+  it('keeps an entry just inside the TTL window and drops one just past it', () => {
+    const dir = join(root, '.gossip');
+    mkdirSync(dir, { recursive: true });
+    const ttl = 6 * 60 * 60 * 1000;
+    const now = Date.now();
+    // 60s margins swamp any wall-clock drift between write and read.
+    writeFileSync(
+      join(dir, 'auth-state.json'),
+      JSON.stringify({
+        justInside: { status: 401, at: now - ttl + 60_000 },  // age < ttl → kept
+        justPast: { status: 401, at: now - ttl - 60_000 },    // age > ttl → dropped
+      }),
+    );
+    const providers = readRecentAuthFailures(root, ttl).map(f => f.provider);
+    expect(providers).toContain('justInside');
+    expect(providers).not.toContain('justPast');
+  });
+});

--- a/tests/orchestrator/llm-client.test.ts
+++ b/tests/orchestrator/llm-client.test.ts
@@ -1,4 +1,7 @@
 import { createProvider, createProviderForAgent, resolveAgentProvider, AnthropicProvider, OpenAIProvider, GeminiProvider, OllamaProvider } from '@gossip/orchestrator';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 describe('LLM Client', () => {
   describe('createProvider', () => {
@@ -294,6 +297,29 @@ describe('LLM Client', () => {
       expect(caught!.message).not.toContain('platform.openai.com');
 
       global.fetch = originalFetch;
+    });
+
+    it('records the auth failure under the key_ref service, not the provider slot (issue #522)', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: async () => 'Incorrect API key provided',
+      }) as unknown as typeof fetch;
+      const root = mkdtempSync(join(tmpdir(), 'auth-keyref-'));
+      try {
+        // An openai-provider agent whose key lives at keychain service "my-corp-key".
+        const provider = createProvider('openai', 'gpt-4', 'bad-key', root, undefined, 'my-corp-key');
+        await provider.generate([{ role: 'user', content: 'hi' }]).catch(() => { /* 401 expected */ });
+        const state = JSON.parse(readFileSync(join(root, '.gossip', 'auth-state.json'), 'utf-8'));
+        // The recorded slot (and thus the `gossipcat key set <X>` hint) must be the
+        // key_ref service, NOT the generic provider name.
+        expect(Object.keys(state)).toEqual(['my-corp-key']);
+        expect(state['my-corp-key'].status).toBe(401);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+        global.fetch = originalFetch;
+      }
     });
 
     it('non-auth 500 still uses the generic OpenAI error path', async () => {


### PR DESCRIPTION
## What
When a provider's API key is rejected (**HTTP 401/403**), record it to a self-healing side-record so `gossip_status` tells the operator exactly which key to fix. **Visibility only** — no cooldown/gate; a 401/403 still fails fast with the existing clear error. Closes backlog **#2**.

## Why this scope
A 3-agent consensus (`382f93f3`) found the *originally-scoped* #2 was moot/by-design:
- **No streaming path exists** → "deepseek-reasoner streaming parse" is a non-issue (`reasoning_content` already handled non-streaming).
- **401/403 time-cooldown was intentionally rejected** and correctly (a wrong key won't fix itself by waiting).
- The auth **circuit-breaker** is marginal (one 401 per agent per round, not a loop — it doesn't abort the consensus round). The agreed-valuable deliverable was **visibility**.

## Changes
- **`packages/orchestrator/src/auth-state.ts`** (new) — `recordAuthFailure` / `clearAuthFailure` / `readRecentAuthFailures` over `.gossip/auth-state.json`. **Separate** from QuotaTracker/quota-state.json (don't conflate "retry later" 429 with "manual fix" 401/403). Provider regex-validated, all fs best-effort `try/catch`, **6h TTL** on read. **Self-heals**: cleared on the next successful request.
- **`llm-client.ts`** — the 3 network providers record on 401/403 (immediately before the unchanged throw) and clear after `onSuccess()`. The auth slot is **`key_ref ?? provider`** (threaded via `createProvider`), kept **distinct** from the quota slot (rate-limit quota is per-endpoint; a rejected key is per-agent credential).
- **`gossip_status`** surfaces: `⚠️ Auth: "<svc>" key rejected (HTTP N) — run 'gossipcat key set <svc>'`. Fail-soft; silent on healthy installs.

## Verification
- `npx tsc --noEmit -p packages/orchestrator/tsconfig.json` → exit 0
- `npx tsc --noEmit -p apps/cli/tsconfig.json` → exit 0
- `npx jest tests/orchestrator/auth-state.test.ts tests/orchestrator/llm-client.test.ts` → 61/61

## Consensus `c2d8bc1b-4eb04ba4` (gemini-reviewer + sonnet-reviewer): 10 confirmed, 0 disputed
Confirmed: no secret leakage (only `{provider,status,at}` persisted), control flow unchanged (record-then-throw), fail-closed write, QuotaTracker untouched, self-heal wiring correct.

**Fixed a consensus-caught MEDIUM before merge:** `key_ref` agents were recording under the *provider* slot, so `gossip_status` named the wrong key (`gossipcat key set openai` instead of the `key_ref` service). Now threads `key_ref ?? provider` as the auth slot, kept separate from the quota slot. Behavioral test added: a `key_ref` agent's 401 records under the `key_ref` service. Also closed the two flagged test gaps (per-entry malformed guard, near-TTL-boundary).

## Depends on
**#527** (`gossipcat key set <svc>`) for the remediation command the status line points at.

Follow-up once #527 merges: have `gossipcat key set <svc>` call `clearAuthFailure` to clear the warning immediately on re-key (currently relies on next-success + TTL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)