### PR TITLE
feat(config): maxToolTurns v2 — gossip_setup wiring, [1,100] ceiling, loop-termination tests

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -119,6 +119,12 @@ export function loadConfig(configPath: string): GossipConfig {
 // bug. If you change one, change the other.
 export const VALID_PROVIDERS = ['anthropic', 'openai', 'deepseek', 'openclaw', 'google', 'local', 'native', 'none'];
 
+// Upper bound for per-agent maxToolTurns. Enforced both here (validateConfig,
+// runtime load of .gossip/config.json) and in the gossip_setup Zod schema
+// (apps/cli/src/mcp-server-sdk.ts) — import this constant in both so the two
+// guards cannot drift apart.
+export const MAX_TOOL_TURNS_CEILING = 100;
+
 // Keychain SERVICE-NAME allowlist for `agent.key_ref`. Mirrors the
 // VALID_PROVIDERS regex in apps/cli/src/keychain.ts:8 — a key_ref is read by
 // Keychain.getKey(service) and MUST pass the same validateProvider gate, so a
@@ -326,8 +332,8 @@ export function validateConfig(raw: any): GossipConfig {
       // positive integer within a sane bound (a runaway cap wastes quota).
       if (agent.maxToolTurns !== undefined) {
         const n = agent.maxToolTurns;
-        if (typeof n !== 'number' || !Number.isInteger(n) || n < 1 || n > 50) {
-          throw new Error(`Agent "${id}" has invalid maxToolTurns (${JSON.stringify(n)}); must be an integer in [1, 50]`);
+        if (typeof n !== 'number' || !Number.isInteger(n) || n < 1 || n > MAX_TOOL_TURNS_CEILING) {
+          throw new Error(`Agent "${id}" has invalid maxToolTurns (${JSON.stringify(n)}); must be an integer in [1, ${MAX_TOOL_TURNS_CEILING}]`);
         }
       }
     }

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -189,6 +189,7 @@ import { createServer as createHttpServer, IncomingMessage, ServerResponse } fro
 
 // ── Extracted modules ────────────────────────────────────────────────────
 import { ctx } from './mcp-context';
+import { MAX_TOOL_TURNS_CEILING } from './config';
 import { getGossipcatVersion } from './version';
 import { captureGitStatus, checkUnexpectedChanges } from './utility-guard';
 import { buildUtilityAgentPrompt, getUncategorizedStatusLine, checkDistMcpStaleness, logStalenessToMcpLog, isValidCategory, seedPermanentDefaults, GLOBAL_PERMANENT_DEFAULTS, IMPLEMENTER_PERMANENT_DEFAULTS, RESEARCHER_REVIEWER_PERMANENT_DEFAULTS } from '@gossip/orchestrator';
@@ -2142,6 +2143,8 @@ export function createMcpServer(): McpServer {
           .describe('Agent role — freeform, e.g. "ui-architect", "security-auditor", "reviewer"'),
         skills: z.array(z.string()).optional()
           .describe('Skill tags (e.g. ["typescript", "code_review"])'),
+        maxToolTurns: z.number().int().min(1).max(MAX_TOOL_TURNS_CEILING).optional()
+          .describe(`Per-agent tool-turn budget override (integer in [1, ${MAX_TOOL_TURNS_CEILING}]). Defaults to 15 when omitted. Useful for slow-reasoning agents (e.g. deepseek-reasoner) that need more turns per cross-review.`),
       })).describe('Array of agents to create'),
     },
     async ({ main_provider, main_model, mode, agents, instruction_agent_ids, instruction_update, instruction_mode }) => {
@@ -2287,6 +2290,7 @@ export function createMcpServer(): McpServer {
             role: (agent as any).role || (agent as any).preset,
             skills: agent.skills || ['general'],
             native: true,
+            ...(agent.maxToolTurns !== undefined ? { maxToolTurns: agent.maxToolTurns } : {}),
           };
         } else {
           // Custom provider agent → gossipcat config only
@@ -2311,6 +2315,7 @@ export function createMcpServer(): McpServer {
             role: (agent as any).role || (agent as any).preset,
             skills: agent.skills || ['general'],
             ...(agent.base_url ? { base_url: agent.base_url } : {}),
+            ...(agent.maxToolTurns !== undefined ? { maxToolTurns: agent.maxToolTurns } : {}),
           };
           customCreated.push(agent.id);
 

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2144,7 +2144,7 @@ export function createMcpServer(): McpServer {
         skills: z.array(z.string()).optional()
           .describe('Skill tags (e.g. ["typescript", "code_review"])'),
         maxToolTurns: z.number().int().min(1).max(MAX_TOOL_TURNS_CEILING).optional()
-          .describe(`Per-agent tool-turn budget override (integer in [1, ${MAX_TOOL_TURNS_CEILING}]). Defaults to 15 when omitted. Useful for slow-reasoning agents (e.g. deepseek-reasoner) that need more turns per cross-review.`),
+          .describe(`Per-agent tool-turn budget override (integer in [1, ${MAX_TOOL_TURNS_CEILING}]). Defaults to 15 when omitted. Useful for slow-reasoning agents (e.g. deepseek-reasoner) that need more turns per cross-review. NOTE: re-declaring an existing agent replaces its whole config entry (even in merge mode) — omitting this field on a re-declare resets the agent to the default.`),
       })).describe('Array of agents to create'),
     },
     async ({ main_provider, main_model, mode, agents, instruction_agent_ids, instruction_update, instruction_mode }) => {

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -19,8 +19,9 @@ export interface AgentConfig {
   key_ref?: string;
   /** Per-agent override for the WorkerAgent tool-turn budget. When omitted,
    *  WorkerAgent falls back to the MAX_TOOL_TURNS default (15). Lets a
-   *  slow-reasoning agent (e.g. deepseek-challenger) get more turns without
-   *  raising the global cap. Validated in validateConfig; carried through
+   *  slow-reasoning agent (e.g. deepseek-challenger at 60-74s/turn, 40-55
+   *  turns per cross-review) get more turns without raising the global cap.
+   *  Validated in validateConfig as an integer in [1, 100]; carried through
    *  configToAgentConfigs. */
   maxToolTurns?: number;
   /** Freeform role description — replaces preset. e.g. "ui-architect", "security-auditor" */

--- a/packages/orchestrator/src/worker-agent.ts
+++ b/packages/orchestrator/src/worker-agent.ts
@@ -257,6 +257,10 @@ export class WorkerAgent {
     ];
 
     try {
+      // Budget-awareness offsets go negative for maxToolTurns < 5 (< 3 for
+      // FINAL_AT), so the warnings are silently suppressed at tiny budgets —
+      // accepted behavior (consensus c9395068 f10): there is no room to warn
+      // inside a 1-2 turn budget anyway.
       const WRAP_UP_AT = this.maxToolTurns - 4;  // warn with 4 turns left
       const FINAL_AT = this.maxToolTurns - 2;    // second-to-last turn: save all work (turn after this is for summary only)
       let lastToolSig = '';   // signature of last tool call for repetition detection

--- a/packages/orchestrator/src/worker-agent.ts
+++ b/packages/orchestrator/src/worker-agent.ts
@@ -1,7 +1,8 @@
 /**
  * WorkerAgent — executes a sub-task using its LLM and requests tools via relay.
  *
- * Multi-turn tool loop with max 10 turns to prevent infinite loops.
+ * Multi-turn tool loop capped at maxToolTurns (default 15, per-agent
+ * configurable up to 100) to prevent infinite loops.
  * Tool calls are sent as RPC_REQUEST to tool-server via relay.
  */
 

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -358,14 +358,50 @@ describe('maxToolTurns config plumbing (fix/per-agent-turn-cap)', () => {
     expect(ac?.maxToolTurns).toBe(25);
   });
 
-  it('rejects a non-integer / out-of-range maxToolTurns', () => {
+  it('rejects 0 (below floor)', () => {
     expect(() => validateConfig({
       main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
       agents: { x: { provider: 'anthropic', model: 'claude-sonnet-4-6', skills: ['typescript'], maxToolTurns: 0 } },
     })).toThrow(/maxToolTurns/);
+  });
+
+  it('rejects 101 (above ceiling)', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: { x: { provider: 'anthropic', model: 'claude-sonnet-4-6', skills: ['typescript'], maxToolTurns: 101 } },
+    })).toThrow(/maxToolTurns/);
+  });
+
+  it('accepts boundary values 1 and 100', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: { x: { provider: 'anthropic', model: 'claude-sonnet-4-6', skills: ['typescript'], maxToolTurns: 1 } },
+    })).not.toThrow();
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: { x: { provider: 'anthropic', model: 'claude-sonnet-4-6', skills: ['typescript'], maxToolTurns: 100 } },
+    })).not.toThrow();
+  });
+
+  it('accepts 99 (was at old 50 ceiling, now valid)', () => {
+    // Previously 99 was rejected (> 50). With the ceiling raised to 100, 99 must be accepted.
     expect(() => validateConfig({
       main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
       agents: { x: { provider: 'anthropic', model: 'claude-sonnet-4-6', skills: ['typescript'], maxToolTurns: 99 } },
+    })).not.toThrow();
+  });
+
+  it('rejects float 2.5 (non-integer)', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: { x: { provider: 'anthropic', model: 'claude-sonnet-4-6', skills: ['typescript'], maxToolTurns: 2.5 } },
+    })).toThrow(/maxToolTurns/);
+  });
+
+  it('rejects string "10" (wrong type)', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: { x: { provider: 'anthropic', model: 'claude-sonnet-4-6', skills: ['typescript'], maxToolTurns: '10' as any } },
     })).toThrow(/maxToolTurns/);
   });
 

