### PR TITLE
fix(cli): verify_memory + gossip_plan re-entry stash outlived by its own protocol (#545)

### DIFF
--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -337,7 +337,7 @@ function recordTimeoutSignal(taskId: string, agentId: string): void {
 /** 24-hour TTL for utility result map — longer than the 2h normal TTL so
  * skill_develop dispatch→relay→re-entry chains that span process restarts
  * don't silently fall back to stale template skills. */
-const UTILITY_RESULT_TTL_MS = 24 * 60 * 60 * 1000;
+export const UTILITY_RESULT_TTL_MS = 24 * 60 * 60 * 1000;
 
 /** Schedule periodic calls to {@link evictStaleNativeTasks}. Returns a
  * handle whose `stop()` clears the interval. The timer is `.unref()`'d so it

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -188,7 +188,7 @@ import { randomUUID, randomBytes, timingSafeEqual } from 'crypto';
 import { createServer as createHttpServer, IncomingMessage, ServerResponse } from 'http';
 
 // ── Extracted modules ────────────────────────────────────────────────────
-import { ctx } from './mcp-context';
+import { ctx, NATIVE_TASK_TTL_MS } from './mcp-context';
 import { MAX_TOOL_TURNS_CEILING } from './config';
 import { getGossipcatVersion } from './version';
 import { captureGitStatus, checkUnexpectedChanges } from './utility-guard';
@@ -1423,15 +1423,16 @@ export function createMcpServer(): McpServer {
               spawnTimeoutWatcher(utilityTaskId, ctx.nativeTaskMap.get(utilityTaskId)!);
               // F13 hardening: evict the stash if the orchestrator never
               // re-enters (agent crash, Claude restart). Matches the
-              // _pendingVerifyData pattern. Issue #545: align the lifetime with
-              // UTILITY_RESULT_TTL_MS (24h) — the relayed result lives that long
-              // in ctx.nativeResultMap, so a shorter stash TTL would evict before
-              // a slow re-entry. Also evict the guard snapshot (deleted inline on
-              // re-entry, otherwise leaks for the process lifetime).
+              // _pendingVerifyData pattern. Issue #545: align the stash lifetime
+              // with the result map lifetime. gossip_plan results go to
+              // ctx.nativeResultMap, swept at NATIVE_TASK_TTL_MS (2h); only
+              // skill_develop results go to the 24h nativeUtilityResultMap.
+              // Also evict the guard snapshot (deleted inline on re-entry,
+              // otherwise leaks for the process lifetime).
               setTimeout(() => {
                 _pendingPlanData.delete(utilityTaskId);
                 _utilityGuardSnapshots.delete(utilityTaskId);
-              }, UTILITY_RESULT_TTL_MS).unref();
+              }, NATIVE_TASK_TTL_MS).unref();
 
               const { assembleUtilityPrompt } = await import('@gossip/orchestrator');
               const modelShort = ctx.nativeUtilityConfig.model;
@@ -4160,6 +4161,13 @@ export function createMcpServer(): McpServer {
             });
             try { ctx.mainAgent.recordNativeTask(taskId, '_utility', `skill_develop:${category}`); } catch { /* best-effort */ }
             spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
+            // Stash eviction: skill_develop results go to ctx.nativeUtilityResultMap
+            // (swept at UTILITY_RESULT_TTL_MS, 24h) — align the stash lifetime so
+            // re-entry never sees a missing stash while the result is still alive.
+            setTimeout(() => {
+              _pendingSkillData.delete(taskId);
+              _utilityGuardSnapshots.delete(taskId);
+            }, UTILITY_RESULT_TTL_MS).unref();
 
             const modelShort = ctx.nativeUtilityConfig.model;
             return {
@@ -4692,6 +4700,12 @@ export function createMcpServer(): McpServer {
         });
         try { ctx.mainAgent.recordNativeTask(taskId, '_utility', 'session_summary'); } catch { /* best-effort */ }
         spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
+        // Stash eviction: session_summary results go to ctx.nativeResultMap
+        // (swept at NATIVE_TASK_TTL_MS, 2h) — align the stash lifetime to match.
+        setTimeout(() => {
+          _pendingSessionData.delete(taskId);
+          _utilityGuardSnapshots.delete(taskId);
+        }, NATIVE_TASK_TTL_MS).unref();
 
         const agentPrompt = `${system}\n\n---\n\n${user}`;
         const modelShort = ctx.nativeUtilityConfig.model;
@@ -4944,20 +4958,17 @@ export function createMcpServer(): McpServer {
       // F3 hardening: spawnTimeoutWatcher only writes a timed_out record into
       // ctx.nativeResultMap; it does not know about _pendingVerifyData. Schedule
       // an independent eviction so the stash never outlives a never-re-entered
-      // dispatch. Issue #545: the eviction must outlive the documented 3-step
-      // re-entry protocol (dispatch → run haiku Agent → relay → re-call), which
-      // routinely exceeds 150s because the haiku agent alone runs 1-3+ minutes.
-      // The relayed result lives in ctx.nativeResultMap for UTILITY_RESULT_TTL_MS
-      // (24h) by design, so the stash must match it — a shorter TTL evicted the
-      // stash before re-entry and forced a spurious INCONCLUSIVE "unknown
-      // _utility_task_id" even though the result was healthy. Also evict the
-      // guard snapshot on the same schedule: on re-entry it is deleted inline,
-      // but if the orchestrator never re-calls it would otherwise leak for the
-      // process lifetime.
+      // dispatch. verify_memory results go to ctx.nativeResultMap, swept at
+      // NATIVE_TASK_TTL_MS (2h); only skill_develop uses the 24h
+      // nativeUtilityResultMap. The stash TTL matches the result map lifetime
+      // so re-entry never sees a missing stash while the result is still alive.
+      // Also evict the guard snapshot on the same schedule: on re-entry it is
+      // deleted inline, but if the orchestrator never re-calls it would
+      // otherwise leak for the process lifetime.
       setTimeout(() => {
         _pendingVerifyData.delete(taskId);
         _utilityGuardSnapshots.delete(taskId);
-      }, UTILITY_RESULT_TTL_MS).unref();
+      }, NATIVE_TASK_TTL_MS).unref();
 
       const modelShort = ctx.nativeUtilityConfig.model;
       return {

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -203,7 +203,7 @@ try {
   const stalenessResult = checkDistMcpStaleness(__filename);
   if (stalenessResult.stale) logStalenessToMcpLog(stalenessResult, process.cwd());
 } catch { /* never break boot */ }
-import { restoreNativeTaskMap, handleNativeRelay, spawnTimeoutWatcher, scheduleNativeTaskEviction } from './handlers/native-tasks';
+import { restoreNativeTaskMap, handleNativeRelay, spawnTimeoutWatcher, scheduleNativeTaskEviction, UTILITY_RESULT_TTL_MS } from './handlers/native-tasks';
 import { handleDispatchSingle, handleDispatchParallel, handleDispatchConsensus, detectLostDispatchWarnings } from './handlers/dispatch';
 import {
   invalidateAgent as invalidateDispatchPromptCacheForAgent,
@@ -1423,11 +1423,15 @@ export function createMcpServer(): McpServer {
               spawnTimeoutWatcher(utilityTaskId, ctx.nativeTaskMap.get(utilityTaskId)!);
               // F13 hardening: evict the stash if the orchestrator never
               // re-enters (agent crash, Claude restart). Matches the
-              // _pendingVerifyData pattern.
-              const STASH_TTL_MS = UTILITY_TTL_MS + 30_000;
+              // _pendingVerifyData pattern. Issue #545: align the lifetime with
+              // UTILITY_RESULT_TTL_MS (24h) — the relayed result lives that long
+              // in ctx.nativeResultMap, so a shorter stash TTL would evict before
+              // a slow re-entry. Also evict the guard snapshot (deleted inline on
+              // re-entry, otherwise leaks for the process lifetime).
               setTimeout(() => {
                 _pendingPlanData.delete(utilityTaskId);
-              }, STASH_TTL_MS).unref();
+                _utilityGuardSnapshots.delete(utilityTaskId);
+              }, UTILITY_RESULT_TTL_MS).unref();
 
               const { assembleUtilityPrompt } = await import('@gossip/orchestrator');
               const modelShort = ctx.nativeUtilityConfig.model;
@@ -4939,12 +4943,21 @@ export function createMcpServer(): McpServer {
       spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
       // F3 hardening: spawnTimeoutWatcher only writes a timed_out record into
       // ctx.nativeResultMap; it does not know about _pendingVerifyData. Schedule
-      // an independent eviction with a small grace window so the stash never
-      // outlives a never-re-entered dispatch.
-      const STASH_TTL_MS = UTILITY_TTL_MS + 30_000;
+      // an independent eviction so the stash never outlives a never-re-entered
+      // dispatch. Issue #545: the eviction must outlive the documented 3-step
+      // re-entry protocol (dispatch → run haiku Agent → relay → re-call), which
+      // routinely exceeds 150s because the haiku agent alone runs 1-3+ minutes.
+      // The relayed result lives in ctx.nativeResultMap for UTILITY_RESULT_TTL_MS
+      // (24h) by design, so the stash must match it — a shorter TTL evicted the
+      // stash before re-entry and forced a spurious INCONCLUSIVE "unknown
+      // _utility_task_id" even though the result was healthy. Also evict the
+      // guard snapshot on the same schedule: on re-entry it is deleted inline,
+      // but if the orchestrator never re-calls it would otherwise leak for the
+      // process lifetime.
       setTimeout(() => {
         _pendingVerifyData.delete(taskId);
-      }, STASH_TTL_MS).unref();
+        _utilityGuardSnapshots.delete(taskId);
+      }, UTILITY_RESULT_TTL_MS).unref();
 
       const modelShort = ctx.nativeUtilityConfig.model;
       return {

--- a/tests/cli/gossip-verify-memory.stash-ttl.test.ts
+++ b/tests/cli/gossip-verify-memory.stash-ttl.test.ts
@@ -1,20 +1,19 @@
 /**
- * Regression test for issue #545 — gossip_verify_memory re-entry failed with
- * `INCONCLUSIVE: unknown _utility_task_id ... (not a verify_memory dispatch)`.
+ * Regression test for issue #545 — gossip_verify_memory / gossip_plan re-entry
+ * failed with `INCONCLUSIVE: unknown _utility_task_id`.
  *
- * Root cause: the dispatch path stashed re-entry data in the module-private
- * `_pendingVerifyData` map and scheduled an eviction after
- * `STASH_TTL_MS = UTILITY_TTL_MS + 30_000` = 150s. The documented 3-step
- * protocol (dispatch → run haiku Agent → gossip_relay → re-call with
- * `_utility_task_id`) routinely takes longer than 150s because the haiku agent
- * alone runs 1-3+ minutes. When the re-call arrived after 150s the stash was
- * already gone, so the re-entry guard returned INCONCLUSIVE even though the
- * relayed result was sitting healthy in `ctx.nativeResultMap` (utility results
- * have a 24h TTL by design).
+ * Root cause: dispatch paths stashed re-entry data and scheduled eviction at
+ * `UTILITY_RESULT_TTL_MS` (24h) regardless of which result map the result lands
+ * in. verify_memory and gossip_plan results go to `ctx.nativeResultMap`, swept
+ * at `NATIVE_TASK_TTL_MS` (2h). The stash was evicted after 2h but the
+ * re-entry code expected the result to still be alive for 24h — a 22h window
+ * where the stash was gone but the result was not.
  *
- * The fix aligns the stash eviction with `UTILITY_RESULT_TTL_MS` (24h) so the
- * stash outlives the slow re-entry, and evicts the guard snapshot on the same
- * schedule so it does not leak when re-entry never happens.
+ * The principle: EACH stash's TTL must equal its result map's TTL.
+ * - verify_memory  → ctx.nativeResultMap → NATIVE_TASK_TTL_MS (2h)
+ * - gossip_plan    → ctx.nativeResultMap → NATIVE_TASK_TTL_MS (2h)
+ * - skill_develop  → ctx.nativeUtilityResultMap → UTILITY_RESULT_TTL_MS (24h)
+ * - session_summary → ctx.nativeResultMap → NATIVE_TASK_TTL_MS (2h)
  *
  * The verify_memory tool wrapper cannot be driven end-to-end under jest: its
  * dispatch branch does `await import('./handlers/verify-memory.js')` and the
@@ -22,13 +21,14 @@
  * documents this and tests the pure handler functions instead). So this suite
  * guards the eviction MECHANICS at the source level — the same drift-guard
  * pattern used by the `utility-task task.created log-hygiene` suite in
- * native-utility.test.ts. The exported TTL constant's value is also asserted at
- * runtime so a future edit to the literal flips this red.
+ * native-utility.test.ts. The exported TTL constant values are also asserted at
+ * runtime so future edits to the literals flip this red.
  */
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 import { UTILITY_RESULT_TTL_MS } from '../../apps/cli/src/handlers/native-tasks';
+import { NATIVE_TASK_TTL_MS } from '../../apps/cli/src/mcp-context';
 
 const MCP_SRC = resolve(__dirname, '../../apps/cli/src/mcp-server-sdk.ts');
 const source = readFileSync(MCP_SRC, 'utf8');
@@ -39,10 +39,15 @@ const OLD_STASH_TTL_MS = 120_000 + 30_000; // the buggy 150s eviction mark
  * Extract the body of the `setTimeout(() => { ... }, <delay>).unref()` block
  * that contains the given stash-map delete call. Returns the matched block text
  * plus the delay expression so tests can assert both the contents and the TTL.
+ *
+ * The interior regex explicitly rejects any nested `setTimeout(` so the match
+ * cannot span across two adjacent eviction blocks. Each match must be <500 chars
+ * (verified by assertion inside the helper) to catch runaway captures early.
  */
 function evictionBlockFor(stashMap: string): { block: string; delay: string } {
+  const interior = `((?:(?!setTimeout\\()[\\s\\S])*?${stashMap}\\.delete(?:(?!setTimeout\\()[\\s\\S])*?)`;
   const re = new RegExp(
-    `setTimeout\\(\\(\\)\\s*=>\\s*\\{([\\s\\S]*?${stashMap}\\.delete[\\s\\S]*?)\\}\\s*,\\s*([A-Za-z0-9_ +]+?)\\)\\.unref\\(\\)`,
+    `setTimeout\\(\\(\\)\\s*=>\\s*\\{${interior}\\}\\s*,\\s*([A-Za-z0-9_ +]+?)\\)\\.unref\\(\\)`,
     'g'
   );
   const matches = [...source.matchAll(re)];
@@ -51,14 +56,25 @@ function evictionBlockFor(stashMap: string): { block: string; delay: string } {
       `expected exactly one eviction block deleting ${stashMap}, found ${matches.length}`
     );
   }
-  return { block: matches[0][1], delay: matches[0][2].trim() };
+  const block = matches[0][1];
+  const delay = matches[0][2].trim();
+  if (block.length >= 500) {
+    throw new Error(
+      `eviction block for ${stashMap} is suspiciously wide (${block.length} chars >= 500) — likely spanning multiple eviction sites`
+    );
+  }
+  return { block, delay };
 }
 
