### PR TITLE
fix(relay): tolerate malformed tool-call argument JSON on the OpenAI-compatible path

### DIFF
--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -482,7 +482,20 @@ export class OpenAIProvider implements ILLMProvider {
     if (msg.tool_calls) {
       for (const tc of msg.tool_calls as Array<Record<string, unknown>>) {
         const fn = tc.function as Record<string, string>;
-        toolCalls.push({ id: tc.id as string, name: fn.name, arguments: JSON.parse(fn.arguments) });
+        let parsedArgs: Record<string, unknown>;
+        try {
+          parsedArgs = JSON.parse(fn.arguments);
+          toolCalls.push({ id: tc.id as string, name: fn.name, arguments: parsedArgs });
+        } catch (parseErr) {
+          const raw = fn.arguments ?? '';
+          toolCalls.push({
+            id: tc.id as string,
+            name: fn.name,
+            arguments: {},
+            argumentsParseError: (parseErr as Error).message,
+            rawArguments: raw.slice(0, 200),
+          });
+        }
       }
     }
     const usage = data.usage as Record<string, number> | undefined;

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -136,6 +136,10 @@ export interface LLMResponse {
     id: string;
     name: string;
     arguments: Record<string, unknown>;
+    /** Set when the model-produced arguments string was not valid JSON. The tool must NOT be executed; feed the error back to the model. */
+    argumentsParseError?: string;
+    /** The raw arguments string that failed to parse (first 200 chars). Included in the error message fed back to the model. */
+    rawArguments?: string;
   }>;
   usage?: { inputTokens: number; outputTokens: number };
 }

