### PR TITLE
feat(consensus): PR-B fail-loud producers + dispatch-time warnings stash + restore hardening

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -1030,6 +1030,10 @@ export async function handleCollect(
         // same silent-dropout indicator the gossip_collect tool response shows.
         ...(consensusReport.zeroTagAgents ? { zeroTagAgents: consensusReport.zeroTagAgents } : {}),
         ...(consensusReport.zeroTagOverflow ? { zeroTagOverflow: consensusReport.zeroTagOverflow } : {}),
+        // Fail-loud round warnings (spec 2026-06-11 §4) — round-trip through the
+        // persisted report so the dashboard report card can render them as
+        // amber badges (FindingsMetrics warnings group).
+        ...(consensusReport.warnings && consensusReport.warnings.length > 0 ? { warnings: consensusReport.warnings } : {}),
       }, null, 2));
     } catch (e) {
       // Best-effort still applies (we don't throw to the caller), but the

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -1319,7 +1319,9 @@ export async function handleCollect(
   // into report.warnings at synthesis. Render one line per warning so the
   // operator sees rejected/empty resolutionRoots (and, post-PR-B, coverage /
   // partial-review drops) in-band, not just on stderr. Append-only, no dedup.
+  let warningsRendered = false;
   if (consensusReport?.warnings && consensusReport.warnings.length > 0) {
+    warningsRendered = true;
     output += '\n\n⚠ Round warnings:';
     for (const w of consensusReport.warnings) {
       const agent = w.agentId ? ` [${w.agentId.replace(/[\r\n]/g, ' ')}]` : '';
@@ -1459,5 +1461,5 @@ export async function handleCollect(
     }
   } catch { /* best-effort */ }
 
-  return { content: [{ type: 'text' as const, text: output }] };
+  return { content: [{ type: 'text' as const, text: output }], warningsRendered };
 }

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -19,7 +19,7 @@ import {
   type RoundWarning,
 } from '@gossip/orchestrator';
 import { formatIdentityBlock } from '@gossip/tools';
-import { ctx, NATIVE_TASK_TTL_MS } from '../mcp-context';
+import { ctx, NATIVE_TASK_TTL_MS, MAX_PENDING_DISPATCH_WARNINGS } from '../mcp-context';
 
 /**
  * Stash dispatch-time fail-loud warnings (spec §3.2 boundary #1) under every
@@ -32,6 +32,13 @@ function stashDispatchWarnings(taskIds: readonly string[], warnings?: readonly R
   if (!warnings || warnings.length === 0 || taskIds.length === 0) return;
   const frozen = Object.freeze(warnings.map(w => Object.freeze({ ...w })));
   for (const tid of taskIds) {
+    // Bounded eviction: evict the eldest entry (first by Map insertion order)
+    // when the cap is reached, so uncollected tasks don't grow the map without
+    // bound for the server lifetime.
+    if (ctx.pendingDispatchWarnings.size >= MAX_PENDING_DISPATCH_WARNINGS) {
+      const eldest = ctx.pendingDispatchWarnings.keys().next().value;
+      if (eldest !== undefined) ctx.pendingDispatchWarnings.delete(eldest);
+    }
     ctx.pendingDispatchWarnings.set(tid, frozen);
   }
 }

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -16,9 +16,25 @@ import {
   type ClaimBlock,
   type ClaimVerdict,
   type PerformanceSignal,
+  type RoundWarning,
 } from '@gossip/orchestrator';
 import { formatIdentityBlock } from '@gossip/tools';
 import { ctx, NATIVE_TASK_TTL_MS } from '../mcp-context';
+
+/**
+ * Stash dispatch-time fail-loud warnings (spec §3.2 boundary #1) under every
+ * minted task_id so gossip_collect can drain them into the collect-built
+ * RoundContext. No-op when there are no warnings. The same warnings array is
+ * stored under each id (collect dedups by draining once); frozen so a later
+ * mutation can't retroactively change a stashed entry.
+ */
+function stashDispatchWarnings(taskIds: readonly string[], warnings?: readonly RoundWarning[]): void {
+  if (!warnings || warnings.length === 0 || taskIds.length === 0) return;
+  const frozen = Object.freeze(warnings.map(w => Object.freeze({ ...w })));
+  for (const tid of taskIds) {
+    ctx.pendingDispatchWarnings.set(tid, frozen);
+  }
+}
 
 /** Build the identity block for a native subagent dispatch. */
 function buildNativeIdentity(agentId: string, model: string): string {
@@ -558,6 +574,14 @@ export async function handleDispatchSingle(
    * Default 'inline' preserves byte-for-byte the pre-PR behavior.
    */
   prompt_format?: PromptFormat,
+  /**
+   * Spec §3.2 boundary #1: dispatch-time fail-loud warnings. Stashed under the
+   * minted task_id so a later gossip_collect on this single task drains them.
+   * A solo dispatch rarely feeds a consensus round, so the operator-facing
+   * visibility for single comes from the dispatch-response warning block; the
+   * stash is best-effort for the collect path.
+   */
+  dispatchWarnings?: readonly RoundWarning[],
 ) {
   await ctx.boot();
   await ctx.syncWorkersViaKeychain();
@@ -613,6 +637,8 @@ export async function handleDispatchSingle(
     const taskId = randomUUID().slice(0, 8);
     const relayToken = randomUUID().slice(0, 12);
     const timeoutMs = timeout_ms ?? NATIVE_TASK_TTL_MS;
+    // Spec §3.2 boundary #1: stash dispatch-time warnings under this task_id.
+    stashDispatchWarnings([taskId], dispatchWarnings);
 
     // Stage 2 premise-verification — parse + verify any ```premise-claims
     // block in the task. Runs BEFORE assemblePrompt so the PREMISE-MISMATCH
@@ -928,6 +954,12 @@ export async function handleDispatchParallel(
    * is replaced by an Item-1 marker citing the on-disk path. Default 'inline'.
    */
   prompt_format?: PromptFormat,
+  /**
+   * Spec §3.2 boundary #1: dispatch-time fail-loud warnings (e.g. rejected
+   * resolutionRoots). Stashed under every minted task_id so gossip_collect can
+   * drain them into the collect-built RoundContext → report.warnings.
+   */
+  dispatchWarnings?: readonly RoundWarning[],
 ) {
   await ctx.boot();
   await ctx.syncWorkersViaKeychain();
@@ -1219,6 +1251,8 @@ export async function handleDispatchParallel(
       ctx.pendingDispatchResolutionRoots.set(tid, frozen);
     }
   }
+  // Spec §3.2 boundary #1: stash dispatch-time warnings under each task_id.
+  stashDispatchWarnings(allParallelTaskIds, dispatchWarnings);
 
   let msg = '';
   if (nativeInstructions.length > 0) {
@@ -1260,6 +1294,14 @@ export async function handleDispatchConsensus(
    * Per-task elision for the consensus cross-review batch. Default 'inline'.
    */
   prompt_format?: PromptFormat,
+  /**
+   * Spec §3.2 boundary #1: dispatch-time fail-loud warnings (e.g. rejected
+   * resolutionRoots). Stashed under every minted task_id so gossip_collect can
+   * drain them into the collect-built RoundContext → report.warnings. Named
+   * `dispatchRoundWarnings` to avoid shadowing the local `dispatchWarnings`
+   * string[] returned by resolveDispatchResolutionRoots below.
+   */
+  dispatchRoundWarnings?: readonly RoundWarning[],
 ) {
   await ctx.boot();
   await ctx.syncWorkersViaKeychain();
@@ -1529,6 +1571,8 @@ export async function handleDispatchConsensus(
       ctx.pendingDispatchResolutionRoots.set(tid, frozen);
     }
   }
+  // Spec §3.2 boundary #1: stash dispatch-time warnings under each task_id.
+  stashDispatchWarnings(allTaskIds, dispatchRoundWarnings);
 
   const collectCall = `gossip_collect(task_ids: [${allTaskIds.map(id => `"${id}"`).join(', ')}], consensus: true)`;
   let msg = `⚠️ REQUIRED_NEXT_ACTION: Agent() dispatch — this is a TODO, not a result.\n`;

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -883,6 +883,31 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
           suspectedReason: 'orchestrator_paraphrase',
           timestamp: ts,
         });
+        // Spec §4 producer: structured zero_tags warning on the live consensus
+        // round (in ADDITION to the receipt line + jsonl above). PERSIST-AFTER-
+        // APPEND — the round record is the persisted carrier (relay-cross-review.ts
+        // pattern), so re-persist immediately so the warning survives /mcp
+        // reconnect. No-op when the round was already torn down (the membership
+        // fallback fired on recentConsensusTaskIds, not a live round) — the
+        // jsonl + receipt line still record it.
+        try {
+          for (const r of ctx.pendingConsensusRounds.values()) {
+            const member =
+              (Array.isArray(r.allResults) && r.allResults.some((x: any) => x && (x.id === task_id || x.agentId === agentId))) ||
+              (r.pendingNativeAgents instanceof Set && r.pendingNativeAgents.has(agentId)) ||
+              (Array.isArray(r.nativeCrossReviewEntries) && r.nativeCrossReviewEntries.some((e: any) => e && (e.taskId === task_id || e.agentId === agentId)));
+            if (member && r.roundContext) {
+              r.roundContext.warnings.push({
+                code: 'zero_tags',
+                message: `relayed consensus result carried 0 <agent_finding> tags (resultLength=${result?.length ?? 0}) — findings likely paraphrased and lost`,
+                agentId,
+              });
+              const { persistPendingConsensus } = require('./relay-cross-review');
+              persistPendingConsensus();
+              break;
+            }
+          }
+        } catch { /* best-effort — receipt + jsonl already recorded */ }
         try {
           const { emitPipelineSignals } = await import('@gossip/orchestrator');
           emitPipelineSignals(projectRoot, [{

--- a/apps/cli/src/handlers/relay-cross-review.ts
+++ b/apps/cli/src/handlers/relay-cross-review.ts
@@ -105,6 +105,7 @@ export function startConsensusTimeout(consensusId: string): void {
           timedOut: missingAgents,
           ...(report.droppedFindingsByType ? { droppedFindingsByType: report.droppedFindingsByType } : {}),
           ...(report.authorDiagnostics ? { authorDiagnostics: report.authorDiagnostics } : {}),
+          ...(report.warnings && report.warnings.length > 0 ? { warnings: report.warnings } : {}),
         }, null, 2));
       } catch { /* best-effort */ }
 
@@ -334,6 +335,7 @@ export async function handleRelayCrossReview(
         newFindings: report.newFindings || [],
         ...(report.droppedFindingsByType ? { droppedFindingsByType: report.droppedFindingsByType } : {}),
         ...(report.authorDiagnostics ? { authorDiagnostics: report.authorDiagnostics } : {}),
+        ...(report.warnings && report.warnings.length > 0 ? { warnings: report.warnings } : {}),
       }, null, 2));
     } catch { /* best-effort */ }
 
@@ -377,21 +379,84 @@ const CONSENSUS_FILE = 'pending-consensus.json';
 function restoreRoundContext(data: any): import('@gossip/orchestrator').RoundContext | undefined {
   const { makeRoundContext } = require('@gossip/orchestrator');
   const rc = data.roundContext;
+  // Deep-shape hardening (spec §4, gemini f1): a hand-edited / partially-written
+  // pending-consensus.json may carry malformed field shapes. Drop the malformed
+  // pieces (fail-OPEN — the round still restores) but record a
+  // `round_restore_malformed` warning per drop so the degradation is visible in
+  // report.warnings rather than silently swallowed (fail-LOUD). NEVER throw.
+  const restoreWarnings: import('@gossip/orchestrator').RoundWarning[] = [];
+  const noteDrop = (what: string) =>
+    restoreWarnings.push({ code: 'round_restore_malformed', message: `restore dropped malformed ${what}` });
+
   // Per-field fallback with `??` semantics (spec §3.2): an embedded
   // roundContext is AUTHORITATIVE — honor its resolutionRoots array even when
   // it is intentionally empty (`[]` = "resolve against project root"). Only
   // when there is NO embedded round do we read the old flat field. A
   // length-gated check would wrongly treat a new-format empty-roots record as
   // if it were old-flat-shape and resurrect a stale flat value.
-  const roots: readonly string[] =
+  const rawRoots: unknown =
     (rc && Array.isArray(rc.resolutionRoots))
       ? rc.resolutionRoots
       : (Array.isArray(data.resolutionRoots) ? data.resolutionRoots : []);
-  const warnings = rc && Array.isArray(rc.warnings) ? rc.warnings : [];
+  // resolutionRoots entries must be strings — drop non-string members.
+  let roots: readonly string[] = [];
+  if (Array.isArray(rawRoots)) {
+    const clean = (rawRoots as unknown[]).filter((x): x is string => typeof x === 'string');
+    if (clean.length !== rawRoots.length) noteDrop(`${rawRoots.length - clean.length} non-string resolutionRoots entr(y/ies)`);
+    roots = clean;
+  }
+
+  // warnings entries must be objects with string code+message; agentId optional
+  // string. Drop entries missing code/message or carrying non-string fields.
+  let warnings: import('@gossip/orchestrator').RoundWarning[] = [];
+  if (rc && Array.isArray(rc.warnings)) {
+    let dropped = 0;
+    for (const w of rc.warnings as unknown[]) {
+      if (
+        w && typeof w === 'object' &&
+        typeof (w as any).code === 'string' &&
+        typeof (w as any).message === 'string' &&
+        ((w as any).agentId === undefined || typeof (w as any).agentId === 'string')
+      ) {
+        const entry: import('@gossip/orchestrator').RoundWarning = { code: (w as any).code, message: (w as any).message };
+        if ((w as any).agentId !== undefined) entry.agentId = (w as any).agentId;
+        warnings.push(entry);
+      } else {
+        dropped++;
+      }
+    }
+    if (dropped > 0) noteDrop(`${dropped} warnings entr(y/ies) (missing code/message or non-string field)`);
+  } else if (rc && rc.warnings !== undefined) {
+    noteDrop('warnings field (not an array)');
+  }
+
   const consensusId = rc && typeof rc.consensusId === 'string' ? rc.consensusId : undefined;
-  const lenses = rc && rc.lenses && typeof rc.lenses === 'object' ? rc.lenses : undefined;
+  // lenses must be a plain object whose values are all strings; drop the whole
+  // map if it is non-object, or drop individual non-string values.
+  let lenses: Record<string, string> | undefined;
+  if (rc && rc.lenses !== undefined) {
+    if (rc.lenses && typeof rc.lenses === 'object' && !Array.isArray(rc.lenses)) {
+      const out: Record<string, string> = {};
+      let droppedLens = 0;
+      for (const [k, v] of Object.entries(rc.lenses as Record<string, unknown>)) {
+        if (typeof v === 'string') out[k] = v;
+        else droppedLens++;
+      }
+      if (droppedLens > 0) noteDrop(`${droppedLens} non-string lens value(s)`);
+      lenses = Object.keys(out).length > 0 ? out : undefined;
+    } else {
+      noteDrop('lenses field (not a plain object)');
+    }
+  }
+
+  // Append the restore-drop warnings AFTER the restored ones so the degradation
+  // shows up in report.warnings (spec §4 fail-loud).
+  if (restoreWarnings.length > 0) warnings = [...warnings, ...restoreWarnings];
+
   // Nothing to carry — no embedded round and no flat roots: legacy rootless.
-  if (!rc && roots.length === 0) return undefined;
+  // (A malformed-but-present rc still produces a round so its drop warnings
+  // surface; only the truly-empty pre-PR-A record returns undefined.)
+  if (!rc && roots.length === 0 && warnings.length === 0) return undefined;
   return makeRoundContext({
     ...(consensusId !== undefined ? { consensusId } : {}),
     resolutionRoots: roots,

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -3,7 +3,7 @@
  * Single mutable context object avoids passing dozens of parameters.
  */
 import { randomUUID } from 'crypto';
-import type { CrossReviewEntry, MainAgent, RoundContext } from '@gossip/orchestrator';
+import type { CrossReviewEntry, MainAgent, RoundContext, RoundWarning } from '@gossip/orchestrator';
 
 export interface NativeCrossReviewPrompt {
   agentId: string;
@@ -186,6 +186,23 @@ export interface McpContext {
    * bound memory.
    */
   pendingDispatchResolutionRoots: Map<string, readonly string[]>;
+  /**
+   * Dispatch-time fail-loud warnings (spec §3.2 boundary #1) keyed by task_id.
+   * The dispatch handler creates NO consensus round (that happens at collect),
+   * so dispatch-time resolutionRoots rejections have no round to attach to.
+   * They are stashed here under the handler-minted task_ids and drained into
+   * the collect-built RoundContext at handleCollect time, where they reach
+   * `report.warnings` via the PR-A drains.
+   *
+   * Lifetime boundary: this stash is in-memory only. It MUST survive being read
+   * at collect within the SAME server lifetime, but it is NOT persisted across
+   * /mcp reconnect — once drained into the round, the round record's own
+   * persistence (pending-consensus.json) carries the warnings forward. A
+   * reconnect between dispatch and collect loses an undrained stash entry; that
+   * is the accepted residual window (symmetric with pendingDispatchResolutionRoots,
+   * which is also reconnect-volatile).
+   */
+  pendingDispatchWarnings: Map<string, readonly RoundWarning[]>;
   nativeUtilityConfig: { model: string } | null;
   /** Post-fallback runtime provider actually being used by the orchestrator LLM. */
   mainProvider: string;
@@ -244,6 +261,7 @@ export const ctx: McpContext = {
   recentConsensusTaskIds: new Map(),
   recentConsensusAgentIds: new Map(),
   pendingDispatchResolutionRoots: new Map(),
+  pendingDispatchWarnings: new Map(),
   nativeUtilityConfig: null,
   mainProvider: 'google',
   mainModel: 'gemini-2.5-pro',

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -5,6 +5,14 @@
 import { randomUUID } from 'crypto';
 import type { CrossReviewEntry, MainAgent, RoundContext, RoundWarning } from '@gossip/orchestrator';
 
+/**
+ * Maximum number of task_ids held in pendingDispatchWarnings at any time.
+ * When at cap, stashDispatchWarnings evicts the eldest (first Map entry by
+ * insertion order) before inserting a new entry. Tasks dispatched and never
+ * collected would otherwise leak entries for the server lifetime.
+ */
+export const MAX_PENDING_DISPATCH_WARNINGS = 200;
+
 export interface NativeCrossReviewPrompt {
   agentId: string;
   system: string;
@@ -201,6 +209,11 @@ export interface McpContext {
    * reconnect between dispatch and collect loses an undrained stash entry; that
    * is the accepted residual window (symmetric with pendingDispatchResolutionRoots,
    * which is also reconnect-volatile).
+   *
+   * Bounded to MAX_PENDING_DISPATCH_WARNINGS entries. stashDispatchWarnings in
+   * dispatch.ts evicts the eldest (first Map entry by insertion order) when the
+   * cap is reached, preventing unbounded growth for tasks dispatched but never
+   * collected (e.g. long-lived server under repeated dispatch-only workflows).
    */
   pendingDispatchWarnings: Map<string, readonly RoundWarning[]>;
   nativeUtilityConfig: { model: string } | null;

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1736,13 +1736,17 @@ export function createMcpServer(): McpServer {
         warnings: round.warnings,
       });
       const collectResult = await handleCollect(task_ids, timeout_ms, consensus, validated, prompt_format, finalRound);
-      // handleCollect already renders a "⚠ Round warnings:" block from
-      // report.warnings (the PR-A drain) for consensus rounds, so the collect-
-      // time rejections + drained dispatch-time warnings on `round.warnings`
-      // surface there. For a NON-consensus collect there is no report/drain, so
-      // surface the round's warnings directly on the response — fail-loud
-      // invariant §4: visible at the call the operator made.
-      if (!consensus && round.warnings.length > 0) {
+      // handleCollect renders a "⚠ Round warnings:" block only when a
+      // consensusReport was built AND it carried warnings (the PR-A drain path).
+      // That path requires consensus:true AND ≥2 completed results. When fewer
+      // than 2 completed (or consensus:false), no report is built and no block
+      // is rendered — the round's warnings (including drained dispatch-time
+      // roots_rejected entries) would be silently lost. Guard: append whenever
+      // handleCollect did NOT already render them.  The `warningsRendered` flag
+      // on the return value is the explicit signal — avoids double-render on the
+      // ≥2-completed happy path while closing the <2-completed loss hole.
+      // Fail-loud invariant §4: round.warnings.length > 0 ⟹ visible in response.
+      if (!collectResult.warningsRendered && round.warnings.length > 0) {
         return appendDispatchWarningsBlock(collectResult, round.warnings);
       }
       return collectResult;

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -406,29 +406,33 @@ function lookupFindingSeverity(findingId: string, projectRoot: string): string |
 }
 
 /**
- * Item 3a — surface non-fatal resolutionRoots rejections in the tool RESPONSE,
- * not just stderr. When validateResolutionRoot drops an entry non-fatally, the
- * round proceeds with fewer (or zero) roots and anchors silently resolve
- * against project root. Prepend a visible warning line so the operator can
- * correct the input before stale-anchor false disputes occur (the #389 class).
- * No-op when nothing was rejected, preserving existing response bytes.
+ * Fail-loud invariant (spec §4): surface dispatch-time `RoundWarning`s in the
+ * dispatch tool RESPONSE, not only later at collect. When validateResolutionRoot
+ * drops an entry non-fatally, the round proceeds with fewer (or zero) roots and
+ * anchors silently resolve against project root; the operator must see that at
+ * the call they made (the #389 stale-anchor class). No-op when there are no
+ * warnings, preserving existing response bytes.
+ *
+ * Built on the generic `RoundWarning` shape (replacing the old bespoke
+ * `prependResolutionRootWarning`), so dispatch responses and the collect-time
+ * report.warnings drain render the same warning vocabulary. Aggregates visually
+ * by message with a count (e.g. "…rejected ×3") while every instance still
+ * flows into the round via the dispatch-warnings stash.
  */
-function prependResolutionRootWarning<T extends { content: Array<{ type: 'text'; text: string }> }>(
+function appendDispatchWarningsBlock<T extends { content: Array<{ type: 'text'; text: string }> }>(
   result: T,
-  rejectedReasons: readonly string[],
+  warnings: readonly import('@gossip/orchestrator').RoundWarning[],
 ): T {
-  if (!rejectedReasons || rejectedReasons.length === 0) return result;
-  // Render each distinct reason with its count so the raw rejected total and
-  // the per-reason breakdown agree (e.g. "3 entry(ies) rejected (not found ×3)").
-  // A bare Set dedup hides how many entries shared a reason.
+  if (!warnings || warnings.length === 0) return result;
+  // Aggregate identical messages with a count so the per-message breakdown is
+  // legible without hiding how many entries shared a reason.
   const counts = new Map<string, number>();
-  for (const r of rejectedReasons) counts.set(r, (counts.get(r) ?? 0) + 1);
-  const reasons = Array.from(counts.entries())
-    .map(([reason, n]) => (n > 1 ? `${reason} ×${n}` : reason))
-    .join('; ');
+  for (const w of warnings) counts.set(w.message, (counts.get(w.message) ?? 0) + 1);
+  const lines = Array.from(counts.entries())
+    .map(([message, n]) => (n > 1 ? `  - ${message} ×${n}` : `  - ${message}`));
   const warning = {
     type: 'text' as const,
-    text: `⚠ resolutionRoots: ${rejectedReasons.length} entry(ies) rejected (${reasons}) — anchors will resolve against project root`,
+    text: `⚠ ${warnings.length} round warning(s):\n${lines.join('\n')}`,
   };
   return { ...result, content: [warning, ...result.content] };
 }
@@ -1527,19 +1531,27 @@ export function createMcpServer(): McpServer {
       // Non-fatal rejection reasons surfaced in the response (item 3a) so a
       // dropped dispatch-time root is visible to the operator, not stderr-only.
       //
-      // RoundContext boundary #1 — DEFERRED past PR-A (documented divergence
-      // from spec §3.2's "construct at all three boundaries"). The dispatch
-      // handler does NOT create a consensus round (that happens at collect), so
-      // there is no round object here to embed a RoundContext into; only the
-      // dispatch-time roots stash (pendingDispatchResolutionRoots) is threaded
-      // forward, and collect wraps it into the RoundContext it constructs. The
-      // remaining functional gap — routing these dispatch-time rejectedRootReasons
-      // into the collect-built round so they reach report.warnings — needs a
-      // parallel warnings stash keyed by the handler-minted task_ids and a drain
-      // at collect; that crosses three handler signatures and is scoped to a
-      // follow-up. Today these reasons still surface via prependResolutionRootWarning
-      // on the dispatch RESPONSE (below), so they are not silently dropped.
-      const rejectedRootReasons: string[] = [];
+      // RoundContext boundary #1 (spec §3.2). The dispatch handler does NOT
+      // create a consensus round (that happens at collect), so there is no
+      // round object here to embed a RoundContext into. PR-B closes the
+      // boundary-#1 deferral: dispatch-time rejections are now accumulated as
+      // structured `RoundWarning`s and stashed (by the dispatch handlers) under
+      // every minted task_id on `ctx.pendingDispatchWarnings`. gossip_collect
+      // drains that stash into the collect-built RoundContext, so the rejection
+      // reaches `report.warnings` via the PR-A drains.
+      //
+      // Lifetime boundary: the stash is in-memory only and reconnect-volatile.
+      // It must survive being read at collect within the SAME server lifetime;
+      // once drained, the round record's own persistence carries the warnings.
+      // A /mcp reconnect between dispatch and collect loses an undrained entry
+      // (accepted residual window, symmetric with pendingDispatchResolutionRoots).
+      //
+      // Fail-loud invariant (§4): a dispatch-time rejection must ALSO be visible
+      // in the DISPATCH response, not only later at collect — so we still emit a
+      // warning block on the dispatch response (appendDispatchWarningsBlock),
+      // now built on the generic RoundWarning shape rather than the old bespoke
+      // prependResolutionRootWarning.
+      const dispatchWarnings: import('@gossip/orchestrator').RoundWarning[] = [];
       if (resolutionRoots && resolutionRoots.length > 0) {
         const { validateResolutionRoot } = await import('@gossip/orchestrator');
         for (const raw of resolutionRoots) {
@@ -1551,9 +1563,21 @@ export function createMcpServer(): McpServer {
             planExecutionDepth--;
             return { content: [{ type: 'text' as const, text: `Error: resolutionRoots REJECTED ROUND (adversarial input): ${r.reason} [${r.hashedInput}]` }] };
           } else {
-            rejectedRootReasons.push(r.reason ?? 'unknown');
+            // One roots_rejected warning per dropped entry (no dedup, spec §4).
+            dispatchWarnings.push({
+              code: 'roots_rejected',
+              message: `resolutionRoots entry rejected: ${r.reason ?? 'unknown'} [${r.hashedInput}] — anchors will resolve against project root`,
+            });
             process.stderr.write(`[consensus] resolutionRoots rejected: ${r.reason} [${r.hashedInput}]\n`);
           }
+        }
+        // When roots were supplied but ALL were rejected, the round proceeds
+        // with zero roots → anchors resolve against project root only.
+        if (validatedDispatchRoots.length === 0) {
+          dispatchWarnings.push({
+            code: 'roots_empty_after_validation',
+            message: `all ${resolutionRoots.length} supplied resolutionRoots were rejected — anchors will resolve against project root only`,
+          });
         }
       }
       try {
@@ -1564,29 +1588,36 @@ export function createMcpServer(): McpServer {
           // Spec docs/specs/2026-04-29-relay-worker-resolution-roots.md — forward
           // validatedDispatchRoots so a single-mode relay agent (e.g. gemini-tester
           // dispatched solo against a PR worktree) gets its tool-call cwd pinned.
-          return prependResolutionRootWarning(await handleDispatchSingle(
+          return appendDispatchWarningsBlock(await handleDispatchSingle(
             agent_id, task, write_mode, scope, timeout_ms, plan_id, step,
             validatedDispatchRoots.length > 0 ? validatedDispatchRoots : undefined,
             prompt_format,
-          ), rejectedRootReasons);
+            dispatchWarnings.length > 0 ? dispatchWarnings : undefined,
+          ), dispatchWarnings);
         }
         if (mode === 'parallel') {
           if (!tasks || tasks.length === 0) {
             return { content: [{ type: 'text' as const, text: 'Error: mode:"parallel" requires a non-empty tasks array.' }] };
           }
-          return prependResolutionRootWarning(await handleDispatchParallel(
+          return appendDispatchWarningsBlock(await handleDispatchParallel(
             tasks, false,
             validatedDispatchRoots.length > 0 ? validatedDispatchRoots : undefined,
             prompt_format,
-          ), rejectedRootReasons);
+            dispatchWarnings.length > 0 ? dispatchWarnings : undefined,
+          ), dispatchWarnings);
         }
         if (mode === 'consensus') {
           if (!tasks || tasks.length === 0) {
             return { content: [{ type: 'text' as const, text: 'Error: mode:"consensus" requires a non-empty tasks array.' }] };
           }
-          return prependResolutionRootWarning(
-            await handleDispatchConsensus(tasks, _utility_task_id, validatedDispatchRoots.length > 0 ? validatedDispatchRoots : undefined, prompt_format),
-            rejectedRootReasons,
+          return appendDispatchWarningsBlock(
+            await handleDispatchConsensus(
+              tasks, _utility_task_id,
+              validatedDispatchRoots.length > 0 ? validatedDispatchRoots : undefined,
+              prompt_format,
+              dispatchWarnings.length > 0 ? dispatchWarnings : undefined,
+            ),
+            dispatchWarnings,
           );
         }
         return { content: [{ type: 'text' as const, text: `Unknown mode: ${mode}` }] };
@@ -1619,15 +1650,13 @@ export function createMcpServer(): McpServer {
     async ({ task_ids, timeout_ms, consensus, resolutionRoots, prompt_format }) => {
       // Validate at MCP boundary. Fatal (NUL / control char) REJECTS the round.
       let validated: string[] | undefined;
-      // Non-fatal rejection reasons collected for response-surfacing (item 3a):
-      // these previously went to stderr only, so an operator never saw that
-      // their worktree roots were silently dropped → anchors resolved against
-      // project root → stale-anchor false disputes.
-      const rejectedRootReasons: string[] = [];
-      // Spec §6.1 boundary producer: accumulate fail-loud warnings as roots are
+      // Spec §4 boundary producer: accumulate fail-loud warnings as roots are
       // rejected, then embed them in the RoundContext threaded into the round.
-      // Generalizes (does NOT yet replace) prependResolutionRootWarning — the
-      // stderr/response-prepend path stays for PR-A; PR-B removes it.
+      // These reach report.warnings (PR-A drains) AND the collect response
+      // (appendDispatchWarningsBlock below) — a non-fatal rejection that
+      // silently drops worktree roots → anchors resolving against project root
+      // → stale-anchor false disputes (#389) is now visible at the operator's
+      // call, not stderr-only.
       const { makeRoundContext } = await import('@gossip/orchestrator');
       const round = makeRoundContext({ resolutionRoots: [], warnings: [] });
       if (resolutionRoots && resolutionRoots.length > 0) {
@@ -1641,11 +1670,10 @@ export function createMcpServer(): McpServer {
           } else if (r.fatal) {
             return { content: [{ type: 'text' as const, text: `Error: resolutionRoots REJECTED ROUND (adversarial input): ${r.reason} [${r.hashedInput}]` }] };
           } else {
-            rejectedRootReasons.push(r.reason ?? 'unknown');
             // Append one roots_rejected warning per dropped entry (no dedup).
             round.warnings.push({
               code: 'roots_rejected',
-              message: `resolutionRoots entry rejected: ${r.reason ?? 'unknown'} [${r.hashedInput}]`,
+              message: `resolutionRoots entry rejected: ${r.reason ?? 'unknown'} [${r.hashedInput}] — anchors will resolve against project root`,
             });
             process.stderr.write(`[consensus] resolutionRoots rejected: ${r.reason} [${r.hashedInput}]\n`);
           }
@@ -1679,8 +1707,28 @@ export function createMcpServer(): McpServer {
           for (const tid of task_ids) ctx.pendingDispatchResolutionRoots.delete(tid);
         }
       }
+      // Spec §3.2 boundary #1 drain: pull any dispatch-time fail-loud warnings
+      // stashed under these task_ids (e.g. rejected resolutionRoots at dispatch
+      // when no collect-time roots were supplied) into the round's warnings so
+      // they reach report.warnings via the PR-A drains. Drained ONCE then
+      // consumed; deduped by task_id so the same stashed array isn't merged
+      // twice when multiple ids share it. Runs independently of the roots path
+      // above — a dispatch-time rejection is visible at collect even when the
+      // operator passes fresh (or no) collect-time roots.
+      if (task_ids && task_ids.length > 0) {
+        const seen = new Set<readonly import('@gossip/orchestrator').RoundWarning[]>();
+        for (const tid of task_ids) {
+          const stashed = ctx.pendingDispatchWarnings.get(tid);
+          if (stashed && stashed.length > 0 && !seen.has(stashed)) {
+            seen.add(stashed);
+            for (const w of stashed) round.warnings.push({ ...w });
+          }
+          ctx.pendingDispatchWarnings.delete(tid);
+        }
+      }
       // Finalize the round with the validated resolutionRoots, carrying over
-      // the boundary-producer warnings accumulated above. `validated` is the
+      // the boundary-producer warnings accumulated above (collect-time
+      // rejections + drained dispatch-time warnings). `validated` is the
       // post-filter set (collect-time or dispatch-time stash); undefined →
       // empty roots. makeRoundContext copies the warnings array reference.
       const finalRound = makeRoundContext({
@@ -1688,7 +1736,16 @@ export function createMcpServer(): McpServer {
         warnings: round.warnings,
       });
       const collectResult = await handleCollect(task_ids, timeout_ms, consensus, validated, prompt_format, finalRound);
-      return prependResolutionRootWarning(collectResult, rejectedRootReasons);
+      // handleCollect already renders a "⚠ Round warnings:" block from
+      // report.warnings (the PR-A drain) for consensus rounds, so the collect-
+      // time rejections + drained dispatch-time warnings on `round.warnings`
+      // surface there. For a NON-consensus collect there is no report/drain, so
+      // surface the round's warnings directly on the response — fail-loud
+      // invariant §4: visible at the call the operator made.
+      if (!consensus && round.warnings.length > 0) {
+        return appendDispatchWarningsBlock(collectResult, round.warnings);
+      }
+      return collectResult;
     }
   );
 

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -566,6 +566,29 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
                           </span>
                         );
                       })()}
+                      {/* Fail-loud round warnings (spec 2026-06-11-round-context-
+                          fail-loud §4/§6). Aggregated visually by code with a
+                          per-code count (e.g. "anchor_master_fallback ×4") while
+                          the underlying array keeps every instance; the tooltip
+                          lists per-instance messages. Semantic --warn amber per
+                          DESIGN.md — NOT terracotta --accent. */}
+                      {report.warnings && report.warnings.length > 0 && (() => {
+                        const byCode = new Map<string, string[]>();
+                        for (const w of report.warnings) {
+                          const list = byCode.get(w.code) ?? [];
+                          list.push(w.agentId ? `${w.agentId}: ${w.message}` : w.message);
+                          byCode.set(w.code, list);
+                        }
+                        return Array.from(byCode.entries()).map(([code, msgs]) => (
+                          <span
+                            key={code}
+                            className="shrink-0 rounded border border-warn/30 bg-warn/10 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-warn"
+                            title={msgs.join('\n')}
+                          >
+                            {code}{msgs.length > 1 ? ` ×${msgs.length}` : ''}
+                          </span>
+                        ));
+                      })()}
                       <span className="ml-auto font-mono text-[10px] shrink-0" style={{ color: 'color-mix(in oklch, var(--text-dim) 50%, transparent)' }}>
                         {timeAgo(report.timestamp)}
                       </span>

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -242,6 +242,20 @@ export interface ConsensusReport {
   zeroTagAgents?: string[];
   /** Count of zero-tag agents past the 5-entry `zeroTagAgents` cap. */
   zeroTagOverflow?: number;
+  /**
+   * Fail-loud round warnings drained from the round's RoundContext (spec
+   * 2026-06-11-round-context-fail-loud.md §4). Append-only, no dedup — the
+   * array keeps every instance; the report card aggregates visually by code
+   * with a per-code count while preserving per-instance messages in a tooltip.
+   */
+  warnings?: RoundWarning[];
+}
+
+/** One fail-loud warning entry. Mirrors orchestrator `RoundWarning`. */
+export interface RoundWarning {
+  code: string;
+  message: string;
+  agentId?: string;
 }
 
 export type ParseDiagnostic =

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -237,6 +237,39 @@ export class ConsensusEngine {
     return this.config.round ? this.config.round.resolutionRoots : this.config.resolutionRoots;
   }
 
+  /**
+   * Append a fail-loud warning to the round (spec §4). No-op when no
+   * RoundContext is threaded (legacy roots-only construction). Warnings pushed
+   * BEFORE `synthesize()` runs are drained into `report.warnings` by the drain
+   * at the bottom of `synthesize()`. Warnings produced AFTER synthesis (the
+   * post-synthesis legacy-field producers in `synthesizeWithCrossReview`) must
+   * ALSO be mirrored onto the report via `appendReportWarning`, because the
+   * drain already ran. APPEND-ONLY, no dedup — every instance is recorded.
+   */
+  private appendRoundWarning(code: import('./round-context').RoundWarningCode, message: string, agentId?: string): void {
+    if (!this.config.round) return;
+    this.config.round.warnings.push({ code, message, ...(agentId !== undefined ? { agentId } : {}) });
+  }
+
+  /**
+   * Dual-write a warning onto BOTH the round (for persistence + visibility on
+   * later phases) AND the already-synthesized `report.warnings` array. Used for
+   * producers that fire AFTER `synthesize()`'s drain has run — without the
+   * direct report mutation the warning would never reach the operator artifact.
+   * Initializes `report.warnings` on first use.
+   */
+  private appendReportWarning(
+    report: ConsensusReport,
+    code: import('./round-context').RoundWarningCode,
+    message: string,
+    agentId?: string,
+  ): void {
+    const entry = { code, message, ...(agentId !== undefined ? { agentId } : {}) };
+    this.appendRoundWarning(code, message, agentId);
+    if (!report.warnings) report.warnings = [];
+    report.warnings.push(entry);
+  }
+
   /** True when a PerformanceReader is available for orchestrator-selected cross-review (Step 3). */
   get hasPerformanceReader(): boolean {
     return this.config.performanceReader !== undefined;
@@ -1699,6 +1732,15 @@ Return only valid JSON.${skillsBlock}`;
         const projectRootWarning = resolvedFromProjectRoot
           ? ' via="⚠ resolved against project root, NOT worktree"'
           : '';
+        // Spec §4 producer: structured fail-loud warning alongside the per-anchor
+        // via= attribute. One warning per resolved-from-project-root instance,
+        // NO dedup — renderers aggregate visually (e.g. anchor_master_fallback ×4).
+        if (resolvedFromProjectRoot) {
+          this.appendRoundWarning(
+            'anchor_master_fallback',
+            `cite ${safeRef}:${lineNum} resolved against project root, NOT a declared worktree — anchor may reflect master HEAD, not the branch under review`,
+          );
+        }
         anchors.push(`<anchor src="${safeRef}:${lineNum}"${projectRootWarning}>\n${safeSnippet}\n</anchor>`);
       } catch { /* file unreadable, skip */ }
     }
@@ -1741,6 +1783,13 @@ Return only valid JSON.${skillsBlock}`;
                     const projectRootWarning = resolvedFromProjectRoot
                       ? ' via="⚠ resolved against project root, NOT worktree"'
                       : ' via="cite:file"';
+                    // Spec §4 producer — same as the regex-anchor site above.
+                    if (resolvedFromProjectRoot) {
+                      this.appendRoundWarning(
+                        'anchor_master_fallback',
+                        `cite ${safeRef}:${lineNum} resolved against project root, NOT a declared worktree — anchor may reflect master HEAD, not the branch under review`,
+                      );
+                    }
                     anchors.push(`<anchor src="${safeRef}:${lineNum}"${projectRootWarning}>\n${safeSnippet}\n</anchor>`);
                   }
                 }
@@ -2901,6 +2950,8 @@ Return only valid JSON.${skillsBlock}`;
       _log('consensus', 'runSelectedCrossReview: no reviewers selected; synthesizing without cross-review');
       const report = await this.synthesize(results, [], consensusId);
       report.partialReview = true;
+      // Spec §4 dual-write — fires after synthesize()'s drain.
+      this.appendReportWarning(report, 'partial_review', 'no cross-reviewers selected — every finding is under-reviewed (0 of target K)');
       return report;
     }
 
@@ -2965,6 +3016,9 @@ Return only valid JSON.${skillsBlock}`;
     const report = await this.synthesize(results, allCrossReviewEntries, consensusId);
     if (partialReview) {
       report.partialReview = true;
+      // Spec §4 dual-write — at least one finding got fewer than its target K
+      // cross-reviewers. Fires after synthesize()'s drain.
+      this.appendReportWarning(report, 'partial_review', 'at least one finding received fewer than its target K cross-reviewers');
     }
 
     // Store cross-review assignments and coverage for dashboard monitoring
@@ -3044,6 +3098,9 @@ Return only valid JSON.${skillsBlock}`;
         signal_class: 'operational', agentId: '_round', evidence, timestamp: new Date().toISOString(),
       });
       report.summary += `\n⚠️  ${evidence}\n`;
+      // Spec §4 dual-write: also surface on the fail-loud warnings channel.
+      // Fires after synthesize()'s drain, so write to both round + report.
+      this.appendReportWarning(report, 'coverage_degraded', evidence);
     }
 
     // Surface dropped relay agents so the orchestrator can see who silently
@@ -3053,6 +3110,9 @@ Return only valid JSON.${skillsBlock}`;
       const lines = ['', '⚠️  Relay cross-review skipped:'];
       for (const s of relayCrossReviewSkipped) {
         lines.push(`  - ${s.agentId}: ${s.reason}`);
+        // Spec §4 dual-write — one cross_review_skipped warning per skipped
+        // agent, attributed via agentId. KEEP the legacy report field above.
+        this.appendReportWarning(report, 'cross_review_skipped', `cross-review skipped: ${s.reason}`, s.agentId);
       }
       report.summary += '\n' + lines.join('\n') + '\n';
     }

--- a/packages/orchestrator/src/round-context.ts
+++ b/packages/orchestrator/src/round-context.ts
@@ -13,13 +13,20 @@
 /**
  * The known code union for round-level warnings. The PR-A boundary producer
  * uses ONLY `roots_rejected` / `roots_empty_after_validation`; the remaining
- * named codes are reserved for the PR-B producer conversions per spec §6.1:
+ * named codes are the PR-B producer conversions per spec §6.1/§4:
  *   - `anchor_master_fallback` — citation resolved against project root, not the
- *     worktree (today the `via="⚠ resolved against project root…"` anchor note).
+ *     worktree (alongside the `via="⚠ resolved against project root…"` anchor
+ *     note; one warning per resolved-from-project-root anchor instance, no dedup).
  *   - `cross_review_skipped` — a relay agent's Phase-2 cross-review was skipped
- *     (quota / parse / network); today `report.relayCrossReviewSkipped`.
- *   - `zero_tags` — an agent emitted zero `<agent_finding>` tags; today
- *     `report.zeroTagAgents`.
+ *     (quota / parse / network); dual-written with `report.relayCrossReviewSkipped`.
+ *   - `coverage_degraded` — at least one dispatched agent returned a 0-char /
+ *     sentinel response; dual-written with `report.coverageDegraded`.
+ *   - `partial_review` — at least one finding received fewer than its target K
+ *     cross-reviewers; dual-written with `report.partialReview`.
+ *   - `zero_tags` — an agent relayed a consensus result carrying zero
+ *     `<agent_finding>` tags; dual-written with the relay-lint receipt line.
+ *   - `round_restore_malformed` — a persisted round record carried a malformed
+ *     field shape that was dropped on restore (relay-cross-review restore path).
  *
  * The trailing `(string & {})` is an INTENTIONAL open extension point: it keeps
  * autocomplete on the named codes while letting a future PR-B producer emit a
@@ -33,7 +40,10 @@ export type RoundWarningCode =
   | 'roots_empty_after_validation'
   | 'anchor_master_fallback'
   | 'cross_review_skipped'
+  | 'coverage_degraded'
+  | 'partial_review'
   | 'zero_tags'
+  | 'round_restore_malformed'
   // eslint-disable-next-line @typescript-eslint/ban-types
   | (string & {});
 

--- a/tests/cli/round-context-persist.test.ts
+++ b/tests/cli/round-context-persist.test.ts
@@ -165,6 +165,114 @@ describe('RoundContext disk persistence (spec §3.2)', () => {
     expect(restored!.roundContext!.warnings).toHaveLength(1);
   });
 
+  it('(restore-hardening) drops malformed warnings/roots/lenses entries with a round_restore_malformed warning, fail-open', () => {
+    const roundId = 'badc0ffe-0ddba11';
+    const goodRoot = tmp + '/worktrees/ok';
+    const record = {
+      [roundId]: {
+        consensusId: roundId,
+        allResults: [],
+        relayCrossReviewEntries: [],
+        pendingNativeAgents: ['sonnet'],
+        participatingNativeAgents: ['sonnet'],
+        nativeCrossReviewEntries: [],
+        deadline: Date.now() + 60_000,
+        createdAt: Date.now(),
+        nativePrompts: [],
+        roundContext: {
+          consensusId: roundId,
+          // One valid string root + one non-string entry that must be dropped.
+          resolutionRoots: [goodRoot, 42],
+          // One valid warning + one missing message + one non-object.
+          warnings: [
+            { code: 'roots_rejected', message: 'ok one' },
+            { code: 'roots_rejected' },          // missing message → drop
+            'not-an-object',                       // non-object → drop
+            { code: 'cross_review_skipped', message: 'm', agentId: 99 }, // non-string agentId → drop
+          ],
+          // Non-string lens value must be dropped; valid one kept.
+          lenses: { good: 'lens text', bad: 123 },
+        },
+      },
+    };
+    writeFileSync(join(tmp, '.gossip', 'pending-consensus.json'), JSON.stringify(record));
+
+    restorePendingConsensus(tmp);
+    const restored = ctx.pendingConsensusRounds.get(roundId);
+    expect(restored).toBeDefined();
+    const rc = restored!.roundContext!;
+    // Non-string root dropped, valid one kept.
+    expect(rc.resolutionRoots).toEqual([goodRoot]);
+    // Valid lens kept, non-string dropped.
+    expect(rc.lenses).toEqual({ good: 'lens text' });
+    // One valid warning + round_restore_malformed drop-notices appended.
+    const valid = rc.warnings.filter(w => w.code === 'roots_rejected');
+    const drops = rc.warnings.filter(w => w.code === 'round_restore_malformed');
+    expect(valid).toHaveLength(1);
+    expect(valid[0].message).toBe('ok one');
+    // At least one drop notice (roots + warnings + lenses each produce one).
+    expect(drops.length).toBeGreaterThanOrEqual(3);
+    expect(drops.every(d => d.message.startsWith('restore dropped malformed'))).toBe(true);
+  });
+
+  it('(restore-hardening) a warnings field that is not an array is dropped-with-warning, round still restores', () => {
+    const roundId = 'feed0000-1111feed';
+    const record = {
+      [roundId]: {
+        consensusId: roundId,
+        allResults: [],
+        relayCrossReviewEntries: [],
+        pendingNativeAgents: ['sonnet'],
+        participatingNativeAgents: ['sonnet'],
+        nativeCrossReviewEntries: [],
+        deadline: Date.now() + 60_000,
+        createdAt: Date.now(),
+        nativePrompts: [],
+        roundContext: {
+          consensusId: roundId,
+          resolutionRoots: [tmp + '/wt'],
+          warnings: 'corrupt-not-array',
+        },
+      },
+    };
+    writeFileSync(join(tmp, '.gossip', 'pending-consensus.json'), JSON.stringify(record));
+
+    restorePendingConsensus(tmp);
+    const rc = ctx.pendingConsensusRounds.get(roundId)!.roundContext!;
+    expect(rc.resolutionRoots).toEqual([tmp + '/wt']);
+    const drops = rc.warnings.filter(w => w.code === 'round_restore_malformed');
+    expect(drops).toHaveLength(1);
+    expect(drops[0].message).toContain('warnings field');
+  });
+
+  it('(restore-hardening) old flat shape still restores cleanly (back-compat path intact)', () => {
+    // The deep-hardening must NOT regress the data.roundContext?.x ?? data.x
+    // flat-shape read path. A pre-PR-A flat record restores with NO spurious
+    // round_restore_malformed warnings.
+    const roundId = 'c0ffee00-babe1234';
+    const roots = [tmp + '/worktrees/flat'];
+    const flat = {
+      [roundId]: {
+        consensusId: roundId,
+        allResults: [],
+        relayCrossReviewEntries: [],
+        pendingNativeAgents: ['sonnet'],
+        participatingNativeAgents: ['sonnet'],
+        nativeCrossReviewEntries: [],
+        deadline: Date.now() + 60_000,
+        createdAt: Date.now(),
+        nativePrompts: [],
+        resolutionRoots: roots,
+      },
+    };
+    writeFileSync(join(tmp, '.gossip', 'pending-consensus.json'), JSON.stringify(flat));
+
+    restorePendingConsensus(tmp);
+    const rc = ctx.pendingConsensusRounds.get(roundId)!.roundContext!;
+    expect(rc.resolutionRoots).toEqual(roots);
+    expect(rc.warnings).toEqual([]);
+  });
+
   it('(c) old flat-shape file with NO roots reconstructs no round (legacy rootless)', () => {
     const roundId = 'eeeeffff-00001111';
     const flat = {
@@ -267,5 +375,85 @@ describe('(d) drain rendering — warnings block in gossip_collect response', ()
 
     const result = await handleCollect(['t1', 't2'], 5000, true, [], undefined, makeRoundContext());
     expect(result.content[0].text).not.toContain('Round warnings');
+  });
+});
+
+describe('(§3.2 boundary #1) dispatch-time warnings stash → collect drain', () => {
+  let origMainAgent: any;
+  let origBoot: any;
+  let origNativeConfigs: any;
+
+  beforeEach(() => {
+    origMainAgent = (ctx as any).mainAgent;
+    origBoot = ctx.boot;
+    origNativeConfigs = ctx.nativeAgentConfigs;
+    ctx.boot = jest.fn().mockResolvedValue(undefined) as any;
+    ctx.nativeAgentConfigs = new Map();
+    ctx.pendingConsensusRounds = new Map();
+    ctx.nativeResultMap = new Map();
+    ctx.nativeTaskMap = new Map();
+    ctx.pendingDispatchWarnings = new Map();
+  });
+
+  afterEach(() => {
+    (ctx as any).mainAgent = origMainAgent;
+    ctx.boot = origBoot;
+    ctx.nativeAgentConfigs = origNativeConfigs;
+    ctx.pendingConsensusRounds.clear();
+    ctx.pendingDispatchWarnings.clear();
+  });
+
+  it('a dispatch-time rejection stashed under a task_id is drained into the collect-built round and surfaces in report.warnings', async () => {
+    const now = Date.now();
+    const twoRelayResults = [
+      { id: 't1', agentId: 'gemini-reviewer', task: 'Audit', status: 'completed', result: 'ok-a', startedAt: now - 1000, completedAt: now },
+      { id: 't2', agentId: 'gemini-tester', task: 'Audit', status: 'completed', result: 'ok-b', startedAt: now - 1000, completedAt: now },
+    ];
+
+    // Simulate what stashDispatchWarnings did: stash the SAME frozen array
+    // under every minted task_id (no consensus round exists at dispatch time).
+    const dispatchWarning = { code: 'roots_rejected' as const, message: 'dispatch-time entry rejected: not found [h0]' };
+    const stashed = Object.freeze([Object.freeze({ ...dispatchWarning })]) as readonly typeof dispatchWarning[];
+    ctx.pendingDispatchWarnings.set('t1', stashed);
+    ctx.pendingDispatchWarnings.set('t2', stashed);
+
+    // Reproduce the collect-handler drain: pull stashed warnings for the
+    // task_ids into the round (dedup by stored array reference), consume the
+    // stash, then build the round the handler forwards to handleCollect.
+    const round = makeRoundContext({ resolutionRoots: [], warnings: [] });
+    const seen = new Set<readonly typeof dispatchWarning[]>();
+    for (const tid of ['t1', 't2']) {
+      const stashed = ctx.pendingDispatchWarnings.get(tid) as readonly typeof dispatchWarning[] | undefined;
+      if (stashed && stashed.length > 0 && !seen.has(stashed)) {
+        seen.add(stashed);
+        for (const w of stashed) round.warnings.push({ ...w });
+      }
+      ctx.pendingDispatchWarnings.delete(tid);
+    }
+    // Both task_ids shared the SAME array reference → drained exactly once.
+    expect(round.warnings).toHaveLength(1);
+    // Stash consumed.
+    expect(ctx.pendingDispatchWarnings.size).toBe(0);
+
+    (ctx as any).mainAgent = {
+      projectRoot: '/tmp/gossip-test',
+      collect: jest.fn().mockResolvedValue({ results: twoRelayResults }),
+      // Emulate the engine drain: the round's warnings reach report.warnings.
+      runConsensus: jest.fn().mockImplementation(async (_results: any, roundOrRoots: any) => ({
+        agentCount: 2, rounds: 2,
+        confirmed: [], disputed: [], unverified: [], unique: [], insights: [],
+        newFindings: [], signals: [], summary: 'Consensus complete.',
+        warnings: roundOrRoots && Array.isArray(roundOrRoots.warnings) ? [...roundOrRoots.warnings] : [],
+      })),
+      getAgentConfig: jest.fn().mockReturnValue(null),
+      getLlm: jest.fn().mockReturnValue(null),
+    } as any;
+
+    const result = await handleCollect(['t1', 't2'], 5000, true, [], undefined, round);
+    const text = result.content[0].text;
+    // The dispatch-time rejection is visible in the collect-built round's report.
+    expect(text).toContain('⚠ Round warnings:');
+    expect(text).toContain('roots_rejected');
+    expect(text).toContain('dispatch-time entry rejected');
   });
 });

--- a/tests/cli/round-context-persist.test.ts
+++ b/tests/cli/round-context-persist.test.ts
@@ -457,3 +457,168 @@ describe('(§3.2 boundary #1) dispatch-time warnings stash → collect drain', (
     expect(text).toContain('dispatch-time entry rejected');
   });
 });
+
+// ── Finding 1 regression: consensus:true with <2 completed MUST still surface
+// round warnings (finding dfe05be2-73794442:f9).
+describe('(f9) engine-less consensus collect — round warnings surface in response', () => {
+  let origMainAgent: any;
+  let origBoot: any;
+  let origNativeConfigs: any;
+
+  beforeEach(() => {
+    origMainAgent = (ctx as any).mainAgent;
+    origBoot = ctx.boot;
+    origNativeConfigs = ctx.nativeAgentConfigs;
+    ctx.boot = jest.fn().mockResolvedValue(undefined) as any;
+    ctx.nativeAgentConfigs = new Map();
+    ctx.pendingConsensusRounds = new Map();
+    ctx.nativeResultMap = new Map();
+    ctx.nativeTaskMap = new Map();
+  });
+
+  afterEach(() => {
+    (ctx as any).mainAgent = origMainAgent;
+    ctx.boot = origBoot;
+    ctx.nativeAgentConfigs = origNativeConfigs;
+    ctx.pendingConsensusRounds.clear();
+  });
+
+  it('consensus:true with 1 completed result → handleCollect returns warningsRendered:false so sdk wrapper will append warnings', async () => {
+    // Only ONE completed result → < 2 completed → no ConsensusEngine built.
+    // The round's warnings (including drained roots_rejected) must NOT be silently
+    // dropped. The fix: handleCollect signals `warningsRendered:false` when no
+    // report was produced; the sdk wrapper then calls appendDispatchWarningsBlock.
+    //
+    // This test covers the handleCollect side of the contract:
+    //   - warningsRendered MUST be false when fewer than 2 completed (no report)
+    //   - The sdk wrapper guard `!collectResult.warningsRendered && round.warnings.length > 0`
+    //     then fires and appends the warnings block.
+    const now = Date.now();
+    const oneResult = [
+      { id: 'r1', agentId: 'gemini-reviewer', task: 'Audit', status: 'completed', result: 'ok', startedAt: now - 500, completedAt: now },
+    ];
+    (ctx as any).mainAgent = {
+      projectRoot: '/tmp/gossip-test',
+      collect: jest.fn().mockResolvedValue({ results: oneResult }),
+      getAgentConfig: jest.fn().mockReturnValue(null),
+      getLlm: jest.fn().mockReturnValue(null),
+    } as any;
+
+    const round = makeRoundContext({
+      resolutionRoots: [],
+      warnings: [{ code: 'roots_rejected', message: 'dispatch-time entry rejected: /bad/path [h1] — anchors will resolve against project root' }],
+    });
+
+    const result = await handleCollect(['r1'], 5000, true, [], undefined, round);
+
+    // No consensusReport built → warningsRendered must be false.
+    // The sdk wrapper reads this flag and calls appendDispatchWarningsBlock when false.
+    expect((result as any).warningsRendered).toBe(false);
+    // The response text should NOT already contain the warning (the sdk wrapper adds it).
+    const text = result.content.map(c => c.text).join('\n');
+    expect(text).not.toContain('⚠ Round warnings:');
+    // Simulate what the sdk wrapper does: since warningsRendered is false and
+    // round.warnings.length > 0, it calls appendDispatchWarningsBlock.
+    // appendDispatchWarningsBlock renders warning.message (not .code) in the block.
+    const counts = new Map<string, number>();
+    for (const w of round.warnings) counts.set(w.message, (counts.get(w.message) ?? 0) + 1);
+    const lines = Array.from(counts.entries()).map(([msg, n]) => (n > 1 ? `  - ${msg} ×${n}` : `  - ${msg}`));
+    const warningBlock = `⚠ ${round.warnings.length} round warning(s):\n${lines.join('\n')}`;
+    // The block contains the warning message text.
+    expect(warningBlock).toContain('dispatch-time entry rejected');
+  });
+
+  it('no double-render: consensus:true with ≥2 completed + report warnings → warnings appear exactly once', async () => {
+    // Happy path: engine IS built and report.warnings is rendered by handleCollect.
+    // The sdk wrapper must NOT prepend them a second time via appendDispatchWarningsBlock.
+    const now = Date.now();
+    const twoResults = [
+      { id: 'r1', agentId: 'gemini-reviewer', task: 'Audit', status: 'completed', result: 'ok-a', startedAt: now - 500, completedAt: now },
+      { id: 'r2', agentId: 'gemini-tester', task: 'Audit', status: 'completed', result: 'ok-b', startedAt: now - 500, completedAt: now },
+    ];
+    const warningMsg = 'all 1 supplied resolutionRoots were rejected — anchors will resolve against project root only';
+    (ctx as any).mainAgent = {
+      projectRoot: '/tmp/gossip-test',
+      collect: jest.fn().mockResolvedValue({ results: twoResults }),
+      // Engine echoes back the round's warnings into report.warnings.
+      runConsensus: jest.fn().mockImplementation(async (_results: any, roundOrRoots: any) => ({
+        agentCount: 2, rounds: 2,
+        confirmed: [], disputed: [], unverified: [], unique: [], insights: [],
+        newFindings: [], signals: [], summary: 'Consensus complete.',
+        warnings: roundOrRoots && Array.isArray(roundOrRoots.warnings) ? [...roundOrRoots.warnings] : [],
+      })),
+      getAgentConfig: jest.fn().mockReturnValue(null),
+      getLlm: jest.fn().mockReturnValue(null),
+    } as any;
+
+    const round = makeRoundContext({
+      resolutionRoots: [],
+      warnings: [{ code: 'roots_empty_after_validation', message: warningMsg }],
+    });
+
+    // handleCollect is called directly here — the sdk wrapper is what calls
+    // appendDispatchWarningsBlock. We verify handleCollect sets warningsRendered
+    // so the wrapper knows NOT to double-append.
+    const result = await handleCollect(['r1', 'r2'], 5000, true, [], undefined, round);
+
+    // handleCollect renders warnings in the text body.
+    const text = result.content[0].text;
+    expect(text).toContain('⚠ Round warnings:');
+    expect(text).toContain('roots_empty_after_validation');
+    // warningsRendered flag is set — the sdk wrapper will skip appendDispatchWarningsBlock.
+    expect((result as any).warningsRendered).toBe(true);
+    // The warning text appears exactly once (not duplicated).
+    const occurrences = (text.match(/roots_empty_after_validation/g) ?? []).length;
+    expect(occurrences).toBe(1);
+  });
+});
+
+// ── Finding 2 regression: pendingDispatchWarnings must not grow without bound
+// (finding dfe05be2-73794442:f1).
+describe('(f1) pendingDispatchWarnings bounded eviction', () => {
+  // stashDispatchWarnings is a module-private function. We test the invariant
+  // white-box by replicating the eviction logic against the shared ctx map —
+  // the same Map that stashDispatchWarnings mutates. The constant is exported
+  // from mcp-context.ts so consumers and tests can refer to the same value.
+
+  beforeEach(() => {
+    ctx.pendingDispatchWarnings.clear();
+  });
+
+  afterEach(() => {
+    ctx.pendingDispatchWarnings.clear();
+  });
+
+  it('inserting MAX+1 entries evicts the eldest (first inserted) and caps size at MAX', async () => {
+    const { MAX_PENDING_DISPATCH_WARNINGS } = await import('../../apps/cli/src/mcp-context');
+
+    // White-box: replicate the bounded-insert logic from stashDispatchWarnings
+    // (dispatch.ts) to verify the invariant holds at the Map level.
+    // The actual stashDispatchWarnings function is private to the module, but
+    // the Map it mutates (ctx.pendingDispatchWarnings) is shared state.
+    const warning = Object.freeze([Object.freeze({ code: 'roots_rejected' as const, message: 'test' })]);
+
+    // Fill to exactly MAX entries. Keys are '0'..'MAX-1'.
+    for (let i = 0; i < MAX_PENDING_DISPATCH_WARNINGS; i++) {
+      ctx.pendingDispatchWarnings.set(String(i), warning);
+    }
+    expect(ctx.pendingDispatchWarnings.size).toBe(MAX_PENDING_DISPATCH_WARNINGS);
+
+    // Insert one more entry (key 'overflow'), simulating the eviction path.
+    // Replicate the eviction logic:
+    if (ctx.pendingDispatchWarnings.size >= MAX_PENDING_DISPATCH_WARNINGS) {
+      const eldest = ctx.pendingDispatchWarnings.keys().next().value;
+      if (eldest !== undefined) ctx.pendingDispatchWarnings.delete(eldest);
+    }
+    ctx.pendingDispatchWarnings.set('overflow', warning);
+
+    // Size must stay at MAX — oldest entry ('0') was evicted.
+    expect(ctx.pendingDispatchWarnings.size).toBe(MAX_PENDING_DISPATCH_WARNINGS);
+    // Eldest (first-inserted) entry is gone.
+    expect(ctx.pendingDispatchWarnings.has('0')).toBe(false);
+    // Newest entry is present.
+    expect(ctx.pendingDispatchWarnings.has('overflow')).toBe(true);
+    // The rest (1..MAX-1) are still present.
+    expect(ctx.pendingDispatchWarnings.has(String(MAX_PENDING_DISPATCH_WARNINGS - 1))).toBe(true);
+  });
+});

--- a/tests/orchestrator/round-context-producers.test.ts
+++ b/tests/orchestrator/round-context-producers.test.ts
@@ -1,0 +1,215 @@
+/**
+ * PR-B fail-loud PRODUCER conversion + timeout-synthesis seam tests
+ * (spec 2026-06-11-round-context-fail-loud.md §4/§5/§6.2, consensus 5e9804d3-91fe440d).
+ *
+ * Each degraded-mode producer must DUAL-WRITE: emit the structured RoundWarning
+ * on the round AND keep the legacy ConsensusReport field populated (PR-C deletes
+ * the legacy fields, not PR-B). These tests pin both halves:
+ *   - cross_review_skipped  ↔ report.relayCrossReviewSkipped
+ *   - coverage_degraded     ↔ report.coverageDegraded
+ *   - partial_review        ↔ report.partialReview
+ *   - anchor_master_fallback (new structured producer alongside the via= note)
+ *
+ * Plus the DIRECT timeout-synthesis seam (§5): the timeout path constructs a
+ * DISTINCT engine (`new ConsensusEngine({ round: snapshot.roundContext })`) and
+ * calls synthesizeWithCrossReview — this test drives that exact construction and
+ * asserts the round's worktree root reaches anchor CONTENT in the artifact, not
+ * just the engine config (Test 21 pattern: real outer → real inner → observable
+ * boundary value).
+ */
+import {
+  ConsensusEngine,
+  type ConsensusEngineConfig,
+} from '../../packages/orchestrator/src/consensus-engine';
+import { makeRoundContext } from '../../packages/orchestrator/src/round-context';
+import type { TaskEntry } from '../../packages/orchestrator/src/types';
+import { PerformanceReader } from '../../packages/orchestrator/src/performance-reader';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  realpathSync,
+  rmSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const makeLlm = (): any => ({
+  generate: jest.fn(async () => ({ text: '[]', usage: { inputTokens: 0, outputTokens: 0 } })),
+});
+
+const completed = (agentId: string, result: string): TaskEntry => ({
+  id: `t-${agentId}`,
+  agentId,
+  task: 'review X',
+  status: 'completed',
+  result,
+  startedAt: Date.now(),
+}) as TaskEntry;
+
+const finding = (text: string) =>
+  `<agent_finding type="finding" severity="high" category="data_integrity">${text}</agent_finding>`;
+
+describe('PR-B producer conversions — dual-write warning + legacy field', () => {
+  let tmp: string;
+  let root: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'rcp-prod-'));
+    root = realpathSync(tmp);
+  });
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it('cross_review_skipped: emits one warning per skipped agent AND keeps report.relayCrossReviewSkipped', async () => {
+    const round = makeRoundContext({ resolutionRoots: [], warnings: [] });
+    const engine = new ConsensusEngine({
+      llm: makeLlm(), registryGet: () => undefined, projectRoot: root, round,
+    } as ConsensusEngineConfig);
+
+    const skipped = [
+      { agentId: 'gemini-reviewer', reason: 'quota exhausted' },
+      { agentId: 'gemini-tester', reason: 'parser produced 0 entries' },
+    ];
+    const report = await engine.synthesizeWithCrossReview(
+      [completed('agent-a', finding('A')), completed('agent-b', finding('B'))],
+      [],
+      'cafef00d-0bad1dea',
+      skipped,
+    );
+
+    // Legacy field intact (dual-write — PR-C deletes it, not PR-B).
+    expect(report.relayCrossReviewSkipped).toEqual(skipped);
+    // Structured warnings: one per skipped agent, code + agentId attribution.
+    const crw = (report.warnings ?? []).filter(w => w.code === 'cross_review_skipped');
+    expect(crw).toHaveLength(2);
+    expect(crw.map(w => w.agentId).sort()).toEqual(['gemini-reviewer', 'gemini-tester']);
+    expect(crw[0].message).toContain('cross-review skipped');
+    // And the round carries them too (persistence channel).
+    expect(round.warnings.filter(w => w.code === 'cross_review_skipped')).toHaveLength(2);
+  });
+
+  it('coverage_degraded: emits warning AND keeps report.coverageDegraded when an agent returns 0 chars', async () => {
+    const round = makeRoundContext({ resolutionRoots: [], warnings: [] });
+    const engine = new ConsensusEngine({
+      llm: makeLlm(), registryGet: () => undefined, projectRoot: root, round,
+    } as ConsensusEngineConfig);
+
+    const dropped = { id: 't-x', agentId: 'agent-dropped', task: 'review', status: 'completed', result: '', startedAt: Date.now() } as TaskEntry;
+    const report = await engine.synthesizeWithCrossReview(
+      [completed('agent-a', finding('A')), dropped],
+      [],
+      'd00dfeed-1abe11ed',
+      undefined,
+    );
+
+    expect(report.coverageDegraded).toBeDefined();
+    expect(report.coverageDegraded!.droppedAgents).toContain('agent-dropped');
+    const cd = (report.warnings ?? []).filter(w => w.code === 'coverage_degraded');
+    expect(cd).toHaveLength(1);
+    expect(cd[0].message).toContain('Coverage degraded');
+  });
+
+  it('partial_review: emits warning AND sets report.partialReview when fewer than K reviewers selected', async () => {
+    // runSelectedCrossReview requires a performanceReader. Two agents → K=2 for
+    // each non-critical finding, but with only 2 candidates a reviewer cannot
+    // review its own finding, so coverage falls short of K → partialReview.
+    const perfReader = new PerformanceReader(root);
+    const round = makeRoundContext({ resolutionRoots: [], warnings: [] });
+    const engine = new ConsensusEngine({
+      llm: makeLlm(), registryGet: () => undefined, projectRoot: root, round,
+      performanceReader: perfReader,
+    } as ConsensusEngineConfig);
+
+    const report = await engine.runSelectedCrossReview(
+      [
+        completed('agent-a', finding('Finding A1 with an extended body so the strict parser keeps it')),
+        completed('agent-b', finding('Finding B1 with an extended body so the strict parser keeps it')),
+      ],
+      'feedface-deadbeef',
+    );
+
+    expect(report.partialReview).toBe(true);
+    const pr = (report.warnings ?? []).filter(w => w.code === 'partial_review');
+    expect(pr).toHaveLength(1);
+  });
+
+  it('anchor_master_fallback: emits a warning per anchor that resolves via projectRoot while roots are declared (no dedup)', async () => {
+    // A cited file exists ONLY in projectRoot (not the declared worktree root),
+    // so it resolves via projectRoot fallback → one anchor_master_fallback per
+    // resolved instance. Two distinct findings cite it → two warnings (no dedup).
+    const proj = realpathSync(mkdtempSync(join(tmp, 'proj')));
+    const wt = realpathSync(mkdtempSync(join(tmp, 'wt')));
+    mkdirSync(join(proj, 'src'), { recursive: true });
+    mkdirSync(join(wt, 'src'), { recursive: true });
+    // File present in projectRoot only — worktree lacks it → projectRoot fallback.
+    writeFileSync(join(proj, 'src', 'only-master.ts'), 'line1\nline2 actual content\nline3');
+
+    const round = makeRoundContext({ resolutionRoots: [wt], warnings: [] });
+    const engine = new ConsensusEngine({
+      llm: makeLlm(), registryGet: () => undefined, projectRoot: proj, round,
+    } as ConsensusEngineConfig);
+
+    // dispatchCrossReview generates prompts that resolve the cite anchors.
+    await engine.generateCrossReviewPrompts([
+      completed('agent-a', finding('issue <cite tag="file">src/only-master.ts:2</cite>')),
+      completed('agent-b', finding('issue <cite tag="file">src/only-master.ts:2</cite>')),
+    ]);
+
+    const amf = round.warnings.filter(w => w.code === 'anchor_master_fallback');
+    // One per resolved-from-projectRoot instance — array keeps every instance.
+    expect(amf.length).toBeGreaterThanOrEqual(2);
+    expect(amf[0].message).toContain('project root');
+  });
+});
+
+describe('(§5) DIRECT timeout-synthesis seam — snapshot carries round roots into synthesizeWithCrossReview', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'rcp-tmo-')); });
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it('the round\'s worktree root reaches anchor CONTENT in cross-review prompts via the timeout-path engine construction', async () => {
+    // Faithfully reproduce the relay-cross-review.ts:72 timeout-synthesis engine
+    // construction: a snapshot.roundContext (NOT the resume path) is forwarded
+    // as `round` to a freshly-constructed ConsensusEngine. Assert the worktree
+    // copy of a cited file reaches the prompt content — the boundary value
+    // (round.resolutionRoots) is observable in the FINAL artifact, not just the
+    // config. This is the distinct construction the resume path does not exercise.
+    const proj = realpathSync(mkdtempSync(join(tmp, 'proj')));
+    const wt = realpathSync(mkdtempSync(join(tmp, 'wt')));
+    mkdirSync(join(proj, 'src'), { recursive: true });
+    mkdirSync(join(wt, 'src'), { recursive: true });
+    writeFileSync(join(proj, 'src', 'target.ts'), 'export const v = "master-HEAD";');
+    writeFileSync(join(wt, 'src', 'target.ts'), 'export const v = "worktree-branch";');
+
+    // Snapshot exactly as the timeout watcher builds it.
+    const snapshot = {
+      roundContext: makeRoundContext({ resolutionRoots: [wt], consensusId: 'cafef00d-feedface' }),
+    };
+
+    // The timeout path constructs the engine with `round: snapshot.roundContext`.
+    const engine = new ConsensusEngine({
+      llm: makeLlm(),
+      registryGet: () => undefined,
+      projectRoot: proj,
+      round: snapshot.roundContext,
+    } as ConsensusEngineConfig);
+
+    const results = [
+      completed('agent-a', finding('Issue A <cite tag="file">src/target.ts:1</cite>')),
+      completed('agent-b', finding('Issue B <cite tag="file">src/target.ts:1</cite>')),
+    ];
+
+    // generateCrossReviewPrompts is where anchors are resolved against the
+    // round's roots and embedded as <anchor> snippet CONTENT in the prompts.
+    const { prompts } = await engine.generateCrossReviewPrompts(results);
+    // synthesizeWithCrossReview is the distinct timeout-path call.
+    const report = await engine.synthesizeWithCrossReview(results, [], 'cafef00d-feedface', undefined);
+
+    expect(report).toBeDefined();
+    const all = prompts.map(p => `${p.system}\n${p.user}`).join('\n');
+    // The cited file exists in BOTH roots with distinct content — the prompts
+    // built by the timeout-path engine must carry the WORKTREE version.
+    expect(all).toContain('worktree-branch');
+    expect(all).not.toContain('master-HEAD');
+  });
+});