--- a/tests/cli/mcp-server-sdk.test.ts
+++ b/tests/cli/mcp-server-sdk.test.ts
@@ -74,6 +74,64 @@ describe('gossip_setup merge logic', () => {
     });
 });
 
+// Simulate the configAgents write-literal logic from gossip_setup for maxToolTurns.
+// This mirrors the actual code at the native + custom agent write-literal blocks
+// in mcp-server-sdk.ts, ensuring maxToolTurns is carried into the persisted config.
+function buildNativeAgentEntry(agent: { id: string; skills?: string[]; maxToolTurns?: number }) {
+  return {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    skills: agent.skills || ['general'],
+    native: true,
+    ...(agent.maxToolTurns !== undefined ? { maxToolTurns: agent.maxToolTurns } : {}),
+  };
+}
+
+function buildCustomAgentEntry(agent: { id: string; provider: string; model: string; skills?: string[]; base_url?: string; maxToolTurns?: number }) {
+  return {
+    provider: agent.provider,
+    model: agent.model,
+    skills: agent.skills || ['general'],
+    ...(agent.base_url ? { base_url: agent.base_url } : {}),
+    ...(agent.maxToolTurns !== undefined ? { maxToolTurns: agent.maxToolTurns } : {}),
+  };
+}
+
+describe('gossip_setup — maxToolTurns persisted into config (v2 follow-up)', () => {
+  it('native agent with maxToolTurns includes it in config entry', () => {
+    const entry = buildNativeAgentEntry({ id: 'haiku-researcher', skills: ['typescript'], maxToolTurns: 30 });
+    expect(entry.maxToolTurns).toBe(30);
+  });
+
+  it('native agent without maxToolTurns omits the field (no undefined pollution)', () => {
+    const entry = buildNativeAgentEntry({ id: 'haiku-researcher', skills: ['typescript'] });
+    expect('maxToolTurns' in entry).toBe(false);
+  });
+
+  it('custom agent with maxToolTurns includes it in config entry', () => {
+    const entry = buildCustomAgentEntry({ id: 'deepseek-challenger', provider: 'deepseek', model: 'deepseek-chat', skills: ['typescript'], maxToolTurns: 55 });
+    expect(entry.maxToolTurns).toBe(55);
+  });
+
+  it('custom agent without maxToolTurns omits the field', () => {
+    const entry = buildCustomAgentEntry({ id: 'gemini-reviewer', provider: 'google', model: 'gemini-2.5-pro', skills: ['code_review'] });
+    expect('maxToolTurns' in entry).toBe(false);
+  });
+
+  it('custom agent preserves base_url alongside maxToolTurns', () => {
+    const entry = buildCustomAgentEntry({
+      id: 'deepseek-challenger',
+      provider: 'openai',
+      model: 'deepseek-chat',
+      skills: ['typescript'],
+      base_url: 'https://api.deepseek.com/v1',
+      maxToolTurns: 25,
+    });
+    expect(entry.base_url).toBe('https://api.deepseek.com/v1');
+    expect(entry.maxToolTurns).toBe(25);
+  });
+});
+
 function defaultImportanceScores(): { relevance: number; accuracy: number; uniqueness: number } {
   return { relevance: 3, accuracy: 3, uniqueness: 3 };
 }

