### PR TITLE
fix(setup): validate-before-write, config preservation, status + postinstall resilience

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -218,7 +218,7 @@ import { restorePendingConsensus } from './handlers/relay-cross-review';
 import { filterWatchEvents, WATCH_MAX_EVENTS } from './gossip-watch';
 import { persistRelayTasks, restoreRelayTasksAsFailed } from './handlers/relay-tasks';
 import { pickStickyPort, writeStickyPort, RELAY_STICKY_FILE, HTTP_MCP_STICKY_FILE } from './stickyPort';
-import { buildDashboardAdvisory } from './setup-response';
+import { buildDashboardAdvisory, mergeSetupConfig, buildMalformedConfigHint } from './setup-response';
 import { refreshNativeAgentFromDisk } from './native-agent-cache';
 import { generateRulesContent } from './rules-content';
 import { formatDropReceipt } from './format-drop-receipt';
@@ -2037,16 +2037,23 @@ export function createMcpServer(): McpServer {
       const gossipAgents: string[] = [];
       const existingIds = new Set<string>();
       if (configPath) {
-        const config = loadConfig(configPath);
-        const agents = configToAgentConfigs(config);
-        for (const a of agents) {
-          existingIds.add(a.id);
-          gossipAgents.push(`  - ${a.id}: ${a.provider}/${a.model} (${a.preset || 'custom'}) — skills: ${a.skills.join(', ')}`);
-        }
-        // In Claude Code MCP mode, the orchestrator is Claude Code itself — don't show the
-        // internal tool LLM as "Orchestrator" or "Internal LLM", it's an implementation detail.
-        if (env.host !== 'claude-code') {
-          agentSections.push(`Orchestrator LLM: ${config.main_agent.model} (${config.main_agent.provider})`);
+        // f19: a malformed/invalid config.json must not throw the whole status
+        // tool. Render the rest of status plus a clear fix hint instead, mirroring
+        // the keychain-doctor guard above.
+        try {
+          const config = loadConfig(configPath);
+          const agents = configToAgentConfigs(config);
+          for (const a of agents) {
+            existingIds.add(a.id);
+            gossipAgents.push(`  - ${a.id}: ${a.provider}/${a.model} (${a.preset || 'custom'}) — skills: ${a.skills.join(', ')}`);
+          }
+          // In Claude Code MCP mode, the orchestrator is Claude Code itself — don't show the
+          // internal tool LLM as "Orchestrator" or "Internal LLM", it's an implementation detail.
+          if (env.host !== 'claude-code') {
+            agentSections.push(`Orchestrator LLM: ${config.main_agent.model} (${config.main_agent.provider})`);
+          }
+        } catch (err) {
+          agentSections.push(buildMalformedConfigHint(configPath, (err as Error).message));
         }
       }
 
@@ -2419,16 +2426,29 @@ export function createMcpServer(): McpServer {
       const nativeCreated: string[] = [];
       const customCreated: string[] = [];
       const errors: string[] = [];
+      // f15: defer native .md writes until AFTER validateConfig passes, so a
+      // validation failure can't leave orphan .claude/agents/<id>.md files that
+      // (a) appear as phantom subagents and (b) block re-registering the id as
+      // custom via the wasNative existsSync guard. We stage {path, content} here
+      // and flush them only on the success path below.
+      const pendingNativeWrites: Array<{ path: string; content: string }> = [];
 
-      // Load existing agents up front — needed inside the loop to detect native→custom conflicts
+      // Load the existing config up front. We need its `agents` map inside the
+      // loop to detect native→custom conflicts, AND its other top-level fields
+      // (consensus, utility_model, autoDiscoverWorktrees, …) so they survive a
+      // re-run instead of being silently dropped. `existingConfig` is preserved
+      // and spread back into the rebuilt config below in BOTH merge and replace
+      // modes; only `existingAgents` is mode-gated (replace starts agents fresh).
+      let existingConfig: Record<string, any> = {};
       let existingAgents: Record<string, any> = {};
-      if (mode === 'merge') {
-        try {
-          const { readFileSync } = require('fs');
-          const existing = JSON.parse(readFileSync(join(root, '.gossip', 'config.json'), 'utf-8'));
-          existingAgents = existing.agents || {};
-        } catch { /* no existing config — start fresh */ }
-      }
+      try {
+        const { readFileSync } = require('fs');
+        const existing = JSON.parse(readFileSync(join(root, '.gossip', 'config.json'), 'utf-8'));
+        if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
+          existingConfig = existing;
+          if (mode === 'merge') existingAgents = existing.agents || {};
+        }
+      } catch { /* no existing config (or unparseable) — start fresh */ }
 
       for (const agent of agents) {
         if (isReservedAgentId(agent.id)) {
@@ -2464,9 +2484,11 @@ export function createMcpServer(): McpServer {
             body,
           ].join('\n');
 
-          const agentsDir = join(root, '.claude', 'agents');
-          mkdirSync(agentsDir, { recursive: true });
-          writeFileSync(join(agentsDir, `${agent.id}.md`), md, 'utf-8');
+          // Stage the .md write — flushed only after validateConfig passes (f15).
+          pendingNativeWrites.push({
+            path: join(root, '.claude', 'agents', `${agent.id}.md`),
+            content: md,
+          });
           nativeCreated.push(agent.id);
 
           // Register in gossipcat config — marked native so dispatch uses Agent tool bridge
@@ -2514,18 +2536,36 @@ export function createMcpServer(): McpServer {
         }
       }
 
-      // Write gossipcat config — merge with existing or replace
-
-      const config = {
-        main_agent: { provider: main_provider, model: main_model },
-        agents: { ...existingAgents, ...configAgents },
-      };
+      // Write gossipcat config — merge with existing or replace.
+      // f16: spread existingConfig first so unknown/other top-level fields
+      // (consensus.siblingRoots, autoDiscoverWorktrees, orchestratorOwnedGlobs,
+      // utility_model, …) survive a re-run in BOTH modes. main_agent and agents
+      // are then overwritten. In replace mode existingAgents is {} (agents map
+      // is replaced); in merge mode existing agents are kept and updated. Other
+      // top-level fields are preserved either way — replace replaces the team,
+      // not the whole top-level config.
+      const config = mergeSetupConfig({
+        existingConfig,
+        mainAgent: { provider: main_provider, model: main_model },
+        existingAgents,
+        newAgents: configAgents,
+      });
 
       try {
         const { validateConfig } = await import('./config');
         validateConfig(config);
       } catch (err) {
+        // f15: validation failed — no native .md files were written yet, so
+        // there is nothing to roll back. Phantom-subagent files cannot leak.
         return { content: [{ type: 'text' as const, text: `Invalid config: ${(err as Error).message}` }] };
+      }
+
+      // Validation passed — now flush the staged native .md writes (f15).
+      if (pendingNativeWrites.length > 0) {
+        mkdirSync(join(root, '.claude', 'agents'), { recursive: true });
+        for (const w of pendingNativeWrites) {
+          writeFileSync(w.path, w.content, 'utf-8');
+        }
       }
 
       mkdirSync(join(root, '.gossip'), { recursive: true });

--- a/apps/cli/src/setup-response.ts
+++ b/apps/cli/src/setup-response.ts
@@ -52,3 +52,46 @@ export function buildDashboardAdvisory(input: DashboardAdvisoryInput): string[] 
 
   return out;
 }
+
+/**
+ * Build the rebuilt gossipcat config for gossip_setup, preserving unknown
+ * top-level fields (f16). Extracted as a pure function so the field-preservation
+ * invariant is unit-testable without booting the MCP server.
+ *
+ * - `existingConfig` is spread first so any top-level field we don't manage
+ *   (consensus.siblingRoots, autoDiscoverWorktrees, orchestratorOwnedGlobs,
+ *   utility_model, …) survives a re-run in BOTH merge and replace modes.
+ * - `main_agent` is always overwritten from the request.
+ * - `agents` is `{ ...existingAgents, ...newAgents }`. The caller passes an
+ *   empty `existingAgents` in replace mode (team replaced) and the prior agent
+ *   map in merge mode. Either way, OTHER top-level fields are preserved —
+ *   replace replaces the team, not the whole top-level config.
+ */
+export interface MergedSetupConfig {
+  main_agent: { provider: string; model: string };
+  agents: Record<string, Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+export function mergeSetupConfig(input: {
+  existingConfig: Record<string, unknown>;
+  mainAgent: { provider: string; model: string };
+  existingAgents: Record<string, Record<string, unknown>>;
+  newAgents: Record<string, Record<string, unknown>>;
+}): MergedSetupConfig {
+  const { existingConfig, mainAgent, existingAgents, newAgents } = input;
+  return {
+    ...existingConfig,
+    main_agent: { provider: mainAgent.provider, model: mainAgent.model },
+    agents: { ...existingAgents, ...newAgents },
+  };
+}
+
+/**
+ * Build the gossip_status agent-list line shown when .gossip/config.json fails
+ * to load/validate (f19). Keeps the exact fix-hint wording in one testable place
+ * so a regression in the message format is caught by a unit test.
+ */
+export function buildMalformedConfigHint(configPath: string, message: string): string {
+  return `⚠️ config.json is malformed: ${message} — fix or delete ${configPath}`;
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -22,16 +22,19 @@ const isGitClone = existsSync(join(packageRoot, '.git'));
 // For git clones: skip writing if .mcp.json already exists. Still warn if the
 // built server is older than package.json — stale-build warning is the most
 // valuable signal on a developer re-running npm install after a pull.
-if (isGitClone && existsSync(join(packageRoot, '.mcp.json'))) {
-  if (existsSync(mcpServerPath)) {
-    try {
-      const serverMtime = statSync(mcpServerPath).mtime;
-      const pkgMtime = statSync(join(packageRoot, 'package.json')).mtime;
-      if (serverMtime < pkgMtime) {
-        console.log("gossipcat: dist-mcp/ is older than package.json — run 'npm run build:mcp' to rebuild");
-      }
-    } catch (_) { /* stat failure is non-fatal */ }
-  }
+//
+// f18: only take this early exit when the built server actually exists. If
+// dist-mcp/mcp-server.js is absent (fresh clone, deleted dist, interrupted
+// build), exiting here would leave the project unrunnable — fall through to the
+// build-recovery path at the end of this script instead.
+if (isGitClone && existsSync(join(packageRoot, '.mcp.json')) && existsSync(mcpServerPath)) {
+  try {
+    const serverMtime = statSync(mcpServerPath).mtime;
+    const pkgMtime = statSync(join(packageRoot, 'package.json')).mtime;
+    if (serverMtime < pkgMtime) {
+      console.log("gossipcat: dist-mcp/ is older than package.json — run 'npm run build:mcp' to rebuild");
+    }
+  } catch (_) { /* stat failure is non-fatal */ }
   console.log('gossipcat: .mcp.json already exists — skipping (git clone)');
   process.exit(0);
 }

--- a/tests/cli/install-packaging.test.ts
+++ b/tests/cli/install-packaging.test.ts
@@ -151,4 +151,22 @@ describe('scripts/postinstall.js — error-path regression guard', () => {
     // npm install breaks on a corrupt user file we can't parse.
     expect(source).toMatch(/malformed[\s\S]*process\.exit\(0\)/);
   });
+
+  it('git-clone early-exit is gated on the built server existing (f18 build recovery)', () => {
+    // Regression guard (f18, consensus 6eed37aa-dfba43ca): the
+    // "git clone — .mcp.json exists, skip" early-exit must NOT fire when
+    // dist-mcp/mcp-server.js is absent. Otherwise a fresh clone (or a deleted
+    // dist) exits 0 and never reaches the auto-build path at the end of the
+    // script, leaving the project unrunnable. The early-exit condition must
+    // include existsSync(mcpServerPath).
+    const earlyExit = source.match(
+      /if\s*\(\s*isGitClone\s*&&\s*existsSync\([^)]*\.mcp\.json[^)]*\)([\s\S]*?)\)\s*{/,
+    );
+    expect(earlyExit).not.toBeNull();
+    // The condition guarding the `.mcp.json already exists — skipping` exit
+    // must also require existsSync(mcpServerPath).
+    expect(earlyExit![0]).toMatch(/existsSync\(mcpServerPath\)/);
+    // And the auto-build recovery path (git clone, missing server) must remain.
+    expect(source).toMatch(/!existsSync\(mcpServerPath\)[\s\S]*npm run build:mcp/);
+  });
 });

--- a/tests/cli/setup-config-preservation.test.ts
+++ b/tests/cli/setup-config-preservation.test.ts
@@ -1,0 +1,132 @@
+/**
+ * gossip_setup transactionality + config preservation + status resilience.
+ *
+ * Covers consensus 6eed37aa-dfba43ca findings:
+ *  - f15 (MEDIUM): validateConfig must run BEFORE any native .claude/agents/<id>.md
+ *    file is written, so a validation failure leaves no orphan phantom-subagent
+ *    files and does not block re-registering the id as custom.
+ *  - f16 (MEDIUM): the rebuilt config must preserve unknown top-level fields
+ *    (consensus.siblingRoots, utility_model, autoDiscoverWorktrees, …) across a
+ *    re-run in BOTH merge and replace modes.
+ *  - f19 (LOW): gossip_status must not throw when .gossip/config.json is
+ *    malformed — it renders a fix hint instead.
+ *
+ * The merge/preservation logic and the status fix-hint are tested as pure
+ * functions (mergeSetupConfig / buildMalformedConfigHint), mirroring the
+ * setup-response.test.ts precedent. The f15 ordering invariant — which is
+ * inline in the giant gossip_setup handler — is guarded by source inspection,
+ * the same technique used by install-packaging.test.ts for postinstall.js.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { mergeSetupConfig, buildMalformedConfigHint } from '../../apps/cli/src/setup-response';
+import { validateConfig } from '../../apps/cli/src/config';
+
+const PROJECT_ROOT = resolve(__dirname, '..', '..');
+
+describe('mergeSetupConfig — top-level field preservation (f16)', () => {
+  const mainAgent = { provider: 'anthropic', model: 'claude-opus-4-6' };
+
+  it('preserves consensus.siblingRoots and utility_model in merge mode', () => {
+    const existingConfig = {
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: { 'old-agent': { provider: 'anthropic', model: 'claude-haiku-4-5' } },
+      consensus: { siblingRoots: ['../sibling-repo'] },
+      utility_model: { provider: 'native', model: 'haiku' },
+      autoDiscoverWorktrees: true,
+    };
+    const merged = mergeSetupConfig({
+      existingConfig,
+      mainAgent,
+      existingAgents: existingConfig.agents,
+      newAgents: { 'new-agent': { provider: 'anthropic', model: 'claude-sonnet-4-6' } },
+    }) as typeof existingConfig & { agents: Record<string, unknown> };
+
+    // Unknown/other top-level fields survive untouched.
+    expect(merged.consensus).toEqual({ siblingRoots: ['../sibling-repo'] });
+    expect(merged.utility_model).toEqual({ provider: 'native', model: 'haiku' });
+    expect(merged.autoDiscoverWorktrees).toBe(true);
+    // main_agent is overwritten from the request.
+    expect(merged.main_agent).toEqual(mainAgent);
+    // merge keeps the prior agent AND adds the new one.
+    expect(Object.keys(merged.agents).sort()).toEqual(['new-agent', 'old-agent']);
+  });
+
+  it('preserves unrelated top-level fields in replace mode (empty existingAgents)', () => {
+    const existingConfig = {
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      agents: { 'old-agent': { provider: 'anthropic', model: 'claude-haiku-4-5' } },
+      consensus: { siblingRoots: ['../sibling-repo'], autoResolveOnRoundClose: true },
+      orchestratorOwnedGlobs: ['.gossip/**'],
+    };
+    // replace mode passes existingAgents: {} (team replaced) but keeps the
+    // existingConfig spread for other top-level fields.
+    const merged = mergeSetupConfig({
+      existingConfig,
+      mainAgent,
+      existingAgents: {},
+      newAgents: { 'fresh-agent': { provider: 'anthropic', model: 'claude-opus-4-6' } },
+    }) as typeof existingConfig & { agents: Record<string, unknown> };
+
+    // The team is replaced — old agent is gone, only the fresh one remains.
+    expect(Object.keys(merged.agents)).toEqual(['fresh-agent']);
+    // Other top-level fields are still preserved in replace mode.
+    expect(merged.consensus).toEqual({ siblingRoots: ['../sibling-repo'], autoResolveOnRoundClose: true });
+    expect(merged.orchestratorOwnedGlobs).toEqual(['.gossip/**']);
+  });
+
+  it('produces a config that validateConfig accepts when inputs are valid', () => {
+    const merged = mergeSetupConfig({
+      existingConfig: { consensus: { siblingRoots: ['../x'] } },
+      mainAgent,
+      existingAgents: {},
+      newAgents: {},
+    });
+    expect(() => validateConfig(merged)).not.toThrow();
+  });
+});
+
+describe('buildMalformedConfigHint — status resilience (f19)', () => {
+  it('renders a fix-or-delete hint with the path and parse message', () => {
+    const hint = buildMalformedConfigHint('/proj/.gossip/config.json', 'Unexpected token } in JSON');
+    expect(hint).toContain('config.json is malformed');
+    expect(hint).toContain('Unexpected token } in JSON');
+    expect(hint).toContain('fix or delete /proj/.gossip/config.json');
+  });
+});
+
+describe('gossip_setup handler — validate-before-write ordering (f15)', () => {
+  let source: string;
+
+  beforeAll(() => {
+    source = readFileSync(resolve(PROJECT_ROOT, 'apps', 'cli', 'src', 'mcp-server-sdk.ts'), 'utf-8');
+  });
+
+  it('does not writeFileSync the native .md inside the agent loop', () => {
+    // The loop must STAGE writes (pendingNativeWrites), not perform them. A
+    // direct writeFileSync of `${agent.id}.md` inside the loop would re-introduce
+    // the orphan-file leak on a validation failure.
+    expect(source).toContain('pendingNativeWrites');
+    // No writeFileSync of an `<id>.md` agent file may appear with the loop's
+    // per-agent `${agent.id}.md` template — those are flushed post-validation.
+    expect(source).not.toMatch(/writeFileSync\(join\(agentsDir, `\$\{agent\.id\}\.md`\)/);
+  });
+
+  it('flushes staged native .md writes only after validateConfig succeeds', () => {
+    // Ordering guarantee: validateConfig(config) must appear in the source
+    // BEFORE the pendingNativeWrites flush loop. If validation fails it returns
+    // early, so the flush never runs and no orphan .md is written.
+    const validateIdx = source.indexOf('validateConfig(config)');
+    const flushIdx = source.indexOf('for (const w of pendingNativeWrites)');
+    expect(validateIdx).toBeGreaterThan(-1);
+    expect(flushIdx).toBeGreaterThan(-1);
+    expect(flushIdx).toBeGreaterThan(validateIdx);
+  });
+
+  it('guards the gossip_status agent-list loadConfig in try/catch (f19)', () => {
+    // loadConfig in the agent-list section must be wrapped so a malformed
+    // config.json renders buildMalformedConfigHint instead of throwing the
+    // whole status tool.
+    expect(source).toMatch(/try\s*{[\s\S]*?loadConfig\(configPath\)[\s\S]*?}\s*catch[\s\S]*?buildMalformedConfigHint/);
+  });
+});


### PR DESCRIPTION
## Summary
Fix batch 3 of 4 from the audit, findings f15/f16 (MEDIUM) + f18/f19 (LOW). New-user safety for gossip_setup and install paths (impact-adjacent: install/bootstrap).

- **Validate-before-write (f15):** native `.claude/agents/<id>.md` writes are staged and flushed only after `validateConfig` passes — a first-setup validation failure no longer strands orphan agent files that block re-registration via the `wasNative` guard.
- **Config preservation (f16):** `gossip_setup` now reads the full existing config and spreads it (`mergeSetupConfig` helper), so `consensus.siblingRoots`, `autoDiscoverWorktrees`, `orchestratorOwnedGlobs`, `utility_model` survive merge AND replace. Decision: replace mode replaces the team (`main_agent` + `agents`), not unrelated top-level fields.
- **Status resilience (f19):** the agent-list `loadConfig` is try/catch-wrapped (mirroring keychain-doctor) — a malformed config.json renders a fix hint instead of crashing the whole `gossip_status` tool.
- **Postinstall recovery (f18):** the git-clone early-exit is gated on `existsSync(mcpServerPath)` — a checkout with `.mcp.json` but no built dist now falls through to the auto-build instead of exiting 0.

Noted follow-up (not in scope): custom-agent `instructions.md` writes still happen inside the loop; full loop-transactionality is a possible v2.

## Tests
- New `tests/cli/setup-config-preservation.test.ts` (orphan-free validation failure, merge/replace field preservation, malformed-config status hint); f18 guard in `install-packaging.test.ts`
- `npx jest tests/cli`: 85 suites, 1105 passed, 14 skipped, 0 failed; `npm run build:mcp` clean

Note: shares `apps/cli/src/mcp-server-sdk.ts` with #557's branch (disjoint regions); merging this one after it, with CI re-run.

consensus-id: 6eed37aa-dfba43ca

🤖 Generated with [Claude Code](https://claude.com/claude-code)