### PR TITLE
chore(release): v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ## [Unreleased]
 
+## [0.5.5] — 2026-06-09
+
+Operator-facing credential UX + a new native model. Published-binary users can now store API keys without the source repo, see at a glance which keys are stale or rejected, and register a Claude Fable 5 native agent. Follows up the #522 DeepSeek/key_ref work in 0.5.4.
+
+### Added
+
+- **`gossipcat key set <provider>` / `gossipcat key list`** (PR #527). The published binary is the MCP-server bundle and previously had no way to store an API key — the setup wizard lives only in the source repo, and no MCP tool stores keys, so a `gossip_setup`-created OpenAI/DeepSeek/OpenClaw agent was dead-on-arrival. `key set` reads the secret from stdin (hidden TTY prompt or a pipe) and stores it in the OS keychain (service `gossip-mesh`, account = the agent's `key_ref ?? provider`); `key list` shows which providers have a key (never the value). Terminal-only by design — secrets never traverse the LLM tool layer. The post-install hint now points here instead of the non-existent `gossipcat setup`.
+- **Keychain doctor in `gossip_status`** (PR #526). Surfaces stale/placeholder API-key entries (e.g. test placeholders left in a real keychain, or implausibly short values) so a misconfigured key is visible at a glance. Backend-agnostic (macOS Keychain / Linux secret-tool / encrypted-file fallback); the secret value is never printed.
+- **Auth-failure visibility in `gossip_status`** (PR #528, closes #2). When a provider rejects a key (HTTP 401/403), the status now shows `⚠️ Auth: "<service>" key rejected (HTTP N) — run 'gossipcat key set <service>'`, naming the exact keychain service to fix (honors per-agent `key_ref`). Self-healing: cleared on the next successful request and filtered by a 6h TTL. Recorded separately from quota state — a wrong key is a manual-fix condition, not a wait-it-out cooldown (which is why 401/403 deliberately has no backoff). Visibility only; a 401/403 still fails fast.
+- **`fable` (Claude Fable 5) as a native agent model** (PR #529). `model: fable` → `claude-fable-5` is now accepted by `gossip_setup` and the `.claude/agents/*.md` loader (previously skipped as "unknown model"), and dispatches as fable rather than silently falling back to sonnet.
+
 ## [0.5.4] — 2026-06-09
 
 Reliability fixes from real-world operator reports (issue reporter: GravyaDev): the worktree-isolation detector no longer destroys the orchestrator's own concurrent writes, and OpenAI-compatible custom agents (DeepSeek) no longer crash-loop the MCP server. Adds per-agent keychain credentials and a first-class DeepSeek provider.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gossipcat",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gossipcat",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossipcat",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
   "mcpName": "io.github.ataberk-xyz/gossipcat",
   "repository": {


### PR DESCRIPTION
Release **v0.5.5** — operator-facing credential UX + the Fable-5 native model.

Bundles four merged PRs from this cycle:
- **#527** `gossipcat key set/list` — store/list provider API keys from the published binary (closes the credential-bootstrap dead-end; published users had no in-product way to set a key).
- **#526** keychain doctor in `gossip_status` — flag stale/placeholder keys.
- **#528** auth-failure visibility in `gossip_status` — name the exact rejected key to fix (closes #2; honors per-agent `key_ref`).
- **#529** `fable` (`claude-fable-5`) accepted as a native agent model.

### Changes
- `package.json` + `package-lock.json`: `0.5.4` → `0.5.5`.
- `CHANGELOG.md`: `[Unreleased]` → `[0.5.5]` with the four user-visible entries.

### Verification (on master, post-merge of all four)
- `npm run build` (all workspaces) → clean
- `npm run build:mcp` (published bundle) → clean
- Release-relevant suites (keychain-doctor, key-command, key-shim-boot-gate, auth-state, config, native-agent-cache, llm-client) → **127/127**
- The `#526` keychain-doctor and `#528` auth blocks coexist correctly in the `gossip_status` status section (the one cross-PR conflict, resolved during #528's rebase).

### After merge
`npm publish` (operator-run) to ship v0.5.5 so users can pick up `gossipcat key set` + the Fable-5 native model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)