### PR TITLE
feat(consensus): consensus.siblingRoots — resolve citations into declared sibling repos (closes #520)

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -358,7 +358,9 @@ export function resolveSiblingRoots(config: GossipConfig, projectRoot: string): 
       }
       for (const name of names) {
         const childAbs = join(parentAbs, name);
-        if (statSync(childAbs).isDirectory()) out.push(validateDir(childAbs));
+        let childStat;
+        try { childStat = statSync(childAbs); } catch { continue; } // broken symlink / vanished entry — skip, don't crash boot
+        if (childStat.isDirectory()) out.push(validateDir(childAbs));
       }
     } else {
       out.push(validateDir(resolve(projectRoot, entry)));

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -357,13 +357,17 @@ export function resolveSiblingRoots(config: GossipConfig, projectRoot: string): 
   };
   for (const entry of declared) {
     if (entry.endsWith('/*')) {
-      const parentAbs = resolve(projectRoot, entry.slice(0, -2));
+      // Validate the glob parent (stat + isDirectory + uid + realpath) before
+      // listing it — the children are individually validateDir'd below, but the
+      // parent itself must pass the same ownership/realpath gate so a swapped
+      // symlink parent can't redirect the listing (consensus 318a16c1, sonnet:f16).
+      const parentReal = validateDir(resolve(projectRoot, entry.slice(0, -2)));
       let names: string[];
-      try { names = readdirSync(parentAbs); } catch (e) {
-        throw new Error(`Config "consensus.siblingRoots": glob parent "${parentAbs}" not readable: ${(e as Error).message}`);
+      try { names = readdirSync(parentReal); } catch (e) {
+        throw new Error(`Config "consensus.siblingRoots": glob parent "${parentReal}" not readable: ${(e as Error).message}`);
       }
       for (const name of names) {
-        const childAbs = join(parentAbs, name);
+        const childAbs = join(parentReal, name);
         let childStat;
         try { childStat = statSync(childAbs); } catch { continue; } // broken symlink / vanished entry — skip, don't crash boot
         if (childStat.isDirectory()) {

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, readdirSync, statSync, realpathSync } from 'fs';
-import { resolve, join } from 'path';
+import { resolve, join, relative } from 'path';
 import { AgentConfig } from '@gossip/orchestrator';
 
 export interface GossipConfig {
@@ -349,6 +349,12 @@ export function resolveSiblingRoots(config: GossipConfig, projectRoot: string): 
       throw new Error(`Config "consensus.siblingRoots": realpath failed for "${abs}": ${(e as Error).message}`);
     }
   };
+  let rootReal = projectRoot;
+  try { rootReal = realpathSync(projectRoot); } catch { /* keep */ }
+  const isInsideProject = (abs: string): boolean => {
+    const rel = relative(rootReal, abs);
+    return rel === '' || (!rel.startsWith('..') && !rel.startsWith('/'));
+  };
   for (const entry of declared) {
     if (entry.endsWith('/*')) {
       const parentAbs = resolve(projectRoot, entry.slice(0, -2));
@@ -360,10 +366,20 @@ export function resolveSiblingRoots(config: GossipConfig, projectRoot: string): 
         const childAbs = join(parentAbs, name);
         let childStat;
         try { childStat = statSync(childAbs); } catch { continue; } // broken symlink / vanished entry — skip, don't crash boot
-        if (childStat.isDirectory()) out.push(validateDir(childAbs));
+        if (childStat.isDirectory()) {
+          const canonical = validateDir(childAbs);
+          if (isInsideProject(canonical)) {
+            throw new Error(`Config "consensus.siblingRoots": "${canonical}" is inside the project root — siblingRoots are for EXTERNAL repos; use a normal scope instead`);
+          }
+          out.push(canonical);
+        }
       }
     } else {
-      out.push(validateDir(resolve(projectRoot, entry)));
+      const canonical = validateDir(resolve(projectRoot, entry));
+      if (isInsideProject(canonical)) {
+        throw new Error(`Config "consensus.siblingRoots": "${canonical}" is inside the project root — siblingRoots are for EXTERNAL repos; use a normal scope instead`);
+      }
+      out.push(canonical);
     }
   }
   return out;

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync, readdirSync } from 'fs';
+import { readFileSync, existsSync, readdirSync, statSync, realpathSync } from 'fs';
 import { resolve, join } from 'path';
 import { AgentConfig } from '@gossip/orchestrator';
 
@@ -52,6 +52,15 @@ export interface GossipConfig {
      * validateConfig.
      */
     orchestratorOwnedGlobs?: string[];
+    /**
+     * Issue #520. Operator-declared external repo roots (and worktree `/*` globs)
+     * that citations + scoped writes may resolve into. Each entry is absolute or
+     * relative to the project root; a trailing `/*` expands to present subdirs.
+     * Realpath'd + validated at load (resolveSiblingRoots). Default absent ⇒
+     * single-repo installs unchanged. Declaring a root bypasses ONLY the
+     * git-common-dir + worktree-list gates, never the other security gates.
+     */
+    siblingRoots?: string[];
   };
   agents?: Record<string, {
     provider: string;
@@ -198,6 +207,26 @@ export function validateConfig(raw: any): GossipConfig {
         }
       }
     }
