### PR TITLE
feat(consensus): RoundContext carrier + fail-loud warnings drain (PR-A)

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -11,7 +11,7 @@ import { FILE_TOOLS, FileTools, GitTools, Sandbox } from '@gossip/tools';
 import { MemorySearcher } from '@gossip/orchestrator';
 import type { PromptFormat } from './dispatch';
 import { discoverVerifier, type VerifierBinding } from './auto-verify-discovery';
-import type { RelayWarningEntry } from '@gossip/orchestrator';
+import type { RelayWarningEntry, RoundContext } from '@gossip/orchestrator';
 import { mkdirSync, appendFileSync } from 'node:fs';
 import { join as joinPath } from 'node:path';
 
@@ -247,6 +247,16 @@ export async function handleCollect(
    * preserves the existing ---SYSTEM---/---USER--- embedded block.
    */
   prompt_format?: PromptFormat,
+  /**
+   * Per-round consensus context (spec §3.1/§3.2) constructed at the MCP
+   * boundary AFTER validateResolutionRoot filtering. Carries the validated
+   * resolutionRoots plus the fail-loud warnings array (roots_rejected /
+   * roots_empty_after_validation). Alias mode (PR-A): when present it WINS and
+   * is threaded to the engine + embedded in the pending round; the loose
+   * `resolutionRoots` param above stays populated in parallel. When absent the
+   * legacy path is byte-identical.
+   */
+  round?: RoundContext,
 ) {
   await ctx.boot();
 
@@ -461,9 +471,12 @@ export async function handleCollect(
       // autoDiscoverWorktrees block in the native-present branch below).
       const allRelayRoots: readonly string[] = resolutionRoots ?? [];
       outerEffectiveRoots = allRelayRoots;
+      // Alias mode: a RoundContext WINS — forward it whole so the round's
+      // warnings array drains into report.warnings. Without a round, fall back
+      // to the legacy roots-only path (byte-identical).
       consensusReport = await ctx.mainAgent.runConsensus(
         allResults,
-        allRelayRoots.length > 0 ? allRelayRoots : undefined,
+        round ?? (allRelayRoots.length > 0 ? allRelayRoots : undefined),
       );
     } else {
       // Two-phase flow: relay agents cross-reviewed inline, native agents get prompts returned
@@ -595,7 +608,13 @@ export async function handleCollect(
         projectRoot: process.cwd(),
         agentLlm: (id: string) => agentLlmCache.get(id),
         performanceReader,
-        resolutionRoots: effectiveRoots,
+        // Alias mode: a RoundContext WINS — forward it whole so its warnings
+        // array drains into report.warnings (the immediate-synthesis path at
+        // :811 builds the report on THIS engine). Else fall back to the legacy
+        // roots-only field (byte-identical). The pending-round path below
+        // re-seeds resolutionRoots from snapshot/round per phase, so this only
+        // governs the immediate synthesizeWithCrossReview branch.
+        ...(round ? { round } : { resolutionRoots: effectiveRoots }),
         verifierDispatch: _autoVerifyDispatch,
         warningSink: _autoVerifyWarningSink,
         verifierToolRunner: async (agentId: string, toolName: string, args: Record<string, unknown>): Promise<string> => {
@@ -835,6 +854,11 @@ export async function handleCollect(
           createdAt: Date.now(),
           nativePrompts: nativePrompts.map((p: any) => ({ agentId: p.agentId, system: p.system, user: p.user })),
           resolutionRoots: effectiveRoots.length > 0 ? [...effectiveRoots] : undefined,
+          // Alias mode (spec §3.2): embed the round so later phases
+          // (relay-cross-review arrival/timeout/synthesis) can drain its
+          // warnings + read its roots. The flat resolutionRoots above stays
+          // populated in parallel for old-reader back-compat.
+          roundContext: round,
         });
 
         // Seed the relay-lint fallback membership map — keeps round-membership
@@ -1285,6 +1309,19 @@ export async function handleCollect(
     const overflow = consensusReport.zeroTagOverflow ?? 0;
     const suffix = overflow > 0 ? ` (+${overflow} more)` : '';
     output += `\n⚠ zeroTagAgents: ${shown}${suffix}`;
+  }
+
+  // Fail-loud round warnings (spec §6.1) — drained from RoundContext.warnings
+  // into report.warnings at synthesis. Render one line per warning so the
+  // operator sees rejected/empty resolutionRoots (and, post-PR-B, coverage /
+  // partial-review drops) in-band, not just on stderr. Append-only, no dedup.
+  if (consensusReport?.warnings && consensusReport.warnings.length > 0) {
+    output += '\n\n⚠ Round warnings:';
+    for (const w of consensusReport.warnings) {
+      const agent = w.agentId ? ` [${w.agentId.replace(/[\r\n]/g, ' ')}]` : '';
+      const msg = w.message.replace(/[\r\n]/g, ' ');
+      output += `\n  • ${w.code}${agent}: ${msg}`;
+    }
   }
 
   if (provisionalSignalCount > 0) {

--- a/apps/cli/src/handlers/relay-cross-review.ts
+++ b/apps/cli/src/handlers/relay-cross-review.ts
@@ -377,8 +377,14 @@ const CONSENSUS_FILE = 'pending-consensus.json';
 function restoreRoundContext(data: any): import('@gossip/orchestrator').RoundContext | undefined {
   const { makeRoundContext } = require('@gossip/orchestrator');
   const rc = data.roundContext;
+  // Per-field fallback with `??` semantics (spec §3.2): an embedded
+  // roundContext is AUTHORITATIVE — honor its resolutionRoots array even when
+  // it is intentionally empty (`[]` = "resolve against project root"). Only
+  // when there is NO embedded round do we read the old flat field. A
+  // length-gated check would wrongly treat a new-format empty-roots record as
+  // if it were old-flat-shape and resurrect a stale flat value.
   const roots: readonly string[] =
-    (rc && Array.isArray(rc.resolutionRoots) && rc.resolutionRoots.length > 0)
+    (rc && Array.isArray(rc.resolutionRoots))
       ? rc.resolutionRoots
       : (Array.isArray(data.resolutionRoots) ? data.resolutionRoots : []);
   const warnings = rc && Array.isArray(rc.warnings) ? rc.warnings : [];

--- a/apps/cli/src/handlers/relay-cross-review.ts
+++ b/apps/cli/src/handlers/relay-cross-review.ts
@@ -29,7 +29,7 @@ export function startConsensusTimeout(consensusId: string): void {
 
     const missingAgents = [...current.pendingNativeAgents];
     // Delete round BEFORE async work to prevent double-synthesis race with concurrent relay
-    const snapshot = { allResults: current.allResults, relayCrossReviewEntries: current.relayCrossReviewEntries, relayCrossReviewSkipped: current.relayCrossReviewSkipped, nativeCrossReviewEntries: [...current.nativeCrossReviewEntries], resolutionRoots: current.resolutionRoots };
+    const snapshot = { allResults: current.allResults, relayCrossReviewEntries: current.relayCrossReviewEntries, relayCrossReviewSkipped: current.relayCrossReviewSkipped, nativeCrossReviewEntries: [...current.nativeCrossReviewEntries], resolutionRoots: current.resolutionRoots, roundContext: current.roundContext };
     // PR #270 v3 review (HIGH): seed the agent-id fallback BEFORE delete from
     // the EXHAUSTIVE participation set, not just the still-pending agents.
     // Covers two cases: (1) agents that never relayed (still in
@@ -73,7 +73,11 @@ export function startConsensusTimeout(consensusId: string): void {
         llm: timeoutLlm,
         registryGet: (id: string) => ctx.mainAgent.getAgentConfig(id),
         projectRoot: process.cwd(),
-        resolutionRoots: snapshot.resolutionRoots,
+        // Alias mode: forward the embedded round when present so its warnings
+        // drain into the timeout-synthesis report; else legacy roots-only.
+        ...(snapshot.roundContext
+          ? { round: snapshot.roundContext }
+          : { resolutionRoots: snapshot.resolutionRoots }),
       });
 
       const allEntries = [...snapshot.relayCrossReviewEntries, ...snapshot.nativeCrossReviewEntries];
@@ -154,7 +158,11 @@ export async function handleRelayCrossReview(
       llm: parseLlm || ({ generate: async () => ({ text: '', usage: { inputTokens: 0, outputTokens: 0 } }) } as any),
       registryGet: (id: string) => ctx.mainAgent.getAgentConfig(id),
       projectRoot: process.cwd(),
-      resolutionRoots: round.resolutionRoots,
+      // Alias mode: forward embedded round when present (parse-only path, but
+      // keep the boundary consistent); else legacy roots-only.
+      ...(round.roundContext
+        ? { round: round.roundContext }
+        : { resolutionRoots: round.resolutionRoots }),
     });
     const entries = engine.parseCrossReviewResponse(agent_id, result, 50);
     parsedCount = entries.length;
@@ -259,6 +267,7 @@ export async function handleRelayCrossReview(
     // synthesis step because the engine re-runs projectRoot-only
     // validation (round-3 consensus e507e375-50c2420b:f10).
     resolutionRoots: round.resolutionRoots,
+    roundContext: round.roundContext,
   };
   // PR #270 v3 review (HIGH): seed the agent-id fallback BEFORE delete from the
   // EXHAUSTIVE participation set, not the post-parse derivation. The previous
@@ -284,7 +293,11 @@ export async function handleRelayCrossReview(
       llm: mainLlm,
       registryGet: (id: string) => ctx.mainAgent.getAgentConfig(id),
       projectRoot: process.cwd(),
-      resolutionRoots: synthSnapshot.resolutionRoots,
+      // Alias mode: forward the embedded round so its fail-loud warnings drain
+      // into the final-synthesis report; else legacy roots-only.
+      ...(synthSnapshot.roundContext
+        ? { round: synthSnapshot.roundContext }
+        : { resolutionRoots: synthSnapshot.resolutionRoots }),
     });
 
     const allCrossReviewEntries = [
@@ -352,6 +365,35 @@ export async function handleRelayCrossReview(
 
 const CONSENSUS_FILE = 'pending-consensus.json';
 
+/**
+ * Reconstruct a RoundContext from a persisted pending-round record (spec §3.2
+ * disk back-compat). Prefers the embedded `roundContext`; per field, falls back
+ * to the old flat shape — `data.roundContext?.resolutionRoots ?? data.resolutionRoots`,
+ * mirroring the participatingNativeAgents back-compat pattern. Returns undefined
+ * only when NEITHER an embedded round nor flat roots are present (a pre-#126
+ * record with no roots at all), so old flat-shape files restore with roots
+ * intact.
+ */
+function restoreRoundContext(data: any): import('@gossip/orchestrator').RoundContext | undefined {
+  const { makeRoundContext } = require('@gossip/orchestrator');
+  const rc = data.roundContext;
+  const roots: readonly string[] =
+    (rc && Array.isArray(rc.resolutionRoots) && rc.resolutionRoots.length > 0)
+      ? rc.resolutionRoots
+      : (Array.isArray(data.resolutionRoots) ? data.resolutionRoots : []);
+  const warnings = rc && Array.isArray(rc.warnings) ? rc.warnings : [];
+  const consensusId = rc && typeof rc.consensusId === 'string' ? rc.consensusId : undefined;
+  const lenses = rc && rc.lenses && typeof rc.lenses === 'object' ? rc.lenses : undefined;
+  // Nothing to carry — no embedded round and no flat roots: legacy rootless.
+  if (!rc && roots.length === 0) return undefined;
+  return makeRoundContext({
+    ...(consensusId !== undefined ? { consensusId } : {}),
+    resolutionRoots: roots,
+    ...(lenses !== undefined ? { lenses } : {}),
+    warnings,
+  });
+}
+
 /** Persist pending consensus rounds to disk so /mcp reconnects don't lose them */
 export function persistPendingConsensus(): void {
   try {
@@ -381,6 +423,17 @@ export function persistPendingConsensus(): void {
         nativePrompts: (round.nativePrompts || []).filter(p => round.pendingNativeAgents.has(p.agentId)),
         // #126 PR-B: carry validated resolution roots across reconnects.
         resolutionRoots: round.resolutionRoots ? [...round.resolutionRoots] : undefined,
+        // Spec §3.2: persist the embedded RoundContext (resolutionRoots +
+        // warnings) so fail-loud state survives /mcp reconnect. The flat
+        // resolutionRoots above is kept in parallel for old-reader back-compat.
+        roundContext: round.roundContext
+          ? {
+              ...(round.roundContext.consensusId !== undefined ? { consensusId: round.roundContext.consensusId } : {}),
+              resolutionRoots: [...round.roundContext.resolutionRoots],
+              ...(round.roundContext.lenses !== undefined ? { lenses: round.roundContext.lenses } : {}),
+              warnings: [...round.roundContext.warnings],
+            }
+          : undefined,
       };
     }
     writeFileSync(join(dir, CONSENSUS_FILE), JSON.stringify(rounds));
@@ -429,6 +482,12 @@ export function restorePendingConsensus(projectRoot: string): void {
         resolutionRoots: Array.isArray(data.resolutionRoots) && data.resolutionRoots.length > 0
           ? data.resolutionRoots
           : undefined,
+        // Spec §3.2 disk back-compat: prefer the embedded roundContext; fall
+        // back per-field to the old flat shape (mirrors the
+        // participatingNativeAgents back-compat pattern above). Old pre-PR-A
+        // files lack `roundContext` entirely — reconstruct one from the flat
+        // resolutionRoots so downstream phases still see a RoundContext.
+        roundContext: restoreRoundContext(data),
       });
 
       // Re-arm timeout watcher

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -3,7 +3,7 @@
  * Single mutable context object avoids passing dozens of parameters.
  */
 import { randomUUID } from 'crypto';
-import type { CrossReviewEntry, MainAgent } from '@gossip/orchestrator';
+import type { CrossReviewEntry, MainAgent, RoundContext } from '@gossip/orchestrator';
 
 export interface NativeCrossReviewPrompt {
   agentId: string;
@@ -44,6 +44,15 @@ export interface PendingConsensusRound {
    * via persistPendingConsensus.
    */
   resolutionRoots?: readonly string[];
+  /**
+   * Per-round consensus context (spec §3.1/§3.2) EMBEDDING the resolutionRoots
+   * plus the fail-loud warnings array. Constructed at the MCP boundary
+   * immediately after validateResolutionRoot filtering. Alias mode (PR-A): the
+   * loose `resolutionRoots` field above is kept populated in parallel; readers
+   * prefer `roundContext` when present and fall back to the flat field for
+   * old persisted records. Persisted/restored with per-field back-compat.
+   */
+  roundContext?: RoundContext;
 }
 
 export interface NativeTaskInfo {

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1611,6 +1611,12 @@ export function createMcpServer(): McpServer {
       // their worktree roots were silently dropped → anchors resolved against
       // project root → stale-anchor false disputes.
       const rejectedRootReasons: string[] = [];
+      // Spec §6.1 boundary producer: accumulate fail-loud warnings as roots are
+      // rejected, then embed them in the RoundContext threaded into the round.
+      // Generalizes (does NOT yet replace) prependResolutionRootWarning — the
+      // stderr/response-prepend path stays for PR-A; PR-B removes it.
+      const { makeRoundContext } = await import('@gossip/orchestrator');
+      const round = makeRoundContext({ resolutionRoots: [], warnings: [] });
       if (resolutionRoots && resolutionRoots.length > 0) {
         const { validateResolutionRoot } = await import('@gossip/orchestrator');
         const out: string[] = [];
@@ -1623,10 +1629,24 @@ export function createMcpServer(): McpServer {
             return { content: [{ type: 'text' as const, text: `Error: resolutionRoots REJECTED ROUND (adversarial input): ${r.reason} [${r.hashedInput}]` }] };
           } else {
             rejectedRootReasons.push(r.reason ?? 'unknown');
+            // Append one roots_rejected warning per dropped entry (no dedup).
+            round.warnings.push({
+              code: 'roots_rejected',
+              message: `resolutionRoots entry rejected: ${r.reason ?? 'unknown'} [${r.hashedInput}]`,
+            });
             process.stderr.write(`[consensus] resolutionRoots rejected: ${r.reason} [${r.hashedInput}]\n`);
           }
         }
         validated = out;
+        // When at least one root was supplied but ALL were rejected, the round
+        // proceeds with zero roots → anchors resolve against project root only.
+        // Surface that loudly so the operator can correct before false disputes.
+        if (out.length === 0) {
+          round.warnings.push({
+            code: 'roots_empty_after_validation',
+            message: `all ${resolutionRoots.length} supplied resolutionRoots were rejected — anchors will resolve against project root only`,
+          });
+        }
       } else if (task_ids && task_ids.length > 0) {
         // No collect-time input — fall back to any dispatch-time roots stashed
         // under these task_ids. If NONE are found but the round has a persisted
@@ -1646,7 +1666,15 @@ export function createMcpServer(): McpServer {
           for (const tid of task_ids) ctx.pendingDispatchResolutionRoots.delete(tid);
         }
       }
-      const collectResult = await handleCollect(task_ids, timeout_ms, consensus, validated, prompt_format);
+      // Finalize the round with the validated resolutionRoots, carrying over
+      // the boundary-producer warnings accumulated above. `validated` is the
+      // post-filter set (collect-time or dispatch-time stash); undefined →
+      // empty roots. makeRoundContext copies the warnings array reference.
+      const finalRound = makeRoundContext({
+        resolutionRoots: validated ?? [],
+        warnings: round.warnings,
+      });
+      const collectResult = await handleCollect(task_ids, timeout_ms, consensus, validated, prompt_format, finalRound);
       return prependResolutionRootWarning(collectResult, rejectedRootReasons);
     }
   );

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1526,6 +1526,19 @@ export function createMcpServer(): McpServer {
       let validatedDispatchRoots: string[] = [];
       // Non-fatal rejection reasons surfaced in the response (item 3a) so a
       // dropped dispatch-time root is visible to the operator, not stderr-only.
+      //
+      // RoundContext boundary #1 — DEFERRED past PR-A (documented divergence
+      // from spec §3.2's "construct at all three boundaries"). The dispatch
+      // handler does NOT create a consensus round (that happens at collect), so
+      // there is no round object here to embed a RoundContext into; only the
+      // dispatch-time roots stash (pendingDispatchResolutionRoots) is threaded
+      // forward, and collect wraps it into the RoundContext it constructs. The
+      // remaining functional gap — routing these dispatch-time rejectedRootReasons
+      // into the collect-built round so they reach report.warnings — needs a
+      // parallel warnings stash keyed by the handler-minted task_ids and a drain
+      // at collect; that crosses three handler signatures and is scoped to a
+      // follow-up. Today these reasons still surface via prependResolutionRootWarning
+      // on the dispatch RESPONSE (below), so they are not silently dropped.
       const rejectedRootReasons: string[] = [];
       if (resolutionRoots && resolutionRoots.length > 0) {
         const { validateResolutionRoot } = await import('@gossip/orchestrator');

--- a/packages/orchestrator/src/consensus-coordinator.ts
+++ b/packages/orchestrator/src/consensus-coordinator.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import { ILLMProvider, createProvider } from './llm-client';
 import { ConsensusEngine } from './consensus-engine';
 import { ConsensusReport } from './consensus-types';
+import type { RoundContext } from './round-context';
 import { MemoryWriter } from './memory-writer';
 import { AgentConfig, TaskEntry } from './types';
 import { GossipPublisher } from './gossip-publisher';
@@ -24,6 +25,12 @@ export interface ConsensusCoordinatorConfig {
    * #126 / PR-B.
    */
   resolutionRoots?: readonly string[];
+  /**
+   * Per-round consensus context (spec §3.1). Alias-mode default forwarded to
+   * ConsensusEngine when no per-round override is supplied to runConsensus.
+   * When present it WINS over the loose `resolutionRoots` field.
+   */
+  round?: RoundContext;
 }
 
 type ConsensusPhase = 'idle' | 'review' | 'cross_review' | 'synthesis';
@@ -35,6 +42,7 @@ export class ConsensusCoordinator {
   private keyProvider: ((provider: string) => Promise<string | null>) | null;
   private getAgentSkillsContent?: (agentId: string, task: string) => string | undefined;
   private resolutionRoots?: readonly string[];
+  private round?: RoundContext;
   private gossipPublisher: GossipPublisher | null = null;
   private memWriter: MemoryWriter;
 
@@ -49,6 +57,7 @@ export class ConsensusCoordinator {
     this.keyProvider = config.keyProvider;
     this.getAgentSkillsContent = config.getAgentSkillsContent;
     this.resolutionRoots = config.resolutionRoots;
+    this.round = config.round;
     this.memWriter = new MemoryWriter(config.projectRoot);
   }
 
@@ -65,19 +74,39 @@ export class ConsensusCoordinator {
   }
 
   /**
-   * @param perRoundRoots Optional collect-time resolution roots (already
-   *   validated at the MCP boundary). When non-empty these OVERRIDE the
-   *   constructor default `this.resolutionRoots`, mirroring the "collect-time
-   *   REPLACES dispatch-time" spec semantics (collect.ts:478-487). Threaded
-   *   through the all-relay consensus path so a zero-native round still pins
-   *   anchors to the feature-branch worktree instead of master HEAD.
+   * @param roundOrRoots Optional per-round context OR collect-time resolution
+   *   roots (already validated at the MCP boundary). Alias mode (spec §3.2):
+   *   - A `RoundContext` WINS — it is forwarded whole to the engine (carrying
+   *     resolutionRoots AND the warnings array), overriding the constructor
+   *     default `this.round` / `this.resolutionRoots`.
+   *   - A non-empty `readonly string[]` (legacy shape) OVERRIDES the
+   *     constructor default `this.resolutionRoots`, mirroring the "collect-time
+   *     REPLACES dispatch-time" semantics (collect.ts). Byte-identical to the
+   *     pre-RoundContext path.
+   *   When absent, the constructor defaults are used (round wins over roots).
    */
-  async runConsensus(results: TaskEntry[], perRoundRoots?: readonly string[]): Promise<ConsensusReport | undefined> {
+  async runConsensus(
+    results: TaskEntry[],
+    roundOrRoots?: RoundContext | readonly string[],
+  ): Promise<ConsensusReport | undefined> {
     if (!this.llm || results.filter(r => r.status === 'completed').length < 2) return undefined;
 
-    const effectiveResolutionRoots = (perRoundRoots && perRoundRoots.length > 0)
-      ? perRoundRoots
-      : this.resolutionRoots;
+    // Discriminate the union: a RoundContext is a plain object with a
+    // `resolutionRoots` array field; the legacy shape is the array itself.
+    const perRoundRound: RoundContext | undefined =
+      roundOrRoots && !Array.isArray(roundOrRoots) ? (roundOrRoots as RoundContext) : undefined;
+    const perRoundRoots: readonly string[] | undefined =
+      roundOrRoots && Array.isArray(roundOrRoots) ? (roundOrRoots as readonly string[]) : undefined;
+
+    // Effective round: per-round context wins, else constructor default.
+    const effectiveRound: RoundContext | undefined = perRoundRound ?? this.round;
+    // Effective legacy roots: only used when NO round is in play (round carries
+    // its own resolutionRoots). Per-round legacy array overrides constructor.
+    const effectiveResolutionRoots = effectiveRound
+      ? effectiveRound.resolutionRoots
+      : (perRoundRoots && perRoundRoots.length > 0)
+        ? perRoundRoots
+        : this.resolutionRoots;
 
     try {
       this.currentPhase = 'review';
@@ -110,7 +139,12 @@ export class ConsensusCoordinator {
         projectRoot: this.projectRoot,
         agentLlm,
         getAgentSkillsContent: this.getAgentSkillsContent,
-        resolutionRoots: effectiveResolutionRoots,
+        // Alias mode: when a round is in play, forward it whole (it carries its
+        // own resolutionRoots AND the warnings array the engine drains into the
+        // report). Else fall back to the legacy loose roots — byte-identical.
+        ...(effectiveRound
+          ? { round: effectiveRound }
+          : { resolutionRoots: effectiveResolutionRoots }),
       });
       const consensusReport = await engine.run(results);
       this.currentPhase = 'cross_review';

--- a/packages/orchestrator/src/consensus-coordinator.ts
+++ b/packages/orchestrator/src/consensus-coordinator.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import { ILLMProvider, createProvider } from './llm-client';
 import { ConsensusEngine } from './consensus-engine';
 import { ConsensusReport } from './consensus-types';
-import type { RoundContext } from './round-context';
+import { isRoundContext, type RoundContext } from './round-context';
 import { MemoryWriter } from './memory-writer';
 import { AgentConfig, TaskEntry } from './types';
 import { GossipPublisher } from './gossip-publisher';
@@ -91,12 +91,15 @@ export class ConsensusCoordinator {
   ): Promise<ConsensusReport | undefined> {
     if (!this.llm || results.filter(r => r.status === 'completed').length < 2) return undefined;
 
-    // Discriminate the union: a RoundContext is a plain object with a
-    // `resolutionRoots` array field; the legacy shape is the array itself.
+    // Discriminate the union via a structural type guard — a bare
+    // !Array.isArray check would let any non-array object pass as a
+    // RoundContext, then read .resolutionRoots as undefined and silently fall
+    // through to empty roots (the stale-anchor bug class). isRoundContext
+    // validates the resolutionRoots + warnings array fields.
     const perRoundRound: RoundContext | undefined =
-      roundOrRoots && !Array.isArray(roundOrRoots) ? (roundOrRoots as RoundContext) : undefined;
+      isRoundContext(roundOrRoots) ? roundOrRoots : undefined;
     const perRoundRoots: readonly string[] | undefined =
-      roundOrRoots && Array.isArray(roundOrRoots) ? (roundOrRoots as readonly string[]) : undefined;
+      Array.isArray(roundOrRoots) ? (roundOrRoots as readonly string[]) : undefined;
 
     // Effective round: per-round context wins, else constructor default.
     const effectiveRound: RoundContext | undefined = perRoundRound ?? this.round;

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -13,6 +13,7 @@ import { LLMMessage, ToolDefinition } from '@gossip/types';
 import { ILLMProvider } from './llm-client';
 import { AgentConfig, TaskEntry } from './types';
 import { ConsensusReport, ConsensusFinding, ConsensusNewFinding, ConsensusSignal, CrossReviewEntry, RelayWarningEntry } from './consensus-types';
+import type { RoundContext } from './round-context';
 import { autoVerifyUnverifiedFindings, buildSkipSignal, type AutoVerifiableFinding } from './consensus-auto-verify';
 import { getRuntimeFlagBool } from './runtime-config';
 import { selectCrossReviewers, FindingForSelection, AgentCandidate } from './cross-reviewer-selection';
@@ -122,6 +123,15 @@ export interface ConsensusEngineConfig {
    */
   resolutionRoots?: readonly string[];
   /**
+   * Per-round consensus context (spec 2026-06-11-round-context-fail-loud.md
+   * §3.1). When present it WINS over the loose `resolutionRoots` field: the
+   * constructor seeds worktree roots from `round.resolutionRoots` instead, and
+   * synthesize() drains `round.warnings` into `report.warnings`. When absent,
+   * the legacy `resolutionRoots` path is byte-identical. Alias mode (PR-A) —
+   * the loose field is removed in PR-C.
+   */
+  round?: RoundContext;
+  /**
    * Verifier dispatcher resolved by the cli layer via `discoverVerifier(team)`
    * (spec docs/superpowers/specs/2026-05-21-consensus-auto-verify-design.md).
    * When omitted AND `GOSSIP_CONSENSUS_AUTO_VERIFY_UNVERIFIED='1'`, the engine
@@ -182,12 +192,16 @@ export class ConsensusEngine {
   constructor(config: ConsensusEngineConfig) {
     this.config = config;
 
-    // Seed BOTH root sets from config.resolutionRoots so round-1
+    // Seed BOTH root sets from the round's resolutionRoots so round-1
     // getValidRoots() — called before any updateWorktreeRoots invocation —
     // returns projectRoot + seeded roots. Paths arrive post-validation
     // and post-realpath (invariant enforced at MCP boundary); mis-supplied
     // input here is a programmer error that throws immediately.
-    const seeded = config.resolutionRoots;
+    //
+    // Alias mode (PR-A): when `config.round` is present it WINS — seed from
+    // `round.resolutionRoots`. Otherwise fall back to the legacy loose
+    // `config.resolutionRoots`. Same validation/throw semantics for both.
+    const seeded = config.round ? config.round.resolutionRoots : config.resolutionRoots;
     if (seeded && seeded.length > 0) {
       for (const p of seeded) {
         if (typeof p !== 'string' || p.length === 0) {
@@ -211,6 +225,16 @@ export class ConsensusEngine {
         catch { this.currentRealpathRoots.add(resolve(config.projectRoot)); }
       }
     }
+  }
+
+  /**
+   * Effective per-round resolution roots: `config.round.resolutionRoots` when a
+   * RoundContext is present (alias mode — round WINS), else the legacy loose
+   * `config.resolutionRoots`. Every `updateWorktreeRoots` call site reads this
+   * so the round and legacy paths stay byte-identical at the boundary.
+   */
+  private effectiveResolutionRoots(): readonly string[] | undefined {
+    return this.config.round ? this.config.round.resolutionRoots : this.config.resolutionRoots;
   }
 
   /** True when a PerformanceReader is available for orchestrator-selected cross-review (Step 3). */
@@ -480,7 +504,7 @@ export class ConsensusEngine {
 
     const consensusStart = Date.now();
     _log('consensus', `Starting cross-review for ${successful.length} agents`);
-    this.updateWorktreeRoots(results, this.config.resolutionRoots);
+    this.updateWorktreeRoots(results, this.effectiveResolutionRoots());
     // Generate consensusId ONCE per round and thread it through cross-review
     // and synthesize so NEW findingIds rewritten in crossReviewForAgent match
     // the consensusId used by synthesize's signal/finding id assembly.
@@ -528,7 +552,7 @@ export class ConsensusEngine {
    * Each agent reviews all peer summaries and produces agree/disagree/new entries.
    */
   async dispatchCrossReview(results: TaskEntry[], consensusId?: string): Promise<CrossReviewEntry[]> {
-    this.updateWorktreeRoots(results, this.config.resolutionRoots);
+    this.updateWorktreeRoots(results, this.effectiveResolutionRoots());
     const successful = results.filter(r => r.status === 'completed' && r.result);
     if (successful.length < 2) return [];
 
@@ -915,7 +939,7 @@ Return only valid JSON.${skillsBlock}`;
     summaries: Map<string, string>;
     consensusId: string;
   }> {
-    this.updateWorktreeRoots(results, this.config.resolutionRoots);
+    this.updateWorktreeRoots(results, this.effectiveResolutionRoots());
     const successful = results.filter(r => r.status === 'completed' && r.result);
     const consensusId = shortConsensusId();
 
@@ -945,7 +969,7 @@ Return only valid JSON.${skillsBlock}`;
    * Phase 3: Synthesize Phase 1 results and Phase 2 cross-review entries into a consensus report.
    */
   async synthesize(results: TaskEntry[], crossReviewEntries: CrossReviewEntry[], externalConsensusId?: string): Promise<ConsensusReport> {
-    this.updateWorktreeRoots(results, this.config.resolutionRoots);
+    this.updateWorktreeRoots(results, this.effectiveResolutionRoots());
     const consensusId = externalConsensusId ?? shortConsensusId();
     const signals: ConsensusSignal[] = [];
     const newFindings: ConsensusNewFinding[] = [];
@@ -1602,6 +1626,12 @@ Return only valid JSON.${skillsBlock}`;
       // Surface zero-tag agents in-band so the gossip_collect tool response
       // + dashboard JSON can highlight the silent dropout, not just stderr.
       ...(zeroTagAgents.length > 0 ? { zeroTagAgents, ...(zeroTagOverflow > 0 ? { zeroTagOverflow } : {}) } : {}),
+      // Drain fail-loud round warnings into the report (spec §6.1). Copy
+      // (not alias) so later mutation of round.warnings can't retroactively
+      // change a synthesized report. Omitted when the round carried none.
+      ...(this.config.round && this.config.round.warnings.length > 0
+        ? { warnings: [...this.config.round.warnings] }
+        : {}),
     };
   }
 
@@ -2820,7 +2850,7 @@ Return only valid JSON.${skillsBlock}`;
       };
     }
 
-    this.updateWorktreeRoots(results, this.config.resolutionRoots);
+    this.updateWorktreeRoots(results, this.effectiveResolutionRoots());
 
     // Build summaries and rawResults maps (same pattern as dispatchCrossReview)
     const summaries = new Map<string, string>();

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -142,6 +142,14 @@ export interface ConsensusReport {
   zeroTagAgents?: string[];
   /** Count of zero-tag agents past the 5-entry `zeroTagAgents` cap. */
   zeroTagOverflow?: number;
+  /**
+   * Fail-loud warnings drained from the round's `RoundContext.warnings` at
+   * synthesis (spec §6.1). Populated only when the round carried a
+   * RoundContext with at least one warning; clean rounds keep it undefined.
+   * Surfaced in the gossip_collect tool response (PR-A) and the dashboard
+   * (PR-B). Append-only — mirrors the producer order, no dedup.
+   */
+  warnings?: import('./round-context').RoundWarning[];
 }
 
 /** Return type for collect() */

--- a/packages/orchestrator/src/dispatch-pipeline.ts
+++ b/packages/orchestrator/src/dispatch-pipeline.ts
@@ -709,7 +709,7 @@ export class DispatchPipeline {
     this.sessionContext.registerPlan(plan);
   }
 
-  async collect(taskIds?: string[], timeoutMs: number = 120_000, options?: { consensus?: boolean; consume?: boolean; resolutionRoots?: readonly string[] }): Promise<CollectResult> {
+  async collect(taskIds?: string[], timeoutMs: number = 120_000, options?: { consensus?: boolean; consume?: boolean; resolutionRoots?: readonly string[]; round?: import('./round-context').RoundContext }): Promise<CollectResult> {
     const targets = taskIds
       ? taskIds.map(id => this.tasks.get(id)).filter((t): t is TrackedTask => t !== undefined)
       : Array.from(this.tasks.values());
@@ -906,7 +906,8 @@ export class DispatchPipeline {
     // Consensus round
     let consensusReport: import('./consensus-types').ConsensusReport | undefined;
     if (options?.consensus && this.llm && results.filter(r => r.status === 'completed').length >= MIN_AGENTS_FOR_CONSENSUS) {
-      consensusReport = await this.runConsensus(results, options?.resolutionRoots);
+      // Alias mode: a supplied round WINS over the loose resolutionRoots.
+      consensusReport = await this.runConsensus(results, options?.round ?? options?.resolutionRoots);
     }
 
     // Cleanup tasks from tracking map.
@@ -1271,16 +1272,18 @@ export class DispatchPipeline {
    * Run consensus cross-review + judge verification + signal pipeline on any set of results.
    * Delegates to ConsensusCoordinator which owns the full consensus logic.
    *
-   * @param resolutionRoots Optional per-round collect-time roots (validated at
-   *   the MCP boundary). Forwarded so the all-relay consensus path — which
-   *   short-circuits here from collect.ts without going through the dispatch
-   *   handler — still pins citation anchors to the feature-branch worktree.
+   * @param roundOrRoots Optional per-round context OR collect-time roots
+   *   (validated at the MCP boundary). Alias mode (spec §3.2): a RoundContext
+   *   WINS; a legacy `readonly string[]` behaves byte-identically. Forwarded so
+   *   the all-relay consensus path — which short-circuits here from collect.ts
+   *   without going through the dispatch handler — still pins citation anchors
+   *   to the feature-branch worktree.
    */
   async runConsensus(
     results: TaskEntry[],
-    resolutionRoots?: readonly string[],
+    roundOrRoots?: import('./round-context').RoundContext | readonly string[],
   ): Promise<import('./consensus-types').ConsensusReport | undefined> {
-    return this.consensusCoordinator.runConsensus(results, resolutionRoots);
+    return this.consensusCoordinator.runConsensus(results, roundOrRoots);
   }
 
   /** Flush TaskGraph index on shutdown */

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -29,6 +29,8 @@ export type { AuthFailure } from './auth-state';
 export * from './types';
 export * from './consensus-types';
 export type { ImplSignal, MetaSignal, PerformanceSignal } from './consensus-types';
+export { makeRoundContext, testRound } from './round-context';
+export type { RoundContext, RoundWarning, RoundWarningCode } from './round-context';
 export { SkillCatalog } from './skill-catalog';
 export type { CatalogEntry } from './skill-catalog';
 export { SkillGapTracker, SKILL_FRESHNESS_MS } from './skill-gap-tracker';

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -29,7 +29,7 @@ export type { AuthFailure } from './auth-state';
 export * from './types';
 export * from './consensus-types';
 export type { ImplSignal, MetaSignal, PerformanceSignal } from './consensus-types';
-export { makeRoundContext, testRound } from './round-context';
+export { makeRoundContext, testRound, isRoundContext } from './round-context';
 export type { RoundContext, RoundWarning, RoundWarningCode } from './round-context';
 export { SkillCatalog } from './skill-catalog';
 export type { CatalogEntry } from './skill-catalog';

--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -245,7 +245,7 @@ export class MainAgent {
   /** Update bootstrap prompt after MCP reconnect so agents see fresh session context. */
   setBootstrapPrompt(prompt: string) { this.bootstrapPrompt = prompt; }
   dispatch(agentId: string, task: string, options?: DispatchOptions) { return this.pipeline.dispatch(agentId, task, options); }
-  async collect(taskIds?: string[], timeoutMs?: number, options?: { consensus?: boolean; consume?: boolean }) { return this.pipeline.collect(taskIds, timeoutMs, options); }
+  async collect(taskIds?: string[], timeoutMs?: number, options?: { consensus?: boolean; consume?: boolean; resolutionRoots?: readonly string[]; round?: import('./round-context').RoundContext }) { return this.pipeline.collect(taskIds, timeoutMs, options); }
   async dispatchParallel(tasks: Array<{ agentId: string; task: string; options?: DispatchOptions }>, options?: { consensus?: boolean }) { return this.pipeline.dispatchParallel(tasks, options); }
   async dispatchParallelWithLenses(tasks: Array<{ agentId: string; task: string; options?: DispatchOptions }>, options?: { consensus?: boolean }, precomputedLenses?: Map<string, string>) { return this.pipeline.dispatchParallelWithLenses(tasks, options, precomputedLenses); }
   async generateLensesForAgents(taskDefs: Array<{ agentId: string; task: string }>) { return this.pipeline.generateLensesForAgents(taskDefs); }
@@ -256,7 +256,7 @@ export class MainAgent {
   getTask(taskId: string) { return this.pipeline.getTask(taskId); }
   setGossipPublisher(publisher: any) { this.pipeline.setGossipPublisher(publisher); }
   setOverlapDetector(detector: any): void { this.pipeline.setOverlapDetector(detector); }
-  async runConsensus(results: any[], resolutionRoots?: readonly string[]): Promise<any> { return this.pipeline.runConsensus(results, resolutionRoots); }
+  async runConsensus(results: any[], roundOrRoots?: import('./round-context').RoundContext | readonly string[]): Promise<any> { return this.pipeline.runConsensus(results, roundOrRoots); }
   setLensGenerator(generator: any): void { this.pipeline.setLensGenerator(generator); }
   setDispatchDifferentiator(differ: any): void { this.pipeline.setDispatchDifferentiator(differ); }
   getSkillGapSuggestions() { return this.pipeline.getSkillGapSuggestions(); }

--- a/packages/orchestrator/src/round-context.ts
+++ b/packages/orchestrator/src/round-context.ts
@@ -11,19 +11,31 @@
  */
 
 /**
- * The closed code union for round-level warnings. New codes are added here, not
- * invented at producer sites — an unknown code string would silently slip past
- * the drain renderer's switch and never reach the operator. Only the boundary
- * producer (roots_rejected / roots_empty_after_validation) is wired in PR-A;
- * the remaining codes are reserved for PR-B producer conversions
- * (relayCrossReviewSkipped → coverage_degraded, partialReview → partial_review).
+ * The known code union for round-level warnings. The PR-A boundary producer
+ * uses ONLY `roots_rejected` / `roots_empty_after_validation`; the remaining
+ * named codes are reserved for the PR-B producer conversions per spec §6.1:
+ *   - `anchor_master_fallback` — citation resolved against project root, not the
+ *     worktree (today the `via="⚠ resolved against project root…"` anchor note).
+ *   - `cross_review_skipped` — a relay agent's Phase-2 cross-review was skipped
+ *     (quota / parse / network); today `report.relayCrossReviewSkipped`.
+ *   - `zero_tags` — an agent emitted zero `<agent_finding>` tags; today
+ *     `report.zeroTagAgents`.
+ *
+ * The trailing `(string & {})` is an INTENTIONAL open extension point: it keeps
+ * autocomplete on the named codes while letting a future PR-B producer emit a
+ * not-yet-enumerated code without a compile error against this union (and
+ * without editing this PR-A file). Unknown codes still render in the drain block
+ * (it iterates, not switches), so they reach the operator rather than slipping
+ * past silently.
  */
 export type RoundWarningCode =
   | 'roots_rejected'
   | 'roots_empty_after_validation'
-  | 'coverage_degraded'
-  | 'partial_review'
-  | 'relay_cross_review_skipped';
+  | 'anchor_master_fallback'
+  | 'cross_review_skipped'
+  | 'zero_tags'
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  | (string & {});
 
 /**
  * A single fail-loud warning produced during a consensus round. `agentId` is
@@ -58,8 +70,10 @@ export interface RoundContext {
    * boundary (`validateResolutionRoot`). An empty array means "resolve against
    * project root only" and is the correct shape for boundaries that have no
    * roots (e.g. ToolRouter's in-process consensus). NEVER undefined: use `[]`.
+   * The FIELD REFERENCE is readonly (cannot reassign), symmetric with the
+   * `warnings` field below and the array element-readonly already on the type.
    */
-  resolutionRoots: readonly string[];
+  readonly resolutionRoots: readonly string[];
 
   /**
    * Optional per-agent (or per-key) descriptive lenses. PLAIN OBJECT, never a
@@ -80,6 +94,26 @@ export interface RoundContext {
    * intentional: each push records a distinct rejection event.
    */
   readonly warnings: RoundWarning[];
+}
+
+/**
+ * Type guard: is `value` a structurally-valid RoundContext? Used at union
+ * boundaries (e.g. `coordinator.runConsensus(results, roundOrRoots)`) where the
+ * alternative is a `readonly string[]`. A bare `!Array.isArray` check is NOT
+ * sufficient — any non-array object ({}, a Map, a Date) would slip through and
+ * be cast to RoundContext, then read `.resolutionRoots` as undefined and
+ * silently fall through to empty roots (the exact stale-anchor bug class this
+ * carrier exists to prevent). Validates the two required-shape fields:
+ * `resolutionRoots` is an array and `warnings` is an array.
+ */
+export function isRoundContext(value: unknown): value is RoundContext {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Array.isArray((value as { resolutionRoots?: unknown }).resolutionRoots) &&
+    Array.isArray((value as { warnings?: unknown }).warnings)
+  );
 }
 
 /**

--- a/packages/orchestrator/src/round-context.ts
+++ b/packages/orchestrator/src/round-context.ts
@@ -1,0 +1,119 @@
+/**
+ * RoundContext — single carrier for per-consensus-round state that today is
+ * threaded as a loose `resolutionRoots?: readonly string[]` through five
+ * separate door boundaries (collect handler, dispatch handler, coordinator,
+ * pipeline, engine). This is the alias-mode introduction (PR-A): every call
+ * site that accepts `resolutionRoots` gains an OPTIONAL `round?: RoundContext`
+ * alongside it. When `round` is present it WINS; when absent, the legacy
+ * `resolutionRoots` path behaves byte-identically. PR-C removes the aliases.
+ *
+ * Spec: 2026-06-11-round-context-fail-loud.md §3.1, consensus 5e9804d3-91fe440d.
+ */
+
+/**
+ * The closed code union for round-level warnings. New codes are added here, not
+ * invented at producer sites — an unknown code string would silently slip past
+ * the drain renderer's switch and never reach the operator. Only the boundary
+ * producer (roots_rejected / roots_empty_after_validation) is wired in PR-A;
+ * the remaining codes are reserved for PR-B producer conversions
+ * (relayCrossReviewSkipped → coverage_degraded, partialReview → partial_review).
+ */
+export type RoundWarningCode =
+  | 'roots_rejected'
+  | 'roots_empty_after_validation'
+  | 'coverage_degraded'
+  | 'partial_review'
+  | 'relay_cross_review_skipped';
+
+/**
+ * A single fail-loud warning produced during a consensus round. `agentId` is
+ * present only when the warning is attributable to a specific agent (e.g. a
+ * skipped relay cross-review); root-level warnings (rejected resolutionRoots)
+ * omit it.
+ */
+export interface RoundWarning {
+  code: RoundWarningCode;
+  message: string;
+  agentId?: string;
+}
+
+/**
+ * Per-round consensus context. Construct one at each trust boundary
+ * (MCP collect/dispatch handlers, ToolRouter) immediately AFTER input
+ * validation, and thread it through the consensus call chain.
+ */
+export interface RoundContext {
+  /**
+   * The consensus round id, when known at construction time. OPTIONAL — the
+   * id is sometimes minted downstream (the engine derives it from
+   * `report.signals[0]?.consensusId` or a fresh `randomUUID().slice(0,12)`),
+   * so boundaries that build a RoundContext before synthesis legitimately omit
+   * it. Never throw on absence; a RoundContext without a consensusId is valid.
+   */
+  consensusId?: string;
+
+  /**
+   * Post-validation, post-realpath citation resolution roots. INVARIANT: every
+   * entry is an absolute, realpath'd path — validation lives at the MCP
+   * boundary (`validateResolutionRoot`). An empty array means "resolve against
+   * project root only" and is the correct shape for boundaries that have no
+   * roots (e.g. ToolRouter's in-process consensus). NEVER undefined: use `[]`.
+   */
+  resolutionRoots: readonly string[];
+
+  /**
+   * Optional per-agent (or per-key) descriptive lenses. PLAIN OBJECT, never a
+   * Map — this record is persisted to disk inside the pending-consensus JSON
+   * and read back across /mcp reconnects, so it must survive a
+   * `JSON.stringify`/`JSON.parse` round-trip intact. A Map serializes to `{}`
+   * and would silently drop every lens.
+   */
+  lenses?: Readonly<Record<string, string>>;
+
+  /**
+   * Fail-loud warnings accumulated during the round. The FIELD REFERENCE is
+   * readonly (you cannot reassign `round.warnings = [...]`), but the array
+   * CONTENTS are mutable: producers append in place via `warnings.push(...)`.
+   * By convention this array is APPEND-ONLY — never spliced, reordered, or
+   * deduped. The drain copies it into `ConsensusReport.warnings` at synthesis
+   * and renders it in the gossip_collect tool response. Storing duplicates is
+   * intentional: each push records a distinct rejection event.
+   */
+  readonly warnings: RoundWarning[];
+}
+
+/**
+ * Construct a RoundContext from a partial. Fills the two required-shape fields
+ * (`resolutionRoots` defaults to `[]`, `warnings` defaults to a fresh array) so
+ * callers can pass only what they have. The returned object's `warnings` array
+ * is always a NEW array unless the caller supplied one — never a shared
+ * singleton — so two rounds never alias each other's warnings.
+ */
+export function makeRoundContext(
+  partial: {
+    consensusId?: string;
+    resolutionRoots?: readonly string[];
+    lenses?: Readonly<Record<string, string>>;
+    warnings?: RoundWarning[];
+  } = {},
+): RoundContext {
+  return {
+    ...(partial.consensusId !== undefined ? { consensusId: partial.consensusId } : {}),
+    resolutionRoots: partial.resolutionRoots ?? [],
+    ...(partial.lenses !== undefined ? { lenses: partial.lenses } : {}),
+    warnings: partial.warnings ?? [],
+  };
+}
+
+/**
+ * Test fixture helper — a RoundContext with sensible defaults, overridable per
+ * field. Exported for tests; production code uses `makeRoundContext`.
+ */
+export function testRound(overrides: Partial<RoundContext> = {}): RoundContext {
+  return {
+    consensusId: overrides.consensusId,
+    resolutionRoots: overrides.resolutionRoots ?? [],
+    lenses: overrides.lenses,
+    warnings: overrides.warnings ?? [],
+  };
+}

--- a/packages/orchestrator/src/tool-router.ts
+++ b/packages/orchestrator/src/tool-router.ts
@@ -4,6 +4,7 @@
  */
 
 import { TOOL_SCHEMAS, PLAN_CHOICES, PENDING_PLAN_CHOICES } from './tool-definitions';
+import { makeRoundContext } from './round-context';
 import type { ToolCall, ToolResult, DispatchPlan, PlannedTask, TaskProgressEvent } from './types';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
@@ -769,7 +770,12 @@ Be concise — 10-15 lines max. The developer has already seen the progress bars
       return { text: `Tool error: ${errors.join('; ')}`, agents: agentIds };
     }
 
-    const collectResult: CollectResultLike = await this.pipeline.collect(taskIds, 600_000, { consensus: true });
+    // Spec §3.2 boundary #3: construct a minimal RoundContext for the
+    // in-process consensus path. The router has no resolutionRoots today
+    // (consensus runs against project root), so roots is the empty array and
+    // warnings starts empty; consensusId is minted downstream by the engine.
+    const round = makeRoundContext({ resolutionRoots: [], warnings: [] });
+    const collectResult: CollectResultLike = await this.pipeline.collect(taskIds, 600_000, { consensus: true, round });
     const lines = collectResult.results.map(r =>
       `[${r.agentId}] ${r.status === 'completed' ? r.result : `ERROR: ${r.error}`}`
     );

--- a/tests/cli/round-context-persist.test.ts
+++ b/tests/cli/round-context-persist.test.ts
@@ -1,0 +1,230 @@
+/**
+ * RoundContext disk back-compat + drain-rendering seams (spec
+ * 2026-06-11-round-context-fail-loud.md §3.2/§5/§6.1, consensus
+ * 5e9804d3-91fe440d).
+ *
+ * Covers:
+ *   (c) old-flat-shape restore: a pre-PR-A pending-consensus.json (no embedded
+ *       roundContext) restores with roots intact AND a reconstructed
+ *       RoundContext.
+ *   embedded roundContext persist→restore round-trip (resolutionRoots +
+ *       warnings + lenses survive /mcp reconnect).
+ *   (d) drain rendering: a consensus report carrying warnings renders a
+ *       "Round warnings" block in the gossip_collect tool response.
+ *
+ * GAP NOTE: the MCP-boundary producer (mcp-server-sdk.ts gossip_collect handler
+ * appending roots_rejected / roots_empty_after_validation) is inline in the
+ * server tool closure and not independently importable. Its EFFECT — warnings
+ * threaded through the round into report.warnings and rendered — is what these
+ * tests pin, by injecting the warnings at the round boundary the producer feeds.
+ * The producer logic itself (one warning per rejected entry, +1 when all
+ * rejected) is small and unit-covered via the coordinator drain seam in
+ * tests/orchestrator/round-context-seams.test.ts.
+ */
+import { mkdtempSync, rmSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { persistPendingConsensus, restorePendingConsensus } from '../../apps/cli/src/handlers/relay-cross-review';
+import { handleCollect } from '../../apps/cli/src/handlers/collect';
+import { ctx } from '../../apps/cli/src/mcp-context';
+import { makeRoundContext } from '@gossip/orchestrator';
+
+describe('RoundContext disk persistence (spec §3.2)', () => {
+  let tmp: string;
+  let origCwd: string;
+  let origMainAgent: any;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'rcp-'));
+    origCwd = process.cwd();
+    process.chdir(tmp);
+    mkdirSync(join(tmp, '.gossip'), { recursive: true });
+    origMainAgent = (ctx as any).mainAgent;
+    (ctx as any).mainAgent = { projectRoot: tmp } as any;
+  });
+
+  afterEach(() => {
+    ctx.pendingConsensusRounds.clear();
+    process.chdir(origCwd);
+    (ctx as any).mainAgent = origMainAgent;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('persists + restores the embedded roundContext (roots + warnings + lenses)', () => {
+    const roundId = 'deadbeef-cafebabe';
+    const roots = [tmp + '/worktrees/feature-x'];
+    const roundContext = makeRoundContext({
+      consensusId: roundId,
+      resolutionRoots: roots,
+      lenses: { 'sonnet': 'security lens' },
+      warnings: [{ code: 'roots_rejected', message: 'entry y rejected' }],
+    });
+    ctx.pendingConsensusRounds.set(roundId, {
+      consensusId: roundId,
+      allResults: [],
+      relayCrossReviewEntries: [],
+      pendingNativeAgents: new Set(['sonnet']),
+      participatingNativeAgents: new Set(['sonnet']),
+      nativeCrossReviewEntries: [],
+      deadline: Date.now() + 60_000,
+      createdAt: Date.now(),
+      resolutionRoots: roots,
+      roundContext,
+    });
+    persistPendingConsensus();
+
+    const raw = JSON.parse(readFileSync(join(tmp, '.gossip', 'pending-consensus.json'), 'utf-8'));
+    expect(raw[roundId].roundContext.resolutionRoots).toEqual(roots);
+    expect(raw[roundId].roundContext.warnings).toHaveLength(1);
+    expect(raw[roundId].roundContext.lenses).toEqual({ sonnet: 'security lens' });
+
+    ctx.pendingConsensusRounds.clear();
+    restorePendingConsensus(tmp);
+    const restored = ctx.pendingConsensusRounds.get(roundId);
+    expect(restored).toBeDefined();
+    expect(restored!.roundContext).toBeDefined();
+    expect(restored!.roundContext!.resolutionRoots).toEqual(roots);
+    expect(restored!.roundContext!.warnings).toHaveLength(1);
+    expect(restored!.roundContext!.warnings[0].code).toBe('roots_rejected');
+    expect(restored!.roundContext!.lenses).toEqual({ sonnet: 'security lens' });
+    // Flat field stays populated in parallel (alias mode).
+    expect(restored!.resolutionRoots).toEqual(roots);
+  });
+
+  it('(c) old flat-shape file (no roundContext) restores with roots intact + reconstructed round', () => {
+    const roundId = 'aaaabbbb-ccccdddd';
+    const roots = [tmp + '/worktrees/legacy'];
+    // Hand-write a PRE-MIGRATION pending-consensus.json: flat resolutionRoots,
+    // NO roundContext field (the exact shape a pre-PR-A binary persisted).
+    const flat = {
+      [roundId]: {
+        consensusId: roundId,
+        allResults: [],
+        relayCrossReviewEntries: [],
+        relayCrossReviewSkipped: undefined,
+        pendingNativeAgents: ['sonnet'],
+        participatingNativeAgents: ['sonnet'],
+        nativeCrossReviewEntries: [],
+        deadline: Date.now() + 60_000,
+        createdAt: Date.now(),
+        nativePrompts: [],
+        resolutionRoots: roots,
+      },
+    };
+    writeFileSync(join(tmp, '.gossip', 'pending-consensus.json'), JSON.stringify(flat));
+
+    restorePendingConsensus(tmp);
+    const restored = ctx.pendingConsensusRounds.get(roundId);
+    expect(restored).toBeDefined();
+    // Flat roots survive.
+    expect(restored!.resolutionRoots).toEqual(roots);
+    // A RoundContext is reconstructed from the flat roots (per-field fallback).
+    expect(restored!.roundContext).toBeDefined();
+    expect(restored!.roundContext!.resolutionRoots).toEqual(roots);
+    expect(restored!.roundContext!.warnings).toEqual([]);
+  });
+
+  it('(c) old flat-shape file with NO roots reconstructs no round (legacy rootless)', () => {
+    const roundId = 'eeeeffff-00001111';
+    const flat = {
+      [roundId]: {
+        consensusId: roundId,
+        allResults: [],
+        relayCrossReviewEntries: [],
+        pendingNativeAgents: [],
+        participatingNativeAgents: [],
+        nativeCrossReviewEntries: [],
+        deadline: Date.now() + 60_000,
+        createdAt: Date.now(),
+        nativePrompts: [],
+      },
+    };
+    writeFileSync(join(tmp, '.gossip', 'pending-consensus.json'), JSON.stringify(flat));
+
+    restorePendingConsensus(tmp);
+    const restored = ctx.pendingConsensusRounds.get(roundId);
+    expect(restored).toBeDefined();
+    expect(restored!.resolutionRoots).toBeUndefined();
+    expect(restored!.roundContext).toBeUndefined();
+  });
+});
+
+describe('(d) drain rendering — warnings block in gossip_collect response', () => {
+  let origMainAgent: any;
+  let origBoot: any;
+  let origNativeConfigs: any;
+
+  beforeEach(() => {
+    origMainAgent = (ctx as any).mainAgent;
+    origBoot = ctx.boot;
+    origNativeConfigs = ctx.nativeAgentConfigs;
+    ctx.boot = jest.fn().mockResolvedValue(undefined) as any;
+    ctx.nativeAgentConfigs = new Map();
+    ctx.pendingConsensusRounds = new Map();
+    ctx.nativeResultMap = new Map();
+    ctx.nativeTaskMap = new Map();
+  });
+
+  afterEach(() => {
+    (ctx as any).mainAgent = origMainAgent;
+    ctx.boot = origBoot;
+    ctx.nativeAgentConfigs = origNativeConfigs;
+    ctx.pendingConsensusRounds.clear();
+  });
+
+  it('renders a "Round warnings" block when the report carries warnings', async () => {
+    const now = Date.now();
+    const twoRelayResults = [
+      { id: 't1', agentId: 'gemini-reviewer', task: 'Audit', status: 'completed', result: 'ok-a', startedAt: now - 1000, completedAt: now },
+      { id: 't2', agentId: 'gemini-tester', task: 'Audit', status: 'completed', result: 'ok-b', startedAt: now - 1000, completedAt: now },
+    ];
+    (ctx as any).mainAgent = {
+      projectRoot: '/tmp/gossip-test',
+      collect: jest.fn().mockResolvedValue({ results: twoRelayResults }),
+      // Emulate the engine drain: report carries the round's warnings.
+      runConsensus: jest.fn().mockResolvedValue({
+        agentCount: 2, rounds: 2,
+        confirmed: [], disputed: [], unverified: [], unique: [], insights: [],
+        newFindings: [], signals: [], summary: 'Consensus complete.',
+        warnings: [
+          { code: 'roots_empty_after_validation', message: 'all 2 supplied resolutionRoots were rejected' },
+        ],
+      }),
+      getAgentConfig: jest.fn().mockReturnValue(null),
+      getLlm: jest.fn().mockReturnValue(null),
+    } as any;
+
+    // Pass a round whose warnings the (mocked) engine will drain.
+    const round = makeRoundContext({
+      resolutionRoots: [],
+      warnings: [{ code: 'roots_empty_after_validation', message: 'all 2 supplied resolutionRoots were rejected' }],
+    });
+    const result = await handleCollect(['t1', 't2'], 5000, true, [], undefined, round);
+    const text = result.content[0].text;
+    expect(text).toContain('⚠ Round warnings:');
+    expect(text).toContain('roots_empty_after_validation');
+    expect(text).toContain('all 2 supplied resolutionRoots were rejected');
+  });
+
+  it('renders NO warnings block when the report has none (clean round regression)', async () => {
+    const now = Date.now();
+    const twoRelayResults = [
+      { id: 't1', agentId: 'gemini-reviewer', task: 'Audit', status: 'completed', result: 'ok-a', startedAt: now - 1000, completedAt: now },
+      { id: 't2', agentId: 'gemini-tester', task: 'Audit', status: 'completed', result: 'ok-b', startedAt: now - 1000, completedAt: now },
+    ];
+    (ctx as any).mainAgent = {
+      projectRoot: '/tmp/gossip-test',
+      collect: jest.fn().mockResolvedValue({ results: twoRelayResults }),
+      runConsensus: jest.fn().mockResolvedValue({
+        agentCount: 2, rounds: 2,
+        confirmed: [], disputed: [], unverified: [], unique: [], insights: [],
+        newFindings: [], signals: [], summary: 'Consensus complete.',
+      }),
+      getAgentConfig: jest.fn().mockReturnValue(null),
+      getLlm: jest.fn().mockReturnValue(null),
+    } as any;
+
+    const result = await handleCollect(['t1', 't2'], 5000, true, [], undefined, makeRoundContext());
+    expect(result.content[0].text).not.toContain('Round warnings');
+  });
+});

--- a/tests/cli/round-context-persist.test.ts
+++ b/tests/cli/round-context-persist.test.ts
@@ -122,6 +122,47 @@ describe('RoundContext disk persistence (spec §3.2)', () => {
     expect(restored!.roundContext).toBeDefined();
     expect(restored!.roundContext!.resolutionRoots).toEqual(roots);
     expect(restored!.roundContext!.warnings).toEqual([]);
+    // No lenses field existed in the flat record — the reconstructed round must
+    // not invent one (back-compat lenses behavior, spec §5 lens-propagation).
+    expect(restored!.roundContext!.lenses).toBeUndefined();
+  });
+
+  it('new-format record with intentionally-empty roundContext.resolutionRoots is honored (not flat-fallback)', () => {
+    // A NEW-format record may legitimately carry roundContext.resolutionRoots:[]
+    // ("resolve against project root"). The restore MUST honor that empty array
+    // as authoritative — NOT fall through to a stale flat resolutionRoots. This
+    // pins the `??`-semantics fix (no length-gated fallback).
+    const roundId = '11112222-33334444';
+    const record = {
+      [roundId]: {
+        consensusId: roundId,
+        allResults: [],
+        relayCrossReviewEntries: [],
+        pendingNativeAgents: ['sonnet'],
+        participatingNativeAgents: ['sonnet'],
+        nativeCrossReviewEntries: [],
+        deadline: Date.now() + 60_000,
+        createdAt: Date.now(),
+        nativePrompts: [],
+        // A divergent flat value that MUST be ignored in favor of the embedded
+        // empty roundContext.resolutionRoots.
+        resolutionRoots: [tmp + '/stale/flat'],
+        roundContext: {
+          consensusId: roundId,
+          resolutionRoots: [],
+          warnings: [{ code: 'roots_empty_after_validation', message: 'all rejected' }],
+        },
+      },
+    };
+    writeFileSync(join(tmp, '.gossip', 'pending-consensus.json'), JSON.stringify(record));
+
+    restorePendingConsensus(tmp);
+    const restored = ctx.pendingConsensusRounds.get(roundId);
+    expect(restored).toBeDefined();
+    expect(restored!.roundContext).toBeDefined();
+    // Embedded empty roots win — the stale flat value is NOT resurrected.
+    expect(restored!.roundContext!.resolutionRoots).toEqual([]);
+    expect(restored!.roundContext!.warnings).toHaveLength(1);
   });
 
   it('(c) old flat-shape file with NO roots reconstructs no round (legacy rootless)', () => {

--- a/tests/orchestrator/consensus-engine-resolution-roots.test.ts
+++ b/tests/orchestrator/consensus-engine-resolution-roots.test.ts
@@ -6,6 +6,7 @@ import {
   type ConsensusEngineConfig,
 } from '../../packages/orchestrator/src/consensus-engine';
 import { ConsensusCoordinator } from '../../packages/orchestrator/src/consensus-coordinator';
+import { makeRoundContext } from '../../packages/orchestrator/src/round-context';
 import {
   mkdtempSync,
   mkdirSync,
@@ -334,6 +335,54 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
     const all = seen.join('\n');
     // The cited file exists in BOTH roots with distinct content — the prompts
     // must carry the worktree version, never the master copy.
+    expect(all).toContain('worktree-branch');
+    expect(all).not.toContain('master-HEAD');
+  });
+  it('Test 22 — e2e: a RoundContext OBJECT via the coordinator union reaches anchor CONTENT (ToolRouter/door-#5 seam)', async () => {
+    // Test 21 proves the legacy roots-ARRAY arm of the coordinator union
+    // delivers worktree content. This test proves the RoundContext-OBJECT arm
+    // — the shape the in-process ToolRouter boundary (#3) constructs and
+    // pipeline.collect forwards — reaches anchor content too. Spec §5 row
+    // "in-process ToolRouter": the seam that was structurally impossible
+    // before PR-A. Chain pinned elsewhere: router constructs the round
+    // (tool-router.test.ts) and pipeline forwards it (plumbing suite); this
+    // test closes the final link: round object → coordinator → real engine →
+    // prompt content from the round's worktree root.
+    const proj = realpathSync(mkdtempSync(join(tmp, 'proj')));
+    const wt = realpathSync(mkdtempSync(join(tmp, 'wt')));
+    mkdirSync(join(proj, 'src'), { recursive: true });
+    mkdirSync(join(wt, 'src'), { recursive: true });
+    writeFileSync(join(proj, 'src', 'target.ts'), 'export function old() { return "master-HEAD"; }');
+    writeFileSync(join(wt, 'src', 'target.ts'), 'export function newImpl() { return "worktree-branch"; }');
+
+    const seen: string[] = [];
+    const llm = {
+      generate: jest.fn(async (messages: Array<{ content?: string }>) => {
+        for (const m of messages) if (typeof m?.content === 'string') seen.push(m.content);
+        return { text: '[]', usage: { inputTokens: 0, outputTokens: 0 } };
+      }),
+    };
+
+    const coordinator = new ConsensusCoordinator({
+      llm: llm as any,
+      registryGet: () => undefined,
+      projectRoot: proj,
+      keyProvider: null,
+      getAgentSkillsContent: () => undefined,
+    });
+
+    const finding = (desc: string) =>
+      `<agent_finding type="finding" severity="low">${desc} <cite tag="file">src/target.ts:1</cite></agent_finding>`;
+    const results = [
+      { id: 't1', agentId: 'agent-a', task: 'review', status: 'completed', result: finding('Issue A') },
+      { id: 't2', agentId: 'agent-b', task: 'review', status: 'completed', result: finding('Issue B') },
+    ] as any;
+
+    const round = makeRoundContext({ resolutionRoots: [wt] });
+    await coordinator.runConsensus(results, round);
+
+    expect(llm.generate).toHaveBeenCalled();
+    const all = seen.join('\n');
     expect(all).toContain('worktree-branch');
     expect(all).not.toContain('master-HEAD');
   });

--- a/tests/orchestrator/round-context-seams.test.ts
+++ b/tests/orchestrator/round-context-seams.test.ts
@@ -1,0 +1,245 @@
+/**
+ * RoundContext + fail-loud seam tests (spec 2026-06-11-round-context-fail-loud.md §5,
+ * consensus 5e9804d3-91fe440d).
+ *
+ * These tests pin the PR-A alias-mode threading at the layers the existing test
+ * utilities can drive without a giant new harness:
+ *   (a) coordinator-level: a RoundContext passed to runConsensus reaches the
+ *       ConsensusEngine config (the Test 21 e2e content path is covered by
+ *       consensus-engine-resolution-roots.test.ts:289; here we prove the round
+ *       OBJECT — carrying warnings — reaches the engine).
+ *   (d) boundary producer: round.warnings drain into report.warnings.
+ *   (e) round supplied at coordinator.runConsensus WINS over the legacy roots arg.
+ *   (f) lenses Record survives a JSON.stringify/parse round-trip.
+ *   (g) legacy mode regression: no round → engine seeds from loose resolutionRoots,
+ *       byte-identical to the pre-RoundContext path.
+ *
+ * The handleCollect-level all-relay seam (a') and the timeout-synthesis seam (b)
+ * are driven through the disk-restore boundary in
+ * tests/cli/round-context-persist.test.ts (closest layer the CLI utilities
+ * support without mocking the relay transport). See the gap note there.
+ */
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  makeRoundContext,
+  testRound,
+  type RoundContext,
+  type RoundWarning,
+} from '../../packages/orchestrator/src/round-context';
+
+// Capture the config each ConsensusEngine is constructed with, while stubbing
+// out the heavy run()/synthesize() path. Mirrors the plumbing-suite stub so the
+// coordinator test stays fast and deterministic. The stub's run() RETURNS the
+// round's warnings inside the report so we can assert the drain end-to-end at
+// the coordinator boundary without exercising the real synthesize().
+const engineConfigs: Array<{ resolutionRoots?: readonly string[]; round?: RoundContext }> = [];
+
+jest.mock('../../packages/orchestrator/src/consensus-engine', () => {
+  const actual = jest.requireActual('../../packages/orchestrator/src/consensus-engine');
+  class StubEngine {
+    config: any;
+    constructor(config: any) {
+      this.config = config;
+      engineConfigs.push(config);
+    }
+    async run() {
+      // Emulate the real synthesize() drain: copy round.warnings into the
+      // report when a round carries any (spec §6.1).
+      const warnings = this.config.round?.warnings ?? [];
+      return {
+        agentCount: 2,
+        rounds: 2,
+        confirmed: [], disputed: [], unverified: [], unique: [],
+        insights: [], newFindings: [], signals: [],
+        summary: 'stub',
+        ...(warnings.length > 0 ? { warnings: [...warnings] } : {}),
+      };
+    }
+  }
+  return { ...actual, ConsensusEngine: StubEngine };
+});
+
+import { ConsensusCoordinator } from '../../packages/orchestrator/src/consensus-coordinator';
+import type { TaskEntry } from '../../packages/orchestrator/src/types';
+
+const makeLlm = (): any => ({
+  generate: jest.fn(async () => ({ text: '[]', usage: { inputTokens: 0, outputTokens: 0 } })),
+});
+
+const completed = (agentId: string): TaskEntry => ({
+  id: `t-${agentId}`,
+  agentId,
+  task: 'review X',
+  status: 'completed',
+  result: '<agent_finding type="finding" severity="low">noted</agent_finding>',
+  startedAt: Date.now(),
+});
+
+describe('round-context.ts — makeRoundContext / testRound shape', () => {
+  it('makeRoundContext defaults resolutionRoots to [] and warnings to a fresh array', () => {
+    const r = makeRoundContext();
+    expect(r.resolutionRoots).toEqual([]);
+    expect(r.warnings).toEqual([]);
+    expect(r.consensusId).toBeUndefined();
+    expect(r.lenses).toBeUndefined();
+  });
+
+  it('makeRoundContext never aliases warnings arrays between rounds', () => {
+    const a = makeRoundContext();
+    const b = makeRoundContext();
+    a.warnings.push({ code: 'roots_rejected', message: 'x' });
+    expect(b.warnings).toHaveLength(0);
+  });
+
+  it('makeRoundContext preserves a supplied warnings array reference (boundary producer pattern)', () => {
+    const shared: RoundWarning[] = [{ code: 'roots_rejected', message: 'a' }];
+    const r = makeRoundContext({ resolutionRoots: ['/abs/x'], warnings: shared });
+    expect(r.warnings).toBe(shared);
+    expect(r.resolutionRoots).toEqual(['/abs/x']);
+  });
+
+  it('testRound fixture is overridable per field', () => {
+    const r = testRound({ consensusId: 'abc', resolutionRoots: ['/r'] });
+    expect(r.consensusId).toBe('abc');
+    expect(r.resolutionRoots).toEqual(['/r']);
+    expect(r.warnings).toEqual([]);
+  });
+
+  it('(f) lenses Record survives a JSON.stringify/parse round-trip intact', () => {
+    const r = makeRoundContext({
+      resolutionRoots: ['/abs/wt'],
+      lenses: { 'agent-a': 'security lens', 'agent-b': 'perf lens' },
+    });
+    const roundTripped = JSON.parse(JSON.stringify(r)) as RoundContext;
+    expect(roundTripped.lenses).toEqual({ 'agent-a': 'security lens', 'agent-b': 'perf lens' });
+    // A Map would have serialized to {} — assert it did NOT.
+    expect(Object.keys(roundTripped.lenses ?? {})).toHaveLength(2);
+  });
+});
+
+describe('(a/e/g) coordinator.runConsensus alias-mode threading', () => {
+  let tmp: string;
+  let root: string;
+
+  beforeEach(() => {
+    engineConfigs.length = 0;
+    tmp = mkdtempSync(join(tmpdir(), 'rcs-'));
+    root = realpathSync(tmp);
+  });
+
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it('(a) a RoundContext passed to runConsensus reaches the engine config as `round`', async () => {
+    const wt = realpathSync(mkdtempSync(join(tmp, 'wt')));
+    const round = makeRoundContext({ resolutionRoots: [wt], consensusId: 'cafef00d' });
+    const coordinator = new ConsensusCoordinator({
+      llm: makeLlm(), registryGet: () => undefined, projectRoot: root, keyProvider: null,
+    });
+
+    await coordinator.runConsensus([completed('relay-a'), completed('relay-b')], round);
+
+    expect(engineConfigs).toHaveLength(1);
+    expect(engineConfigs[0].round).toBe(round);
+    // Round wins → the loose resolutionRoots field is NOT set in alias mode.
+    expect(engineConfigs[0].resolutionRoots).toBeUndefined();
+  });
+
+  it('(e) a round arg WINS over the constructor default round', async () => {
+    const ctorRound = makeRoundContext({ resolutionRoots: [realpathSync(mkdtempSync(join(tmp, 'ctor')))] });
+    const perRoundRound = makeRoundContext({ resolutionRoots: [realpathSync(mkdtempSync(join(tmp, 'round')))] });
+    const coordinator = new ConsensusCoordinator({
+      llm: makeLlm(), registryGet: () => undefined, projectRoot: root, keyProvider: null,
+      round: ctorRound,
+    });
+
+    await coordinator.runConsensus([completed('relay-a'), completed('relay-b')], perRoundRound);
+    expect(engineConfigs[engineConfigs.length - 1].round).toBe(perRoundRound);
+
+    // No per-round arg → constructor default round is used.
+    await coordinator.runConsensus([completed('relay-a'), completed('relay-b')]);
+    expect(engineConfigs[engineConfigs.length - 1].round).toBe(ctorRound);
+  });
+
+  it('(g) legacy mode: no round, loose roots arg → engine gets resolutionRoots, no round (byte-identical)', async () => {
+    const wt = realpathSync(mkdtempSync(join(tmp, 'legacy')));
+    const coordinator = new ConsensusCoordinator({
+      llm: makeLlm(), registryGet: () => undefined, projectRoot: root, keyProvider: null,
+    });
+
+    await coordinator.runConsensus([completed('relay-a'), completed('relay-b')], [wt]);
+
+    expect(engineConfigs[0].round).toBeUndefined();
+    expect(engineConfigs[0].resolutionRoots).toEqual([wt]);
+  });
+
+  it('(d) round.warnings drain into the consensus report', async () => {
+    const round = makeRoundContext({
+      resolutionRoots: [],
+      warnings: [
+        { code: 'roots_empty_after_validation', message: 'all roots rejected' },
+        { code: 'roots_rejected', message: 'entry x rejected' },
+      ],
+    });
+    const coordinator = new ConsensusCoordinator({
+      llm: makeLlm(), registryGet: () => undefined, projectRoot: root, keyProvider: null,
+    });
+
+    const report = await coordinator.runConsensus([completed('relay-a'), completed('relay-b')], round);
+    expect(report?.warnings).toBeDefined();
+    expect(report!.warnings).toHaveLength(2);
+    expect(report!.warnings!.map(w => w.code)).toEqual([
+      'roots_empty_after_validation',
+      'roots_rejected',
+    ]);
+  });
+});
+
+describe('(g) ConsensusEngine constructor — round-vs-legacy seeding parity', () => {
+  let tmp: string;
+  let root: string;
+  let wt: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'rcs-eng-'));
+    root = realpathSync(tmp);
+    wt = realpathSync(mkdtempSync(join(tmp, 'wt')));
+    mkdirSync(join(wt, 'src'), { recursive: true });
+    writeFileSync(join(wt, 'src', 'A.ts'), 'worktree-copy');
+  });
+
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it('round.resolutionRoots seeds currentWorktreeRoots identically to loose resolutionRoots', () => {
+    // Use the REAL engine (the module mock above only swaps for the coordinator
+    // import; here we requireActual to exercise the constructor seeding).
+    const { ConsensusEngine: RealEngine } = jest.requireActual(
+      '../../packages/orchestrator/src/consensus-engine',
+    );
+    const llm = makeLlm();
+
+    const viaLegacy = new RealEngine({
+      llm, registryGet: () => undefined, projectRoot: root, resolutionRoots: [wt],
+    });
+    const viaRound = new RealEngine({
+      llm, registryGet: () => undefined, projectRoot: root,
+      round: makeRoundContext({ resolutionRoots: [wt] }),
+    });
+
+    const legacyRoots: Set<string> = (viaLegacy as any).currentWorktreeRoots;
+    const roundRoots: Set<string> = (viaRound as any).currentWorktreeRoots;
+    expect([...roundRoots].sort()).toEqual([...legacyRoots].sort());
+    expect(roundRoots.has(wt)).toBe(true);
+  });
+
+  it('round path enforces the same absolute-path invariant (throws on relative)', () => {
+    const { ConsensusEngine: RealEngine } = jest.requireActual(
+      '../../packages/orchestrator/src/consensus-engine',
+    );
+    expect(() => new RealEngine({
+      llm: makeLlm(), registryGet: () => undefined, projectRoot: root,
+      round: makeRoundContext({ resolutionRoots: ['relative/path'] }),
+    })).toThrow(/absolute/);
+  });
+});

--- a/tests/orchestrator/tool-router.test.ts
+++ b/tests/orchestrator/tool-router.test.ts
@@ -427,7 +427,17 @@ describe('ToolExecutor', () => {
       ]),
       { consensus: true },
     );
-    expect(mockPipeline.collect).toHaveBeenCalledWith(['task-1', 'task-2'], 600_000, { consensus: true });
+    // PR-A: the router now constructs a minimal RoundContext (boundary #3,
+    // spec §3.2) and threads it alongside consensus:true. Roots empty, warnings
+    // empty — the in-process consensus path has no resolutionRoots today.
+    expect(mockPipeline.collect).toHaveBeenCalledWith(
+      ['task-1', 'task-2'],
+      600_000,
+      expect.objectContaining({
+        consensus: true,
+        round: expect.objectContaining({ resolutionRoots: [], warnings: [] }),
+      }),
+    );
     expect(result.text).toContain('Review done');
     expect(result.text).toContain('Consensus Report');
     expect(result.text).toContain('Both agents agree');


### PR DESCRIPTION
## Summary

PR-A of the RoundContext + fail-loud spec (`docs/specs/2026-06-11-round-context-fail-loud.md`, local) — the structural fix for the wiring-drop bug class that produced five "doors" of the #389 stale-anchor family (#365, #541, #542 history).

**RoundContext** (`packages/orchestrator/src/round-context.ts`): one per-round carrier (optional `consensusId`, boundary-validated `resolutionRoots`, JSON-safe `lenses` Record, append-only `warnings`) constructed at the boundaries and threaded by reference:
- `handleCollect` (MCP boundary) — embeds into `pendingConsensusRounds` with disk back-compat (`restoreRoundContext` reads old flat-shape files via the `participatingNativeAgents` precedent; intentionally-empty new-format roots are authoritative)
- **ToolRouter** (in-process boundary, door #5) — `MainAgent.collect` options widened; the interactive consensus path can finally carry roots at the type level
- `handleDispatch*` — deferred to PR-B by orchestrator adjudication (no round exists at dispatch; documented in-code)

**Alias mode (PR-A scoping):** `round?` is optional everywhere; legacy `resolutionRoots` byte-identical when absent (side-by-side parity test). All 98 existing engine-constructor test sites untouched and green. `isRoundContext` structural guard at the coordinator union. Hard-required break + alias deletion is PR-C (`testRound()` fixture ships now).

**Fail-loud drains:** `ConsensusReport.warnings` + render block in the collect response; one boundary producer (`roots_rejected` / `roots_empty_after_validation`). Producer conversions (relayCrossReviewSkipped/coverageDegraded/partialReview subsumption) are PR-B.

**Seam tests:** `round-context-seams.test.ts`, `round-context-persist.test.ts` (old-flat-shape restore fixture, lens JSON round-trip, legacy parity), Test 22 (RoundContext-object arm → real engine → anchor content, the door-#5 proof).

## Review
Pre-merge consensus `dc26a72f-84c24a35`: 6 confirmed / 0 disputed; gemini-reviewer's injection claim refuted in cross-review (messages carry sha256-truncated hashes, never raw paths); the one MEDIUM (missing anchor-content seam assertion) closed by `8c2596df`. Spec-conformance reviewed by sonnet-reviewer against the authoritative spec: structurally conformant, no correctness defects. Prior architecture consensus on the spec itself: `5e9804d3-91fe440d`.

## Verification
- Root `tsc --noEmit`: clean (pre-existing dashboard-v2 noise only)
- `tests/orchestrator/`: 161 suites / 2370+ passed; `tests/cli/`: 80 suites / 1064 passed; touched suites 24/24 post-fixup
- `npm run build` + `npm run build:mcp`: clean

consensus-id: dc26a72f-84c24a35

🤖 Generated with [Claude Code](https://claude.com/claude-code)