### PR TITLE
feat(isolation): #538 — worktree engagement detection + isolation-contract hardening

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -51,6 +51,26 @@ import { existsSync } from 'fs';
 export type PromptFormat = 'inline' | 'elided';
 
 /**
+ * Check whether `cwd` is inside a git repository.
+ *
+ * Used by all three dispatch paths (single, parallel, consensus) to gate
+ * worktree isolation: if the project is not a git repo, we silently downgrade
+ * `write_mode === 'worktree'` to a non-worktree dispatch and emit a visible
+ * warning so the operator knows isolation was not engaged.
+ *
+ * Exported for unit tests.
+ */
+export function isGitRepo(cwd: string): boolean {
+  try {
+    const { execSync } = require('child_process');
+    execSync('git rev-parse --git-dir', { cwd, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Stamp concurrency taint at dispatch time.
  *
  * If ANY existing entry in the map has `writeMode === 'worktree'`, mutate all
@@ -705,19 +725,25 @@ export async function handleDispatchSingle(
 
     // Only use worktree if explicitly requested AND project is a git repo
     let useWorktree = write_mode === 'worktree';
-    if (useWorktree) {
-      try {
-        const { execSync } = require('child_process');
-        execSync('git rev-parse --git-dir', { cwd: process.cwd(), stdio: 'ignore' });
-      } catch {
-        useWorktree = false; // not a git repo, skip worktree
-      }
+    let gitDowngradeReason: string | undefined;
+    if (useWorktree && !isGitRepo(process.cwd())) {
+      useWorktree = false;
+      gitDowngradeReason = 'not a git repository — worktree isolation unavailable';
+    }
+
+    // When we downgraded, record the effective mode back onto the nativeTaskMap
+    // entry (set above at L633, before this point) so the relay-receipt isolation
+    // checker can avoid false-positive alerts.
+    if (!useWorktree && write_mode === 'worktree') {
+      const info = ctx.nativeTaskMap.get(taskId);
+      if (info) info.effectiveWriteMode = 'sequential';
     }
 
     recordDispatchMetadata(process.cwd(), {
       taskId,
       agentId: agent_id,
       writeMode: write_mode,
+      effectiveWriteMode: useWorktree ? 'worktree' : (write_mode === 'worktree' ? 'sequential' : write_mode as any),
       scope,
       worktreePath: undefined,
       timestamp: Date.now(),
@@ -767,6 +793,7 @@ export async function handleDispatchSingle(
         `Task ID: ${taskId}\n` +
         `Agent: ${agent_id}\n` +
         `Model: ${nativeConfig.model}\n` +
+        (gitDowngradeReason ? `⚠️ Isolation downgraded: requested write_mode="worktree" but ${gitDowngradeReason}. Agent will run without worktree isolation.\n` : '') +
         (useWorktree ? `Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"\n\n` : `\n`) +
         promptInstruction +
         `Step 2 — REQUIRED after agent completes:\n` +
@@ -1143,7 +1170,17 @@ export async function handleDispatchParallel(
       ? parallelElision.marker
       : `<AGENT_PROMPT:${taskId} below>`;
 
-    const parallelUseWorktree = def.write_mode === 'worktree';
+    let parallelUseWorktree = def.write_mode === 'worktree';
+    if (parallelUseWorktree && !isGitRepo(process.cwd())) {
+      parallelUseWorktree = false;
+      parallelDispatchWarnings.push(
+        `Task ${taskId} (${def.agent_id}): requested write_mode="worktree" but not a git repository — isolation downgraded to sequential.`,
+      );
+      // Record effective mode on the nativeTaskMap entry so the relay-receipt
+      // isolation checker avoids false-positive alerts on this dispatch.
+      const parallelInfo = ctx.nativeTaskMap.get(taskId);
+      if (parallelInfo) parallelInfo.effectiveWriteMode = 'sequential';
+    }
     const parallelWorktreeBanner = parallelUseWorktree
       ? `\n  Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"`
       : '';
@@ -1449,7 +1486,17 @@ export async function handleDispatchConsensus(
     // Spec 2026-05-22: this consensus-dispatch site previously did NOT emit
     // isolation:"worktree" at all (latent gap from before write_mode existed in
     // the consensus path). Closing the gap and applying multi-line hardening.
-    const consensusUseWorktree = def.write_mode === 'worktree';
+    let consensusUseWorktree = def.write_mode === 'worktree';
+    if (consensusUseWorktree && !isGitRepo(process.cwd())) {
+      consensusUseWorktree = false;
+      dispatchWarnings.push(
+        `Task ${taskId} (${def.agent_id}): requested write_mode="worktree" but not a git repository — isolation downgraded to sequential.`,
+      );
+      // Record effective mode on the nativeTaskMap entry so the relay-receipt
+      // isolation checker avoids false-positive alerts on this dispatch.
+      const consensusInfo = ctx.nativeTaskMap.get(taskId);
+      if (consensusInfo) consensusInfo.effectiveWriteMode = 'sequential';
+    }
     const consensusWorktreeBanner = consensusUseWorktree
       ? `\n  Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"`
       : '';

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -149,7 +149,7 @@ export function taskWasInConsensusRound(
 /** Append one warning line to .gossip/relay-warnings.jsonl. Fail-open. */
 function appendRelayWarning(
   projectRoot: string,
-  entry: { taskId: string; agentId: string; reason: string; resultLength: number; suspectedReason: string; timestamp: string },
+  entry: { taskId: string; agentId: string; reason: string; resultLength: number; suspectedReason: string; timestamp: string; triageClass?: string; concurrentWorktreeTaint?: boolean },
 ): void {
   try {
     const { appendFileSync, mkdirSync } = require('fs');
@@ -159,6 +159,42 @@ function appendRelayWarning(
     appendFileSync(join(dir, RELAY_WARNINGS_FILE), JSON.stringify(entry) + '\n', 'utf8');
   } catch (err) {
     process.stderr.write(`[gossipcat] append relay-warning failed: ${(err as Error).message}\n`);
+  }
+}
+
+/**
+ * Check whether a worktree actually engaged for a `write_mode: "worktree"`
+ * native dispatch. Looks for an `agent-*` subdirectory under
+ * `.claude/worktrees/` whose mtime is >= the task's startedAt timestamp.
+ *
+ * Returns `true` when at least one candidate directory is found (engaged),
+ * `false` when the directory doesn't exist or has no fresh enough entries
+ * (engagement unknown — isolation may have been silently skipped).
+ *
+ * Exported for unit tests.
+ */
+export function checkWorktreeEngaged(startedAt: number, projectRoot: string = process.cwd()): boolean {
+  try {
+    const { readdirSync, statSync } = require('fs');
+    const { join } = require('path');
+    const wtDir = join(projectRoot, '.claude', 'worktrees');
+    let entries: string[];
+    try {
+      entries = readdirSync(wtDir) as string[];
+    } catch (err: any) {
+      if (err && err.code === 'ENOENT') return false; // directory doesn't exist → no worktrees
+      throw err;
+    }
+    for (const entry of entries) {
+      if (!entry.startsWith('agent-')) continue;
+      try {
+        const st = statSync(join(wtDir, entry));
+        if (st.isDirectory() && st.mtimeMs >= startedAt) return true;
+      } catch { /* skip unreadable entries */ }
+    }
+    return false;
+  } catch {
+    return false; // fail-open — engagement check never blocks relay
   }
 }
 
@@ -649,7 +685,11 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
   let isolationDiff:
     | { headChanged: boolean; dirtyPathsAdded: string[]; isViolation: boolean; excludedPaths?: string[] }
     | null = null;
-  if (taskInfo.writeMode === 'worktree' && taskInfo.isolationSnapshot) {
+  // Use effectiveWriteMode when present (set after git-repo downgrade at
+  // dispatch). Falls back to raw writeMode for old persisted entries that
+  // pre-date the effectiveWriteMode field.
+  const effectiveMode = taskInfo.effectiveWriteMode ?? taskInfo.writeMode;
+  if (effectiveMode === 'worktree' && taskInfo.isolationSnapshot) {
     try {
       // Operator-configured extra orchestrator-owned globs (spec 2026-06-09
       // Layer A, §3.4). Unioned with the built-in .gossip//.claude/ prefixes
@@ -679,6 +719,38 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
         orchestratorOwnedGlobs,
       );
     } catch { /* best-effort — detector must not block relay completion */ }
+  }
+
+  // Worktree engagement check (issue #538 item 1): when write_mode was
+  // effectively 'worktree' (i.e. not downgraded), verify that a worktree
+  // directory actually appeared after dispatch. Detection-only — does NOT
+  // fail the relay. Records a warning in the receipt text and in
+  // .gossip/relay-warnings.jsonl so operators can see silent engagement gaps.
+  let worktreeEngagementWarning = false;
+  if (effectiveMode === 'worktree' && !error) {
+    try {
+      const projectRoot = ctx.mainAgent?.projectRoot ?? process.cwd();
+      const engaged = checkWorktreeEngaged(taskInfo.startedAt, projectRoot);
+      if (!engaged) {
+        worktreeEngagementWarning = true;
+        appendRelayWarning(projectRoot, {
+          taskId: task_id,
+          agentId: taskInfo.agentId,
+          reason: 'worktree_engagement_unknown',
+          // 3-class triage (issue #538, GravyaDev): this event is the
+          // 'engage_gap_candidate' class — distinct from recovery-FP
+          // (orchestrator-owned dirty paths, handled by the isolation
+          // detector's owned-prefix exclusion) and deliberate non-isolation
+          // (downgrade path, recorded via effectiveWriteMode). The taint flag
+          // lets parallel-vs-sequential correlation be read off the ledger.
+          triageClass: 'engage_gap_candidate',
+          concurrentWorktreeTaint: taskInfo.concurrentWorktreeTaint === true,
+          resultLength: result?.length ?? 0,
+          suspectedReason: 'no_agent_worktree_dir_found_after_dispatch',
+          timestamp: new Date().toISOString(),
+        });
+      }
+    } catch { /* best-effort — engagement check never blocks relay completion */ }
   }
 
   // Worktree cleanup: on error, prune orphan gossip-wt-* worktrees whose task
@@ -1017,6 +1089,9 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
   }
   if (relayLintFired) {
     responseText += `\n⚠ relay_findings_dropped: result has 0 <agent_finding> tags but task was a consensus dispatch — orchestrator may have paraphrased; original tagged findings are lost from the dashboard.`;
+  }
+  if (worktreeEngagementWarning) {
+    responseText += `\n⚠ worktree_engagement_unknown: write_mode="worktree" dispatch but no agent- worktree directory found with mtime >= task startedAt — the Agent() call may have silently dropped isolation:"worktree". Run gossip_setup to (re-)register the sandbox hook; verify via .gossip/relay-warnings.jsonl.`;
   }
   // Base-rate audit (spec 2026-06-09 §3.1 / §8.2 item 5): record orchestrator-
   // owned paths excluded from attribution BEFORE the violation/revert decision,

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -189,12 +189,17 @@ export function checkWorktreeEngaged(startedAt: number, projectRoot: string = pr
       if (!entry.startsWith('agent-')) continue;
       try {
         const st = statSync(join(wtDir, entry));
-        if (st.isDirectory() && st.mtimeMs >= startedAt) return true;
+        // 2s backdate mirrors stampTaskSentinel (sandbox.ts): coarse-mtime
+        // filesystems can round a same-second creation below startedAt.
+        if (st.isDirectory() && st.mtimeMs >= startedAt - 2000) return true;
       } catch { /* skip unreadable entries */ }
     }
     return false;
-  } catch {
-    return false; // fail-open — engagement check never blocks relay
+  } catch (err) {
+    // fail-open — engagement check never blocks relay; log so persistent
+    // non-ENOENT failures (e.g. EACCES) stay diagnosable.
+    process.stderr.write(`[gossipcat] worktree engagement check failed: ${(err as Error).message}\n`);
+    return false;
   }
 }
 

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -55,6 +55,14 @@ export interface NativeTaskInfo {
   step?: number;
   utilityType?: 'lens' | 'gossip' | 'summary' | 'session_summary' | 'verify_memory' | 'skill_develop' | 'plan';
   writeMode?: 'sequential' | 'scoped' | 'worktree';
+  /**
+   * The effective write mode after runtime downgrade decisions (e.g. git-repo
+   * check at dispatch). When present, the relay-receipt isolation checker uses
+   * this instead of `writeMode` to avoid false-positive violation alerts on
+   * dispatches that were silently downgraded. Falls back to `writeMode` when
+   * absent (for old persisted entries restored from .gossip/native-tasks.json).
+   */
+  effectiveWriteMode?: 'sequential' | 'scoped' | 'worktree';
   /** One-time token that must accompany gossip_relay — prevents task-ID spoofing */
   relayToken?: string;
   /**

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1776,6 +1776,19 @@ export function createMcpServer(): McpServer {
         }
       } catch { /* auth-state.json not present — skip */ }
 
+      // Worktree-sandbox hook registration check (issue #538 item 4): when the
+      // hook script exists on disk but the PreToolUse settings.json entry is
+      // missing, emit a one-line warning so the operator knows to re-run
+      // gossip_setup. Silent when healthy (both present or both absent).
+      try {
+        const { existsSync: hookExists } = await import('fs');
+        const hookScriptPath = join(process.cwd(), '.claude', 'hooks', 'worktree-sandbox.sh');
+        const { isWorktreeSandboxHookRegistered } = await import('@gossip/orchestrator');
+        if (hookExists(hookScriptPath) && !isWorktreeSandboxHookRegistered(process.cwd())) {
+          lines.push('  ⚠️ Sandbox: worktree-sandbox hook installed but UNREGISTERED — run gossip_setup to re-register');
+        }
+      } catch { /* fail-open — hook check must never break status output */ }
+
       // Signals pending — recent consensus rounds with no manually-recorded signals.
       // Surfaces the back-search gap (per consensus 4c88bcd3, haiku:f17) so the
       // orchestrator can SEE which rounds it skipped without having to remember.
@@ -2354,7 +2367,9 @@ export function createMcpServer(): McpServer {
         const { installWorktreeSandboxHook, writeOrchestratorRoleMarker } = require('@gossip/orchestrator') as typeof import('@gossip/orchestrator');
         const hookResult = installWorktreeSandboxHook(root);
         hookSummary = hookResult.installed
-          ? 'Sandbox hook: .claude/hooks/worktree-sandbox.sh installed (Layer 2)'
+          ? (hookResult.action === 'already-registered'
+              ? 'Sandbox hook: already registered (Layer 2)'
+              : 'Sandbox hook: .claude/hooks/worktree-sandbox.sh registered (Layer 2)')
           : `Sandbox hook: skipped (${hookResult.reason ?? 'unknown'})`;
         // Issue #176: write orchestrator-role marker so the hook auto-exempts
         // the orchestrator when it cd's into a worktree. Idempotent no-op if

--- a/apps/cli/src/sandbox.ts
+++ b/apps/cli/src/sandbox.ts
@@ -46,6 +46,12 @@ export interface DispatchMetadata {
   taskId: string;
   agentId: string;
   writeMode?: DispatchWriteMode;
+  /**
+   * The effective write mode after runtime downgrade (e.g. non-git-repo
+   * causes worktree → sequential downgrade). When absent, falls back to
+   * writeMode for backward compatibility with old persisted entries.
+   */
+  effectiveWriteMode?: DispatchWriteMode;
   scope?: string;
   worktreePath?: string;
   timestamp: number;

--- a/packages/orchestrator/src/hook-installer.ts
+++ b/packages/orchestrator/src/hook-installer.ts
@@ -16,6 +16,13 @@ import { join, resolve, dirname } from 'path';
 
 export interface HookInstallResult {
   installed: boolean;
+  /**
+   * Distinguishes fresh registration from an idempotent no-op.
+   * Only present when `installed: true`.
+   *   - `"registered"` — hook entry was written to settings.json for the first time.
+   *   - `"already-registered"` — the exact command was already present; no write needed.
+   */
+  action?: 'registered' | 'already-registered';
   reason?: string;
 }
 
@@ -168,9 +175,41 @@ export function installWorktreeSandboxHook(projectRoot: string): HookInstallResu
       writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
     }
 
-    return { installed: true };
+    return { installed: true, action: mutated ? 'registered' : 'already-registered' };
   } catch (err) {
     return { installed: false, reason: (err as Error).message };
+  }
+}
+
+/**
+ * Check whether the worktree-sandbox PreToolUse hook entry is registered in
+ * `<projectRoot>/.claude/settings.json`. Used by gossip_status to emit a
+ * visible warning when the hook script exists on disk but the settings entry
+ * is missing (i.e. the hook was installed but the registration was lost, e.g.
+ * via settings.json reset or manual edit).
+ *
+ * Returns `true` when the exact HOOK_COMMAND is registered, `false` otherwise.
+ * Returns `false` (silently) on any IO or parse error — the status handler
+ * must fail-open.
+ */
+export function isWorktreeSandboxHookRegistered(projectRoot: string): boolean {
+  try {
+    const settingsPath = join(projectRoot, '.claude', 'settings.json');
+    let settings: Record<string, any>;
+    try {
+      settings = loadSettings(settingsPath);
+    } catch {
+      return false; // malformed → treat as not registered
+    }
+    const hooks = settings.hooks;
+    if (!hooks || !Array.isArray(hooks.PreToolUse)) return false;
+    for (const entry of hooks.PreToolUse) {
+      if (!entry || !Array.isArray(entry.hooks)) continue;
+      if (entry.hooks.some((h: any) => h && h.command === HOOK_COMMAND)) return true;
+    }
+    return false;
+  } catch {
+    return false;
   }
 }
 

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -90,7 +90,7 @@ export {
 export type { StalenessResult } from './dist-mcp-staleness';
 export type { BootstrapResult } from './bootstrap';
 export { findBundledRules, ensureRulesFile, readRulesContent } from './rules-loader';
-export { installWorktreeSandboxHook, findBundledHook, writeOrchestratorRoleMarker, installDisciplineHooks, installBootstrapHook, BOOTSTRAP_HOOK_COMMAND } from './hook-installer';
+export { installWorktreeSandboxHook, findBundledHook, writeOrchestratorRoleMarker, installDisciplineHooks, installBootstrapHook, BOOTSTRAP_HOOK_COMMAND, isWorktreeSandboxHookRegistered } from './hook-installer';
 export type { HookInstallResult, DisciplineHookInstallResult, BootstrapHookInstallResult } from './hook-installer';
 export { OverlapDetector } from './overlap-detector';
 export { LensGenerator } from './lens-generator';

--- a/packages/orchestrator/src/project-initializer.ts
+++ b/packages/orchestrator/src/project-initializer.ts
@@ -244,6 +244,10 @@ Respond with JSON:
           `[gossipcat] worktree sandbox hook skipped: ${hookResult.reason ?? 'unknown reason'}\n`,
         );
       } catch { /* best-effort logging */ }
+    } else if (hookResult.action === 'registered') {
+      try {
+        process.stderr.write('[gossipcat] worktree sandbox hook: registered in .claude/settings.json\n');
+      } catch { /* best-effort logging */ }
     }
   }
 

--- a/tests/cli/dispatch-git-repo-guard.test.ts
+++ b/tests/cli/dispatch-git-repo-guard.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for isGitRepo helper (issue #538 item 5).
+ *
+ * Also covers: effectiveWriteMode — downgraded dispatch does not trigger the
+ * isolation snapshot check (item 2d).
+ */
+
+import { isGitRepo } from '../../apps/cli/src/handlers/dispatch';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execSync } from 'child_process';
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'gossip-isgit-'));
+}
+
+describe('isGitRepo', () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    while (created.length) {
+      const dir = created.pop()!;
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+  });
+
+  it('returns false for a plain empty directory', () => {
+    const dir = makeTmpDir();
+    created.push(dir);
+    expect(isGitRepo(dir)).toBe(false);
+  });
+
+  it('returns false for a directory with arbitrary files but no .git', () => {
+    const dir = makeTmpDir();
+    created.push(dir);
+    writeFileSync(join(dir, 'file.txt'), 'hello');
+    expect(isGitRepo(dir)).toBe(false);
+  });
+
+  it('returns true for an initialized git repo', () => {
+    const dir = makeTmpDir();
+    created.push(dir);
+    try {
+      execSync('git init', { cwd: dir, stdio: 'ignore' });
+      expect(isGitRepo(dir)).toBe(true);
+    } catch {
+      // If git is unavailable in the test environment, skip gracefully.
+      console.warn('git not available, skipping isGitRepo(true) test');
+    }
+  });
+
+  it('returns false for a non-existent path without throwing', () => {
+    expect(isGitRepo('/non-existent-path-for-gossip-test')).toBe(false);
+  });
+});
+
+describe('effectiveWriteMode isolation skip', () => {
+  /**
+   * Verify the contract: when effectiveWriteMode is 'sequential' (downgraded from
+   * 'worktree'), the relay-receipt isolation checker does NOT trigger.
+   *
+   * We test this by inspecting the logic branch condition directly, since
+   * handleNativeRelay is deep infra. The guard is:
+   *   const effectiveMode = taskInfo.effectiveWriteMode ?? taskInfo.writeMode;
+   *   if (effectiveMode === 'worktree' && taskInfo.isolationSnapshot) { ... }
+   *
+   * A task with writeMode='worktree' + effectiveWriteMode='sequential' must
+   * produce effectiveMode='sequential', so the if-branch is NOT taken.
+   */
+  it('effectiveWriteMode overrides writeMode for guard evaluation', () => {
+    const taskInfo: { writeMode: string; effectiveWriteMode?: string; isolationSnapshot: object } = {
+      writeMode: 'worktree',
+      effectiveWriteMode: 'sequential',
+      isolationSnapshot: { head: 'abc', dirty: [], takenAt: new Date().toISOString() },
+    };
+    const effectiveMode = taskInfo.effectiveWriteMode ?? taskInfo.writeMode;
+    expect(effectiveMode).toBe('sequential');
+    // The isolation check condition evaluates false when downgraded
+    expect(effectiveMode === 'worktree' && !!taskInfo.isolationSnapshot).toBe(false);
+  });
+
+  it('falls back to writeMode when effectiveWriteMode is absent (backward compat)', () => {
+    const taskInfo: { writeMode: 'worktree'; effectiveWriteMode?: string; isolationSnapshot: object } = {
+      writeMode: 'worktree' as const,
+      // effectiveWriteMode absent — simulates old persisted entry
+      isolationSnapshot: { head: 'abc', dirty: [], takenAt: new Date().toISOString() },
+    };
+    const effectiveMode = taskInfo.effectiveWriteMode ?? taskInfo.writeMode;
+    expect(effectiveMode).toBe('worktree');
+    expect(effectiveMode === 'worktree' && !!taskInfo.isolationSnapshot).toBe(true);
+  });
+});

--- a/tests/cli/dispatch-native-prompt.test.ts
+++ b/tests/cli/dispatch-native-prompt.test.ts
@@ -979,3 +979,38 @@ describe('worktree-isolation prompt hardening (spec 2026-05-22)', () => {
     expect(promptFile.startsWith('// GOSSIP_ISOLATION')).toBe(false);
   });
 });
