### PR TITLE
fix(orchestrator): rate-limit torn-line warns + reuse long-lived PerfReader (4ee5ced2:f1)

### DIFF
--- a/packages/orchestrator/src/agent-registry.ts
+++ b/packages/orchestrator/src/agent-registry.ts
@@ -48,6 +48,15 @@ export class AgentRegistry {
     this.perfReader = reader;
   }
 
+  /**
+   * Expose the long-lived PerformanceReader so callers reuse its mtime-keyed
+   * score cache instead of constructing a fresh (empty-cache) reader per call.
+   * Returns null when no reader was wired (perf data optional).
+   */
+  getPerformanceReader(): PerformanceReader | null {
+    return this.perfReader;
+  }
+
   setSuggesterCache(cache: Map<string, Set<string>>): void {
     this.suggesterCache = cache;
   }

--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -446,11 +446,12 @@ export class MainAgent {
   async classifyTaskComplexity(task: string): Promise<{ complexity: 'single' | 'multi'; agentId?: string }> {
     const agents = this.registry.getAll();
 
-    // Build agent summary with dispatch weights + category strengths so the LLM respects scoring
+    // Build agent summary with dispatch weights + category strengths so the LLM respects scoring.
+    // Reuse the long-lived reader (wired at construction) so its mtime-keyed score cache is shared;
+    // a fresh PerformanceReader here would have an empty cache and re-read on every call.
     let perfScores: Map<string, any> | null = null;
     try {
-      const { PerformanceReader: PerfR } = require('./performance-reader');
-      perfScores = new PerfR(this.projectRoot).getScores();
+      perfScores = this.registry.getPerformanceReader()?.getScores() ?? null;
     } catch { /* no perf data */ }
 
     const agentLines = agents.map(a => {

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -39,17 +39,50 @@ function stripBom(content: string): string {
 }
 
 /**
+ * Minimum interval between torn-line warnings for the SAME source file. During a
+ * consensus round the same torn file is re-read many times within milliseconds
+ * (every agent completion triggers a dispatch-weight lookup), so an unthrottled
+ * per-read warn floods mcp.log with identical lines. Rate-limit to one warn per
+ * source per window; suppressed occurrences are counted and surfaced on the next
+ * emit so no information is lost (f1, consensus 4ee5ced2-b654497a).
+ */
+const WARN_RATE_LIMIT_WINDOW_MS = 60_000;
+
+/**
+ * Per-source warn state: timestamp of last emitted warn and the number of warns
+ * suppressed since then. Keyed by the full source path so different files
+ * rate-limit independently.
+ */
+const warnRateLimiter = new Map<string, { lastWarnMs: number; suppressed: number }>();
+
+/**
+ * Test-only hook to clear the module-level warn rate-limiter between cases.
+ * Not part of the public API.
+ */
+export function __resetWarnRateLimiterForTests(): void {
+  warnRateLimiter.clear();
+}
+
+/**
  * Parse JSONL lines, silently skipping unparseable (torn) rows — the skip is
  * deliberate hardening so a single corrupt line never refuses the whole file.
  * f2: surface the drop with ONE console.warn per read when count > 0, never
  * one warn per line (files can have thousands of lines).
+ * f1: additionally rate-limit warns across rapid re-reads of the same source to
+ * one per WARN_RATE_LIMIT_WINDOW_MS, carrying the suppressed count forward. The
+ * dropped-line COUNTING and the returned array are unaffected — only how often
+ * the warn is emitted changes. `now` is injectable for deterministic tests.
  *
  * Non-object parses count as torn too: a literal `null` line is valid JSON
  * (JSON.parse('null') returns null without throwing), and propagating it would
  * make a downstream property access throw inside the caller's try/catch —
  * collapsing the entire read to []. See consensus 4ee5ced2-b654497a (n1).
  */
-function parseJsonlLines<T>(lines: string[], sourcePath: string): T[] {
+export function parseJsonlLines<T>(
+  lines: string[],
+  sourcePath: string,
+  now: () => number = Date.now,
+): T[] {
   let dropped = 0;
   const out: T[] = [];
   for (const line of lines) {
@@ -65,11 +98,30 @@ function parseJsonlLines<T>(lines: string[], sourcePath: string): T[] {
     }
   }
   if (dropped > 0) {
-    console.warn(
-      `[performance-reader] dropped ${dropped} unparseable JSONL line(s) from ${basename(sourcePath)}`,
-    );
+    emitTornLineWarn(sourcePath, dropped, now());
   }
   return out;
+}
+
+/**
+ * Emit the torn-line warning for `sourcePath`, throttled to one per window.
+ * Within the window the call is suppressed and counted; the next emit after the
+ * window reports how many similar warns were suppressed so nothing is lost.
+ */
+function emitTornLineWarn(sourcePath: string, dropped: number, nowMs: number): void {
+  const state = warnRateLimiter.get(sourcePath);
+  if (state && nowMs - state.lastWarnMs < WARN_RATE_LIMIT_WINDOW_MS) {
+    state.suppressed++;
+    return;
+  }
+  const suppressedNote =
+    state && state.suppressed > 0
+      ? ` (suppressed ${state.suppressed} similar warn(s) in the last ${WARN_RATE_LIMIT_WINDOW_MS / 1000}s)`
+      : '';
+  console.warn(
+    `[performance-reader] dropped ${dropped} unparseable JSONL line(s) from ${basename(sourcePath)}${suppressedNote}`,
+  );
+  warnRateLimiter.set(sourcePath, { lastWarnMs: nowMs, suppressed: 0 });
 }
 
 export function readJsonlWithRotated(filePath: string): string {

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -43,17 +43,20 @@ function stripBom(content: string): string {
  * consensus round the same torn file is re-read many times within milliseconds
  * (every agent completion triggers a dispatch-weight lookup), so an unthrottled
  * per-read warn floods mcp.log with identical lines. Rate-limit to one warn per
- * source per window; suppressed occurrences are counted and surfaced on the next
- * emit so no information is lost (f1, consensus 4ee5ced2-b654497a).
+ * source per window; suppressed occurrences are counted (with the peak dropped-line
+ * count among them) and surfaced on the next emit. Per-read dropped totals from
+ * suppressed reads are NOT preserved — only the event count and the peak
+ * (f1, consensus 4ee5ced2-b654497a; wording/maxDropped per 8b23a8f3-2cc348d1).
  */
 const WARN_RATE_LIMIT_WINDOW_MS = 60_000;
 
 /**
- * Per-source warn state: timestamp of last emitted warn and the number of warns
- * suppressed since then. Keyed by the full source path so different files
+ * Per-source warn state: timestamp of last emitted warn, the number of warns
+ * suppressed since then, and the largest dropped-line count seen among the
+ * suppressed reads. Keyed by the full source path so different files
  * rate-limit independently.
  */
-const warnRateLimiter = new Map<string, { lastWarnMs: number; suppressed: number }>();
+const warnRateLimiter = new Map<string, { lastWarnMs: number; suppressed: number; maxDropped: number }>();
 
 /**
  * Test-only hook to clear the module-level warn rate-limiter between cases.
@@ -105,23 +108,26 @@ export function parseJsonlLines<T>(
 
 /**
  * Emit the torn-line warning for `sourcePath`, throttled to one per window.
- * Within the window the call is suppressed and counted; the next emit after the
- * window reports how many similar warns were suppressed so nothing is lost.
+ * Within the window the call is suppressed and counted (tracking the peak dropped
+ * count); the next emit reports how many warns were suppressed since the last
+ * emitted warn and the largest dropped count among them. Per-read dropped totals
+ * from suppressed reads are not preserved.
  */
 function emitTornLineWarn(sourcePath: string, dropped: number, nowMs: number): void {
   const state = warnRateLimiter.get(sourcePath);
   if (state && nowMs - state.lastWarnMs < WARN_RATE_LIMIT_WINDOW_MS) {
     state.suppressed++;
+    if (dropped > state.maxDropped) state.maxDropped = dropped;
     return;
   }
   const suppressedNote =
     state && state.suppressed > 0
-      ? ` (suppressed ${state.suppressed} similar warn(s) in the last ${WARN_RATE_LIMIT_WINDOW_MS / 1000}s)`
+      ? ` (suppressed ${state.suppressed} similar warn(s) since last warn, max dropped=${state.maxDropped})`
       : '';
   console.warn(
     `[performance-reader] dropped ${dropped} unparseable JSONL line(s) from ${basename(sourcePath)}${suppressedNote}`,
   );
-  warnRateLimiter.set(sourcePath, { lastWarnMs: nowMs, suppressed: 0 });
+  warnRateLimiter.set(sourcePath, { lastWarnMs: nowMs, suppressed: 0, maxDropped: 0 });
 }
 
 export function readJsonlWithRotated(filePath: string): string {

--- a/tests/orchestrator/performance-reader-rotation.test.ts
+++ b/tests/orchestrator/performance-reader-rotation.test.ts
@@ -8,7 +8,11 @@
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { readJsonlWithRotated, PerformanceReader } from '../../packages/orchestrator/src/performance-reader';
+import {
+  readJsonlWithRotated,
+  PerformanceReader,
+  __resetWarnRateLimiterForTests,
+} from '../../packages/orchestrator/src/performance-reader';
 import * as RoundCounter from '../../packages/orchestrator/src/round-counter';
 
 let tmpDir: string;
@@ -129,6 +133,7 @@ describe('PerformanceReader — warns once per read on torn JSONL lines (f2)', (
   let warnSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    __resetWarnRateLimiterForTests();
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 

--- a/tests/orchestrator/performance-reader-warn-rate-limit.test.ts
+++ b/tests/orchestrator/performance-reader-warn-rate-limit.test.ts
@@ -1,0 +1,115 @@
+// @gossip:impact-adjacent:signal-pipeline
+/**
+ * Tests for warn rate-limiting in parseJsonlLines — torn-line warnings are
+ * throttled to one per source file per WARN_RATE_LIMIT_WINDOW_MS so a hot
+ * re-read loop (e.g. a 25-agent consensus round doing per-completion
+ * dispatch-weight lookups) does not flood mcp.log with identical lines.
+ *
+ * Fix for consensus 4ee5ced2-b654497a (f1, MEDIUM).
+ */
+
+import {
+  parseJsonlLines,
+  __resetWarnRateLimiterForTests,
+} from '../../packages/orchestrator/src/performance-reader';
+
+const WINDOW_MS = 60_000;
+
+// A torn file: one valid object line plus one unparseable line so dropped > 0.
+const TORN_LINES = ['{"ok":1}', '{ not json'];
+
+describe('parseJsonlLines — warn rate-limiting (f1)', () => {
+  let warnSpy: jest.SpyInstance;
+  let nowMs: number;
+  const now = () => nowMs;
+
+  function tornWarnCalls(): unknown[][] {
+    return warnSpy.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('unparseable JSONL line(s)'),
+    );
+  }
+
+  beforeEach(() => {
+    __resetWarnRateLimiterForTests();
+    nowMs = 1_000_000;
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('emits exactly one warn for two rapid reads of the same torn source', () => {
+    const src = '/tmp/agent-performance.jsonl';
+
+    const first = parseJsonlLines<{ ok: number }>(TORN_LINES, src, now);
+    nowMs += 5; // milliseconds later — still inside the window
+    const second = parseJsonlLines<{ ok: number }>(TORN_LINES, src, now);
+
+    // Parsing/return is unaffected: the one valid object survives each read.
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+
+    const warns = tornWarnCalls();
+    expect(warns).toHaveLength(1);
+    expect(warns[0][0]).toContain('dropped 1 unparseable JSONL line(s)');
+    expect(warns[0][0]).toContain('agent-performance.jsonl');
+  });
+
+  it('warns again after the window elapses and reports the suppressed count', () => {
+    const src = '/tmp/agent-performance.jsonl';
+
+    parseJsonlLines(TORN_LINES, src, now); // emit #1
+    // Three reads inside the window are suppressed but counted.
+    for (let i = 0; i < 3; i++) {
+      nowMs += 10;
+      parseJsonlLines(TORN_LINES, src, now);
+    }
+    // Cross the window boundary — next read warns again.
+    nowMs += WINDOW_MS;
+    parseJsonlLines(TORN_LINES, src, now);
+
+    const warns = tornWarnCalls();
+    expect(warns).toHaveLength(2);
+    expect(warns[1][0]).toContain('suppressed 3 similar warn(s) in the last 60s');
+  });
+
+  it('rate-limits different source files independently', () => {
+    const a = '/tmp/a/agent-performance.jsonl';
+    const b = '/tmp/b/agent-performance.jsonl';
+
+    parseJsonlLines(TORN_LINES, a, now); // emit for a
+    parseJsonlLines(TORN_LINES, b, now); // emit for b — different key, not throttled
+    nowMs += 5;
+    parseJsonlLines(TORN_LINES, a, now); // suppressed (a, in-window)
+    parseJsonlLines(TORN_LINES, b, now); // suppressed (b, in-window)
+
+    const warns = tornWarnCalls();
+    expect(warns).toHaveLength(2);
+    expect(warns.map((c) => c[0])).toEqual([
+      expect.stringContaining('agent-performance.jsonl'),
+      expect.stringContaining('agent-performance.jsonl'),
+    ]);
+  });
+
+  it('does not change dropped-line filtering: torn lines stay excluded from results', () => {
+    const src = '/tmp/filter/agent-performance.jsonl';
+    const lines = ['{"keep":1}', 'null', '{ broken', '{"keep":2}'];
+
+    const out = parseJsonlLines<{ keep: number }>(lines, src, now);
+
+    // Both torn rows (the syntax error and the literal null) are excluded; the
+    // two valid objects survive.
+    expect(out).toEqual([{ keep: 1 }, { keep: 2 }]);
+    const warns = tornWarnCalls();
+    expect(warns).toHaveLength(1);
+    expect(warns[0][0]).toContain('dropped 2 unparseable JSONL line(s)');
+  });
+
+  it('does not warn for a clean source (no dropped lines)', () => {
+    const src = '/tmp/clean/agent-performance.jsonl';
+    const out = parseJsonlLines<{ ok: number }>(['{"ok":1}', '{"ok":2}'], src, now);
+    expect(out).toHaveLength(2);
+    expect(tornWarnCalls()).toHaveLength(0);
+  });
+});

--- a/tests/orchestrator/performance-reader-warn-rate-limit.test.ts
+++ b/tests/orchestrator/performance-reader-warn-rate-limit.test.ts
@@ -71,12 +71,47 @@ describe('parseJsonlLines — warn rate-limiting (f1)', () => {
 
     const warns = tornWarnCalls();
     expect(warns).toHaveLength(2);
-    expect(warns[1][0]).toContain('suppressed 3 similar warn(s) in the last 60s');
+    expect(warns[1][0]).toContain('suppressed 3 similar warn(s) since last warn');
+  });
+
+  it('reports the peak dropped count among suppressed reads', () => {
+    const src = '/tmp/peak/agent-performance.jsonl';
+    const tornN = (n: number) => ['{"ok":1}', ...Array.from({ length: n }, () => '{ torn')];
+
+    parseJsonlLines(tornN(10), src, now); // emit #1: dropped 10
+    nowMs += 5;
+    parseJsonlLines(tornN(50), src, now); // suppressed, peak 50
+    nowMs += 5;
+    parseJsonlLines(tornN(2), src, now); // suppressed, peak stays 50
+    nowMs += WINDOW_MS;
+    parseJsonlLines(tornN(2), src, now); // emit #2: current dropped 2, reports peak
+
+    const warns = tornWarnCalls();
+    expect(warns).toHaveLength(2);
+    expect(warns[1][0]).toContain('dropped 2 unparseable JSONL line(s)');
+    expect(warns[1][0]).toContain('suppressed 2 similar warn(s) since last warn, max dropped=50');
+  });
+
+  it('reports suppressed count accurately after a long silence past the window', () => {
+    const src = '/tmp/gap/agent-performance.jsonl';
+
+    parseJsonlLines(TORN_LINES, src, now); // emit #1
+    nowMs += 5;
+    parseJsonlLines(TORN_LINES, src, now); // suppressed at t≈0
+    nowMs += 10 * WINDOW_MS; // long silence — suppression happened far in the past
+    parseJsonlLines(TORN_LINES, src, now); // emit #2
+
+    const warns = tornWarnCalls();
+    expect(warns).toHaveLength(2);
+    // The message claims "since last warn", which stays accurate however long the
+    // gap is — it must NOT claim a fixed recency window like "in the last 60s".
+    expect(warns[1][0]).toContain('suppressed 1 similar warn(s) since last warn');
+    expect(warns[1][0]).not.toContain('in the last');
   });
 
   it('rate-limits different source files independently', () => {
-    const a = '/tmp/a/agent-performance.jsonl';
-    const b = '/tmp/b/agent-performance.jsonl';
+    const a = '/tmp/a/a.jsonl';
+    const b = '/tmp/b/b.jsonl';
 
     parseJsonlLines(TORN_LINES, a, now); // emit for a
     parseJsonlLines(TORN_LINES, b, now); // emit for b — different key, not throttled
@@ -86,9 +121,10 @@ describe('parseJsonlLines — warn rate-limiting (f1)', () => {
 
     const warns = tornWarnCalls();
     expect(warns).toHaveLength(2);
+    // Distinct basenames make the per-file assertions discriminating.
     expect(warns.map((c) => c[0])).toEqual([
-      expect.stringContaining('agent-performance.jsonl'),
-      expect.stringContaining('agent-performance.jsonl'),
+      expect.stringContaining('a.jsonl'),
+      expect.stringContaining('b.jsonl'),
     ]);
   });
 

--- a/tests/orchestrator/performance-reader.test.ts
+++ b/tests/orchestrator/performance-reader.test.ts
@@ -1,4 +1,7 @@
-import { PerformanceReader } from '../../packages/orchestrator/src/performance-reader';
+import {
+  PerformanceReader,
+  __resetWarnRateLimiterForTests,
+} from '../../packages/orchestrator/src/performance-reader';
 import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 
@@ -23,9 +26,19 @@ function writeSignals(signals: any[]): void {
   writeFileSync(join(TEST_DIR, '.gossip', 'agent-performance.jsonl'), data);
 }
 
+let warnSpy: jest.SpyInstance;
+
 beforeEach(() => {
   if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
   mkdirSync(TEST_DIR, { recursive: true });
+  // Torn-line fixtures route through the module-level warn rate-limiter; reset
+  // it and silence the warn so tests stay hermetic and CI output stays clean.
+  __resetWarnRateLimiterForTests();
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
 });
 
 afterAll(() => {


### PR DESCRIPTION
Closes consensus finding `4ee5ced2-b654497a:f1` (MEDIUM) — torn-line warn flooding across rapid re-reads.

## Changes

- **`parseJsonlLines` warn rate-limiting** (`performance-reader.ts`): module-level `warnRateLimiter` Map keyed by full source path; at most one warn per source per `WARN_RATE_LIMIT_WINDOW_MS` (60s). Suppressed warns are counted (with the peak dropped-line count among them) and reported on the next emit as `(suppressed N similar warn(s) since last warn, max dropped=M)`. Dropped-line counting and the returned array are byte-identical — only warn emission frequency changed.
- **`classifyTaskComplexity` reuses the long-lived reader** (`main-agent.ts:452-455`): the old per-call `new PerfR(...)` had an empty cache and bypassed the mtime score cache entirely; now reuses the registry-wired instance via a new `getPerformanceReader()` accessor on `AgentRegistry`. Fail-soft (`?? null` + try/catch) preserved.
- **Tests**: new `performance-reader-warn-rate-limit.test.ts` (7 cases, injectable clock): one-emit-per-window, suppressed-count report, peak-dropped report, long-silence accuracy, per-path independence (distinct basenames), filtering unchanged, clean-source no-warn. Hermeticity: `__resetWarnRateLimiterForTests()` + warn spy added to the rotation and base suites.

## Review

Pre-merge consensus (3 agents, 2 rounds): 12 confirmed / 1 disputed-refuted / 3 unique-verified / 1 new; 17 signals recorded. The disputed finding (deepseek's basename-keying claim) was refuted by fable-reviewer and orchestrator-verified. Post-consensus fixups in 21564b19 address f1/f2/f4/f8/f9/f12 (wording, maxDropped, test coverage). Follow-ups deferred: getImplScore warn parity (pre-existing, tracked), ReadonlyMap typing on getScores() (latent, fable n1).

consensus-id: 8b23a8f3-2cc348d1

Verification: `npx jest tests/orchestrator/performance-reader` → 124/124 green (10 suites); `npx tsc --noEmit` → zero non-pre-existing errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)