### PR TITLE
fix(dashboard): surface fetch errors, harden /consensus against torn JSONL, add fetch timeout (#547)

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -502,7 +502,7 @@ function FindingsPage({
 
 function Dashboard() {
   const route = useRoute();
-  const { overview, agents, tasks, consensus, consensusReports, fleetTrend, signalActivity, skills, loading, refresh } = useDashboardData();
+  const { overview, agents, tasks, consensus, consensusReports, fleetTrend, signalActivity, skills, loading, error, refresh } = useDashboardData();
   const [activeTaskCount, setActiveTaskCount] = useState(0);
 
   const handleWsEvent = useCallback((event: DashboardEvent) => {
@@ -511,6 +511,34 @@ function Dashboard() {
   }, [refresh]);
 
   useWebSocket(handleWsEvent);
+
+  // Error state: a core fetch failed (e.g. "overview: HTTP 500"). We still
+  // lack gate data, so we can't render the dashboard — but we must NOT keep
+  // showing the indefinite spinner. Show the error with a retry hint so the
+  // user knows why they're blocked and that recovery is automatic.
+  if (!loading && error && (!overview || !consensus)) {
+    return (
+      <div className="min-h-screen" style={{ background: 'var(--surface)' }}>
+        <TopBar />
+        <div className="flex items-center justify-center py-20">
+          <div
+            className="w-full max-w-sm rounded-xl border p-8 text-center"
+            style={{ borderColor: 'var(--border)', background: 'var(--surface-elev)' }}
+          >
+            <p className="mb-2 text-sm font-semibold" style={{ color: 'var(--bad)' }}>
+              Dashboard fetch failed
+            </p>
+            <p className="mb-4 font-mono text-xs" style={{ color: 'var(--bad)' }}>
+              {error}
+            </p>
+            <p className="text-xs" style={{ color: 'var(--ink-3)' }}>
+              Relay may be restarting — retrying every 5s. Check the relay terminal if this persists.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (loading || !overview || !consensus) {
     return (

--- a/packages/dashboard-v2/src/hooks/useDashboardData.ts
+++ b/packages/dashboard-v2/src/hooks/useDashboardData.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { api } from '@/lib/api';
+import { formatFetchError } from '@/lib/fetchError';
 import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, MemoryFile, FleetTrendResponse, SignalActivityResponse } from '@/lib/types';
 import type { SkillsApiResponse } from '@gossip/types';
 
@@ -56,6 +57,25 @@ export interface DashboardState {
   error: string | null;
 }
 
+/**
+ * Wraps an api() call with an endpoint label so that when Promise.all rejects,
+ * the error message names the failing endpoint and HTTP status (e.g.
+ * "overview: HTTP 500", "consensus: network error") instead of a bare
+ * "Failed to fetch" that gives the user zero diagnostic context.
+ *
+ * Only used for the core endpoints that do NOT have .catch() fallbacks — the
+ * optional endpoints (fleet-trend, skills, etc.) already swallow their errors
+ * and return safe defaults.
+ */
+async function namedFetch<T>(endpoint: string, path: string): Promise<T> {
+  try {
+    return await api<T>(path);
+  } catch (err) {
+    const raw = err instanceof Error ? err.message : String(err);
+    throw new Error(formatFetchError(endpoint, raw));
+  }
+}
+
 export function useDashboardData() {
   const [state, setState] = useState<DashboardState>({
     overview: null, agents: null, tasks: null, consensus: null, consensusReports: null,
@@ -76,13 +96,15 @@ export function useDashboardData() {
     inFlight.current = true;
     try {
       const [overview, agents, tasks, consensus, consensusReports, fleetTrend, signalActivity, skills, nativeResp, gossipResp] = await Promise.all([
-        api<OverviewData>('overview'),
-        api<AgentData[]>('agents'),
-        api<TasksData>('tasks?limit=2000'),
+        // Core endpoints: no .catch() — a failure here rejects the whole Promise.all
+        // so the catch block below can set error with a named-endpoint message.
+        namedFetch<OverviewData>('overview', 'overview'),
+        namedFetch<AgentData[]>('agents', 'agents'),
+        namedFetch<TasksData>('tasks', 'tasks?limit=2000'),
         // pageSize=50 matches api-consensus MAX_PAGE_SIZE so header aggregates
         // (confirmedTotal/disputedTotal/unverifiedTotal in App.tsx:383-385) cover
         // the full round history instead of the first 10 runs.
-        api<ConsensusData>('consensus?pageSize=500'),
+        namedFetch<ConsensusData>('consensus', 'consensus?pageSize=500'),
         // pageSize=200 (was 5) — Step 6 useSeverityCounts needs recent reports
         // to derive per-agent severity distributions for the card gauge/strip.
         api<ConsensusReportsData>('consensus-reports?page=1&pageSize=200').catch(() => ({ reports: [] })),

--- a/packages/dashboard-v2/src/lib/api.ts
+++ b/packages/dashboard-v2/src/lib/api.ts
@@ -34,8 +34,11 @@ export async function api<T>(path: string, options?: RequestInit): Promise<T> {
   try {
     const res = await fetch(`${BASE}/${path}`, {
       credentials: 'include',
-      signal: timeoutSignal,
       ...options,
+      // After the spread so a caller-supplied options.signal can never
+      // silently disable the timeout (the hang class this guard closes).
+      // A future cancellable caller must compose via AbortSignal.any.
+      signal: timeoutSignal,
     });
     if (res.status === 401) throw new Error('unauthorized');
     if (!res.ok) throw new Error(`API error: ${res.status}`);

--- a/packages/dashboard-v2/src/lib/api.ts
+++ b/packages/dashboard-v2/src/lib/api.ts
@@ -1,13 +1,56 @@
 const BASE = '/dashboard/api';
 
+/** Default abort timeout for polled api() calls (milliseconds). */
+export const API_TIMEOUT_MS = 30_000;
+
+/**
+ * Returns a formatted timeout message used both by the abort handler and by
+ * tests that verify the message format. Exported so unit tests can assert the
+ * exact string that namedFetch will surface in the dashboard error card.
+ */
+export function timeoutMessage(ms: number): string {
+  return `timeout after ${ms / 1000}s`;
+}
+
+/**
+ * Builds an AbortSignal that fires after `ms` milliseconds.
+ * Prefers AbortSignal.timeout() (available in modern browsers + Node ≥17.3)
+ * and falls back to a manual AbortController + setTimeout pair.
+ */
+function makeTimeoutSignal(ms: number): { signal: AbortSignal; cleanup: () => void } {
+  if (typeof AbortSignal !== 'undefined' && typeof (AbortSignal as { timeout?: unknown }).timeout === 'function') {
+    return { signal: (AbortSignal as { timeout: (ms: number) => AbortSignal }).timeout(ms), cleanup: () => {} };
+  }
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(new Error(timeoutMessage(ms))), ms);
+  return {
+    signal: controller.signal,
+    cleanup: () => clearTimeout(id),
+  };
+}
+
 export async function api<T>(path: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(`${BASE}/${path}`, {
-    credentials: 'include',
-    ...options,
-  });
-  if (res.status === 401) throw new Error('unauthorized');
-  if (!res.ok) throw new Error(`API error: ${res.status}`);
-  return res.json();
+  const { signal: timeoutSignal, cleanup } = makeTimeoutSignal(API_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${BASE}/${path}`, {
+      credentials: 'include',
+      signal: timeoutSignal,
+      ...options,
+    });
+    if (res.status === 401) throw new Error('unauthorized');
+    if (!res.ok) throw new Error(`API error: ${res.status}`);
+    return res.json() as Promise<T>;
+  } catch (err) {
+    // Re-map AbortError / TimeoutError from the signal into a human-readable
+    // "timeout after Xs" message so namedFetch can label it with the endpoint
+    // name and the error card displays e.g. "consensus: timeout after 30s".
+    if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
+      throw new Error(timeoutMessage(API_TIMEOUT_MS));
+    }
+    throw err;
+  } finally {
+    cleanup();
+  }
 }
 
 export type LoginResult = { ok: true } | { ok: false; kind: 'bad_key' | 'network' };

--- a/packages/dashboard-v2/src/lib/fetchError.ts
+++ b/packages/dashboard-v2/src/lib/fetchError.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure error-formatting helpers for dashboard fetch diagnostics.
+ * No browser-API or React dependencies — safe to import in node test environments.
+ */
+
+/**
+ * Formats a raw fetch error into an actionable user-facing message that names
+ * the failing endpoint. Exported for unit testing.
+ *
+ * Examples:
+ *   formatFetchError('overview', 'API error: 500') → 'overview: HTTP 500'
+ *   formatFetchError('consensus', 'Failed to fetch') → 'consensus: Failed to fetch'
+ *
+ * The "API error: <status>" pattern is emitted by packages/dashboard-v2/src/lib/api.ts
+ * for any non-ok HTTP response. The 401 case is separately thrown as 'unauthorized'
+ * (not "API error: 401"), so it passes through verbatim.
+ */
+export function formatFetchError(endpoint: string, rawMessage: string): string {
+  const httpMatch = rawMessage.match(/^API error: (\d+)$/);
+  const detail = httpMatch ? `HTTP ${httpMatch[1]}` : rawMessage;
+  return `${endpoint}: ${detail}`;
+}

--- a/packages/relay/src/dashboard/api-consensus.ts
+++ b/packages/relay/src/dashboard/api-consensus.ts
@@ -120,9 +120,14 @@ export async function consensusHandler(projectRoot: string, query?: URLSearchPar
     // Only show real consensus runs (multiple signals from cross-review), not manual recordings
     if (agents.size >= 2 && taskSignals.length >= 3) {
       const tombstone = retractionByConsensusId.get(taskId);
+      // Derive run timestamp defensively: find first signal with a non-empty
+      // string timestamp. A torn/partial JSONL write can produce a signal whose
+      // timestamp field is missing or non-string; falling back to '' sorts the
+      // run last (lexicographic) rather than throwing a TypeError at sort time.
+      const runTimestamp = taskSignals.find(s => typeof s.timestamp === 'string' && s.timestamp)?.timestamp ?? '';
       runs.push({
         taskId,
-        timestamp: taskSignals[0].timestamp,
+        timestamp: runTimestamp,
         agents: [...agents].sort(),
         signals: taskSignals.map(s => {
           // Forward findingId and resolve display signal
@@ -145,8 +150,10 @@ export async function consensusHandler(projectRoot: string, query?: URLSearchPar
     }
   }
 
-  // Most recent first
-  runs.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  // Most recent first. Use nullish fallback so a run whose timestamp ended up
+  // as '' (malformed first signal, defensive derivation above) sorts last
+  // without throwing.
+  runs.sort((a, b) => (b.timestamp ?? '').localeCompare(a.timestamp ?? ''));
 
   // Paginate
   const totalRuns = runs.length;

--- a/packages/relay/src/dashboard/api-consensus.ts
+++ b/packages/relay/src/dashboard/api-consensus.ts
@@ -100,8 +100,11 @@ export async function consensusHandler(projectRoot: string, query?: URLSearchPar
     const counts = { agreement: 0, disagreement: 0, unverified: 0, unique: 0, hallucination: 0, new: 0, insights: 0 };
 
     for (const s of taskSignals) {
-      agents.add(s.agentId);
-      if (s.counterpartId) agents.add(s.counterpartId);
+      // Torn JSONL writes can omit agentId/counterpartId (same class as the
+      // missing-timestamp case below) — an undefined entry would corrupt the
+      // agents array and could even satisfy the agents.size >= 2 gate.
+      if (typeof s.agentId === 'string' && s.agentId) agents.add(s.agentId);
+      if (typeof s.counterpartId === 'string' && s.counterpartId) agents.add(s.counterpartId);
 
       // Resolve UNVERIFIED signals that have a later resolution for the same findingId
       let effectiveSignal = s.signal;

--- a/tests/dashboard/api-timeout.test.ts
+++ b/tests/dashboard/api-timeout.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the fetch timeout mechanism added to packages/dashboard-v2/src/lib/api.ts
+ * (issue #547 client-side vector, a3a35da1-060d4a81:f6).
+ *
+ * Root cause: api() had no timeout, so a never-resolving request kept
+ * useDashboardData's inFlight ref permanently true (set before fetch, cleared
+ * in finally), freezing the 5-second poll forever and leaving the dashboard
+ * in a silent "Loading dashboard..." state.
+ *
+ * Fix: api() wraps every fetch with an AbortController timeout (default 30s).
+ * On abort, it throws Error('timeout after 30s') so namedFetch can label the
+ * error with the endpoint name: "consensus: timeout after 30s".
+ *
+ * WHAT IS TESTED HERE (pure helpers, node-safe):
+ *   - timeoutMessage(): format contract that the error card depends on.
+ *   - API_TIMEOUT_MS: value is a positive number (sanity, catches accidental 0).
+ *   - Message produced for abort is in the format namedFetch expects.
+ *
+ * WHAT IS NOT TESTED HERE (requires fetch + jsdom):
+ *   - The actual AbortController/AbortSignal.timeout path inside api() requires
+ *     a fetch mock and jsdom timer control not available in the node test env.
+ *     Hook-level coverage should be added when jsdom is configured (precedent:
+ *     useDashboardData.test.ts:75-80, useTheme.test.ts:10-12).
+ */
+
+import { timeoutMessage, API_TIMEOUT_MS } from '../../packages/dashboard-v2/src/lib/api';
+
+describe('api timeout — timeoutMessage helper', () => {
+  it('formats 30s timeout correctly', () => {
+    expect(timeoutMessage(30_000)).toBe('timeout after 30s');
+  });
+
+  it('formats 5s timeout correctly (edge case)', () => {
+    expect(timeoutMessage(5_000)).toBe('timeout after 5s');
+  });
+
+  it('message matches the pattern that namedFetch labels with endpoint', () => {
+    // namedFetch wraps raw message: formatFetchError('consensus', timeoutMessage(30_000))
+    // → 'consensus: timeout after 30s'
+    // Verify the raw message does NOT look like an HTTP error so it passes through verbatim.
+    const msg = timeoutMessage(30_000);
+    expect(msg).not.toMatch(/^API error: \d+$/);
+    expect(msg).toContain('timeout');
+    expect(msg).toContain('30s');
+  });
+
+  it('API_TIMEOUT_MS is a positive number', () => {
+    expect(typeof API_TIMEOUT_MS).toBe('number');
+    expect(API_TIMEOUT_MS).toBeGreaterThan(0);
+  });
+
+  it('API_TIMEOUT_MS matches the value used in timeoutMessage (self-consistency)', () => {
+    // If someone changes the constant, the message must stay coherent.
+    const msg = timeoutMessage(API_TIMEOUT_MS);
+    expect(msg).toBe(`timeout after ${API_TIMEOUT_MS / 1000}s`);
+  });
+});
+
+describe('api timeout — abort path (documented, not mechanically testable in node env)', () => {
+  it.todo(
+    'api() aborts after API_TIMEOUT_MS and throws Error whose message is timeoutMessage(API_TIMEOUT_MS)',
+  );
+
+  it.todo(
+    'when api() throws a timeout error, namedFetch labels it: "consensus: timeout after 30s"',
+  );
+
+  it.todo(
+    'after a timeout, inFlight ref is cleared (finally block runs) so the next poll fires normally',
+  );
+});

--- a/tests/dashboard/useDashboardData.test.ts
+++ b/tests/dashboard/useDashboardData.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression tests for issue #547 — dashboard silent infinite "Loading dashboard..." state.
+ *
+ * THE BUG (verified against the pre-fix code):
+ *   - useDashboardData fetches 4 core endpoints via Promise.all with no .catch().
+ *   - If any rejects, the whole Promise.all rejects with a bare "Failed to fetch" or
+ *     "API error: 500" — no endpoint name, zero diagnostic context.
+ *   - The catch block (line ~153) set loading:false + error, but App.tsx never read
+ *     `error` from the hook destructure — so the gate `if (loading || !overview)`
+ *     stayed true forever with a spinner and no user-visible error message.
+ *
+ * WHAT IS TESTED HERE:
+ *   - formatFetchError (exported pure helper): verifies the error labeling contract
+ *     that names the failing endpoint + formats HTTP status vs. network errors.
+ *
+ * WHAT IS NOT TESTED HERE (component + hook layer):
+ *   - The React hook (useState/useEffect) and the App.tsx rendering gate require
+ *     jsdom + @testing-library/react, which are not wired up for dashboard-v2 in this
+ *     project's jest config (testEnvironment: 'node'). This matches the precedent in
+ *     tests/dashboard/useTheme.test.ts:10-12 and useEventStream.test.ts:3-5.
+ *   - Hook-level and component-level coverage should be added when jsdom is configured.
+ */
+
+import { formatFetchError } from '../../packages/dashboard-v2/src/lib/fetchError';
+
+describe('formatFetchError — endpoint error labeling (issue #547 regression)', () => {
+  it('formats HTTP 500 errors with endpoint name', () => {
+    expect(formatFetchError('overview', 'API error: 500')).toBe('overview: HTTP 500');
+  });
+
+  it('formats HTTP 503 errors with endpoint name', () => {
+    expect(formatFetchError('consensus', 'API error: 503')).toBe('consensus: HTTP 503');
+  });
+
+  it('formats HTTP 404 errors with endpoint name', () => {
+    expect(formatFetchError('agents', 'API error: 404')).toBe('agents: HTTP 404');
+  });
+
+  it('passes through network errors verbatim after endpoint name', () => {
+    expect(formatFetchError('overview', 'Failed to fetch')).toBe('overview: Failed to fetch');
+  });
+
+  it('passes through "unauthorized" verbatim (api() throws this on 401)', () => {
+    // api() throws Error('unauthorized') specifically for 401 — NOT 'API error: 401'
+    expect(formatFetchError('overview', 'unauthorized')).toBe('overview: unauthorized');
+  });
+
+  it('passes through JSON parse errors verbatim after endpoint name', () => {
+    expect(formatFetchError('tasks', 'Unexpected token < in JSON at position 0')).toBe(
+      'tasks: Unexpected token < in JSON at position 0',
+    );
+  });
+
+  it('does NOT mistake non-standard error strings for HTTP status', () => {
+    // "API error: " prefix is load-bearing — partial matches must not trigger.
+    expect(formatFetchError('consensus', 'API error')).toBe('consensus: API error');
+    expect(formatFetchError('consensus', 'API error: abc')).toBe('consensus: API error: abc');
+  });
+
+  // Validates that the error message pattern produced by namedFetch gives users
+  // actionable context: "<endpoint>: <detail>" so they can identify WHICH fetch
+  // is failing from the dashboard error card without opening DevTools.
+  it('message is in the "<endpoint>: <detail>" format that the App.tsx error card displays', () => {
+    const msg = formatFetchError('overview', 'API error: 500');
+    expect(msg).toMatch(/^overview: /);
+    expect(msg).toContain('HTTP 500');
+  });
+});
+
+describe('recovery contract (documented, not mechanically testable in node env)', () => {
+  // This describe block documents the recovery behavior that IS implemented but
+  // cannot be exercised without jsdom. It serves as a specification anchor —
+  // when jsdom is added, these should become real renderHook tests.
+
+  it.todo(
+    'hook recovery: after a failing poll, a successful subsequent poll clears error and populates data',
+  );
+
+  it.todo(
+    'gate test: when error is set and overview is null, App.tsx renders the error message, not "Loading dashboard..."',
+  );
+});

--- a/tests/relay/api-consensus-missing-timestamp.test.ts
+++ b/tests/relay/api-consensus-missing-timestamp.test.ts
@@ -98,4 +98,62 @@ describe('consensusHandler — missing timestamp on run first signal', () => {
     expect(res.runs[0].taskId).toBe('good-ddd');
     expect(res.runs[1].taskId).toBe('torn-ccc');
   });
+
+  it('TWO fully-torn runs (the deterministic pre-fix repro) — both returned, both sort last, no throw', async () => {
+    // Live replication on 2026-06-12 (consensus 712cb6d4-aa34460f:f5/f6): ONE
+    // torn run only threw when V8's sort happened to use it in the `b` role;
+    // TWO torn runs always compared against each other and threw
+    // deterministically. This pins the exact incident shape from issue #547.
+    const root = makeTmpRoot();
+
+    const torn = (task: string, cid: string, a: string, b: string): object[] => [
+      { type: 'consensus', taskId: task, consensusId: cid, signal: 'agreement', agentId: a, counterpartId: b },
+      { type: 'consensus', taskId: task, consensusId: cid, signal: 'agreement', agentId: b, counterpartId: a },
+      { type: 'consensus', taskId: task, consensusId: cid, signal: 'unique_confirmed', agentId: a, counterpartId: b },
+    ];
+    const goodRun: object[] = [
+      { type: 'consensus', taskId: 'good', consensusId: 'good-eee', signal: 'agreement', agentId: 'agent-a', counterpartId: 'agent-b', timestamp: '2026-06-11T08:00:00Z' },
+      { type: 'consensus', taskId: 'good', consensusId: 'good-eee', signal: 'agreement', agentId: 'agent-b', counterpartId: 'agent-a', timestamp: '2026-06-11T08:01:00Z' },
+      { type: 'consensus', taskId: 'good', consensusId: 'good-eee', signal: 'unique_confirmed', agentId: 'agent-a', counterpartId: 'agent-b', timestamp: '2026-06-11T08:02:00Z' },
+    ];
+
+    writeFileSync(
+      join(root, '.gossip', 'agent-performance.jsonl'),
+      [...torn('tA', 'torn-one', 'agent-p', 'agent-q'), ...torn('tB', 'torn-two', 'agent-r', 'agent-s'), ...goodRun]
+        .map(r => JSON.stringify(r)).join('\n') + '\n',
+    );
+
+    const res = await consensusHandler(root);
+    expect(res.runs).toHaveLength(3);
+    expect(res.runs[0].taskId).toBe('good-eee');
+    const tail = res.runs.slice(1).map(r => r.taskId).sort();
+    expect(tail).toEqual(['torn-one', 'torn-two']);
+    for (const id of tail) {
+      expect(res.runs.find(r => r.taskId === id)?.timestamp).toBe('');
+    }
+  });
+
+  it('a signal missing agentId does not corrupt the agents array (712cb6d4-aa34460f:f1)', async () => {
+    const root = makeTmpRoot();
+
+    // 4 signals, 2 REAL agents, one torn signal with no agentId at all.
+    const run: object[] = [
+      { type: 'consensus', taskId: 'tg', consensusId: 'guard-fff', signal: 'agreement', agentId: 'agent-a', counterpartId: 'agent-b', timestamp: '2026-06-11T07:00:00Z' },
+      { type: 'consensus', taskId: 'tg', consensusId: 'guard-fff', signal: 'agreement', /* no agentId */ counterpartId: 'agent-b', timestamp: '2026-06-11T07:01:00Z' },
+      { type: 'consensus', taskId: 'tg', consensusId: 'guard-fff', signal: 'agreement', agentId: 'agent-b', counterpartId: 'agent-a', timestamp: '2026-06-11T07:02:00Z' },
+      { type: 'consensus', taskId: 'tg', consensusId: 'guard-fff', signal: 'unique_confirmed', agentId: 'agent-a', counterpartId: 'agent-b', timestamp: '2026-06-11T07:03:00Z' },
+    ];
+
+    writeFileSync(
+      join(root, '.gossip', 'agent-performance.jsonl'),
+      run.map(r => JSON.stringify(r)).join('\n') + '\n',
+    );
+
+    const res = await consensusHandler(root);
+    const guarded = res.runs.find(r => r.taskId === 'guard-fff');
+    expect(guarded).toBeDefined();
+    // No undefined/null leaked into the agents array
+    expect(guarded?.agents).toEqual(['agent-a', 'agent-b']);
+    expect(guarded?.agents.every(a => typeof a === 'string' && a.length > 0)).toBe(true);
+  });
 });

--- a/tests/relay/api-consensus-missing-timestamp.test.ts
+++ b/tests/relay/api-consensus-missing-timestamp.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression tests for issue #547 server-side vector:
+ * /consensus 500s when a qualifying run's first signal has no timestamp field.
+ *
+ * Root cause (a3a35da1-060d4a81:f1): the pre-fix code set run.timestamp from
+ * taskSignals[0].timestamp unconditionally, then called b.timestamp.localeCompare()
+ * at sort time. A torn/partial JSONL write where the first signal lacks a
+ * timestamp field produced undefined, causing localeCompare to throw TypeError.
+ *
+ * Fix: derive run timestamp as the first signal WITH a string timestamp (fail-open
+ * to '' so the run sorts last but the endpoint returns 200 with the other runs).
+ */
+
+import { consensusHandler } from '@gossip/relay/dashboard/api-consensus';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+function makeTmpRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'gossip-test-cts-'));
+  mkdirSync(join(root, '.gossip'), { recursive: true });
+  return root;
+}
+
+describe('consensusHandler — missing timestamp on run first signal', () => {
+  it('returns 200-shaped data when the first signal of a run has no timestamp', async () => {
+    const root = makeTmpRoot();
+
+    // Run 1 (good): 3 signals, 2 agents, all with timestamps — should appear in results
+    const run1: object[] = [
+      { type: 'consensus', taskId: 't1', consensusId: 'run1-aaa', signal: 'agreement', agentId: 'agent-a', counterpartId: 'agent-b', timestamp: '2026-06-11T10:00:00Z' },
+      { type: 'consensus', taskId: 't1', consensusId: 'run1-aaa', signal: 'agreement', agentId: 'agent-b', counterpartId: 'agent-a', timestamp: '2026-06-11T10:01:00Z' },
+      { type: 'consensus', taskId: 't1', consensusId: 'run1-aaa', signal: 'unique_confirmed', agentId: 'agent-a', counterpartId: 'agent-b', timestamp: '2026-06-11T10:02:00Z' },
+    ];
+
+    // Run 2 (torn): first signal has NO timestamp — this is the repro shape from the bug.
+    // Second and third signals have timestamps so the run still qualifies (≥2 agents, ≥3 signals).
+    const run2: object[] = [
+      { type: 'consensus', taskId: 't2', consensusId: 'run2-bbb', signal: 'agreement', agentId: 'agent-c', counterpartId: 'agent-d' /* no timestamp */ },
+      { type: 'consensus', taskId: 't2', consensusId: 'run2-bbb', signal: 'agreement', agentId: 'agent-d', counterpartId: 'agent-c', timestamp: '2026-06-11T09:00:00Z' },
+      { type: 'consensus', taskId: 't2', consensusId: 'run2-bbb', signal: 'unique_confirmed', agentId: 'agent-c', counterpartId: 'agent-d', timestamp: '2026-06-11T09:01:00Z' },
+    ];
+
+    writeFileSync(
+      join(root, '.gossip', 'agent-performance.jsonl'),
+      [...run1, ...run2].map(r => JSON.stringify(r)).join('\n') + '\n',
+    );
+
+    // Must NOT throw — this was the TypeError before the fix
+    const res = await consensusHandler(root);
+
+    // Both qualifying runs must be present
+    expect(res.runs).toHaveLength(2);
+    expect(res.runs.map(r => r.taskId)).toContain('run1-aaa');
+    expect(res.runs.map(r => r.taskId)).toContain('run2-bbb');
+
+    // The torn run falls back to '' for its timestamp — it sorts last (empty < '2026...')
+    const run1Result = res.runs.find(r => r.taskId === 'run1-aaa');
+    const run2Result = res.runs.find(r => r.taskId === 'run2-bbb');
+    expect(run1Result?.timestamp).toBe('2026-06-11T10:00:00Z');
+    // Torn run picks the FIRST signal that has a valid timestamp (second signal)
+    expect(run2Result?.timestamp).toBe('2026-06-11T09:00:00Z');
+
+    // Run with full timestamps sorts before the torn run (most-recent-first)
+    expect(res.runs[0].taskId).toBe('run1-aaa');
+    expect(res.runs[1].taskId).toBe('run2-bbb');
+  });
+
+  it('handles a run where ALL signals have no timestamp — sorts last, does not throw', async () => {
+    const root = makeTmpRoot();
+
+    // A fully-torn run where no signal has a timestamp
+    const tornRun: object[] = [
+      { type: 'consensus', taskId: 'torn', consensusId: 'torn-ccc', signal: 'agreement', agentId: 'agent-x', counterpartId: 'agent-y' },
+      { type: 'consensus', taskId: 'torn', consensusId: 'torn-ccc', signal: 'agreement', agentId: 'agent-y', counterpartId: 'agent-x' },
+      { type: 'consensus', taskId: 'torn', consensusId: 'torn-ccc', signal: 'unique_confirmed', agentId: 'agent-x', counterpartId: 'agent-y' },
+    ];
+
+    // A good run that should sort first
+    const goodRun: object[] = [
+      { type: 'consensus', taskId: 'good', consensusId: 'good-ddd', signal: 'agreement', agentId: 'agent-a', counterpartId: 'agent-b', timestamp: '2026-06-11T08:00:00Z' },
+      { type: 'consensus', taskId: 'good', consensusId: 'good-ddd', signal: 'agreement', agentId: 'agent-b', counterpartId: 'agent-a', timestamp: '2026-06-11T08:01:00Z' },
+      { type: 'consensus', taskId: 'good', consensusId: 'good-ddd', signal: 'unique_confirmed', agentId: 'agent-a', counterpartId: 'agent-b', timestamp: '2026-06-11T08:02:00Z' },
+    ];
+
+    writeFileSync(
+      join(root, '.gossip', 'agent-performance.jsonl'),
+      [...tornRun, ...goodRun].map(r => JSON.stringify(r)).join('\n') + '\n',
+    );
+
+    const res = await consensusHandler(root);
+    expect(res.runs).toHaveLength(2);
+
+    const tornResult = res.runs.find(r => r.taskId === 'torn-ccc');
+    expect(tornResult?.timestamp).toBe(''); // defensive fallback
+
+    // Good run sorts before torn run (non-empty > empty in localeCompare)
+    expect(res.runs[0].taskId).toBe('good-ddd');
+    expect(res.runs[1].taskId).toBe('torn-ccc');
+  });
+});


### PR DESCRIPTION
Fixes the dashboard-hang class reported in #547. The reporter's proposed root cause (SSE EventSource auth) was empirically falsified — SSE streams fine with the session cookie a logged-in browser sends, and the loading gate never depended on SSE. The real failure chain, established by a three-hypothesis parallel investigation (consensus `a3a35da1-060d4a81`, 11 confirmed findings):

**Enabling bug (every hang funnels through it):** any failure in the four uncaught gate fetches left `overview`/`consensus` null with the error invisibly set; `App.tsx` rendered "Loading dashboard..." forever and `useAuth` never re-validates.

**Concrete failure vectors found:** a torn JSONL consensus signal (missing `timestamp`) 500s `/consensus` (live-replicated: one torn run throws only when V8's sort uses it in the `b` role; two torn runs throw deterministically); `Secure` session cookie on plain-HTTP origins (Safari/macOS, non-localhost — silent login "success" then all-401s); relay-restart session wipe; no fetch timeout (a hung request froze polling permanently). The auth-design vectors are split into #548.

consensus-id: 712cb6d4-aa34460f

## Changes

- **Error surfacing** (`095d95cd`): `useDashboardData` labels failures by endpoint via `namedFetch`/`formatFetchError` ("consensus: HTTP 500"); `App.tsx` renders a DESIGN.md-compliant error card (rose `--bad`, hairline border) with a retry hint instead of the eternal spinner; the 5s poll self-heals and clears the error. Visually verified on the live relay: injected torn signals → error card; restored → dashboard recovers without reload.
- **Server hardening** (`38a4a396`): `/consensus` derives run timestamps defensively (first signal with a string timestamp, `''` fallback, null-safe sort) — torn writes can no longer 500 the endpoint; 30s `AbortController` timeout on the polled `api()` helper (timeouts surface as "consensus: timeout after 30s"); `login()`/`checkAuth()` untouched.
- **Pre-merge consensus fixes** (`03e45e1c`): `agentId`/`counterpartId` guarded the same way (torn line can't inject `undefined` into `run.agents` or satisfy the ≥2-agents gate); `signal: timeoutSignal` moved after the options spread so a future caller-supplied signal can't silently disable the timeout; explicit two-torn-runs regression test pinning the deterministic incident shape.

## Pre-merge consensus

Round `712cb6d4-aa34460f` (gemini-reviewer, gemini-tester, sonnet-reviewer): 7 confirmed / 2 disputed / 4 unique, 13 signals. Both disputes adjudicated: the two-runs test gap was real but LOW (added anyway as incident documentation); sonnet-reviewer's "no tests exist" claim was a wrong-directory miss it retracted itself in cross-review (recorded as a hallucination catch). Both MEDIUMs (agentId guard, signal-spread order) fixed pre-merge. Deferred as LOW suggestions: unmount-abort on in-flight fetches, abort-reason message specificity.

## Verification

- jest `tests/relay` + `tests/dashboard`: 17 suites, 172 passed + 5 todo, 0 failures (orchestrator-run post-fixup)
- jest `tests/cli` + `tests/orchestrator`: 3475 passed, 0 failures
- `npm run build` + `build:dashboard`: green
- Live replication: before/after screenshots captured against the running relay (torn-signal 500 → error card naming the endpoint; restore → self-recovery on next poll)

Related: #548 (auth-design follow-ups: Secure cookie on http, dead `?key=` banner URL, session persistence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)