+
+describe('native dispatch — git-downgrade warning text (issue #538 item 2)', () => {
+  let testDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    // mkdtemp under os.tmpdir() — NOT a git repo, so write_mode:"worktree"
+    // must downgrade and the warning text must appear in the banner.
+    testDir = mkdtempSync(join(tmpdir(), 'gossip-downgrade-warn-'));
+    mkdirSync(join(testDir, '.gossip', 'skills'), { recursive: true });
+    process.chdir(testDir);
+    resetCtx();
+  });
+
+  afterEach(() => {
+    restoreCtx();
+    process.chdir(prevCwd);
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('handleDispatchSingle banner carries the Isolation downgraded warning and omits the isolation flag', async () => {
+    ctx.nativeAgentConfigs.set('native-claude', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Native reviewer',
+      skills: [],
+    });
+
+    const result = await handleDispatchSingle('native-claude', 'Implement a thing', 'worktree');
+    const banner = (result.content[0] as { text: string }).text;
+    expect(banner).toContain('Isolation downgraded');
+    expect(banner).not.toContain('isolation: "worktree"');
+  });
+});

--- a/tests/cli/relay-isolation-warning.test.ts
+++ b/tests/cli/relay-isolation-warning.test.ts
@@ -415,3 +415,49 @@ describe('handleNativeRelay — worktree isolation warning integration', () => {
     expect(skippedEntry.reason).toBe('worktree_isolation_skipped');
   });
 });
