### PR TITLE
fix(orchestrator): type getScores() as ReadonlyMap (8b23a8f3 n1)

### DIFF
--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -449,7 +449,7 @@ export class MainAgent {
     // Build agent summary with dispatch weights + category strengths so the LLM respects scoring.
     // Reuse the long-lived reader (wired at construction) so its mtime-keyed score cache is shared;
     // a fresh PerformanceReader here would have an empty cache and re-read on every call.
-    let perfScores: Map<string, any> | null = null;
+    let perfScores: ReadonlyMap<string, any> | null = null;
     try {
       perfScores = this.registry.getPerformanceReader()?.getScores() ?? null;
     } catch { /* no perf data */ }

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -399,8 +399,13 @@ export class PerformanceReader {
     return out;
   }
 
-  /** Read all signals and compute per-agent scores (cached by file mtime) */
-  getScores(): Map<string, AgentScore> {
+  /**
+   * Read all signals and compute per-agent scores (cached by file mtime).
+   * Returns the LIVE cache by reference — typed ReadonlyMap so callers cannot
+   * mutate it and silently corrupt scores for every other consumer
+   * (consensus 8b23a8f3-2cc348d1, fable n1).
+   */
+  getScores(): ReadonlyMap<string, AgentScore> {
     // Check if file changed since last read
     let mtimeMs = 0;
     try { mtimeMs = statSync(this.filePath).mtimeMs; } catch { /* file doesn't exist */ }

--- a/packages/relay/src/dashboard/api-agents.ts
+++ b/packages/relay/src/dashboard/api-agents.ts
@@ -295,7 +295,7 @@ export async function agentsHandler(
   onlineAgents: string[] = [],
 ): Promise<AgentResponse[]> {
   const reader = new PerformanceReader(projectRoot);
-  let scores: Map<string, AgentScore>;
+  let scores: ReadonlyMap<string, AgentScore>;
   try { scores = reader.getScores(); } catch { scores = new Map(); }
 
   const taskDataByAgent = readTaskGraphByAgent(projectRoot);


### PR DESCRIPTION
Implements the NEW finding from pre-merge consensus `8b23a8f3-2cc348d1` (fable-reviewer n1, LOW/data_integrity): `getScores()` returns the live `cachedScores` Map by reference, so any caller mutation would silently corrupt scores for every other consumer until the next mtime change. All current consumers are read-only — this types the return as `ReadonlyMap<string, AgentScore>` to make that a compile-time guarantee at zero runtime cost.

Ripple (verified by survey of all 7 `getScores()` call sites): two annotation updates — `main-agent.ts` `perfScores` and `api-agents.ts` `scores`; every other call site uses `const` inference with read-only access.

consensus-id: 8b23a8f3-2cc348d1

Verification: full `npm run build` clean (orchestrator + relay + all workspaces); `npx jest tests/orchestrator/performance-reader tests/orchestrator/main-agent` → 135/135 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)