--- a/tests/orchestrator/worker-agent.test.ts
+++ b/tests/orchestrator/worker-agent.test.ts
@@ -386,4 +386,85 @@ describe('WorkerAgent per-agent maxToolTurns (fix/per-agent-turn-cap)', () => {
     const w = new WorkerAgent('a1', stubLlm as any, 'ws://x', [], undefined, false, undefined);
     expect((w as any).maxToolTurns).toBe(15);
   });
+
+  it('executeTask loop terminates after exactly maxToolTurns turns when LLM always returns a tool call', async () => {
+    // Mock @gossip/client so WorkerAgent can be constructed and started without
+    // a real relay. The mock GossipAgent captures the 'message' handler registered
+    // in start() and fires back a synthetic RPC_RESPONSE so callTool() resolves
+    // immediately instead of timing out.
+    const { MessageType } = require('@gossip/types');
+
+    let messageHandler: ((data: unknown, envelope: unknown) => void) | null = null;
+    const mockGossipAgent = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn().mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === 'message') messageHandler = handler as (data: unknown, envelope: unknown) => void;
+      }),
+      sendEnvelope: jest.fn().mockImplementation(async (envelope: { rid_req?: string }) => {
+        // Fire the RPC_RESPONSE on the next tick so callTool's Promise is already registered
+        setImmediate(() => {
+          if (messageHandler && envelope.rid_req) {
+            messageHandler(
+              { result: 'tool-ok' },
+              { t: MessageType.RPC_RESPONSE, rid_req: envelope.rid_req }
+            );
+          }
+        });
+      }),
+      subscribe: jest.fn().mockResolvedValue(undefined),
+      unsubscribe: jest.fn().mockResolvedValue(undefined),
+    };
+
+    // Reload WorkerAgent with the mock in scope. jest.doMock (unlike
+    // jest.mock) is not hoisted, so it reliably applies to the require()
+    // below after resetModules — jest.mock inside a test body has
+    // resolution-order-dependent behavior.
+    jest.resetModules();
+    jest.doMock('@gossip/client', () => ({
+      GossipAgent: jest.fn().mockImplementation(() => mockGossipAgent),
+    }));
+    const { WorkerAgent: WA } = require('@gossip/orchestrator');
+
+    let llmCallCount = 0;
+    const dummyTool: ToolDefinition = {
+      name: 'noop',
+      description: 'no-op',
+      parameters: { type: 'object', properties: {} },
+    };
+    const stubLlm: ILLMProvider = {
+      generate: jest.fn().mockImplementation(async () => {
+        const callN = (stubLlm.generate as jest.Mock).mock.calls.length;
+        // After 3 tool-turn calls the budget is exhausted; executeTask then
+        // calls generate once more for the summary. Return plain text for that.
+        if (callN > 3) {
+          return { text: 'summary after budget exhausted' };
+        }
+        // Vary the argument each turn so the repeat-detection (same toolSig
+        // 3x = exit early) doesn't fire before the budget cap.
+        llmCallCount++;
+        return {
+          text: `turn ${llmCallCount}`,
+          toolCalls: [{ id: `call_${llmCallCount}`, name: 'noop', arguments: { turn: llmCallCount } }],
+        };
+      }),
+    };
+
+    const worker = new WA('test-agent', stubLlm, 'ws://localhost:9999', [dummyTool], undefined, false, undefined, 3);
+    await worker.start();
+
+    // Drain the async generator to completion
+    const events: unknown[] = [];
+    for await (const event of worker.executeTask('run forever', undefined, undefined, 'task-1')) {
+      events.push(event);
+    }
+
+    // The LLM was called 3 times for tool turns + 1 summary call after budget exhausted
+    const llmCalls = (stubLlm.generate as jest.Mock).mock.calls.length;
+    expect(llmCalls).toBe(4); // 3 tool turns + 1 summary
+    expect(llmCallCount).toBe(3); // incremented only during tool-turn calls
+
+    // Restore mocks so subsequent tests in the file are not affected
+    jest.resetModules();
+  }, 15_000);
 });

