### PR TITLE
test(consensus): e2e coordinator-path anchor-content test + stale comment fix

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -457,7 +457,8 @@ export async function handleCollect(
       // structurally suppressed (recurrence of the #389 stale-anchor class).
       // effectiveRoots is block-scoped to the native-present branch below, so
       // recompute here from the collect-validated input (auto-discovery is
-      // discovery-only and never augments effectiveRoots — collect.ts:483-486).
+      // discovery-only and never augments effectiveRoots — see the
+      // autoDiscoverWorktrees block in the native-present branch below).
       const allRelayRoots: readonly string[] = resolutionRoots ?? [];
       outerEffectiveRoots = allRelayRoots;
       consensusReport = await ctx.mainAgent.runConsensus(

--- a/tests/orchestrator/consensus-engine-resolution-roots.test.ts
+++ b/tests/orchestrator/consensus-engine-resolution-roots.test.ts
@@ -5,6 +5,7 @@ import {
   ConsensusEngine,
   type ConsensusEngineConfig,
 } from '../../packages/orchestrator/src/consensus-engine';
+import { ConsensusCoordinator } from '../../packages/orchestrator/src/consensus-coordinator';
 import {
   mkdtempSync,
   mkdirSync,
@@ -283,5 +284,57 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
     const wt2 = realpathSync(mkdtempSync(join(tmp, 'wt2')));
     (engine as any).updateWorktreeRoots([], [wt2]);
     expect((engine as any).anchorPathCache.size).toBe(0);
+  });
+
+  it('Test 21 — e2e: per-round roots via ConsensusCoordinator reach anchor CONTENT in cross-review prompts', async () => {
+    // Tests 16/18/19 prove the engine resolves anchors worktree-first when
+    // constructed directly with resolutionRoots. This test covers the layer
+    // above: ConsensusCoordinator.runConsensus(results, perRoundRoots) must
+    // deliver the roots through engine construction AND engine.run() such
+    // that the cross-review prompts sent to the LLM embed the WORKTREE copy
+    // of a cited file, not the projectRoot (master HEAD) copy. This is the
+    // exact hop that broke in the all-relay path (PR #541 / round 840fcedf):
+    // the engine internals were correct, but a wiring layer above them
+    // constructed the engine rootless.
+    const proj = realpathSync(mkdtempSync(join(tmp, 'proj')));
+    const wt = realpathSync(mkdtempSync(join(tmp, 'wt')));
+    mkdirSync(join(proj, 'src'), { recursive: true });
+    mkdirSync(join(wt, 'src'), { recursive: true });
+    writeFileSync(join(proj, 'src', 'target.ts'), 'export function old() { return "master-HEAD"; }');
+    writeFileSync(join(wt, 'src', 'target.ts'), 'export function newImpl() { return "worktree-branch"; }');
+
+    // Capture every message content the engine sends to the LLM — the
+    // cross-review prompts (with embedded <anchor> blocks) flow through here.
+    const seen: string[] = [];
+    const llm = {
+      generate: jest.fn(async (messages: Array<{ content?: string }>) => {
+        for (const m of messages) if (typeof m?.content === 'string') seen.push(m.content);
+        return { text: '[]', usage: { inputTokens: 0, outputTokens: 0 } };
+      }),
+    };
+
+    const coordinator = new ConsensusCoordinator({
+      llm: llm as any,
+      registryGet: () => undefined,
+      projectRoot: proj,
+      keyProvider: null,
+      getAgentSkillsContent: () => undefined,
+    });
+
+    const finding = (desc: string) =>
+      `<agent_finding type="finding" severity="low">${desc} <cite tag="file">src/target.ts:1</cite></agent_finding>`;
+    const results = [
+      { id: 't1', agentId: 'agent-a', task: 'review', status: 'completed', result: finding('Issue A') },
+      { id: 't2', agentId: 'agent-b', task: 'review', status: 'completed', result: finding('Issue B') },
+    ] as any;
+
+    await coordinator.runConsensus(results, [wt]);
+
+    expect(llm.generate).toHaveBeenCalled();
+    const all = seen.join('\n');
+    // The cited file exists in BOTH roots with distinct content — the prompts
+    // must carry the worktree version, never the master copy.
+    expect(all).toContain('worktree-branch');
+    expect(all).not.toContain('master-HEAD');
   });
 });


### PR DESCRIPTION
## Summary

Closes out the two follow-ups from consensus round `40e0dfc2-50ab4036` (post-merge review of PR #541):

- **Test 21** (`tests/orchestrator/consensus-engine-resolution-roots.test.ts`): drives the **real** `ConsensusCoordinator.runConsensus(results, perRoundRoots)` into the real engine and asserts the cross-review prompts sent to the LLM embed the **worktree** copy of a cited file, never the projectRoot (master HEAD) copy. Engine-level worktree-first coverage already existed (Tests 16/18/19, constructed the engine directly); the coordinator wiring hop — the exact layer that broke in the all-relay incident (round `840fcedf`) — did not. A rootless coordinator would serve master content and fail both assertions.
- **Stale comment fix** (`apps/cli/src/handlers/collect.ts`): the all-relay branch comment referenced the fictional `collect.ts:483-486`; now references the autoDiscoverWorktrees block by name instead of by line number (found by deepseek-challenger, consensus f4 — first verified catch under its new citation-grounding skill).

## Verification
- `npx jest tests/orchestrator/consensus-engine-resolution-roots.test.ts` — 12/12 (Test 21 new)
- Root `tsc --noEmit` — zero errors outside known pre-existing dashboard-v2 config noise

consensus-id: 40e0dfc2-50ab4036

🤖 Generated with [Claude Code](https://claude.com/claude-code)