--- a/packages/orchestrator/src/worker-agent.ts
+++ b/packages/orchestrator/src/worker-agent.ts
@@ -382,13 +382,21 @@ export class WorkerAgent {
         let turnErrors = 0;
         for (const toolCall of response.toolCalls) {
           let result: string;
-          try {
-            const toolStart = Date.now();
-            result = await this.callTool(toolCall.name, toolCall.arguments);
-            yield logAndYield(`  tool ${toolCall.name} → ${Date.now() - toolStart}ms, ${result.length}chars${result.startsWith('Error:') ? ' ERROR: ' + result.slice(0, 100) : ''}`);
-          } catch (err) {
-            result = `Error: ${(err as Error).message}`;
-            yield logAndYield(`  tool ${toolCall.name} → THREW: ${result.slice(0, 150)}`);
+          if (toolCall.argumentsParseError !== undefined) {
+            // Model produced invalid JSON for this tool's arguments — do NOT execute the tool.
+            // Return an error result identical in shape to a THREW result so the retry-streak
+            // machinery (consecutiveErrors) applies and the model can correct its output.
+            result = `Error: tool call arguments were not valid JSON (${toolCall.argumentsParseError}): ${toolCall.rawArguments ?? ''}`;
+            yield logAndYield(`  tool ${toolCall.name} → INVALID JSON ARGS: ${result.slice(0, 150)}`);
+          } else {
+            try {
+              const toolStart = Date.now();
+              result = await this.callTool(toolCall.name, toolCall.arguments);
+              yield logAndYield(`  tool ${toolCall.name} → ${Date.now() - toolStart}ms, ${result.length}chars${result.startsWith('Error:') ? ' ERROR: ' + result.slice(0, 100) : ''}`);
+            } catch (err) {
+              result = `Error: ${(err as Error).message}`;
+              yield logAndYield(`  tool ${toolCall.name} → THREW: ${result.slice(0, 150)}`);
+            }
           }
           if (result.startsWith('Error:')) turnErrors++;
           messages.push({

--- a/tests/orchestrator/llm-client.test.ts
+++ b/tests/orchestrator/llm-client.test.ts
@@ -336,6 +336,106 @@ describe('LLM Client', () => {
 
       global.fetch = originalFetch;
     });
+
+    it('malformed tool-call arguments (unquoted key — {depth: 2}) set argumentsParseError, do not throw', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{
+                id: 'call_bad', type: 'function',
+                function: { name: 'file_tree', arguments: '{depth: 2}' },
+              }],
+            },
+          }],
+        }),
+      }) as unknown as typeof fetch;
+
+      const provider = new OpenAIProvider('test-key', 'deepseek-chat', undefined, 'https://api.deepseek.com/v1');
+      const response = await provider.generate([{ role: 'user', content: 'list' }]);
+
+      expect(response.toolCalls).toHaveLength(1);
+      const tc = response.toolCalls![0];
+      expect(tc.name).toBe('file_tree');
+      expect(tc.arguments).toEqual({});
+      expect(tc.argumentsParseError).toBeDefined();
+      expect(tc.rawArguments).toBe('{depth: 2}');
+
+      global.fetch = originalFetch;
+    });
+
+    it('malformed tool-call arguments (single-quoted key — {\'path\': \'x\'}) set argumentsParseError', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{
+                id: 'call_sq', type: 'function',
+                function: { name: 'file_read', arguments: "{'path': 'x'}" },
+              }],
+            },
+          }],
+        }),
+      }) as unknown as typeof fetch;
+
+      const provider = new OpenAIProvider('test-key', 'deepseek-chat');
+      const response = await provider.generate([{ role: 'user', content: 'read' }]);
+
+      expect(response.toolCalls).toHaveLength(1);
+      const tc = response.toolCalls![0];
+      expect(tc.argumentsParseError).toBeDefined();
+      expect(tc.rawArguments).toBe("{'path': 'x'}");
+
+      global.fetch = originalFetch;
+    });
+
+    it('one malformed + one valid tool call in same response: valid call parses normally', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_bad', type: 'function',
+                  function: { name: 'file_tree', arguments: '{depth: 2}' },
+                },
+                {
+                  id: 'call_ok', type: 'function',
+                  function: { name: 'file_read', arguments: '{"path": "/src/main.ts"}' },
+                },
+              ],
+            },
+          }],
+        }),
+      }) as unknown as typeof fetch;
+
+      const provider = new OpenAIProvider('test-key', 'deepseek-chat');
+      const response = await provider.generate([{ role: 'user', content: 'go' }]);
+
+      expect(response.toolCalls).toHaveLength(2);
+      const [bad, ok] = response.toolCalls!;
+
+      // Bad call carries the error marker
+      expect(bad.name).toBe('file_tree');
+      expect(bad.argumentsParseError).toBeDefined();
+      expect(bad.rawArguments).toBe('{depth: 2}');
+
+      // Good call parses normally with no marker
+      expect(ok.name).toBe('file_read');
+      expect(ok.arguments).toEqual({ path: '/src/main.ts' });
+      expect(ok.argumentsParseError).toBeUndefined();
+
+      global.fetch = originalFetch;
+    });
   });
 
   describe('createProviderForAgent — pre-flight key check (issue #522)', () => {

--- a/tests/orchestrator/worker-agent.test.ts
+++ b/tests/orchestrator/worker-agent.test.ts
@@ -529,3 +529,266 @@ describe('WorkerAgent per-agent maxToolTurns (fix/per-agent-turn-cap)', () => {
     jest.resetModules();
   }, 15_000);
 });
