### PR TITLE
feat(dashboard): auth design pass — conditional Secure cookie, ?key= auto-login, session persistence + 401 recovery (#548)

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -236,6 +236,20 @@ function memoryDirForProject(cwd: string): string {
   return join(homedir(), '.claude', 'projects', cwd.replaceAll('/', '-'), 'memory');
 }
 
+/**
+ * Compose the clickable dashboard URL with the key embedded as a query param:
+ * `http://localhost:<port>/dashboard?key=<key>`. The SPA consumes `?key=` on
+ * load (auto-login) and immediately scrubs it from the URL bar (issue #548 item
+ * 2), so this is now a truthful one-click link rather than the old
+ * `... (key: <key>)` form that no code path consumed. Falls back to the bare
+ * URL when no key is set (key is URL-encoded defensively, though it is hex).
+ */
+function dashboardClickableUrl(url: string, key: string): string {
+  if (!key) return url;
+  const sep = url.includes('?') ? '&' : '?';
+  return `${url}${sep}key=${encodeURIComponent(key)}`;
+}
+
 // ── Environment detection ────────────────────────────────────────────────
 
 type HostEnvironment = 'claude-code' | 'cursor' | 'vscode' | 'windsurf' | 'unknown';
@@ -630,7 +644,7 @@ async function doBoot() {
   });
 
   if (ctx.relay.dashboardUrl) {
-    process.stderr.write(`[gossipcat] 🌐 Dashboard: ${ctx.relay.dashboardUrl} (key: ${ctx.relay.dashboardKey})\n`);
+    process.stderr.write(`[gossipcat] 🌐 Dashboard: ${dashboardClickableUrl(ctx.relay.dashboardUrl, ctx.relay.dashboardKey)}\n`);
   }
 
   // Create performance writer for ATI signal collection
