### PR TITLE
feat(consensus): PR-C round-context single-source-of-truth + cleanup

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -11,6 +11,7 @@ import { FILE_TOOLS, FileTools, GitTools, Sandbox } from '@gossip/tools';
 import { MemorySearcher } from '@gossip/orchestrator';
 import type { PromptFormat } from './dispatch';
 import { discoverVerifier, type VerifierBinding } from './auto-verify-discovery';
+import { makeRoundContext } from '@gossip/orchestrator';
 import type { RelayWarningEntry, RoundContext } from '@gossip/orchestrator';
 import { mkdirSync, appendFileSync } from 'node:fs';
 import { join as joinPath } from 'node:path';
@@ -545,6 +546,12 @@ export async function handleCollect(
       }
       outerEffectiveRoots = effectiveRoots;
 
+      // PR-C: the engine REQUIRES a RoundContext. Prefer the boundary-built
+      // round (carries the fail-loud warnings array); otherwise wrap the
+      // collect-validated effectiveRoots into a fresh one so its warnings still
+      // drain into report.warnings.
+      const effectiveRound: RoundContext = round ?? makeRoundContext({ resolutionRoots: effectiveRoots });
+
       // Hoisted so verifierToolRunner callback can close over it when building the engine config.
       // Constructed AFTER effectiveRoots so fileSearch can prioritize matches under a
       // resolution root (e.g. sibling worktrees) instead of blindly taking the first hit.
@@ -608,13 +615,12 @@ export async function handleCollect(
         projectRoot: process.cwd(),
         agentLlm: (id: string) => agentLlmCache.get(id),
         performanceReader,
-        // Alias mode: a RoundContext WINS — forward it whole so its warnings
+        // PR-C: forward the effective RoundContext (required) so its warnings
         // array drains into report.warnings (the immediate-synthesis path at
-        // :811 builds the report on THIS engine). Else fall back to the legacy
-        // roots-only field (byte-identical). The pending-round path below
-        // re-seeds resolutionRoots from snapshot/round per phase, so this only
+        // :811 builds the report on THIS engine). The pending-round path below
+        // re-seeds the round from snapshot/roundContext per phase, so this only
         // governs the immediate synthesizeWithCrossReview branch.
-        ...(round ? { round } : { resolutionRoots: effectiveRoots }),
+        round: effectiveRound,
         verifierDispatch: _autoVerifyDispatch,
         warningSink: _autoVerifyWarningSink,
         verifierToolRunner: async (agentId: string, toolName: string, args: Record<string, unknown>): Promise<string> => {
@@ -854,11 +860,12 @@ export async function handleCollect(
           createdAt: Date.now(),
           nativePrompts: nativePrompts.map((p: any) => ({ agentId: p.agentId, system: p.system, user: p.user })),
           resolutionRoots: effectiveRoots.length > 0 ? [...effectiveRoots] : undefined,
-          // Alias mode (spec §3.2): embed the round so later phases
+          // Spec §3.2: embed the effective round so later phases
           // (relay-cross-review arrival/timeout/synthesis) can drain its
           // warnings + read its roots. The flat resolutionRoots above stays
-          // populated in parallel for old-reader back-compat.
-          roundContext: round,
+          // populated in parallel for old-reader back-compat. PR-C: this is
+          // always a concrete RoundContext (the engine now requires one).
+          roundContext: effectiveRound,
         });
 
         // Seed the relay-lint fallback membership map — keeps round-membership

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -65,24 +65,29 @@ function markDispatchWarningsStashedIfNeeded(taskId: string): void {
 /**
  * f11 follow-up (consensus dfe05be2-73794442:f11): the in-memory
  * `pendingDispatchWarnings` stash is reconnect-volatile. For each collected
- * task whose native entry carries the persisted `dispatchWarningsStashed`
- * marker but has NO live stash entry, a /mcp reconnect wiped the warnings
- * between dispatch and collect. Returns one `dispatch_warnings_lost`
- * RoundWarning per affected task so the LOSS is fail-loud rather than silently
- * unobservable. Pure over (taskMap, stash) — unit-testable in isolation.
+ * task whose native entry (task map OR result map) carries the persisted
+ * `dispatchWarningsStashed` marker but has NO live stash entry, the warnings
+ * were lost — either by /mcp reconnect or by bounded stash eviction (cap=200,
+ * eldest-evict). Returns one `dispatch_warnings_lost` RoundWarning per
+ * affected task so the LOSS is fail-loud rather than silently unobservable.
+ * Pure over (taskMap, resultMap, stash) — unit-testable in isolation.
  */
 export function detectLostDispatchWarnings(
   taskIds: readonly string[],
   nativeTaskMap: Map<string, { dispatchWarningsStashed?: boolean }>,
   stash: Map<string, unknown>,
+  nativeResultMap?: Map<string, { dispatchWarningsStashed?: boolean }>,
 ): RoundWarning[] {
   const out: RoundWarning[] = [];
   for (const tid of taskIds) {
-    const native = nativeTaskMap.get(tid);
-    if (native?.dispatchWarningsStashed === true && !stash.has(tid)) {
+    if (stash.has(tid)) continue; // live stash — no loss
+    const marker =
+      nativeTaskMap.get(tid)?.dispatchWarningsStashed === true ||
+      nativeResultMap?.get(tid)?.dispatchWarningsStashed === true;
+    if (marker) {
       out.push({
         code: 'dispatch_warnings_lost',
-        message: `dispatch-time warnings for task ${tid} were stashed but lost before collect (likely /mcp reconnect) — their content is unrecoverable`,
+        message: `dispatch-time warnings for task ${tid} were lost before collect (server reconnect or stash eviction) — rejected-root reasons unavailable`,
       });
     }
   }

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -40,7 +40,53 @@ function stashDispatchWarnings(taskIds: readonly string[], warnings?: readonly R
       if (eldest !== undefined) ctx.pendingDispatchWarnings.delete(eldest);
     }
     ctx.pendingDispatchWarnings.set(tid, frozen);
+    // Spec §3.2 / f11 follow-up: persist a marker on the native task entry (when
+    // one exists) so a reconnect that wipes the in-memory stash above leaves a
+    // durable breadcrumb. Collect emits `dispatch_warnings_lost` when the marker
+    // is set but the stash entry is gone. Set unconditionally where the entry
+    // already exists; the single-native path (entry created after stash) marks
+    // at creation via markDispatchWarningsStashedIfNeeded.
+    const native = ctx.nativeTaskMap.get(tid);
+    if (native) native.dispatchWarningsStashed = true;
   }
+}
+
+/**
+ * Set the persisted `dispatchWarningsStashed` marker on a native task entry when
+ * dispatch-time warnings were stashed under its task_id but the entry was created
+ * AFTER the stash call (single-native dispatch path). Spec §3.2 / f11 follow-up.
+ */
+function markDispatchWarningsStashedIfNeeded(taskId: string): void {
+  if (!ctx.pendingDispatchWarnings.has(taskId)) return;
+  const native = ctx.nativeTaskMap.get(taskId);
+  if (native) native.dispatchWarningsStashed = true;
+}
+
+/**
+ * f11 follow-up (consensus dfe05be2-73794442:f11): the in-memory
+ * `pendingDispatchWarnings` stash is reconnect-volatile. For each collected
+ * task whose native entry carries the persisted `dispatchWarningsStashed`
+ * marker but has NO live stash entry, a /mcp reconnect wiped the warnings
+ * between dispatch and collect. Returns one `dispatch_warnings_lost`
+ * RoundWarning per affected task so the LOSS is fail-loud rather than silently
+ * unobservable. Pure over (taskMap, stash) — unit-testable in isolation.
+ */
+export function detectLostDispatchWarnings(
+  taskIds: readonly string[],
+  nativeTaskMap: Map<string, { dispatchWarningsStashed?: boolean }>,
+  stash: Map<string, unknown>,
+): RoundWarning[] {
+  const out: RoundWarning[] = [];
+  for (const tid of taskIds) {
+    const native = nativeTaskMap.get(tid);
+    if (native?.dispatchWarningsStashed === true && !stash.has(tid)) {
+      out.push({
+        code: 'dispatch_warnings_lost',
+        message: `dispatch-time warnings for task ${tid} were stashed but lost before collect (likely /mcp reconnect) — their content is unrecoverable`,
+      });
+    }
+  }
+  return out;
 }
 
 /** Build the identity block for a native subagent dispatch. */
@@ -684,6 +730,9 @@ export async function handleDispatchSingle(
       ? stampConcurrencyTaint(ctx.nativeTaskMap) || undefined
       : undefined;
     ctx.nativeTaskMap.set(taskId, { agentId: agent_id, task, startedAt: Date.now(), timeoutMs, planId: plan_id, step, writeMode: write_mode, relayToken, preDispatchSha, isolationSnapshot, concurrentWorktreeTaint });
+    // Entry created AFTER stashDispatchWarnings([taskId]) above — mark it now so
+    // the persisted breadcrumb survives a reconnect (spec §3.2 / f11 follow-up).
+    markDispatchWarningsStashedIfNeeded(taskId);
     spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
     // promptPath is filled in below after elision (if requested).
     process.stderr.write(`[gossipcat] → dispatch → ${agent_id} (${nativeConfig.model}) [${taskId}]\n`);

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -404,6 +404,9 @@ export function persistNativeTaskMap(): void {
         id: info.id, agentId: info.agentId, task: info.task?.slice(0, 5000),
         status: info.status, startedAt: info.startedAt, completedAt: info.completedAt,
         error: info.error, result: info.result?.slice(0, 50000),
+        // Persist the breadcrumb so detectLostDispatchWarnings works across
+        // /mcp reconnects for tasks that completed before the reconnect.
+        ...(info.dispatchWarningsStashed ? { dispatchWarningsStashed: true } : {}),
       };
     }
     // Filter utility tasks — they're ephemeral, don't persist
@@ -652,6 +655,11 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
     result: effectiveResult,
     error: effectiveError || undefined,
     startedAt: effectiveStart, completedAt: Date.now(),
+    // Carry the dispatch-warnings breadcrumb onto the result record so the
+    // detect-lost-warnings check at collect time can find it even after the
+    // native task entry is deleted above. Persisted via slimResults so it
+    // survives /mcp reconnect.
+    ...(taskInfo.dispatchWarningsStashed ? { dispatchWarningsStashed: true as const } : {}),
   };
   // skill_develop utility results go to the separate non-evicted map so that
   // long-running dispatch→relay→re-entry chains (>2h) don't fall back to stale

--- a/apps/cli/src/handlers/relay-cross-review.ts
+++ b/apps/cli/src/handlers/relay-cross-review.ts
@@ -4,6 +4,99 @@
  */
 import { ctx, RECENT_CONSENSUS_TASK_TTL_MS } from '../mcp-context';
 import { seedRecentConsensusAgentIds } from './native-tasks';
+import type {
+  ConsensusEngine as ConsensusEngineType,
+  ConsensusReport,
+  CrossReviewEntry,
+  ILLMProvider,
+  RoundContext,
+  TaskEntry,
+} from '@gossip/orchestrator';
+
+/**
+ * The minimal slice of a pending-round snapshot the timeout-synthesis path
+ * consumes. Mirrors the object the timeout watcher builds from the live round.
+ */
+export interface TimeoutSynthesisSnapshot {
+  allResults: TaskEntry[];
+  relayCrossReviewEntries: CrossReviewEntry[];
+  relayCrossReviewSkipped?: Array<{ agentId: string; reason: string }>;
+  nativeCrossReviewEntries: CrossReviewEntry[];
+  resolutionRoots?: readonly string[];
+  roundContext?: RoundContext;
+}
+
+/**
+ * REAL timeout-synthesis core (spec §5 / consensus f8 follow-up). Extracted from
+ * the `checkTimeout` closure so a test can drive the genuine outer→inner layers:
+ * it constructs the SAME engine the timeout watcher does, resolves cross-review
+ * prompt anchors against the round's roots, runs `synthesizeWithCrossReview`, and
+ * persists the report. Returns the report PLUS the resolved prompts so the
+ * boundary value (round.resolutionRoots reaching anchor CONTENT) is observable in
+ * the final artifact — not just asserted on the engine config.
+ *
+ * The engine REQUIRES a RoundContext (PR-C). When the snapshot lacks an embedded
+ * round (old pre-PR-A persisted record), one is reconstructed from the flat
+ * resolutionRoots so the synthesis still pins anchors to the worktree.
+ */
+export async function synthesizeTimeoutRound(
+  snapshot: TimeoutSynthesisSnapshot,
+  consensusId: string,
+  missingAgents: string[],
+  llm: ILLMProvider,
+  projectRoot: string = process.cwd(),
+): Promise<{ report: ConsensusReport; prompts: Array<{ system: string; user: string }> }> {
+  const { ConsensusEngine, makeRoundContext } = await import('@gossip/orchestrator');
+  const round: RoundContext =
+    snapshot.roundContext ?? makeRoundContext({ resolutionRoots: snapshot.resolutionRoots ?? [] });
+  const engine: ConsensusEngineType = new ConsensusEngine({
+    llm,
+    registryGet: (id: string) => ctx.mainAgent.getAgentConfig(id),
+    projectRoot,
+    // PR-C: the engine requires a round; forward the effective one so its
+    // warnings drain into the timeout-synthesis report and its roots pin anchors.
+    round,
+  });
+
+  const allEntries = [...snapshot.relayCrossReviewEntries, ...snapshot.nativeCrossReviewEntries];
+  // Resolve anchors against the round's roots — the prompts carry the worktree
+  // version of cited files as <anchor> CONTENT. Surfaced for the §5 seam test.
+  const { prompts } = await engine.generateCrossReviewPrompts(snapshot.allResults);
+  const report = await engine.synthesizeWithCrossReview(
+    snapshot.allResults,
+    allEntries,
+    consensusId,
+    snapshot.relayCrossReviewSkipped,
+  );
+
+  // Persist report
+  try {
+    const { writeFileSync, mkdirSync } = require('fs');
+    const { join } = require('path');
+    const reportsDir = join(projectRoot, '.gossip', 'consensus-reports');
+    mkdirSync(reportsDir, { recursive: true });
+    const topic = snapshot.allResults?.find((r: any) => r.task)?.task?.slice(0, 500) || '';
+    writeFileSync(join(reportsDir, `${consensusId}.json`), JSON.stringify({
+      id: consensusId,
+      timestamp: new Date().toISOString(),
+      topic,
+      agentCount: report.agentCount,
+      rounds: report.rounds,
+      confirmed: report.confirmed || [],
+      disputed: report.disputed || [],
+      unverified: report.unverified || [],
+      unique: report.unique || [],
+      insights: report.insights || [],
+      newFindings: report.newFindings || [],
+      timedOut: missingAgents,
+      ...(report.droppedFindingsByType ? { droppedFindingsByType: report.droppedFindingsByType } : {}),
+      ...(report.authorDiagnostics ? { authorDiagnostics: report.authorDiagnostics } : {}),
+      ...(report.warnings && report.warnings.length > 0 ? { warnings: report.warnings } : {}),
+    }, null, 2));
+  } catch { /* best-effort */ }
+
+  return { report, prompts: prompts.map(p => ({ system: p.system, user: p.user })) };
+}
 
 /**
  * Start a timeout watcher for a pending consensus round.
@@ -61,54 +154,14 @@ export function startConsensusTimeout(consensusId: string): void {
       })));
     } catch { /* best-effort */ }
 