+    if (raw.consensus.siblingRoots !== undefined) {
+      const roots = raw.consensus.siblingRoots;
+      if (!Array.isArray(roots)) {
+        throw new Error('Config "consensus.siblingRoots" must be an array of strings');
+      }
+      for (const p of roots) {
+        if (typeof p !== 'string' || p.length === 0) {
+          throw new Error('Config "consensus.siblingRoots" entries must be non-empty strings');
+        }
+        // eslint-disable-next-line no-control-regex
+        if (/[\x00-\x1f]/.test(p)) {
+          throw new Error('Config "consensus.siblingRoots" entry contains a control character');
+        }
+        // A bare wildcard would declare "trust everything" — reject. A trailing
+        // `/*` glob on a concrete parent is allowed and expanded at load.
+        if (p === '*' || p === '**' || p === '/*') {
+          throw new Error(`Config "consensus.siblingRoots" entry "${p}" is wildcard-only and would over-trust`);
+        }
+      }
+    }
   }
 
   if (raw.sandboxEnforcement !== undefined) {
@@ -294,6 +323,48 @@ export function validateConfig(raw: any): GossipConfig {
   }
 
   return raw as GossipConfig;
+}
+
+/**
+ * #520. Resolve `consensus.siblingRoots` into canonical absolute directory paths:
+ * expand trailing `/*` globs against the on-disk parent, then validate each entry
+ * (exists, is a directory, realpath, ownership) FAIL-FAST — a bad entry throws at
+ * boot, never a silent drop. Returns [] when no siblingRoots are configured.
+ */
+export function resolveSiblingRoots(config: GossipConfig, projectRoot: string): string[] {
+  const declared = config.consensus?.siblingRoots ?? [];
+  if (declared.length === 0) return [];
+  const out: string[] = [];
+  const uid = typeof process.getuid === 'function' ? process.getuid() : null;
+  const validateDir = (abs: string): string => {
+    let st;
+    try { st = statSync(abs); } catch (e) {
+      throw new Error(`Config "consensus.siblingRoots": "${abs}" does not resolve to directory: ${(e as Error).message}`);
+    }
+    if (!st.isDirectory()) throw new Error(`Config "consensus.siblingRoots": "${abs}" is not a directory`);
+    if (uid != null && st.uid !== uid) {
+      throw new Error(`Config "consensus.siblingRoots": "${abs}" owner uid mismatch (file=${st.uid}, current=${uid})`);
+    }
+    try { return realpathSync(abs); } catch (e) {
+      throw new Error(`Config "consensus.siblingRoots": realpath failed for "${abs}": ${(e as Error).message}`);
+    }
+  };
+  for (const entry of declared) {
+    if (entry.endsWith('/*')) {
+      const parentAbs = resolve(projectRoot, entry.slice(0, -2));
+      let names: string[];
+      try { names = readdirSync(parentAbs); } catch (e) {
+        throw new Error(`Config "consensus.siblingRoots": glob parent "${parentAbs}" not readable: ${(e as Error).message}`);
+      }
+      for (const name of names) {
+        const childAbs = join(parentAbs, name);
+        if (statSync(childAbs).isDirectory()) out.push(validateDir(childAbs));
+      }
+    } else {
+      out.push(validateDir(resolve(projectRoot, entry)));
+    }
+  }
+  return out;
 }
 
 export function configToAgentConfigs(config: GossipConfig): AgentConfig[] {

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -276,6 +276,11 @@ import { isReservedAgentId } from './reserved-ids';
 let booted = false;
 let bootPromise: Promise<void> | null = null;
 
+// #520: sibling roots resolved once at MCP boot. Empty array → byte-identical
+// behavior to before this feature. Tool handlers (in createMcpServer) close
+// over this module-level variable so they always see the post-boot value.
+let configuredSiblingRoots: string[] = [];
+
 // #522 SEV-1: install ONCE per process. main() runs on every connect (boot AND
 // reconnect), so guard the handler registration to avoid stacking duplicate
 // listeners across reconnects.
@@ -479,6 +484,15 @@ async function doBoot() {
       agents: {},
     };
   }
+  // #520: resolve declared sibling roots once at boot (fail-fast on a bad entry).
+  // Empty when no config / no siblingRoots → byte-identical to prior behavior.
+  try {
+    if (config && !ctx.bootedInDegradedMode) configuredSiblingRoots = m.resolveSiblingRoots(config, process.cwd());
+  } catch (e) {
+    process.stderr.write(`[gossipcat] FATAL: invalid consensus.siblingRoots — ${(e as Error).message}\n`);
+    throw e; // fail fast: a misconfigured sibling root must not boot silently
+  }
+
   const agentConfigs = m.configToAgentConfigs(config);
   ctx.keychain = new m.Keychain();
 