@@ -1823,7 +1837,7 @@ export function createMcpServer(): McpServer {
         `  Claude subagents found: ${claudeSubagentsList.length}`,
       ];
       if (ctx.relay?.dashboardUrl) {
-        lines.push(`  Dashboard: ${ctx.relay.dashboardUrl}${ctx.relayPortSource === 'sticky' ? ' (sticky)' : ''} (key: ${ctx.relay.dashboardKey})`);
+        lines.push(`  Dashboard: ${dashboardClickableUrl(ctx.relay.dashboardUrl, ctx.relay.dashboardKey)}${ctx.relayPortSource === 'sticky' ? ' (sticky)' : ''}`);
       }
       if (ctx.httpMcpPort) {
         lines.push(`  HTTP MCP: :${ctx.httpMcpPort}/mcp${ctx.httpMcpPortSource === 'sticky' ? ' (sticky)' : ''}`);
@@ -2652,7 +2666,7 @@ export function createMcpServer(): McpServer {
       lines.push(`\nMode: ${mode} | Config: .gossip/config.json (${Object.keys(config.agents).length} agents total)`);
       lines.push(`Rules: ${env.rulesFile} (${env.host} will read this on next session)`);
       if (ctx.relay?.dashboardUrl) {
-        lines.push(`Dashboard: ${ctx.relay.dashboardUrl} (key: ${ctx.relay.dashboardKey})`);
+        lines.push(`Dashboard: ${dashboardClickableUrl(ctx.relay.dashboardUrl, ctx.relay.dashboardKey)}`);
       }
       if (hookSummary) {
         lines.push(hookSummary);

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -173,7 +173,7 @@ function readSecretFromStdin(): Promise<string> {
 if (process.env.GOSSIPCAT_MCP_NO_MAIN !== '1' && !__argvShimHandled) {
   const gossipDir = join(process.cwd(), '.gossip');
   try { mkdirSync(gossipDir, { recursive: true }); } catch {}
-  const logStream = createWriteStream(join(gossipDir, 'mcp.log'), { flags: 'a' });
+  const logStream = createWriteStream(join(gossipDir, 'mcp.log'), { flags: 'a', mode: 0o600 });
   process.stderr.write = ((chunk: any, ...args: any[]) => {
     // Route ALL stderr to log file — Claude Code interprets any MCP stderr as server errors
     return logStream.write(chunk, ...args as any);
@@ -644,7 +644,7 @@ async function doBoot() {
   });
 
   if (ctx.relay.dashboardUrl) {
-    process.stderr.write(`[gossipcat] 🌐 Dashboard: ${dashboardClickableUrl(ctx.relay.dashboardUrl, ctx.relay.dashboardKey)}\n`);
+    process.stderr.write(`[gossipcat] 🌐 Dashboard: ${ctx.relay.dashboardUrl}\n`);
   }
 
   // Create performance writer for ATI signal collection

--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -500,9 +500,9 @@ function FindingsPage({
   );
 }
 
-function Dashboard() {
+function Dashboard({ onUnauthorized }: { onUnauthorized: () => void }) {
   const route = useRoute();
-  const { overview, agents, tasks, consensus, consensusReports, fleetTrend, signalActivity, skills, loading, error, refresh } = useDashboardData();
+  const { overview, agents, tasks, consensus, consensusReports, fleetTrend, signalActivity, skills, loading, error, refresh } = useDashboardData(onUnauthorized);
   const [activeTaskCount, setActiveTaskCount] = useState(0);
 
   const handleWsEvent = useCallback((event: DashboardEvent) => {
@@ -607,7 +607,7 @@ function Dashboard() {
 }
 
 export function App() {
-  const { authed, login, error } = useAuth();
+  const { authed, login, error, recheck } = useAuth();
 
   if (authed === null) {
     return <div className="flex min-h-screen items-center justify-center" style={{ color: 'var(--ink-3)' }}>Loading...</div>;
@@ -619,7 +619,7 @@ export function App() {
 
   return (
     <>
-      <Dashboard />
+      <Dashboard onUnauthorized={recheck} />
       <NotificationStack />
     </>
   );

--- a/packages/dashboard-v2/src/components/AuthGate.tsx
+++ b/packages/dashboard-v2/src/components/AuthGate.tsx
@@ -32,6 +32,8 @@ export function AuthGate({ onLogin, error }: AuthGateProps) {
       ? 'Invalid key. Check your terminal for the correct key.'
       : error === 'network'
       ? 'Connection error — relay may be offline.'
+      : error === 'no_cookie'
+      ? 'Your browser did not store the session cookie. Disable private/incognito mode or allow cookies for this site, then try again.'
       : null;
 
   return (

--- a/packages/dashboard-v2/src/hooks/useAuth.ts
+++ b/packages/dashboard-v2/src/hooks/useAuth.ts
@@ -1,25 +1,78 @@
 import { useState, useEffect, useCallback } from 'react';
 import { checkAuth, login as apiLogin } from '@/lib/api';
 
-export type AuthError = 'bad_key' | 'network' | null;
+export type AuthError = 'bad_key' | 'network' | 'no_cookie' | null;
+
+/**
+ * Read `?key=<key>` from the current URL exactly once, then strip it from the
+ * address bar + history entry via replaceState (issue #548 item 2). Returns the
+ * key if present so the SPA can auto-login with it; the URL is scrubbed
+ * regardless so the secret never lingers in history or gets copy-pasted.
+ */
+function consumeKeyFromUrl(): string | null {
+  if (typeof window === 'undefined') return null;
+  const params = new URLSearchParams(window.location.search);
+  const key = params.get('key');
+  if (key === null) return null;
+
+  params.delete('key');
+  const qs = params.toString();
+  const scrubbed = window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash;
+  window.history.replaceState(null, '', scrubbed);
+
+  return key.trim() || null;
+}
 
 export function useAuth() {
   const [authed, setAuthed] = useState<boolean | null>(null);
   const [error, setError] = useState<AuthError>(null);
 
-  useEffect(() => {
-    checkAuth().then(setAuthed);
-  }, []);
-
-  const login = useCallback(async (key: string) => {
+  const login = useCallback(async (key: string): Promise<void> => {
     setError(null);
     const result = await apiLogin(key);
     if (result.ok) {
       setAuthed(true);
     } else {
       setError(result.kind);
+      setAuthed(false);
     }
   }, []);
 
-  return { authed, login, error };
+  /**
+   * Re-verify the session against the relay. Wired to data-layer 401s (issue
+   * #548 item 3b): when a fetch 401s (e.g. the relay restarted and the session
+   * is gone), this lands the user back at AuthGate instead of an error card or
+   * infinite spinner.
+   */
+  const recheck = useCallback(async (): Promise<boolean> => {
+    const ok = await checkAuth();
+    setAuthed(ok);
+    return ok;
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const urlKey = consumeKeyFromUrl();
+
+    (async () => {
+      // 1. If we already have a working session cookie, use it.
+      if (await checkAuth()) {
+        if (!cancelled) setAuthed(true);
+        return;
+      }
+      // 2. Otherwise, if the URL carried a ?key=, auto-login with it.
+      if (urlKey) {
+        if (!cancelled) await login(urlKey);
+        return;
+      }
+      // 3. No session, no key — fall through to the AuthGate login form.
+      if (!cancelled) setAuthed(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [login]);
+
+  return { authed, login, error, recheck };
 }

--- a/packages/dashboard-v2/src/hooks/useAuth.ts
+++ b/packages/dashboard-v2/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { checkAuth, login as apiLogin } from '@/lib/api';
 
 export type AuthError = 'bad_key' | 'network' | 'no_cookie' | null;
@@ -26,6 +26,10 @@ function consumeKeyFromUrl(): string | null {
 export function useAuth() {
   const [authed, setAuthed] = useState<boolean | null>(null);
   const [error, setError] = useState<AuthError>(null);
+  // Guard: true while any auth check is in flight (mount IIFE or recheck).
+  // Prevents recheck from racing the mount-time async IIFE — both call
+  // checkAuth concurrently and the last setAuthed wins non-deterministically.
+  const checkInFlight = useRef<boolean>(false);
 
   const login = useCallback(async (key: string): Promise<void> => {
     setError(null);
@@ -43,30 +47,49 @@ export function useAuth() {
    * #548 item 3b): when a fetch 401s (e.g. the relay restarted and the session
    * is gone), this lands the user back at AuthGate instead of an error card or
    * infinite spinner.
+   *
+   * Returns current `authed` value immediately (without a new fetch) when
+   * another check is already in flight, preventing a race with the mount-time
+   * async IIFE.
    */
   const recheck = useCallback(async (): Promise<boolean> => {
-    const ok = await checkAuth();
-    setAuthed(ok);
-    return ok;
-  }, []);
+    if (checkInFlight.current) {
+      // A check is already running — return the current state rather than
+      // kicking off a concurrent fetch that could clobber the result.
+      return authed === true;
+    }
+    checkInFlight.current = true;
+    try {
+      const ok = await checkAuth();
+      setAuthed(ok);
+      return ok;
+    } finally {
+      checkInFlight.current = false;
+    }
+  }, [authed]);
 
   useEffect(() => {
     let cancelled = false;
     const urlKey = consumeKeyFromUrl();
 
+    checkInFlight.current = true;
     (async () => {
-      // 1. If we already have a working session cookie, use it.
-      if (await checkAuth()) {
-        if (!cancelled) setAuthed(true);
-        return;
+      try {
+        // 1. If we already have a working session cookie, use it.
+        if (await checkAuth()) {
+          if (!cancelled) setAuthed(true);
+          return;
+        }
+        // 2. Otherwise, if the URL carried a ?key=, auto-login with it.
+        if (urlKey) {
+          if (!cancelled) await login(urlKey);
+          return;
+        }
+        // 3. No session, no key — fall through to the AuthGate login form.
+        if (!cancelled) setAuthed(false);
+      } finally {
+        checkInFlight.current = false;
       }
-      // 2. Otherwise, if the URL carried a ?key=, auto-login with it.
-      if (urlKey) {
-        if (!cancelled) await login(urlKey);
-        return;
-      }
-      // 3. No session, no key — fall through to the AuthGate login form.
-      if (!cancelled) setAuthed(false);
     })();
 
     return () => {

--- a/packages/dashboard-v2/src/hooks/useDashboardData.ts
+++ b/packages/dashboard-v2/src/hooks/useDashboardData.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { api } from '@/lib/api';
+import { api, isUnauthorizedError } from '@/lib/api';
 import { formatFetchError } from '@/lib/fetchError';
 import type { OverviewData, AgentData, TasksData, ConsensusData, ConsensusReportsData, MemoryFile, FleetTrendResponse, SignalActivityResponse } from '@/lib/types';
 import type { SkillsApiResponse } from '@gossip/types';
@@ -76,7 +76,13 @@ async function namedFetch<T>(endpoint: string, path: string): Promise<T> {
   }
 }
 
-export function useDashboardData() {
+/**
+ * @param onUnauthorized Called when a core fetch returns 401 — wired by App to
+ * the auth recheck so a dead session (e.g. relay restarted, cookie expired)
+ * sends the user back to AuthGate instead of an error card / infinite spinner
+ * (issue #548 item 3b).
+ */
+export function useDashboardData(onUnauthorized?: () => void) {
   const [state, setState] = useState<DashboardState>({
     overview: null, agents: null, tasks: null, consensus: null, consensusReports: null,
     fleetTrend: null,
@@ -90,6 +96,10 @@ export function useDashboardData() {
   // project with thousands of auto-memory files). Skipping is safe — the next
   // tick fires a fresh request.
   const inFlight = useRef(false);
+  // Keep the latest onUnauthorized in a ref so refresh stays a stable callback
+  // (empty dep array) — the polling interval below depends on refresh identity.
+  const onUnauthorizedRef = useRef(onUnauthorized);
+  onUnauthorizedRef.current = onUnauthorized;
 
   const refresh = useCallback(async () => {
     if (inFlight.current) return;
@@ -146,7 +156,16 @@ export function useDashboardData() {
         loading: false, error: null,
       });
     } catch (err) {
-      setState((s) => ({ ...s, loading: false, error: (err as Error).message }));
+      // A 401 means the session died (relay restart, expired cookie). Hand off
+      // to the auth recheck instead of rendering an error card — it lands the
+      // user back at AuthGate. Skip setting the error string so we don't flash
+      // a stale "unauthorized" card during the transition.
+      if (isUnauthorizedError(err)) {
+        onUnauthorizedRef.current?.();
+        setState((s) => ({ ...s, loading: false }));
+      } else {
+        setState((s) => ({ ...s, loading: false, error: (err as Error).message }));
+      }
     } finally {
       inFlight.current = false;
     }

--- a/packages/dashboard-v2/src/lib/api.ts
+++ b/packages/dashboard-v2/src/lib/api.ts
@@ -1,5 +1,17 @@
 const BASE = '/dashboard/api';
 
+/**
+ * Message thrown by api() on an HTTP 401. Exported so the data layer can tell a
+ * dead-session 401 apart from a generic fetch failure and trigger an auth
+ * re-check (issue #548 item 3b) instead of showing an error card forever.
+ */
+export const UNAUTHORIZED = 'unauthorized';
+
+/** True if `err` is the 401 sentinel from api(), even after endpoint-wrapping. */
+export function isUnauthorizedError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes(UNAUTHORIZED);
+}
+
 /** Default abort timeout for polled api() calls (milliseconds). */
 export const API_TIMEOUT_MS = 30_000;
 
@@ -40,7 +52,7 @@ export async function api<T>(path: string, options?: RequestInit): Promise<T> {
       // A future cancellable caller must compose via AbortSignal.any.
       signal: timeoutSignal,
     });
-    if (res.status === 401) throw new Error('unauthorized');
+    if (res.status === 401) throw new Error(UNAUTHORIZED);
     if (!res.ok) throw new Error(`API error: ${res.status}`);
     return res.json() as Promise<T>;
   } catch (err) {
@@ -56,8 +68,17 @@ export async function api<T>(path: string, options?: RequestInit): Promise<T> {
   }
 }
 
-export type LoginResult = { ok: true } | { ok: false; kind: 'bad_key' | 'network' };
+export type LoginResult =
+  | { ok: true }
+  | { ok: false; kind: 'bad_key' | 'network' | 'no_cookie' };
 
+/**
+ * POST the key, then immediately verify the session actually works by hitting
+ * the authed /auth/check endpoint (issue #548 item 1: fail loudly instead of
+ * dismissing AuthGate into an infinite spinner). If the POST returned 200 but
+ * the follow-up check 401s, the browser silently dropped the session cookie —
+ * surface that as `no_cookie` so the user sees a real error.
+ */
 export async function login(key: string): Promise<LoginResult> {
   try {
     const res = await fetch(`${BASE}/auth`, {
@@ -66,17 +87,27 @@ export async function login(key: string): Promise<LoginResult> {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ key }),
     });
-    if (res.ok) return { ok: true };
-    if (res.status === 401 || res.status === 403) return { ok: false, kind: 'bad_key' };
-    return { ok: false, kind: 'network' };
+    if (!res.ok) {
+      if (res.status === 401 || res.status === 403) return { ok: false, kind: 'bad_key' };
+      return { ok: false, kind: 'network' };
+    }
+    // Auth POST succeeded — confirm the cookie round-trips before declaring victory.
+    const stored = await checkAuth();
+    if (!stored) return { ok: false, kind: 'no_cookie' };
+    return { ok: true };
   } catch {
     return { ok: false, kind: 'network' };
   }
 }
 
+/**
+ * Verify the current session by calling the dedicated /auth/check probe. Used
+ * on mount (was a session restored from a persisted cookie?) and right after
+ * login (did the browser actually store the cookie?).
+ */
 export async function checkAuth(): Promise<boolean> {
   try {
-    const res = await fetch(`${BASE}/overview`, { credentials: 'include' });
+    const res = await fetch(`${BASE}/auth/check`, { credentials: 'include' });
     return res.ok;
   } catch {
     return false;

--- a/packages/dashboard-v2/src/lib/api.ts
+++ b/packages/dashboard-v2/src/lib/api.ts
@@ -80,12 +80,14 @@ export type LoginResult =
  * surface that as `no_cookie` so the user sees a real error.
  */
 export async function login(key: string): Promise<LoginResult> {
+  const { signal: timeoutSignal, cleanup } = makeTimeoutSignal(API_TIMEOUT_MS);
   try {
     const res = await fetch(`${BASE}/auth`, {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ key }),
+      signal: timeoutSignal,
     });
     if (!res.ok) {
       if (res.status === 401 || res.status === 403) return { ok: false, kind: 'bad_key' };
@@ -97,6 +99,8 @@ export async function login(key: string): Promise<LoginResult> {
     return { ok: true };
   } catch {
     return { ok: false, kind: 'network' };
+  } finally {
+    cleanup();
   }
 }
 
@@ -106,10 +110,13 @@ export async function login(key: string): Promise<LoginResult> {
  * login (did the browser actually store the cookie?).
  */
 export async function checkAuth(): Promise<boolean> {
+  const { signal: timeoutSignal, cleanup } = makeTimeoutSignal(API_TIMEOUT_MS);
   try {
-    const res = await fetch(`${BASE}/auth/check`, { credentials: 'include' });
+    const res = await fetch(`${BASE}/auth/check`, { credentials: 'include', signal: timeoutSignal });
     return res.ok;
   } catch {
     return false;
+  } finally {
+    cleanup();
   }
 }

--- a/packages/relay/src/dashboard/auth.ts
+++ b/packages/relay/src/dashboard/auth.ts
@@ -176,10 +176,17 @@ function isPersistedAuth(v: unknown): v is PersistedAuth {
   if (o.version !== 1) return false;
   if (typeof o.key !== 'string' || !/^[0-9a-f]{32}$/.test(o.key)) return false;
   if (!Array.isArray(o.sessions)) return false;
+  // Reject files that list more sessions than createSession ever allows — a
+  // file with an inflated session count could be tampered or corrupt.
+  if (o.sessions.length > MAX_SESSIONS) return false;
   return o.sessions.every(
     (s) =>
       typeof s === 'object' && s !== null &&
       typeof (s as Session).token === 'string' &&
-      typeof (s as Session).expiresAt === 'number',
+      // Session tokens are randomBytes(32).toString('hex') — exactly 64 hex chars.
+      /^[0-9a-f]{64}$/.test((s as Session).token) &&
+      typeof (s as Session).expiresAt === 'number' &&
+      // expiresAt must be a finite number (not NaN / Infinity from JSON tricks).
+      Number.isFinite((s as Session).expiresAt),
   );
 }

--- a/packages/relay/src/dashboard/auth.ts
+++ b/packages/relay/src/dashboard/auth.ts
@@ -1,26 +1,69 @@
 import { randomBytes, timingSafeEqual, createHash } from 'crypto';
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
 
 const KEY_LENGTH = 16; // 16 bytes = 32 hex chars
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const MAX_SESSIONS = 50;
+
+/** Basename of the persisted auth file under `.gossip/`. */
+export const AUTH_FILE_NAME = 'dashboard-auth.json';
 
 interface Session {
   token: string;
   expiresAt: number;
 }
 
+/**
+ * On-disk shape of `.gossip/dashboard-auth.json`. The key + every session is an
+ * opaque random token; nothing here is derived from user input. `version` lets
+ * future format changes prune-and-regenerate instead of crashing on a stale
+ * shape.
+ */
+interface PersistedAuth {
+  version: 1;
+  key: string;
+  sessions: Session[];
+}
+
 export class DashboardAuth {
   private key: string = '';
   private sessions: Map<string, Session> = new Map();
+  /**
+   * Absolute path to `.gossip/dashboard-auth.json`, or null when running in
+   * memory-only mode (no `projectRoot` passed to init()). Existing callers and
+   * tests that call `init()` with no argument keep the original ephemeral
+   * behavior — a fresh key per process, no disk writes.
+   */
+  private persistPath: string | null = null;
 
-  init(): void {
+  /**
+   * @param projectRoot Directory that contains `.gossip/`. When provided, the
+   * key and active sessions survive relay restarts (load + prune on init,
+   * persist on every session mutation). Omit for in-memory-only mode.
+   */
+  init(projectRoot?: string): void {
+    this.persistPath = projectRoot ? join(projectRoot, '.gossip', AUTH_FILE_NAME) : null;
+
+    if (this.persistPath && this.loadPersisted(this.persistPath)) {
+      // Loaded an existing key + pruned sessions. Re-persist so the file
+      // reflects the pruned set immediately (a long-dead relay may have left
+      // many expired sessions on disk).
+      this.persist();
+      return;
+    }
+
+    // No persisted state (or memory-only mode, or a corrupt/stale file) — mint
+    // a fresh key and an empty session set.
     this.key = randomBytes(KEY_LENGTH).toString('hex');
     this.sessions.clear();
+    this.persist();
   }
 
   regenerateKey(): void {
     this.key = randomBytes(KEY_LENGTH).toString('hex');
     this.sessions.clear();
+    this.persist();
   }
 
   getKey(): string {
@@ -39,18 +82,15 @@ export class DashboardAuth {
     const b = createHash('sha256').update(this.key).digest();
     if (!timingSafeEqual(a, b)) return null;
 
-    // Evict expired sessions before creating new one
-    const now = Date.now();
-    for (const [t, s] of this.sessions) {
-      if (now > s.expiresAt) this.sessions.delete(t);
-    }
+    this.pruneExpired();
     // Cap active sessions
     if (this.sessions.size >= MAX_SESSIONS) {
       const oldest = [...this.sessions.entries()].sort((a, b) => a[1].expiresAt - b[1].expiresAt)[0];
       if (oldest) this.sessions.delete(oldest[0]);
     }
     const token = randomBytes(32).toString('hex');
-    this.sessions.set(token, { token, expiresAt: now + SESSION_TTL_MS });
+    this.sessions.set(token, { token, expiresAt: Date.now() + SESSION_TTL_MS });
+    this.persist();
     return token;
   }
 
@@ -60,8 +100,86 @@ export class DashboardAuth {
     if (!session) return false;
     if (Date.now() > session.expiresAt) {
       this.sessions.delete(token);
+      this.persist();
       return false;
     }
     return true;
   }
+
+  /** Drop every expired session from the in-memory map. */
+  private pruneExpired(): void {
+    const now = Date.now();
+    for (const [t, s] of this.sessions) {
+      if (now > s.expiresAt) this.sessions.delete(t);
+    }
+  }
+
+  /**
+   * Load key + sessions from disk, pruning expired sessions. Returns true when
+   * a usable key was loaded, false on any failure (missing file, parse error,
+   * stale shape) so the caller falls back to minting a fresh key.
+   *
+   * Trust boundary: the file lives under `.gossip/` and is written 0600 by this
+   * class, but it is still persisted state that could be tampered with or
+   * left half-written by a crash. Validate the shape before trusting it and
+   * fail closed (regenerate) on anything unexpected — never throw.
+   */
+  private loadPersisted(path: string): boolean {
+    try {
+      if (!existsSync(path)) return false;
+      const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
+      if (!isPersistedAuth(parsed)) return false;
+
+      this.key = parsed.key;
+      this.sessions.clear();
+      const now = Date.now();
+      for (const s of parsed.sessions) {
+        if (s.expiresAt > now) this.sessions.set(s.token, { token: s.token, expiresAt: s.expiresAt });
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Atomically persist key + active sessions to `.gossip/dashboard-auth.json`
+   * (temp file + rename, matching signal-aggregate-index.ts). No-op in
+   * memory-only mode. Writes are best-effort: a disk failure must not take down
+   * auth, so errors are swallowed (the in-memory state stays authoritative for
+   * this process).
+   */
+  private persist(): void {
+    if (!this.persistPath) return;
+    const data: PersistedAuth = {
+      version: 1,
+      key: this.key,
+      sessions: [...this.sessions.values()],
+    };
+    const tmp = `${this.persistPath}.${process.pid}.tmp`;
+    try {
+      mkdirSync(dirname(this.persistPath), { recursive: true });
+      // 0600: the key + session tokens are bearer credentials. Matches
+      // keychain.ts:99's mode for the encrypted credential store.
+      writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
+      renameSync(tmp, this.persistPath);
+    } catch {
+      try { unlinkSync(tmp); } catch { /* ignore */ }
+    }
+  }
+}
+
+/** Fail-closed shape guard for the persisted auth file (untrusted disk state). */
+function isPersistedAuth(v: unknown): v is PersistedAuth {
+  if (typeof v !== 'object' || v === null) return false;
+  const o = v as Record<string, unknown>;
+  if (o.version !== 1) return false;
+  if (typeof o.key !== 'string' || !/^[0-9a-f]{32}$/.test(o.key)) return false;
+  if (!Array.isArray(o.sessions)) return false;
+  return o.sessions.every(
+    (s) =>
+      typeof s === 'object' && s !== null &&
+      typeof (s as Session).token === 'string' &&
+      typeof (s as Session).expiresAt === 'number',
+  );
 }

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -36,6 +36,44 @@ interface AgentConfigLike {
   native?: boolean;
 }
 
+/**
+ * True when the request reached us over TLS. The relay is its own HTTP server
+ * (no bundled TLS termination today), so direct socket detection — a
+ * TLSSocket exposes `.encrypted === true` — is the primary signal. We also
+ * honor `x-forwarded-proto: https` for the reverse-proxy-in-front case, but
+ * only as a secondary check; a plain-HTTP relay never sets it itself.
+ *
+ * Why this matters (issue #548 item 1): the session cookie was always sent
+ * with `Secure`, but the relay serves plain HTTP. Browsers drop a `Secure`
+ * cookie on http:// origins (Safari does NOT exempt localhost), so login
+ * "succeeded" with a 200 yet every subsequent API call 401'd. Emitting
+ * `Secure` only over real TLS fixes that without weakening HTTPS deployments.
+ */
+export function isRequestSecure(req: IncomingMessage): boolean {
+  const socket = req.socket as { encrypted?: boolean } | undefined;
+  if (socket?.encrypted === true) return true;
+  const xfp = req.headers['x-forwarded-proto'];
+  const proto = Array.isArray(xfp) ? xfp[0] : xfp;
+  return typeof proto === 'string' && proto.split(',')[0].trim().toLowerCase() === 'https';
+}
+
+/**
+ * Build the session Set-Cookie value. `Secure` is included only when the
+ * request arrived over TLS — see isRequestSecure. HttpOnly + SameSite=Strict +
+ * the 24h Max-Age are unchanged.
+ */
+export function buildSessionCookie(token: string, secure: boolean): string {
+  const attrs = [
+    `dashboard_session=${token}`,
+    'HttpOnly',
+    'SameSite=Strict',
+    'Path=/dashboard',
+    'Max-Age=86400',
+  ];
+  if (secure) attrs.splice(1, 0, 'Secure');
+  return attrs.join('; ');
+}
+
 interface DashboardContext {
   agentConfigs: AgentConfigLike[];
   relayConnections: number;
@@ -258,7 +296,7 @@ export class DashboardRouter {
       this.authAttempts.delete(ip);
       res.writeHead(200, {
         'Content-Type': 'application/json',
-        'Set-Cookie': `dashboard_session=${token}; HttpOnly; Secure; SameSite=Strict; Path=/dashboard; Max-Age=86400`,
+        'Set-Cookie': buildSessionCookie(token, isRequestSecure(req)),
       });
       res.end(JSON.stringify({ ok: true }));
     } catch {
@@ -354,6 +392,17 @@ export class DashboardRouter {
 
   private async handleApi(req: IncomingMessage, res: ServerResponse, url: string, query: URLSearchParams | null): Promise<boolean> {
     try {
+      // Lightweight "does my session actually work" probe (issue #548 item 1).
+      // Reaching here means the session/Bearer auth in handle() already passed,
+      // so a 200 here is proof the cookie was stored and is being sent back.
+      // The SPA calls this right after a successful login POST and shows a
+      // clear "your browser did not store the session cookie" error on 401,
+      // instead of dismissing AuthGate into an infinite-loading state.
+      if (url === '/dashboard/api/auth/check' && req.method === 'GET') {
+        this.json(res, 200, { ok: true });
+        return true;
+      }
+
       if (url === '/dashboard/api/overview' && req.method === 'GET') {
         const data = await overviewHandler(this.projectRoot, this.ctx);
         this.json(res, 200, data);

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -85,7 +85,10 @@ export class RelayServer {
 
       if (this.config.dashboard) {
         this.dashboardAuth = new DashboardAuth();
-        this.dashboardAuth.init();
+        // Pass projectRoot so the key + active sessions persist under
+        // `.gossip/dashboard-auth.json` across relay restarts (issue #548 item
+        // 3a) instead of regenerating and 401-ing every open tab.
+        this.dashboardAuth.init(this.config.dashboard.projectRoot);
         this.dashboardWs = new DashboardWs();
         this.dashboardWs.startLogWatcher(this.config.dashboard.projectRoot);
         this.dashboardUpgrader = new WebSocketServer({ noServer: true });

--- a/tests/cli/mcp-server-setup-dashboard.test.ts
+++ b/tests/cli/mcp-server-setup-dashboard.test.ts
@@ -26,9 +26,14 @@ function buildSetupResponseLines(opts: {
   const lines: string[] = [];
   lines.push(`\nMode: ${opts.mode} | Config: .gossip/config.json (${opts.agentCount} agents total)`);
   lines.push(`Rules: ${opts.rulesFile} (${opts.host} will read this on next session)`);
-  // This is the logic added by Change 4 of the install-drift fix.
+  // This is the logic added by Change 4 of the install-drift fix. Issue #548
+  // item 2 changed the format from `... (key: <key>)` to a clickable
+  // `<url>?key=<key>` link that the SPA consumes + scrubs on load.
   if (opts.dashboardUrl) {
-    lines.push(`Dashboard: ${opts.dashboardUrl} (key: ${opts.dashboardKey})`);
+    const url = opts.dashboardKey
+      ? `${opts.dashboardUrl}${opts.dashboardUrl.includes('?') ? '&' : '?'}key=${encodeURIComponent(opts.dashboardKey)}`
+      : opts.dashboardUrl;
+    lines.push(`Dashboard: ${url}`);
   }
   return lines;
 }
@@ -47,6 +52,9 @@ describe('gossip_setup handler — dashboard URL in response', () => {
     expect(text).toContain('http://localhost:');
     expect(text).toContain('http://localhost:52731');
     expect(text).toContain('test-key-abc');
+    // Issue #548 item 2: key is now a clickable ?key= param, not "(key: ...)".
+    expect(text).toContain('http://localhost:52731?key=test-key-abc');
+    expect(text).not.toContain('(key:');
   });
 
   it('omits dashboard line when relay is not running', () => {

--- a/tests/relay/dashboard-auth-cookie.test.ts
+++ b/tests/relay/dashboard-auth-cookie.test.ts
@@ -1,0 +1,59 @@
+import { isRequestSecure, buildSessionCookie } from '@gossip/relay/dashboard/routes';
+import { IncomingMessage } from 'http';
+
+function mockReq(opts: { encrypted?: boolean; headers?: Record<string, string | string[]> }): IncomingMessage {
+  return {
+    socket: opts.encrypted === undefined ? {} : { encrypted: opts.encrypted },
+    headers: opts.headers ?? {},
+  } as unknown as IncomingMessage;
+}
+
+describe('isRequestSecure (issue #548 item 1)', () => {
+  it('returns true when the socket is a TLSSocket (encrypted)', () => {
+    expect(isRequestSecure(mockReq({ encrypted: true }))).toBe(true);
+  });
+
+  it('returns false on a plain HTTP socket', () => {
+    expect(isRequestSecure(mockReq({ encrypted: false }))).toBe(false);
+  });
+
+  it('returns false when there is no encrypted flag and no forwarded header', () => {
+    expect(isRequestSecure(mockReq({}))).toBe(false);
+  });
+
+  it('honors x-forwarded-proto: https', () => {
+    expect(isRequestSecure(mockReq({ headers: { 'x-forwarded-proto': 'https' } }))).toBe(true);
+  });
+
+  it('treats x-forwarded-proto: http as insecure', () => {
+    expect(isRequestSecure(mockReq({ headers: { 'x-forwarded-proto': 'http' } }))).toBe(false);
+  });
+
+  it('reads the first proto in a comma-joined forwarded header', () => {
+    expect(isRequestSecure(mockReq({ headers: { 'x-forwarded-proto': 'https, http' } }))).toBe(true);
+    expect(isRequestSecure(mockReq({ headers: { 'x-forwarded-proto': 'http, https' } }))).toBe(false);
+  });
+
+  it('reads the first value of an array forwarded header', () => {
+    expect(isRequestSecure(mockReq({ headers: { 'x-forwarded-proto': ['https', 'http'] } }))).toBe(true);
+  });
+});
+
+describe('buildSessionCookie (issue #548 item 1)', () => {
+  it('omits Secure over plain HTTP so the browser actually stores the cookie', () => {
+    const cookie = buildSessionCookie('tok123', false);
+    expect(cookie).not.toMatch(/;\s*Secure/);
+    expect(cookie).toContain('dashboard_session=tok123');
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('SameSite=Strict');
+    expect(cookie).toContain('Path=/dashboard');
+    expect(cookie).toContain('Max-Age=86400');
+  });
+
+  it('includes Secure when served over TLS', () => {
+    const cookie = buildSessionCookie('tok123', true);
+    expect(cookie).toContain('Secure');
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('SameSite=Strict');
+  });
+});

--- a/tests/relay/dashboard-auth-persistence.test.ts
+++ b/tests/relay/dashboard-auth-persistence.test.ts
@@ -105,6 +105,78 @@ describe('DashboardAuth persistence (issue #548 item 3a)', () => {
     expect(existsSync(authFile(root))).toBe(false);
   });
 
+  it('fails closed when the file lists more than MAX_SESSIONS sessions', () => {
+    // A persisted file with 60 future-dated sessions exceeds the MAX_SESSIONS (50)
+    // cap enforced by isPersistedAuth — the file must be rejected and a fresh key
+    // + empty session set minted instead (fail-closed).
+    const root = makeRoot();
+    const auth = new DashboardAuth();
+    auth.init(root);
+    const originalKey = auth.getKey();
+
+    // Write a tampered file: 60 valid-looking future-dated sessions.
+    const tamperedSessions = Array.from({ length: 60 }, (_, i) => ({
+      token: String(i).padStart(64, 'a'),
+      expiresAt: Date.now() + 60_000,
+    }));
+    writeFileSync(
+      authFile(root),
+      JSON.stringify({ version: 1, key: originalKey, sessions: tamperedSessions }),
+      'utf8',
+    );
+
+    const auth2 = new DashboardAuth();
+    auth2.init(root);
+    // Must have regenerated — old key is NOT reused.
+    expect(auth2.getKey()).not.toBe(originalKey);
+    expect(auth2.getKey()).toMatch(/^[0-9a-f]{32}$/);
+    // Sessions must be empty after fail-closed reset.
+    const onDisk = JSON.parse(readFileSync(authFile(root), 'utf8'));
+    expect(onDisk.sessions).toHaveLength(0);
+  });
+
+  it('fails closed when a session token is not 64 hex chars', () => {
+    // Tokens that are wrong length or contain non-hex chars must be rejected.
+    const root = makeRoot();
+    const auth = new DashboardAuth();
+    auth.init(root);
+    const originalKey = auth.getKey();
+
+    const badCases = [
+      // 63 chars — one short
+      { token: 'a'.repeat(63), expiresAt: Date.now() + 60_000 },
+    ];
+    writeFileSync(
+      authFile(root),
+      JSON.stringify({ version: 1, key: originalKey, sessions: badCases }),
+      'utf8',
+    );
+
+    const auth2 = new DashboardAuth();
+    auth2.init(root);
+    expect(auth2.getKey()).not.toBe(originalKey);
+    expect(auth2.getKey()).toMatch(/^[0-9a-f]{32}$/);
+
+    // Also verify a non-hex token is rejected.
+    const root2 = makeRoot();
+    const auth3 = new DashboardAuth();
+    auth3.init(root2);
+    const key3 = auth3.getKey();
+    writeFileSync(
+      authFile(root2),
+      JSON.stringify({
+        version: 1,
+        key: key3,
+        sessions: [{ token: 'z'.repeat(64), expiresAt: Date.now() + 60_000 }],
+      }),
+      'utf8',
+    );
+    const auth4 = new DashboardAuth();
+    auth4.init(root2);
+    expect(auth4.getKey()).not.toBe(key3);
+    expect(auth4.getKey()).toMatch(/^[0-9a-f]{32}$/);
+  });
+
   it('regenerateKey() clears sessions and re-persists', () => {
     const root = makeRoot();
     const auth = new DashboardAuth();

--- a/tests/relay/dashboard-auth-persistence.test.ts
+++ b/tests/relay/dashboard-auth-persistence.test.ts
@@ -1,0 +1,124 @@
+import { DashboardAuth, AUTH_FILE_NAME } from '@gossip/relay/dashboard/auth';
+import { mkdtempSync, readFileSync, writeFileSync, existsSync, mkdirSync, statSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'gossip-auth-'));
+  mkdirSync(join(root, '.gossip'), { recursive: true });
+  return root;
+}
+
+function authFile(root: string): string {
+  return join(root, '.gossip', AUTH_FILE_NAME);
+}
+
+describe('DashboardAuth persistence (issue #548 item 3a)', () => {
+  it('persists the key + sessions across init() calls (relay restart)', () => {
+    const root = makeRoot();
+
+    const a1 = new DashboardAuth();
+    a1.init(root);
+    const key = a1.getKey();
+    const token = a1.createSession(key);
+    expect(token).toBeTruthy();
+
+    // Simulate a relay restart: a fresh instance loads from disk.
+    const a2 = new DashboardAuth();
+    a2.init(root);
+    expect(a2.getKey()).toBe(key); // same key, not regenerated
+    expect(a2.validateSession(token!)).toBe(true); // session survived
+  });
+
+  it('writes the auth file under .gossip/ with mode 0600', () => {
+    const root = makeRoot();
+    const auth = new DashboardAuth();
+    auth.init(root);
+    auth.createSession(auth.getKey());
+
+    const path = authFile(root);
+    expect(existsSync(path)).toBe(true);
+    // Lower 9 permission bits should be 0o600 (owner read/write only).
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  it('prunes expired sessions on init() instead of wiping the key', () => {
+    const root = makeRoot();
+
+    const a1 = new DashboardAuth();
+    a1.init(root);
+    const key = a1.getKey();
+    const liveToken = a1.createSession(key)!;
+
+    // Hand-craft a file with one expired + one live session and the same key.
+    const onDisk = JSON.parse(readFileSync(authFile(root), 'utf8'));
+    onDisk.sessions.push({ token: 'a'.repeat(64), expiresAt: Date.now() - 1000 });
+    writeFileSync(authFile(root), JSON.stringify(onDisk), 'utf8');
+
+    const a2 = new DashboardAuth();
+    a2.init(root);
+    expect(a2.getKey()).toBe(key); // key kept
+    expect(a2.validateSession(liveToken)).toBe(true); // live session kept
+    expect(a2.validateSession('a'.repeat(64))).toBe(false); // expired pruned
+
+    // The pruned expired session must not linger on disk after init re-persist.
+    const after = JSON.parse(readFileSync(authFile(root), 'utf8'));
+    expect(after.sessions.some((s: { token: string }) => s.token === 'a'.repeat(64))).toBe(false);
+  });
+
+  it('regenerates a fresh key when no file is persisted', () => {
+    const root = makeRoot();
+    const auth = new DashboardAuth();
+    auth.init(root);
+    expect(auth.getKey()).toMatch(/^[0-9a-f]{32}$/);
+    expect(existsSync(authFile(root))).toBe(true);
+  });
+
+  it('fails closed (regenerates) on a corrupt auth file', () => {
+    const root = makeRoot();
+    writeFileSync(authFile(root), '{ not valid json', 'utf8');
+
+    const auth = new DashboardAuth();
+    auth.init(root);
+    expect(auth.getKey()).toMatch(/^[0-9a-f]{32}$/); // minted fresh, no throw
+  });
+
+  it('fails closed on a stale/invalid shape (wrong version, bad key)', () => {
+    const root = makeRoot();
+    writeFileSync(
+      authFile(root),
+      JSON.stringify({ version: 99, key: 'not-hex', sessions: [] }),
+      'utf8',
+    );
+
+    const auth = new DashboardAuth();
+    auth.init(root);
+    expect(auth.getKey()).toMatch(/^[0-9a-f]{32}$/);
+    expect(auth.getKey()).not.toBe('not-hex');
+  });
+
+  it('stays in-memory (no file) when init() is called without a projectRoot', () => {
+    const root = makeRoot();
+    const auth = new DashboardAuth();
+    auth.init(); // memory-only mode
+    auth.createSession(auth.getKey());
+    expect(existsSync(authFile(root))).toBe(false);
+  });
+
+  it('regenerateKey() clears sessions and re-persists', () => {
+    const root = makeRoot();
+    const auth = new DashboardAuth();
+    auth.init(root);
+    const token = auth.createSession(auth.getKey())!;
+    const oldKey = auth.getKey();
+
+    auth.regenerateKey();
+    expect(auth.getKey()).not.toBe(oldKey);
+    expect(auth.validateSession(token)).toBe(false);
+
+    // A restart picks up the new key, not the old one.
+    const a2 = new DashboardAuth();
+    a2.init(root);
+    expect(a2.getKey()).toBe(auth.getKey());
+  });
+});

--- a/tests/relay/dashboard-routes.test.ts
+++ b/tests/relay/dashboard-routes.test.ts
@@ -51,7 +51,7 @@ describe('DashboardRouter', () => {
     expect(handled).toBe(false);
   });
 
-  it('POST /dashboard/api/auth sets session cookie on valid key', async () => {
+  it('POST /dashboard/api/auth sets session cookie on valid key (no Secure over HTTP)', async () => {
     const req = mockReq('POST', '/dashboard/api/auth');
     const body = JSON.stringify({ key: auth.getKey() });
     const res = mockRes();
@@ -65,8 +65,41 @@ describe('DashboardRouter', () => {
     expect(res._status).toBe(200);
     expect(res._headers['Set-Cookie']).toContain('dashboard_session=');
     expect(res._headers['Set-Cookie']).toContain('HttpOnly');
-    expect(res._headers['Set-Cookie']).toContain('Secure');
     expect(res._headers['Set-Cookie']).toContain('SameSite=Strict');
+    // Issue #548 item 1: the relay serves plain HTTP, so Secure must be
+    // omitted or the browser silently drops the cookie.
+    expect(res._headers['Set-Cookie']).not.toMatch(/;\s*Secure/);
+  });
+
+  it('POST /dashboard/api/auth includes Secure when served over TLS', async () => {
+    const req = mockReq('POST', '/dashboard/api/auth');
+    (req as unknown as { socket: { encrypted: boolean } }).socket = { encrypted: true };
+    const body = JSON.stringify({ key: auth.getKey() });
+    const res = mockRes();
+
+    const handled = router.handle(req, res);
+    req.emit('data', Buffer.from(body));
+    req.emit('end');
+    await handled;
+
+    expect(res._status).toBe(200);
+    expect(res._headers['Set-Cookie']).toContain('Secure');
+  });
+
+  it('GET /dashboard/api/auth/check returns 200 with a valid session cookie', async () => {
+    const token = auth.createSession(auth.getKey())!;
+    const req = mockReq('GET', '/dashboard/api/auth/check', { cookie: `dashboard_session=${token}` });
+    const res = mockRes();
+    await router.handle(req, res);
+    expect(res._status).toBe(200);
+    expect(JSON.parse(res._body)).toEqual({ ok: true });
+  });
+
+  it('GET /dashboard/api/auth/check returns 401 without a session', async () => {
+    const req = mockReq('GET', '/dashboard/api/auth/check');
+    const res = mockRes();
+    await router.handle(req, res);
+    expect(res._status).toBe(401);
   });
 
   it('POST /dashboard/api/auth rejects invalid key', async () => {


### PR DESCRIPTION
Closes #548. Design-pass implementation of all three bundled auth items, plus a consensus-driven hardening fixup.

consensus-id: a8503bfb-70a14888

## Item 1 — Conditional `Secure` cookie + fail-loud login (HIGH)
- `isRequestSecure(req)` (TLSSocket `.encrypted` primary, `x-forwarded-proto: https` secondary) — `Secure` flag only emitted over TLS, fixing Safari-on-localhost and all non-localhost plain-HTTP origins.
- New `GET /dashboard/api/auth/check` probe; the SPA verifies the cookie round-trips after login and surfaces "your browser did not store the session cookie" instead of an infinite spinner.

## Item 2 — `?key=` auto-login + URL scrub (HIGH, UX)
- SPA consumes `?key=` on load, auto-logs-in, and scrubs it via `history.replaceState` (synchronously, before any network call — verified in review).
- All 3 `gossip_status` banner sites now print the truthful clickable `http://localhost:<port>/dashboard?key=<key>` form.

## Item 3 — Session persistence + 401 recovery (MEDIUM)
- Key + sessions persisted to `.gossip/dashboard-auth.json` (atomic temp+rename, `0600`, fail-closed shape guard); restarts prune expired sessions instead of wiping everything.
- 401s from the data-fetch layer propagate into a global auth re-check, landing dead sessions back at AuthGate.

## Consensus hardening fixup (318761ad)
Pre-merge consensus (3 agents, 2 rounds: 11 confirmed / 1 disputed-refuted / 24 signals recorded):
- `isPersistedAuth` enforces 64-hex token format, finite `expiresAt`, `MAX_SESSIONS` cap on load (f15, MEDIUM)
- `mcp.log` created `0600`; boot log line no longer embeds the dashboard key (f16, MEDIUM)
- `login()`/`checkAuth()` fetch timeouts via `makeTimeoutSignal` (f17)
- `useAuth` in-flight guard for the recheck/mount race (f1)

## Tests
- New: `dashboard-auth-persistence.test.ts` (10 tests incl. fail-closed guards), `dashboard-auth-cookie.test.ts`
- Updated: `dashboard-routes.test.ts` (Secure-flag branches, `/auth/check` 200/401), `mcp-server-setup-dashboard.test.ts` (new banner format)
- Full suite: 308 suites, 4113 passed. `npm run build` + `build:mcp` + `build:dashboard` + dashboard tsc clean.

## Known follow-ups (out of scope, from consensus)
- dashboard-v2 has no test runner — `useAuth` hook logic ships untested (HIGH coverage gap, needs a vitest harness)
- Pre-existing: unbounded `authAttempts` map pruning, `readBody` outside try/catch in `handleAuth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)