+
+describe('handleNativeRelay — worktree engagement warning (issue #538)', () => {
+  it('appends worktree_engagement_unknown to receipt and ledger when no fresh agent worktree exists', async () => {
+    seedWorktreeTask(TASK_ID, AGENT_ID, { withSnapshot: false, concurrentWorktreeTaint: true });
+    // testDir has no .claude/worktrees at all → engagement unknown
+
+    const res = await handleNativeRelay(TASK_ID, 'task complete');
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain('worktree_engagement_unknown');
+
+    const { readFileSync } = require('fs');
+    const raw = readFileSync(join(testDir, '.gossip', 'relay-warnings.jsonl'), 'utf8').trim();
+    const evt = raw.split('\n').filter(Boolean)
+      .map((l: string) => JSON.parse(l))
+      .find((e: any) => e.reason === 'worktree_engagement_unknown');
+    expect(evt).toBeDefined();
+    expect(evt.taskId).toBe(TASK_ID);
+    expect(evt.triageClass).toBe('engage_gap_candidate');
+    expect(evt.concurrentWorktreeTaint).toBe(true);
+  });
+
+  it('stays silent when a fresh agent worktree directory exists', async () => {
+    const { mkdirSync } = require('fs');
+    seedWorktreeTask('iso-task-engaged', AGENT_ID, { withSnapshot: false });
+    mkdirSync(join(testDir, '.claude', 'worktrees', 'agent-fresh-xyz'), { recursive: true });
+
+    const res = await handleNativeRelay('iso-task-engaged', 'task complete');
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).not.toContain('worktree_engagement_unknown');
+  });
+
+  it('does not run the engagement check for downgraded dispatches (effectiveWriteMode sequential)', async () => {
+    ctx.nativeTaskMap.set('iso-task-downgraded', {
+      agentId: AGENT_ID,
+      task: 'downgraded task',
+      startedAt: Date.now() - 1000,
+      timeoutMs: 120_000,
+      writeMode: 'worktree',
+      effectiveWriteMode: 'sequential',
+    } as any);
+
+    const res = await handleNativeRelay('iso-task-downgraded', 'task complete');
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).not.toContain('worktree_engagement_unknown');
+  });
+});

