### PR TITLE
fix(dashboard): harden handleAuth body-read + bound authAttempts growth

### DIFF
--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -82,6 +82,17 @@ interface DashboardContext {
 
 const AUTH_MAX_ATTEMPTS = 10;
 const AUTH_LOCKOUT_MS = 60_000; // 1 minute lockout after max attempts
+// Idle TTL for never-locked authAttempts entries (count below the lockout
+// threshold, lockedUntil still 0). A slow distributed scan never trips a
+// lockout, so the expired-lockout sweep alone never reaps these and the map
+// grows unbounded. 15 minutes is well past the 1-minute lockout window — long
+// enough that a real (bursty) attacker's in-progress count survives, short
+// enough that abandoned slow-scan entries fall out promptly.
+const AUTH_ATTEMPT_TTL_MS = 15 * 60_000; // 15 minutes
+// Hard cap backstop: if the map still exceeds this after a sweep, evict the
+// oldest non-locked entries by lastAttemptAt. Active lockouts are never
+// evicted — memory safety must not weaken the lockout guarantee.
+const AUTH_ATTEMPTS_HARD_CAP = 1000;
 
 interface LegacyRoundWarning { code: string; message: string; agentId?: string }
 
@@ -162,7 +173,7 @@ function resolveDashboardRoot(projectRoot: string): string | null {
 }
 
 export class DashboardRouter {
-  private authAttempts = new Map<string, { count: number; lockedUntil: number }>();
+  private authAttempts = new Map<string, { count: number; lockedUntil: number; lastAttemptAt: number }>();
   private dashboardRoot: string | null;
   // Chatbot seam (P2). Null until the app layer injects an agent via
   // setChatbot; a null agent is the graceful-degrade path (handleChat emits an
@@ -283,8 +294,13 @@ export class DashboardRouter {
       return true;
     }
 
-    const body = await readBody(req);
+    // readBody must run INSIDE the try: it rejects on an aborted socket or an
+    // oversized body (maxBytes), and an escaped rejection would surface as an
+    // unhandled promise rejection rather than a clean HTTP error. A body-read
+    // failure is NOT a failed auth attempt — the key was never evaluated, so we
+    // do not call recordFailedAuthAttempt here.
     try {
+      const body = await readBody(req);
       const { key } = JSON.parse(body);
       const token = this.auth.createSession(key);
       if (!token) {
@@ -312,13 +328,43 @@ export class DashboardRouter {
    */
   private isIpLockedOut(ip: string): boolean {
     const now = Date.now();
-    if (this.authAttempts.size > 100) {
-      for (const [k, v] of this.authAttempts) {
-        if (v.lockedUntil > 0 && v.lockedUntil < now) this.authAttempts.delete(k);
-      }
-    }
+    if (this.authAttempts.size > 100) this.sweepAuthAttempts(now);
     const attempt = this.authAttempts.get(ip);
     return !!(attempt && attempt.lockedUntil > now);
+  }
+
+  /**
+   * Opportunistic, timer-free reaper for the authAttempts map. Runs only when
+   * the map crosses 100 entries (called from isIpLockedOut). Removes two
+   * classes of dead entry, then applies a hard-cap backstop:
+   *   1. Expired lockouts — `lockedUntil > 0 && lockedUntil < now`.
+   *   2. Stale never-locked entries — `lockedUntil === 0` and the last attempt
+   *      is older than AUTH_ATTEMPT_TTL_MS. These come from slow distributed
+   *      scans that never reach AUTH_MAX_ATTEMPTS, so the expired-lockout rule
+   *      alone never reaps them and the map grows unbounded.
+   * INVARIANT: an ACTIVE lockout (`lockedUntil > now`) is never deleted here,
+   * including by the hard-cap backstop — pruning must never shorten a lockout.
+   */
+  private sweepAuthAttempts(now: number): void {
+    for (const [k, v] of this.authAttempts) {
+      const expiredLockout = v.lockedUntil > 0 && v.lockedUntil < now;
+      const staleNeverLocked = v.lockedUntil === 0 && now - v.lastAttemptAt > AUTH_ATTEMPT_TTL_MS;
+      if (expiredLockout || staleNeverLocked) this.authAttempts.delete(k);
+    }
+    // Backstop against memory exhaustion: if the map is still over the hard cap
+    // after the sweep, evict the oldest NON-LOCKED entries (oldest lastAttemptAt
+    // first) until back under the cap. Active lockouts are excluded.
+    if (this.authAttempts.size > AUTH_ATTEMPTS_HARD_CAP) {
+      const evictable = [...this.authAttempts.entries()]
+        .filter(([, v]) => !(v.lockedUntil > now))
+        .sort((a, b) => a[1].lastAttemptAt - b[1].lastAttemptAt);
+      let toEvict = this.authAttempts.size - AUTH_ATTEMPTS_HARD_CAP;
+      for (const [k] of evictable) {
+        if (toEvict <= 0) break;
+        this.authAttempts.delete(k);
+        toEvict--;
+      }
+    }
   }
 
   /**
@@ -353,10 +399,12 @@ export class DashboardRouter {
    * counter so an attacker can't double-dip.
    */
   private recordFailedAuthAttempt(ip: string): void {
-    const current = this.authAttempts.get(ip) || { count: 0, lockedUntil: 0 };
+    const now = Date.now();
+    const current = this.authAttempts.get(ip) || { count: 0, lockedUntil: 0, lastAttemptAt: now };
     current.count++;
+    current.lastAttemptAt = now;
     if (current.count >= AUTH_MAX_ATTEMPTS) {
-      current.lockedUntil = Date.now() + AUTH_LOCKOUT_MS;
+      current.lockedUntil = now + AUTH_LOCKOUT_MS;
       current.count = 0;
     }
     this.authAttempts.set(ip, current);

--- a/tests/relay/api-chat.test.ts
+++ b/tests/relay/api-chat.test.ts
@@ -464,15 +464,19 @@ describe('readBody backward-compat (per-route cap parametrization)', () => {
   it('(5) default call sites still enforce the shared 8KB cap', async () => {
     const { router } = freshRouter();
     // POST /api/auth reads with the DEFAULT cap (MAX_BODY_SIZE = 8KB) — proving
-    // the parametrization left existing call sites unchanged. readBody rejects
-    // an over-8KB body exactly as before this change.
+    // the parametrization left existing call sites unchanged. An over-8KB body
+    // still trips the cap; since Fix A moved readBody INSIDE handleAuth's try,
+    // the rejection is now caught and surfaced as a clean 400 instead of
+    // escaping handle() as an unhandled promise rejection.
     const req = routerReq('POST', '/dashboard/api/auth');
     const res = routerRes();
     const handled = router.handle(req, res);
     // 9KB body — over the 8KB default cap → readBody destroys req + rejects.
     req.emit('data', Buffer.alloc(9 * 1024, 0x61));
     req.emit('end');
-    await expect(handled).rejects.toThrow(/too large/i);
+    await expect(handled).resolves.toBe(true);
+    expect(res._status).toBe(400);
+    expect(JSON.parse(res._body)).toEqual({ error: 'Invalid request body' });
   });
 
   it('(5a) a normal sub-8KB auth body still parses under the default cap', async () => {

--- a/tests/relay/dashboard-routes.test.ts
+++ b/tests/relay/dashboard-routes.test.ts
@@ -290,6 +290,130 @@ describe('DashboardRouter', () => {
       expect(goodRes._status).toBe(200);
     });
   });
+
+  // ─── handleAuth body-read failures (Fix A) ──────────────────────────────
+  // readBody runs INSIDE the try in handleAuth, so an oversized or aborted
+  // body produces a clean 400 instead of an unhandled promise rejection, and
+  // it is NOT counted as a failed auth attempt (the key was never evaluated).
+  describe('handleAuth body-read failures', () => {
+    it('oversized body → 400, no unhandled rejection, no failed-attempt recorded', async () => {
+      const ip = '10.20.30.50';
+      const req = mockReq('POST', '/dashboard/api/auth');
+      (req as any).socket = { remoteAddress: ip };
+      // readBody calls req.destroy() before rejecting on overflow.
+      (req as any).destroy = () => {};
+      const res = mockRes();
+
+      const handled = router.handle(req, res);
+      // 9 KB exceeds the 8 KB MAX_BODY_SIZE for the auth route.
+      req.emit('data', Buffer.alloc(9 * 1024, 0x61));
+      // The promise must resolve (return true) without rejecting.
+      await expect(handled).resolves.toBe(true);
+      expect(res._status).toBe(400);
+      expect(JSON.parse(res._body)).toEqual({ error: 'Invalid request body' });
+      // A body-read failure must not pollute the lockout counter.
+      const attempts = (router as any).authAttempts as Map<string, unknown>;
+      expect(attempts.has(ip)).toBe(false);
+    });
+
+    it('aborted socket (error event) → 400, no failed-attempt recorded', async () => {
+      const ip = '10.20.30.51';
+      const req = mockReq('POST', '/dashboard/api/auth');
+      (req as any).socket = { remoteAddress: ip };
+      const res = mockRes();
+
+      const handled = router.handle(req, res);
+      req.emit('error', new Error('socket hang up'));
+      await expect(handled).resolves.toBe(true);
+      expect(res._status).toBe(400);
+      const attempts = (router as any).authAttempts as Map<string, unknown>;
+      expect(attempts.has(ip)).toBe(false);
+    });
+  });
+
+  // ─── authAttempts opportunistic sweep + hard cap (Fix B) ────────────────
+  // The sweep runs only when the map crosses 100 entries (inside isIpLockedOut).
+  // It reaps stale never-locked entries (lockedUntil 0, lastAttemptAt past the
+  // TTL) and expired lockouts, but must never evict an ACTIVE lockout — not
+  // even the hard-cap backstop.
+  describe('authAttempts sweep', () => {
+    const TTL_MS = 15 * 60_000;
+    const HARD_CAP = 1000;
+
+    type Attempt = { count: number; lockedUntil: number; lastAttemptAt: number };
+    const seed = (n: number, make: (i: number) => Attempt) => {
+      const map = (router as any).authAttempts as Map<string, Attempt>;
+      for (let i = 0; i < n; i++) map.set(`ip-${i}`, make(i));
+      return map;
+    };
+    // Drives the private isIpLockedOut sweep without coupling to its name.
+    const triggerSweep = (ip = 'trigger-ip') => router.handle(
+      Object.assign(mockReq('GET', '/dashboard/api/overview', { authorization: 'Bearer wrong' }), {
+        socket: { remoteAddress: ip },
+      }),
+      mockRes(),
+    );
+
+    it('removes a stale never-locked entry (lockedUntil 0, past TTL) when map size > 100', async () => {
+      const now = Date.now();
+      const map = seed(150, () => ({ count: 1, lockedUntil: 0, lastAttemptAt: now }));
+      map.set('stale-ip', { count: 1, lockedUntil: 0, lastAttemptAt: now - TTL_MS - 1 });
+      expect(map.size).toBe(151);
+
+      await triggerSweep();
+
+      expect(map.has('stale-ip')).toBe(false);
+      // Fresh never-locked entries must survive.
+      expect(map.has('ip-0')).toBe(true);
+    });
+
+    it('does not sweep stale entries while map size is at or below 100', async () => {
+      const now = Date.now();
+      const map = seed(50, () => ({ count: 1, lockedUntil: 0, lastAttemptAt: now }));
+      map.set('stale-ip', { count: 1, lockedUntil: 0, lastAttemptAt: now - TTL_MS - 1 });
+
+      await triggerSweep();
+
+      // Below the 100 threshold the opportunistic sweep does not run.
+      expect(map.has('stale-ip')).toBe(true);
+    });
+
+    it('an active lockout survives the sweep', async () => {
+      const now = Date.now();
+      const map = seed(150, () => ({ count: 1, lockedUntil: 0, lastAttemptAt: now - TTL_MS - 1 }));
+      // Active lockout with a stale lastAttemptAt — must NOT be pruned.
+      map.set('locked-ip', { count: 0, lockedUntil: now + 30_000, lastAttemptAt: now - TTL_MS - 1 });
+
+      await triggerSweep();
+
+      expect(map.has('locked-ip')).toBe(true);
+      expect(map.get('locked-ip')!.lockedUntil).toBe(now + 30_000);
+    });
+
+    it('hard-cap backstop evicts oldest non-locked entries only', async () => {
+      const now = Date.now();
+      // All FRESH never-locked (within TTL) so the TTL sweep reaps none — only
+      // the hard cap can bring the map down. Oldest lastAttemptAt evicts first.
+      const map = seed(HARD_CAP + 200, (i) => ({ count: 1, lockedUntil: 0, lastAttemptAt: now - (HARD_CAP + 200 - i) }));
+      // An active lockout that is also one of the oldest — must survive the cap.
+      map.set('locked-ip', { count: 0, lockedUntil: now + 30_000, lastAttemptAt: now - 10 * (HARD_CAP + 200) });
+      const sizeBefore = map.size;
+      expect(sizeBefore).toBeGreaterThan(HARD_CAP);
+
+      await triggerSweep();
+
+      // The sweep caps at HARD_CAP; the triggering Bearer-wrong request then
+      // records its own failed attempt (trigger-ip), so the post-call size is
+      // HARD_CAP + 1 at most.
+      expect(map.size).toBeLessThanOrEqual(HARD_CAP + 1);
+      // Active lockout is excluded from the evictable set, so it survives the
+      // cap even though its lastAttemptAt is the oldest of all.
+      expect(map.has('locked-ip')).toBe(true);
+      // Oldest non-locked entry (ip-0) should be gone before newest (ip-N).
+      expect(map.has('ip-0')).toBe(false);
+      expect(map.has(`ip-${HARD_CAP + 199}`)).toBe(true);
+    });
+  });
 });
 
 describe('URL query string handling', () => {


### PR DESCRIPTION
## Summary
The two `handleAuth` follow-ups deferred from PR #551/#548, both audit-confirmed open. Auth-boundary code in `packages/relay/src/dashboard/routes.ts`.

**Fix A — `readBody` inside the try.** `const body = await readBody(req)` ran *outside* `handleAuth`'s try block, so an aborted socket or oversized body escaped as a rejected promise — and `server.ts:423` calls `dashboardRouter.handle()` with no `.catch`, making it a process-level unhandled rejection with no HTTP response. Moved inside the try → clean `400 {error:'Invalid request body'}`. A body-read failure is **not** counted as a failed auth attempt (the key was never evaluated; counting it would let a garbage-body flood lock out a legitimate IP).

**Fix B — bounded `authAttempts`.** Added `lastAttemptAt` to each entry; `sweepAuthAttempts(now)` extends the existing `>100` opportunistic sweep to also reap never-locked entries idle past `AUTH_ATTEMPT_TTL_MS` (15 min), with an `AUTH_ATTEMPTS_HARD_CAP` (1000) backstop that evicts oldest non-locked entries only. **Active lockouts are never evicted** by either path — mutation-verified.

## Verification
- `tests/relay`: 30 suites, 261 passed, 1 skipped, 0 failed (6 new + 1 corrected); `npm run build:mcp` clean
- Pre-merge consensus `7f358c40-ba0e417a` (3 agents, 2 rounds): **17 confirmed, 0 blocking**. fable-reviewer mutation-tested the new suite (each targeted mutation fails exactly its intended test). Two findings DISPUTED and refuted 2-1: a HIGH "counter-reset" claim (false — `count` is zeroed the instant a lockout starts at routes.ts:408, so eviction erases nothing; the 60s cycle is the designed per-IP rate limit, not a regression) and a "trailing-chunk accumulation" claim (false — `readBody` returns before the push once oversized).

Confirmed non-blocking follow-ups (not in this PR): O(n) sweep on the hot path could be timer-driven; a rate-limited warn when the hard-cap backstop fires; comment the body-fail-vs-missing-key counting asymmetry; inconsistent Bearer/cookie 401 strings.

consensus-id: 7f358c40-ba0e417a

🤖 Generated with [Claude Code](https://claude.com/claude-code)