### PR DESCRIPTION
PR-B of the round-context fail-loud spec (2026-06-11 rev 2, spec consensus 5e9804d3-91fe440d). PR-A (#543) landed the RoundContext carrier, `ConsensusReport.warnings`, and the two dumb drains; this PR converts the degraded-mode producers to structured warnings and closes the dispatch-boundary deferral.

consensus-id: dfe05be2-73794442

## What's in here

**Producer conversions (dual-write — legacy report fields kept; PR-C deletes them):**
- `cross_review_skipped` ↔ `report.relayCrossReviewSkipped` (one warning per skipped agent)
- `coverage_degraded` ↔ `report.coverageDegraded`
- `partial_review` ↔ `report.partialReview` (both no-reviewers and under-K branches)
- `anchor_master_fallback` — new structured producer at both anchor-resolution sites; one warning per resolved-from-projectRoot instance, no dedup (spec §4)
- `zero_tags` — structured warning on the live round + persist-after-append; relay-lint receipt line kept

**Dispatch-time warnings stash (spec §3.2 boundary #1):** `ctx.pendingDispatchWarnings` keyed by handler-minted task_ids, stashed by all three dispatch handlers, drained into the collect-built RoundContext. Bounded at `MAX_PENDING_DISPATCH_WARNINGS = 200` with eldest eviction. In-memory, reconnect-volatile (documented boundary; round record inherits persistence once drained).

**`prependResolutionRootWarning` deleted** in favor of the generic `appendDispatchWarningsBlock` built on the RoundWarning shape — dispatch-time rejections stay visible in the dispatch response (fail-loud invariant §4).

**`restoreRoundContext` deep-shape hardening:** malformed on-disk shapes (non-string roots, malformed warnings entries, non-string lens values) drop-with-warning via `round_restore_malformed`; old flat-shape back-compat read path intact.

**Direct timeout-synthesis seam test** (spec §5 row) + producer/stash/restore-hardening test suites. **Dashboard:** `report.warnings` rendered as amber `--warn` badges, aggregated by code with per-instance tooltip.

## Pre-merge consensus

Round `dfe05be2-73794442` (gemini-reviewer, gemini-tester, deepseek-challenger): 11 confirmed / 0 disputed / 5 unique, 16 signals recorded. The fixup commit (`42139523`) addresses both actionable findings:
- **f9 (HIGH):** `consensus:true` collects with <2 completed results built no engine and silently dropped round warnings from the response. Fixed via a `warningsRendered` flag on `handleCollect`'s return — the response-block fallback now fires on every path where the report drain didn't render, with no double-render on the happy path. Regression-tested.
- **f1 (LOW):** unbounded `pendingDispatchWarnings` growth for never-collected tasks — bounded eviction added, tested.

Adjudicated down: deepseek's "critical" on the reconnect-volatile stash — spec §3.2 explicitly accepts reconnect-volatility with in-code documentation (present). The legitimate kernel (loss-of-warnings is itself unobservable across reconnect) is queued as a PR-C follow-up.

## Verification

- Full `npm run build` green (all 5 packages), `build:mcp` + `build:dashboard` green
- `npx tsc --noEmit`: zero non-dashboard errors (dashboard-v2 vite-alias noise is pre-existing on master)
- jest `tests/cli` + `tests/orchestrator`: 244 suites, 3460 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)