### PR TITLE
feat(config): per-agent maxToolTurns override (default 15)

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -67,6 +67,8 @@ export interface GossipConfig {
      *  stays in the OS keychain. Validated against /^[a-zA-Z0-9_-]{1,32}$/ in
      *  validateConfig; carried through configToAgentConfigs. #522 */
     key_ref?: string;
+    /** Per-agent override for the WorkerAgent tool-turn budget (default 15). */
+    maxToolTurns?: number;
   }>;
 }
 
@@ -290,6 +292,14 @@ export function validateConfig(raw: any): GossipConfig {
           );
         }
       }
+      // Per-agent tool-turn budget override. Optional; when present must be a
+      // positive integer within a sane bound (a runaway cap wastes quota).
+      if (agent.maxToolTurns !== undefined) {
+        const n = agent.maxToolTurns;
+        if (typeof n !== 'number' || !Number.isInteger(n) || n < 1 || n > 50) {
+          throw new Error(`Agent "${id}" has invalid maxToolTurns (${JSON.stringify(n)}); must be an integer in [1, 50]`);
+        }
+      }
     }
   }
 
@@ -310,6 +320,7 @@ export function configToAgentConfigs(config: GossipConfig): AgentConfig[] {
     // #522: carry the keychain service name through so the resolver reads the
     // per-agent key (key_ref ?? provider) at both resolution sites.
     key_ref: agent.key_ref,
+    maxToolTurns: agent.maxToolTurns,
   }));
 }
 

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -665,7 +665,7 @@ async function doBoot() {
     const identityBlock = identity ? m.formatIdentityBlock(identity) + '\n' : '';
     const instructions = (identityBlock + baseInstructions).trim() || undefined;
     const enableWebSearch = ac.preset === 'researcher' || (ac.skills ?? []).includes('research');
-    const worker = new m.WorkerAgent(ac.id, llm, ctx.relay.url, m.ALL_TOOLS, instructions, enableWebSearch, relayApiKey);
+    const worker = new m.WorkerAgent(ac.id, llm, ctx.relay.url, m.ALL_TOOLS, instructions, enableWebSearch, relayApiKey, ac.maxToolTurns);
     // ATI profiling signals (task_completed + task_tool_turns + format_compliance +
     // finding_dropped_format) are emitted from the dispatch-pipeline via the shared
     // `emitCompletionSignals` helper on FINAL_RESULT / ERROR. Emitting them here too

--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -211,7 +211,7 @@ export class MainAgent {
 
       // Enable web search for researcher agents (they need to look things up)
       const enableWebSearch = config.preset === 'researcher' || config.skills.includes('research');
-      const worker = new WorkerAgent(config.id, llm, this.relayUrl, ALL_TOOLS, instructions, enableWebSearch, this.relayApiKey);
+      const worker = new WorkerAgent(config.id, llm, this.relayUrl, ALL_TOOLS, instructions, enableWebSearch, this.relayApiKey, config.maxToolTurns);
       await worker.start();
       // Record the key snapshot so the first syncWorkers call can short-circuit
       // when the keychain hasn't changed — otherwise every dispatch tears down
@@ -398,7 +398,7 @@ export class MainAgent {
         ? readFileSync(instructionsPath, 'utf-8') : undefined;
 
       const enableWebSearch = ac.preset === 'researcher' || ac.skills.includes('research');
-      const worker = new WorkerAgent(ac.id, llm, this.relayUrl, ALL_TOOLS, instructions, enableWebSearch, this.relayApiKey);
+      const worker = new WorkerAgent(ac.id, llm, this.relayUrl, ALL_TOOLS, instructions, enableWebSearch, this.relayApiKey, ac.maxToolTurns);
       await worker.start();
       this.workers.set(ac.id, worker);
       this.lastKeyByAgent.set(ac.id, key);

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -17,6 +17,12 @@ export interface AgentConfig {
    *  NAME, never the key itself (the key stays in the OS keychain). Validated
    *  against /^[a-zA-Z0-9_-]{1,32}$/ in validateConfig (issue #522). */
   key_ref?: string;
+  /** Per-agent override for the WorkerAgent tool-turn budget. When omitted,
+   *  WorkerAgent falls back to the MAX_TOOL_TURNS default (15). Lets a
+   *  slow-reasoning agent (e.g. deepseek-challenger) get more turns without
+   *  raising the global cap. Validated in validateConfig; carried through
+   *  configToAgentConfigs. */
+  maxToolTurns?: number;
   /** Freeform role description — replaces preset. e.g. "ui-architect", "security-auditor" */
   role?: string;
   /** @deprecated Use role instead */

--- a/packages/orchestrator/src/worker-agent.ts
+++ b/packages/orchestrator/src/worker-agent.ts
@@ -135,6 +135,7 @@ export class WorkerAgent {
   }> = new Map();
 
   private webSearchEnabled: boolean;
+  private maxToolTurns: number;
   private validToolNames: Set<string>;
   private onTaskComplete?: TaskCompleteCallback;
 
@@ -146,8 +147,10 @@ export class WorkerAgent {
     instructions?: string,
     webSearch?: boolean,
     apiKey?: string,
+    maxToolTurns?: number,
   ) {
     this.webSearchEnabled = webSearch ?? false;
+    this.maxToolTurns = maxToolTurns ?? MAX_TOOL_TURNS;
     this.validToolNames = new Set(tools.map(t => t.name));
     this.instructions = instructions || 'You are a skilled developer agent. Complete the assigned task using the available tools. Be concise and focused.\n\nIf you encounter a domain your skills don\'t cover, call suggest_skill(name, reason) — it helps the system learn. Don\'t stop working to suggest; note the gap and keep going.';
     this.agent = new GossipAgent({ agentId, relayUrl, apiKey, reconnect: true });
@@ -233,7 +236,7 @@ export class WorkerAgent {
    - Turn 3: Verify with file_tree or file_read, fix any issues
    That's a complete task in 3 turns. Aim for efficiency.
 
-3. **Budget: ${MAX_TOOL_TURNS} tool turns.** Each LLM response that includes tool calls costs 1 turn, regardless of how many tools you call in that response. Use multiple tool calls per turn.
+3. **Budget: ${this.maxToolTurns} tool turns.** Each LLM response that includes tool calls costs 1 turn, regardless of how many tools you call in that response. Use multiple tool calls per turn.
 
 4. **Signal completion.** When you're done, respond with a concise summary (no tool calls) listing: files created/modified, technology choices made, and what the next step should be.
 
@@ -253,14 +256,14 @@ export class WorkerAgent {
     ];
 
     try {
-      const WRAP_UP_AT = MAX_TOOL_TURNS - 4;  // warn with 4 turns left
-      const FINAL_AT = MAX_TOOL_TURNS - 2;    // second-to-last turn: save all work (turn after this is for summary only)
+      const WRAP_UP_AT = this.maxToolTurns - 4;  // warn with 4 turns left
+      const FINAL_AT = this.maxToolTurns - 2;    // second-to-last turn: save all work (turn after this is for summary only)
       let lastToolSig = '';   // signature of last tool call for repetition detection
       let repeatCount = 0;    // consecutive identical tool calls
       let consecutiveErrors = 0; // consecutive turns where ALL tool calls return errors
       let providerRetryAttempted = false; // one retry per dispatch for provider-side placeholders
 
-      for (let turn = 0; turn < MAX_TOOL_TURNS; turn++) {
+      for (let turn = 0; turn < this.maxToolTurns; turn++) {
         // Inject any pending gossip before the next LLM turn
         while (this.gossipQueue.length > 0) {
           const gossip = this.gossipQueue.shift()!;
@@ -274,7 +277,7 @@ export class WorkerAgent {
         if (turn === WRAP_UP_AT) {
           messages.push({
             role: 'user',
-            content: `[System] ${MAX_TOOL_TURNS - turn} turns left. Finish writing any open files now. On your next response, you can make multiple tool calls to save everything at once.`,
+            content: `[System] ${this.maxToolTurns - turn} turns left. Finish writing any open files now. On your next response, you can make multiple tool calls to save everything at once.`,
           });
         } else if (turn === FINAL_AT) {
           messages.push({
@@ -283,7 +286,7 @@ export class WorkerAgent {
           });
         }
 
-        yield logAndYield(`turn ${turn}/${MAX_TOOL_TURNS} — calling LLM (${messages.length} messages)`);
+        yield logAndYield(`turn ${turn}/${this.maxToolTurns} — calling LLM (${messages.length} messages)`);
         const llmStart = Date.now();
         let response = await this.llm.generate(messages, {
           tools: this.tools,
@@ -407,7 +410,7 @@ export class WorkerAgent {
         }
       }
 
-      yield logAndYield(`hit max turns (${MAX_TOOL_TURNS}), requesting summary. Total tool calls: ${toolCallCount}`);
+      yield logAndYield(`hit max turns (${this.maxToolTurns}), requesting summary. Total tool calls: ${toolCallCount}`);
       try {
         messages.push({ role: 'user', content: 'Your turn budget is exhausted. Summarize what you accomplished and what remains unfinished. List files created/modified.' });
         const summary = await this.llm.generate(messages);

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -347,3 +347,33 @@ describe('loadClaudeSubagents — fable tier allowlist', () => {
     expect(agents.find(a => a.name === 'Bogus Agent')).toBeUndefined();
   });
 });
+
+describe('maxToolTurns config plumbing (fix/per-agent-turn-cap)', () => {
+  it('carries maxToolTurns through configToAgentConfigs', () => {
+    const cfg = validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: { x: { provider: 'anthropic', model: 'claude-sonnet-4-6', skills: ['typescript'], maxToolTurns: 25 } },
+    });
+    const ac = configToAgentConfigs(cfg).find(a => a.id === 'x');
+    expect(ac?.maxToolTurns).toBe(25);
+  });
+
+  it('rejects a non-integer / out-of-range maxToolTurns', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: { x: { provider: 'anthropic', model: 'claude-sonnet-4-6', skills: ['typescript'], maxToolTurns: 0 } },
+    })).toThrow(/maxToolTurns/);
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: { x: { provider: 'anthropic', model: 'claude-sonnet-4-6', skills: ['typescript'], maxToolTurns: 99 } },
+    })).toThrow(/maxToolTurns/);
+  });
+
+  it('accepts a config with no maxToolTurns (default path)', () => {
+    const cfg = validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: { x: { provider: 'anthropic', model: 'claude-sonnet-4-6', skills: ['typescript'] } },
+    });
+    expect(configToAgentConfigs(cfg).find(a => a.id === 'x')?.maxToolTurns).toBeUndefined();
+  });
+});

--- a/tests/orchestrator/worker-agent.test.ts
+++ b/tests/orchestrator/worker-agent.test.ts
@@ -371,3 +371,19 @@ describe('instructions and gossip', () => {
     expect(worker.getInstructions()).toBe('New instructions');
   });
 });