--- a/tests/cli/worktree-engagement-check.test.ts
+++ b/tests/cli/worktree-engagement-check.test.ts
@@ -86,10 +86,38 @@ describe('checkWorktreeEngaged', () => {
     // Create a file (not a directory) named agent-xyz
     writeFileSync(join(root, '.claude', 'worktrees', 'agent-file'), 'not a dir');
     const startedAt = Date.now() - 1000;
-    // A file stat will still succeed but we require isDirectory() to be true
-    // — actually the implementation uses statSync without isDirectory check,
-    // so this tests the current behaviour: any stat with fresh mtime returns true.
-    // Update: implementation checks isDirectory() — file should NOT match.
+    // A fresh-mtime FILE must not count as an engaged worktree.
+    expect(checkWorktreeEngaged(startedAt, root)).toBe(false);
+  });
+
+  it('returns false when .claude/worktrees exists but is empty', () => {
+    const root = makeTmpDir();
+    created.push(root);
+    mkdirSync(join(root, '.claude', 'worktrees'), { recursive: true });
+    expect(checkWorktreeEngaged(Date.now(), root)).toBe(false);
+  });
+
+  it('tolerates up to 2s of filesystem mtime granularity (backdate window)', () => {
+    const root = makeTmpDir();
+    created.push(root);
+    const wtDir = join(root, '.claude', 'worktrees', 'agent-coarse');
+    mkdirSync(wtDir, { recursive: true });
+    // Entry mtime 1.5s BEFORE startedAt — within the 2s tolerance, so it
+    // still counts as engaged (mirrors the stampTaskSentinel backdate).
+    const startedAt = Date.now();
+    const justBefore = new Date(startedAt - 1500);
+    utimesSync(wtDir, justBefore, justBefore);
+    expect(checkWorktreeEngaged(startedAt, root)).toBe(true);
+  });
+
+  it('stays stale beyond the 2s tolerance window', () => {
+    const root = makeTmpDir();
+    created.push(root);
+    const wtDir = join(root, '.claude', 'worktrees', 'agent-too-old');
+    mkdirSync(wtDir, { recursive: true });
+    const startedAt = Date.now();
+    const beyond = new Date(startedAt - 3500);
+    utimesSync(wtDir, beyond, beyond);
     expect(checkWorktreeEngaged(startedAt, root)).toBe(false);
   });
 });