--- a/tests/orchestrator/worker-agent.test.ts
+++ b/tests/orchestrator/worker-agent.test.ts
@@ -467,4 +467,65 @@ describe('WorkerAgent per-agent maxToolTurns (fix/per-agent-turn-cap)', () => {
     // Restore mocks so subsequent tests in the file are not affected
     jest.resetModules();
   }, 15_000);
+
+  it('executeTask loop runs exactly once for the minimal maxToolTurns of 1', async () => {
+    const { MessageType } = require('@gossip/types');
+
+    let messageHandler: ((data: unknown, envelope: unknown) => void) | null = null;
+    const mockGossipAgent = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn().mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === 'message') messageHandler = handler as (data: unknown, envelope: unknown) => void;
+      }),
+      sendEnvelope: jest.fn().mockImplementation(async (envelope: { rid_req?: string }) => {
+        setImmediate(() => {
+          if (messageHandler && envelope.rid_req) {
+            messageHandler(
+              { result: 'tool-ok' },
+              { t: MessageType.RPC_RESPONSE, rid_req: envelope.rid_req }
+            );
+          }
+        });
+      }),
+      subscribe: jest.fn().mockResolvedValue(undefined),
+      unsubscribe: jest.fn().mockResolvedValue(undefined),
+    };
+
+    jest.resetModules();
+    jest.doMock('@gossip/client', () => ({
+      GossipAgent: jest.fn().mockImplementation(() => mockGossipAgent),
+    }));
+    const { WorkerAgent: WA } = require('@gossip/orchestrator');
+
+    const dummyTool: ToolDefinition = {
+      name: 'noop',
+      description: 'no-op',
+      parameters: { type: 'object', properties: {} },
+    };
+    const stubLlm: ILLMProvider = {
+      generate: jest.fn().mockImplementation(async () => {
+        const callN = (stubLlm.generate as jest.Mock).mock.calls.length;
+        if (callN > 1) {
+          return { text: 'summary after budget exhausted' };
+        }
+        return {
+          text: 'turn 1',
+          toolCalls: [{ id: 'call_1', name: 'noop', arguments: { turn: 1 } }],
+        };
+      }),
+    };
+
+    const worker = new WA('test-agent', stubLlm, 'ws://localhost:9999', [dummyTool], undefined, false, undefined, 1);
+    await worker.start();
+
+    for await (const _event of worker.executeTask('run forever', undefined, undefined, 'task-min')) {
+      // drain
+    }
+
+    // 1 tool turn + 1 summary call after the budget is exhausted
+    expect((stubLlm.generate as jest.Mock).mock.calls.length).toBe(2);
+
+    jest.resetModules();
+  }, 15_000);
 });


