### PR TITLE
feat(consensus): enumerate sibling-repo git worktrees in resolveSiblingRoots (#520 v2)

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -1,7 +1,7 @@
 import { readFileSync, existsSync, readdirSync, statSync, realpathSync } from 'fs';
 import { resolve, join, relative } from 'path';
 import { execFileSync } from 'child_process';
-import { AgentConfig, parseWorktreePorcelain } from '@gossip/orchestrator';
+import { AgentConfig, parseWorktreePorcelain, GIT_ENV } from '@gossip/orchestrator';
 
 export interface GossipConfig {
   main_agent: {
@@ -373,8 +373,15 @@ export function resolveSiblingRoots(config: GossipConfig, projectRoot: string): 
   // by parseWorktreePorcelain; each is independently validateDir-gated by the caller.
   const enumerateWorktrees = (repoRoot: string): string[] => {
     try {
+      // Harden git: neutralize global/system config (GIT_ENV, shared with
+      // validateResolutionRoot) AND clear any inherited GIT_DIR/GIT_WORK_TREE so
+      // `git -C <repoRoot>` enumerates the declared sibling, not an outer repo
+      // (consensus f65b8bc3 deepseek:f1 + sonnet:f13).
+      const env: Record<string, string | undefined> = { ...process.env, ...GIT_ENV };
+      delete env.GIT_DIR;
+      delete env.GIT_WORK_TREE;
       const stdout = execFileSync('git', ['-C', repoRoot, 'worktree', 'list', '-z', '--porcelain'], {
-        encoding: 'utf8', timeout: 5000, maxBuffer: 10 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'],
+        encoding: 'utf8', timeout: 5000, maxBuffer: 1 << 20, stdio: ['ignore', 'pipe', 'ignore'], env,
       });
       return parseWorktreePorcelain(stdout, { includeLocked: true });
     } catch {

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync, readdirSync, statSync, realpathSync } from 'fs';
 import { resolve, join, relative } from 'path';
-import { AgentConfig } from '@gossip/orchestrator';
+import { execFileSync } from 'child_process';
+import { AgentConfig, parseWorktreePorcelain } from '@gossip/orchestrator';
 
 export interface GossipConfig {
   main_agent: {
@@ -365,6 +366,21 @@ export function resolveSiblingRoots(config: GossipConfig, projectRoot: string): 
     const rel = relative(rootReal, abs);
     return rel === '' || (!rel.startsWith('..') && !rel.startsWith('/'));
   };
+  // v2 (#520): enumerate a declared repo's real worktree checkouts from git so
+  // path-carrying cites resolve regardless of where `git worktree add` put the
+  // tree. Fail-soft: a non-git dir / git absent / parse error yields [] (the
+  // declared root itself is still a valid root). The returned paths are realpath'd
+  // by parseWorktreePorcelain; each is independently validateDir-gated by the caller.
+  const enumerateWorktrees = (repoRoot: string): string[] => {
+    try {
+      const stdout = execFileSync('git', ['-C', repoRoot, 'worktree', 'list', '-z', '--porcelain'], {
+        encoding: 'utf8', timeout: 5000, maxBuffer: 10 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      return parseWorktreePorcelain(stdout, { includeLocked: true });
+    } catch {
+      return [];
+    }
+  };
   for (const entry of declared) {
     if (entry.endsWith('/*')) {
       // Validate the glob parent (stat + isDirectory + uid + realpath) before
@@ -394,9 +410,16 @@ export function resolveSiblingRoots(config: GossipConfig, projectRoot: string): 
         throw new Error(`Config "consensus.siblingRoots": "${canonical}" is inside the project root — siblingRoots are for EXTERNAL repos; use a normal scope instead`);
       }
       out.push(canonical);
+      // v2: also admit the declared repo's checked-out worktrees (primary path).
+      for (const wt of enumerateWorktrees(canonical)) {
+        let wtCanonical: string;
+        try { wtCanonical = validateDir(wt); } catch { continue; } // vanished / uid-mismatch → skip, don't fail boot
+        if (isInsideProject(wtCanonical)) continue; // worktrees inside projectRoot are not external siblings — skip
+        out.push(wtCanonical);
+      }
     }
   }
-  return out;
+  return [...new Set(out)]; // dedup by canonical path (parseWorktreePorcelain + validateDir both realpath)
 }
 
 export function configToAgentConfigs(config: GossipConfig): AgentConfig[] {

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -109,7 +109,7 @@ export type { SignalAggregateIndexData, SignalAggregateBucket } from './signal-a
 export type { AgentScore } from './performance-reader';
 export { ConsensusEngine } from './consensus-engine';
 export type { ConsensusEngineConfig } from './consensus-engine';
-export { validateResolutionRoot, parseWorktreePorcelain, listWorktreePaths, gitCommonDir, hashPath } from './validate-resolution-root';
+export { validateResolutionRoot, parseWorktreePorcelain, listWorktreePaths, gitCommonDir, hashPath, GIT_ENV } from './validate-resolution-root';
 export type { ValidationResult } from './validate-resolution-root';
 export { discoverGitWorktrees } from './discover-git-worktrees';
 export type { DiscoverResult } from './discover-git-worktrees';

--- a/packages/orchestrator/src/validate-resolution-root.ts
+++ b/packages/orchestrator/src/validate-resolution-root.ts
@@ -28,7 +28,7 @@ import { promisify } from 'util';
 
 const execFileP = promisify(execFile);
 
-const GIT_ENV = {
+export const GIT_ENV = {
   GIT_CONFIG_GLOBAL: '/dev/null',
   GIT_CONFIG_SYSTEM: '/dev/null',
   GIT_CONFIG_NOSYSTEM: '1',

--- a/tests/orchestrator/sibling-roots.test.ts
+++ b/tests/orchestrator/sibling-roots.test.ts
@@ -174,6 +174,35 @@ describe('resolveSiblingRoots — rejects a sibling root inside projectRoot (con
   });
 });
 
+describe('resolveSiblingRoots — v2 git worktree enumeration (#520)', () => {
+  it("enumerates a declared repo's git worktrees (v2 — path-carrying cites resolve)", () => {
+    execFileSync('git', ['-C', sibling, 'commit', '--allow-empty', '-q', '-m', 'init']);
+    const wt = join(dirname(sibling), 'product-wt-feature');
+    execFileSync('git', ['-C', sibling, 'worktree', 'add', '-q', wt]);
+    const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: ['../product'] } });
+    const resolved = resolveSiblingRoots(cfg, root);
+    expect(resolved).toContain(realpathSync(sibling));
+    expect(resolved).toContain(realpathSync(wt));
+    // cleanup
+    execFileSync('git', ['-C', sibling, 'worktree', 'prune']);
+  });
+
+  it('dedups the root + its worktrees (no duplicate canonical paths)', () => {
+    const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: ['../product'] } });
+    const resolved = resolveSiblingRoots(cfg, root);
+    expect(resolved.length).toBe(new Set(resolved).size);
+    expect(resolved.filter(p => p === realpathSync(sibling)).length).toBe(1);
+  });
+
+  it('fail-soft: a non-git declared sibling root still resolves (enumeration returns [])', () => {
+    const plainDir = join(dirname(sibling), 'plain-ext'); mkdirSync(plainDir, { recursive: true });
+    const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: [join('..', 'plain-ext')] } });
+    let resolved: string[] = [];
+    expect(() => { resolved = resolveSiblingRoots(cfg, root); }).not.toThrow();
+    expect(resolved).toContain(realpathSync(plainDir));
+  });
+});
+
 describe('consensus 318a16c1 hardening', () => {
   it('rejects a prefix-adjacent sibling (/base/product-evil vs declared /base/product) — no startsWith escape', async () => {
     const base = dirname(sibling);

--- a/tests/orchestrator/sibling-roots.test.ts
+++ b/tests/orchestrator/sibling-roots.test.ts
@@ -187,11 +187,42 @@ describe('resolveSiblingRoots — v2 git worktree enumeration (#520)', () => {
     execFileSync('git', ['-C', sibling, 'worktree', 'prune']);
   });
 
-  it('dedups the root + its worktrees (no duplicate canonical paths)', () => {
+  it('dedups the root + its worktrees (root appears once despite enumeration returning it)', () => {
+    execFileSync('git', ['-C', sibling, 'commit', '--allow-empty', '-q', '-m', 'init']);
+    const wt = join(dirname(sibling), 'product-wt-dedup');
+    execFileSync('git', ['-C', sibling, 'worktree', 'add', '-q', wt]);
     const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: ['../product'] } });
     const resolved = resolveSiblingRoots(cfg, root);
-    expect(resolved.length).toBe(new Set(resolved).size);
     expect(resolved.filter(p => p === realpathSync(sibling)).length).toBe(1);
+    expect(new Set(resolved).size).toBe(resolved.length);
+    expect(resolved).toContain(realpathSync(wt));
+    execFileSync('git', ['-C', sibling, 'worktree', 'remove', '-f', wt]);
+  });
+
+  it('enumerates N simultaneous worktrees of one declared repo', () => {
+    execFileSync('git', ['-C', sibling, 'commit', '--allow-empty', '-q', '-m', 'init']);
+    const wtA = join(dirname(sibling), 'product-wt-a');
+    const wtB = join(dirname(sibling), 'product-wt-b');
+    execFileSync('git', ['-C', sibling, 'worktree', 'add', '-q', wtA]);
+    execFileSync('git', ['-C', sibling, 'worktree', 'add', '-q', wtB]);
+    const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: ['../product'] } });
+    const resolved = resolveSiblingRoots(cfg, root);
+    expect(resolved).toContain(realpathSync(wtA));
+    expect(resolved).toContain(realpathSync(wtB));
+    execFileSync('git', ['-C', sibling, 'worktree', 'remove', '-f', wtA]);
+    execFileSync('git', ['-C', sibling, 'worktree', 'remove', '-f', wtB]);
+  });
+
+  it('skips (does not throw on) an enumerated worktree checked out inside projectRoot', () => {
+    execFileSync('git', ['-C', sibling, 'commit', '--allow-empty', '-q', '-m', 'init']);
+    const insideWt = join(root, 'nested-product-wt');
+    execFileSync('git', ['-C', sibling, 'worktree', 'add', '-q', insideWt]);
+    const cfg = validateConfig({ ...minimalSkeleton, consensus: { siblingRoots: ['../product'] } });
+    let resolved: string[] = [];
+    expect(() => { resolved = resolveSiblingRoots(cfg, root); }).not.toThrow();
+    expect(resolved).toContain(realpathSync(sibling));
+    expect(resolved).not.toContain(realpathSync(insideWt));
+    execFileSync('git', ['-C', sibling, 'worktree', 'remove', '-f', insideWt]);
   });
 
   it('fail-soft: a non-git declared sibling root still resolves (enumeration returns [])', () => {


### PR DESCRIPTION
## What

v2 of sibling-roots (#520, builds on shipped #534). Makes `resolveSiblingRoots` **enumerate a declared repo's real git worktrees** as the primary discovery path, instead of relying solely on a static glob.

**Motivation (GravyaDev #520):** the static glob is repo-convention-specific — `git worktree add <path>` puts checkouts anywhere, and `.git/worktrees/*` is git-*administrative* (HEAD/gitdir pointers), not source. So path-carrying cites into worktrees came back `verified=0`. Enumeration via `git worktree list --porcelain` is convention-agnostic and handles N simultaneous worktrees.

## Changes

- `config.ts` `resolveSiblingRoots` — for each declared plain-root sibling, `enumerateWorktrees()` runs `git -C <root> worktree list -z --porcelain` (sync, fail-soft → `[]`) and adds each checked-out worktree; each is `validateDir`-gated (stat/isDirectory/uid/realpath) + `isInsideProject`-skipped; union deduped via `Set`. The `/*` glob stays as the explicit fallback.
- Reuses the exported pure `parseWorktreePorcelain` (`@gossip/orchestrator`); keeps `resolveSiblingRoots` **synchronous** (no caller ripple).

## Security hardening (pre-merge consensus `f65b8bc3-f495435d`)

A 3-agent security consensus (17 confirmed, 0 disputed) found **no escape** — array-arg `execFileSync` (no shell), every enumerated path uid+realpath+isInsideProject gated, per-cite `validateResolutionRoot` 7-gate still enforced downstream, fail-soft, 100-entry capped. Two confirmed items were fixed in `58787314`:

- **MEDIUM (trust_boundaries):** `enumerateWorktrees` now passes the exported `GIT_ENV` (neutralizes global/system config) **and clears inherited `GIT_DIR`/`GIT_WORK_TREE`** — the actual wrong-repo vector that `GIT_ENV` alone doesn't close. `maxBuffer` aligned to `1<<20`.
- **MEDIUM (testing):** replaced a vacuous dedup test (it never created a worktree) with a real one; added N-worktree and enumerated-worktree-inside-projectRoot-skip tests.

## Tests

- sibling-roots **27 passed** (22 → 25 build → 27 hardening)
- Regression: validate-resolution-root + dispatch-pipeline + cli/config **128 passed**
- `tsc` 0 new errors; `build:mcp` clean

consensus-id: f65b8bc3-f495435d

🤖 Generated with [Claude Code](https://claude.com/claude-code)