### PR TITLE
fix(cli): gossip_setup accepts model: fable (complete #529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Operator-facing credential UX + a new native model. Published-binary users can n
 - **Auth-failure visibility in `gossip_status`** (PR #528, closes #2). When a provider rejects a key (HTTP 401/403), the status now shows `⚠️ Auth: "<service>" key rejected (HTTP N) — run 'gossipcat key set <service>'`, naming the exact keychain service to fix (honors per-agent `key_ref`). Self-healing: cleared on the next successful request and filtered by a 6h TTL. Recorded separately from quota state — a wrong key is a manual-fix condition, not a wait-it-out cooldown (which is why 401/403 deliberately has no backoff). Visibility only; a 401/403 still fails fast.
 - **`fable` (Claude Fable 5) as a native agent model** (PR #529). `model: fable` → `claude-fable-5` is now accepted by `gossip_setup` and the `.claude/agents/*.md` loader (previously skipped as "unknown model"), and dispatches as fable rather than silently falling back to sonnet.
 
+### Fixed
+
+- **`gossip_setup` now actually creates `model: fable` native agents** (follow-up to #529, in the re-cut 0.5.5 tarball). The native-agent **creation** path in `gossip_setup` kept its own private `CLAUDE_MODEL_MAP` (only `opus`/`sonnet`/`haiku`), so #529 — which patched the input `z.enum`, the canonical `config.ts` map, and the dispatch-time tier maps — left this one untouched. The result: the tool schema accepted `model: "fable"` and then the handler rejected it with `unknown model tier "fable"`. The creation map now includes `fable → claude-fable-5`, matching the canonical map. The duplicated map remains a known debt (every new model still re-breaks native registration across the remaining touchpoints).
+
 ## [0.5.4] — 2026-06-09
 
 Reliability fixes from real-world operator reports (issue reporter: GravyaDev): the worktree-isolation detector no longer destroys the orchestrator's own concurrent writes, and OpenAI-compatible custom agents (DeepSeek) no longer crash-loop the MCP server. Adds per-agent keychain credentials and a first-class DeepSeek provider.

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2208,6 +2208,7 @@ export function createMcpServer(): McpServer {
         opus:   { provider: 'anthropic', model: 'claude-opus-4-6' },
         sonnet: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
         haiku:  { provider: 'anthropic', model: 'claude-haiku-4-5' },
+        fable:  { provider: 'anthropic', model: 'claude-fable-5' },
       };
 
       const configAgents: Record<string, any> = {};


### PR DESCRIPTION
## What

PR #529 added Claude Fable 5 (`model: fable`) as a native agent model, but missed one touchpoint: the **native-agent creation** path inside the `gossip_setup` handler keeps its *own* private `CLAUDE_MODEL_MAP` (`apps/cli/src/mcp-server-sdk.ts:2207`) with only `opus`/`sonnet`/`haiku`.

Result: the tool input `z.enum` accepts `model: "fable"`, the call passes validation, and then the handler rejects it downstream with:

```
✗ fable-reviewer: unknown model tier "fable"
```

So **no fable native agent could actually be created** via `gossip_setup`, despite the CHANGELOG claiming it was supported.

## Fix

One line — add `fable → claude-fable-5` to the creation map, matching the canonical `CLAUDE_MODEL_MAP` in `apps/cli/src/config.ts:139`.

## Verification

- `npm run build:mcp` + `/mcp` reconnect → `gossip_setup({ model: "fable" })` now creates the agent (`✓ .claude/agents/fable-reviewer.md`).
- Full workspace build green (5 packages).
- `npm test` → 289 suites, 3915 passed, 0 failed.
- `tsc` clean in `apps/cli`.

## Known debt (not fixed here)

This is the **8th** fable touchpoint; #529 patched 7. The root cause is that `gossip_setup` *duplicates* `CLAUDE_MODEL_MAP` instead of importing the canonical one. The durable fix (dedup the map / `claude-*` pass-through so new models stop re-breaking native registration) is tracked as the "Fable hardcode debt" follow-up and is out of scope for this hotfix.

This fix is destined for an **in-place re-cut of the 0.5.5 tarball** (the bug only blocks a brand-new 0.5.5 feature; no regression to existing installs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)