### PR DESCRIPTION
## Summary

v2 follow-ups deferred from PR #536 (consensus `c9395068-202e4c5d`), verified fresh against master before implementation.

- **`gossip_setup` wiring**: the Zod `agents` schema now accepts `maxToolTurns` and persists it into both the native and custom `configAgents` write literals — previously hand-edit-only.
- **Ceiling raised [1,50] → [1,100]** via a shared exported `MAX_TOOL_TURNS_CEILING` constant in `apps/cli/src/config.ts`, imported by both `validateConfig` and the Zod schema so the two guards cannot drift. Rationale: deepseek-reasoner runs 60-74s/turn; multi-file cross-reviews need 40-55 turns. Default stays 15.
- **Test gaps closed**: integration test proving the `executeTask` loop terminates at the cap (`maxToolTurns:3` → exactly 3 tool turns + 1 summary call), minimal-boundary test (`maxToolTurns:1` → 2 LLM calls), boundary tests (1/100 accepted, 0/101 rejected), type-rejection tests (`2.5`, `'10'`), and `gossip_setup` persistence tests (native/custom/absent/base_url coexistence).
- **Docs**: stale "max 10 turns" header in `worker-agent.ts` corrected; merge-mode re-declare reset warning added to the Zod `.describe()`; low-budget warning-suppression note at the `WRAP_UP_AT`/`FINAL_AT` offsets.

## Consensus

@gossip:impact-adjacent (worker-agent.ts, config write path). consensus-id: 13a5b09f-1ba8449b (gemini-tester confirmed the integration-test design + suggested the maxToolTurns:1 boundary test, applied in ce4aca11) plus adversarial source review task `a262c205` (deepseek-challenger: merge-mode shallow-spread clobber → documented; project-initializer omission → deferred to v3 as enhancement; validation-alignment positively verified, no NaN/Infinity/float bypass). gemini-reviewer errored twice (provider-side `malformed_function_call` / `fetch failed`) — its slot was covered by the deepseek adversarial pass and orchestrator verification. All signals recorded with finding_ids.

## Test plan

- `npx jest tests/cli/config.test.ts tests/orchestrator/worker-agent.test.ts tests/cli/mcp-server-sdk.test.ts` → 66/66
- `npx tsc --noEmit -p tsconfig.json` → clean (pre-existing dashboard-v2 errors excluded)
- `npm run build` → full workspace clean

## Deferred to v3

- Propagate `maxToolTurns` through the archetype proposal pipeline (`project-initializer.ts:220`)
- Optional: per-agent deep-merge semantics for `gossip_setup mode='merge'` (currently whole-entry replace, now documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