--- a/tests/cli/worktree-engagement-check.test.ts
+++ b/tests/cli/worktree-engagement-check.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for checkWorktreeEngaged — the post-relay detector that verifies
+ * whether a write_mode:"worktree" dispatch actually engaged a worktree.
+ *
+ * Issue #538 item 1.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, utimesSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { checkWorktreeEngaged } from '../../apps/cli/src/handlers/native-tasks';
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'gossip-wt-engage-'));
+}
+
+describe('checkWorktreeEngaged', () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    while (created.length) {
+      const dir = created.pop()!;
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+  });
+
+  it('returns false when .claude/worktrees directory does not exist', () => {
+    const root = makeTmpDir();
+    created.push(root);
+    // No .claude/worktrees created
+    expect(checkWorktreeEngaged(Date.now(), root)).toBe(false);
+  });
+
+  it('returns false when .claude/worktrees dir exists but has no agent- entries', () => {
+    const root = makeTmpDir();
+    created.push(root);
+    mkdirSync(join(root, '.claude', 'worktrees'), { recursive: true });
+    // Only a non-agent entry
+    mkdirSync(join(root, '.claude', 'worktrees', 'other-dir'), { recursive: true });
+    expect(checkWorktreeEngaged(Date.now(), root)).toBe(false);
+  });
+
+  it('returns false when all agent- entries have mtime before startedAt', () => {
+    const root = makeTmpDir();
+    created.push(root);
+    const wtDir = join(root, '.claude', 'worktrees', 'agent-old123');
+    mkdirSync(wtDir, { recursive: true });
+    // Back-date mtime to 10 seconds ago
+    const tenSecondsAgo = new Date(Date.now() - 10_000);
+    utimesSync(wtDir, tenSecondsAgo, tenSecondsAgo);
+    // startedAt is "now" — so the old entry is stale
+    expect(checkWorktreeEngaged(Date.now(), root)).toBe(false);
+  });
+
+  it('returns true when an agent- entry has mtime >= startedAt', () => {
+    const root = makeTmpDir();
+    created.push(root);
+    const startedAt = Date.now() - 1000; // 1 second ago
+    const wtDir = join(root, '.claude', 'worktrees', 'agent-fresh456');
+    mkdirSync(wtDir, { recursive: true });
+    // mtime is "now" (fresh) — stat after mkdir is always >= startedAt
+    expect(checkWorktreeEngaged(startedAt, root)).toBe(true);
+  });
+
+  it('returns true when one entry is fresh even if another is stale', () => {
+    const root = makeTmpDir();
+    created.push(root);
+    const startedAt = Date.now() - 2000;
+
+    // Stale entry
+    const staleDir = join(root, '.claude', 'worktrees', 'agent-stale');
+    mkdirSync(staleDir, { recursive: true });
+    const veryOld = new Date(startedAt - 10_000);
+    utimesSync(staleDir, veryOld, veryOld);
+
+    // Fresh entry
+    mkdirSync(join(root, '.claude', 'worktrees', 'agent-fresh'), { recursive: true });
+
+    expect(checkWorktreeEngaged(startedAt, root)).toBe(true);
+  });
+
+  it('ignores non-directory agent- entries', () => {
+    const root = makeTmpDir();
+    created.push(root);
+    mkdirSync(join(root, '.claude', 'worktrees'), { recursive: true });
+    // Create a file (not a directory) named agent-xyz
+    writeFileSync(join(root, '.claude', 'worktrees', 'agent-file'), 'not a dir');
+    const startedAt = Date.now() - 1000;
+    // A file stat will still succeed but we require isDirectory() to be true
+    // — actually the implementation uses statSync without isDirectory check,
+    // so this tests the current behaviour: any stat with fresh mtime returns true.
+    // Update: implementation checks isDirectory() — file should NOT match.
+    expect(checkWorktreeEngaged(startedAt, root)).toBe(false);
+  });
+});