+
+describe('WorkerAgent per-agent maxToolTurns (fix/per-agent-turn-cap)', () => {
+  it('uses the provided maxToolTurns when set', () => {
+    const stubLlm = { generate: jest.fn().mockResolvedValue({ text: 'ok' }) };
+    const { WorkerAgent } = require('@gossip/orchestrator');
+    const w = new WorkerAgent('a1', stubLlm as any, 'ws://x', [], undefined, false, undefined, 25);
+    expect((w as any).maxToolTurns).toBe(25);
+  });
+
+  it('falls back to the default (15) when omitted', () => {
+    const stubLlm = { generate: jest.fn().mockResolvedValue({ text: 'ok' }) };
+    const { WorkerAgent } = require('@gossip/orchestrator');
+    const w = new WorkerAgent('a1', stubLlm as any, 'ws://x', [], undefined, false, undefined);
+    expect((w as any).maxToolTurns).toBe(15);
+  });
+});


### PR DESCRIPTION
## What

Makes the WorkerAgent tool-turn cap a per-agent config value instead of a hard global constant. `MAX_TOOL_TURNS = 15` stays as the default; agents can opt into a higher budget via `consensus`/agent config `maxToolTurns`.

**Motivation:** slow-reasoning agents (deepseek-challenger, R1-style) hit the 15-turn ceiling mid-task and get truncated. Raising the global cap would waste quota on fast agents. Per-agent override targets the budget where it's needed.

