### PR TITLE
feat(dashboard-v2): loading skeletons — route fallthrough, AgentPage, page-level

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -12,6 +12,7 @@ import { AgentPage } from '@/components/AgentPage';
 import { LogsPage } from '@/components/LogsPage';
 import { SignalsPage } from '@/components/SignalsPage';
 import { TaskRow } from '@/components/TaskRow';
+import { OverviewSkeleton, TeamPageSkeleton, TasksPageSkeleton, DebatesPageSkeleton } from '@/components/Skeleton';
 import { useAuth } from '@/hooks/useAuth';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import { useDashboardData } from '@/hooks/useDashboardData';
@@ -544,7 +545,7 @@ function Dashboard({ onUnauthorized }: { onUnauthorized: () => void }) {
     return (
       <div className="min-h-screen" style={{ background: 'var(--surface)' }}>
         <TopBar />
-        <div className="flex items-center justify-center py-20" style={{ color: 'var(--ink-3)' }}>Loading dashboard...</div>
+        <OverviewSkeleton />
       </div>
     );
   }
@@ -558,12 +559,30 @@ function Dashboard({ onUnauthorized }: { onUnauthorized: () => void }) {
   } else if (consensusFlowMatch) {
     const consensusId = decodeURIComponent(consensusFlowMatch[1]);
     content = <ConsensusFlowPage consensusId={consensusId} />;
-  } else if (route === '/team' && agents) {
-    content = <TeamPage agents={agents} tasks={tasks} consensusReports={consensusReports} fleetTrend={fleetTrend} />;
-  } else if (route === '/tasks' && tasks) {
-    content = <TasksPage tasks={tasks} />;
-  } else if (route === '/debates' && consensus) {
-    content = <FindingsPage consensus={consensus} consensusReports={consensusReports} />;
+  } else if (route === '/team') {
+    content = agents
+      ? <TeamPage agents={agents} tasks={tasks} consensusReports={consensusReports} fleetTrend={fleetTrend} />
+      : (
+        <div className="mx-auto max-w-7xl space-y-6 px-6 py-6">
+          <TeamPageSkeleton />
+        </div>
+      );
+  } else if (route === '/tasks') {
+    content = tasks
+      ? <TasksPage tasks={tasks} />
+      : (
+        <div className="mx-auto max-w-7xl space-y-6 px-6 py-6">
+          <TasksPageSkeleton />
+        </div>
+      );
+  } else if (route === '/debates') {
+    content = consensus
+      ? <FindingsPage consensus={consensus} consensusReports={consensusReports} />
+      : (
+        <div className="mx-auto max-w-7xl space-y-6 px-6 py-6">
+          <DebatesPageSkeleton />
+        </div>
+      );
   } else if (route === '/logs') {
     content = <LogsPage />;
   } else if (route === '/signals') {

--- a/packages/dashboard-v2/src/components/AgentPage.tsx
+++ b/packages/dashboard-v2/src/components/AgentPage.tsx
@@ -9,6 +9,7 @@ import { FindingDetailDrawer } from './FindingDetailDrawer';
 import { SignalTimeline } from './SignalTimeline';
 import { TaskRow } from './TaskRow';
 import { TaskDetailModal } from './TaskDetailModal';
+import { AgentMemorySkeleton, AgentReportsSkeleton } from './Skeleton';
 import { timeAgo, renderFindingMarkdown } from '@/lib/utils';
 import { getBenchBadgeKind } from '@/lib/bench';
 import { escapeHtml } from '@/lib/sanitize';
@@ -30,7 +31,9 @@ const DIAGNOSTIC_BANNER_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps) {
   const agent = agents.find(a => a.id === agentId);
   const [memories, setMemories] = useState<MemoryFile[]>([]);
+  const [memoriesLoading, setMemoriesLoading] = useState(true);
   const [reports, setReports] = useState<ConsensusReport[]>([]);
+  const [reportsLoading, setReportsLoading] = useState(true);
   const [expandedMem, setExpandedMem] = useState<string | null>(null);
   const [expandedRun, setExpandedRun] = useState<string | null>(null);
   const [drawerFinding, setDrawerFinding] = useState<{ consensusId: string; findingId: string } | null>(null);
@@ -39,9 +42,10 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
   const [selectedTask, setSelectedTask] = useState<TaskItem | null>(null);
 
   useEffect(() => {
+    setMemoriesLoading(true);
     api<MemoryData>(`memory/${agentId}`).then(data => {
       setMemories(data.knowledge || []);
-    }).catch(() => setMemories([]));
+    }).catch(() => setMemories([])).finally(() => setMemoriesLoading(false));
   }, [agentId]);
 
   // Fetch consensus reports to compute per-agent diagnostic frequency.