--- a/tests/orchestrator/hook-installer.test.ts
+++ b/tests/orchestrator/hook-installer.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os';
 import {
   installWorktreeSandboxHook,
   findBundledHook,
+  isWorktreeSandboxHookRegistered,
 } from '../../packages/orchestrator/src/hook-installer';
 
 const HOOK_COMMAND = '$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-sandbox.sh';
@@ -135,5 +136,78 @@ describe('installWorktreeSandboxHook', () => {
     // File must be byte-identical to malformed input — zero data loss.
     const after = readFileSync(join(root, '.claude', 'settings.json'), 'utf-8');
     expect(after).toBe(malformed);
+  });
+
+  // ── action field disambiguation (issue #538 item 3) ────────────────────────
+
+  it('returns action:"registered" on fresh install', () => {
+    const root = makeTmpProject();
+    created.push(root);
+
+    const result = installWorktreeSandboxHook(root);
+    expect(result.installed).toBe(true);
+    expect(result.action).toBe('registered');
+  });
+
+  it('returns action:"already-registered" on second call (idempotent)', () => {
+    const root = makeTmpProject();
+    created.push(root);
+
+    installWorktreeSandboxHook(root);
+    const second = installWorktreeSandboxHook(root);
+    expect(second.installed).toBe(true);
+    expect(second.action).toBe('already-registered');
+  });
+
+  it('returns installed:false with no action field on malformed settings', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    require('fs').mkdirSync(join(root, '.claude'), { recursive: true });
+    writeFileSync(join(root, '.claude', 'settings.json'), '{bad json');
+
+    const result = installWorktreeSandboxHook(root);
+    expect(result.installed).toBe(false);
+    expect(result.action).toBeUndefined();
+    expect(typeof result.reason).toBe('string');
+  });
+});
+
+describe('isWorktreeSandboxHookRegistered', () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    while (created.length) {
+      const dir = created.pop()!;
+      try { require('fs').rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+  });
+
+  it('returns false when settings.json does not exist', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    expect(isWorktreeSandboxHookRegistered(root)).toBe(false);
+  });
+
+  it('returns false when settings.json exists but has no PreToolUse hook', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    require('fs').mkdirSync(join(root, '.claude'), { recursive: true });
+    writeFileSync(join(root, '.claude', 'settings.json'), JSON.stringify({ hooks: {} }));
+    expect(isWorktreeSandboxHookRegistered(root)).toBe(false);
+  });
+
+  it('returns true after installWorktreeSandboxHook registers the entry', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    installWorktreeSandboxHook(root);
+    expect(isWorktreeSandboxHookRegistered(root)).toBe(true);
+  });
+
+  it('returns false on malformed settings.json', () => {
+    const root = makeTmpProject();
+    created.push(root);
+    require('fs').mkdirSync(join(root, '.claude'), { recursive: true });
+    writeFileSync(join(root, '.claude', 'settings.json'), '{not json');
+    expect(isWorktreeSandboxHookRegistered(root)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Detection instrument + hardening package from the issue #538 investigation (two-agent root-cause analysis + GravyaDev's independent negative repro — see the issue thread). The true engage-gap remains unreproduced; this PR builds the missing instrument so any future occurrence leaves a ledger record instead of silence, and removes the adjacent silent-failure modes.

- **Worktree engagement check** — `checkWorktreeEngaged` runs at relay time for worktree-mode native dispatches; when no fresh `agent-*` worktree exists, the relay receipt gains a `worktree_engagement_unknown` line and `.gossip/relay-warnings.jsonl` gets a structured event carrying `triageClass: 'engage_gap_candidate'` and `concurrentWorktreeTaint` (the 3-class triage from the issue discussion: engage-gap candidate vs recovery-FP vs deliberate non-isolation). Detection-only, fail-open, 2s mtime backdate mirroring the `stampTaskSentinel` filesystem-granularity precedent.
- **Silent git-downgrade made visible** — `effectiveWriteMode` recorded in `NativeTaskInfo` + `DispatchMetadata`; relay isolation checker gates on `effectiveWriteMode ?? writeMode` (kills the false-positive violation alerts for downgraded dispatches; old persisted entries fall back); `⚠️ Isolation downgraded` warning in the dispatch banner.
- **Hook-installer disambiguation** — `installWorktreeSandboxHook` returns `action: 'registered' | 'already-registered'`; `gossip_status` warns when the hook script exists on disk but is UNREGISTERED in settings.json (the exact pre-#501 inert-hook mechanism).
- **`isGitRepo` guard** applied to single, parallel, AND consensus dispatch paths (parallel/consensus previously emitted the worktree instruction even in non-git dirs).

**Known limitation (documented, accepted for v1):** the engagement check passes if ANY `agent-*` dir is fresh — a concurrent sibling's worktree can suppress the warning for a task that truly didn't engage. The `concurrentWorktreeTaint` flag on the event marks exactly these ambiguous windows for triage. Per-task worktree naming is not observable from gossipcat today (harness assigns the dir name).

## Consensus

@gossip:impact-adjacent (dispatch.ts, native-tasks.ts). consensus-id: 840fcedf-c450408e — 1 confirmed, 2 disputed-then-orchestrator-verified-REAL (both gemini-reviewer findings were disputed from stale master anchors and verified correct on the branch; disagreement signals recorded against the cross-reviewers), 1 unverified-then-verified. All four findings + the test-gap insight are fixed in dcb76c70. deepseek-challenger output truncated mid-tool-call (second occurrence today — tracked separately).

## Test plan

- 1073 passed across `tests/cli/` + hook-installer suite (16 new unit tests + 4 integration tests for receipt/banner text)
- `npx tsc --noEmit` clean (pre-existing dashboard-v2 errors excluded)
- `npm run build` full workspace clean

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)