@@ -1483,7 +1497,7 @@ export function createMcpServer(): McpServer {
       if (resolutionRoots && resolutionRoots.length > 0) {
         const { validateResolutionRoot } = await import('@gossip/orchestrator');
         for (const raw of resolutionRoots) {
-          const r = await validateResolutionRoot(raw, process.cwd());
+          const r = await validateResolutionRoot(raw, process.cwd(), { siblingRoots: configuredSiblingRoots });
           if (r.valid) {
             validatedDispatchRoots.push(r.canonical);
             process.stderr.write(`[consensus] resolutionRoots accepted: ${r.canonical}\n`);
@@ -1559,7 +1573,7 @@ export function createMcpServer(): McpServer {
         const { validateResolutionRoot } = await import('@gossip/orchestrator');
         const out: string[] = [];
         for (const raw of resolutionRoots) {
-          const r = await validateResolutionRoot(raw, process.cwd());
+          const r = await validateResolutionRoot(raw, process.cwd(), { siblingRoots: configuredSiblingRoots });
           if (r.valid) {
             out.push(r.canonical);
             process.stderr.write(`[consensus] resolutionRoots accepted: ${r.canonical}\n`);

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -773,6 +773,7 @@ async function doBoot() {
       } catch { return ''; }
     })(),
     keyProvider: async (provider: string) => ctx.keychain.getKey(provider),
+    siblingRoots: configuredSiblingRoots,
     toolServer: ctx.toolServer ? {
       assignScope: (agentId: string, scope: string) => ctx.toolServer.assignScope(agentId, scope),
       assignRoot: (agentId: string, root: string) => ctx.toolServer.assignRoot(agentId, root),

--- a/packages/orchestrator/src/dispatch-pipeline.ts
+++ b/packages/orchestrator/src/dispatch-pipeline.ts
@@ -59,6 +59,9 @@ export interface DispatchPipelineConfig {
   syncFactory?: () => TaskGraphSync | null;
   toolServer?: ToolServerCallbacks | null;
   keyProvider?: (provider: string) => Promise<string | null>;
+  /** #520: declared external sibling repo roots, forwarded to ScopeTracker so scoped
+   *  writes into a declared sibling are accepted. Default []. */
+  siblingRoots?: readonly string[];
 }
 
 type TrackedTask = TaskEntry & {
@@ -212,7 +215,7 @@ export class DispatchPipeline {
     this.memReader = new AgentMemoryReader(config.projectRoot);
     this.memCompactor = new MemoryCompactor(config.projectRoot);
     this.gapTracker = new SkillGapTracker(config.projectRoot);
-    this.scopeTracker = new ScopeTracker(config.projectRoot);
+    this.scopeTracker = new ScopeTracker(config.projectRoot, config.siblingRoots ?? []);
     this.worktreeManager = new WorktreeManager(config.projectRoot);
     this.perfReader = new PerformanceReader(config.projectRoot);
     this.consensusCoordinator = new ConsensusCoordinator({

--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -87,6 +87,7 @@ export interface MainAgentConfig {
   syncFactory?: () => TaskGraphSync | null;
   toolServer?: ToolServerCallbacks | null;
   keyProvider?: (provider: string) => Promise<string | null>;
+  siblingRoots?: readonly string[];
 }
 
 export class MainAgent {
@@ -151,6 +152,7 @@ export class MainAgent {
       syncFactory: config.syncFactory,
       toolServer: config.toolServer,
       keyProvider: config.keyProvider,
+      siblingRoots: config.siblingRoots ?? [],
     });
 
     // Wire dispatch differentiator (after pipeline creation)

--- a/packages/orchestrator/src/scope-tracker.ts
+++ b/packages/orchestrator/src/scope-tracker.ts
@@ -5,7 +5,7 @@ export class ScopeTracker {
   private activeScopes: Map<string, string> = new Map(); // normalized scope → taskId
   private taskToScope: Map<string, string> = new Map();  // taskId → scope (for release)
 
-  constructor(private projectRoot: string) {}
+  constructor(private projectRoot: string, private siblingRoots: readonly string[] = []) {}
 
   private normalize(scope: string): string {
     if (!scope || !scope.trim()) throw new Error('Scope must not be empty');
@@ -17,6 +17,20 @@ export class ScopeTracker {
     } catch {
       // Path doesn't exist yet (e.g. new directory) — fall back to resolve-only check
       real = abs;
+    }
+    // #520: a scope under an explicitly-declared sibling root is accepted. The
+    // returned key is the canonical absolute path (unique per root, so the overlap
+    // map in hasOverlap/register stays collision-free across roots). The too-broad
+    // guard is recomputed PER-ROOT against the matched sibling, not against
+    // projectRoot (consensus 56d65741 LOW finding).
+    for (const s of this.siblingRoots) {
+      let realSibling = s;
+      try { realSibling = realpathSync(s); } catch { /* declared roots are realpath'd at config load; keep */ }
+      const relS = relative(realSibling, real);
+      if (relS === '') throw new Error(`Scope "${scope}" resolves to a sibling root — too broad`);
+      if (!relS.startsWith('..') && !relS.startsWith('/') && relS !== '') {
+        return real.endsWith('/') ? real : real + '/';
+      }
     }
     const rel = relative(realRoot, real);
     if (rel.startsWith('..')) throw new Error(`Scope "${scope}" resolves outside project root`);

--- a/packages/orchestrator/src/scope-tracker.ts
+++ b/packages/orchestrator/src/scope-tracker.ts
@@ -28,7 +28,7 @@ export class ScopeTracker {
       try { realSibling = realpathSync(s); } catch { /* declared roots are realpath'd at config load; keep */ }
       const relS = relative(realSibling, real);
       if (relS === '') throw new Error(`Scope "${scope}" resolves to a sibling root — too broad`);
-      if (!relS.startsWith('..') && !relS.startsWith('/') && relS !== '') {
+      if (!relS.startsWith('..') && !relS.startsWith('/') /* '/' guard: Windows cross-drive (path.relative never returns absolute on POSIX) */) {
         return real.endsWith('/') ? real : real + '/';
       }
     }

--- a/packages/orchestrator/src/validate-resolution-root.ts
+++ b/packages/orchestrator/src/validate-resolution-root.ts
@@ -23,7 +23,7 @@
 import { execFile } from 'child_process';
 import { createHash } from 'crypto';
 import { statSync, realpathSync } from 'fs';
-import { normalize, resolve } from 'path';
+import { normalize, resolve, relative, isAbsolute } from 'path';
 import { promisify } from 'util';
 
 const execFileP = promisify(execFile);
@@ -168,6 +168,13 @@ export function parseWorktreePorcelain(
   return out;
 }
 
+/** Realpath-safe containment: is `canonical` equal to or under `root`?
+ *  Both args MUST be realpath'd absolute paths. */
+function isInsideRoot(canonical: string, root: string): boolean {
+  const rel = relative(root, canonical);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
 /**
  * Validate a single user-supplied resolution root against projectRoot.
  * Returns canonical (realpath'd) form on success. Only fatal outcome:
@@ -176,6 +183,7 @@ export function parseWorktreePorcelain(
 export async function validateResolutionRoot(
   rawPath: string,
   projectRoot: string,
+  opts: { siblingRoots?: readonly string[] } = {},
 ): Promise<ValidationResult> {
   const hashed = hashPath(rawPath);
 
@@ -239,55 +247,66 @@ export async function validateResolutionRoot(
     // Non-POSIX host (Windows); skip ownership check gracefully.
   }
 
+  // #520: an explicitly-declared sibling root is a deliberate operator trust
+  // decision. For paths contained in one, bypass the git-common-dir gate (step 6)
+  // AND the worktree-list gate (step 7) — and ONLY those two. All earlier gates
+  // (control-char, `..`, existence, directory, realpath, ownership) have run above.
+  // Default empty ⇒ no behavior change for single-repo installs.
+  const isDeclaredSibling = (opts.siblingRoots ?? []).some((s) => isInsideRoot(canonical, s));
+
   // 6. git-common-dir must match projectRoot's.
-  const [candGcd, rootGcd] = await Promise.all([
-    gitCommonDir(canonical),
-    gitCommonDir(projectRoot),
-  ]);
-  if (!rootGcd) {
-    // Can't verify against an un-git'd projectRoot — drop to be safe.
-    return {
-      valid: false,
-      reason: 'projectRoot git-common-dir lookup failed',
-      hashedInput: hashed,
-    };
-  }
-  if (!candGcd) {
-    return {
-      valid: false,
-      reason: 'candidate git-common-dir lookup failed (not a git repo?)',
-      hashedInput: hashed,
-    };
-  }
-  if (candGcd !== rootGcd) {
-    return {
-      valid: false,
-      reason: 'outside git-common-dir (cross-repo or non-worktree)',
-      hashedInput: hashed,
-    };
+  if (!isDeclaredSibling) {
+    const [candGcd, rootGcd] = await Promise.all([
+      gitCommonDir(canonical),
+      gitCommonDir(projectRoot),
+    ]);
+    if (!rootGcd) {
+      // Can't verify against an un-git'd projectRoot — drop to be safe.
+      return {
+        valid: false,
+        reason: 'projectRoot git-common-dir lookup failed',
+        hashedInput: hashed,
+      };
+    }
+    if (!candGcd) {
+      return {
+        valid: false,
+        reason: 'candidate git-common-dir lookup failed (not a git repo?)',
+        hashedInput: hashed,
+      };
+    }
+    if (candGcd !== rootGcd) {
+      return {
+        valid: false,
+        reason: 'outside git-common-dir (cross-repo or non-worktree)',
+        hashedInput: hashed,
+      };
+    }
   }
 
   // 7. Must appear in `git worktree list`.
   // includeLocked: true — active agent worktrees are always locked by git;
   // rejecting them here would silently break all explicit resolutionRoots
   // that point at in-use worktrees (root cause of consensus 3aa4a6ef regression).
-  const worktrees = await listWorktreePaths(projectRoot, { includeLocked: true });
-  // Project root itself is always a valid worktree by convention — include it.
-  let projectRootReal = projectRoot;
-  try {
-    projectRootReal = realpathSync(projectRoot);
-  } catch {
-    /* keep as-is */
-  }
-  if (
-    canonical !== projectRootReal &&
-    !worktrees.some((w) => w === canonical)
-  ) {
-    return {
-      valid: false,
-      reason: 'not found in `git worktree list`',
-      hashedInput: hashed,
-    };
+  if (!isDeclaredSibling) {
+    const worktrees = await listWorktreePaths(projectRoot, { includeLocked: true });
+    // Project root itself is always a valid worktree by convention — include it.
+    let projectRootReal = projectRoot;
+    try {
+      projectRootReal = realpathSync(projectRoot);
+    } catch {
+      /* keep as-is */
+    }
+    if (
+      canonical !== projectRootReal &&
+      !worktrees.some((w) => w === canonical)
+    ) {
+      return {
+        valid: false,
+        reason: 'not found in `git worktree list`',
+        hashedInput: hashed,
+      };
+    }
   }
 
   return { valid: true, canonical };

--- a/packages/orchestrator/src/validate-resolution-root.ts
+++ b/packages/orchestrator/src/validate-resolution-root.ts
@@ -252,7 +252,14 @@ export async function validateResolutionRoot(
   // AND the worktree-list gate (step 7) — and ONLY those two. All earlier gates
   // (control-char, `..`, existence, directory, realpath, ownership) have run above.
   // Default empty ⇒ no behavior change for single-repo installs.
-  const isDeclaredSibling = (opts.siblingRoots ?? []).some((s) => isInsideRoot(canonical, s));
+  // siblingRoots are realpath'd at config load (resolveSiblingRoots), but realpath
+  // here too so isInsideRoot's "both args canonical" contract holds even if a caller
+  // passes a raw/symlinked root (consensus 318a16c1, deepseek:f5 + sonnet:f12).
+  const isDeclaredSibling = (opts.siblingRoots ?? []).some((s) => {
+    let realS = s;
+    try { realS = realpathSync(s); } catch { /* unresolvable → fall back to raw; fails closed via isInsideRoot */ }
+    return isInsideRoot(canonical, realS);
+  });
 
   // 6. git-common-dir must match projectRoot's.
   if (!isDeclaredSibling) {

--- a/tests/orchestrator/sibling-roots.test.ts
+++ b/tests/orchestrator/sibling-roots.test.ts
@@ -107,6 +107,21 @@ describe('config siblingRoots', () => {
   });
 });
 
+describe('resolveSiblingRoots — broken symlink in glob parent (consensus a5ca8f69 F10)', () => {
+  it('skips a broken symlink child instead of crashing boot', () => {
+    // Build a glob parent: <base>/wt-parent/{real-wt (dir), dead (broken symlink)}
+    const wtParent = join(sibling, 'wt-parent');
+    mkdirSync(join(wtParent, 'real-wt'), { recursive: true });
+    try { symlinkSync(join(wtParent, 'does-not-exist'), join(wtParent, 'dead')); } catch { return; } // skip if symlink unsupported
+    const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: [join(wtParent, '*')] } });
+    let resolved: string[] = [];
+    expect(() => { resolved = resolveSiblingRoots(cfg, root); }).not.toThrow();
+    expect(resolved).toContain(realpathSync(join(wtParent, 'real-wt')));
+    // the broken symlink must not appear
+    expect(resolved.some((p) => p.endsWith('/dead'))).toBe(false);
+  });
+});
+
 describe('#520 integration — path-carrying cite into a sibling repo', () => {
   it('resolves WITH siblingRoots config, fails WITHOUT', async () => {
     // (a) The MCP boundary admits the declared root only with the config.

--- a/tests/orchestrator/sibling-roots.test.ts
+++ b/tests/orchestrator/sibling-roots.test.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, mkdirSync, writeFileSync, realpathSync, symlinkSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { execFileSync } from 'child_process';
 import { validateResolutionRoot } from '../../packages/orchestrator/src/validate-resolution-root';
 import { validateConfig, resolveSiblingRoots } from '../../apps/cli/src/config';
@@ -171,5 +171,29 @@ describe('resolveSiblingRoots — rejects a sibling root inside projectRoot (con
   it('still accepts a genuinely external sibling root', () => {
     const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: [sibling] } });
     expect(resolveSiblingRoots(cfg, root)).toContain(realpathSync(sibling));
+  });
+});
+
+describe('consensus 318a16c1 hardening', () => {
+  it('rejects a prefix-adjacent sibling (/base/product-evil vs declared /base/product) — no startsWith escape', async () => {
+    const base = dirname(sibling);
+    const evil = join(base, 'product-evil'); mkdirSync(evil, { recursive: true }); gitInit(evil);
+    const r = await validateResolutionRoot(evil, root, { siblingRoots: [sibling] });
+    expect(r.valid).toBe(false);
+  });
+
+  it('admits a path under a sibling root declared via a symlink (realpath-at-boundary, FIX 1)', async () => {
+    const base = dirname(sibling);
+    const linkToSibling = join(base, 'product-link');
+    try { symlinkSync(sibling, linkToSibling); } catch { return; }
+    const r = await validateResolutionRoot(siblingSub, root, { siblingRoots: [linkToSibling] });
+    expect(r.valid).toBe(true);
+  });
+
+  it('rejects a glob siblingRoots entry whose parent is not a directory (FIX 2 — glob parent validated)', () => {
+    const base = dirname(sibling);
+    const fileParent = join(base, 'notadir'); writeFileSync(fileParent, 'x');
+    const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: [join('..', 'notadir', '*')] } });
+    expect(() => resolveSiblingRoots(cfg, root)).toThrow(/not a directory|does not resolve to directory/);
   });
 });

--- a/tests/orchestrator/sibling-roots.test.ts
+++ b/tests/orchestrator/sibling-roots.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync, symlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execFileSync } from 'child_process';
+import { validateResolutionRoot } from '../../packages/orchestrator/src/validate-resolution-root';
+
+const gitInit = (dir: string) => {
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 't@t.t'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 't'], { cwd: dir });
+};
+
+let root: string;
+let sibling: string;
+let outside: string;
+let siblingSub: string;
+
+beforeAll(() => {
+  const base = realpathSync(mkdtempSync(join(tmpdir(), 'siblingroots-')));
+  root = join(base, 'orchestration'); mkdirSync(root); gitInit(root);
+  sibling = join(base, 'product'); mkdirSync(sibling); gitInit(sibling);
+  outside = join(base, 'other'); mkdirSync(outside); gitInit(outside);
+  siblingSub = join(sibling, 'services', 'core'); mkdirSync(siblingSub, { recursive: true });
+  writeFileSync(join(siblingSub, 'handler.ts'), 'export const x = 1;\n');
+});
+
+describe('validateResolutionRoot — siblingRoots bypass', () => {
+  it('accepts a path inside a declared sibling root (bypasses steps 6 AND 7)', async () => {
+    const r = await validateResolutionRoot(siblingSub, root, { siblingRoots: [sibling] });
+    expect(r.valid).toBe(true);
+    if (r.valid) expect(r.canonical).toBe(realpathSync(siblingSub));
+  });
+
+  it('still rejects an UNDECLARED cross-repo path (step 6 fires) — selective bypass', async () => {
+    const r = await validateResolutionRoot(outside, root, { siblingRoots: [sibling] });
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.reason).toContain('git-common-dir');
+  });
+
+  it('with no siblingRoots, a sibling path is rejected exactly as today', async () => {
+    const r = await validateResolutionRoot(sibling, root);
+    expect(r.valid).toBe(false);
+  });
+
+  it('ownership/existence gate STILL fires for a path inside a declared sibling root', async () => {
+    const r = await validateResolutionRoot(join(sibling, 'nope'), root, { siblingRoots: [sibling] });
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.reason).toContain('does not resolve to directory');
+  });
+
+  it('a symlink inside a declared root pointing OUTSIDE it does not escape', async () => {
+    const link = join(sibling, 'escape');
+    try { symlinkSync(outside, link); } catch { return; }
+    const r = await validateResolutionRoot(link, root, { siblingRoots: [sibling] });
+    expect(r.valid).toBe(false);
+  });
+});

--- a/tests/orchestrator/sibling-roots.test.ts
+++ b/tests/orchestrator/sibling-roots.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { execFileSync } from 'child_process';
 import { validateResolutionRoot } from '../../packages/orchestrator/src/validate-resolution-root';
+import { validateConfig, resolveSiblingRoots } from '../../apps/cli/src/config';
 import { ScopeTracker } from '../../packages/orchestrator/src/scope-tracker';
 
 const gitInit = (dir: string) => {
@@ -76,5 +77,31 @@ describe('ScopeTracker — sibling roots', () => {
   it('does not change behavior when no sibling roots are configured', () => {
     const st = new ScopeTracker(root);
     expect(() => st.register(join(sibling, 'x'), 'task-4')).toThrow(/outside project root/);
+  });
+});
+
+const minimalSkeleton = { main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' } };
+
+describe('config siblingRoots', () => {
+  it('validateConfig accepts a string array and rejects bare wildcards', () => {
+    expect(() => validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: ['../product'] } })).not.toThrow();
+    expect(() => validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: ['*'] } })).toThrow(/wildcard-only/);
+    expect(() => validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: [123] } })).toThrow(/non-empty strings/);
+  });
+
+  it('resolveSiblingRoots realpaths declared roots', () => {
+    const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: [sibling] } });
+    const resolved = resolveSiblingRoots(cfg, root);
+    expect(resolved).toContain(realpathSync(sibling));
+  });
+
+  it('resolveSiblingRoots throws (fail-fast) on a non-existent entry', () => {
+    const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: [join(sibling, 'does-not-exist')] } });
+    expect(() => resolveSiblingRoots(cfg, root)).toThrow();
+  });
+
+  it('resolveSiblingRoots throws on a file-not-directory entry', () => {
+    const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: [join(siblingSub, 'handler.ts')] } });
+    expect(() => resolveSiblingRoots(cfg, root)).toThrow(/not a directory/);
   });
 });