@@ -49,11 +53,13 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
   // size of 200 covers the 30d window on any realistic project size.
   useEffect(() => {
     let cancelled = false;
+    setReportsLoading(true);
     api<ConsensusReportsData>('consensus-reports?page=1&pageSize=200')
       .then(data => {
         if (!cancelled) setReports(data.reports || []);
       })
-      .catch(() => { if (!cancelled) setReports([]); });
+      .catch(() => { if (!cancelled) setReports([]); })
+      .finally(() => { if (!cancelled) setReportsLoading(false); });
     return () => { cancelled = true; };
   }, []);
 
@@ -404,9 +410,11 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
           drawer surfaces both in one click. */}
       <section className="mb-8">
         <h2 className="mb-3 h-section">
-          Consensus Runs <span style={{ color: 'var(--ink)', fontWeight: 700 }}>{agentRuns.length}</span>
+          Consensus Runs{!reportsLoading && <span style={{ color: 'var(--ink)', fontWeight: 700 }}> {agentRuns.length}</span>}
         </h2>
-        {agentRuns.length > 0 ? (
+        {reportsLoading ? (
+          <AgentReportsSkeleton />
+        ) : agentRuns.length > 0 ? (
           <div className="space-y-2">
             {agentRuns.slice(0, 20).map((run, i) => {
               const c = run.counts;
@@ -521,14 +529,14 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
       <section className="mb-8">
         <div className="mb-3 flex items-center justify-between">
           <h2 className="h-section">
-            Memory <span style={{ color: 'var(--ink)', fontWeight: 700 }}>{memories.length} files</span>
-            {currentDay && (
+            Memory{!memoriesLoading && <span style={{ color: 'var(--ink)', fontWeight: 700 }}> {memories.length} files</span>}
+            {!memoriesLoading && currentDay && (
               <span className="ml-2 font-mono text-[10px]" style={{ color: 'var(--text-dim)' }}>
                 · {currentDay.day} ({currentDay.items.length})
               </span>
             )}
           </h2>
-          {memoryDays.length > 1 && (
+          {!memoriesLoading && memoryDays.length > 1 && (
             <div className="flex items-center gap-2 font-mono text-[10px]" style={{ color: 'var(--text-dim)' }}>
               <button
                 onClick={() => setMemDayIdx(i => Math.max(0, i - 1))}
@@ -546,7 +554,9 @@ export function AgentPage({ agentId, agents, tasks, consensus }: AgentPageProps)
             </div>
           )}
         </div>
-        {currentDay && currentDay.items.length > 0 ? (
+        {memoriesLoading ? (
+          <AgentMemorySkeleton />
+        ) : currentDay && currentDay.items.length > 0 ? (
           <div className="space-y-1.5">
             {currentDay.items.map(mem => {
               const isOpen = expandedMem === mem.filename;

--- a/packages/dashboard-v2/src/components/Skeleton.tsx
+++ b/packages/dashboard-v2/src/components/Skeleton.tsx
@@ -1,0 +1,170 @@
+/**
+ * Skeleton — static placeholder blocks for loading states.
+ *
+ * Design contract (DESIGN.md §State Coverage):
+ * - Color: --border at ~40% opacity
+ * - No animation library; no spinners
+ * - Blocks approximate the shape and density of the real content
+ */
+
+interface SkeletonBlockProps {
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/** Single skeleton rectangle. */
+export function SkeletonBlock({ className = '', style }: SkeletonBlockProps) {
+  return (
+    <div
+      className={`rounded ${className}`}
+      style={{
+        background: 'color-mix(in oklch, var(--border) 40%, transparent)',
+        ...style,
+      }}
+    />
+  );
+}
+
+/** A skeleton row: one narrow block (label-width) + one wider block (value-width). */
+export function SkeletonRow({ labelW = 'w-24', valueW = 'w-40' }: { labelW?: string; valueW?: string }) {
+  return (
+    <div className="flex items-center gap-3 py-2">
+      <SkeletonBlock className={`h-3 ${labelW}`} />
+      <SkeletonBlock className={`h-3 ${valueW}`} />
+    </div>
+  );
+}
+
+/**
+ * OverviewSkeleton — approximates the Overview page layout:
+ * - A SystemPulse-shaped wide rect (hero area)
+ * - 3 widget-height rects (grid row)
+ */
+export function OverviewSkeleton() {
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 px-6 py-6">
+      {/* Hero: SystemPulse-shaped wide rect */}
+      <SkeletonBlock className="h-48 w-full" />
+      {/* Three widget-height rects */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <SkeletonBlock className="h-36" />
+        <SkeletonBlock className="h-36" />
+        <SkeletonBlock className="h-36" />
+      </div>
+      {/* A lower content row */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <SkeletonBlock className="h-48" />
+        <SkeletonBlock className="h-48" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * TeamPageSkeleton — approximates the Team page layout:
+ * - A stat strip (4 cells)
+ * - A table-like block
+ */
+export function TeamPageSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="mb-6">
+        <SkeletonBlock className="mb-2 h-7 w-32" />
+        <SkeletonBlock className="h-3 w-48" />
+      </div>
+      {/* Stat strip */}
+      <div className="grid grid-cols-2 gap-px sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <SkeletonBlock key={i} className="h-16" />
+        ))}
+      </div>
+      {/* Table rows */}
+      <div className="space-y-px overflow-hidden rounded-md">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <SkeletonBlock key={i} className="h-12" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * TasksPageSkeleton — approximates the Tasks page layout:
+ * - A header row
+ * - A list of task rows
+ */
+export function TasksPageSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="mb-6">
+        <SkeletonBlock className="mb-2 h-7 w-24" />
+        <SkeletonBlock className="h-3 w-32" />
+      </div>
+      <div className="space-y-px overflow-hidden rounded-md">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <SkeletonBlock key={i} className="h-11" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * DebatesPageSkeleton — approximates the Consensus Rounds (Debates) page layout:
+ * - A header
+ * - Cards/rows of finding blocks
+ */
+export function DebatesPageSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="mb-6">
+        <SkeletonBlock className="mb-2 h-7 w-48" />
+        <SkeletonBlock className="h-3 w-64" />
+      </div>
+      <div className="space-y-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="overflow-hidden rounded-md">
+            <SkeletonBlock className="h-14" />
+            <div className="mt-px space-y-px">
+              {Array.from({ length: 3 }).map((_, j) => (
+                <SkeletonBlock key={j} className="h-10" />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * AgentMemorySkeleton — approximates the memory panel rows in AgentPage.
+ */
+export function AgentMemorySkeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="flex items-start gap-3 py-2">
+          <SkeletonBlock className="mt-0.5 h-4 w-4 shrink-0 rounded-sm" />
+          <div className="flex-1 space-y-1.5">
+            <SkeletonBlock className="h-3 w-3/4" />
+            <SkeletonBlock className="h-3 w-1/2" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * AgentReportsSkeleton — approximates the consensus-reports rows in AgentPage.
+ */
+export function AgentReportsSkeleton() {
+  return (
+    <div className="space-y-px overflow-hidden rounded-md">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <SkeletonBlock key={i} className="h-10" />
+      ))}
+    </div>
+  );
+}

--- a/packages/dashboard-v2/tsconfig.json
+++ b/packages/dashboard-v2/tsconfig.json
@@ -11,5 +11,6 @@
     "baseUrl": ".",
     "paths": { "@/*": ["./src/*"] }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/**/*.spec.tsx"]
 }


### PR DESCRIPTION
## Summary
Fix batch 4 of 4 from the audit (consensus-id: 6eed37aa-dfba43ca), findings f24/f25/f33 (2 HIGH).

- New `Skeleton.tsx` (8 components, `--border` 40% tint, no spinners per DESIGN.md §State Coverage)
- `/team`, `/tasks`, `/debates` no longer silently render Overview when their data is null — each renders a route-scoped skeleton (HIGH: new-user trap)
- `AgentPage` gains `memoriesLoading`/`reportsLoading` flags + skeleton regions so loading is distinguishable from a genuinely-empty new agent (HIGH)
- Page-level `OverviewSkeleton` replaces the plain-text "Loading dashboard..."
- `tsconfig.json`: exclude `__tests__/**`/`*.test.*` from the app build (fixes `tsc -b` in fresh checkouts after #553 added vitest-typed test files)

## Verification
- vite build clean (99 modules); vitest 12/12

consensus-id: 6eed37aa-dfba43ca

🤖 Generated with [Claude Code](https://claude.com/claude-code)