### PR TITLE
fix(audit-6eed37aa batch-5): BOM strip + torn-line warn + setup loop-transactionality v2

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2305,7 +2305,7 @@ export function createMcpServer(): McpServer {
       instruction_update: z.string().optional().describe('Instruction text to append/replace'),
       instruction_mode: z.enum(['append', 'replace']).optional().describe('How to apply instruction update'),
       agents: z.array(z.object({
-        id: z.string().describe('Agent ID (lowercase, hyphens). e.g. "claude-reviewer", "gemini-impl"'),
+        id: z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/, 'Agent ID must be alphanumeric with hyphens/underscores — path separators and ".." are rejected').describe('Agent ID (lowercase, hyphens). e.g. "claude-reviewer", "gemini-impl"'),
         type: z.enum(['native', 'custom']).describe(
           '"native" = Claude Code subagent (.claude/agents/*.md), uses Anthropic API on the relay. ' +
           '"custom" = any provider (anthropic/openai/google/local)'
@@ -2515,9 +2515,11 @@ export function createMcpServer(): McpServer {
             errors.push(`${agent.id}: custom agent requires "custom_model" field`);
             continue;
           }
-          // Prevent split-brain: warn if this ID was previously a native agent
+          // Prevent split-brain: warn if this ID was previously a native agent.
+          // configAgents is checked too — a native entry earlier in THIS batch
+          // is staged (not yet on disk), so disk-only checks would miss it.
           const nativeFile = join(root, '.claude', 'agents', `${agent.id}.md`);
-          const wasNative = existingAgents[agent.id]?.native || existsSync(nativeFile);
+          const wasNative = existingAgents[agent.id]?.native || configAgents[agent.id]?.native || existsSync(nativeFile);
           if (wasNative) {
             errors.push(`${agent.id}: cannot re-register native agent as custom — .claude/agents/${agent.id}.md exists. Remove the file first or keep it as native.`);
             continue;

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -218,7 +218,7 @@ import { restorePendingConsensus } from './handlers/relay-cross-review';
 import { filterWatchEvents, WATCH_MAX_EVENTS } from './gossip-watch';
 import { persistRelayTasks, restoreRelayTasksAsFailed } from './handlers/relay-tasks';
 import { pickStickyPort, writeStickyPort, RELAY_STICKY_FILE, HTTP_MCP_STICKY_FILE } from './stickyPort';
-import { buildDashboardAdvisory, mergeSetupConfig, buildMalformedConfigHint } from './setup-response';
+import { buildDashboardAdvisory, mergeSetupConfig, buildMalformedConfigHint, flushStagedAgentFileWrites } from './setup-response';
 import { refreshNativeAgentFromDisk } from './native-agent-cache';
 import { generateRulesContent } from './rules-content';
 import { formatDropReceipt } from './format-drop-receipt';
@@ -2426,12 +2426,16 @@ export function createMcpServer(): McpServer {
       const nativeCreated: string[] = [];
       const customCreated: string[] = [];
       const errors: string[] = [];
-      // f15: defer native .md writes until AFTER validateConfig passes, so a
-      // validation failure can't leave orphan .claude/agents/<id>.md files that
-      // (a) appear as phantom subagents and (b) block re-registering the id as
-      // custom via the wasNative existsSync guard. We stage {path, content} here
-      // and flush them only on the success path below.
-      const pendingNativeWrites: Array<{ path: string; content: string }> = [];
+      // f15: defer agent file writes until AFTER validateConfig passes, so a
+      // validation failure can't leave orphan files on disk. For native agents
+      // these are .claude/agents/<id>.md files that (a) appear as phantom
+      // subagents and (b) block re-registering the id as custom via the wasNative
+      // existsSync guard. For custom agents these are .gossip/agents/<id>/
+      // instructions.md files that would otherwise orphan an agent dir while
+      // config.json was never written (loop-transactionality v2). We stage
+      // {dir, path, content} here and flush them only on the success path below,
+      // mkdir-ing each file's dir before the write.
+      const pendingAgentFileWrites: Array<{ dir: string; path: string; content: string }> = [];
 
       // Load the existing config up front. We need its `agents` map inside the
       // loop to detect native→custom conflicts, AND its other top-level fields
@@ -2485,7 +2489,8 @@ export function createMcpServer(): McpServer {
           ].join('\n');
 
           // Stage the .md write — flushed only after validateConfig passes (f15).
-          pendingNativeWrites.push({
+          pendingAgentFileWrites.push({
+            dir: join(root, '.claude', 'agents'),
             path: join(root, '.claude', 'agents', `${agent.id}.md`),
             content: md,
           });
@@ -2527,11 +2532,17 @@ export function createMcpServer(): McpServer {
           };
           customCreated.push(agent.id);
 
-          // Write instructions if provided
+          // Stage instructions.md if provided — flushed only after validateConfig
+          // passes (loop-transactionality v2), so a validation failure can't leave
+          // an orphan .gossip/agents/<id>/instructions.md dir while config.json was
+          // never written.
           if (agent.instructions) {
             const instrDir = join(root, '.gossip', 'agents', agent.id);
-            mkdirSync(instrDir, { recursive: true });
-            writeFileSync(join(instrDir, 'instructions.md'), agent.instructions, 'utf-8');
+            pendingAgentFileWrites.push({
+              dir: instrDir,
+              path: join(instrDir, 'instructions.md'),
+              content: agent.instructions,
+            });
           }
         }
       }
@@ -2555,18 +2566,16 @@ export function createMcpServer(): McpServer {
         const { validateConfig } = await import('./config');
         validateConfig(config);
       } catch (err) {
-        // f15: validation failed — no native .md files were written yet, so
-        // there is nothing to roll back. Phantom-subagent files cannot leak.
+        // f15: validation failed — no agent files were written yet (native .md or
+        // custom instructions.md), so there is nothing to roll back. Phantom
+        // subagents and orphan agent dirs cannot leak.
         return { content: [{ type: 'text' as const, text: `Invalid config: ${(err as Error).message}` }] };
       }
 
-      // Validation passed — now flush the staged native .md writes (f15).
-      if (pendingNativeWrites.length > 0) {
-        mkdirSync(join(root, '.claude', 'agents'), { recursive: true });
-        for (const w of pendingNativeWrites) {
-          writeFileSync(w.path, w.content, 'utf-8');
-        }
-      }
+      // Validation passed — now flush the staged agent file writes (f15 +
+      // loop-transactionality v2). mkdir each file's dir before writing so both
+      // native .md and custom instructions.md land atomically post-validation.
+      flushStagedAgentFileWrites(pendingAgentFileWrites, { mkdirSync, writeFileSync });
 
       mkdirSync(join(root, '.gossip'), { recursive: true });
       writeFileSync(join(root, '.gossip', 'config.json'), JSON.stringify(config, null, 2));

--- a/apps/cli/src/setup-response.ts
+++ b/apps/cli/src/setup-response.ts
@@ -95,3 +95,33 @@ export function mergeSetupConfig(input: {
 export function buildMalformedConfigHint(configPath: string, message: string): string {
   return `⚠️ config.json is malformed: ${message} — fix or delete ${configPath}`;
 }
+
+/** A gossip_setup agent file write deferred until AFTER validateConfig passes. */
+export interface StagedAgentFileWrite {
+  /** Directory to mkdir (recursive) before writing the file. */
+  dir: string;
+  /** Absolute path of the file to write. */
+  path: string;
+  /** File contents. */
+  content: string;
+}
+
+/**
+ * Flush staged agent file writes to disk (loop-transactionality v2). Called
+ * only on the gossip_setup success path, AFTER validateConfig accepts the config,
+ * so a validation failure leaves zero orphan agent files on disk — neither
+ * native .claude/agents/<id>.md nor custom .gossip/agents/<id>/instructions.md.
+ * Each file's dir is created (recursive) immediately before its write.
+ */
+export function flushStagedAgentFileWrites(
+  writes: ReadonlyArray<StagedAgentFileWrite>,
+  fs: {
+    mkdirSync: (dir: string, opts: { recursive: boolean }) => void;
+    writeFileSync: (path: string, content: string, enc: 'utf-8') => void;
+  },
+): void {
+  for (const w of writes) {
+    fs.mkdirSync(w.dir, { recursive: true });
+    fs.writeFileSync(w.path, w.content, 'utf-8');
+  }
+}

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -43,13 +43,23 @@ function stripBom(content: string): string {
  * deliberate hardening so a single corrupt line never refuses the whole file.
  * f2: surface the drop with ONE console.warn per read when count > 0, never
  * one warn per line (files can have thousands of lines).
+ *
+ * Non-object parses count as torn too: a literal `null` line is valid JSON
+ * (JSON.parse('null') returns null without throwing), and propagating it would
+ * make a downstream property access throw inside the caller's try/catch —
+ * collapsing the entire read to []. See consensus 4ee5ced2-b654497a (n1).
  */
 function parseJsonlLines<T>(lines: string[], sourcePath: string): T[] {
   let dropped = 0;
   const out: T[] = [];
   for (const line of lines) {
     try {
-      out.push(JSON.parse(line) as T);
+      const parsed: unknown = JSON.parse(line);
+      if (parsed === null || typeof parsed !== 'object') {
+        dropped++;
+        continue;
+      }
+      out.push(parsed as T);
     } catch {
       dropped++;
     }

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -7,7 +7,7 @@
  */
 
 import { readFileSync, existsSync, statSync, readdirSync } from 'fs';
-import { join } from 'path';
+import { join, basename } from 'path';
 import { ConsensusSignal, ImplSignal, PerformanceSignal } from './consensus-types';
 import { normalizeSkillName } from './skill-name';
 import {
@@ -29,20 +29,53 @@ import {
  * 8cc22d50-93ab4d73). Phase B (write-time aggregate sidecar) is tracked
  * separately at project_signal_log_rotation_data_loss.md.
  */
+/**
+ * Strip a leading UTF-8 BOM (U+FEFF) so the first JSON line of a file that was
+ * written with a BOM doesn't fail JSON.parse and get silently dropped (f4).
+ * Each log file is stripped independently — rotated and live can each carry one.
+ */
+function stripBom(content: string): string {
+  return content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
+}
+
+/**
+ * Parse JSONL lines, silently skipping unparseable (torn) rows — the skip is
+ * deliberate hardening so a single corrupt line never refuses the whole file.
+ * f2: surface the drop with ONE console.warn per read when count > 0, never
+ * one warn per line (files can have thousands of lines).
+ */
+function parseJsonlLines<T>(lines: string[], sourcePath: string): T[] {
+  let dropped = 0;
+  const out: T[] = [];
+  for (const line of lines) {
+    try {
+      out.push(JSON.parse(line) as T);
+    } catch {
+      dropped++;
+    }
+  }
+  if (dropped > 0) {
+    console.warn(
+      `[performance-reader] dropped ${dropped} unparseable JSONL line(s) from ${basename(sourcePath)}`,
+    );
+  }
+  return out;
+}
+
 export function readJsonlWithRotated(filePath: string): string {
   let rotatedContent = '';
   let liveContent = '';
   try {
     const rotatedPath = filePath + '.1';
     if (existsSync(rotatedPath)) {
-      rotatedContent = readFileSync(rotatedPath, 'utf-8');
+      rotatedContent = stripBom(readFileSync(rotatedPath, 'utf-8'));
     }
   } catch {
     /* best-effort */
   }
   try {
     if (existsSync(filePath)) {
-      liveContent = readFileSync(filePath, 'utf-8');
+      liveContent = stripBom(readFileSync(filePath, 'utf-8'));
     }
   } catch {
     /* best-effort */
@@ -592,11 +625,9 @@ export class PerformanceReader {
       const raw = readJsonlWithRotated(this.filePath);
       if (!raw) return [];
       const lines = raw.trim().split('\n').filter(Boolean);
-      const all = lines.map(line => {
-        try { return JSON.parse(line) as ConsensusSignal; }
-        catch { return null; }
-      }).filter((s): s is ConsensusSignal =>
-        s !== null && s.type === 'consensus' && typeof s.agentId === 'string' && s.agentId.length > 0
+      const all = parseJsonlLines<ConsensusSignal>(lines, this.filePath).filter(
+        (s): s is ConsensusSignal =>
+          s !== null && s.type === 'consensus' && typeof s.agentId === 'string' && s.agentId.length > 0,
       );
 
       // Collect retraction keys: agentId + taskId + signalType combos that have been retracted
@@ -652,13 +683,11 @@ export class PerformanceReader {
       const expiryMs = Date.now() - SIGNAL_EXPIRY_DAYS * 86400000;
 
       const lines = raw.trim().split('\n').filter(Boolean);
-      const all = lines.map(line => {
-        try { return JSON.parse(line) as PerformanceSignal; }
-        catch { return null; }
-      }).filter((s): s is PerformanceSignal =>
-        s !== null &&
-        (s.type === 'consensus' || s.type === 'impl') &&
-        typeof s.agentId === 'string' && s.agentId.length > 0
+      const all = parseJsonlLines<PerformanceSignal>(lines, this.filePath).filter(
+        (s): s is PerformanceSignal =>
+          s !== null &&
+          (s.type === 'consensus' || s.type === 'impl') &&
+          typeof s.agentId === 'string' && s.agentId.length > 0,
       );
 
       // Collect retraction keys: agentId + taskId + signalType combos that have been retracted

--- a/tests/cli/setup-config-preservation.test.ts
+++ b/tests/cli/setup-config-preservation.test.ts
@@ -114,7 +114,8 @@ describe('gossip_setup handler — validate-before-write ordering (f15)', () => 
     expect(source).toContain('pendingAgentFileWrites');
     // No writeFileSync of an `<id>.md` agent file may appear with the loop's
     // per-agent `${agent.id}.md` template — those are flushed post-validation.
-    expect(source).not.toMatch(/writeFileSync\(join\(agentsDir, `\$\{agent\.id\}\.md`\)/);
+    // (Matches the handler's actual inline-path shape, not a variable name.)
+    expect(source).not.toMatch(/writeFileSync\(join\(root, '\.claude', 'agents', `\$\{agent\.id\}\.md`\)/);
   });
 
   it('stages custom-agent instructions.md instead of writing it in the loop (v2)', () => {
@@ -164,27 +165,35 @@ describe('flushStagedAgentFileWrites — staged custom instructions.md (v2)', ()
     if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
   });
 
+  // Mirrors the handler's actual sequence: validateConfig, early-return on
+  // throw, flushStagedAgentFileWrites only on success. Driving the staged
+  // array through this REAL guard (not just asserting validateConfig throws)
+  // is what makes the disk assertions meaningful.
+  function validateThenFlush(
+    config: unknown,
+    staged: Array<{ dir: string; path: string; content: string }>,
+  ): boolean {
+    try {
+      validateConfig(config as never);
+    } catch {
+      return false; // handler early-returns — flush never runs
+    }
+    flushStagedAgentFileWrites(staged, realFs);
+    return true;
+  }
+
   it('leaves NO instructions.md on disk when validateConfig fails (flush never runs)', () => {
     const instrDir = join(tmpDir, '.gossip', 'agents', 'custom-x');
     const instrPath = join(instrDir, 'instructions.md');
     const staged = [{ dir: instrDir, path: instrPath, content: 'You are custom-x.' }];
 
-    // Simulate the handler's validate-before-flush guard: validation throws,
-    // so the early return happens and flushStagedAgentFileWrites is never called.
-    let validationFailed = false;
-    try {
-      // A config missing main_agent is rejected by validateConfig.
-      validateConfig({ agents: {} } as never);
-    } catch {
-      validationFailed = true;
-    }
-    expect(validationFailed).toBe(true);
+    // A config missing main_agent is rejected by validateConfig, so the flush
+    // is never reached — even though the write was staged.
+    const flushed = validateThenFlush({ agents: {} }, staged);
 
-    // Because validation failed, the flush is skipped — no orphan file/dir.
+    expect(flushed).toBe(false);
     expect(existsSync(instrPath)).toBe(false);
     expect(existsSync(instrDir)).toBe(false);
-    // And the staged entry was never materialized.
-    expect(staged).toHaveLength(1);
   });
 
   it('writes the custom instructions.md (mkdir-ing its dir) on the success path', () => {

--- a/tests/cli/setup-config-preservation.test.ts
+++ b/tests/cli/setup-config-preservation.test.ts
@@ -17,9 +17,14 @@
  * inline in the giant gossip_setup handler — is guarded by source inspection,
  * the same technique used by install-packaging.test.ts for postinstall.js.
  */
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
-import { mergeSetupConfig, buildMalformedConfigHint } from '../../apps/cli/src/setup-response';
+import { readFileSync, mkdtempSync, existsSync, rmSync } from 'fs';
+import { resolve, join } from 'path';
+import { tmpdir } from 'os';
+import {
+  mergeSetupConfig,
+  buildMalformedConfigHint,
+  flushStagedAgentFileWrites,
+} from '../../apps/cli/src/setup-response';
 import { validateConfig } from '../../apps/cli/src/config';
 
 const PROJECT_ROOT = resolve(__dirname, '..', '..');
@@ -103,21 +108,35 @@ describe('gossip_setup handler — validate-before-write ordering (f15)', () => 
   });
 
   it('does not writeFileSync the native .md inside the agent loop', () => {
-    // The loop must STAGE writes (pendingNativeWrites), not perform them. A
+    // The loop must STAGE writes (pendingAgentFileWrites), not perform them. A
     // direct writeFileSync of `${agent.id}.md` inside the loop would re-introduce
     // the orphan-file leak on a validation failure.
-    expect(source).toContain('pendingNativeWrites');
+    expect(source).toContain('pendingAgentFileWrites');
     // No writeFileSync of an `<id>.md` agent file may appear with the loop's
     // per-agent `${agent.id}.md` template — those are flushed post-validation.
     expect(source).not.toMatch(/writeFileSync\(join\(agentsDir, `\$\{agent\.id\}\.md`\)/);
   });
 
-  it('flushes staged native .md writes only after validateConfig succeeds', () => {
+  it('stages custom-agent instructions.md instead of writing it in the loop (v2)', () => {
+    // loop-transactionality v2: the custom branch must NOT writeFileSync
+    // instructions.md inline — a validation failure would otherwise leave an
+    // orphan .gossip/agents/<id>/instructions.md while config.json was never
+    // written. It must push onto the staged array instead.
+    expect(source).not.toMatch(/writeFileSync\(join\(instrDir, 'instructions\.md'\)/);
+    // The instrDir write must be staged via pendingAgentFileWrites.
+    const instrIdx = source.indexOf("join(instrDir, 'instructions.md')");
+    expect(instrIdx).toBeGreaterThan(-1);
+    const stageIdx = source.lastIndexOf('pendingAgentFileWrites.push', instrIdx + 200);
+    expect(stageIdx).toBeGreaterThan(-1);
+    expect(stageIdx).toBeLessThan(instrIdx);
+  });
+
+  it('flushes staged agent file writes only after validateConfig succeeds', () => {
     // Ordering guarantee: validateConfig(config) must appear in the source
-    // BEFORE the pendingNativeWrites flush loop. If validation fails it returns
-    // early, so the flush never runs and no orphan .md is written.
+    // BEFORE the flushStagedAgentFileWrites call. If validation fails it returns
+    // early, so the flush never runs and no orphan file is written.
     const validateIdx = source.indexOf('validateConfig(config)');
-    const flushIdx = source.indexOf('for (const w of pendingNativeWrites)');
+    const flushIdx = source.indexOf('flushStagedAgentFileWrites(pendingAgentFileWrites');
     expect(validateIdx).toBeGreaterThan(-1);
     expect(flushIdx).toBeGreaterThan(-1);
     expect(flushIdx).toBeGreaterThan(validateIdx);
@@ -128,5 +147,62 @@ describe('gossip_setup handler — validate-before-write ordering (f15)', () => 
     // config.json renders buildMalformedConfigHint instead of throwing the
     // whole status tool.
     expect(source).toMatch(/try\s*{[\s\S]*?loadConfig\(configPath\)[\s\S]*?}\s*catch[\s\S]*?buildMalformedConfigHint/);
+  });
+});
+
+describe('flushStagedAgentFileWrites — staged custom instructions.md (v2)', () => {
+  const realFs = require('fs') as {
+    mkdirSync: (dir: string, opts: { recursive: boolean }) => void;
+    writeFileSync: (path: string, content: string, enc: 'utf-8') => void;
+  };
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'gossip-setup-v2-'));
+  });
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+  });
+
+  it('leaves NO instructions.md on disk when validateConfig fails (flush never runs)', () => {
+    const instrDir = join(tmpDir, '.gossip', 'agents', 'custom-x');
+    const instrPath = join(instrDir, 'instructions.md');
+    const staged = [{ dir: instrDir, path: instrPath, content: 'You are custom-x.' }];
+
+    // Simulate the handler's validate-before-flush guard: validation throws,
+    // so the early return happens and flushStagedAgentFileWrites is never called.
+    let validationFailed = false;
+    try {
+      // A config missing main_agent is rejected by validateConfig.
+      validateConfig({ agents: {} } as never);
+    } catch {
+      validationFailed = true;
+    }
+    expect(validationFailed).toBe(true);
+
+    // Because validation failed, the flush is skipped — no orphan file/dir.
+    expect(existsSync(instrPath)).toBe(false);
+    expect(existsSync(instrDir)).toBe(false);
+    // And the staged entry was never materialized.
+    expect(staged).toHaveLength(1);
+  });
+
+  it('writes the custom instructions.md (mkdir-ing its dir) on the success path', () => {
+    const instrDir = join(tmpDir, '.gossip', 'agents', 'custom-y');
+    const instrPath = join(instrDir, 'instructions.md');
+    const mdDir = join(tmpDir, '.claude', 'agents');
+    const mdPath = join(mdDir, 'native-z.md');
+
+    flushStagedAgentFileWrites(
+      [
+        { dir: mdDir, path: mdPath, content: '---\nname: native-z\n---\nbody' },
+        { dir: instrDir, path: instrPath, content: 'You are custom-y.' },
+      ],
+      realFs,
+    );
+
+    expect(existsSync(instrPath)).toBe(true);
+    expect(readFileSync(instrPath, 'utf-8')).toBe('You are custom-y.');
+    expect(existsSync(mdPath)).toBe(true);
   });
 });

--- a/tests/orchestrator/performance-reader-rotation.test.ts
+++ b/tests/orchestrator/performance-reader-rotation.test.ts
@@ -157,9 +157,36 @@ describe('PerformanceReader — warns once per read on torn JSONL lines (f2)', (
       (c) => typeof c[0] === 'string' && c[0].includes('unparseable JSONL line(s)'),
     );
     // getScores reads via readSignals; exactly one warn for this read path.
-    expect(tornWarns.length).toBeGreaterThanOrEqual(1);
+    expect(tornWarns).toHaveLength(1);
     expect(tornWarns[0][0]).toContain('dropped 2 unparseable JSONL line(s)');
     expect(tornWarns[0][0]).toContain('agent-performance.jsonl');
+  });
+
+  it('counts a literal "null" line as dropped and does not collapse the read', () => {
+    const gossipDir = join(tmpDir, '.gossip');
+    mkdirSync(gossipDir, { recursive: true });
+    const perfPath = join(gossipDir, 'agent-performance.jsonl');
+
+    // JSON.parse('null') succeeds — without the non-object drop in
+    // parseJsonlLines the null would reach the filter predicate and a property
+    // access would throw, collapsing the entire read to [].
+    const content = [
+      makeSignal('agent-z', 'agreement'),
+      'null',
+      makeSignal('agent-z', 'agreement'),
+    ].join('\n') + '\n';
+    writeFileSync(perfPath, content);
+
+    const reader = new PerformanceReader(tmpDir);
+    const scores = reader.getScores();
+
+    // The two valid signals survive — the read did not collapse.
+    expect(scores.get('agent-z')?.totalSignals).toBe(2);
+    const tornWarns = warnSpy.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('unparseable JSONL line(s)'),
+    );
+    expect(tornWarns).toHaveLength(1);
+    expect(tornWarns[0][0]).toContain('dropped 1 unparseable JSONL line(s)');
   });
 
   it('does not warn for a clean file', () => {

--- a/tests/orchestrator/performance-reader-rotation.test.ts
+++ b/tests/orchestrator/performance-reader-rotation.test.ts
@@ -67,6 +67,122 @@ describe('readJsonlWithRotated', () => {
   });
 });
 
+// ── f4: BOM stripping — a leading U+FEFF must not break the first JSON line ───
+
+describe('readJsonlWithRotated — strips a leading UTF-8 BOM (f4)', () => {
+  const BOM = '﻿';
+
+  it('strips a BOM on the live file so its first line parses', () => {
+    const liveFile = join(tmpDir, 'perf.jsonl');
+    writeFileSync(liveFile, BOM + '{"a":1}\n{"b":2}\n');
+    const result = readJsonlWithRotated(liveFile);
+    const lines = result.split('\n').filter(Boolean);
+    expect(JSON.parse(lines[0])).toEqual({ a: 1 });
+    expect(result.charCodeAt(0)).not.toBe(0xfeff);
+  });
+
+  it('strips a BOM on the rotated .1 file independently', () => {
+    const liveFile = join(tmpDir, 'perf.jsonl');
+    writeFileSync(liveFile + '.1', BOM + '{"older":1}\n');
+    writeFileSync(liveFile, '{"newer":2}\n');
+    const result = readJsonlWithRotated(liveFile);
+    const lines = result.split('\n').filter(Boolean);
+    expect(JSON.parse(lines[0])).toEqual({ older: 1 });
+    expect(JSON.parse(lines[1])).toEqual({ newer: 2 });
+    expect(result.charCodeAt(0)).not.toBe(0xfeff);
+  });
+
+  it('strips a BOM when BOTH files carry one', () => {
+    const liveFile = join(tmpDir, 'perf.jsonl');
+    writeFileSync(liveFile + '.1', BOM + '{"older":1}\n');
+    writeFileSync(liveFile, BOM + '{"newer":2}\n');
+    const result = readJsonlWithRotated(liveFile);
+    const lines = result.split('\n').filter(Boolean);
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0])).toEqual({ older: 1 });
+    expect(JSON.parse(lines[1])).toEqual({ newer: 2 });
+    // no stray BOM should survive anywhere in the concatenated output
+    expect(result.includes(BOM)).toBe(false);
+  });
+
+  it('leaves BOM-free content unchanged', () => {
+    const liveFile = join(tmpDir, 'perf.jsonl');
+    writeFileSync(liveFile, '{"a":1}\n{"b":2}\n');
+    const result = readJsonlWithRotated(liveFile);
+    expect(result).toBe('{"a":1}\n{"b":2}\n');
+  });
+});
+
+// ── f2: torn-line drop observability — ONE warn per read, never per line ──────
+
+describe('PerformanceReader — warns once per read on torn JSONL lines (f2)', () => {
+  function makeSignal(agentId: string, signal: string): string {
+    return JSON.stringify({
+      type: 'consensus',
+      agentId,
+      signal,
+      taskId: 'task-abc',
+      timestamp: new Date(Date.now() - 86400000).toISOString(),
+    });
+  }
+
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('emits a single warn for a file with 2 torn lines', () => {
+    const gossipDir = join(tmpDir, '.gossip');
+    mkdirSync(gossipDir, { recursive: true });
+    const perfPath = join(gossipDir, 'agent-performance.jsonl');
+
+    // 2 unparseable lines interleaved with 2 valid signals
+    const content = [
+      makeSignal('agent-x', 'agreement'),
+      '{ this is not json',
+      makeSignal('agent-x', 'agreement'),
+      'also } not { json',
+    ].join('\n') + '\n';
+    writeFileSync(perfPath, content);
+
+    const reader = new PerformanceReader(tmpDir);
+    reader.getScores();
+
+    const tornWarns = warnSpy.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('unparseable JSONL line(s)'),
+    );
+    // getScores reads via readSignals; exactly one warn for this read path.
+    expect(tornWarns.length).toBeGreaterThanOrEqual(1);
+    expect(tornWarns[0][0]).toContain('dropped 2 unparseable JSONL line(s)');
+    expect(tornWarns[0][0]).toContain('agent-performance.jsonl');
+  });
+
+  it('does not warn for a clean file', () => {
+    const gossipDir = join(tmpDir, '.gossip');
+    mkdirSync(gossipDir, { recursive: true });
+    const perfPath = join(gossipDir, 'agent-performance.jsonl');
+
+    const content = [
+      makeSignal('agent-y', 'agreement'),
+      makeSignal('agent-y', 'unique_confirmed'),
+    ].join('\n') + '\n';
+    writeFileSync(perfPath, content);
+
+    const reader = new PerformanceReader(tmpDir);
+    reader.getScores();
+
+    const tornWarns = warnSpy.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('unparseable JSONL line(s)'),
+    );
+    expect(tornWarns).toHaveLength(0);
+  });
+});
+
 // ── PerformanceReader.readSignals migration smoke test ───────────────────────
 
 describe('PerformanceReader — reads signals from both live and rotated files', () => {


### PR DESCRIPTION
## Summary
Batch-5 of the 6eed37aa audit fixes — the three remaining verified-open items, plus consensus-driven fixups.

**f4 — BOM stripping** (`packages/orchestrator/src/performance-reader.ts`): `readJsonlWithRotated` now strips a leading U+FEFF from the rotated and live file independently, so a BOM'd first line no longer fails JSON.parse and silently vanishes.

**f2 — torn-line observability** (same file): new `parseJsonlLines<T>` helper counts dropped lines and emits ONE `console.warn` per read (never per line). Silent-skip hardening behavior preserved. Per consensus finding n1, null/non-object parses (a literal `null` line is valid JSON) now count as dropped too — previously only the downstream `s !== null` guards stood between such a line and a whole-read collapse.

**loop-transactionality v2** (`apps/cli/src/mcp-server-sdk.ts` + `setup-response.ts`): custom-agent `instructions.md` writes are now staged in `pendingAgentFileWrites` (renamed from `pendingNativeWrites`) and flushed only after `validateConfig` passes via the new `flushStagedAgentFileWrites` helper — a validation failure can no longer orphan a `.gossip/agents/<id>/` dir. Success path byte-identical; crash window positionally identical to the #558 native window.

**Consensus-prescribed hardening (pre-existing issues, exact fixes from the panel):**
- `agent.id` Zod regex — rejects path separators/`..` (confirmed pre-existing traversal exposure, defense-in-depth)
- `wasNative` guard now also checks `configAgents` — closes the same-batch native→custom split-brain blindspot

## Pre-merge consensus
3 agents (sonnet-reviewer, fable-reviewer, deepseek-challenger), 2 rounds: **13 confirmed / 1 disputed / 3 unique / 1 new**, 18 signals recorded. The one dispute (sonnet's "vacuous null guards") was empirically refuted by fable-reviewer (`JSON.parse('null')` returns null — the guards are load-bearing); `hallucination_caught` recorded. Deferred as follow-ups: warn-rate-limiting across reads (deepseek f1), `getImplScore`/retraction-readers observability parity (sonnet f10, deepseek f4).

consensus-id: 4ee5ced2-b654497a

## Verification
- `tsc --noEmit` clean for `packages/orchestrator` + `apps/cli`
- `jest tests/orchestrator tests/cli`: 249 suites, 3,525 tests pass
- New tests: 4 BOM cases, exact single-warn pin, literal-null non-collapse, behavioral validate-then-flush failure path

🤖 Generated with [Claude Code](https://claude.com/claude-code)