-    // Synthesize with what we have
+    // Synthesize with what we have — via the extracted, test-driven core.
     try {
-      const { ConsensusEngine } = await import('@gossip/orchestrator');
       const timeoutLlm = ctx.mainAgent.getLlm();
       if (!timeoutLlm) {
         process.stderr.write(`[gossipcat] ⚠️  Timeout synthesis skipped: no LLM configured\n`);
         return;
       }
-      const engine = new ConsensusEngine({
-        llm: timeoutLlm,
-        registryGet: (id: string) => ctx.mainAgent.getAgentConfig(id),
-        projectRoot: process.cwd(),
-        // Alias mode: forward the embedded round when present so its warnings
-        // drain into the timeout-synthesis report; else legacy roots-only.
-        ...(snapshot.roundContext
-          ? { round: snapshot.roundContext }
-          : { resolutionRoots: snapshot.resolutionRoots }),
-      });
-
-      const allEntries = [...snapshot.relayCrossReviewEntries, ...snapshot.nativeCrossReviewEntries];
-      const report = await engine.synthesizeWithCrossReview(snapshot.allResults, allEntries, consensusId, snapshot.relayCrossReviewSkipped);
-
-      // Persist report
-      try {
-        const { writeFileSync, mkdirSync } = require('fs');
-        const { join } = require('path');
-        const reportsDir = join(process.cwd(), '.gossip', 'consensus-reports');
-        mkdirSync(reportsDir, { recursive: true });
-        const topic = snapshot.allResults?.find((r: any) => r.task)?.task?.slice(0, 500) || '';
-        writeFileSync(join(reportsDir, `${consensusId}.json`), JSON.stringify({
-          id: consensusId,
-          timestamp: new Date().toISOString(),
-          topic,
-          agentCount: report.agentCount,
-          rounds: report.rounds,
-          confirmed: report.confirmed || [],
-          disputed: report.disputed || [],
-          unverified: report.unverified || [],
-          unique: report.unique || [],
-          insights: report.insights || [],
-          newFindings: report.newFindings || [],
-          timedOut: missingAgents,
-          ...(report.droppedFindingsByType ? { droppedFindingsByType: report.droppedFindingsByType } : {}),
-          ...(report.authorDiagnostics ? { authorDiagnostics: report.authorDiagnostics } : {}),
-          ...(report.warnings && report.warnings.length > 0 ? { warnings: report.warnings } : {}),
-        }, null, 2));
-      } catch { /* best-effort */ }
-
+      const { report } = await synthesizeTimeoutRound(snapshot, consensusId, missingAgents, timeoutLlm);
       process.stderr.write(`[gossipcat] 🔮 Timeout synthesis complete: ${report.confirmed.length} confirmed, ${report.disputed.length} disputed\n`);
     } catch (err) {
       process.stderr.write(`[gossipcat] ❌ Timeout synthesis failed: ${(err as Error).message}\n`);
@@ -152,18 +205,17 @@ export async function handleRelayCrossReview(
   const rejectedPeerIds = new Set<string>();
   let parseError: string | null = null;
   try {
-    const { ConsensusEngine } = await import('@gossip/orchestrator');
+    const { ConsensusEngine, makeRoundContext } = await import('@gossip/orchestrator');
     const parseLlm = ctx.mainAgent.getLlm();
     // parseCrossReviewResponse doesn't call LLM, but ConsensusEngine requires one in config
     const engine = new ConsensusEngine({
       llm: parseLlm || ({ generate: async () => ({ text: '', usage: { inputTokens: 0, outputTokens: 0 } }) } as any),
       registryGet: (id: string) => ctx.mainAgent.getAgentConfig(id),
       projectRoot: process.cwd(),
-      // Alias mode: forward embedded round when present (parse-only path, but
-      // keep the boundary consistent); else legacy roots-only.
-      ...(round.roundContext
-        ? { round: round.roundContext }
-        : { resolutionRoots: round.resolutionRoots }),
+      // PR-C: the engine requires a round. Forward the embedded one; if an old
+      // restored record lacks it, wrap the flat roots (parse-only path — the
+      // round is just for boundary consistency).
+      round: round.roundContext ?? makeRoundContext({ resolutionRoots: round.resolutionRoots ?? [] }),
     });
     const entries = engine.parseCrossReviewResponse(agent_id, result, 50);
     parsedCount = entries.length;
@@ -285,7 +337,7 @@ export async function handleRelayCrossReview(
   process.stderr.write(`[gossipcat] 🔮 All native cross-reviews received. Synthesizing consensus for ${consensus_id}...\n`);
 
   try {
-    const { ConsensusEngine } = await import('@gossip/orchestrator');
+    const { ConsensusEngine, makeRoundContext } = await import('@gossip/orchestrator');
     const mainLlm = ctx.mainAgent.getLlm();
     if (!mainLlm) {
       return { content: [{ type: 'text' as const, text: 'Error: No LLM configured for consensus synthesis. Check gossip_setup.' }] };
@@ -294,11 +346,10 @@ export async function handleRelayCrossReview(
       llm: mainLlm,
       registryGet: (id: string) => ctx.mainAgent.getAgentConfig(id),
       projectRoot: process.cwd(),
-      // Alias mode: forward the embedded round so its fail-loud warnings drain
-      // into the final-synthesis report; else legacy roots-only.
-      ...(synthSnapshot.roundContext
-        ? { round: synthSnapshot.roundContext }
-        : { resolutionRoots: synthSnapshot.resolutionRoots }),
+      // PR-C: the engine requires a round. Forward the embedded one so its
+      // fail-loud warnings drain into the final-synthesis report; wrap the flat
+      // roots when an old restored record lacks an embedded round.
+      round: synthSnapshot.roundContext ?? makeRoundContext({ resolutionRoots: synthSnapshot.resolutionRoots ?? [] }),
     });
 
     const allCrossReviewEntries = [

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -145,6 +145,13 @@ export interface NativeResultInfo {
   error?: string;
   startedAt: number;
   completedAt: number;
+  /**
+   * Carried over from NativeTaskInfo.dispatchWarningsStashed at relay time.
+   * Survives reconnect via the persisted slimResults. Allows
+   * detectLostDispatchWarnings to detect the lost-warnings case for tasks
+   * that completed before the next /mcp reconnect wiped the in-memory stash.
+   */
+  dispatchWarningsStashed?: boolean;
 }
 
 export interface McpContext {

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -124,6 +124,16 @@ export interface NativeTaskInfo {
    * in favour of a worktree_isolation_skipped breadcrumb.
    */
   concurrentWorktreeTaint?: boolean;
+  /**
+   * True when dispatch-time fail-loud warnings were stashed under this task_id
+   * (spec §3.2 / consensus f11 follow-up). The stash itself
+   * (`pendingDispatchWarnings`) is in-memory only and lost on /mcp reconnect,
+   * but THIS marker is persisted on the native task entry. At collect time, if
+   * the marker is set but the in-memory stash has no entry for the task, the
+   * loss is fail-loud: a `dispatch_warnings_lost` RoundWarning is emitted on the
+   * round so the dropped warnings are observable rather than silently gone.
+   */
+  dispatchWarningsStashed?: boolean;
 }
 
 export interface NativeResultInfo {

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -204,7 +204,7 @@ try {
   if (stalenessResult.stale) logStalenessToMcpLog(stalenessResult, process.cwd());
 } catch { /* never break boot */ }
 import { restoreNativeTaskMap, handleNativeRelay, spawnTimeoutWatcher, scheduleNativeTaskEviction } from './handlers/native-tasks';
-import { handleDispatchSingle, handleDispatchParallel, handleDispatchConsensus } from './handlers/dispatch';
+import { handleDispatchSingle, handleDispatchParallel, handleDispatchConsensus, detectLostDispatchWarnings } from './handlers/dispatch';
 import {
   invalidateAgent as invalidateDispatchPromptCacheForAgent,
   invalidateAll as invalidateAllDispatchPromptCache,
@@ -1716,6 +1716,16 @@ export function createMcpServer(): McpServer {
       // above — a dispatch-time rejection is visible at collect even when the
       // operator passes fresh (or no) collect-time roots.
       if (task_ids && task_ids.length > 0) {
+        // f11 follow-up (consensus dfe05be2-73794442:f11): detect lost
+        // dispatch-time warnings BEFORE draining/deleting the stash — a task
+        // whose native entry carries the persisted `dispatchWarningsStashed`
+        // marker but has no live stash entry lost its warnings to a /mcp
+        // reconnect. Make the LOSS fail-loud (the content is gone, but its
+        // absence is now visible). detectLostDispatchWarnings is pure over
+        // (taskMap, stash) and unit-tested in dispatch.test.ts.
+        for (const w of detectLostDispatchWarnings(task_ids, ctx.nativeTaskMap, ctx.pendingDispatchWarnings)) {
+          round.warnings.push(w);
+        }
         const seen = new Set<readonly import('@gossip/orchestrator').RoundWarning[]>();
         for (const tid of task_ids) {
           const stashed = ctx.pendingDispatchWarnings.get(tid);

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1720,10 +1720,10 @@ export function createMcpServer(): McpServer {
         // dispatch-time warnings BEFORE draining/deleting the stash — a task
         // whose native entry carries the persisted `dispatchWarningsStashed`
         // marker but has no live stash entry lost its warnings to a /mcp
-        // reconnect. Make the LOSS fail-loud (the content is gone, but its
-        // absence is now visible). detectLostDispatchWarnings is pure over
-        // (taskMap, stash) and unit-tested in dispatch.test.ts.
-        for (const w of detectLostDispatchWarnings(task_ids, ctx.nativeTaskMap, ctx.pendingDispatchWarnings)) {
+        // reconnect OR bounded stash eviction. Also checks nativeResultMap
+        // for tasks that completed before the reconnect (the marker is carried
+        // from NativeTaskInfo onto the result record at relay time).
+        for (const w of detectLostDispatchWarnings(task_ids, ctx.nativeTaskMap, ctx.pendingDispatchWarnings, ctx.nativeResultMap)) {
           round.warnings.push(w);
         }
         const seen = new Set<readonly import('@gossip/orchestrator').RoundWarning[]>();

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -647,18 +647,18 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
                         </button>
                       ))}
                     </div>
-                    {report.coverageDegraded && (
-                      <div className="mb-3 rounded-md border border-unverified/20 bg-unverified/8 px-3 py-2">
-                        <p className="font-mono text-[10px] font-semibold text-unverified">
-                          ⚠ Coverage degraded — {report.coverageDegraded.received} of {report.coverageDegraded.expected} agents responded
-                        </p>
-                        {report.coverageDegraded.droppedAgents.length > 0 && (
-                          <p className="mt-0.5 font-mono text-[9px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 70%, transparent)' }}>
-                            Dropped: {report.coverageDegraded.droppedAgents.join(', ')}
-                          </p>
-                        )}
+                    {/* Degraded-mode detail now driven by report.warnings (spec
+                        §4 — the warnings channel subsumes the legacy
+                        coverageDegraded / relayCrossReviewSkipped fields, deleted
+                        in PR-C). Old persisted reports are mapped to synthetic
+                        warnings at READ time (routes.ts
+                        normalizeLegacyDegradedFields), so this single path renders
+                        both. Amber --warn per DESIGN.md. */}
+                    {(report.warnings ?? []).filter(w => w.code === 'coverage_degraded').map((w, i) => (
+                      <div key={`cd-${i}`} className="mb-3 rounded-md border border-warn/30 bg-warn/10 px-3 py-2">
+                        <p className="font-mono text-[10px] font-semibold text-warn">⚠ {w.message}</p>
                       </div>
-                    )}
+                    ))}
                     {report.zeroTagAgents && report.zeroTagAgents.length > 0 && (
                       <div className="mb-3 rounded-md border border-unverified/20 bg-unverified/8 px-3 py-2">
                         <p className="font-mono text-[10px] font-semibold text-unverified">
@@ -676,16 +676,23 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
                         </p>
                       </div>
                     )}
-                    {report.relayCrossReviewSkipped && report.relayCrossReviewSkipped.length > 0 && (
-                      <div className="mb-3 rounded-md border border-unverified/20 bg-unverified/8 px-3 py-2">
-                        <p className="font-mono text-[10px] font-semibold text-unverified">
-                          ⚠ Cross-review skipped: {report.relayCrossReviewSkipped.length} relay agent{report.relayCrossReviewSkipped.length === 1 ? '' : 's'} failed Phase 2
-                        </p>
-                        <p className="mt-0.5 font-mono text-[9px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 70%, transparent)' }}>
-                          {report.relayCrossReviewSkipped.map(s => s.agentId).join(', ')}
-                        </p>
-                      </div>
-                    )}
+                    {(() => {
+                      const skipped = (report.warnings ?? []).filter(w => w.code === 'cross_review_skipped');
+                      if (skipped.length === 0) return null;
+                      const named = skipped.map(w => w.agentId).filter(Boolean) as string[];
+                      return (
+                        <div className="mb-3 rounded-md border border-warn/30 bg-warn/10 px-3 py-2">
+                          <p className="font-mono text-[10px] font-semibold text-warn">
+                            ⚠ Cross-review skipped: {skipped.length} relay agent{skipped.length === 1 ? '' : 's'} failed Phase 2
+                          </p>
+                          {named.length > 0 && (
+                            <p className="mt-0.5 font-mono text-[9px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 70%, transparent)' }}>
+                              {named.join(', ')}
+                            </p>
+                          )}
+                        </div>
+                      );
+                    })()}
                     {(report.crossReviewAssignments || report.crossReviewCoverage) && (() => {
                       // Invert assignments: reviewerId → findingIds
                       const assignments = report.crossReviewAssignments || {};
@@ -694,12 +701,16 @@ export function FindingsMetrics({ consensus, reports, showAll = false, hideHeade
                       const coverage = report.crossReviewCoverage || [];
                       const totalCovered = coverage.length;
                       const underReviewed = coverage.filter(c => c.assigned < c.targetK);
+                      // partial_review is now a warning code (spec §4 — legacy
+                      // report.partialReview field deleted in PR-C; old reports
+                      // mapped at read time).
+                      const isPartial = (report.warnings ?? []).some(w => w.code === 'partial_review');
                       return (
                         <details className="mb-3 rounded-md border border-border/30" style={{ background: 'color-mix(in oklch, var(--surface-elev) 30%, transparent)' }}>
                           <summary className="flex cursor-pointer items-center gap-2 px-3 py-2 h-section select-none">
                             Cross-Review Assignments
-                            {report.partialReview && (
-                              <span className="rounded border border-unverified/15 bg-unverified/5 px-1.5 py-0.5 font-mono text-[9px] font-bold normal-case tracking-normal text-unverified">
+                            {isPartial && (
+                              <span className="rounded border border-warn/20 bg-warn/10 px-1.5 py-0.5 font-mono text-[9px] font-bold normal-case tracking-normal text-warn">
                                 partial
                               </span>
                             )}

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -208,17 +208,6 @@ export interface ConsensusReport {
   newFindings: Array<{ agentId: string; finding: string; evidence: string; confidence: number }>;
   crossReviewAssignments?: Record<string, string[]>;
   crossReviewCoverage?: Array<{ findingId: string; assigned: number; targetK: number }>;
-  partialReview?: boolean;
-  /**
-   * Relay agents whose cross-review LLM call failed (quota / parse / network).
-   * Matches orchestrator ConsensusReport shape exactly.
-   */
-  relayCrossReviewSkipped?: Array<{ agentId: string; reason: string }>;
-  /**
-   * Coverage degraded when a dispatched agent produced a 0-char response.
-   * The round still completes but with fewer voices than dispatched.
-   */
-  coverageDegraded?: { expected: number; received: number; droppedAgents: string[] };
   /**
    * Unknown type values (lowercased) → total drop count. Populated by the
    * strict `<agent_finding>` parser when an agent uses an invented type

--- a/packages/orchestrator/src/consensus-coordinator.ts
+++ b/packages/orchestrator/src/consensus-coordinator.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import { ILLMProvider, createProvider } from './llm-client';
 import { ConsensusEngine } from './consensus-engine';
 import { ConsensusReport } from './consensus-types';
-import { isRoundContext, type RoundContext } from './round-context';
+import { isRoundContext, makeRoundContext, type RoundContext } from './round-context';
 import { MemoryWriter } from './memory-writer';
 import { AgentConfig, TaskEntry } from './types';
 import { GossipPublisher } from './gossip-publisher';
@@ -19,18 +19,6 @@ export interface ConsensusCoordinatorConfig {
   keyProvider: ((provider: string) => Promise<string | null>) | null;
   /** Forwarded to ConsensusEngine so Phase-2 reviewers keep their skills. */
   getAgentSkillsContent?: (agentId: string, task: string) => string | undefined;
-  /**
-   * Post-validation resolution roots forwarded to ConsensusEngine. Must be
-   * realpath'd absolute paths (validation happens at MCP boundary). Issue
-   * #126 / PR-B.
-   */
-  resolutionRoots?: readonly string[];
-  /**
-   * Per-round consensus context (spec §3.1). Alias-mode default forwarded to
-   * ConsensusEngine when no per-round override is supplied to runConsensus.
-   * When present it WINS over the loose `resolutionRoots` field.
-   */
-  round?: RoundContext;
 }
 
 type ConsensusPhase = 'idle' | 'review' | 'cross_review' | 'synthesis';
@@ -41,8 +29,6 @@ export class ConsensusCoordinator {
   private projectRoot: string;
   private keyProvider: ((provider: string) => Promise<string | null>) | null;
   private getAgentSkillsContent?: (agentId: string, task: string) => string | undefined;
-  private resolutionRoots?: readonly string[];
-  private round?: RoundContext;
   private gossipPublisher: GossipPublisher | null = null;
   private memWriter: MemoryWriter;
 
@@ -56,8 +42,6 @@ export class ConsensusCoordinator {
     this.projectRoot = config.projectRoot;
     this.keyProvider = config.keyProvider;
     this.getAgentSkillsContent = config.getAgentSkillsContent;
-    this.resolutionRoots = config.resolutionRoots;
-    this.round = config.round;
     this.memWriter = new MemoryWriter(config.projectRoot);
   }
 
@@ -75,15 +59,15 @@ export class ConsensusCoordinator {
 
   /**
    * @param roundOrRoots Optional per-round context OR collect-time resolution
-   *   roots (already validated at the MCP boundary). Alias mode (spec §3.2):
-   *   - A `RoundContext` WINS — it is forwarded whole to the engine (carrying
-   *     resolutionRoots AND the warnings array), overriding the constructor
-   *     default `this.round` / `this.resolutionRoots`.
-   *   - A non-empty `readonly string[]` (legacy shape) OVERRIDES the
-   *     constructor default `this.resolutionRoots`, mirroring the "collect-time
-   *     REPLACES dispatch-time" semantics (collect.ts). Byte-identical to the
-   *     pre-RoundContext path.
-   *   When absent, the constructor defaults are used (round wins over roots).
+   *   roots (already validated at the MCP boundary). PR-C — the engine now
+   *   REQUIRES a RoundContext, so this method always derives one:
+   *   - A `RoundContext` is forwarded whole to the engine (carrying
+   *     resolutionRoots AND the warnings array).
+   *   - A `readonly string[]` (legacy shape) is wrapped into a fresh
+   *     RoundContext via `makeRoundContext({ resolutionRoots })`.
+   *   - When absent, an empty `makeRoundContext()` is used (resolve against
+   *     project root only). There is no constructor-level default — the sole
+   *     production construction site never passed one (consensus-verified).
    */
   async runConsensus(
     results: TaskEntry[],
@@ -95,21 +79,15 @@ export class ConsensusCoordinator {
     // !Array.isArray check would let any non-array object pass as a
     // RoundContext, then read .resolutionRoots as undefined and silently fall
     // through to empty roots (the stale-anchor bug class). isRoundContext
-    // validates the resolutionRoots + warnings array fields.
-    const perRoundRound: RoundContext | undefined =
-      isRoundContext(roundOrRoots) ? roundOrRoots : undefined;
-    const perRoundRoots: readonly string[] | undefined =
-      Array.isArray(roundOrRoots) ? (roundOrRoots as readonly string[]) : undefined;
-
-    // Effective round: per-round context wins, else constructor default.
-    const effectiveRound: RoundContext | undefined = perRoundRound ?? this.round;
-    // Effective legacy roots: only used when NO round is in play (round carries
-    // its own resolutionRoots). Per-round legacy array overrides constructor.
-    const effectiveResolutionRoots = effectiveRound
-      ? effectiveRound.resolutionRoots
-      : (perRoundRoots && perRoundRoots.length > 0)
-        ? perRoundRoots
-        : this.resolutionRoots;
+    // validates the resolutionRoots + warnings array fields. Always resolve to
+    // a concrete RoundContext: forward a passed round, wrap a legacy roots
+    // array, or build an empty one (project-root-only).
+    const effectiveRound: RoundContext = isRoundContext(roundOrRoots)
+      ? roundOrRoots
+      : makeRoundContext(
+          Array.isArray(roundOrRoots) ? { resolutionRoots: roundOrRoots as readonly string[] } : {},
+        );
+    const effectiveResolutionRoots = effectiveRound.resolutionRoots;
 
     try {
       this.currentPhase = 'review';
@@ -142,12 +120,10 @@ export class ConsensusCoordinator {
         projectRoot: this.projectRoot,
         agentLlm,
         getAgentSkillsContent: this.getAgentSkillsContent,
-        // Alias mode: when a round is in play, forward it whole (it carries its
-        // own resolutionRoots AND the warnings array the engine drains into the
-        // report). Else fall back to the legacy loose roots — byte-identical.
-        ...(effectiveRound
-          ? { round: effectiveRound }
-          : { resolutionRoots: effectiveResolutionRoots }),
+        // PR-C: the engine REQUIRES a round; forward the effective one whole
+        // (it carries resolutionRoots AND the warnings array the engine drains
+        // into the report).
+        round: effectiveRound,
       });
       const consensusReport = await engine.run(results);
       this.currentPhase = 'cross_review';

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -14,6 +14,7 @@ import { ILLMProvider } from './llm-client';
 import { AgentConfig, TaskEntry } from './types';
 import { ConsensusReport, ConsensusFinding, ConsensusNewFinding, ConsensusSignal, CrossReviewEntry, RelayWarningEntry } from './consensus-types';
 import type { RoundContext } from './round-context';
+import { buildCoverageDegradedMessage } from './coverage-degraded';
 import { autoVerifyUnverifiedFindings, buildSkipSignal, type AutoVerifiableFinding } from './consensus-auto-verify';
 import { getRuntimeFlagBool } from './runtime-config';
 import { selectCrossReviewers, FindingForSelection, AgentCandidate } from './cross-reviewer-selection';
@@ -3076,7 +3077,7 @@ Return only valid JSON.${skillsBlock}`;
     const droppedAgents = results.filter(isDropped).map(r => r.agentId);
     const received = results.length - droppedAgents.length;
     if (results.length > 0 && droppedAgents.length > 0) {
-      const evidence = `Coverage degraded: ${received}/${results.length} agents returned content (dropped: ${droppedAgents.join(', ')})`;
+      const evidence = buildCoverageDegradedMessage({ received, expected: results.length, droppedAgents });
       report.signals.push({
         type: 'consensus', taskId: '', consensusId, signal: 'consensus_coverage_degraded',
         signal_class: 'operational', agentId: '_round', evidence, timestamp: new Date().toISOString(),

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -109,28 +109,17 @@ export interface ConsensusEngineConfig {
    */
   getAgentSkillsContent?: (agentId: string, task: string) => string | undefined;
   /**
-   * Post-validation, post-realpath resolution roots supplied by the caller
-   * (e.g. gossip_collect({ resolutionRoots: [...] })) or derived from
-   * opt-in auto-discovery. Used in addition to projectRoot + TaskEntry
-   * worktree paths for citation resolution and path-traversal guards.
-   *
-   * INVARIANT: strings in this array MUST be post-realpath absolute paths.
-   * Validation lives at the MCP boundary (validateResolutionRoot); supplying
-   * unvalidated input here is a programmer error. Any construction-time
-   * issue throws rather than silent-dropping.
-   *
-   * Issue #126 / PR-B.
-   */
-  resolutionRoots?: readonly string[];
-  /**
    * Per-round consensus context (spec 2026-06-11-round-context-fail-loud.md
-   * §3.1). When present it WINS over the loose `resolutionRoots` field: the
-   * constructor seeds worktree roots from `round.resolutionRoots` instead, and
-   * synthesize() drains `round.warnings` into `report.warnings`. When absent,
-   * the legacy `resolutionRoots` path is byte-identical. Alias mode (PR-A) —
-   * the loose field is removed in PR-C.
+   * §3.1/§3.3). REQUIRED — every ConsensusEngine carries a RoundContext. The
+   * constructor seeds worktree roots from `round.resolutionRoots`, and
+   * synthesize() drains `round.warnings` into `report.warnings`. A boundary
+   * with no roots passes `makeRoundContext()` (empty resolutionRoots), NOT
+   * undefined — "resolve against project root only" is `resolutionRoots: []`,
+   * a valid RoundContext. Making this field required (PR-C) turns "forgot to
+   * pass a round" into a compile error, killing the stale-anchor door before
+   * a new code path can open it.
    */
-  round?: RoundContext;
+  round: RoundContext;
   /**
    * Verifier dispatcher resolved by the cli layer via `discoverVerifier(team)`
    * (spec docs/superpowers/specs/2026-05-21-consensus-auto-verify-design.md).
@@ -198,10 +187,9 @@ export class ConsensusEngine {
     // and post-realpath (invariant enforced at MCP boundary); mis-supplied
     // input here is a programmer error that throws immediately.
     //
-    // Alias mode (PR-A): when `config.round` is present it WINS — seed from
-    // `round.resolutionRoots`. Otherwise fall back to the legacy loose
-    // `config.resolutionRoots`. Same validation/throw semantics for both.
-    const seeded = config.round ? config.round.resolutionRoots : config.resolutionRoots;
+    // PR-C: `config.round` is REQUIRED — always seed from
+    // `round.resolutionRoots`. An empty array means "project root only".
+    const seeded = config.round.resolutionRoots;
     if (seeded && seeded.length > 0) {
       for (const p of seeded) {
         if (typeof p !== 'string' || p.length === 0) {
@@ -228,26 +216,23 @@ export class ConsensusEngine {
   }
 
   /**
-   * Effective per-round resolution roots: `config.round.resolutionRoots` when a
-   * RoundContext is present (alias mode — round WINS), else the legacy loose
-   * `config.resolutionRoots`. Every `updateWorktreeRoots` call site reads this
-   * so the round and legacy paths stay byte-identical at the boundary.
+   * Effective per-round resolution roots: `config.round.resolutionRoots`. The
+   * RoundContext is always present (PR-C made it required), so this is the
+   * single source of truth every `updateWorktreeRoots` call site reads.
    */
-  private effectiveResolutionRoots(): readonly string[] | undefined {
-    return this.config.round ? this.config.round.resolutionRoots : this.config.resolutionRoots;
+  private effectiveResolutionRoots(): readonly string[] {
+    return this.config.round.resolutionRoots;
   }
 
   /**
-   * Append a fail-loud warning to the round (spec §4). No-op when no
-   * RoundContext is threaded (legacy roots-only construction). Warnings pushed
-   * BEFORE `synthesize()` runs are drained into `report.warnings` by the drain
-   * at the bottom of `synthesize()`. Warnings produced AFTER synthesis (the
-   * post-synthesis legacy-field producers in `synthesizeWithCrossReview`) must
-   * ALSO be mirrored onto the report via `appendReportWarning`, because the
-   * drain already ran. APPEND-ONLY, no dedup — every instance is recorded.
+   * Append a fail-loud warning to the round (spec §4). Warnings pushed BEFORE
+   * `synthesize()` runs are drained into `report.warnings` by the drain at the
+   * bottom of `synthesize()`. Warnings produced AFTER synthesis (the
+   * post-synthesis producers in `synthesizeWithCrossReview`) must ALSO be
+   * mirrored onto the report via `appendReportWarning`, because the drain
+   * already ran. APPEND-ONLY, no dedup — every instance is recorded.
    */
   private appendRoundWarning(code: import('./round-context').RoundWarningCode, message: string, agentId?: string): void {
-    if (!this.config.round) return;
     this.config.round.warnings.push({ code, message, ...(agentId !== undefined ? { agentId } : {}) });
   }
 
@@ -1662,7 +1647,7 @@ Return only valid JSON.${skillsBlock}`;
       // Drain fail-loud round warnings into the report (spec §6.1). Copy
       // (not alias) so later mutation of round.warnings can't retroactively
       // change a synthesized report. Omitted when the round carried none.
-      ...(this.config.round && this.config.round.warnings.length > 0
+      ...(this.config.round.warnings.length > 0
         ? { warnings: [...this.config.round.warnings] }
         : {}),
     };
@@ -2874,8 +2859,8 @@ Return only valid JSON.${skillsBlock}`;
    * (docs/specs/2026-04-10-relay-only-consensus.md lines 237-242).
    *
    * Requires `config.performanceReader` — throws if not set.
-   * Sets `partialReview: true` on the report if any finding received fewer
-   * than K cross-reviewers (K = 3 for critical, 2 for all others).
+   * Emits a `partial_review` RoundWarning on the report if any finding received
+   * fewer than K cross-reviewers (K = 3 for critical, 2 for all others).
    */
   async runSelectedCrossReview(
     results: TaskEntry[],
@@ -2949,8 +2934,8 @@ Return only valid JSON.${skillsBlock}`;
     if (assignments.size === 0) {
       _log('consensus', 'runSelectedCrossReview: no reviewers selected; synthesizing without cross-review');
       const report = await this.synthesize(results, [], consensusId);
-      report.partialReview = true;
-      // Spec §4 dual-write — fires after synthesize()'s drain.
+      // Spec §4 — the warnings channel SUBSUMES the legacy report.partialReview
+      // field (deleted in PR-C). Fires after synthesize()'s drain.
       this.appendReportWarning(report, 'partial_review', 'no cross-reviewers selected — every finding is under-reviewed (0 of target K)');
       return report;
     }
@@ -3015,9 +3000,9 @@ Return only valid JSON.${skillsBlock}`;
 
     const report = await this.synthesize(results, allCrossReviewEntries, consensusId);
     if (partialReview) {
-      report.partialReview = true;
-      // Spec §4 dual-write — at least one finding got fewer than its target K
-      // cross-reviewers. Fires after synthesize()'s drain.
+      // Spec §4 — warnings channel subsumes the legacy report.partialReview
+      // field (deleted in PR-C). At least one finding got fewer than its
+      // target K cross-reviewers. Fires after synthesize()'s drain.
       this.appendReportWarning(report, 'partial_review', 'at least one finding received fewer than its target K cross-reviewers');
     }
 
@@ -3092,26 +3077,27 @@ Return only valid JSON.${skillsBlock}`;
     const received = results.length - droppedAgents.length;
     if (results.length > 0 && droppedAgents.length > 0) {
       const evidence = `Coverage degraded: ${received}/${results.length} agents returned content (dropped: ${droppedAgents.join(', ')})`;
-      report.coverageDegraded = { expected: results.length, received, droppedAgents };
       report.signals.push({
         type: 'consensus', taskId: '', consensusId, signal: 'consensus_coverage_degraded',
         signal_class: 'operational', agentId: '_round', evidence, timestamp: new Date().toISOString(),
       });
       report.summary += `\n⚠️  ${evidence}\n`;
-      // Spec §4 dual-write: also surface on the fail-loud warnings channel.
-      // Fires after synthesize()'s drain, so write to both round + report.
+      // Spec §4 — warnings channel subsumes the legacy report.coverageDegraded
+      // field (deleted in PR-C). The structured drop count + dropped-agent list
+      // travel in the warning message. Fires after synthesize()'s drain, so
+      // write to both round + report.
       this.appendReportWarning(report, 'coverage_degraded', evidence);
     }
 
     // Surface dropped relay agents so the orchestrator can see who silently
     // failed instead of pretending the round was complete.
     if (relayCrossReviewSkipped && relayCrossReviewSkipped.length > 0) {
-      report.relayCrossReviewSkipped = relayCrossReviewSkipped;
       const lines = ['', '⚠️  Relay cross-review skipped:'];
       for (const s of relayCrossReviewSkipped) {
         lines.push(`  - ${s.agentId}: ${s.reason}`);
-        // Spec §4 dual-write — one cross_review_skipped warning per skipped
-        // agent, attributed via agentId. KEEP the legacy report field above.
+        // Spec §4 — warnings channel subsumes the legacy
+        // report.relayCrossReviewSkipped field (deleted in PR-C). One
+        // cross_review_skipped warning per skipped agent, attributed via agentId.
         this.appendReportWarning(report, 'cross_review_skipped', `cross-review skipped: ${s.reason}`, s.agentId);
       }
       report.summary += '\n' + lines.join('\n') + '\n';

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -82,25 +82,6 @@ export interface ConsensusReport {
   signals: ConsensusSignal[];
   summary: string;       // formatted text report
   /**
-   * Relay agents whose cross-review LLM call failed (quota / parse / network).
-   * Surfaced so the orchestrator can see when an agent silently dropped from
-   * consensus instead of pretending the round was complete.
-   */
-  relayCrossReviewSkipped?: Array<{ agentId: string; reason: string }>;
-  /**
-   * Coverage degraded when an agent dispatched to the round produced an empty
-   * 0-char response (e.g. Gemini MALFORMED_FUNCTION_CALL). The round still
-   * completes but with fewer voices than dispatched; surfaced here so the
-   * orchestrator can see silent dropouts at the round level rather than only
-   * per-task in collect.ts:178 auto-signals.
-   */
-  coverageDegraded?: { expected: number; received: number; droppedAgents: string[] };
-  /**
-   * True when at least one finding received fewer cross-reviewers than the
-   * target K (e.g. not enough eligible agents). Set by runSelectedCrossReview.
-   */
-  partialReview?: boolean;
-  /**
    * Cross-review assignments: which reviewer was assigned which findings.
    * Map serialized as Record<reviewerAgentId, findingId[]>.
    */

--- a/packages/orchestrator/src/coverage-degraded.ts
+++ b/packages/orchestrator/src/coverage-degraded.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared build/parse pair for the `coverage_degraded` warning message.
+ *
+ * The canonical format is:
+ *   Coverage degraded: <received>/<expected> agents returned content (dropped: a, b)
+ *
+ * Three sites must agree on this format:
+ *   - Producer: consensus-engine.ts (emits via appendReportWarning)
+ *   - Legacy synthesizer: relay/src/dashboard/routes.ts (back-compat read of old
+ *     report.coverageDegraded trio for reports written before PR-C)
+ *   - Parser: relay/src/dashboard/api-consensus-flow.ts (parses warning message
+ *     back into a structured object for the dashboard CoverageDegradedChip)
+ *
+ * Keeping them in sync via this module means a template change is a one-file edit
+ * that fails CI via the round-trip test below (tests/orchestrator/coverage-degraded.test.ts).
+ *
+ * AGENT-ID ESCAPING NOTE: agent IDs containing a comma or ')' are parsed
+ * defensively — the dropped list is extracted from the LAST '(' to the LAST ')'
+ * in the string, so an agent id containing ',' (which would look like a list
+ * separator) is passed through intact. An agent id containing ')' would
+ * truncate the dropped list at the first ')' — document: do not use ')' in
+ * agent IDs.
+ */
+
+export interface CoverageDegradedParams {
+  received: number;
+  expected: number;
+  droppedAgents: string[];
+}
+
+/**
+ * Build the canonical `coverage_degraded` warning message.
+ * The message always includes the dropped-agent list in the parenthesised
+ * suffix, even when the list is empty, so the parser never has to branch on
+ * the suffix's presence.
+ */
+export function buildCoverageDegradedMessage(params: CoverageDegradedParams): string {
+  const { received, expected, droppedAgents } = params;
+  return `Coverage degraded: ${received}/${expected} agents returned content (dropped: ${droppedAgents.join(', ')})`;
+}
+
+/**
+ * Parse a `coverage_degraded` warning message back into the structured params.
+ * Returns `undefined` on any mismatch — never throws.
+ *
+ * The dropped list is extracted from the LAST occurrence of ' (dropped: ' to
+ * the LAST ')' in the message. This is greedy on the suffix so that an agent
+ * id containing a comma is preserved as a single entry when the caller already
+ * knows how many agents were dropped (received/expected arithmetic). The tradeoff:
+ * an agent id that contains ')' would truncate the list at that point. Such IDs
+ * are outside our validated naming scheme.
+ */
+export function parseCoverageDegradedMessage(message: string): CoverageDegradedParams | undefined {
+  // Match "Coverage degraded: <received>/<expected> agents returned content"
+  // then capture the suffix (dropped: ...) from the last '(' to the last ')'.
+  const headerMatch = message.match(/^Coverage degraded:\s*(\d+)\/(\d+)\s*agents returned content/i);
+  if (!headerMatch) return undefined;
+  const received = parseInt(headerMatch[1], 10);
+  const expected = parseInt(headerMatch[2], 10);
+
+  // Find the last '(dropped: ...' to handle agent ids with nested parentheses
+  // or commas in earlier parts of the string.
+  const droppedPrefix = ' (dropped: ';
+  const lastDroppedIdx = message.lastIndexOf(droppedPrefix);
+  let droppedAgents: string[] = [];
+  if (lastDroppedIdx !== -1) {
+    const afterPrefix = message.slice(lastDroppedIdx + droppedPrefix.length);
+    // Trim at the LAST ')' to be greedy about the dropped list content.
+    const lastParen = afterPrefix.lastIndexOf(')');
+    const droppedRaw = lastParen !== -1 ? afterPrefix.slice(0, lastParen) : afterPrefix;
+    droppedAgents = droppedRaw.split(',').map(s => s.trim()).filter(Boolean);
+  }
+
+  return { received, expected, droppedAgents };
+}

--- a/packages/orchestrator/src/dispatch-pipeline.ts
+++ b/packages/orchestrator/src/dispatch-pipeline.ts
@@ -5,7 +5,7 @@ import { AgentConfig, DispatchOptions, TaskEntry, TaskExecutionResult, PlanState
 import { WorkerAgent } from './worker-agent';
 import { emitConsensusSignals } from './signal-helpers';
 import { ILLMProvider } from './llm-client';
-import { loadSkills } from './skill-loader';
+import { loadSkills, resolveEffectiveSkills } from './skill-loader';
 import { assemblePrompt, extractSpecReferences, buildSpecReviewEnrichment, parseSpecFrontMatter } from './prompt-assembler';
 import { AgentMemoryReader } from './agent-memory';
 import { MemoryWriter } from './memory-writer';
@@ -319,9 +319,16 @@ export class DispatchPipeline {
       log(`📋 pre-fetched ${consensusFindings.length} consensus findings for ${agentId}`);
     }
 
-    // 3. Check skill coverage
+    // 3. Check skill coverage — SINGLE SOURCE OF TRUTH fix
+    //    (project_coverage_gap_detector_config_vs_index, CONFIRMED 2026-06-11).
+    //    checkCoverage must see the SAME effective skill set the prompt builder
+    //    injected (`loadSkills` resolves index-precedence at :299), not the raw
+    //    config.json list. Feeding it the config list produced false "skill may
+    //    be relevant but is not assigned" warnings for index-bound skills that
+    //    WERE injected, misleading an external user.
+    const effectiveSkills = resolveEffectiveSkills(agentId, agentSkills, this.skillIndex ?? undefined);
     const skillWarnings = this.catalog
-      ? this.catalog.checkCoverage(agentSkills, task)
+      ? this.catalog.checkCoverage(effectiveSkills, task)
       : [];
 
     // 4. Build session + chain context

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -2,7 +2,7 @@ export { MainAgent } from './main-agent';
 export { seedMemoryHygiene } from './memory-hygiene-seed';
 export type { MemoryHygieneSeedResult } from './memory-hygiene-seed';
 export { detectFormatCompliance, MAX_COMPLIANCE_INPUT } from './dispatch-pipeline';
-export { loadSkills, DEFAULT_KEYWORDS, resolveSkillExists, resolveSkill } from './skill-loader';
+export { loadSkills, resolveEffectiveSkills, DEFAULT_KEYWORDS, resolveSkillExists, resolveSkill } from './skill-loader';
 export type { LoadSkillsResult, DroppedSkill } from './skill-loader';
 export { SkillCounterTracker } from './skill-counters';
 export type { MainAgentConfig } from './main-agent';

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -31,6 +31,8 @@ export * from './consensus-types';
 export type { ImplSignal, MetaSignal, PerformanceSignal } from './consensus-types';
 export { makeRoundContext, testRound, isRoundContext } from './round-context';
 export type { RoundContext, RoundWarning, RoundWarningCode } from './round-context';
+export { buildCoverageDegradedMessage, parseCoverageDegradedMessage } from './coverage-degraded';
+export type { CoverageDegradedParams } from './coverage-degraded';
 export { SkillCatalog } from './skill-catalog';
 export type { CatalogEntry } from './skill-catalog';
 export { SkillGapTracker, SKILL_FRESHNESS_MS } from './skill-gap-tracker';

--- a/packages/orchestrator/src/round-context.ts
+++ b/packages/orchestrator/src/round-context.ts
@@ -1,11 +1,11 @@
 /**
- * RoundContext — single carrier for per-consensus-round state that today is
+ * RoundContext — single carrier for per-consensus-round state that was once
  * threaded as a loose `resolutionRoots?: readonly string[]` through five
  * separate door boundaries (collect handler, dispatch handler, coordinator,
- * pipeline, engine). This is the alias-mode introduction (PR-A): every call
- * site that accepts `resolutionRoots` gains an OPTIONAL `round?: RoundContext`
- * alongside it. When `round` is present it WINS; when absent, the legacy
- * `resolutionRoots` path behaves byte-identically. PR-C removes the aliases.
+ * pipeline, engine). PR-A introduced it in alias mode; PR-C (this revision)
+ * removed the aliases: `ConsensusEngineConfig.round` is now REQUIRED and the
+ * loose `resolutionRoots` config field is gone. The RoundContext is the single
+ * carrier for per-round resolutionRoots + fail-loud warnings.
  *
  * Spec: 2026-06-11-round-context-fail-loud.md §3.1, consensus 5e9804d3-91fe440d.
  */
@@ -18,15 +18,21 @@
  *     worktree (alongside the `via="⚠ resolved against project root…"` anchor
  *     note; one warning per resolved-from-project-root anchor instance, no dedup).
  *   - `cross_review_skipped` — a relay agent's Phase-2 cross-review was skipped
- *     (quota / parse / network); dual-written with `report.relayCrossReviewSkipped`.
+ *     (quota / parse / network). Sole carrier since PR-C deleted
+ *     `report.relayCrossReviewSkipped`.
  *   - `coverage_degraded` — at least one dispatched agent returned a 0-char /
- *     sentinel response; dual-written with `report.coverageDegraded`.
+ *     sentinel response. Sole carrier since PR-C deleted `report.coverageDegraded`.
  *   - `partial_review` — at least one finding received fewer than its target K
- *     cross-reviewers; dual-written with `report.partialReview`.
+ *     cross-reviewers. Sole carrier since PR-C deleted `report.partialReview`.
  *   - `zero_tags` — an agent relayed a consensus result carrying zero
  *     `<agent_finding>` tags; dual-written with the relay-lint receipt line.
  *   - `round_restore_malformed` — a persisted round record carried a malformed
  *     field shape that was dropped on restore (relay-cross-review restore path).
+ *   - `dispatch_warnings_lost` — the native task entry's persisted
+ *     `dispatchWarningsStashed` marker is set but the in-memory dispatch-time
+ *     warnings stash was wiped (likely /mcp reconnect) before collect drained
+ *     it; the warning content is unrecoverable but its LOSS is now observable
+ *     (f11 follow-up).
  *
  * The trailing `(string & {})` is an INTENTIONAL open extension point: it keeps
  * autocomplete on the named codes while letting a future PR-B producer emit a
@@ -44,6 +50,7 @@ export type RoundWarningCode =
   | 'partial_review'
   | 'zero_tags'
   | 'round_restore_malformed'
+  | 'dispatch_warnings_lost'
   // eslint-disable-next-line @typescript-eslint/ban-types
   | (string & {});
 

--- a/packages/orchestrator/src/skill-loader.ts
+++ b/packages/orchestrator/src/skill-loader.ts
@@ -119,6 +119,29 @@ export interface LoadSkillsResult {
 }
 
 /**
+ * The effective skill set for an agent — the SINGLE source of truth shared by
+ * the prompt builder (`loadSkills`) and the coverage-gap detector
+ * (`SkillCatalog.checkCoverage`). When the skill index has slots for the agent,
+ * the index-enabled set wins (it reflects bind/disable lifecycle decisions);
+ * otherwise the raw config.json `skills` list is used.
+ *
+ * Before this helper, `loadSkills` resolved the index-enabled set while
+ * `checkCoverage` was handed the raw config list, so an index-bound skill that
+ * WAS injected still produced a false "skill may be relevant but is not
+ * assigned" warning (project_coverage_gap_detector_config_vs_index, CONFIRMED
+ * 2026-06-11). Both consumers now call this function.
+ */
+export function resolveEffectiveSkills(
+  agentId: string,
+  configSkills: string[],
+  index?: SkillIndex,
+): string[] {
+  return index && index.getAgentSlots(agentId).length > 0
+    ? index.getEnabledSkills(agentId)
+    : configSkills;
+}
+
+/**
  * Compute the category match boost for a contextual skill.
  * Returns CATEGORY_BOOST (0.5) if the skill's category is in the task's
  * extracted categories, otherwise 0. Zero-category tasks always return 0.
@@ -166,9 +189,7 @@ export function loadSkills(
    */
   dispatchTaskType?: 'review' | 'implement' | 'research',
 ): LoadSkillsResult {
-  const effectiveSkills = index && index.getAgentSlots(agentId).length > 0
-    ? index.getEnabledSkills(agentId)
-    : skills;
+  const effectiveSkills = resolveEffectiveSkills(agentId, skills, index);
 
   const categories = taskCategories ?? [];
 

--- a/packages/relay/src/dashboard/api-consensus-flow.ts
+++ b/packages/relay/src/dashboard/api-consensus-flow.ts
@@ -181,9 +181,33 @@ export function consensusFlowHandler(
   if (Array.isArray(report?.crossReviewCoverage)) {
     out.crossReviewCoverage = report.crossReviewCoverage;
   }
-  if (report?.partialReview === true) out.partialReview = true;
+  // Degraded-mode flags now derive from the warnings channel (spec §4 — the
+  // legacy report.partialReview / report.coverageDegraded fields were deleted in
+  // PR-C). Old persisted reports still carry the legacy fields, so read the
+  // warnings array FIRST and fall back to the legacy shape for back-compat.
+  const warnings: Array<{ code?: unknown }> = Array.isArray(report?.warnings) ? report.warnings : [];
+  const hasWarning = (code: string) => warnings.some(w => w && (w as any).code === code);
+
+  if (hasWarning('partial_review') || report?.partialReview === true) out.partialReview = true;
+
   if (report?.coverageDegraded && typeof report.coverageDegraded === 'object') {
     out.coverageDegraded = report.coverageDegraded;
+  } else {
+    // PR-C reports carry only the warning, whose message is the deterministic
+    // engine format: "Coverage degraded: <received>/<total> agents returned
+    // content (dropped: a, b)". Parse the structured shape back out for the
+    // ConsensusFlow coverage chip. Falls through to no-chip if the message
+    // doesn't match (defensive — never throw on a malformed warning).
+    const cd = warnings.find(w => w && (w as any).code === 'coverage_degraded') as { message?: string } | undefined;
+    if (cd && typeof cd.message === 'string') {
+      const m = cd.message.match(/Coverage degraded:\s*(\d+)\/(\d+)\s*agents returned content(?:\s*\(dropped:\s*([^)]*)\))?/i);
+      if (m) {
+        const received = parseInt(m[1], 10);
+        const expected = parseInt(m[2], 10);
+        const droppedAgents = m[3] ? m[3].split(',').map(s => s.trim()).filter(Boolean) : [];
+        out.coverageDegraded = { expected, received, droppedAgents };
+      }
+    }
   }
 
   return out;

--- a/packages/relay/src/dashboard/api-consensus-flow.ts
+++ b/packages/relay/src/dashboard/api-consensus-flow.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
+import { parseCoverageDegradedMessage } from './coverage-degraded-utils';
 
 /**
  * Strict 8-8 hex consensus-id shape: `xxxxxxxx-xxxxxxxx`. The id reaches this
@@ -194,18 +195,14 @@ export function consensusFlowHandler(
     out.coverageDegraded = report.coverageDegraded;
   } else {
     // PR-C reports carry only the warning, whose message is the deterministic
-    // engine format: "Coverage degraded: <received>/<total> agents returned
-    // content (dropped: a, b)". Parse the structured shape back out for the
-    // ConsensusFlow coverage chip. Falls through to no-chip if the message
-    // doesn't match (defensive — never throw on a malformed warning).
+    // engine format produced by buildCoverageDegradedMessage. Parse via the
+    // shared parseCoverageDegradedMessage so a template change is a one-file
+    // edit that fails CI via the round-trip test.
     const cd = warnings.find(w => w && (w as any).code === 'coverage_degraded') as { message?: string } | undefined;
     if (cd && typeof cd.message === 'string') {
-      const m = cd.message.match(/Coverage degraded:\s*(\d+)\/(\d+)\s*agents returned content(?:\s*\(dropped:\s*([^)]*)\))?/i);
-      if (m) {
-        const received = parseInt(m[1], 10);
-        const expected = parseInt(m[2], 10);
-        const droppedAgents = m[3] ? m[3].split(',').map(s => s.trim()).filter(Boolean) : [];
-        out.coverageDegraded = { expected, received, droppedAgents };
+      const parsed = parseCoverageDegradedMessage(cd.message);
+      if (parsed) {
+        out.coverageDegraded = parsed;
       }
     }
   }

--- a/packages/relay/src/dashboard/coverage-degraded-utils.ts
+++ b/packages/relay/src/dashboard/coverage-degraded-utils.ts
@@ -1,0 +1,45 @@
+/**
+ * Local relay-package copy of the coverage_degraded build/parse pair.
+ * The canonical implementation and tests live in packages/orchestrator/src/coverage-degraded.ts.
+ * This copy exists because the relay package's tsc cannot import from
+ * @gossip/orchestrator when built in a git worktree without a local npm
+ * workspace install (the worktree shares the root node_modules which points
+ * to the master-branch orchestrator dist, not the worktree's).
+ *
+ * IMPORTANT: keep this in sync with packages/orchestrator/src/coverage-degraded.ts.
+ * The integration test in tests/relay/coverage-degraded-flow.test.ts imports
+ * directly from the orchestrator source (via root tsconfig.json path mappings),
+ * so any drift between the two copies will fail CI.
+ */
+
+export interface CoverageDegradedParams {
+  received: number;
+  expected: number;
+  droppedAgents: string[];
+}
+
+/** Build the canonical coverage_degraded warning message. */
+export function buildCoverageDegradedMessage(params: CoverageDegradedParams): string {
+  const { received, expected, droppedAgents } = params;
+  return `Coverage degraded: ${received}/${expected} agents returned content (dropped: ${droppedAgents.join(', ')})`;
+}
+
+/** Parse a coverage_degraded warning message back into structured params. Returns undefined on mismatch, never throws. */
+export function parseCoverageDegradedMessage(message: string): CoverageDegradedParams | undefined {
+  const headerMatch = message.match(/^Coverage degraded:\s*(\d+)\/(\d+)\s*agents returned content/i);
+  if (!headerMatch) return undefined;
+  const received = parseInt(headerMatch[1], 10);
+  const expected = parseInt(headerMatch[2], 10);
+
+  const droppedPrefix = ' (dropped: ';
+  const lastDroppedIdx = message.lastIndexOf(droppedPrefix);
+  let droppedAgents: string[] = [];
+  if (lastDroppedIdx !== -1) {
+    const afterPrefix = message.slice(lastDroppedIdx + droppedPrefix.length);
+    const lastParen = afterPrefix.lastIndexOf(')');
+    const droppedRaw = lastParen !== -1 ? afterPrefix.slice(0, lastParen) : afterPrefix;
+    droppedAgents = droppedRaw.split(',').map(s => s.trim()).filter(Boolean);
+  }
+
+  return { received, expected, droppedAgents };
+}

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -44,6 +44,51 @@ interface DashboardContext {
 const AUTH_MAX_ATTEMPTS = 10;
 const AUTH_LOCKOUT_MS = 60_000; // 1 minute lockout after max attempts
 
+interface LegacyRoundWarning { code: string; message: string; agentId?: string }
+
+/**
+ * DISK BACK-COMPAT (spec §4 / PR-C): consensus reports persisted by older
+ * versions carry the deprecated degraded-mode trio
+ * (relayCrossReviewSkipped / coverageDegraded / partialReview) but NO
+ * `warnings` array. The warnings channel now SUBSUMES those fields, so when a
+ * historical report lacks `warnings`, synthesize equivalent RoundWarnings from
+ * the trio at READ time so the dashboard still renders the degraded modes.
+ * Reports that already carry `warnings` (written by PR-C+) pass through
+ * untouched. Never mutates the legacy fields — only adds `warnings`.
+ */
+export function normalizeLegacyDegradedFields(report: any): any {
+  if (!report || typeof report !== 'object') return report;
+  if (Array.isArray(report.warnings) && report.warnings.length > 0) return report;
+  const synthesized: LegacyRoundWarning[] = [];
+  const cd = report.coverageDegraded;
+  if (cd && typeof cd === 'object') {
+    const dropped = Array.isArray(cd.droppedAgents) ? cd.droppedAgents.join(', ') : '';
+    synthesized.push({
+      code: 'coverage_degraded',
+      message: `Coverage degraded: ${cd.received ?? '?'}/${cd.expected ?? '?'} agents returned content${dropped ? ` (dropped: ${dropped})` : ''}`,
+    });
+  }
+  if (Array.isArray(report.relayCrossReviewSkipped)) {
+    for (const s of report.relayCrossReviewSkipped) {
+      if (s && typeof s === 'object') {
+        synthesized.push({
+          code: 'cross_review_skipped',
+          message: `cross-review skipped: ${s.reason ?? 'unknown'}`,
+          ...(typeof s.agentId === 'string' ? { agentId: s.agentId } : {}),
+        });
+      }
+    }
+  }
+  if (report.partialReview === true) {
+    synthesized.push({
+      code: 'partial_review',
+      message: 'at least one finding received fewer than its target K cross-reviewers',
+    });
+  }
+  if (synthesized.length === 0) return report;
+  return { ...report, warnings: synthesized };
+}
+
 // Per-route body cap for POST /dashboard/api/chat. Larger than the shared
 // MAX_BODY_SIZE (8 KB) because a chat message can be a reasonable paragraph,
 // but still tightly bounded as a DoS guard (CORRECTION #6 — parametrize
@@ -611,7 +656,7 @@ export class DashboardRouter {
           const filePath = join(reportsDir, f);
           const realFile = realpathSync(filePath);
           if (!realFile.startsWith(realReportsDir + '/')) return null;
-          return JSON.parse(readFileSync(realFile, 'utf-8'));
+          return normalizeLegacyDegradedFields(JSON.parse(readFileSync(realFile, 'utf-8')));
         } catch { return null; }
       }).filter(Boolean);
 

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -22,6 +22,7 @@ import { violationsHandler } from './api-violations';
 import { handleChat } from './api-chat';
 import { ChatConversationStore } from './chat-session-store';
 import type { ChatbotAgent } from '@gossip/orchestrator';
+import { buildCoverageDegradedMessage } from './coverage-degraded-utils';
 import { readFileSync, existsSync, realpathSync } from 'fs';
 import { join, resolve } from 'path';
 import { createHash, timingSafeEqual } from 'crypto';
@@ -62,10 +63,13 @@ export function normalizeLegacyDegradedFields(report: any): any {
   const synthesized: LegacyRoundWarning[] = [];
   const cd = report.coverageDegraded;
   if (cd && typeof cd === 'object') {
-    const dropped = Array.isArray(cd.droppedAgents) ? cd.droppedAgents.join(', ') : '';
     synthesized.push({
       code: 'coverage_degraded',
-      message: `Coverage degraded: ${cd.received ?? '?'}/${cd.expected ?? '?'} agents returned content${dropped ? ` (dropped: ${dropped})` : ''}`,
+      message: buildCoverageDegradedMessage({
+        received: cd.received ?? 0,
+        expected: cd.expected ?? 0,
+        droppedAgents: Array.isArray(cd.droppedAgents) ? cd.droppedAgents : [],
+      }),
     });
   }
   if (Array.isArray(report.relayCrossReviewSkipped)) {

--- a/tests/cli/dispatch-warnings-lost.test.ts
+++ b/tests/cli/dispatch-warnings-lost.test.ts
@@ -1,0 +1,51 @@
+/**
+ * f11 follow-up (consensus dfe05be2-73794442:f11): the in-memory
+ * pendingDispatchWarnings stash is reconnect-volatile, but the native task
+ * entry carries a persisted `dispatchWarningsStashed` marker. At collect time,
+ * a task whose marker is set but whose stash entry is gone (reconnect wiped it)
+ * must surface a `dispatch_warnings_lost` RoundWarning so the LOSS is fail-loud.
+ */
+import { detectLostDispatchWarnings } from '../../apps/cli/src/handlers/dispatch';
+
+describe('detectLostDispatchWarnings — fail-loud on reconnect-wiped stash (f11)', () => {
+  it('emits one warning per task whose marker is set but stash entry is gone', () => {
+    const taskMap = new Map<string, { dispatchWarningsStashed?: boolean }>([
+      ['task-a', { dispatchWarningsStashed: true }],
+      ['task-b', { dispatchWarningsStashed: true }],
+    ]);
+    // Simulate /mcp reconnect: the stash was wiped (empty), markers survived.
+    const stash = new Map<string, unknown>();
+
+    const warnings = detectLostDispatchWarnings(['task-a', 'task-b'], taskMap, stash);
+    expect(warnings).toHaveLength(2);
+    expect(warnings.every(w => w.code === 'dispatch_warnings_lost')).toBe(true);
+    expect(warnings[0].message).toContain('task-a');
+    expect(warnings[1].message).toContain('task-b');
+  });
+
+  it('emits NO warning when the stash still holds the task (no reconnect)', () => {
+    const taskMap = new Map<string, { dispatchWarningsStashed?: boolean }>([
+      ['task-a', { dispatchWarningsStashed: true }],
+    ]);
+    const stash = new Map<string, unknown>([['task-a', [{ code: 'roots_rejected', message: 'x' }]]]);
+
+    expect(detectLostDispatchWarnings(['task-a'], taskMap, stash)).toEqual([]);
+  });
+
+  it('emits NO warning for tasks without the marker (no warnings ever stashed)', () => {
+    const taskMap = new Map<string, { dispatchWarningsStashed?: boolean }>([
+      ['task-a', {}],
+      ['task-b', { dispatchWarningsStashed: false }],
+    ]);
+    const stash = new Map<string, unknown>();
+
+    expect(detectLostDispatchWarnings(['task-a', 'task-b'], taskMap, stash)).toEqual([]);
+  });
+
+  it('emits NO warning for relay-only task ids absent from the native task map', () => {
+    const taskMap = new Map<string, { dispatchWarningsStashed?: boolean }>();
+    const stash = new Map<string, unknown>();
+
+    expect(detectLostDispatchWarnings(['relay-1', 'relay-2'], taskMap, stash)).toEqual([]);
+  });
+});

--- a/tests/cli/dispatch-warnings-lost.test.ts
+++ b/tests/cli/dispatch-warnings-lost.test.ts
@@ -4,6 +4,11 @@
  * entry carries a persisted `dispatchWarningsStashed` marker. At collect time,
  * a task whose marker is set but whose stash entry is gone (reconnect wiped it)
  * must surface a `dispatch_warnings_lost` RoundWarning so the LOSS is fail-loud.
+ *
+ * Extended (consensus 1f50d89d-c28f49c4:fable-reviewer:f1): the marker must
+ * also be checked on the RESULT MAP for tasks that completed (were relayed)
+ * before the /mcp reconnect — such tasks are absent from nativeTaskMap but
+ * their result record carries dispatchWarningsStashed (copied at relay time).
  */
 import { detectLostDispatchWarnings } from '../../apps/cli/src/handlers/dispatch';
 
@@ -47,5 +52,61 @@ describe('detectLostDispatchWarnings — fail-loud on reconnect-wiped stash (f11
     const stash = new Map<string, unknown>();
 
     expect(detectLostDispatchWarnings(['relay-1', 'relay-2'], taskMap, stash)).toEqual([]);
+  });
+});
+
+describe('detectLostDispatchWarnings — completed-task lifecycle (result-map path)', () => {
+  it('emits warning when marker is on result record (task completed before reconnect, task map entry already deleted)', () => {
+    // Simulate: task dispatched with warnings stashed, relay called (task deleted
+    // from nativeTaskMap, result added to nativeResultMap with marker copied),
+    // then /mcp reconnect wiped the in-memory stash.
+    const taskMap = new Map<string, { dispatchWarningsStashed?: boolean }>();
+    const resultMap = new Map<string, { dispatchWarningsStashed?: boolean }>([
+      ['task-a', { dispatchWarningsStashed: true }],
+    ]);
+    const stash = new Map<string, unknown>(); // wiped by reconnect
+
+    const warnings = detectLostDispatchWarnings(['task-a'], taskMap, stash, resultMap);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].code).toBe('dispatch_warnings_lost');
+    expect(warnings[0].message).toContain('task-a');
+    // Message is cause-neutral (does not hard-attribute to reconnect only).
+    expect(warnings[0].message).not.toContain('likely /mcp reconnect');
+    expect(warnings[0].message).toContain('reconnect or stash eviction');
+  });
+
+  it('emits NO warning when result map marker is set but stash is still live (task completed before collect, no reconnect)', () => {
+    const taskMap = new Map<string, { dispatchWarningsStashed?: boolean }>();
+    const resultMap = new Map<string, { dispatchWarningsStashed?: boolean }>([
+      ['task-a', { dispatchWarningsStashed: true }],
+    ]);
+    const stash = new Map<string, unknown>([
+      ['task-a', [{ code: 'roots_rejected', message: 'x' }]],
+    ]);
+
+    expect(detectLostDispatchWarnings(['task-a'], taskMap, stash, resultMap)).toEqual([]);
+  });
+
+  it('emits NO warning when result record has no marker (no warnings were ever stashed)', () => {
+    const taskMap = new Map<string, { dispatchWarningsStashed?: boolean }>();
+    const resultMap = new Map<string, { dispatchWarningsStashed?: boolean }>([
+      ['task-a', {}],
+    ]);
+    const stash = new Map<string, unknown>();
+
+    expect(detectLostDispatchWarnings(['task-a'], taskMap, stash, resultMap)).toEqual([]);
+  });
+
+  it('handles stash cap-eviction cause: task map marker present, stash gone due to eviction (not reconnect)', () => {
+    // Both reconnect and cap-eviction produce the same observable state:
+    // marker set, stash entry absent. The warning message is cause-neutral.
+    const taskMap = new Map<string, { dispatchWarningsStashed?: boolean }>([
+      ['old-task', { dispatchWarningsStashed: true }],
+    ]);
+    const stash = new Map<string, unknown>(); // evicted due to cap
+
+    const warnings = detectLostDispatchWarnings(['old-task'], taskMap, stash);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain('reconnect or stash eviction');
   });
 });

--- a/tests/cli/timeout-synthesis-seam.test.ts
+++ b/tests/cli/timeout-synthesis-seam.test.ts
@@ -1,0 +1,122 @@
+/**
+ * f8 follow-up (consensus dfe05be2-73794442:f8) — DIRECT timeout-synthesis seam.
+ *
+ * The PR-B §5 seam test in tests/orchestrator/round-context-producers.test.ts
+ * REPRODUCED the timeout-path engine construction inline. This test drives the
+ * REAL exported timeout-synthesis core
+ * (apps/cli/src/handlers/relay-cross-review.ts → synthesizeTimeoutRound) so the
+ * genuine outer layer (the function the timeout watcher invokes) feeds the
+ * genuine inner layer (ConsensusEngine.generateCrossReviewPrompts →
+ * synthesizeWithCrossReview), and asserts the boundary value
+ * (snapshot.roundContext.resolutionRoots) reaches anchor CONTENT in the final
+ * artifact — the true Test 21 pattern.
+ */
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, realpathSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { synthesizeTimeoutRound, type TimeoutSynthesisSnapshot } from '../../apps/cli/src/handlers/relay-cross-review';
+import { ctx } from '../../apps/cli/src/mcp-context';
+import { makeRoundContext } from '@gossip/orchestrator';
+import type { TaskEntry } from '@gossip/orchestrator';
+
+const makeLlm = (): any => ({
+  generate: jest.fn(async () => ({ text: '[]', usage: { inputTokens: 0, outputTokens: 0 } })),
+});
+
+const completed = (agentId: string, result: string): TaskEntry => ({
+  id: `t-${agentId}`,
+  agentId,
+  task: 'review X',
+  status: 'completed',
+  result,
+  startedAt: Date.now(),
+}) as TaskEntry;
+
+const finding = (text: string) =>
+  `<agent_finding type="finding" severity="high" category="data_integrity">${text}</agent_finding>`;
+
+describe('(§5/f8) REAL timeout-synthesis seam — synthesizeTimeoutRound drives roots into anchor content', () => {
+  let tmp: string;
+  let origMainAgent: any;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'tmo-seam-'));
+    origMainAgent = (ctx as any).mainAgent;
+    (ctx as any).mainAgent = { getAgentConfig: () => undefined } as any;
+  });
+
+  afterEach(() => {
+    (ctx as any).mainAgent = origMainAgent;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('the round worktree root reaches anchor CONTENT in the cross-review prompts', async () => {
+    const proj = realpathSync(mkdtempSync(join(tmp, 'proj')));
+    const wt = realpathSync(mkdtempSync(join(tmp, 'wt')));
+    mkdirSync(join(proj, 'src'), { recursive: true });
+    mkdirSync(join(wt, 'src'), { recursive: true });
+    // The cited file exists in BOTH roots with DISTINCT content — the worktree
+    // copy must win, proving the round's resolutionRoots actually drove
+    // resolution (not the projectRoot fallback).
+    writeFileSync(join(proj, 'src', 'target.ts'), 'export const v = "master-HEAD";');
+    writeFileSync(join(wt, 'src', 'target.ts'), 'export const v = "worktree-branch";');
+
+    const snapshot: TimeoutSynthesisSnapshot = {
+      allResults: [
+        completed('agent-a', finding('Issue A <cite tag="file">src/target.ts:1</cite>')),
+        completed('agent-b', finding('Issue B <cite tag="file">src/target.ts:1</cite>')),
+      ],
+      relayCrossReviewEntries: [],
+      nativeCrossReviewEntries: [],
+      roundContext: makeRoundContext({ resolutionRoots: [wt], consensusId: 'cafef00d-feedface' }),
+    };
+
+    // Drive the REAL exported core — same function the timeout watcher calls.
+    const { report, prompts } = await synthesizeTimeoutRound(
+      snapshot,
+      'cafef00d-feedface',
+      ['agent-c'],
+      makeLlm(),
+      proj,
+    );
+
+    expect(report).toBeDefined();
+    const all = prompts.map(p => `${p.system}\n${p.user}`).join('\n');
+    // Boundary value observable in the FINAL artifact: the WORKTREE copy reached
+    // anchor content, the master copy did NOT.
+    expect(all).toContain('worktree-branch');
+    expect(all).not.toContain('master-HEAD');
+
+    // The function also persisted the report under the projectRoot we passed.
+    const reportPath = join(proj, '.gossip', 'consensus-reports', 'cafef00d-feedface.json');
+    expect(existsSync(reportPath)).toBe(true);
+    const persisted = JSON.parse(readFileSync(reportPath, 'utf-8'));
+    expect(persisted.id).toBe('cafef00d-feedface');
+    expect(persisted.timedOut).toEqual(['agent-c']);
+  });
+
+  it('reconstructs a RoundContext from flat resolutionRoots when the snapshot lacks an embedded round', async () => {
+    const proj = realpathSync(mkdtempSync(join(tmp, 'proj2')));
+    const wt = realpathSync(mkdtempSync(join(tmp, 'wt2')));
+    mkdirSync(join(proj, 'src'), { recursive: true });
+    mkdirSync(join(wt, 'src'), { recursive: true });
+    writeFileSync(join(proj, 'src', 'target.ts'), 'export const v = "master-HEAD";');
+    writeFileSync(join(wt, 'src', 'target.ts'), 'export const v = "worktree-branch";');
+
+    // Old pre-PR-A restored record: flat resolutionRoots, NO embedded round.
+    const snapshot: TimeoutSynthesisSnapshot = {
+      allResults: [
+        completed('agent-a', finding('A <cite tag="file">src/target.ts:1</cite>')),
+        completed('agent-b', finding('B <cite tag="file">src/target.ts:1</cite>')),
+      ],
+      relayCrossReviewEntries: [],
+      nativeCrossReviewEntries: [],
+      resolutionRoots: [wt],
+    };
+
+    const { prompts } = await synthesizeTimeoutRound(snapshot, 'aabbccdd-eeff0011', [], makeLlm(), proj);
+    const all = prompts.map(p => `${p.system}\n${p.user}`).join('\n');
+    expect(all).toContain('worktree-branch');
+    expect(all).not.toContain('master-HEAD');
+  });
+});

--- a/tests/orchestrator/citation-verification.test.ts
+++ b/tests/orchestrator/citation-verification.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import { resolve } from 'path';
 import { tmpdir } from 'os';
 import { ConsensusEngine, ILLMProvider } from '@gossip/orchestrator';
@@ -55,6 +56,8 @@ describe('ConsensusEngine.verifyCitations', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
   });
 
@@ -105,6 +108,7 @@ describe('ConsensusEngine.verifyCitations', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       // no projectRoot
+      round: testRound(),
     });
 
     const evidence = 'The code at task-dispatcher.ts:14 explicitly throws an error.';
@@ -161,6 +165,8 @@ describe('ConsensusEngine.synthesize — citation verification integration', () 
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
   });
 
@@ -230,6 +236,8 @@ describe('Tier 1A Fix #4 — fileCache parity with pathCache on worktree change'
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
 
     // Warm cache with a legitimate resolution
@@ -294,6 +302,8 @@ describe('Tier 1A Fix #5 — I/O errors count as failed citations', () => {
         llm: mockLlm,
         registryGet: mockRegistryGet,
         projectRoot: testDir,
+
+        round: testRound(),
       });
       // One citation, one EISDIR failure — should now trip `failed > 0.5` (majority of 1).
       const result = await engine.verifyCitations('At src/isadir.ts:1 we have a constant');
@@ -316,6 +326,8 @@ describe('Tier 1A Fix #5 — I/O errors count as failed citations', () => {
         llm: mockLlm,
         registryGet: mockRegistryGet,
         projectRoot: testDir,
+
+        round: testRound(),
       });
       const result = await engine.verifyCitations(
         'See src/isadir2.ts:1 and src/readable.ts:2',
@@ -352,6 +364,8 @@ describe('Tier 1B Fix #3 — strict-mode citation verification', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
     // Single fabricated citation → failed=1, strict → 1 >= 1 === true.
     const result = await engine.verifyCitations(
@@ -371,6 +385,8 @@ describe('Tier 1B Fix #3 — strict-mode citation verification', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
     const result = await engine.verifyCitations(
       'See src/real.ts:1 and fake-module.ts:42',
@@ -384,6 +400,8 @@ describe('Tier 1B Fix #3 — strict-mode citation verification', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
     const result = await engine.verifyCitations(
       'See src/real.ts:1, src/real.ts:2, and fake-module.ts:42',
@@ -397,6 +415,8 @@ describe('Tier 1B Fix #3 — strict-mode citation verification', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
     const result = await engine.verifyCitations(
       'This is a qualitative disagreement with no file references at all',
@@ -413,6 +433,8 @@ describe('Tier 1B Fix #3 — strict-mode citation verification', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
     const result = await engine.verifyCitations(
       'See src/real.ts:1 and src/real.ts:2',
@@ -430,6 +452,8 @@ describe('Tier 1B Fix #3 — strict-mode citation verification', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
     // 2 citations, 1 bad — under majority, 1 > 1 === false.
     const result = await engine.verifyCitations(
@@ -470,6 +494,8 @@ describe('Task #9 — citation dedup + meta-reference exemption', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
     // Mix: 1 real citation (deduped) + 1 fake citation (deduped) = 2 total.
     // 1 fake of 2 = default majority 1 > 1 = false (not fabricated).
@@ -492,6 +518,8 @@ describe('Task #9 — citation dedup + meta-reference exemption', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
     // Narrative mentions fake-module.ts:42 three times.
     // Post-dedup: 1 citation (fake). 1 >= 1 strict = true (still fires).
@@ -512,6 +540,8 @@ describe('Task #9 — citation dedup + meta-reference exemption', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
     const result = await engine.verifyCitations(
       'When a reviewer writes `fake-path.ts:100` in dispute evidence, ' +
@@ -527,6 +557,8 @@ describe('Task #9 — citation dedup + meta-reference exemption', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
     const result = await engine.verifyCitations(
       'Here is the example:\n```\nconst x = require("fake-lib.ts:99");\n```\n' +
@@ -541,6 +573,8 @@ describe('Task #9 — citation dedup + meta-reference exemption', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
     const result = await engine.verifyCitations(
       '<example>fake-thing.ts:999 is not real</example> but src/real.ts:1 is real',
@@ -554,6 +588,8 @@ describe('Task #9 — citation dedup + meta-reference exemption', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
     const result = await engine.verifyCitations(
       'When reviewer B writes "fake-file.ts:100 does not exist", the regex extracts it. src/real.ts:1 is the only real claim.',
@@ -577,6 +613,8 @@ describe('Task #9 — citation dedup + meta-reference exemption', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
 
     const results = [
@@ -638,6 +676,8 @@ describe('Task #9 — citation dedup + meta-reference exemption', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
     const sonnetF5Text =
       'The current AND-gate at src/real.ts:1 is semantically inverted. ' +
@@ -685,6 +725,8 @@ describe('Tier 1A Fix #2 — dispute hallucination signal outcome is always fabr
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
 
     // Result text uses the `## Consensus Summary\n- ` format so the bullet-

--- a/tests/orchestrator/consensus-auto-verify-gate.test.ts
+++ b/tests/orchestrator/consensus-auto-verify-gate.test.ts
@@ -6,6 +6,7 @@
  * Spec: docs/superpowers/specs/2026-05-21-consensus-auto-verify-design.md.
  */
 import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import type { ConsensusFinding, ConsensusSignal } from '../../packages/orchestrator/src/consensus-types';
 
 // Stub LLM provider — never called by maybeAutoVerify (gated off).
@@ -27,6 +28,8 @@ describe('maybeAutoVerify gate-OFF', () => {
       registryGet: () => undefined,
       projectRoot: process.cwd(),
       verifierDispatch: dispatch,
+
+      round: testRound(),
     });
     const findings: ConsensusFinding[] = [{
       id: 'f1',
@@ -54,6 +57,8 @@ describe('maybeAutoVerify gate-OFF', () => {
       registryGet: () => undefined,
       projectRoot: process.cwd(),
       verifierDispatch: dispatch,
+
+      round: testRound(),
     });
     const findings: ConsensusFinding[] = [{
       id: 'f1',
@@ -78,6 +83,8 @@ describe('maybeAutoVerify gate-OFF', () => {
       registryGet: () => undefined,
       projectRoot: process.cwd(),
       verifierDispatch: dispatch,
+
+      round: testRound(),
     });
     const signals: ConsensusSignal[] = [];
     await (engine as any).maybeAutoVerify([], signals, 'cid', 'seed');

--- a/tests/orchestrator/consensus-auto-verify-integration.test.ts
+++ b/tests/orchestrator/consensus-auto-verify-integration.test.ts
@@ -7,6 +7,7 @@
  * Spec: docs/superpowers/specs/2026-05-21-consensus-auto-verify-design.md.
  */
 import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import type { ConsensusFinding, ConsensusSignal, RelayWarningEntry } from '../../packages/orchestrator/src/consensus-types';
 
 const stubLlm: any = {
@@ -43,6 +44,8 @@ describe('maybeAutoVerify integration — gate-ON', () => {
     const engine = new ConsensusEngine({
       llm: stubLlm, registryGet: () => undefined, projectRoot: process.cwd(),
       verifierDispatch: dispatch,
+
+      round: testRound(),
     });
     const sig: ConsensusSignal[] = [];
     const fs = findings(3);
@@ -61,6 +64,8 @@ describe('maybeAutoVerify integration — gate-ON', () => {
       llm: stubLlm, registryGet: () => undefined, projectRoot: process.cwd(),
       // verifierDispatch intentionally omitted
       warningSink,
+
+      round: testRound(),
     });
     const sig: ConsensusSignal[] = [];
     const fs = findings(2);
@@ -81,6 +86,8 @@ describe('maybeAutoVerify integration — gate-ON', () => {
     const engine = new ConsensusEngine({
       llm: stubLlm, registryGet: () => undefined, projectRoot: process.cwd(),
       verifierDispatch: dispatch, warningSink,
+
+      round: testRound(),
     });
     const sig: ConsensusSignal[] = [];
     const r = await (engine as any).maybeAutoVerify(findings(2), sig, 'cid', 'seed') as ConsensusFinding[];
@@ -107,6 +114,8 @@ describe('maybeAutoVerify integration — gate-ON', () => {
     const engine = new ConsensusEngine({
       llm: stubLlm, registryGet: () => undefined, projectRoot: process.cwd(),
       verifierDispatch: dispatch, warningSink,
+
+      round: testRound(),
     });
     const sig: ConsensusSignal[] = [];
     // The synchronous throw is caught inside verifyOne (rejected promise);
@@ -132,6 +141,8 @@ describe('maybeAutoVerify integration — idempotency under retry', () => {
     const engine = new ConsensusEngine({
       llm: stubLlm, registryGet: () => undefined, projectRoot: process.cwd(),
       verifierDispatch: dispatch,
+
+      round: testRound(),
     });
     const sig: ConsensusSignal[] = [];
     const fs = findings(4);
@@ -150,6 +161,8 @@ describe('maybeAutoVerify integration — idempotency under retry', () => {
     const engine = new ConsensusEngine({
       llm: stubLlm, registryGet: () => undefined, projectRoot: process.cwd(),
       verifierDispatch: dispatch,
+
+      round: testRound(),
     });
     const fs = findings(3);
     // Pre-stamp f1 with a "first pass" verdict.

--- a/tests/orchestrator/consensus-e2e.test.ts
+++ b/tests/orchestrator/consensus-e2e.test.ts
@@ -5,6 +5,7 @@
  * Run: npx jest tests/orchestrator/consensus-e2e.test.ts --testTimeout=600000
  */
 import { createProvider } from '../../packages/orchestrator/src/llm-client';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import { existsSync, readFileSync, unlinkSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { execFileSync } from 'child_process';
@@ -70,7 +71,9 @@ describe('Consensus Protocol E2E', () => {
       return { id, provider: ac.provider, model: ac.model, preset: ac.preset, skills: ac.skills || [] };
     };
 
-    const engine = new ConsensusEngine({ llm, registryGet });
+    const engine = new ConsensusEngine({ llm, registryGet,
+      round: testRound(),
+    });
 
     // Synthetic Phase 1 results — 4 agents reviewing consensus-engine.ts
     const mockResults = [

--- a/tests/orchestrator/consensus-engine-category-parse.test.ts
+++ b/tests/orchestrator/consensus-engine-category-parse.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import { resolve } from 'path';
 import { tmpdir } from 'os';
 import { ConsensusEngine, CrossReviewEntry } from '../../packages/orchestrator/src/consensus-engine';
@@ -8,6 +9,7 @@ import { TaskEntry } from '../../packages/orchestrator/src/types';
 const makeEngine = () => new ConsensusEngine({
   llm: { generate: jest.fn() } as any,
   registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: `preset-${id}`, skills: [] }),
+  round: testRound(),
 } as any);
 
 // Minimal stub: synthesize() only needs status/result/id/agentId from TaskEntry
@@ -25,7 +27,9 @@ const makeTask = (agentId: string, result: string): TaskEntry => ({
 
 describe('ConsensusEngine — category attribute parsing', () => {
   it('extracts category from <agent_finding> tag attribute', () => {
-    const engine = new ConsensusEngine({} as any);
+    const engine = new ConsensusEngine({
+      round: testRound(),
+    } as any);
     const raw = `## Consensus Summary
 <agent_finding type="finding" severity="high" category="injection_vectors">
 SQL injection at db.ts:42
@@ -36,7 +40,9 @@ SQL injection at db.ts:42
   });
 
   it('returns undefined category when attribute is absent', () => {
-    const engine = new ConsensusEngine({} as any);
+    const engine = new ConsensusEngine({
+      round: testRound(),
+    } as any);
     const raw = `<agent_finding type="finding" severity="high">No category here at all</agent_finding>`;
     const findings = (engine as any).parseAgentFindings('agent-x', raw);
     expect(findings).toHaveLength(1);
@@ -309,7 +315,9 @@ SQL injection at db.ts:42
 
   describe('deduplicateFindings — category merge', () => {
     it('surviving entry inherits category from loser when survivor has none (A-wins branch)', () => {
-      const engine = new ConsensusEngine({} as any);
+      const engine = new ConsensusEngine({
+        round: testRound(),
+      } as any);
 
       // entryA: no category (will survive as A-wins default branch)
       // entryB: has category "injection_vectors" (will be merged into A)
@@ -349,7 +357,9 @@ SQL injection at db.ts:42
     });
 
     it('surviving entry inherits category from loser when survivor has none (B-wins branch)', () => {
-      const engine = new ConsensusEngine({} as any);
+      const engine = new ConsensusEngine({
+        round: testRound(),
+      } as any);
 
       // entryA: HAS category "injection_vectors", but NO line citation (so B wins — B has :42 citation)
       // entryB: no category but has a line citation (B-wins branch, B survives without category)
@@ -409,6 +419,8 @@ describe('record-undefined policy — hallucination_caught with projectRoot (cit
     llm: { generate: async () => ({ text: '', toolCalls: [] }) } as any,
     registryGet: () => undefined,
     projectRoot: testDir,
+
+    round: testRound(),
   });
 
   it('hallucination_caught (pre-filter path) — emitted with category undefined when no CATEGORY_PATTERNS keyword matches', async () => {
@@ -515,7 +527,9 @@ describe('record-undefined policy — hallucination_caught with projectRoot (cit
 
 describe('parseCrossReviewResponse — category attribute (PARTS C + F)', () => {
   it('extracts a valid category from cross-review JSON', () => {
-    const engine = new ConsensusEngine({} as any);
+    const engine = new ConsensusEngine({
+      round: testRound(),
+    } as any);
     const raw = JSON.stringify([{
       action: 'new',
       findingId: 'self:n1',
@@ -530,7 +544,9 @@ describe('parseCrossReviewResponse — category attribute (PARTS C + F)', () => 
   });
 
   it('rejects invalid category — yields undefined silently', () => {
-    const engine = new ConsensusEngine({} as any);
+    const engine = new ConsensusEngine({
+      round: testRound(),
+    } as any);
     const raw = JSON.stringify([{
       action: 'new',
       findingId: 'self:n1',
@@ -551,6 +567,8 @@ describe('synthesize() — bullet-fallback populates category at insertion (PART
     const engine = (() => new ConsensusEngine({
       llm: { generate: jest.fn() } as any,
       registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: `preset-${id}`, skills: [] }),
+
+      round: testRound(),
     } as any))();
 
     // Agent A emits NO <agent_finding> tags but a bullet containing "race condition"

--- a/tests/orchestrator/consensus-engine-resolution-roots.test.ts
+++ b/tests/orchestrator/consensus-engine-resolution-roots.test.ts
@@ -3,7 +3,6 @@
  */
 import {
   ConsensusEngine,
-  type ConsensusEngineConfig,
 } from '../../packages/orchestrator/src/consensus-engine';
 import { ConsensusCoordinator } from '../../packages/orchestrator/src/consensus-coordinator';
 import { makeRoundContext, testRound } from '../../packages/orchestrator/src/round-context';
@@ -42,7 +41,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
       registryGet: () => undefined,
       projectRoot: root,
       round: testRound({ resolutionRoots: [real] }),
-    } as ConsensusEngineConfig);
+    });
     // getValidRoots is private — exercise via matchesRelativePath which
     // works off the roots the engine was seeded with.
     const m = (engine as any).matchesRelativePath(real, join(real, 'a.ts'), 'a.ts');
@@ -55,7 +54,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
       registryGet: () => undefined,
       projectRoot: root,
       round: testRound({ resolutionRoots: ['relative/path'] }),
-    } as ConsensusEngineConfig)).toThrow(/absolute/);
+    })).toThrow(/absolute/);
   });
 
   it('Test 14 — matchesRelativePath: exact trailing match', () => {
@@ -115,7 +114,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
       registryGet: () => undefined,
       projectRoot: proj,
       round: testRound({ resolutionRoots: [extra] }),
-    } as ConsensusEngineConfig);
+    });
     const resolved = await (engine as any).resolveFilePath('A.ts');
     // Bare-filename recursion restricted to projectRoot — must find the
     // proj copy, never the extra copy.
@@ -132,7 +131,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
     const engine = new ConsensusEngine({
       llm: makeLlm(), registryGet: () => undefined, projectRoot: proj,
       round: testRound({ resolutionRoots: [wt1] }),
-    } as ConsensusEngineConfig);
+    });
 
     // Trigger cache population via updateWorktreeRoots
     (engine as any).updateWorktreeRoots([], [wt1]);
@@ -162,7 +161,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
       registryGet: () => undefined,
       projectRoot: proj,
       round: testRound({ resolutionRoots: [wt] }),
-    } as ConsensusEngineConfig);
+    });
 
     // snippetsForFinding is protected — invoke via cast.
     const snippets: string = await (engine as any).snippetsForFinding(
@@ -193,7 +192,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
       registryGet: () => undefined,
       projectRoot: proj,
       round: testRound({ resolutionRoots: [wt] }),
-    } as ConsensusEngineConfig);
+    });
 
     const snippets: string = await (engine as any).snippetsForFinding(
       'Potential issue at src/master-only.ts:1',
@@ -226,7 +225,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
       registryGet: () => undefined,
       projectRoot: proj,
       round: testRound({ resolutionRoots: [wt] }),
-    } as ConsensusEngineConfig);
+    });
 
     const snippets: string = await (engine as any).snippetsForFinding(
       'Potential issue at src/new-feature.ts:1',
@@ -259,7 +258,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
       registryGet: () => undefined,
       projectRoot: proj,
       round: testRound({ resolutionRoots: [wt] }),
-    } as ConsensusEngineConfig);
+    });
 
     const snippets: string = await (engine as any).snippetsForFinding(
       'Potential issue at src/master-only.ts:1',
@@ -281,7 +280,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
     const engine = new ConsensusEngine({
       llm: makeLlm(), registryGet: () => undefined, projectRoot: proj,
       round: testRound({ resolutionRoots: [wt] }),
-    } as ConsensusEngineConfig);
+    });
 
     // Seed the anchorPathCache with a stale entry.
     (engine as any).anchorPathCache.set('src/a.ts', '/stale/path/a.ts');

--- a/tests/orchestrator/consensus-engine-resolution-roots.test.ts
+++ b/tests/orchestrator/consensus-engine-resolution-roots.test.ts
@@ -6,7 +6,7 @@ import {
   type ConsensusEngineConfig,
 } from '../../packages/orchestrator/src/consensus-engine';
 import { ConsensusCoordinator } from '../../packages/orchestrator/src/consensus-coordinator';
-import { makeRoundContext } from '../../packages/orchestrator/src/round-context';
+import { makeRoundContext, testRound } from '../../packages/orchestrator/src/round-context';
 import {
   mkdtempSync,
   mkdirSync,
@@ -41,7 +41,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
       llm: makeLlm(),
       registryGet: () => undefined,
       projectRoot: root,
-      resolutionRoots: [real],
+      round: testRound({ resolutionRoots: [real] }),
     } as ConsensusEngineConfig);
     // getValidRoots is private — exercise via matchesRelativePath which
     // works off the roots the engine was seeded with.
@@ -54,13 +54,15 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
       llm: makeLlm(),
       registryGet: () => undefined,
       projectRoot: root,
-      resolutionRoots: ['relative/path'],
+      round: testRound({ resolutionRoots: ['relative/path'] }),
     } as ConsensusEngineConfig)).toThrow(/absolute/);
   });
 
   it('Test 14 — matchesRelativePath: exact trailing match', () => {
     const engine = new ConsensusEngine({
       llm: makeLlm(), registryGet: () => undefined, projectRoot: root,
+
+      round: testRound(),
     });
     const m = (engine as any).matchesRelativePath.bind(engine);
     // trailing match succeeds
@@ -88,6 +90,8 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
     symlinkSync(outside, join(repo, 'packages', 'evil'));
     const engine = new ConsensusEngine({
       llm: makeLlm(), registryGet: () => undefined, projectRoot: repo,
+
+      round: testRound(),
     });
     // findFile is private — invoke via the resolver path.
     const resolved = await (engine as any).resolveFilePath('config.ts');
@@ -110,7 +114,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
       llm: makeLlm(),
       registryGet: () => undefined,
       projectRoot: proj,
-      resolutionRoots: [extra],
+      round: testRound({ resolutionRoots: [extra] }),
     } as ConsensusEngineConfig);
     const resolved = await (engine as any).resolveFilePath('A.ts');
     // Bare-filename recursion restricted to projectRoot — must find the
@@ -127,7 +131,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
 
     const engine = new ConsensusEngine({
       llm: makeLlm(), registryGet: () => undefined, projectRoot: proj,
-      resolutionRoots: [wt1],
+      round: testRound({ resolutionRoots: [wt1] }),
     } as ConsensusEngineConfig);
 
     // Trigger cache population via updateWorktreeRoots
@@ -157,7 +161,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
       llm: makeLlm(),
       registryGet: () => undefined,
       projectRoot: proj,
-      resolutionRoots: [wt],
+      round: testRound({ resolutionRoots: [wt] }),
     } as ConsensusEngineConfig);
 
     // snippetsForFinding is protected — invoke via cast.
@@ -188,7 +192,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
       llm: makeLlm(),
       registryGet: () => undefined,
       projectRoot: proj,
-      resolutionRoots: [wt],
+      round: testRound({ resolutionRoots: [wt] }),
     } as ConsensusEngineConfig);
 
     const snippets: string = await (engine as any).snippetsForFinding(
@@ -221,7 +225,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
       llm: makeLlm(),
       registryGet: () => undefined,
       projectRoot: proj,
-      resolutionRoots: [wt],
+      round: testRound({ resolutionRoots: [wt] }),
     } as ConsensusEngineConfig);
 
     const snippets: string = await (engine as any).snippetsForFinding(
@@ -254,7 +258,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
       llm: makeLlm(),
       registryGet: () => undefined,
       projectRoot: proj,
-      resolutionRoots: [wt],
+      round: testRound({ resolutionRoots: [wt] }),
     } as ConsensusEngineConfig);
 
     const snippets: string = await (engine as any).snippetsForFinding(
@@ -276,7 +280,7 @@ describe('ConsensusEngine resolutionRoots + findFile hardening', () => {
 
     const engine = new ConsensusEngine({
       llm: makeLlm(), registryGet: () => undefined, projectRoot: proj,
-      resolutionRoots: [wt],
+      round: testRound({ resolutionRoots: [wt] }),
     } as ConsensusEngineConfig);
 
     // Seed the anchorPathCache with a stale entry.

--- a/tests/orchestrator/consensus-engine-selected-review.test.ts
+++ b/tests/orchestrator/consensus-engine-selected-review.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { ConsensusEngine, ConsensusEngineConfig } from '../../packages/orchestrator/src/consensus-engine';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import { TaskEntry } from '../../packages/orchestrator/src/types';
 import { ILLMProvider } from '../../packages/orchestrator/src/llm-client';
 import { PerformanceReader } from '../../packages/orchestrator/src/performance-reader';
@@ -111,6 +112,8 @@ function makeEngine(opts: {
     projectRoot: TEST_ROOT,
     performanceReader: opts.performanceReader ?? new PerformanceReader(TEST_ROOT),
     verifierToolRunner: opts.verifierToolRunner,
+
+    round: testRound(),
   });
 }
 
@@ -127,6 +130,7 @@ describe('runSelectedCrossReview (Step 3)', () => {
       llm: makeMockLlm('[]'),
       registryGet: makeMockRegistryGet(),
       // no performanceReader
+      round: testRound(),
     });
 
     await expect(engine.runSelectedCrossReview([])).rejects.toThrow(
@@ -207,10 +211,12 @@ describe('runSelectedCrossReview (Step 3)', () => {
 
     const report = await engine.runSelectedCrossReview(results);
 
-    // With only one non-author agent and K=2 for medium, partialReview should be true
+    // With only one non-author agent and K=2 for medium, partial_review fires.
     expect(report).toBeDefined();
-    // agent-b is the only candidate (agent-a is author), but K=2 → partial
-    expect(report.partialReview).toBe(true);
+    // agent-b is the only candidate (agent-a is author), but K=2 → partial.
+    // PR-C: legacy report.partialReview is gone — assert the warning.
+    expect((report as unknown as { partialReview?: unknown }).partialReview).toBeUndefined();
+    expect((report.warnings ?? []).some(w => w.code === 'partial_review')).toBe(true);
   });
 
   describe('Scoped Summaries', () => {
@@ -301,6 +307,7 @@ describe('runSelectedCrossReview (Step 3)', () => {
         registryGet: makeMockRegistryGet(),
         projectRoot: TEST_ROOT,
         performanceReader: new PerformanceReader(TEST_ROOT),
+        round: testRound(),
       });
 
       // Spy on crossReviewForAgent to avoid actual LLM calls
@@ -419,8 +426,10 @@ describe('runSelectedCrossReview (Step 3)', () => {
 
       const report = await engine.runSelectedCrossReview(results);
 
-      // K=3 for critical but only 2 non-author candidates → partial
-      expect(report.partialReview).toBe(true);
+      // K=3 for critical but only 2 non-author candidates → partial.
+      // PR-C: legacy report.partialReview is gone — assert the warning.
+      expect((report as unknown as { partialReview?: unknown }).partialReview).toBeUndefined();
+      expect((report.warnings ?? []).some(w => w.code === 'partial_review')).toBe(true);
     });
 
     it('should NOT set partialReview when all findings have sufficient reviewers', async () => {

--- a/tests/orchestrator/consensus-engine-tier2.test.ts
+++ b/tests/orchestrator/consensus-engine-tier2.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import { resolve } from 'path';
 import { tmpdir } from 'os';
 import { ConsensusEngine, ILLMProvider } from '@gossip/orchestrator';
@@ -45,6 +46,8 @@ describe('Tier 2 fabrication pre-filter — unverified branch', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
   });
 
@@ -167,6 +170,8 @@ describe('Tier 2 fabrication pre-filter — fallthrough branch', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
   });
 
@@ -256,6 +261,8 @@ describe('capAutoSeverity — clamping via Tier 2 fallthrough branch', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
   });
 
@@ -349,6 +356,8 @@ describe('authorFindingId — per-agent id carried through synthesis', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: testDir,
+
+      round: testRound(),
     });
   });
 

--- a/tests/orchestrator/consensus-engine-verifier-tools.test.ts
+++ b/tests/orchestrator/consensus-engine-verifier-tools.test.ts
@@ -10,6 +10,7 @@
 //   - engine config: { llm, registryGet, verifierToolRunner? }
 
 import { ConsensusEngine, ConsensusEngineConfig } from '../../packages/orchestrator/src/consensus-engine';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import { TaskEntry, LLMResponse } from '../../packages/orchestrator/src/types';
 import { ILLMProvider } from '../../packages/orchestrator/src/llm-client';
 
@@ -86,6 +87,8 @@ describe('crossReviewForAgent — text-only fallback (no verifierToolRunner)', (
     const config: ConsensusEngineConfig = {
       llm: mockLlm,
       registryGet: makeMockRegistryGet(),
+
+      round: testRound(),
     };
     engine = new ConsensusEngine(config);
   });
@@ -136,6 +139,8 @@ describe('crossReviewForAgent — tool loop basic', () => {
       llm: mockLlm,
       registryGet: makeMockRegistryGet(),
       verifierToolRunner,
+
+      round: testRound(),
     };
     engine = new ConsensusEngine(config);
   });
@@ -229,6 +234,8 @@ describe('crossReviewForAgent — cap-hit recovery at MAX_VERIFIER_TURNS=7', () 
       llm: mockLlm,
       registryGet: makeMockRegistryGet(),
       verifierToolRunner,
+
+      round: testRound(),
     };
     engine = new ConsensusEngine(config);
   });
@@ -309,6 +316,8 @@ describe('crossReviewForAgent — tool error handling', () => {
       llm: mockLlm,
       registryGet: makeMockRegistryGet(),
       verifierToolRunner,
+
+      round: testRound(),
     };
     engine = new ConsensusEngine(config);
   });
@@ -379,6 +388,8 @@ describe('crossReviewForAgent — tool output truncation', () => {
       llm: mockLlm,
       registryGet: makeMockRegistryGet(),
       verifierToolRunner,
+
+      round: testRound(),
     };
     engine = new ConsensusEngine(config);
   });

--- a/tests/orchestrator/consensus-engine.dos.test.ts
+++ b/tests/orchestrator/consensus-engine.dos.test.ts
@@ -1,4 +1,5 @@
 import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import { CrossReviewEntry } from '../../packages/orchestrator/src/consensus-types';
 import { AgentConfig, TaskEntry } from '../../packages/orchestrator/src/types';
 import { ILLMProvider } from '../../packages/orchestrator/src/llm-client';
@@ -31,6 +32,8 @@ describe('ConsensusEngine DoS', () => {
       registryGet: (agentId: string): AgentConfig | undefined => ({
         id: agentId, provider: 'local', model: 'test-model', skills: [], preset: 'test-preset'
       }),
+
+      round: testRound(),
     });
   });
 

--- a/tests/orchestrator/consensus-engine.security.test.ts
+++ b/tests/orchestrator/consensus-engine.security.test.ts
@@ -1,4 +1,5 @@
 import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import { AgentConfig, TaskEntry } from '../../packages/orchestrator/src/types';
 import { ILLMProvider, LLMGenerateOptions } from '../../packages/orchestrator/src/llm-client';
 import { LLMMessage } from '@gossip/types';
@@ -23,6 +24,8 @@ describe('ConsensusEngine Security', () => {
     engine = new ConsensusEngine({
       llm: mockLlm,
       registryGet: (agentId: string) => mockRegistry.get(agentId),
+
+      round: testRound(),
     });
   });
 
@@ -117,6 +120,8 @@ describe('ConsensusEngine Security', () => {
       const localEngine = new ConsensusEngine({
         llm: mockLlm,
         registryGet: (agentId: string) => mockRegistry.get(agentId),
+
+        round: testRound(),
       });
 
       // Access the private method via bracket notation for the test.

--- a/tests/orchestrator/consensus-engine.test.ts
+++ b/tests/orchestrator/consensus-engine.test.ts
@@ -1,5 +1,6 @@
 // tests/orchestrator/consensus-engine.test.ts
 import { ConsensusEngine, ConsensusEngineConfig, CrossReviewEntry } from '../../packages/orchestrator/src/consensus-engine';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import { AgentConfig, TaskEntry, LLMResponse } from '../../packages/orchestrator/src/types';
 import { ILLMProvider } from '../../packages/orchestrator/src/llm-client';
 import { join } from 'path';
@@ -23,6 +24,7 @@ const mockRegistryGet = jest.fn((agentId: string): AgentConfig | undefined => {
 const baseConfig: ConsensusEngineConfig = {
   llm: mockLlm,
   registryGet: mockRegistryGet,
+  round: testRound(),
 };
 
 // Helper to create TaskEntry objects
@@ -796,7 +798,9 @@ Summary: 1 agree, 1 disagree.`;
         return undefined;
       });
 
-      const engineWithAgentLlm = new ConsensusEngine({ ...baseConfig, agentLlm });
+      const engineWithAgentLlm = new ConsensusEngine({ ...baseConfig, agentLlm,
+        round: testRound(),
+      });
 
       agentALlm.generate.mockResolvedValue({
         text: JSON.stringify([
@@ -827,7 +831,9 @@ Summary: 1 agree, 1 disagree.`;
         return undefined;
       });
 
-      const engineWithSkills = new ConsensusEngine({ ...baseConfig, getAgentSkillsContent });
+      const engineWithSkills = new ConsensusEngine({ ...baseConfig, getAgentSkillsContent,
+        round: testRound(),
+      });
       const results: TaskEntry[] = [
         createTaskEntry('agent-a', 'completed', '## Consensus Summary\n- Finding A at file.ts:10'),
         createTaskEntry('agent-b', 'completed', '## Consensus Summary\n- Finding B at other.ts:20'),
@@ -849,7 +855,9 @@ Summary: 1 agree, 1 disagree.`;
 
     it('survives a throw from getAgentSkillsContent without aborting the round (F8)', async () => {
       const getAgentSkillsContent = jest.fn(() => { throw new Error('skill loader blew up'); });
-      const engineWithBad = new ConsensusEngine({ ...baseConfig, getAgentSkillsContent });
+      const engineWithBad = new ConsensusEngine({ ...baseConfig, getAgentSkillsContent,
+        round: testRound(),
+      });
       const results: TaskEntry[] = [
         createTaskEntry('agent-a', 'completed', '## Consensus Summary\n- Finding A'),
         createTaskEntry('agent-b', 'completed', '## Consensus Summary\n- Finding B'),
@@ -862,7 +870,9 @@ Summary: 1 agree, 1 disagree.`;
     it('falls back to default llm when agentLlm returns undefined', async () => {
       const agentLlm = jest.fn((_agentId: string): ILLMProvider | undefined => undefined);
 
-      const engineWithFallback = new ConsensusEngine({ ...baseConfig, agentLlm });
+      const engineWithFallback = new ConsensusEngine({ ...baseConfig, agentLlm,
+        round: testRound(),
+      });
 
       mockLlm.generate.mockResolvedValue({
         text: JSON.stringify([
@@ -945,6 +955,8 @@ describe('snippetsForFinding()', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: tmpDir,
+
+      round: testRound(),
     });
   });
 
@@ -1074,6 +1086,8 @@ describe('crossReviewForAgent per-finding snippets', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       projectRoot: tmpDir,
+
+      round: testRound(),
     });
 
     mockLlm.generate.mockResolvedValue({
@@ -1357,7 +1371,13 @@ describe('synthesizeWithCrossReview()', () => {
 
     const report = await engine.synthesizeWithCrossReview(results, [], 'skip0001-skip0001', skipped);
 
-    expect(report.relayCrossReviewSkipped).toEqual(skipped);
+    // PR-C: legacy report.relayCrossReviewSkipped is gone — assert the warning
+    // channel + the human-readable summary text instead.
+    expect((report as unknown as { relayCrossReviewSkipped?: unknown }).relayCrossReviewSkipped).toBeUndefined();
+    const crw = (report.warnings ?? []).filter(w => w.code === 'cross_review_skipped');
+    expect(crw).toHaveLength(1);
+    expect(crw[0].agentId).toBe('gemini-reviewer');
+    expect(crw[0].message).toContain('google quota exhausted');
     expect(report.summary).toContain('Relay cross-review skipped');
     expect(report.summary).toContain('gemini-reviewer');
     expect(report.summary).toContain('google quota exhausted');

--- a/tests/orchestrator/consensus-resolution-roots-plumbing.test.ts
+++ b/tests/orchestrator/consensus-resolution-roots-plumbing.test.ts
@@ -18,7 +18,7 @@ import { join } from 'path';
 
 // Capture the config each ConsensusEngine is constructed with, while stubbing
 // out the heavy run()/synthesize() path so the coordinator test stays fast.
-const engineConfigs: Array<{ resolutionRoots?: readonly string[] }> = [];
+const engineConfigs: Array<{ round?: { resolutionRoots?: readonly string[] } }> = [];
 
 jest.mock('../../packages/orchestrator/src/consensus-engine', () => {
   const actual = jest.requireActual('../../packages/orchestrator/src/consensus-engine');
@@ -40,6 +40,7 @@ jest.mock('../../packages/orchestrator/src/consensus-engine', () => {
 });
 
 import { ConsensusCoordinator } from '../../packages/orchestrator/src/consensus-coordinator';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import type { TaskEntry } from '../../packages/orchestrator/src/types';
 
 const makeLlm = (): any => ({
@@ -79,36 +80,39 @@ describe('all-relay consensus resolutionRoots plumbing', () => {
       [wt],
     );
 
+    // PR-C: the engine now REQUIRES a RoundContext, so the coordinator wraps the
+    // legacy roots array into `round.resolutionRoots` (no loose config field).
     expect(engineConfigs).toHaveLength(1);
-    expect(engineConfigs[0].resolutionRoots).toEqual([wt]);
+    expect(engineConfigs[0].round?.resolutionRoots).toEqual([wt]);
   });
 
-  it('per-round roots OVERRIDE the coordinator constructor default', async () => {
-    const ctorRoot = realpathSync(mkdtempSync(join(tmp, 'ctor')));
+  it('per-round roots are wrapped into round.resolutionRoots; absent → empty round', async () => {
     const perRoundRoot = realpathSync(mkdtempSync(join(tmp, 'round')));
 
+    // PR-C deleted the coordinator constructor `resolutionRoots`/`round`
+    // defaults (consensus-verified production-dead — the sole construction site
+    // never passed them). runConsensus(results, round) is the only carrier.
     const coordinator = new ConsensusCoordinator({
       llm: makeLlm(),
       registryGet: () => undefined,
       projectRoot: root,
       keyProvider: null,
-      resolutionRoots: [ctorRoot],
     });
 
-    // Per-round value supplied → must REPLACE the constructor default.
+    // Per-round roots array → wrapped into round.resolutionRoots.
     await coordinator.runConsensus(
       [completed('relay-a'), completed('relay-b')],
       [perRoundRoot],
     );
-    expect(engineConfigs[engineConfigs.length - 1].resolutionRoots).toEqual([perRoundRoot]);
+    expect(engineConfigs[engineConfigs.length - 1].round?.resolutionRoots).toEqual([perRoundRoot]);
 
-    // No per-round value → constructor default is used (back-compat).
+    // No per-round value → a fresh empty round (project-root-only).
     await coordinator.runConsensus([completed('relay-a'), completed('relay-b')]);
-    expect(engineConfigs[engineConfigs.length - 1].resolutionRoots).toEqual([ctorRoot]);
+    expect(engineConfigs[engineConfigs.length - 1].round?.resolutionRoots).toEqual([]);
 
-    // Empty per-round array → treated as absent, constructor default used.
+    // Empty per-round array → wrapped into an empty round.
     await coordinator.runConsensus([completed('relay-a'), completed('relay-b')], []);
-    expect(engineConfigs[engineConfigs.length - 1].resolutionRoots).toEqual([ctorRoot]);
+    expect(engineConfigs[engineConfigs.length - 1].round?.resolutionRoots).toEqual([]);
   });
 });
 
@@ -133,6 +137,7 @@ describe('ConsensusEngine.updateWorktreeRoots unions TaskEntry.resolutionRoots',
       llm: makeLlm(),
       registryGet: () => undefined,
       projectRoot: root,
+      round: testRound(),
     });
 
     const entry: TaskEntry = {
@@ -165,7 +170,7 @@ describe('ConsensusEngine.updateWorktreeRoots unions TaskEntry.resolutionRoots',
       llm: makeLlm(),
       registryGet: () => undefined,
       projectRoot: root,
-      resolutionRoots: [configRoot],
+      round: testRound({ resolutionRoots: [configRoot] }),
     });
 
     const entry: TaskEntry = {
@@ -197,6 +202,7 @@ describe('ConsensusEngine.updateWorktreeRoots unions TaskEntry.resolutionRoots',
       llm: makeLlm(),
       registryGet: () => undefined,
       projectRoot: root,
+      round: testRound(),
     });
 
     const entry: TaskEntry = {

--- a/tests/orchestrator/consensus-two-phase.test.ts
+++ b/tests/orchestrator/consensus-two-phase.test.ts
@@ -1,4 +1,5 @@
 import { ConsensusEngine, ConsensusEngineConfig, CrossReviewEntry } from '../../packages/orchestrator/src/consensus-engine';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import { TaskEntry } from '../../packages/orchestrator/src/types';
 import { ILLMProvider } from '../../packages/orchestrator/src/llm-client';
 
@@ -22,6 +23,8 @@ describe('Two-phase consensus flow', () => {
     const config: ConsensusEngineConfig = {
       llm: mockLlm,
       registryGet: mockRegistryGet,
+
+      round: testRound(),
     };
     const engine = new ConsensusEngine(config);
 
@@ -70,6 +73,8 @@ describe('Two-phase consensus flow', () => {
       llm: mockLlm,
       registryGet: mockRegistryGet,
       agentLlm: (id) => id === 'relay-b' ? relayLlm : undefined,
+
+      round: testRound(),
     };
     const engine = new ConsensusEngine(config);
 
@@ -125,6 +130,7 @@ describe('Two-phase consensus flow', () => {
       registryGet: mockRegistryGet,
       // Intentionally NO agentLlm — mirrors all-native reality where
       // agentLlmCache would be empty.
+      round: testRound(),
     };
     const engine = new ConsensusEngine(config);
 
@@ -156,6 +162,8 @@ describe('Two-phase consensus flow', () => {
     const config: ConsensusEngineConfig = {
       llm: mockLlm,
       registryGet: mockRegistryGet,
+
+      round: testRound(),
     };
     const engine = new ConsensusEngine(config);
 
@@ -176,7 +184,7 @@ describe('Two-phase consensus flow', () => {
   });
 
   it('flags coverageDegraded and emits consensus_coverage_degraded signal for 0-char dropouts', async () => {
-    const config: ConsensusEngineConfig = { llm: mockLlm, registryGet: mockRegistryGet };
+    const config: ConsensusEngineConfig = { llm: mockLlm, registryGet: mockRegistryGet, round: testRound() };
     const engine = new ConsensusEngine(config);
 
     // Three dispatched agents, one returns empty text (simulating Gemini MFC).
@@ -190,17 +198,20 @@ describe('Two-phase consensus flow', () => {
     const { consensusId } = await engine.generateCrossReviewPrompts(results, nativeIds);
     const report = await engine.synthesizeWithCrossReview(results, [], consensusId);
 
-    expect(report.coverageDegraded).toBeDefined();
-    expect(report.coverageDegraded!.expected).toBe(3);
-    expect(report.coverageDegraded!.received).toBe(2);
-    expect(report.coverageDegraded!.droppedAgents).toEqual(['native-c']);
+    // PR-C: legacy report.coverageDegraded is gone — assert the warning message
+    // (carries received/total + dropped-agent list) + the round-level signal.
+    expect((report as unknown as { coverageDegraded?: unknown }).coverageDegraded).toBeUndefined();
+    const cd = (report.warnings ?? []).filter(w => w.code === 'coverage_degraded');
+    expect(cd).toHaveLength(1);
+    expect(cd[0].message).toContain('2/3');
+    expect(cd[0].message).toContain('native-c');
     const covSignals = report.signals.filter(s => s.signal === 'consensus_coverage_degraded');
     expect(covSignals).toHaveLength(1);
     expect(covSignals[0].agentId).toBe('_round');
   });
 
   it('flags coverageDegraded for Gemini MALFORMED_FUNCTION_CALL sentinel (non-empty dropout)', async () => {
-    const config: ConsensusEngineConfig = { llm: mockLlm, registryGet: mockRegistryGet };
+    const config: ConsensusEngineConfig = { llm: mockLlm, registryGet: mockRegistryGet, round: testRound() };
     const engine = new ConsensusEngine(config);
 
     // One agent returns the Gemini sentinel — non-empty string, zero analytical content.
@@ -215,9 +226,12 @@ describe('Two-phase consensus flow', () => {
     const { consensusId } = await engine.generateCrossReviewPrompts(results, nativeIds);
     const report = await engine.synthesizeWithCrossReview(results, [], consensusId);
 
-    expect(report.coverageDegraded).toBeDefined();
-    expect(report.coverageDegraded!.droppedAgents).toEqual(['gemini-reviewer']);
-    expect(report.coverageDegraded!.received).toBe(2);
+    // PR-C: legacy report.coverageDegraded is gone — assert the warning.
+    expect((report as unknown as { coverageDegraded?: unknown }).coverageDegraded).toBeUndefined();
+    const cd = (report.warnings ?? []).filter(w => w.code === 'coverage_degraded');
+    expect(cd).toHaveLength(1);
+    expect(cd[0].message).toContain('gemini-reviewer');
+    expect(cd[0].message).toContain('2/3');
     const covSignals = report.signals.filter(s => s.signal === 'consensus_coverage_degraded');
     expect(covSignals).toHaveLength(1);
   });

--- a/tests/orchestrator/coverage-degraded.test.ts
+++ b/tests/orchestrator/coverage-degraded.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Round-trip contract for buildCoverageDegradedMessage / parseCoverageDegradedMessage.
+ *
+ * Intent: any future drift in the template (consensus-engine.ts producer,
+ * routes.ts legacy synthesizer, api-consensus-flow.ts parser) breaks THIS
+ * test before it breaks the dashboard chip — giving a single red CI gate
+ * rather than a silent rendering regression.
+ *
+ * consensus 1f50d89d-c28f49c4:fable-reviewer:f2
+ */
+import {
+  buildCoverageDegradedMessage,
+  parseCoverageDegradedMessage,
+} from '../../packages/orchestrator/src/coverage-degraded';
+
+describe('buildCoverageDegradedMessage', () => {
+  it('builds the canonical format', () => {
+    const msg = buildCoverageDegradedMessage({ received: 2, expected: 3, droppedAgents: ['agent-x'] });
+    expect(msg).toBe('Coverage degraded: 2/3 agents returned content (dropped: agent-x)');
+  });
+
+  it('joins multiple dropped agents with ", "', () => {
+    const msg = buildCoverageDegradedMessage({ received: 1, expected: 3, droppedAgents: ['a', 'b'] });
+    expect(msg).toContain('dropped: a, b');
+  });
+
+  it('produces an empty dropped list when droppedAgents is empty', () => {
+    const msg = buildCoverageDegradedMessage({ received: 2, expected: 2, droppedAgents: [] });
+    expect(msg).toContain('(dropped: )');
+  });
+});
+
+describe('parseCoverageDegradedMessage', () => {
+  it('round-trips a standard message', () => {
+    const params = { received: 2, expected: 3, droppedAgents: ['agent-x'] };
+    const parsed = parseCoverageDegradedMessage(buildCoverageDegradedMessage(params));
+    expect(parsed).toEqual(params);
+  });
+
+  it('round-trips with multiple dropped agents', () => {
+    const params = { received: 1, expected: 3, droppedAgents: ['gemini-reviewer', 'haiku-researcher'] };
+    const parsed = parseCoverageDegradedMessage(buildCoverageDegradedMessage(params));
+    expect(parsed).toEqual(params);
+  });
+
+  it('round-trips with an empty dropped list', () => {
+    const params = { received: 2, expected: 2, droppedAgents: [] };
+    const parsed = parseCoverageDegradedMessage(buildCoverageDegradedMessage(params));
+    expect(parsed).toEqual(params);
+  });
+
+  it('returns undefined for an unrelated string', () => {
+    expect(parseCoverageDegradedMessage('some random warning')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', () => {
+    expect(parseCoverageDegradedMessage('')).toBeUndefined();
+  });
+
+  it('handles an agent id containing a comma — extracted as separate entries (documented limitation)', () => {
+    // An agent id with a comma looks like two separate list entries after split(',').
+    // This is a known limitation documented in coverage-degraded.ts. The test
+    // pins the current behavior so any change is deliberate.
+    const msg = buildCoverageDegradedMessage({ received: 1, expected: 2, droppedAgents: ['agent,comma'] });
+    const parsed = parseCoverageDegradedMessage(msg);
+    // The comma in the agent id splits into two entries — known behavior.
+    expect(parsed).toBeDefined();
+    expect(parsed!.received).toBe(1);
+    expect(parsed!.expected).toBe(2);
+    expect(parsed!.droppedAgents).toEqual(['agent', 'comma']);
+  });
+
+  it('handles an agent id containing a parenthesis — greedy last-paren parse', () => {
+    // The parse is greedy to the LAST ')' so an agent id containing '(' does
+    // not prematurely end the dropped list.
+    const msg = 'Coverage degraded: 1/2 agents returned content (dropped: agent(v2))';
+    const parsed = parseCoverageDegradedMessage(msg);
+    expect(parsed).toBeDefined();
+    expect(parsed!.droppedAgents).toContain('agent(v2)');
+  });
+});

--- a/tests/orchestrator/round-context-producers.test.ts
+++ b/tests/orchestrator/round-context-producers.test.ts
@@ -19,7 +19,6 @@
  */
 import {
   ConsensusEngine,
-  type ConsensusEngineConfig,
 } from '../../packages/orchestrator/src/consensus-engine';
 import { makeRoundContext } from '../../packages/orchestrator/src/round-context';
 import type { TaskEntry } from '../../packages/orchestrator/src/types';
@@ -60,11 +59,11 @@ describe('PR-B producer conversions — dual-write warning + legacy field', () =
   });
   afterEach(() => rmSync(tmp, { recursive: true, force: true }));
 
-  it('cross_review_skipped: emits one warning per skipped agent AND keeps report.relayCrossReviewSkipped', async () => {
+  it('cross_review_skipped: emits one warning per skipped agent AND legacy report.relayCrossReviewSkipped is absent (warnings-channel sole carrier)', async () => {
     const round = makeRoundContext({ resolutionRoots: [], warnings: [] });
     const engine = new ConsensusEngine({
       llm: makeLlm(), registryGet: () => undefined, projectRoot: root, round,
-    } as ConsensusEngineConfig);
+    });
 
     const skipped = [
       { agentId: 'gemini-reviewer', reason: 'quota exhausted' },
@@ -89,11 +88,11 @@ describe('PR-B producer conversions — dual-write warning + legacy field', () =
     expect(round.warnings.filter(w => w.code === 'cross_review_skipped')).toHaveLength(2);
   });
 
-  it('coverage_degraded: emits warning AND keeps report.coverageDegraded when an agent returns 0 chars', async () => {
+  it('coverage_degraded: emits warning via warnings-channel AND legacy report.coverageDegraded is absent (PR-C: warnings sole carrier)', async () => {
     const round = makeRoundContext({ resolutionRoots: [], warnings: [] });
     const engine = new ConsensusEngine({
       llm: makeLlm(), registryGet: () => undefined, projectRoot: root, round,
-    } as ConsensusEngineConfig);
+    });
 
     const dropped = { id: 't-x', agentId: 'agent-dropped', task: 'review', status: 'completed', result: '', startedAt: Date.now() } as TaskEntry;
     const report = await engine.synthesizeWithCrossReview(
@@ -112,7 +111,7 @@ describe('PR-B producer conversions — dual-write warning + legacy field', () =
     expect(cd[0].message).toContain('agent-dropped');
   });
 
-  it('partial_review: emits warning AND sets report.partialReview when fewer than K reviewers selected', async () => {
+  it('partial_review: emits warning via warnings-channel AND legacy report.partialReview is absent (PR-C: warnings sole carrier)', async () => {
     // runSelectedCrossReview requires a performanceReader. Two agents → K=2 for
     // each non-critical finding, but with only 2 candidates a reviewer cannot
     // review its own finding, so coverage falls short of K → partialReview.
@@ -121,7 +120,7 @@ describe('PR-B producer conversions — dual-write warning + legacy field', () =
     const engine = new ConsensusEngine({
       llm: makeLlm(), registryGet: () => undefined, projectRoot: root, round,
       performanceReader: perfReader,
-    } as ConsensusEngineConfig);
+    });
 
     const report = await engine.runSelectedCrossReview(
       [
@@ -152,7 +151,7 @@ describe('PR-B producer conversions — dual-write warning + legacy field', () =
     const round = makeRoundContext({ resolutionRoots: [wt], warnings: [] });
     const engine = new ConsensusEngine({
       llm: makeLlm(), registryGet: () => undefined, projectRoot: proj, round,
-    } as ConsensusEngineConfig);
+    });
 
     // dispatchCrossReview generates prompts that resolve the cite anchors.
     await engine.generateCrossReviewPrompts([

--- a/tests/orchestrator/round-context-producers.test.ts
+++ b/tests/orchestrator/round-context-producers.test.ts
@@ -2,12 +2,12 @@
  * PR-B fail-loud PRODUCER conversion + timeout-synthesis seam tests
  * (spec 2026-06-11-round-context-fail-loud.md §4/§5/§6.2, consensus 5e9804d3-91fe440d).
  *
- * Each degraded-mode producer must DUAL-WRITE: emit the structured RoundWarning
- * on the round AND keep the legacy ConsensusReport field populated (PR-C deletes
- * the legacy fields, not PR-B). These tests pin both halves:
- *   - cross_review_skipped  ↔ report.relayCrossReviewSkipped
- *   - coverage_degraded     ↔ report.coverageDegraded
- *   - partial_review        ↔ report.partialReview
+ * PR-C deleted the legacy ConsensusReport degraded-mode trio; the warnings
+ * channel is now the SOLE carrier. These tests pin that each producer emits the
+ * structured RoundWarning AND that the deleted legacy field is absent:
+ *   - cross_review_skipped  (was report.relayCrossReviewSkipped)
+ *   - coverage_degraded     (was report.coverageDegraded)
+ *   - partial_review        (was report.partialReview)
  *   - anchor_master_fallback (new structured producer alongside the via= note)
  *
  * Plus the DIRECT timeout-synthesis seam (§5): the timeout path constructs a
@@ -77,8 +77,9 @@ describe('PR-B producer conversions — dual-write warning + legacy field', () =
       skipped,
     );
 
-    // Legacy field intact (dual-write — PR-C deletes it, not PR-B).
-    expect(report.relayCrossReviewSkipped).toEqual(skipped);
+    // PR-C: the legacy report.relayCrossReviewSkipped field is GONE — the
+    // warnings channel is the sole carrier.
+    expect((report as unknown as { relayCrossReviewSkipped?: unknown }).relayCrossReviewSkipped).toBeUndefined();
     // Structured warnings: one per skipped agent, code + agentId attribution.
     const crw = (report.warnings ?? []).filter(w => w.code === 'cross_review_skipped');
     expect(crw).toHaveLength(2);
@@ -102,11 +103,13 @@ describe('PR-B producer conversions — dual-write warning + legacy field', () =
       undefined,
     );
 
-    expect(report.coverageDegraded).toBeDefined();
-    expect(report.coverageDegraded!.droppedAgents).toContain('agent-dropped');
+    // PR-C: the legacy report.coverageDegraded field is GONE — the warning
+    // message carries the structured drop info (dropped-agent list inline).
+    expect((report as unknown as { coverageDegraded?: unknown }).coverageDegraded).toBeUndefined();
     const cd = (report.warnings ?? []).filter(w => w.code === 'coverage_degraded');
     expect(cd).toHaveLength(1);
     expect(cd[0].message).toContain('Coverage degraded');
+    expect(cd[0].message).toContain('agent-dropped');
   });
 
   it('partial_review: emits warning AND sets report.partialReview when fewer than K reviewers selected', async () => {
@@ -128,7 +131,9 @@ describe('PR-B producer conversions — dual-write warning + legacy field', () =
       'feedface-deadbeef',
     );
 
-    expect(report.partialReview).toBe(true);
+    // PR-C: the legacy report.partialReview field is GONE — the warning is
+    // the sole signal.
+    expect((report as unknown as { partialReview?: unknown }).partialReview).toBeUndefined();
     const pr = (report.warnings ?? []).filter(w => w.code === 'partial_review');
     expect(pr).toHaveLength(1);
   });
@@ -162,54 +167,10 @@ describe('PR-B producer conversions — dual-write warning + legacy field', () =
   });
 });
 
-describe('(§5) DIRECT timeout-synthesis seam — snapshot carries round roots into synthesizeWithCrossReview', () => {
-  let tmp: string;
-  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'rcp-tmo-')); });
-  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
-
-  it('the round\'s worktree root reaches anchor CONTENT in cross-review prompts via the timeout-path engine construction', async () => {
-    // Faithfully reproduce the relay-cross-review.ts:72 timeout-synthesis engine
-    // construction: a snapshot.roundContext (NOT the resume path) is forwarded
-    // as `round` to a freshly-constructed ConsensusEngine. Assert the worktree
-    // copy of a cited file reaches the prompt content — the boundary value
-    // (round.resolutionRoots) is observable in the FINAL artifact, not just the
-    // config. This is the distinct construction the resume path does not exercise.
-    const proj = realpathSync(mkdtempSync(join(tmp, 'proj')));
-    const wt = realpathSync(mkdtempSync(join(tmp, 'wt')));
-    mkdirSync(join(proj, 'src'), { recursive: true });
-    mkdirSync(join(wt, 'src'), { recursive: true });
-    writeFileSync(join(proj, 'src', 'target.ts'), 'export const v = "master-HEAD";');
-    writeFileSync(join(wt, 'src', 'target.ts'), 'export const v = "worktree-branch";');
-
-    // Snapshot exactly as the timeout watcher builds it.
-    const snapshot = {
-      roundContext: makeRoundContext({ resolutionRoots: [wt], consensusId: 'cafef00d-feedface' }),
-    };
-
-    // The timeout path constructs the engine with `round: snapshot.roundContext`.
-    const engine = new ConsensusEngine({
-      llm: makeLlm(),
-      registryGet: () => undefined,
-      projectRoot: proj,
-      round: snapshot.roundContext,
-    } as ConsensusEngineConfig);
-
-    const results = [
-      completed('agent-a', finding('Issue A <cite tag="file">src/target.ts:1</cite>')),
-      completed('agent-b', finding('Issue B <cite tag="file">src/target.ts:1</cite>')),
-    ];
-
-    // generateCrossReviewPrompts is where anchors are resolved against the
-    // round's roots and embedded as <anchor> snippet CONTENT in the prompts.
-    const { prompts } = await engine.generateCrossReviewPrompts(results);
-    // synthesizeWithCrossReview is the distinct timeout-path call.
-    const report = await engine.synthesizeWithCrossReview(results, [], 'cafef00d-feedface', undefined);
-
-    expect(report).toBeDefined();
-    const all = prompts.map(p => `${p.system}\n${p.user}`).join('\n');
-    // The cited file exists in BOTH roots with distinct content — the prompts
-    // built by the timeout-path engine must carry the WORKTREE version.
-    expect(all).toContain('worktree-branch');
-    expect(all).not.toContain('master-HEAD');
-  });
-});
+// (§5) DIRECT timeout-synthesis seam MOVED to tests/cli/timeout-synthesis-seam.test.ts
+// (f8 follow-up). The previous block here REPRODUCED the timeout-path engine
+// construction inline. It now drives the REAL exported core
+// (apps/cli/src/handlers/relay-cross-review.ts → synthesizeTimeoutRound), so the
+// genuine outer layer feeds the genuine inner layer and the boundary value
+// (round.resolutionRoots → anchor CONTENT) is observed in the final artifact —
+// the true Test 21 pattern, not a hand-rebuilt copy.

--- a/tests/orchestrator/round-context-seams.test.ts
+++ b/tests/orchestrator/round-context-seams.test.ts
@@ -141,28 +141,27 @@ describe('(a/e/g) coordinator.runConsensus alias-mode threading', () => {
     await coordinator.runConsensus([completed('relay-a'), completed('relay-b')], round);
 
     expect(engineConfigs).toHaveLength(1);
+    // PR-C: the engine REQUIRES a round; the passed RoundContext is forwarded
+    // whole as `round`. There is no loose `resolutionRoots` config field.
     expect(engineConfigs[0].round).toBe(round);
-    // Round wins → the loose resolutionRoots field is NOT set in alias mode.
-    expect(engineConfigs[0].resolutionRoots).toBeUndefined();
+    expect((engineConfigs[0] as { resolutionRoots?: unknown }).resolutionRoots).toBeUndefined();
   });
 
-  it('(e) a round arg WINS over the constructor default round', async () => {
-    const ctorRound = makeRoundContext({ resolutionRoots: [realpathSync(mkdtempSync(join(tmp, 'ctor')))] });
-    const perRoundRound = makeRoundContext({ resolutionRoots: [realpathSync(mkdtempSync(join(tmp, 'round')))] });
+  it('(e) no per-round arg → a fresh empty round is built (no constructor default exists)', async () => {
+    // PR-C deleted the coordinator constructor `round` default. With no
+    // per-round arg, runConsensus builds an empty makeRoundContext().
     const coordinator = new ConsensusCoordinator({
       llm: makeLlm(), registryGet: () => undefined, projectRoot: root, keyProvider: null,
-      round: ctorRound,
     });
 
-    await coordinator.runConsensus([completed('relay-a'), completed('relay-b')], perRoundRound);
-    expect(engineConfigs[engineConfigs.length - 1].round).toBe(perRoundRound);
-
-    // No per-round arg → constructor default round is used.
     await coordinator.runConsensus([completed('relay-a'), completed('relay-b')]);
-    expect(engineConfigs[engineConfigs.length - 1].round).toBe(ctorRound);
+    const cfg = engineConfigs[engineConfigs.length - 1];
+    expect(cfg.round).toBeDefined();
+    expect(cfg.round!.resolutionRoots).toEqual([]);
+    expect(cfg.round!.warnings).toEqual([]);
   });
 
-  it('(g) legacy mode: no round, loose roots arg → engine gets resolutionRoots, no round (byte-identical)', async () => {
+  it('(g) a loose roots arg is wrapped into round.resolutionRoots (no loose config field)', async () => {
     const wt = realpathSync(mkdtempSync(join(tmp, 'legacy')));
     const coordinator = new ConsensusCoordinator({
       llm: makeLlm(), registryGet: () => undefined, projectRoot: root, keyProvider: null,
@@ -170,8 +169,9 @@ describe('(a/e/g) coordinator.runConsensus alias-mode threading', () => {
 
     await coordinator.runConsensus([completed('relay-a'), completed('relay-b')], [wt]);
 
-    expect(engineConfigs[0].round).toBeUndefined();
-    expect(engineConfigs[0].resolutionRoots).toEqual([wt]);
+    expect(engineConfigs[0].round).toBeDefined();
+    expect(engineConfigs[0].round!.resolutionRoots).toEqual([wt]);
+    expect((engineConfigs[0] as { resolutionRoots?: unknown }).resolutionRoots).toBeUndefined();
   });
 
   it('(d) round.warnings drain into the consensus report', async () => {
@@ -211,26 +211,29 @@ describe('(g) ConsensusEngine constructor — round-vs-legacy seeding parity', (
 
   afterEach(() => rmSync(tmp, { recursive: true, force: true }));
 
-  it('round.resolutionRoots seeds currentWorktreeRoots identically to loose resolutionRoots', () => {
+  it('round.resolutionRoots seeds currentWorktreeRoots from the required round', () => {
     // Use the REAL engine (the module mock above only swaps for the coordinator
     // import; here we requireActual to exercise the constructor seeding).
+    // PR-C: the loose `resolutionRoots` config field is gone — `round` is the
+    // single source. Seeding is driven entirely by round.resolutionRoots.
     const { ConsensusEngine: RealEngine } = jest.requireActual(
       '../../packages/orchestrator/src/consensus-engine',
     );
     const llm = makeLlm();
 
-    const viaLegacy = new RealEngine({
-      llm, registryGet: () => undefined, projectRoot: root, resolutionRoots: [wt],
-    });
     const viaRound = new RealEngine({
       llm, registryGet: () => undefined, projectRoot: root,
       round: makeRoundContext({ resolutionRoots: [wt] }),
     });
+    const emptyRound = new RealEngine({
+      llm, registryGet: () => undefined, projectRoot: root,
+      round: makeRoundContext({ resolutionRoots: [] }),
+    });
 
-    const legacyRoots: Set<string> = (viaLegacy as any).currentWorktreeRoots;
     const roundRoots: Set<string> = (viaRound as any).currentWorktreeRoots;
-    expect([...roundRoots].sort()).toEqual([...legacyRoots].sort());
     expect(roundRoots.has(wt)).toBe(true);
+    // Empty round → no seeded worktree roots (project-root-only).
+    expect((emptyRound as any).currentWorktreeRoots.size).toBe(0);
   });
 
   it('round path enforces the same absolute-path invariant (throws on relative)', () => {

--- a/tests/orchestrator/sibling-roots.test.ts
+++ b/tests/orchestrator/sibling-roots.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, mkdirSync, writeFileSync, realpathSync, symlinkSync } from 'fs';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import { tmpdir } from 'os';
 import { join, dirname } from 'path';
 import { execFileSync } from 'child_process';
@@ -135,7 +136,7 @@ describe('#520 integration — path-carrying cite into a sibling repo', () => {
     if (!accepted.valid) throw new Error('precondition');
     const eng = new ConsensusEngine({
       projectRoot: root,
-      resolutionRoots: [accepted.canonical],
+      round: testRound({ resolutionRoots: [accepted.canonical] }),
       registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: id, skills: [] }),
     } as any);
     const resolved = await (eng as any).resolveFilePath('services/core/handler.ts');
@@ -145,6 +146,8 @@ describe('#520 integration — path-carrying cite into a sibling repo', () => {
     const engNoRoot = new ConsensusEngine({
       projectRoot: root,
       registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: id, skills: [] }),
+
+      round: testRound(),
     } as any);
     const unresolved = await (engNoRoot as any).resolveFilePath('services/core/handler.ts');
     expect(unresolved).toBeNull();

--- a/tests/orchestrator/skill-catalog.test.ts
+++ b/tests/orchestrator/skill-catalog.test.ts
@@ -46,6 +46,61 @@ describe('SkillCatalog', () => {
     const issues = catalog.validate();
     expect(issues).toEqual([]);
   });
+
+  // Regression: coverage-gap detector single-source-of-truth
+  // (project_coverage_gap_detector_config_vs_index, CONFIRMED 2026-06-11).
+  // checkCoverage must receive the SAME effective skill set the prompt builder
+  // injects — index-precedence, not the raw config.json list. A skill enabled
+  // in the index but absent from the config list WAS injected, so it must NOT
+  // produce a false "skill may be relevant but is not assigned" warning.
+  it('no coverage warning for a skill enabled in the index but absent from the config list', () => {
+    const { SkillIndex } = require('../../packages/orchestrator/src/skill-index');
+    const { resolveEffectiveSkills } = require('../../packages/orchestrator/src/skill-loader');
+    const dir = join(tmpdir(), `gossip-coverage-single-source-${Date.now()}`);
+    mkdirSync(join(dir, '.gossip'), { recursive: true });
+    try {
+      const index = new SkillIndex(dir);
+      // security-audit is bound in the INDEX but NOT in the config list below.
+      index.bind('agent-x', 'security-audit', { source: 'auto', mode: 'contextual' });
+
+      const configSkills = ['code-review']; // does NOT list security-audit
+      const effective = resolveEffectiveSkills('agent-x', configSkills, index);
+      // Index has slots → effective set is the index-enabled list.
+      expect(effective).toContain('security-audit');
+
+      // Feeding the EFFECTIVE set (the fix) yields no false warning.
+      const warnEffective = catalog.checkCoverage(
+        effective,
+        'review this code for security vulnerabilities and injection attacks',
+      );
+      expect(warnEffective.some(w => w.includes('security-audit'))).toBe(false);
+
+      // Feeding the raw CONFIG list (the bug) WOULD have produced the false
+      // warning — pin that the difference is real, not vacuous.
+      const warnConfig = catalog.checkCoverage(
+        configSkills,
+        'review this code for security vulnerabilities and injection attacks',
+      );
+      expect(warnConfig.some(w => w.includes('security-audit'))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('resolveEffectiveSkills falls back to the config list when the index has no slots', () => {
+    const { SkillIndex } = require('../../packages/orchestrator/src/skill-index');
+    const { resolveEffectiveSkills } = require('../../packages/orchestrator/src/skill-loader');
+    const dir = join(tmpdir(), `gossip-coverage-fallback-${Date.now()}`);
+    mkdirSync(join(dir, '.gossip'), { recursive: true });
+    try {
+      const index = new SkillIndex(dir); // no binds → no slots for agent-y
+      expect(resolveEffectiveSkills('agent-y', ['code-review'], index)).toEqual(['code-review']);
+      // No index at all → config list.
+      expect(resolveEffectiveSkills('agent-y', ['debugging'], undefined)).toEqual(['debugging']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('SkillCatalog with project skills', () => {

--- a/tests/orchestrator/verified-finding-chaining.test.ts
+++ b/tests/orchestrator/verified-finding-chaining.test.ts
@@ -1,4 +1,5 @@
 import { getRuntimeFlagBool } from '../../packages/orchestrator/src/runtime-config';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import { RUNTIME_FLAG_REGISTRY } from '../../packages/orchestrator/src/runtime-config-schema';
 import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
 import { TaskEntry } from '../../packages/orchestrator/src/types';
@@ -8,7 +9,9 @@ const makeTask = (agentId: string, result: string): TaskEntry => ({
   startedAt: 1, completedAt: 2, inputTokens: 0, outputTokens: 0,
 });
 
-const engine = () => new ConsensusEngine({} as any);
+const engine = () => new ConsensusEngine({
+  round: testRound(),
+} as any);
 
 describe('GOSSIP_VERIFIED_CHAINING flag', () => {
   it('is registered and defaults to off', () => {
@@ -49,6 +52,8 @@ describe('synthesize — NEW entry verification + field carry', () => {
     const eng = new ConsensusEngine({
       llm: { generate: jest.fn() } as any,
       registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: id, skills: [] }),
+
+      round: testRound(),
     } as any);
     const results = [makeTask('a', 'x'), makeTask('b', 'y')];
     const entries = [{
@@ -67,6 +72,8 @@ describe('synthesize — NEW entry verification + field carry', () => {
     const eng = new ConsensusEngine({
       llm: { generate: jest.fn() } as any,
       registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: id, skills: [] }),
+
+      round: testRound(),
     } as any);
     (eng as any).verifyCitations = jest.fn().mockResolvedValue(true);
     const results = [makeTask('a', 'x'), makeTask('b', 'y')];
@@ -89,6 +96,8 @@ describe('cross-review prompt — chaining solicitation', () => {
     else delete process.env.GOSSIP_VERIFIED_CHAINING;
     const eng = new ConsensusEngine({
       registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: id, skills: [] }),
+
+      round: testRound(),
     } as any);
     const results = [
       makeTask('a', '<agent_finding type="finding" severity="high">SQL inj at db.ts:42</agent_finding>'),
@@ -117,6 +126,8 @@ describe('formatReport — chain rendering', () => {
     const eng = new ConsensusEngine({
       llm: { generate: jest.fn() } as any,
       registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: id, skills: [] }),
+
+      round: testRound(),
     } as any);
     const results = [makeTask('a', 'x'), makeTask('b', 'y')];
     const entries = [{
@@ -134,6 +145,8 @@ describe('synthesize — chained extension does not mutate parent', () => {
     const eng = new ConsensusEngine({
       llm: { generate: jest.fn() } as any,
       registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: id, skills: [] }),
+
+      round: testRound(),
     } as any);
     // agent 'a' emits a real low-severity finding so it lands in the report
     const results = [
@@ -166,6 +179,8 @@ describe('synthesize — chaining metric', () => {
       const eng = new ConsensusEngine({
         llm: { generate: jest.fn() } as any,
         registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: id, skills: [] }),
+
+        round: testRound(),
       } as any);
       const results = [makeTask('a', 'x'), makeTask('b', 'y')];
       const entries = [{

--- a/tests/orchestrator/verify-citations.test.ts
+++ b/tests/orchestrator/verify-citations.test.ts
@@ -1,4 +1,5 @@
 import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 
 describe('verifyCitations — I/O error handling', () => {
   it('returns false on I/O read error (benefit of doubt)', async () => {
@@ -6,6 +7,8 @@ describe('verifyCitations — I/O error handling', () => {
       llm: { generate: async () => '' } as any,
       registryGet: () => undefined,
       projectRoot: '/nonexistent/path/that/triggers/io/error',
+
+      round: testRound(),
     });
     const result = await (engine as any).verifyCitations('Found bug at real-file.ts:999');
     expect(result).toBe(false);

--- a/tests/orchestrator/zero-tag-agents.test.ts
+++ b/tests/orchestrator/zero-tag-agents.test.ts
@@ -1,10 +1,12 @@
 import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
+import { testRound } from '../../packages/orchestrator/src/round-context';
 import { TaskEntry } from '../../packages/orchestrator/src/types';
 
 // Minimal engine config so formatReport's registryGet call doesn't throw.
 const makeEngine = () => new ConsensusEngine({
   llm: { generate: jest.fn() } as any,
   registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: `preset-${id}`, skills: [] }),
+  round: testRound(),
 } as any);
 
 const makeTask = (agentId: string, result: string): TaskEntry => ({

--- a/tests/relay/coverage-degraded-flow.test.ts
+++ b/tests/relay/coverage-degraded-flow.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Integration test: consensusFlowHandler correctly parses coverage_degraded
+ * warnings from a PR-C style report (no legacy coverageDegraded field, only
+ * the warnings array) and from a legacy report (coverageDegraded field only).
+ *
+ * Purpose: any template drift between buildCoverageDegradedMessage and the
+ * parser used in consensusFlowHandler breaks this test before it breaks the
+ * dashboard CoverageDegradedChip.
+ *
+ * consensus 1f50d89d-c28f49c4:fable-reviewer:f2
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { consensusFlowHandler } from '../../packages/relay/src/dashboard/api-consensus-flow';
+import { buildCoverageDegradedMessage } from '../../packages/orchestrator/src/coverage-degraded';
+
+function makeProjectRoot(): string {
+  const tmp = mkdtempSync(join(tmpdir(), 'cf-test-'));
+  mkdirSync(join(tmp, '.gossip', 'consensus-reports'), { recursive: true });
+  return tmp;
+}
+
+function writeReport(root: string, consensusId: string, report: object): void {
+  writeFileSync(
+    join(root, '.gossip', 'consensus-reports', `${consensusId}.json`),
+    JSON.stringify(report),
+  );
+}
+
+const VALID_ID = 'aabbccdd-11223344';
+
+describe('consensusFlowHandler — coverage_degraded parsing from warning message (PR-C path)', () => {
+  let root: string;
+  beforeEach(() => { root = makeProjectRoot(); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('parses coverageDegraded from the warnings channel when legacy field is absent', () => {
+    const droppedAgents = ['gemini-tester'];
+    const msg = buildCoverageDegradedMessage({ received: 2, expected: 3, droppedAgents });
+    writeReport(root, VALID_ID, {
+      consensusId: VALID_ID,
+      timestamp: '2026-06-11T00:00:00.000Z',
+      agentCount: 3,
+      confirmed: [],
+      disputed: [],
+      unverified: [],
+      unique: [],
+      newFindings: [],
+      warnings: [{ code: 'coverage_degraded', message: msg }],
+    });
+
+    const result = consensusFlowHandler(root, new URLSearchParams({ consensusId: VALID_ID }));
+    expect('error' in result).toBe(false);
+    const response = result as Exclude<typeof result, { error: string }>;
+    expect(response.coverageDegraded).toEqual({ received: 2, expected: 3, droppedAgents });
+  });
+
+  it('reads coverageDegraded directly from legacy field when no warnings array', () => {
+    const legacyCd = { expected: 3, received: 1, droppedAgents: ['a', 'b'] };
+    writeReport(root, VALID_ID, {
+      consensusId: VALID_ID,
+      timestamp: '2026-06-11T00:00:00.000Z',
+      agentCount: 3,
+      confirmed: [],
+      disputed: [],
+      unverified: [],
+      unique: [],
+      newFindings: [],
+      coverageDegraded: legacyCd,
+    });
+
+    const result = consensusFlowHandler(root, new URLSearchParams({ consensusId: VALID_ID }));
+    const response = result as Exclude<typeof result, { error: string }>;
+    expect(response.coverageDegraded).toEqual(legacyCd);
+  });
+
+  it('returns no coverageDegraded when neither field nor warning is present', () => {
+    writeReport(root, VALID_ID, {
+      consensusId: VALID_ID,
+      timestamp: '2026-06-11T00:00:00.000Z',
+      agentCount: 2,
+      confirmed: [],
+      disputed: [],
+      unverified: [],
+      unique: [],
+      newFindings: [],
+      warnings: [{ code: 'roots_rejected', message: 'x' }],
+    });
+
+    const result = consensusFlowHandler(root, new URLSearchParams({ consensusId: VALID_ID }));
+    const response = result as Exclude<typeof result, { error: string }>;
+    expect(response.coverageDegraded).toBeUndefined();
+  });
+
+  it('round-trips a coverage_degraded warning with a comma-containing agent id', () => {
+    // Agents with commas in IDs are outside our naming scheme, but parse must
+    // not throw — it just splits on comma, which is acceptable behavior.
+    const msg = buildCoverageDegradedMessage({ received: 1, expected: 2, droppedAgents: ['agent-with,comma'] });
+    writeReport(root, VALID_ID, {
+      consensusId: VALID_ID,
+      timestamp: '2026-06-11T00:00:00.000Z',
+      agentCount: 2,
+      confirmed: [],
+      disputed: [],
+      unverified: [],
+      unique: [],
+      newFindings: [],
+      warnings: [{ code: 'coverage_degraded', message: msg }],
+    });
+
+    const result = consensusFlowHandler(root, new URLSearchParams({ consensusId: VALID_ID }));
+    expect('error' in result).toBe(false);
+    const response = result as Exclude<typeof result, { error: string }>;
+    // Comma in agent id splits — coverageDegraded is still populated (no crash).
+    expect(response.coverageDegraded).toBeDefined();
+    expect(response.coverageDegraded!.received).toBe(1);
+    expect(response.coverageDegraded!.expected).toBe(2);
+  });
+});

--- a/tests/relay/legacy-degraded-fields-mapping.test.ts
+++ b/tests/relay/legacy-degraded-fields-mapping.test.ts
@@ -1,0 +1,74 @@
+/**
+ * PR-C disk back-compat: consensus reports persisted by older versions carry the
+ * deprecated degraded-mode trio (relayCrossReviewSkipped / coverageDegraded /
+ * partialReview) but NO `warnings` array. The dashboard read path maps those to
+ * synthetic RoundWarnings at READ time so historical rounds still render their
+ * degraded modes (spec §4 — the warnings channel subsumes the trio). New reports
+ * (carrying `warnings`) pass through untouched.
+ */
+import { normalizeLegacyDegradedFields } from '../../packages/relay/src/dashboard/routes';
+
+describe('normalizeLegacyDegradedFields — legacy trio → synthetic warnings', () => {
+  it('maps coverageDegraded → coverage_degraded warning with counts + dropped agents', () => {
+    const out = normalizeLegacyDegradedFields({
+      id: 'r1',
+      coverageDegraded: { expected: 3, received: 2, droppedAgents: ['gemini-tester'] },
+    });
+    const cd = (out.warnings ?? []).filter((w: any) => w.code === 'coverage_degraded');
+    expect(cd).toHaveLength(1);
+    expect(cd[0].message).toContain('2/3');
+    expect(cd[0].message).toContain('gemini-tester');
+  });
+
+  it('maps relayCrossReviewSkipped → one cross_review_skipped warning per agent (attributed)', () => {
+    const out = normalizeLegacyDegradedFields({
+      id: 'r2',
+      relayCrossReviewSkipped: [
+        { agentId: 'gemini-reviewer', reason: 'quota exhausted' },
+        { agentId: 'gemini-tester', reason: 'parser produced 0 entries' },
+      ],
+    });
+    const crw = (out.warnings ?? []).filter((w: any) => w.code === 'cross_review_skipped');
+    expect(crw).toHaveLength(2);
+    expect(crw.map((w: any) => w.agentId).sort()).toEqual(['gemini-reviewer', 'gemini-tester']);
+    expect(crw[0].message).toContain('quota exhausted');
+  });
+
+  it('maps partialReview:true → partial_review warning', () => {
+    const out = normalizeLegacyDegradedFields({ id: 'r3', partialReview: true });
+    expect((out.warnings ?? []).some((w: any) => w.code === 'partial_review')).toBe(true);
+  });
+
+  it('maps all three trio fields together', () => {
+    const out = normalizeLegacyDegradedFields({
+      id: 'r4',
+      coverageDegraded: { expected: 2, received: 1, droppedAgents: ['a'] },
+      relayCrossReviewSkipped: [{ agentId: 'b', reason: 'network' }],
+      partialReview: true,
+    });
+    const codes = (out.warnings ?? []).map((w: any) => w.code).sort();
+    expect(codes).toEqual(['coverage_degraded', 'cross_review_skipped', 'partial_review']);
+  });
+
+  it('does NOT clobber a report that already carries warnings (new PR-C reports)', () => {
+    const existing = [{ code: 'roots_rejected', message: 'x' }];
+    const out = normalizeLegacyDegradedFields({
+      id: 'r5',
+      warnings: existing,
+      // even if a stray legacy field is present, the existing warnings win
+      partialReview: true,
+    });
+    expect(out.warnings).toBe(existing);
+    expect(out.warnings).toHaveLength(1);
+  });
+
+  it('leaves a clean report (no trio, no warnings) untouched — does not crash', () => {
+    const report = { id: 'r6', confirmed: [], disputed: [] };
+    expect(normalizeLegacyDegradedFields(report)).toBe(report);
+  });
+
+  it('tolerates malformed input without throwing', () => {
+    expect(normalizeLegacyDegradedFields(null)).toBeNull();
+    expect(() => normalizeLegacyDegradedFields({ relayCrossReviewSkipped: 'not-an-array' })).not.toThrow();
+  });
+});


### PR DESCRIPTION
PR-C — final installment of the round-context fail-loud spec (2026-06-11 rev 2, spec consensus 5e9804d3-91fe440d). PR-A (#543) introduced the RoundContext carrier + drains; PR-B (#544) converted the producers. This PR deletes the deprecated aliases and subsumed legacy fields, makes the round field a compile-time requirement, and closes the single-source-of-truth items.

consensus-id: 1f50d89d-c28f49c4

## What's in here

**Required round field (spec §3.3):** `ConsensusEngineConfig.round: RoundContext` is now required — a new code path constructing a ConsensusEngine without a RoundContext is a compile error, killing door #6 before it exists. Deleted: the `resolutionRoots` config alias, the ConsensusCoordinator boot-time constructor default (consensus-verified production-dead), and the loose round-record write field. The old-flat-shape disk **read** back-compat stays.

**Subsumed trio deletion:** `relayCrossReviewSkipped` / `coverageDegraded` / `partialReview` removed from `ConsensusReport`; producers are warnings-only. Old persisted reports map their trio fields to synthetic warnings at read time (`routes.ts:normalizeLegacyDegradedFields`); `api-consensus-flow.ts` reads warnings-first with legacy fallback. CLI refs that remain are the round-record **feeders** carrying skipped-agent data into synthesis — the warning source, not the deleted field (adversarially trace-verified).

**testRound() migration:** 95 construction sites across 20 test files migrated to the fixture (the spec's 104 estimate counted shared-config reuse); 13 `as ConsensusEngineConfig` casts removed so the compile door isn't propped open in tests.

**Coverage-gap detector single-source fix:** new `resolveEffectiveSkills()` in `skill-loader.ts` feeds both `loadSkills` and `checkCoverage` — ends the false "skill may be relevant but is not assigned" warnings for index-bound skills (the config-vs-index bug that misled an external user). Regression-tested.

**Consensus follow-ups from PR-B's round:** `dispatch_warnings_lost` instrumentation (persisted `dispatchWarningsStashed` marker; stash loss on reconnect is now itself fail-loud), and the timeout-synthesis seam test now drives the real extracted `synthesizeTimeoutRound()` instead of reproducing its logic.

## Pre-merge consensus

Round `1f50d89d-c28f49c4` (gemini-reviewer, gemini-tester, fable-reviewer): 10 verified findings, 0 disputed. deepseek-challenger's leg crashed (relay output-capture bug, 4th occurrence — tracked in backlog) and was re-run on fable-reviewer, which upheld all three implementer spec deviations with full data-flow traces and found two real MEDIUMs, both fixed in `3a37b6d0`:
- `dispatch_warnings_lost` was blind to tasks completing before reconnect (marker died with the task entry) — marker now survives on the result record + persisted slimResults; loss message made cause-neutral.
- The coverage-degraded message format existed in 3 unpinned copies with zero handler tests — now a shared `build`/`parse` pair with a cross-package round-trip CI gate (orchestrator builder → relay handler parser), including comma/paren agent-id edge cases.

One gemini-reviewer finding was retracted as a hallucination (claimed the dashboard report type still carried the trio; the cited fields are on the intentionally-kept derived `ConsensusFlowResponse`).

**Known wart (deliberate):** `packages/relay/src/dashboard/coverage-degraded-utils.ts` duplicates the orchestrator build/parse pair because worktree `node_modules` symlinks resolve to the root-branch dist. The round-trip test pins the two copies together (drift fails CI). Post-merge follow-up: switch relay to import `@gossip/orchestrator` and delete the local copy.

## Verification

- Full `npm run build` (all packages) + `build:mcp` + `build:dashboard`: green
- `npx tsc --noEmit`: zero non-dashboard errors (dashboard-v2 vite-alias noise pre-existing on master)
- jest `tests/cli` + `tests/orchestrator` + `tests/relay`: 274 suites, 3710 passed, 0 failures (orchestrator-verified independently of the implementer run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)