-describe('gossip_verify_memory — stash eviction TTL (issue #545)', () => {
+describe('gossip stash eviction TTL — per-map alignment (issue #545)', () => {
   it('exports a 24h UTILITY_RESULT_TTL_MS from native-tasks', () => {
     expect(UTILITY_RESULT_TTL_MS).toBe(24 * 60 * 60 * 1000);
     // Must be far longer than the buggy 150s mark so a slow re-entry survives.
     expect(UTILITY_RESULT_TTL_MS).toBeGreaterThan(OLD_STASH_TTL_MS);
+  });
+
+  it('exports a 2h NATIVE_TASK_TTL_MS from mcp-context', () => {
+    expect(NATIVE_TASK_TTL_MS).toBe(2 * 60 * 60 * 1000);
   });
 
   it('mcp-server-sdk imports UTILITY_RESULT_TTL_MS from native-tasks', () => {
@@ -67,20 +83,38 @@ describe('gossip_verify_memory — stash eviction TTL (issue #545)', () => {
     );
   });
 
-  it('verify_memory stash eviction uses UTILITY_RESULT_TTL_MS, not the old 150s STASH_TTL', () => {
+  it('mcp-server-sdk imports NATIVE_TASK_TTL_MS from mcp-context', () => {
+    expect(source).toMatch(
+      /import\s*\{[^}]*\bNATIVE_TASK_TTL_MS\b[^}]*\}\s*from\s*'\.\/mcp-context'/
+    );
+  });
+
+  it('_pendingVerifyData stash eviction uses NATIVE_TASK_TTL_MS (verify_memory → nativeResultMap, 2h)', () => {
     const { block, delay } = evictionBlockFor('_pendingVerifyData');
-    expect(delay).toBe('UTILITY_RESULT_TTL_MS');
-    // The buggy literal must be gone from the eviction scheduling.
-    expect(delay).not.toMatch(/UTILITY_TTL_MS\s*\+\s*30_000/);
-    // Same callback must evict the guard snapshot so it cannot leak when the
-    // orchestrator never re-enters.
+    expect(delay).toBe('NATIVE_TASK_TTL_MS');
     expect(block).toContain('_utilityGuardSnapshots.delete');
   });
 
-  it('the buggy STASH_TTL_MS = UTILITY_TTL_MS + 30_000 eviction is no longer scheduled for verify_memory', () => {
+  it('_pendingPlanData stash eviction uses NATIVE_TASK_TTL_MS (gossip_plan → nativeResultMap, 2h)', () => {
+    const { block, delay } = evictionBlockFor('_pendingPlanData');
+    expect(delay).toBe('NATIVE_TASK_TTL_MS');
+    expect(block).toContain('_utilityGuardSnapshots.delete');
+  });
+
+  it('_pendingSkillData stash eviction uses UTILITY_RESULT_TTL_MS (skill_develop → nativeUtilityResultMap, 24h)', () => {
+    const { block, delay } = evictionBlockFor('_pendingSkillData');
+    expect(delay).toBe('UTILITY_RESULT_TTL_MS');
+    expect(block).toContain('_utilityGuardSnapshots.delete');
+  });
+
+  it('_pendingSessionData stash eviction uses NATIVE_TASK_TTL_MS (session_summary → nativeResultMap, 2h)', () => {
+    const { block, delay } = evictionBlockFor('_pendingSessionData');
+    expect(delay).toBe('NATIVE_TASK_TTL_MS');
+    expect(block).toContain('_utilityGuardSnapshots.delete');
+  });
+
+  it('the buggy STASH_TTL_MS = UTILITY_TTL_MS + 30_000 eviction is no longer scheduled', () => {
     // Guard against a regression that reintroduces the 150s eviction mark.
-    // (gossip_plan historically shared this literal; the #545 fix removed it
-    // from both — so the pattern must not appear next to a stash .delete.)
     expect(source).not.toMatch(
       /const STASH_TTL_MS = UTILITY_TTL_MS \+ 30_000;\s*setTimeout/
     );

--- a/tests/cli/gossip-verify-memory.stash-ttl.test.ts
+++ b/tests/cli/gossip-verify-memory.stash-ttl.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression test for issue #545 — gossip_verify_memory re-entry failed with
+ * `INCONCLUSIVE: unknown _utility_task_id ... (not a verify_memory dispatch)`.
+ *
+ * Root cause: the dispatch path stashed re-entry data in the module-private
+ * `_pendingVerifyData` map and scheduled an eviction after
+ * `STASH_TTL_MS = UTILITY_TTL_MS + 30_000` = 150s. The documented 3-step
+ * protocol (dispatch → run haiku Agent → gossip_relay → re-call with
+ * `_utility_task_id`) routinely takes longer than 150s because the haiku agent
+ * alone runs 1-3+ minutes. When the re-call arrived after 150s the stash was
+ * already gone, so the re-entry guard returned INCONCLUSIVE even though the
+ * relayed result was sitting healthy in `ctx.nativeResultMap` (utility results
+ * have a 24h TTL by design).
+ *
+ * The fix aligns the stash eviction with `UTILITY_RESULT_TTL_MS` (24h) so the
+ * stash outlives the slow re-entry, and evicts the guard snapshot on the same
+ * schedule so it does not leak when re-entry never happens.
+ *
+ * The verify_memory tool wrapper cannot be driven end-to-end under jest: its
+ * dispatch branch does `await import('./handlers/verify-memory.js')` and the
+ * test harness has no `.js`→`.ts` module mapper (the existing fixture suite
+ * documents this and tests the pure handler functions instead). So this suite
+ * guards the eviction MECHANICS at the source level — the same drift-guard
+ * pattern used by the `utility-task task.created log-hygiene` suite in
+ * native-utility.test.ts. The exported TTL constant's value is also asserted at
+ * runtime so a future edit to the literal flips this red.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { UTILITY_RESULT_TTL_MS } from '../../apps/cli/src/handlers/native-tasks';
+
+const MCP_SRC = resolve(__dirname, '../../apps/cli/src/mcp-server-sdk.ts');
+const source = readFileSync(MCP_SRC, 'utf8');
+
+const OLD_STASH_TTL_MS = 120_000 + 30_000; // the buggy 150s eviction mark
+
+/**
+ * Extract the body of the `setTimeout(() => { ... }, <delay>).unref()` block
+ * that contains the given stash-map delete call. Returns the matched block text
+ * plus the delay expression so tests can assert both the contents and the TTL.
+ */
+function evictionBlockFor(stashMap: string): { block: string; delay: string } {
+  const re = new RegExp(
+    `setTimeout\\(\\(\\)\\s*=>\\s*\\{([\\s\\S]*?${stashMap}\\.delete[\\s\\S]*?)\\}\\s*,\\s*([A-Za-z0-9_ +]+?)\\)\\.unref\\(\\)`,
+    'g'
+  );
+  const matches = [...source.matchAll(re)];
+  if (matches.length !== 1) {
+    throw new Error(
+      `expected exactly one eviction block deleting ${stashMap}, found ${matches.length}`
+    );
+  }
+  return { block: matches[0][1], delay: matches[0][2].trim() };
+}
+
+describe('gossip_verify_memory — stash eviction TTL (issue #545)', () => {
+  it('exports a 24h UTILITY_RESULT_TTL_MS from native-tasks', () => {
+    expect(UTILITY_RESULT_TTL_MS).toBe(24 * 60 * 60 * 1000);
+    // Must be far longer than the buggy 150s mark so a slow re-entry survives.
+    expect(UTILITY_RESULT_TTL_MS).toBeGreaterThan(OLD_STASH_TTL_MS);
+  });
+
+  it('mcp-server-sdk imports UTILITY_RESULT_TTL_MS from native-tasks', () => {
+    expect(source).toMatch(
+      /import\s*\{[^}]*\bUTILITY_RESULT_TTL_MS\b[^}]*\}\s*from\s*'\.\/handlers\/native-tasks'/
+    );
+  });
+
+  it('verify_memory stash eviction uses UTILITY_RESULT_TTL_MS, not the old 150s STASH_TTL', () => {
+    const { block, delay } = evictionBlockFor('_pendingVerifyData');
+    expect(delay).toBe('UTILITY_RESULT_TTL_MS');
+    // The buggy literal must be gone from the eviction scheduling.
+    expect(delay).not.toMatch(/UTILITY_TTL_MS\s*\+\s*30_000/);
+    // Same callback must evict the guard snapshot so it cannot leak when the
+    // orchestrator never re-enters.
+    expect(block).toContain('_utilityGuardSnapshots.delete');
+  });
+
+  it('the buggy STASH_TTL_MS = UTILITY_TTL_MS + 30_000 eviction is no longer scheduled for verify_memory', () => {
+    // Guard against a regression that reintroduces the 150s eviction mark.
+    // (gossip_plan historically shared this literal; the #545 fix removed it
+    // from both — so the pattern must not appear next to a stash .delete.)
+    expect(source).not.toMatch(
+      /const STASH_TTL_MS = UTILITY_TTL_MS \+ 30_000;\s*setTimeout/
+    );
+  });
+});


### PR DESCRIPTION
Closes #545.

consensus-id: ce8cba40-63564b12

## Root cause
The documented 3-step re-entry protocol (dispatch → haiku Agent → `gossip_relay` → re-call with `_utility_task_id`) routinely takes longer than 150s, but the re-entry stash (`_pendingVerifyData` / `_pendingPlanData`) was evicted at `UTILITY_TTL_MS + 30s = 150s`. Following the documented steps in order returned INCONCLUSIVE `unknown _utility_task_id` while the relayed result sat healthy in `nativeResultMap`. (The issue's original hypothesis — relay consuming the task — was wrong: late relay deliberately overwrites `timed_out`.)

## Fix (consensus-adjudicated)
Each re-entry stash's TTL now equals **its result map's TTL**:
- `_pendingVerifyData`, `_pendingPlanData`, `_pendingSessionData` → `NATIVE_TASK_TTL_MS` (2h, `nativeResultMap` sweep)
- `_pendingSkillData` → `UTILITY_RESULT_TTL_MS` (24h, `nativeUtilityResultMap`)

The skill/session stashes previously had **no eviction at all** (process-lifetime leak of stash + guard-snapshot entries, confirmed 3-for-3). All four eviction callbacks also clear `_utilityGuardSnapshots`.

The first iteration used 24h for all stashes; cross-review (deepseek-challenger f2 + fable-reviewer f1, verified by sonnet-reviewer) caught that verify_memory/plan results actually evict at 2h — only skill_develop uses the 24h map — so the TTLs and the comments/test prose were realigned. fable-reviewer also refuted the competing 30min-bound proposal (late-relay-wins means the stash must cover the full 2h relay window).

## Review
2-round consensus, 3 agents (sonnet-reviewer, fable-reviewer, deepseek-challenger): 6 confirmed, 3 disputed (all resolved), 16 signals recorded. Security adjudication: no widened verdict-fabrication surface (relay remains token-gated; re-entry alone can only yield INCONCLUSIVE).

## Tests
`tests/cli/gossip-verify-memory.stash-ttl.test.ts` — 9 tests: per-map TTL assertions for all four stashes, guard-snapshot delete checks, runtime constant assertions (2h + 24h), old-150s-literal absence, and a block-isolation guard on the source-matching helper (negative-lookahead regex; was spanning 192KB).

Full suite: 307 suites, 4100 passed. `npm run build` + `build:mcp` clean.

## Known follow-ups (out of scope, from consensus)
- Guard-snapshot timestamping to suppress false "modified unexpected files" warnings on late re-entry (fable suggestion)
- Exported `scheduleStashEviction` helper + fake-timer behavioral test (durable replacement for the source-level drift guard)
- Honest "result expired" evidence when stash exists but result was swept

🤖 Generated with [Claude Code](https://claude.com/claude-code)