--- a/tests/orchestrator/sibling-roots.test.ts
+++ b/tests/orchestrator/sibling-roots.test.ts
@@ -6,6 +6,7 @@ import { validateResolutionRoot } from '../../packages/orchestrator/src/validate
 import { validateConfig, resolveSiblingRoots } from '../../apps/cli/src/config';
 import { ScopeTracker } from '../../packages/orchestrator/src/scope-tracker';
 import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
+import { DispatchPipeline } from '../../packages/orchestrator/src/dispatch-pipeline';
 
 const gitInit = (dir: string) => {
   execFileSync('git', ['init', '-q'], { cwd: dir });
@@ -147,5 +148,28 @@ describe('#520 integration — path-carrying cite into a sibling repo', () => {
     } as any);
     const unresolved = await (engNoRoot as any).resolveFilePath('services/core/handler.ts');
     expect(unresolved).toBeNull();
+  });
+});
+
+describe('#520 wiring — DispatchPipeline threads siblingRoots into ScopeTracker', () => {
+  it('a scoped write into a declared sibling root is accepted (not "outside project root")', () => {
+    const pipeline = new DispatchPipeline({ projectRoot: root, siblingRoots: [sibling] } as any);
+    expect(() => (pipeline as any).scopeTracker.register(join(sibling, 'services'), 'task-wire-1')).not.toThrow();
+  });
+  it('without siblingRoots, the same sibling scope is rejected (proves the wiring is load-bearing)', () => {
+    const pipeline = new DispatchPipeline({ projectRoot: root } as any);
+    expect(() => (pipeline as any).scopeTracker.register(join(sibling, 'services'), 'task-wire-2')).toThrow(/outside project root/);
+  });
+});
+
+describe('resolveSiblingRoots — rejects a sibling root inside projectRoot (consensus 01909cc9)', () => {
+  it('throws when a declared sibling root is inside the project root', () => {
+    const inside = join(root, 'packages-x'); mkdirSync(inside, { recursive: true });
+    const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: [inside] } });
+    expect(() => resolveSiblingRoots(cfg, root)).toThrow(/inside the project root/);
+  });
+  it('still accepts a genuinely external sibling root', () => {
+    const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: [sibling] } });
+    expect(resolveSiblingRoots(cfg, root)).toContain(realpathSync(sibling));
   });
 });