## Changes

- `types.ts` — `AgentConfig.maxToolTurns?: number`
- `config.ts` — GossipConfig agent shape field + `validateConfig` guard (integer in `[1, 50]`) + carry through `configToAgentConfigs`
- `worker-agent.ts` — instance field + 8th optional ctor param; `this.maxToolTurns = maxToolTurns ?? MAX_TOOL_TURNS`; all 7 `executeTask` usages now read the instance field
- `main-agent.ts` (2 sites) + `mcp-server-sdk.ts` (1 site) — thread the per-agent value into every `WorkerAgent` construction

**Default-preserving:** an agent with no `maxToolTurns` is byte-identical to before (falls back to 15).

## Tests

- worker-agent: ctor uses provided value (25) / falls back to default (15) — 2 passed
- config: carries through `configToAgentConfigs`, rejects non-integer/out-of-range, accepts omitted — 3 passed
- Regression: dispatch-pipeline 43, worker-agent + config suites 51 — green
- `tsc` 0 errors (orchestrator + cli); `build:mcp` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

consensus-id: c9395068-202e4c5d
_Impact-adjacency consensus: 4 agents, 2 rounds — 15 confirmed, 0 disputed. No correctness defects; confirmed findings are enhancement/test-polish follow-ups (raise [1,50] ceiling, wire gossip_setup, add boundary/integration tests)._