+
+// ─── argumentsParseError short-circuit ───────────────────────────────────────
+describe('WorkerAgent — argumentsParseError short-circuit (deepseek relay crash fix)', () => {
+  /**
+   * Helper: build a WorkerAgent backed by a mock relay (no real WebSocket).
+   * sendEnvelope resolves the pending callTool promise immediately via
+   * messageHandler — same pattern as the per-agent maxToolTurns tests above.
+   */
+  function buildWorkerWithRelay(stubLlm: ILLMProvider, dummyTools: ToolDefinition[], maxTurns: number) {
+    const { MessageType } = require('@gossip/types');
+
+    let messageHandler: ((data: unknown, envelope: unknown) => void) | null = null;
+    const sendEnvelopeCalls: Array<{ rid_req?: string }> = [];
+
+    const mockGossipAgent = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn().mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === 'message') messageHandler = handler as (data: unknown, envelope: unknown) => void;
+      }),
+      sendEnvelope: jest.fn().mockImplementation(async (envelope: { rid_req?: string }) => {
+        sendEnvelopeCalls.push(envelope);
+        setImmediate(() => {
+          if (messageHandler && envelope.rid_req) {
+            messageHandler(
+              { result: 'relay-tool-ok' },
+              { t: MessageType.RPC_RESPONSE, rid_req: envelope.rid_req }
+            );
+          }
+        });
+      }),
+      subscribe: jest.fn().mockResolvedValue(undefined),
+      unsubscribe: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const { WorkerAgent: WA } = require('@gossip/orchestrator');
+    const worker = new WA('test-agent', stubLlm, 'ws://localhost:9999', dummyTools, undefined, false, undefined, maxTurns);
+    return { worker, mockGossipAgent, sendEnvelopeCalls };
+  }
+
+  it('a call with argumentsParseError is NOT forwarded to the relay (tool not executed)', async () => {
+    jest.resetModules();
+    jest.doMock('@gossip/client', () => ({
+      GossipAgent: jest.fn().mockImplementation((..._args: unknown[]) => buildWorkerWithRelay(null as any, [], 5).mockGossipAgent),
+    }));
+
+    const dummyTool: ToolDefinition = { name: 'file_tree', description: 'tree', parameters: { type: 'object', properties: {} } };
+
+    let llmCallCount = 0;
+    const capturedToolMessages: string[] = [];
+
+    const stubLlm: ILLMProvider = {
+      generate: jest.fn().mockImplementation(async (messages: LLMMessage[]) => {
+        llmCallCount++;
+        if (llmCallCount === 1) {
+          // Return one call with invalid JSON args (position-8 class: unquoted key)
+          return {
+            text: 'calling file_tree',
+            toolCalls: [{
+              id: 'call_bad',
+              name: 'file_tree',
+              arguments: {},
+              argumentsParseError: "Expected ':' after property name in JSON at position 8 (line 1 column 9)",
+              rawArguments: '{depth: 2}',
+            }],
+          };
+        }
+        // Second call: capture any tool result messages that were fed back
+        for (const msg of messages) {
+          if (msg.role === 'tool') {
+            capturedToolMessages.push(typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content));
+          }
+        }
+        return { text: 'done after seeing error' };
+      }),
+    };
+
+    // Build relay mock directly so we can capture sendEnvelope calls
+    const { MessageType } = require('@gossip/types');
+    let messageHandler: ((data: unknown, envelope: unknown) => void) | null = null;
+    const sendEnvelopeCalls: Array<unknown> = [];
+    const mockGossipAgent = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn().mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === 'message') messageHandler = handler as (data: unknown, envelope: unknown) => void;
+      }),
+      sendEnvelope: jest.fn().mockImplementation(async (envelope: { rid_req?: string }) => {
+        sendEnvelopeCalls.push(envelope);
+        setImmediate(() => {
+          if (messageHandler && envelope.rid_req) {
+            messageHandler({ result: 'relay-ok' }, { t: MessageType.RPC_RESPONSE, rid_req: envelope.rid_req });
+          }
+        });
+      }),
+      subscribe: jest.fn().mockResolvedValue(undefined),
+      unsubscribe: jest.fn().mockResolvedValue(undefined),
+    };
+
+    jest.resetModules();
+    jest.doMock('@gossip/client', () => ({
+      GossipAgent: jest.fn().mockImplementation(() => mockGossipAgent),
+    }));
+    const { WorkerAgent: WA } = require('@gossip/orchestrator');
+
+    const worker = new WA('test-agent', stubLlm, 'ws://localhost:9999', [dummyTool], undefined, false, undefined, 5);
+    await worker.start();
+
+    for await (const _event of worker.executeTask('do something', undefined, undefined, 'task-bad-args')) {
+      // drain
+    }
+
+    // The tool was NOT forwarded to the relay: sendEnvelope never called
+    expect(sendEnvelopeCalls).toHaveLength(0);
+
+    // The error message was fed back to the model and names "invalid JSON" + the raw snippet
+    expect(capturedToolMessages).toHaveLength(1);
+    expect(capturedToolMessages[0]).toContain('not valid JSON');
+    expect(capturedToolMessages[0]).toContain('{depth: 2}');
+
+    jest.resetModules();
+  }, 15_000);
+
+  it('a call with argumentsParseError increments turnErrors (streak machinery applies)', async () => {
+    jest.resetModules();
+
+    const dummyTool: ToolDefinition = { name: 'file_tree', description: 'tree', parameters: { type: 'object', properties: {} } };
+    let llmCallCount = 0;
+
+    // Three consecutive turns each returning ONE call with argumentsParseError
+    // → consecutiveErrors hits 3 → loop exits with ERROR event, not FATAL ERROR
+    const stubLlm: ILLMProvider = {
+      generate: jest.fn().mockImplementation(async () => {
+        llmCallCount++;
+        if (llmCallCount <= 3) {
+          return {
+            text: `bad turn ${llmCallCount}`,
+            toolCalls: [{
+              id: `call_bad_${llmCallCount}`,
+              name: 'file_tree',
+              arguments: {},
+              argumentsParseError: 'Unexpected token d',
+              rawArguments: `{depth: ${llmCallCount}}`,
+            }],
+          };
+        }
+        return { text: 'should not reach here' };
+      }),
+    };
+
+    const mockGossipAgent = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn(),
+      sendEnvelope: jest.fn().mockResolvedValue(undefined),
+      subscribe: jest.fn().mockResolvedValue(undefined),
+      unsubscribe: jest.fn().mockResolvedValue(undefined),
+    };
+
+    jest.doMock('@gossip/client', () => ({
+      GossipAgent: jest.fn().mockImplementation(() => mockGossipAgent),
+    }));
+    const { WorkerAgent: WA } = require('@gossip/orchestrator');
+
+    const worker = new WA('test-agent', stubLlm, 'ws://localhost:9999', [dummyTool], undefined, false, undefined, 10);
+    await worker.start();
+
+    const { TaskStreamEventType } = require('@gossip/orchestrator');
+    const events: Array<{ type: string }> = [];
+    for await (const event of worker.executeTask('trigger streak', undefined, undefined, 'task-streak')) {
+      events.push(event as { type: string });
+    }
+
+    // After 3 all-error turns the loop exits with FINAL_RESULT (error loop),
+    // NOT with a FATAL ERROR (which would mean an exception escaped parseOpenAIResponse)
+    const hasError = events.some(e => e.type === TaskStreamEventType.ERROR);
+    const hasFinal = events.some(e => e.type === TaskStreamEventType.FINAL_RESULT);
+    // The loop should exit cleanly — no FATAL ERROR type event
+    expect(hasError).toBe(false);
+    expect(hasFinal).toBe(true);
+    // Only 3 LLM calls before the streak exits (no summary call in the streak path)
+    expect(llmCallCount).toBe(3);
+
+    jest.resetModules();
+  }, 15_000);
+
+  it('sibling valid call in same response executes while the malformed call does not reach relay', async () => {
+    jest.resetModules();
+
+    const dummyTools: ToolDefinition[] = [
+      { name: 'file_tree', description: 'tree', parameters: { type: 'object', properties: {} } },
+      { name: 'file_read', description: 'read', parameters: { type: 'object', properties: { path: { type: 'string', description: 'path' } } } },
+    ];
+
+    let llmCallCount = 0;
+    const { MessageType } = require('@gossip/types');
+
+    let messageHandler: ((data: unknown, envelope: unknown) => void) | null = null;
+    const sendEnvelopeCalls: Array<{ rid_req?: string }> = [];
+
+    const mockGossipAgent = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn().mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === 'message') messageHandler = handler as (data: unknown, envelope: unknown) => void;
+      }),
+      sendEnvelope: jest.fn().mockImplementation(async (envelope: { rid_req?: string }) => {
+        sendEnvelopeCalls.push(envelope);
+        setImmediate(() => {
+          if (messageHandler && envelope.rid_req) {
+            messageHandler({ result: 'read-ok' }, { t: MessageType.RPC_RESPONSE, rid_req: envelope.rid_req });
+          }
+        });
+      }),
+      subscribe: jest.fn().mockResolvedValue(undefined),
+      unsubscribe: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const stubLlm: ILLMProvider = {
+      generate: jest.fn().mockImplementation(async () => {
+        llmCallCount++;
+        if (llmCallCount === 1) {
+          // First turn: one malformed call + one valid call
+          return {
+            text: 'mixed batch',
+            toolCalls: [
+              {
+                id: 'call_bad',
+                name: 'file_tree',
+                arguments: {},
+                argumentsParseError: 'Unexpected token d',
+                rawArguments: '{depth: 2}',
+              },
+              {
+                id: 'call_ok',
+                name: 'file_read',
+                arguments: { path: '/src/index.ts' },
+              },
+            ],
+          };
+        }
+        return { text: 'all done' };
+      }),
+    };
+
+    jest.doMock('@gossip/client', () => ({
+      GossipAgent: jest.fn().mockImplementation(() => mockGossipAgent),
+    }));
+    const { WorkerAgent: WA } = require('@gossip/orchestrator');
+
+    const worker = new WA('test-agent', stubLlm, 'ws://localhost:9999', dummyTools, undefined, false, undefined, 5);
+    await worker.start();
+
+    for await (const _event of worker.executeTask('mixed batch task', undefined, undefined, 'task-mixed')) {
+      // drain
+    }
+
+    // Only the valid file_read was forwarded to the relay
+    expect(sendEnvelopeCalls).toHaveLength(1);
+
+    jest.resetModules();
+  }, 15_000);
+});