--- a/tests/orchestrator/sibling-roots.test.ts
+++ b/tests/orchestrator/sibling-roots.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { execFileSync } from 'child_process';
 import { validateResolutionRoot } from '../../packages/orchestrator/src/validate-resolution-root';
+import { ScopeTracker } from '../../packages/orchestrator/src/scope-tracker';
 
 const gitInit = (dir: string) => {
   execFileSync('git', ['init', '-q'], { cwd: dir });
@@ -53,5 +54,27 @@ describe('validateResolutionRoot — siblingRoots bypass', () => {
     try { symlinkSync(outside, link); } catch { return; }
     const r = await validateResolutionRoot(link, root, { siblingRoots: [sibling] });
     expect(r.valid).toBe(false);
+  });
+});
+
+describe('ScopeTracker — sibling roots', () => {
+  it('accepts a scope under a declared sibling root', () => {
+    const st = new ScopeTracker(root, [sibling]);
+    expect(() => st.register(join(sibling, 'services'), 'task-1')).not.toThrow();
+  });
+
+  it('rejects a scope equal to the entire sibling root (per-root too-broad guard)', () => {
+    const st = new ScopeTracker(root, [sibling]);
+    expect(() => st.register(sibling, 'task-2')).toThrow(/too broad/);
+  });
+
+  it('still rejects a scope outside all roots', () => {
+    const st = new ScopeTracker(root, [sibling]);
+    expect(() => st.register(outside, 'task-3')).toThrow(/outside project root/);
+  });
+
+  it('does not change behavior when no sibling roots are configured', () => {
+    const st = new ScopeTracker(root);
+    expect(() => st.register(join(sibling, 'x'), 'task-4')).toThrow(/outside project root/);
   });
 });

