### PR TITLE
fix(consensus): thread per-round resolutionRoots through the all-relay path

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -448,8 +448,22 @@ export async function handleCollect(
     }
 
     if (nativeAgentIds.size === 0) {
-      // All relay — use existing path (each agent cross-reviewed by its own LLM)
-      consensusReport = await ctx.mainAgent.runConsensus(allResults);
+      // All relay — use existing path (each agent cross-reviewed by its own LLM).
+      // Thread the collect-validated roots through so a zero-native round still
+      // pins <anchor> resolution to the feature-branch worktree instead of
+      // master HEAD. Without this the round builds ConsensusEngine with
+      // resolutionRoots:undefined → empty currentWorktreeRoots → every anchor
+      // resolves against project root and the rootless-degraded warning is
+      // structurally suppressed (recurrence of the #389 stale-anchor class).
+      // effectiveRoots is block-scoped to the native-present branch below, so
+      // recompute here from the collect-validated input (auto-discovery is
+      // discovery-only and never augments effectiveRoots — collect.ts:483-486).
+      const allRelayRoots: readonly string[] = resolutionRoots ?? [];
+      outerEffectiveRoots = allRelayRoots;
+      consensusReport = await ctx.mainAgent.runConsensus(
+        allResults,
+        allRelayRoots.length > 0 ? allRelayRoots : undefined,
+      );
     } else {
       // Two-phase flow: relay agents cross-reviewed inline, native agents get prompts returned
       const { ConsensusEngine, createProvider } = await import('@gossip/orchestrator');

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -418,7 +418,14 @@ function prependResolutionRootWarning<T extends { content: Array<{ type: 'text';
   rejectedReasons: readonly string[],
 ): T {
   if (!rejectedReasons || rejectedReasons.length === 0) return result;
-  const reasons = Array.from(new Set(rejectedReasons)).join('; ');
+  // Render each distinct reason with its count so the raw rejected total and
+  // the per-reason breakdown agree (e.g. "3 entry(ies) rejected (not found ×3)").
+  // A bare Set dedup hides how many entries shared a reason.
+  const counts = new Map<string, number>();
+  for (const r of rejectedReasons) counts.set(r, (counts.get(r) ?? 0) + 1);
+  const reasons = Array.from(counts.entries())
+    .map(([reason, n]) => (n > 1 ? `${reason} ×${n}` : reason))
+    .join('; ');
   const warning = {
     type: 'text' as const,
     text: `⚠ resolutionRoots: ${rejectedReasons.length} entry(ies) rejected (${reasons}) — anchors will resolve against project root`,

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -405,6 +405,27 @@ function lookupFindingSeverity(findingId: string, projectRoot: string): string |
   return null;
 }
 
+/**
+ * Item 3a — surface non-fatal resolutionRoots rejections in the tool RESPONSE,
+ * not just stderr. When validateResolutionRoot drops an entry non-fatally, the
+ * round proceeds with fewer (or zero) roots and anchors silently resolve
+ * against project root. Prepend a visible warning line so the operator can
+ * correct the input before stale-anchor false disputes occur (the #389 class).
+ * No-op when nothing was rejected, preserving existing response bytes.
+ */
+function prependResolutionRootWarning<T extends { content: Array<{ type: 'text'; text: string }> }>(
+  result: T,
+  rejectedReasons: readonly string[],
+): T {
+  if (!rejectedReasons || rejectedReasons.length === 0) return result;
+  const reasons = Array.from(new Set(rejectedReasons)).join('; ');
+  const warning = {
+    type: 'text' as const,
+    text: `⚠ resolutionRoots: ${rejectedReasons.length} entry(ies) rejected (${reasons}) — anchors will resolve against project root`,
+  };
+  return { ...result, content: [warning, ...result.content] };
+}
+
 async function getModules() {
   if (_modules) return _modules;
   _modules = {
@@ -1496,6 +1517,9 @@ export function createMcpServer(): McpServer {
       // #126 PR-B: validate resolutionRoots at the MCP boundary. Fatal (NUL /
       // control char) outcomes REJECT the round — do not dispatch.
       let validatedDispatchRoots: string[] = [];
+      // Non-fatal rejection reasons surfaced in the response (item 3a) so a
+      // dropped dispatch-time root is visible to the operator, not stderr-only.
+      const rejectedRootReasons: string[] = [];
       if (resolutionRoots && resolutionRoots.length > 0) {
         const { validateResolutionRoot } = await import('@gossip/orchestrator');
         for (const raw of resolutionRoots) {
@@ -1507,6 +1531,7 @@ export function createMcpServer(): McpServer {
             planExecutionDepth--;
             return { content: [{ type: 'text' as const, text: `Error: resolutionRoots REJECTED ROUND (adversarial input): ${r.reason} [${r.hashedInput}]` }] };
           } else {
+            rejectedRootReasons.push(r.reason ?? 'unknown');
             process.stderr.write(`[consensus] resolutionRoots rejected: ${r.reason} [${r.hashedInput}]\n`);
           }
         }
@@ -1519,27 +1544,30 @@ export function createMcpServer(): McpServer {
           // Spec docs/specs/2026-04-29-relay-worker-resolution-roots.md — forward
           // validatedDispatchRoots so a single-mode relay agent (e.g. gemini-tester
           // dispatched solo against a PR worktree) gets its tool-call cwd pinned.
-          return handleDispatchSingle(
+          return prependResolutionRootWarning(await handleDispatchSingle(
             agent_id, task, write_mode, scope, timeout_ms, plan_id, step,
             validatedDispatchRoots.length > 0 ? validatedDispatchRoots : undefined,
             prompt_format,
-          );
+          ), rejectedRootReasons);
         }
         if (mode === 'parallel') {
           if (!tasks || tasks.length === 0) {
             return { content: [{ type: 'text' as const, text: 'Error: mode:"parallel" requires a non-empty tasks array.' }] };
           }
-          return handleDispatchParallel(
+          return prependResolutionRootWarning(await handleDispatchParallel(
             tasks, false,
             validatedDispatchRoots.length > 0 ? validatedDispatchRoots : undefined,
             prompt_format,
-          );
+          ), rejectedRootReasons);
         }
         if (mode === 'consensus') {
           if (!tasks || tasks.length === 0) {
             return { content: [{ type: 'text' as const, text: 'Error: mode:"consensus" requires a non-empty tasks array.' }] };
           }
-          return handleDispatchConsensus(tasks, _utility_task_id, validatedDispatchRoots.length > 0 ? validatedDispatchRoots : undefined, prompt_format);
+          return prependResolutionRootWarning(
+            await handleDispatchConsensus(tasks, _utility_task_id, validatedDispatchRoots.length > 0 ? validatedDispatchRoots : undefined, prompt_format),
+            rejectedRootReasons,
+          );
         }
         return { content: [{ type: 'text' as const, text: `Unknown mode: ${mode}` }] };
       } finally {
@@ -1571,6 +1599,11 @@ export function createMcpServer(): McpServer {
     async ({ task_ids, timeout_ms, consensus, resolutionRoots, prompt_format }) => {
       // Validate at MCP boundary. Fatal (NUL / control char) REJECTS the round.
       let validated: string[] | undefined;
+      // Non-fatal rejection reasons collected for response-surfacing (item 3a):
+      // these previously went to stderr only, so an operator never saw that
+      // their worktree roots were silently dropped → anchors resolved against
+      // project root → stale-anchor false disputes.
+      const rejectedRootReasons: string[] = [];
       if (resolutionRoots && resolutionRoots.length > 0) {
         const { validateResolutionRoot } = await import('@gossip/orchestrator');
         const out: string[] = [];
@@ -1582,6 +1615,7 @@ export function createMcpServer(): McpServer {
           } else if (r.fatal) {
             return { content: [{ type: 'text' as const, text: `Error: resolutionRoots REJECTED ROUND (adversarial input): ${r.reason} [${r.hashedInput}]` }] };
           } else {
+            rejectedRootReasons.push(r.reason ?? 'unknown');
             process.stderr.write(`[consensus] resolutionRoots rejected: ${r.reason} [${r.hashedInput}]\n`);
           }
         }
@@ -1605,7 +1639,8 @@ export function createMcpServer(): McpServer {
           for (const tid of task_ids) ctx.pendingDispatchResolutionRoots.delete(tid);
         }
       }
-      return handleCollect(task_ids, timeout_ms, consensus, validated, prompt_format);
+      const collectResult = await handleCollect(task_ids, timeout_ms, consensus, validated, prompt_format);
+      return prependResolutionRootWarning(collectResult, rejectedRootReasons);
     }
   );
 

--- a/packages/orchestrator/src/consensus-coordinator.ts
+++ b/packages/orchestrator/src/consensus-coordinator.ts
@@ -40,7 +40,7 @@ export class ConsensusCoordinator {
 
   private currentPhase: ConsensusPhase = 'idle';
 
-  readonly sessionConsensusHistory: Array<{ timestamp: string; confirmed: number; disputed: number; unverified: number; unique: number; newFindings?: number; agents?: string[]; summary: string }> = [];
+  readonly sessionConsensusHistory: Array<{ timestamp: string; confirmed: number; disputed: number; unverified: number; unique: number; newFindings?: number; agents?: string[]; summary: string; resolutionRoots?: string[] }> = [];
 
   constructor(config: ConsensusCoordinatorConfig) {
     this.llm = config.llm;
@@ -180,7 +180,7 @@ export class ConsensusCoordinator {
           }));
           const participants = new Set(results.filter(r => r.status === 'completed').map(r => r.agentId));
           for (const agentId of participants) {
-            this.memWriter.writeConsensusKnowledge(agentId, findings, this.resolutionRoots ? [...this.resolutionRoots] : undefined, consensusId);
+            this.memWriter.writeConsensusKnowledge(agentId, findings, (effectiveResolutionRoots && effectiveResolutionRoots.length > 0) ? [...effectiveResolutionRoots] : undefined, consensusId);
           }
           for (const agentId of participants) {
             try { this.memWriter.rebuildIndex(agentId); } catch { /* best-effort */ }
@@ -198,6 +198,12 @@ export class ConsensusCoordinator {
         newFindings: consensusReport.newFindings?.length ?? 0,
         agents: results.filter(r => r.status === 'completed').map(r => r.agentId),
         summary: consensusReport.summary.slice(0, 2000),
+        // Per-round audit trail: which resolution roots anchored this round's
+        // citations (the effective set, not the constructor default). undefined
+        // when the round ran with no roots (resolved against project root only).
+        resolutionRoots: (effectiveResolutionRoots && effectiveResolutionRoots.length > 0)
+          ? [...effectiveResolutionRoots]
+          : undefined,
       };
       this.sessionConsensusHistory.push(historyEntry);
 

--- a/packages/orchestrator/src/consensus-coordinator.ts
+++ b/packages/orchestrator/src/consensus-coordinator.ts
@@ -64,8 +64,20 @@ export class ConsensusCoordinator {
     return this.currentPhase;
   }
 
-  async runConsensus(results: TaskEntry[]): Promise<ConsensusReport | undefined> {
+  /**
+   * @param perRoundRoots Optional collect-time resolution roots (already
+   *   validated at the MCP boundary). When non-empty these OVERRIDE the
+   *   constructor default `this.resolutionRoots`, mirroring the "collect-time
+   *   REPLACES dispatch-time" spec semantics (collect.ts:478-487). Threaded
+   *   through the all-relay consensus path so a zero-native round still pins
+   *   anchors to the feature-branch worktree instead of master HEAD.
+   */
+  async runConsensus(results: TaskEntry[], perRoundRoots?: readonly string[]): Promise<ConsensusReport | undefined> {
     if (!this.llm || results.filter(r => r.status === 'completed').length < 2) return undefined;
+
+    const effectiveResolutionRoots = (perRoundRoots && perRoundRoots.length > 0)
+      ? perRoundRoots
+      : this.resolutionRoots;
 
     try {
       this.currentPhase = 'review';
@@ -98,7 +110,7 @@ export class ConsensusCoordinator {
         projectRoot: this.projectRoot,
         agentLlm,
         getAgentSkillsContent: this.getAgentSkillsContent,
-        resolutionRoots: this.resolutionRoots,
+        resolutionRoots: effectiveResolutionRoots,
       });
       const consensusReport = await engine.run(results);
       this.currentPhase = 'cross_review';

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -232,6 +232,18 @@ export class ConsensusEngine {
       if (wt && typeof wt === 'string') {
         next.add(resolve(wt));
       }
+      // Defense-in-depth: per-task resolutionRoots are stamped on the TaskEntry
+      // at dispatch time (dispatch-pipeline.ts:406-408) but were otherwise
+      // ignored here. Union them so a round whose roots only ever lived on the
+      // task entries (not on worktreeInfo and not on config.resolutionRoots)
+      // still anchors citations correctly. Same validation/dedup as the
+      // worktreeInfo and extraRoots entries (non-empty string → resolve()).
+      const taskRoots = r.resolutionRoots;
+      if (taskRoots) {
+        for (const p of taskRoots) {
+          if (typeof p === 'string' && p.length > 0) next.add(resolve(p));
+        }
+      }
     }
     // extraRoots arrive post-validation (realpath'd absolute paths from
     // validateResolutionRoot + optional discovery). Union into `next` so
@@ -278,6 +290,25 @@ export class ConsensusEngine {
       this.fileCache.clear();
       this.anchorPathCache.clear();
       this.anchorWarnedRefs.clear();
+    }
+  }
+
+  /**
+   * Loud-fail observability for the rootless-degraded state: when the round was
+   * constructed WITH resolutionRoots but they all dropped during validation /
+   * union (currentWorktreeRoots ended up empty), every <anchor> silently
+   * resolves against project root and isResolvedFromProjectRootOnly is
+   * structurally suppressed. Surface that on stderr so the regression is
+   * visible at cross-review time. Does NOT alter isResolvedFromProjectRootOnly.
+   */
+  private warnIfRootsDroppedToEmpty(): void {
+    const declared = this.config.resolutionRoots;
+    if (declared && declared.length > 0 && this.currentWorktreeRoots.size === 0) {
+      process.stderr.write(
+        `[consensus] ⚠ resolutionRoots: ${declared.length} root(s) declared but 0 resolved ` +
+        `(all dropped during validation) — every anchor will resolve against project root, ` +
+        `NOT the feature-branch worktree. Stale-anchor false disputes likely.\n`,
+      );
     }
   }
 
@@ -465,6 +496,7 @@ export class ConsensusEngine {
     const consensusStart = Date.now();
     _log('consensus', `Starting cross-review for ${successful.length} agents`);
     this.updateWorktreeRoots(results, this.config.resolutionRoots);
+    this.warnIfRootsDroppedToEmpty();
     // Generate consensusId ONCE per round and thread it through cross-review
     // and synthesize so NEW findingIds rewritten in crossReviewForAgent match
     // the consensusId used by synthesize's signal/finding id assembly.

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -1,7 +1,7 @@
 import { readFile, readdir, stat } from 'fs/promises';
 import { mkdirSync, writeFileSync, realpathSync } from 'fs';
 import { randomUUID } from 'crypto';
-import { join, resolve, dirname, relative, sep } from 'path';
+import { join, resolve, dirname, relative, sep, isAbsolute } from 'path';
 import { log as _log } from './log';
 
 /** Generate a short consensus round ID: xxxxxxxx-xxxxxxxx (17 chars from UUID) */
@@ -241,7 +241,11 @@ export class ConsensusEngine {
       const taskRoots = r.resolutionRoots;
       if (taskRoots) {
         for (const p of taskRoots) {
-          if (typeof p === 'string' && p.length > 0) next.add(resolve(p));
+          // Mirror the constructor's absolute-path discipline as
+          // defense-in-depth. TaskEntry roots are post-validation, but unlike
+          // the constructor (programmer-error contract → throw) this path
+          // fails soft: silently skip non-absolute entries rather than throw.
+          if (typeof p === 'string' && p.length > 0 && isAbsolute(p)) next.add(resolve(p));
         }
       }
     }
@@ -290,25 +294,6 @@ export class ConsensusEngine {
       this.fileCache.clear();
       this.anchorPathCache.clear();
       this.anchorWarnedRefs.clear();
-    }
-  }
-
-  /**
-   * Loud-fail observability for the rootless-degraded state: when the round was
-   * constructed WITH resolutionRoots but they all dropped during validation /
-   * union (currentWorktreeRoots ended up empty), every <anchor> silently
-   * resolves against project root and isResolvedFromProjectRootOnly is
-   * structurally suppressed. Surface that on stderr so the regression is
-   * visible at cross-review time. Does NOT alter isResolvedFromProjectRootOnly.
-   */
-  private warnIfRootsDroppedToEmpty(): void {
-    const declared = this.config.resolutionRoots;
-    if (declared && declared.length > 0 && this.currentWorktreeRoots.size === 0) {
-      process.stderr.write(
-        `[consensus] ⚠ resolutionRoots: ${declared.length} root(s) declared but 0 resolved ` +
-        `(all dropped during validation) — every anchor will resolve against project root, ` +
-        `NOT the feature-branch worktree. Stale-anchor false disputes likely.\n`,
-      );
     }
   }
 
@@ -496,7 +481,6 @@ export class ConsensusEngine {
     const consensusStart = Date.now();
     _log('consensus', `Starting cross-review for ${successful.length} agents`);
     this.updateWorktreeRoots(results, this.config.resolutionRoots);
-    this.warnIfRootsDroppedToEmpty();
     // Generate consensusId ONCE per round and thread it through cross-review
     // and synthesize so NEW findingIds rewritten in crossReviewForAgent match
     // the consensusId used by synthesize's signal/finding id assembly.

--- a/packages/orchestrator/src/dispatch-pipeline.ts
+++ b/packages/orchestrator/src/dispatch-pipeline.ts
@@ -1270,9 +1270,17 @@ export class DispatchPipeline {
   /**
    * Run consensus cross-review + judge verification + signal pipeline on any set of results.
    * Delegates to ConsensusCoordinator which owns the full consensus logic.
+   *
+   * @param resolutionRoots Optional per-round collect-time roots (validated at
+   *   the MCP boundary). Forwarded so the all-relay consensus path — which
+   *   short-circuits here from collect.ts without going through the dispatch
+   *   handler — still pins citation anchors to the feature-branch worktree.
    */
-  async runConsensus(results: TaskEntry[]): Promise<import('./consensus-types').ConsensusReport | undefined> {
-    return this.consensusCoordinator.runConsensus(results);
+  async runConsensus(
+    results: TaskEntry[],
+    resolutionRoots?: readonly string[],
+  ): Promise<import('./consensus-types').ConsensusReport | undefined> {
+    return this.consensusCoordinator.runConsensus(results, resolutionRoots);
   }
 
   /** Flush TaskGraph index on shutdown */

--- a/packages/orchestrator/src/dispatch-pipeline.ts
+++ b/packages/orchestrator/src/dispatch-pipeline.ts
@@ -709,7 +709,7 @@ export class DispatchPipeline {
     this.sessionContext.registerPlan(plan);
   }
 
-  async collect(taskIds?: string[], timeoutMs: number = 120_000, options?: { consensus?: boolean; consume?: boolean }): Promise<CollectResult> {
+  async collect(taskIds?: string[], timeoutMs: number = 120_000, options?: { consensus?: boolean; consume?: boolean; resolutionRoots?: readonly string[] }): Promise<CollectResult> {
     const targets = taskIds
       ? taskIds.map(id => this.tasks.get(id)).filter((t): t is TrackedTask => t !== undefined)
       : Array.from(this.tasks.values());
@@ -906,7 +906,7 @@ export class DispatchPipeline {
     // Consensus round
     let consensusReport: import('./consensus-types').ConsensusReport | undefined;
     if (options?.consensus && this.llm && results.filter(r => r.status === 'completed').length >= MIN_AGENTS_FOR_CONSENSUS) {
-      consensusReport = await this.runConsensus(results);
+      consensusReport = await this.runConsensus(results, options?.resolutionRoots);
     }
 
     // Cleanup tasks from tracking map.

--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -256,7 +256,7 @@ export class MainAgent {
   getTask(taskId: string) { return this.pipeline.getTask(taskId); }
   setGossipPublisher(publisher: any) { this.pipeline.setGossipPublisher(publisher); }
   setOverlapDetector(detector: any): void { this.pipeline.setOverlapDetector(detector); }
-  async runConsensus(results: any[]): Promise<any> { return this.pipeline.runConsensus(results); }
+  async runConsensus(results: any[], resolutionRoots?: readonly string[]): Promise<any> { return this.pipeline.runConsensus(results, resolutionRoots); }
   setLensGenerator(generator: any): void { this.pipeline.setLensGenerator(generator); }
   setDispatchDifferentiator(differ: any): void { this.pipeline.setDispatchDifferentiator(differ); }
   getSkillGapSuggestions() { return this.pipeline.getSkillGapSuggestions(); }

--- a/tests/orchestrator/consensus-resolution-roots-plumbing.test.ts
+++ b/tests/orchestrator/consensus-resolution-roots-plumbing.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Regression tests for the all-relay consensus resolutionRoots DROP
+ * (root cause of stale-anchor false disputes in round 840fcedf, recurrence of
+ * the #389 class).
+ *
+ * The existing tests in consensus-engine-resolution-roots.test.ts construct
+ * ConsensusEngine directly and therefore CANNOT catch a regression in the
+ * plumbing that feeds resolutionRoots INTO the engine. These tests drive that
+ * plumbing:
+ *
+ *   1. ConsensusCoordinator.runConsensus forwards per-round roots to the engine.
+ *   2. Per-round roots OVERRIDE the coordinator's constructor default.
+ *   3. ConsensusEngine.updateWorktreeRoots unions TaskEntry.resolutionRoots.
+ */
+import { realpathSync, mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Capture the config each ConsensusEngine is constructed with, while stubbing
+// out the heavy run()/synthesize() path so the coordinator test stays fast.
+const engineConfigs: Array<{ resolutionRoots?: readonly string[] }> = [];
+
+jest.mock('../../packages/orchestrator/src/consensus-engine', () => {
+  const actual = jest.requireActual('../../packages/orchestrator/src/consensus-engine');
+  class StubEngine {
+    config: any;
+    constructor(config: any) {
+      this.config = config;
+      engineConfigs.push(config);
+    }
+    async run() {
+      return {
+        confirmed: [], disputed: [], unverified: [], unique: [],
+        insights: [], newFindings: [], signals: [],
+        summary: 'stub',
+      };
+    }
+  }
+  return { ...actual, ConsensusEngine: StubEngine };
+});
+
+import { ConsensusCoordinator } from '../../packages/orchestrator/src/consensus-coordinator';
+import type { TaskEntry } from '../../packages/orchestrator/src/types';
+
+const makeLlm = (): any => ({
+  generate: jest.fn(async () => ({ text: '[]', usage: { inputTokens: 0, outputTokens: 0 } })),
+});
+
+const completed = (agentId: string): TaskEntry => ({
+  id: `t-${agentId}`,
+  agentId,
+  task: 'review X',
+  status: 'completed',
+  result: '<agent_finding type="finding" severity="low">noted</agent_finding>',
+  startedAt: Date.now(),
+});
+
+describe('all-relay consensus resolutionRoots plumbing', () => {
+  let tmp: string;
+  let root: string;
+
+  beforeEach(() => {
+    engineConfigs.length = 0;
+    tmp = mkdtempSync(join(tmpdir(), 'crp-'));
+    root = realpathSync(tmp);
+  });
+
+  it('ConsensusCoordinator.runConsensus forwards per-round roots to the engine', async () => {
+    const wt = realpathSync(mkdtempSync(join(tmp, 'wt')));
+    const coordinator = new ConsensusCoordinator({
+      llm: makeLlm(),
+      registryGet: () => undefined,
+      projectRoot: root,
+      keyProvider: null,
+    });
+
+    await coordinator.runConsensus(
+      [completed('relay-a'), completed('relay-b')],
+      [wt],
+    );
+
+    expect(engineConfigs).toHaveLength(1);
+    expect(engineConfigs[0].resolutionRoots).toEqual([wt]);
+  });
+
+  it('per-round roots OVERRIDE the coordinator constructor default', async () => {
+    const ctorRoot = realpathSync(mkdtempSync(join(tmp, 'ctor')));
+    const perRoundRoot = realpathSync(mkdtempSync(join(tmp, 'round')));
+
+    const coordinator = new ConsensusCoordinator({
+      llm: makeLlm(),
+      registryGet: () => undefined,
+      projectRoot: root,
+      keyProvider: null,
+      resolutionRoots: [ctorRoot],
+    });
+
+    // Per-round value supplied → must REPLACE the constructor default.
+    await coordinator.runConsensus(
+      [completed('relay-a'), completed('relay-b')],
+      [perRoundRoot],
+    );
+    expect(engineConfigs[engineConfigs.length - 1].resolutionRoots).toEqual([perRoundRoot]);
+
+    // No per-round value → constructor default is used (back-compat).
+    await coordinator.runConsensus([completed('relay-a'), completed('relay-b')]);
+    expect(engineConfigs[engineConfigs.length - 1].resolutionRoots).toEqual([ctorRoot]);
+
+    // Empty per-round array → treated as absent, constructor default used.
+    await coordinator.runConsensus([completed('relay-a'), completed('relay-b')], []);
+    expect(engineConfigs[engineConfigs.length - 1].resolutionRoots).toEqual([ctorRoot]);
+  });
+});
+
+describe('ConsensusEngine.updateWorktreeRoots unions TaskEntry.resolutionRoots', () => {
+  let tmp: string;
+  let root: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'crp-uwr-'));
+    root = realpathSync(tmp);
+  });
+
+  it('per-task resolutionRoots are unioned into currentWorktreeRoots', () => {
+    // Use the REAL engine here (not the stubbed one) via requireActual so the
+    // private updateWorktreeRoots logic is exercised, not the mock.
+    const { ConsensusEngine: RealEngine } = jest.requireActual(
+      '../../packages/orchestrator/src/consensus-engine',
+    );
+    const taskRoot = realpathSync(mkdtempSync(join(tmp, 'task-wt')));
+
+    const engine = new RealEngine({
+      llm: makeLlm(),
+      registryGet: () => undefined,
+      projectRoot: root,
+    });
+
+    const entry: TaskEntry = {
+      id: 't1',
+      agentId: 'relay-a',
+      task: 'review',
+      status: 'completed',
+      result: 'x',
+      startedAt: Date.now(),
+      resolutionRoots: [taskRoot],
+    };
+
+    // updateWorktreeRoots is private — invoke via cast. No config roots, no
+    // worktreeInfo: the ONLY source of the root is the TaskEntry field.
+    (engine as any).updateWorktreeRoots([entry]);
+
+    const roots: Set<string> = (engine as any).currentWorktreeRoots;
+    expect(roots.has(taskRoot)).toBe(true);
+  });
+
+  it('TaskEntry roots union alongside worktreeInfo.path and config roots', () => {
+    const { ConsensusEngine: RealEngine } = jest.requireActual(
+      '../../packages/orchestrator/src/consensus-engine',
+    );
+    const taskRoot = realpathSync(mkdtempSync(join(tmp, 'task-wt2')));
+    const wtInfoRoot = realpathSync(mkdtempSync(join(tmp, 'info-wt')));
+    const configRoot = realpathSync(mkdtempSync(join(tmp, 'cfg-wt')));
+
+    const engine = new RealEngine({
+      llm: makeLlm(),
+      registryGet: () => undefined,
+      projectRoot: root,
+      resolutionRoots: [configRoot],
+    });
+
+    const entry: TaskEntry = {
+      id: 't1',
+      agentId: 'relay-a',
+      task: 'review',
+      status: 'completed',
+      result: 'x',
+      startedAt: Date.now(),
+      worktreeInfo: { path: wtInfoRoot, branch: 'feat' },
+      resolutionRoots: [taskRoot],
+    };
+
+    (engine as any).updateWorktreeRoots([entry], [configRoot]);
+
+    const roots: Set<string> = (engine as any).currentWorktreeRoots;
+    expect(roots.has(taskRoot)).toBe(true);
+    expect(roots.has(wtInfoRoot)).toBe(true);
+    expect(roots.has(configRoot)).toBe(true);
+  });
+});

--- a/tests/orchestrator/consensus-resolution-roots-plumbing.test.ts
+++ b/tests/orchestrator/consensus-resolution-roots-plumbing.test.ts
@@ -186,4 +186,121 @@ describe('ConsensusEngine.updateWorktreeRoots unions TaskEntry.resolutionRoots',
     expect(roots.has(wtInfoRoot)).toBe(true);
     expect(roots.has(configRoot)).toBe(true);
   });
+
+  it('non-absolute TaskEntry.resolutionRoots entries are skipped (fail-soft)', () => {
+    const { ConsensusEngine: RealEngine } = jest.requireActual(
+      '../../packages/orchestrator/src/consensus-engine',
+    );
+    const absRoot = realpathSync(mkdtempSync(join(tmp, 'abs-wt')));
+
+    const engine = new RealEngine({
+      llm: makeLlm(),
+      registryGet: () => undefined,
+      projectRoot: root,
+    });
+
+    const entry: TaskEntry = {
+      id: 't1',
+      agentId: 'relay-a',
+      task: 'review',
+      status: 'completed',
+      result: 'x',
+      startedAt: Date.now(),
+      // Mix of one absolute (kept) and two non-absolute (skipped) entries.
+      resolutionRoots: [absRoot, 'relative/path', './also-relative'],
+    };
+
+    // updateWorktreeRoots must not throw on non-absolute entries — unlike the
+    // constructor's programmer-error contract, this path fails soft.
+    expect(() => (engine as any).updateWorktreeRoots([entry])).not.toThrow();
+
+    const roots: Set<string> = (engine as any).currentWorktreeRoots;
+    expect(roots.has(absRoot)).toBe(true);
+    // The relative entries were resolve()'d against cwd in the old code; assert
+    // they are NOT present in either raw or resolved form.
+    expect([...roots].some(r => r.endsWith('relative/path'))).toBe(false);
+    expect([...roots].some(r => r.endsWith('also-relative'))).toBe(false);
+    expect(roots.size).toBe(1);
+  });
+});
+
+describe('DispatchPipeline.collect forwards options.resolutionRoots to runConsensus', () => {
+  // Use the real (non-stubbed) modules here — this block exercises the pipeline
+  // → runConsensus signature, spying on runConsensus so we don't run a real
+  // consensus round. requireActual bypasses the module-level engine mock above.
+  const { DispatchPipeline } = jest.requireActual('@gossip/orchestrator');
+  const { TaskStreamEventType } = jest.requireActual('@gossip/orchestrator');
+
+  let projectRoot: string;
+  let worktree: string;
+
+  beforeEach(() => {
+    projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'pipe-rr-collect-proj-')));
+    worktree = realpathSync(mkdtempSync(join(tmpdir(), 'pipe-rr-collect-wt-')));
+  });
+
+  function relayWorker() {
+    return {
+      executeTask: jest.fn().mockImplementation(async function* () {
+        yield {
+          type: TaskStreamEventType.FINAL_RESULT,
+          payload: { result: 'done', inputTokens: 0, outputTokens: 0 },
+          timestamp: Date.now(),
+        };
+      }),
+      subscribeToBatch: jest.fn().mockResolvedValue(undefined),
+      unsubscribeFromBatch: jest.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  it('collect({ consensus, resolutionRoots }) forwards roots to runConsensus', async () => {
+    const workers = new Map<string, any>();
+    const pipeline = new DispatchPipeline({
+      projectRoot,
+      workers,
+      registryGet: (id: string) => ({ id, provider: 'local', model: 'mock', skills: [] }),
+      llm: makeLlm(),
+    });
+    const spy = jest
+      .spyOn(pipeline as any, 'runConsensus')
+      .mockResolvedValue(undefined);
+
+    workers.set('relay-a', relayWorker());
+    workers.set('relay-b', relayWorker());
+    const a = pipeline.dispatch('relay-a', 'review');
+    const b = pipeline.dispatch('relay-b', 'review');
+    await Promise.all([a.finalResultPromise, b.finalResultPromise]);
+
+    await pipeline.collect([a.taskId, b.taskId], 120_000, {
+      consensus: true,
+      resolutionRoots: [worktree],
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][1]).toEqual([worktree]);
+  });
+
+  it('collect without resolutionRoots forwards undefined (back-compat)', async () => {
+    const workers = new Map<string, any>();
+    const pipeline = new DispatchPipeline({
+      projectRoot,
+      workers,
+      registryGet: (id: string) => ({ id, provider: 'local', model: 'mock', skills: [] }),
+      llm: makeLlm(),
+    });
+    const spy = jest
+      .spyOn(pipeline as any, 'runConsensus')
+      .mockResolvedValue(undefined);
+
+    workers.set('relay-a', relayWorker());
+    workers.set('relay-b', relayWorker());
+    const a = pipeline.dispatch('relay-a', 'review');
+    const b = pipeline.dispatch('relay-b', 'review');
+    await Promise.all([a.finalResultPromise, b.finalResultPromise]);
+
+    await pipeline.collect([a.taskId, b.taskId], 120_000, { consensus: true });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][1]).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the all-relay consensus `resolutionRoots` drop — the root cause of stale-anchor false disputes in round `840fcedf` (recurrence of the #389 class).

When a consensus round has **zero native agents**, `handleCollect` short-circuited to `ctx.mainAgent.runConsensus(allResults)` without the collect-validated roots. The `ConsensusCoordinator` is constructed once at pipeline boot with no `resolutionRoots`, so the per-round `ConsensusEngine` was built rootless: every Phase-2 `<anchor>` resolved against master HEAD, and the `⚠ resolved against project root, NOT worktree` warning was structurally suppressed (`isResolvedFromProjectRootOnly` short-circuits when `currentWorktreeRoots` is empty) — silent exactly in the degraded state. Cross-reviewers judged branch code from master anchors and disputed real findings.

## Changes

**ff161cee — primary fix**
- `runConsensus` (main-agent delegate + dispatch-pipeline) accepts optional `resolutionRoots` and forwards to `ConsensusCoordinator.runConsensus(results, perRoundRoots?)`; per-round roots OVERRIDE the constructor default (collect-replaces-dispatch semantics)
- `collect.ts` all-relay branch passes the collect-validated `effectiveRoots`
- `updateWorktreeRoots` unions per-task `TaskEntry.resolutionRoots` (defense-in-depth; cache-clear semantics preserved)
- `prependResolutionRootWarning`: non-fatal root rejections now surface in dispatch/collect tool responses (was stderr-only)
- New plumbing regression suite — the prior tests constructed the engine directly, below the broken hop

**c60265fe — consensus fixup (f6/f11/f13/f14/f15)**
- Removed structurally unreachable `warnIfRootsDroppedToEmpty()` (constructor throws rather than drops)
- Coordinator audit trail records the round's `effectiveResolutionRoots` (memory writer + session history)
- Pipeline-internal `collect()` can now forward `options.resolutionRoots` to `runConsensus`
- TaskEntry-roots union skips non-absolute entries fail-soft; rejected-roots warning message counts agree

## Verification
- Root `tsc --noEmit` clean; `npm run build` clean across 5 workspaces
- Plumbing + resolution-roots suites 18/18; full consensus/cli suites green at ff161cee (1333 tests)
- Pre-merge consensus: 6 confirmed / 0 disputed / 1 new; 15 signals recorded

consensus-id: 91240a8d-6a1f4738

🤖 Generated with [Claude Code](https://claude.com/claude-code)