### PR TITLE
fix(llm-client): give the deepseek provider a 600s timeout (#522 gap)

### DIFF
--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -806,11 +806,13 @@ export function createProvider(provider: string, model: string, apiKey?: string,
     // DeepSeek is OpenAI-wire-compatible — reuse OpenAIProvider. Default the
     // base_url to api.deepseek.com/v1 (an explicit base_url still overrides),
     // give it a 'deepseek' quota slot, and a 'DeepSeek' label so 401/403 auth
-    // errors name DeepSeek instead of the generic "OpenAI-compatible". #522
+    // errors name DeepSeek instead of the generic "OpenAI-compatible". #522.
+    // 600s timeout (like openclaw): deepseek-reasoner streams long reasoning_content
+    // and per-turn latency was observed at 60-74s — the 120s default terminates it.
     case 'deepseek': return new OpenAIProvider(
       apiKey ?? '', model, projectRoot,
       baseUrl ?? 'https://api.deepseek.com/v1',
-      'deepseek', undefined, 'DeepSeek', authSlot,
+      'deepseek', 600_000, 'DeepSeek', authSlot,
     );
     // OpenClaw is a remote agentic LLM with its own server-side tool chain
     // (web_fetch, exec, browser, etc.). Its wallclock regularly exceeds the

--- a/tests/orchestrator/create-provider-timeout.test.ts
+++ b/tests/orchestrator/create-provider-timeout.test.ts
@@ -1,0 +1,16 @@
+import { createProvider } from '../../packages/orchestrator/src/llm-client';
+
+describe('createProvider — deepseek timeout (regression: #522 missed the long timeout)', () => {
+  it('gives deepseek the 600s timeout like openclaw, not the 120s default', () => {
+    const p = createProvider('deepseek', 'deepseek-chat', 'sk-test') as any;
+    expect(p.timeoutMs).toBe(600_000);
+  });
+  it('openclaw keeps its 600s timeout (control)', () => {
+    const p = createProvider('openclaw', 'x', 'sk-test') as any;
+    expect(p.timeoutMs).toBe(600_000);
+  });
+  it('plain openai keeps the 120s default (control)', () => {
+    const p = createProvider('openai', 'gpt-4o', 'sk-test') as any;
+    expect(p.timeoutMs).toBe(120_000);
+  });
+});


### PR DESCRIPTION
## Summary

`createProvider`'s `case 'deepseek'` constructed `OpenAIProvider` with **no `timeoutMs`**, so it fell back to the **120s default** — while the sibling slow OpenAI-compatible provider `openclaw` correctly passes **600_000** with a comment explaining its wallclock routinely exceeds 120s. #522 wired DeepSeek but missed this.

Found by a **live smoke test**: a `deepseek-reasoner` agent doing a real adversarial code review died with `FATAL ERROR in executeTask: terminated` — its reasoning turns were measured at **60–74s each** (R1 streams long `reasoning_content`), perilously close to the 120s cap.

## Fix

```diff
-      'deepseek', undefined, 'DeepSeek', authSlot,
+      'deepseek', 600_000, 'DeepSeek', authSlot,
```

One positional arg (`timeoutMs`), mirroring the already-reviewed `openclaw` case in the same function. Comment expanded with the latency rationale.

## Test

`tests/orchestrator/create-provider-timeout.test.ts` — white-box assertion on the constructed provider's timeout:
- deepseek → **600_000** (was 120_000, the bug)
- openclaw → 600_000 (control)
- openai → 120_000 (control — proves we didn't change everything)

## Verification

- 3/3 new tests pass (RED→GREEN)
- `npx tsc --noEmit`: 0 errors in `packages/orchestrator`
- `npm run build:mcp`: clean
- Regression: `llm-client` + `config` suites, 35 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)