--- a/tests/orchestrator/sibling-roots.test.ts
+++ b/tests/orchestrator/sibling-roots.test.ts
@@ -5,6 +5,7 @@ import { execFileSync } from 'child_process';
 import { validateResolutionRoot } from '../../packages/orchestrator/src/validate-resolution-root';
 import { validateConfig, resolveSiblingRoots } from '../../apps/cli/src/config';
 import { ScopeTracker } from '../../packages/orchestrator/src/scope-tracker';
+import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
 
 const gitInit = (dir: string) => {
   execFileSync('git', ['init', '-q'], { cwd: dir });
@@ -103,5 +104,33 @@ describe('config siblingRoots', () => {
   it('resolveSiblingRoots throws on a file-not-directory entry', () => {
     const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: [join(siblingSub, 'handler.ts')] } });
     expect(() => resolveSiblingRoots(cfg, root)).toThrow(/not a directory/);
+  });
+});
+
+describe('#520 integration — path-carrying cite into a sibling repo', () => {
+  it('resolves WITH siblingRoots config, fails WITHOUT', async () => {
+    // (a) The MCP boundary admits the declared root only with the config.
+    const accepted = await validateResolutionRoot(sibling, root, { siblingRoots: [realpathSync(sibling)] });
+    expect(accepted.valid).toBe(true);
+    const rejected = await validateResolutionRoot(sibling, root); // no config
+    expect(rejected.valid).toBe(false);
+
+    // (b) Once admitted, the resolver anchors a path-carrying cite into the sibling.
+    if (!accepted.valid) throw new Error('precondition');
+    const eng = new ConsensusEngine({
+      projectRoot: root,
+      resolutionRoots: [accepted.canonical],
+      registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: id, skills: [] }),
+    } as any);
+    const resolved = await (eng as any).resolveFilePath('services/core/handler.ts');
+    expect(resolved).toBe(realpathSync(join(siblingSub, 'handler.ts')));
+
+    // (c) Same cite, engine WITHOUT the sibling root → unresolved (the #520 bug).
+    const engNoRoot = new ConsensusEngine({
+      projectRoot: root,
+      registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: id, skills: [] }),
+    } as any);
+    const unresolved = await (engNoRoot as any).resolveFilePath('services/core/handler.ts');
+    expect(unresolved).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Fixes the `verified=0` failure in **two-repo layouts** (#520, reported by @GravyaDev): when consensus runs from a sibling orchestration repo and cites into a separate product repo, citations never anchored — every cross-review came back unverified.

Adds an opt-in `consensus.siblingRoots` config that lets an operator declare external repo roots (and their worktree globs) so citations **and** scoped writes resolve into them — **without** reopening the #126 cross-project-contamination guard for *undeclared* roots. Default empty ⇒ single-repo installs are byte-for-byte unchanged.

Closes #520.

## Root cause (from GravyaDev's data + code trace)

`validateResolutionRoot` rejected sibling roots at **three** gates, so a declared root never entered `getValidRoots()` and even a correct deep path-carrying cite (`services/core/handler.ts:N`) couldn't anchor:
- step 2 (`..` traversal), step 6 (git-common-dir mismatch), **step 7 (worktree-list membership)** — the last one was missed in the first analysis and caught by pre-merge consensus.

GravyaDev's 106-event dataset ruled out the bare-filename guard ("Rule 1") as the cause — path-carrying cites failed too, proving the problem was root-admission, not cite shape.

## What changed (6 commits)

| Commit | Change |
|--------|--------|
| `f4afe454` | `validateResolutionRoot` admits a declared sibling root past **steps 6 AND 7** (containment-gated; all other gates run unconditionally) |
| `edbefe6d` | `ScopeTracker` accepts scopes under declared sibling roots (per-root too-broad guard) |
| `bc752397` | `consensus.siblingRoots` config field + `resolveSiblingRoots()` loader (glob-expand + realpath + fail-fast validation) |
| `8f6caee0` | thread `configuredSiblingRoots` into the two `validateResolutionRoot` call sites |
| `7da6acb6` | the #520 repo-external-worktree regression guard (cite resolves WITH config, null WITHOUT) |
| `1b11615c` | consensus fixup: skip broken-symlink children in glob expansion (no boot crash) |

**The resolver leg is "free":** once a root is admitted at the validation boundary, it flows into `getValidRoots()` and path-carrying cites resolve with **no `resolveFilePath` change** — independently confirmed in consensus.

## Security

Declaring a sibling root bypasses **only** the git-common-dir + worktree-list gates, **and only for paths contained in an explicitly-declared, realpath'd root.** All other gates — control-char, `..`, existence, directory, realpath, **ownership** — run unconditionally. Containment is realpath-safe on both sides (no symlink escape). Config-load validation is fail-fast (a bad root errors at boot, never a silent drop).

## Pre-merge consensus

Routed through impact-adjacent consensus `a5ca8f69-eb624f18` (sonnet-reviewer, gemini-reviewer, gemini-tester). Security verdict: **PASS** — all §4.5 invariants verified to hold. One MEDIUM finding (unguarded `statSync` in glob expansion → boot crash on a broken symlink) fixed in `1b11615c`. (gemini-tester's 6 "missing test" findings were hallucinations — it reviewed the wrong test file; verified against `tests/orchestrator/sibling-roots.test.ts` and signalled.)

The design itself cleared a prior 3-agent consensus `56d65741-7aad48ea` (which is what surfaced the step-7 gate).

## Verification

- `tests/orchestrator/sibling-roots.test.ts`: **15 tests** (validator bypass + selective-bypass/anti-traversal + ownership-still-fires + symlink-escape + ScopeTracker ×4 + config ×4 + #520 integration + broken-symlink-skip)
- Regression sweep (validator + scope-tracker + config): **76 tests green**
- `npx tsc --noEmit`: 0 errors in `apps/cli` + `packages/orchestrator`
- `npm run build:mcp`: clean

## Config

```jsonc
"consensus": {
  "siblingRoots": ["../product", "../product/.git/worktrees/*"]
}
```

Deferred to v2 (not in this PR): Rule-1 relaxation for *bare* cites into siblings; a glob load-time-snapshot runtime test.

Thanks again to @GravyaDev — the forensic detail (mixed cite-depth data, two-repo layout confirmation) turned a plausible-but-wrong single-leg fix into the correct one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

consensus-id: 318a16c1-8f5d47c4
_Pre-merge security consensus (4 agents, 2 rounds): 15 confirmed, 0 real defects. Both panel "HIGH" findings (TOCTOU escape; citation-roots-dropped) were falsified against the code. Two defense-in-depth hardening fixes folded in (commit d37e2d56). Earlier rounds: design 56d65741, impl a5ca8f69, defect-fix 01909cc9._