### PR DESCRIPTION
Fixes the deepseek relay output-capture crash (4 occurrences; latest: task `92603772`, 2026-06-11 17:59:33, `FATAL ERROR in executeTask: Expected ':' after property name in JSON at position 8`).

**Root cause:** `parseOpenAIResponse` called `JSON.parse(fn.arguments)` unguarded on the model-produced tool-call arguments string. The relay already tolerates *schema-invalid* args (zod rejection → tool error fed back to the model, retry-streak machinery applies), but *syntactically invalid* argument JSON — which DeepSeek emits periodically (unquoted keys `{depth: 2}`, single quotes `{'path': 'x'}`) — threw inside response parsing and killed the entire task. One malformed tool call = one dead consensus leg.

consensus-id: 13d77b2f-dfe242f9

## Change

Fail-open at the task level, fail-loud to the model — the malformed call now behaves exactly like the already-tolerated invalid-args class:

- `LLMResponse.toolCalls` entries gain optional `argumentsParseError` + `rawArguments` (200-char snippet) fields; `parseOpenAIResponse` catches the per-call parse failure and pushes a marked call with `arguments: {}` instead of throwing.
- The worker-agent tool loop short-circuits marked calls into the error-result path — `Error: tool call arguments were not valid JSON (<parse error>): <snippet>` — **without executing the tool**, feeding the existing `turnErrors`/`consecutiveErrors` machinery. Sibling valid calls in the same response execute normally.
- Gemini/Anthropic provider paths untouched (structured args, no parse step).

Tests pin the exact incident shapes (`{depth: 2}` — the position-8 class — and `{'path': 'x'}`), the not-executed guarantee (sendEnvelope spy), the sibling-still-executes case, and the graceful streak exit.

## Pre-merge consensus

Round `13d77b2f-dfe242f9` (gemini-reviewer, gemini-tester): 12 findings, all verified, 12 signals. Adjudications: history replay of marked calls as `arguments: "{}"` kept deliberately (the suggested `'null'` replacement risks 400s from strict OpenAI-compatible providers on history replay; the paired tool error result already tells the model what happened); `rawArguments` in the error/log channel accepted (bounded at 200 chars, same sink class as every tool-result echo of model text). Deferred LOW: a varying-signatures test for the `consecutiveErrors >= 3` exit (no-FATAL already proven via the STUCK exit).

## Verification

- jest `tests/orchestrator` + `tests/relay`: 2647 passed, 0 failures (191 suites)
- `npx tsc --noEmit`: zero non-dashboard errors; full `npm run build` green

Scoring note from the audit: relay-task failures record `signal_class: "operational"` signals which `performance-reader` already excludes from accuracy — these crashes inflated dashboard failure counters, not deepseek-challenger's accuracy. With this fix, deepseek-challenger comes off the consensus bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)