### PR TITLE
feat(cli): accept `fable` (claude-fable-5) as a native agent model

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -136,6 +136,7 @@ const CLAUDE_MODEL_MAP: Record<string, { provider: string; model: string }> = {
   opus:   { provider: 'anthropic', model: 'claude-opus-4-6' },
   sonnet: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
   haiku:  { provider: 'anthropic', model: 'claude-haiku-4-5' },
+  fable:  { provider: 'anthropic', model: 'claude-fable-5' },
 };
 
 export function validateConfig(raw: any): GossipConfig {
@@ -359,7 +360,7 @@ export function loadClaudeSubagents(projectRoot?: string, existingIds?: Set<stri
 
       const mapped = CLAUDE_MODEL_MAP[modelKey];
       if (!mapped) {
-        process.stderr.write(`[gossipcat] Skipping .claude/agents/${file}: unknown model "${modelKey}" (expected: opus, sonnet, haiku)\n`);
+        process.stderr.write(`[gossipcat] Skipping .claude/agents/${file}: unknown model "${modelKey}" (expected: opus, sonnet, haiku, fable)\n`);
         continue;
       }
 

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -550,7 +550,7 @@ async function doBoot() {
       } else if (ex(instrPath)) {
         instructions = rf(instrPath, 'utf-8');
       }
-      const modelTier = ac.model.includes('opus') ? 'opus' : ac.model.includes('haiku') ? 'haiku' : 'sonnet';
+      const modelTier = ac.model.includes('opus') ? 'opus' : ac.model.includes('haiku') ? 'haiku' : ac.model.includes('fable') ? 'fable' : 'sonnet';
       ctx.nativeAgentConfigs.set(ac.id, { model: modelTier, instructions, description: ac.role || ac.preset || '', skills: ac.skills || [] });
       process.stderr.write(`[gossipcat] 🤖 ${ac.id}: native agent (${modelTier})\n`);
       continue;
@@ -597,7 +597,7 @@ async function doBoot() {
       const ac = claudeConfigs[i];
       agentConfigs.push(ac);
       // Map model tier for Agent tool dispatch
-      const modelTier = sa.model.includes('opus') ? 'opus' : sa.model.includes('haiku') ? 'haiku' : 'sonnet';
+      const modelTier = sa.model.includes('opus') ? 'opus' : sa.model.includes('haiku') ? 'haiku' : sa.model.includes('fable') ? 'fable' : 'sonnet';
       ctx.nativeAgentConfigs.set(ac.id, { model: modelTier, instructions: sa.instructions, description: sa.description, skills: ac.skills || [] });
       // Register in identityRegistry so self_identity returns runtime/provider/model
       ctx.identityRegistry.set(ac.id, { agent_id: ac.id, runtime: 'native', provider: ac.provider, model: ac.model });
@@ -1001,7 +1001,7 @@ async function doSyncWorkers() {
         const ac = claudeConfigs[i];
         ctx.mainAgent.registerAgent(ac);
         // [H2 fix] Populate nativeAgentConfigs for hot-reloaded subagents
-        const modelTier = sa.model.includes('opus') ? 'opus' : sa.model.includes('haiku') ? 'haiku' : 'sonnet';
+        const modelTier = sa.model.includes('opus') ? 'opus' : sa.model.includes('haiku') ? 'haiku' : sa.model.includes('fable') ? 'fable' : 'sonnet';
         ctx.nativeAgentConfigs.set(ac.id, { model: modelTier, instructions: sa.instructions, description: sa.description, skills: ac.skills || [] });
         ctx.identityRegistry.set(ac.id, { agent_id: ac.id, runtime: 'native', provider: ac.provider, model: ac.model });
       }
@@ -1972,7 +1972,7 @@ export function createMcpServer(): McpServer {
           '"custom" = any provider (anthropic/openai/google/local)'
         ),
         // Native agent fields
-        model: z.enum(['opus', 'sonnet', 'haiku']).optional()
+        model: z.enum(['opus', 'sonnet', 'haiku', 'fable']).optional()
           .describe('For native agents: Claude model tier'),
         description: z.string().optional()
           .describe('For native agents: one-line description for the .claude/agents/*.md frontmatter'),

--- a/apps/cli/src/native-agent-cache.ts
+++ b/apps/cli/src/native-agent-cache.ts
@@ -63,9 +63,10 @@ const realFs: FsLike = {
  * Map a model id to a Claude tier label. Mirrors the inline logic that was
  * previously duplicated across the bootstrap and config-sync paths.
  */
-export function modelTierFromId(modelId: string): 'opus' | 'sonnet' | 'haiku' {
+export function modelTierFromId(modelId: string): 'opus' | 'sonnet' | 'haiku' | 'fable' {
   if (modelId.includes('opus')) return 'opus';
   if (modelId.includes('haiku')) return 'haiku';
+  if (modelId.includes('fable')) return 'fable';
   return 'sonnet';
 }
 

--- a/packages/orchestrator/src/bootstrap.ts
+++ b/packages/orchestrator/src/bootstrap.ts
@@ -192,7 +192,7 @@ gossip_setup({
 \`\`\`
 
 Available presets: reviewer, researcher, implementer, tester, architect, debugger, security, designer, planner, devops, documenter
-Available native models: opus, sonnet, haiku
+Available native models: opus, sonnet, haiku, fable
 
 ## Permissions for Native Agents
 

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -43,6 +43,7 @@ const MODEL_BUDGETS: Record<string, number> = {
   'sonnet':  400_000,   // 200K token context
   'haiku':   400_000,   // 200K token context
   'opus':    400_000,   // 200K token context
+  'fable':   400_000,   // 200K token context
   'gemini':  2_400_000, // ~1M token context
   'gpt':     320_000,   // 128K token context
 };

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { validateConfig, findConfigPath, configToAgentConfigs, VALID_MAIN_PROVIDERS } from '../../apps/cli/src/config';
+import { validateConfig, findConfigPath, configToAgentConfigs, loadClaudeSubagents, VALID_MAIN_PROVIDERS } from '../../apps/cli/src/config';
 import { CREATE_PROVIDER_CASES } from '../../packages/orchestrator/src/llm-client';
 
 describe('Config Validation', () => {
@@ -46,6 +46,15 @@ describe('Config Validation', () => {
     });
     expect(config.utility_model?.provider).toBe('native');
     expect(config.utility_model?.model).toBe('haiku');
+  });
+
+  it('accepts utility_model with native provider and fable tier', () => {
+    const config = validateConfig({
+      main_agent: { provider: 'google', model: 'gemini-2.5-pro' },
+      utility_model: { provider: 'native', model: 'fable' },
+    });
+    expect(config.utility_model?.provider).toBe('native');
+    expect(config.utility_model?.model).toBe('fable');
   });
 
   it('rejects native utility_model with invalid model tier', () => {
@@ -302,5 +311,39 @@ describe('findConfigPath', () => {
     const filePath = join(tmpDir, 'gossip.agents.json');
     writeFileSync(filePath, '{}');
     expect(findConfigPath(tmpDir)).toBe(filePath);
+  });
+});
+
+describe('loadClaudeSubagents — fable tier allowlist', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `gossip-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(tmpDir, '.claude', 'agents'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does NOT skip a .claude/agents/*.md with model: fable — loads as anthropic/claude-fable-5', () => {
+    writeFileSync(
+      join(tmpDir, '.claude', 'agents', 'fable-agent.md'),
+      `---\nname: Fable Agent\nmodel: fable\ndescription: A fable-tier agent\n---\nYou are a fable agent.\n`,
+    );
+    const agents = loadClaudeSubagents(tmpDir);
+    const fable = agents.find(a => a.name === 'Fable Agent');
+    expect(fable).toBeDefined();
+    expect(fable?.provider).toBe('anthropic');
+    expect(fable?.model).toBe('claude-fable-5');
+  });
+
+  it('still skips an .md with a genuinely unknown model tier', () => {
+    writeFileSync(
+      join(tmpDir, '.claude', 'agents', 'bogus-agent.md'),
+      `---\nname: Bogus Agent\nmodel: gpt-9\ndescription: unknown tier\n---\nbody\n`,
+    );
+    const agents = loadClaudeSubagents(tmpDir);
+    expect(agents.find(a => a.name === 'Bogus Agent')).toBeUndefined();
   });
 });

--- a/tests/cli/native-agent-cache.test.ts
+++ b/tests/cli/native-agent-cache.test.ts
@@ -295,6 +295,10 @@ describe('modelTierFromId', () => {
     expect(modelTierFromId('claude-haiku-4-5')).toBe('haiku');
   });
 
+  it('maps fable models to "fable"', () => {
+    expect(modelTierFromId('claude-fable-5')).toBe('fable');
+  });
+
   it('defaults everything else to "sonnet"', () => {
     expect(modelTierFromId('claude-sonnet-4-6')).toBe('sonnet');
     expect(modelTierFromId('gemini-2.5-pro')).toBe('sonnet');


### PR DESCRIPTION
## What
Adds **`fable` → `claude-fable-5`** to gossipcat's native-agent model allowlist so a Fable-5 native agent can be registered and dispatched.

## Why
Claude Fable 5 is a current Anthropic model the Claude Code Agent tool supports, but gossipcat's hardcoded `{opus,sonnet,haiku}` tier allowlist:
- made the `.claude/agents/*.md` loader **skip** a `model: fable` agent (`Skipping … unknown model "fable"`), and
- made `gossip_setup`'s native model enum **reject** `fable`.

A reported native Fable-5 reviewer (a same-vendor decorrelated consensus voice) couldn't be registered without a `model: opus` placeholder + a manual per-dispatch override.

## The subtle part
`fable` had to be added at **every** tier-resolution touchpoint, or a registered fable agent would **silently dispatch as sonnet** (`modelTierFromId('claude-fable-5')` → `'sonnet'` feeds `nativeAgentConfigs.model` → `Agent(model:)`). All touchpoints:
- `config.ts` `CLAUDE_MODEL_MAP` (root allowlist → fixes the `.md` loader + `utility_model` validation) + the skip-message text
- `mcp-server-sdk.ts` `gossip_setup` `z.enum` + the **three** inline `modelTier` maps (`:553/:600/:1004`)
- `native-agent-cache.ts` `modelTierFromId` (return union widened + fable branch)
- `consensus-engine.ts` `MODEL_BUDGETS` (200K-class context)
- `bootstrap.ts` "Available native models" doc line

## Scope
**Narrow fix** — mirrors the existing tier-alias pattern. The durable *"accept any `claude-*` ID / pass through to the Agent tool"* refactor (the report's "better" suggestion) is a deliberate follow-up, **not** done here. Did **not** add `fable` to `CREATE_PROVIDER_CASES`/`VALID_PROVIDERS` (it's a native tier alias, not a `createProvider` provider case) — the schema↔runtime parity test still passes.

## Verification
- `npx tsc --noEmit` (orchestrator + cli) → clean
- `npx jest tests/cli/config.test.ts tests/cli/native-agent-cache.test.ts` → 48/48
- Tests added: `modelTierFromId('claude-fable-5')==='fable'`; the `.md` loader does **not** skip `model: fable` (loads as `anthropic`/`claude-fable-5`) + a regression guard that a genuinely unknown tier (`gpt-9`) **is** still skipped; `validateConfig` accepts a native `utility_model` `fable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)