### PR TITLE
fix(dashboard-v2): severity color ramp + DESIGN.md token violations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,13 @@
         "ts-node": "^10.9.2"
       }
     },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
@@ -2957,6 +2964,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3006,6 +3014,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
@@ -3032,6 +3067,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -4179,6 +4228,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssstyle": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
@@ -5236,6 +5292,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -6651,6 +6717,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -7278,6 +7354,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7820,6 +7910,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -9452,7 +9555,9 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
-        "@testing-library/react": "^16.0.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/d3-force": "^3.0.10",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -9461,7 +9566,7 @@
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.0",
         "vite": "^6.0.0",
-        "vitest": "^3.0.0"
+        "vitest": "^3.2.6"
       }
     },
     "packages/orchestrator": {

--- a/packages/dashboard-v2/package.json
+++ b/packages/dashboard-v2/package.json
@@ -22,7 +22,9 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
-    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/d3-force": "^3.0.10",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
@@ -31,6 +33,6 @@
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
     "vite": "^6.0.0",
-    "vitest": "^3.0.0"
+    "vitest": "^3.2.6"
   }
 }

--- a/packages/dashboard-v2/src/components/AgentCardBig.tsx
+++ b/packages/dashboard-v2/src/components/AgentCardBig.tsx
@@ -176,7 +176,7 @@ export function AgentCardBig({ agent, severityCounts, trendPoints }: AgentCardBi
                   const kind = getBenchBadgeKind(s);
                   if (kind === 'benched') return (
                     <span
-                      className="shrink-0 rounded-sm bg-destructive/10 px-1 py-0.5 font-mono text-[8px] font-bold text-destructive"
+                      className="shrink-0 rounded-sm bg-bad/10 px-1 py-0.5 font-mono text-[8px] font-bold text-bad"
                       aria-label={`Benched (${s.bench.reason ?? 'auto'}). Excluded from dispatch until recovery.`}
                       data-tooltip={`Benched (${s.bench.reason ?? 'auto'}). Excluded from dispatch until recovery.`}
                     >

--- a/packages/dashboard-v2/src/components/AuthGate.tsx
+++ b/packages/dashboard-v2/src/components/AuthGate.tsx
@@ -49,11 +49,16 @@ export function AuthGate({ onLogin, error }: AuthGateProps) {
           />
         </div>
 
-        {/* Wordmark */}
+        {/* Wordmark — Geist body at 26px, not Fraunces (h-route is reserved for
+            route titles only per DESIGN.md §Typography rule 1). */}
         <p
-          className="h-route mb-1"
+          className="mb-1 font-semibold"
           style={{
+            fontFamily: "'Geist', var(--font-sans)",
+            fontSize: 26,
+            lineHeight: 1.1,
             letterSpacing: '-0.02em',
+            color: 'var(--ink)',
             textShadow: '0 0 24px var(--accent)',
           }}
         >

--- a/packages/dashboard-v2/src/components/CircuitAlerts.tsx
+++ b/packages/dashboard-v2/src/components/CircuitAlerts.tsx
@@ -15,12 +15,12 @@ function describe(agent: AgentData): Reason {
   const s = agent.scores;
   if (s.bench?.state === 'benched') {
     if (s.bench.reason === 'chronic-low-accuracy') {
-      return { label: 'benched (chronic)', cls: 'bg-destructive/15 text-destructive' };
+      return { label: 'benched (chronic)', cls: 'bg-bad/15 text-bad' };
     }
     if (s.bench.reason === 'burst-hallucination') {
-      return { label: 'benched (burst)', cls: 'bg-destructive/15 text-destructive' };
+      return { label: 'benched (burst)', cls: 'bg-bad/15 text-bad' };
     }
-    return { label: 'benched', cls: 'bg-destructive/15 text-destructive' };
+    return { label: 'benched', cls: 'bg-bad/15 text-bad' };
   }
   if (s.bench?.state === 'kept-for-coverage') {
     return { label: 'kept for coverage', cls: 'border border-unverified/40 bg-unverified/10 text-unverified' };
@@ -37,16 +37,16 @@ export function CircuitAlerts({ agents }: CircuitAlertsProps) {
 
   return (
     <div className="rounded-lg border border-border" style={{ background: 'var(--surface-elev)' }}>
-      <div className="flex items-center justify-between border-b border-border bg-destructive/[0.04] px-3.5 py-3">
+      <div className="flex items-center justify-between border-b border-border bg-bad/[0.04] px-3.5 py-3">
         <div className="flex items-center gap-2">
-          <span className="inline-flex h-4 w-4 items-center justify-center rounded-sm bg-destructive/15 font-mono text-[11px] font-bold text-destructive">
+          <span className="inline-flex h-4 w-4 items-center justify-center rounded-sm bg-bad/15 font-mono text-[11px] font-bold text-bad">
             !
           </span>
-          <span className="font-mono text-[11px] font-bold uppercase tracking-wider text-destructive">
+          <span className="font-mono text-[11px] font-bold uppercase tracking-wider text-bad">
             Agents Needing Attention
           </span>
         </div>
-        <span className="rounded-full border border-destructive/20 bg-destructive/10 px-2 py-0.5 font-mono text-xs font-bold text-destructive">
+        <span className="rounded-full border border-bad/20 bg-bad/10 px-2 py-0.5 font-mono text-xs font-bold text-bad">
           {attention.length}
         </span>
       </div>
@@ -59,13 +59,13 @@ export function CircuitAlerts({ agents }: CircuitAlertsProps) {
             <a
               key={agent.id}
               href={`/dashboard/agent/${encodeURIComponent(agent.id)}`}
-              className={`block px-3.5 py-3 transition hover:bg-destructive/[0.03] ${
+              className={`block px-3.5 py-3 transition hover:bg-bad/[0.03] ${
                 i > 0 ? 'border-t border-border/40' : ''
               }`}
             >
               <div className="mb-1 flex items-center gap-2.5">
                 <span
-                  className={`h-1.5 w-1.5 rounded-full ${isBenched ? 'bg-destructive' : 'bg-unverified'}`}
+                  className={`h-1.5 w-1.5 rounded-full ${isBenched ? 'bg-bad' : 'bg-unverified'}`}
                   style={isBenched ? { boxShadow: '0 0 6px color-mix(in oklch, var(--bad) 60%, transparent)' } : undefined}
                 />
                 <span className="text-sm font-semibold" style={{ color: 'var(--text)' }}>{agent.id}</span>

--- a/packages/dashboard-v2/src/components/FindingsMetrics.tsx
+++ b/packages/dashboard-v2/src/components/FindingsMetrics.tsx
@@ -49,14 +49,14 @@ const SEV_FILTER_CHIPS: { key: 'all' | 'critical' | 'high' | 'medium' | 'low'; l
   { key: 'all', label: 'All', cls: 'border-border/40 hover:border-border/60', activeCls: 'border-border', activeStyle: { color: 'var(--text)', background: 'var(--surface-sunk)' }, inactiveStyle: { color: 'var(--text-dim)' } },
   { key: 'critical', label: 'Critical', cls: 'text-bad/50 border-bad/20 hover:border-bad/40', activeCls: 'text-bad bg-bad/10 border-bad/40' },
   { key: 'high', label: 'High', cls: 'text-severity-high/50 border-severity-high/20 hover:border-severity-high/40', activeCls: 'text-severity-high bg-severity-high/10 border-severity-high/40' },
-  { key: 'medium', label: 'Medium', cls: 'text-warn/50 border-warn/20 hover:border-warn/40', activeCls: 'text-warn bg-warn/10 border-warn/40' },
+  { key: 'medium', label: 'Medium', cls: 'text-severity-medium/50 border-severity-medium/20 hover:border-severity-medium/40', activeCls: 'text-severity-medium bg-severity-medium/10 border-severity-medium/40' },
   { key: 'low', label: 'Low', cls: 'border-border/40 hover:border-border/60', activeCls: 'border-border', activeStyle: { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--surface-sunk) 50%, transparent)' }, inactiveStyle: { color: 'color-mix(in oklch, var(--text-dim) 50%, transparent)' } },
 ];
 
 const SEVERITY_CLS: Record<string, string> = {
   critical: 'text-bad bg-bad/10',
   high: 'text-severity-high bg-severity-high/10',
-  medium: 'text-warn bg-warn/10',
+  medium: 'text-severity-medium bg-severity-medium/10',
   low: '',
 };
 const SEVERITY_STYLE_LOW: React.CSSProperties = { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--surface-sunk) 50%, transparent)' };

--- a/packages/dashboard-v2/src/components/NarrativeStripe.tsx
+++ b/packages/dashboard-v2/src/components/NarrativeStripe.tsx
@@ -81,7 +81,7 @@ export function NarrativeStripe() {
           if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }}
         className="ml-auto rounded px-1.5 py-0.5 font-mono text-[10px] transition hover:[background:color-mix(in_oklch,var(--info)_12%,transparent)]"
-        style={{ color: 'var(--text-faint)', cursor: 'pointer' }}
+        style={{ color: 'var(--ink-3)', cursor: 'pointer' }}
       >
         watch ↓
       </button>

--- a/packages/dashboard-v2/src/components/RecentSignalsPeek.tsx
+++ b/packages/dashboard-v2/src/components/RecentSignalsPeek.tsx
@@ -28,9 +28,9 @@ const VERDICT_COLOR: Record<string, string> = {
   consensus_verified: 'var(--ok)',
   disagreement: 'var(--bad)',
   hallucination_caught: 'var(--bad)',
-  unique_confirmed: 'var(--info)',
+  unique_confirmed: 'var(--unique)',
   unique_unconfirmed: 'var(--warn)',
-  new_finding: 'var(--info)',
+  new_finding: 'var(--unique)',
   unverified: 'var(--info)',
 };
 

--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -57,7 +57,7 @@ const SIGNAL_LABELS: Record<string, string> = {
 // DESIGN.md Step 8 — semantic verdict color per signal type. Applied as inline
 // color on a .h-section span (small-caps Geist) so verdict text reads as a
 // section-label, not all-caps mono. Confirmed = --ok green, disputed/
-// hallucination = --bad rose, unique/new_finding/unverified = --info teal.
+// hallucination = --bad rose, unique/new_finding = --unique purple, unverified = --info teal.
 // Operational pass/fail signals (impl_test_*, impl_typecheck_*) map onto the
 // same ok/bad axis. boundary_escape = --bad (security violation).
 const VERDICT_COLOR: Record<string, string> = {

--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -72,9 +72,9 @@ const VERDICT_COLOR: Record<string, string> = {
   impl_typecheck_fail: 'var(--bad)',
   impl_peer_rejected: 'var(--bad)',
   boundary_escape: 'var(--bad)',
-  unique_confirmed: 'var(--info)',
-  unique_unconfirmed: 'var(--info)',
-  new_finding: 'var(--info)',
+  unique_confirmed: 'var(--unique)',
+  unique_unconfirmed: 'var(--unique)',
+  new_finding: 'var(--unique)',
   unverified: 'var(--info)',
 };
 

--- a/packages/dashboard-v2/src/components/SkillCard.tsx
+++ b/packages/dashboard-v2/src/components/SkillCard.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const STATUS_TOOLTIP: Record<SkillStatus, string> = {
   silent_skill: 'No signals recorded after bind — skill may not be injecting correctly',
-  insufficient_evidence: 'Fewer than 120 post-bind signals — verdict pending more data',
+  insufficient_evidence: 'Fewer than 80 post-bind signals — verdict pending more data',
   inconclusive: 'Mixed signals — needs further evaluation',
   passed: 'Skill verified effective',
   failed: 'Skill verified ineffective',

--- a/packages/dashboard-v2/src/components/SkillGraduationGrid.tsx
+++ b/packages/dashboard-v2/src/components/SkillGraduationGrid.tsx
@@ -360,15 +360,15 @@ function GridSkeleton() {
         >
           <span
             className="h-3 w-3/4 rounded-sm"
-            style={{ background: 'color-mix(in oklch, var(--text-dim) 18%, transparent)' }}
+            style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }}
           />
           <span
             className="h-[30px] w-full rounded-sm"
-            style={{ background: 'color-mix(in oklch, var(--text-dim) 10%, transparent)' }}
+            style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }}
           />
           <span
             className="h-3 w-1/2 rounded-sm"
-            style={{ background: 'color-mix(in oklch, var(--text-dim) 14%, transparent)' }}
+            style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }}
           />
         </li>
       ))}

--- a/packages/dashboard-v2/src/components/SystemPulse.tsx
+++ b/packages/dashboard-v2/src/components/SystemPulse.tsx
@@ -199,7 +199,7 @@ export function SystemPulse({ overview, activeTasks, mode = 'dense', showActivit
           {overview.tasksFailed > 0 && (
             <div className="flex items-center justify-between py-1 font-mono text-[11px]">
               <span style={{ color: 'var(--ink-3)' }}>tasks failed</span>
-              <span className="font-semibold text-destructive tabular-nums">{overview.tasksFailed}</span>
+              <span className="font-semibold text-bad tabular-nums">{overview.tasksFailed}</span>
             </div>
           )}
           <div className="flex items-center justify-between py-1 font-mono text-[11px]">
@@ -209,7 +209,7 @@ export function SystemPulse({ overview, activeTasks, mode = 'dense', showActivit
           <div className="flex items-center justify-between py-1 font-mono text-[11px]">
             <span style={{ color: 'var(--ink-3)' }}>success rate</span>
             <span
-              className={`font-semibold tabular-nums ${successRate !== null && successRate >= 95 ? 'text-confirmed' : successRate !== null && successRate >= 80 ? 'text-unverified' : successRate !== null ? 'text-destructive' : ''}`}
+              className={`font-semibold tabular-nums ${successRate !== null && successRate >= 95 ? 'text-confirmed' : successRate !== null && successRate >= 80 ? 'text-unverified' : successRate !== null ? 'text-bad' : ''}`}
               style={successRate === null ? { color: 'var(--ink-3)' } : undefined}
             >
               {successRate === null ? '—' : `${successRate}%`}

--- a/packages/dashboard-v2/src/components/TaskRow.tsx
+++ b/packages/dashboard-v2/src/components/TaskRow.tsx
@@ -57,8 +57,8 @@ const STATUS_META: Record<StatusKey, {
   },
   failed: {
     label: 'Failed',
-    iconBox: 'bg-destructive/10 border-destructive/30',
-    text: 'text-destructive',
+    iconBox: 'bg-bad/10 border-bad/30',
+    text: 'text-bad',
     pulse: false,
   },
   cancelled: {

--- a/packages/dashboard-v2/src/components/TeamHero.tsx
+++ b/packages/dashboard-v2/src/components/TeamHero.tsx
@@ -48,8 +48,8 @@ export function TeamHero({ agents, highlightedAgentId, severityMap, trendByAgent
               key={agent.id}
               style={{
                 borderRadius: '0.5rem',
-                boxShadow: isHighlighted ? '0 0 0 2px var(--border-strong)' : undefined,
-                transition: 'box-shadow 200ms cubic-bezier(0.4,0,0.2,1)',
+                outline: isHighlighted ? '2px solid var(--border-strong)' : undefined,
+                transition: 'outline-color 200ms cubic-bezier(0.4,0,0.2,1)',
               }}
             >
               <AgentCardBig

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -67,7 +67,7 @@
   --color-warn: #B47A2A;
   --color-bad: #A53A4A;
   --color-info: #3F8B86;
-  --color-severity-high: #c0392b;
+  --color-severity-high: #B47A2A;
   --color-impact: #cc785c;
   --color-insight: #6b6a64;
   --color-text-dim: #6b6a64;
@@ -148,6 +148,10 @@
      freeing --info to mean only unverified/info. Severity ramp: --bad rose
      (critical) → --warn amber (high) → --severity-medium blue → --idle slate (low). */
   --severity-medium: #3E6DA8;
+  /* Unique verdict — purple #7c5cbf (matches --color-unique in @theme).
+     Exposed as --unique so inline style={{ color: 'var(--unique)' }} works
+     alongside the Tailwind text-unique / bg-unique utility classes. */
+  --unique: #7c5cbf;
   /* Citations — file path vs function name in finding evidence. NOT severity,
      NOT agent identity. Muted indigo/violet chosen to clear --severity-medium
      blue (cite-file ~15deg + lower saturation) and --c2 plum (cite-fn ~33deg).
@@ -329,6 +333,8 @@
   --cite-fn: #7A6FBA;
   --idle: #807A71;
   --idle-soft: #2A2722;
+  /* Unique verdict dark — brighter purple for dark canvas. */
+  --unique: #9d7fd5;
   /* Chart palette stays identical across themes (semantically same hues). */
   /* Per-agent identity hues stay identical too. */
   /* --c8 magenta needs a slightly brighter shade in dark mode for legibility. */


### PR DESCRIPTION
## Summary
Fix batch 1 of 4 from the signal/data/visual/new-user audit (consensus-id: 6eed37aa-dfba43ca). All findings panel-confirmed by 4-agent cross-review.

- `--color-severity-high` `#c0392b` (red, colliding with `--bad`) → `#B47A2A` amber per the DESIGN.md severity ramp; resolves the `#c0392b` one-hex-three-meanings collision and the red-vs-amber "high" inconsistency between FindingsMetrics and RecentSignalsPeek
- Medium severity → `--severity-medium` blue in `SEVERITY_CLS` + `SEV_FILTER_CHIPS` (was amber = high's color, regressing PR #509's intent)
- `unique_confirmed`/`new_finding` verdicts → `--unique` purple (`--info` teal is status-only per DESIGN.md); `--unique` alias added to light+dark token blocks
- WCAG fix: NarrativeStripe label `--text-faint` (~2.6:1) → `--ink-3`
- SkillGraduationGrid skeleton tint: text token → `--border` 40%
- TeamHero highlight ring: box-shadow → outline (no-drop-shadow rule)
- AuthGate wordmark: Fraunces `h-route` → Geist 26px semibold (Fraunces is route-titles only)
- All `text-destructive`/`bg-destructive` → `text-bad`/`bg-bad` (SystemPulse, CircuitAlerts, AgentCardBig, TaskRow)
- SkillCard tooltip: stale "120 post-bind signals" → 80 (matches MIN_EVIDENCE)

## Verification
- Build (`tsc -b && vite build`) clean; vitest 12/12
- Grep: zero remaining `c0392b`/`text-destructive`/`bg-destructive` hits in scoped components

consensus-id: 6eed37aa-dfba43ca

🤖 Generated with [Claude Code](https://claude.com/claude-code)