### PR TITLE
fix(orchestrator): torn-line warn parity for retraction readers + getImplScore (4ee5ced2:f4/f10)

### DIFF
--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -465,14 +465,12 @@ export class PerformanceReader {
       const raw = readJsonlWithRotated(this.filePath);
       if (!raw) return new Set();
       const lines = raw.trim().split('\n').filter(Boolean);
+      const parsed = parseJsonlLines<Record<string, unknown>>(lines, this.filePath);
       const ids = new Set<string>();
-      for (const line of lines) {
-        try {
-          const r = JSON.parse(line);
-          if (r && r.type === 'consensus' && r.signal === 'consensus_round_retracted' && typeof r.consensus_id === 'string') {
-            ids.add(r.consensus_id);
-          }
-        } catch { /* skip */ }
+      for (const r of parsed) {
+        if (r.type === 'consensus' && r.signal === 'consensus_round_retracted' && typeof r.consensus_id === 'string') {
+          ids.add(r.consensus_id);
+        }
       }
       return ids;
     } catch {
@@ -489,18 +487,18 @@ export class PerformanceReader {
       const raw = readJsonlWithRotated(this.filePath);
       if (!raw) return [];
       const lines = raw.trim().split('\n').filter(Boolean);
+      const parsed = parseJsonlLines<Record<string, unknown>>(lines, this.filePath);
       const out: Array<{ consensus_id: string; reason: string; retracted_at: string }> = [];
-      for (const line of lines) {
-        try {
-          const r = JSON.parse(line);
-          if (r && r.type === 'consensus' && r.signal === 'consensus_round_retracted' && typeof r.consensus_id === 'string') {
-            out.push({
-              consensus_id: r.consensus_id,
-              reason: typeof r.reason === 'string' ? r.reason : '',
-              retracted_at: typeof r.retracted_at === 'string' ? r.retracted_at : (r.timestamp || ''),
-            });
-          }
-        } catch { /* skip */ }
+      for (const r of parsed) {
+        if (r.type === 'consensus' && r.signal === 'consensus_round_retracted' && typeof r.consensus_id === 'string') {
+          out.push({
+            consensus_id: r.consensus_id,
+            reason: typeof r.reason === 'string' ? r.reason : '',
+            retracted_at: typeof r.retracted_at === 'string'
+              ? r.retracted_at
+              : (typeof r.timestamp === 'string' ? r.timestamp : ''),
+          });
+        }
       }
       return out;
     } catch {
@@ -1381,19 +1379,19 @@ export class PerformanceReader {
       const now = Date.now();
       const expiryMs = now - SIGNAL_EXPIRY_DAYS * 86400000;
       const lines = readJsonlWithRotated(this.filePath).trim().split('\n').filter(Boolean);
+      const signals = parseJsonlLines<Record<string, unknown>>(lines, this.filePath);
       let pass = 0, fail = 0, approved = 0, rejected = 0, lastImplSignalMs = 0;
-      for (const line of lines) {
-        try {
-          const s = JSON.parse(line);
-          if (s.type !== 'impl' || s.agentId !== agentId) continue;
-          const ts = s.timestamp ? new Date(s.timestamp).getTime() : 0;
-          if (ts < expiryMs) continue;
-          if (ts > lastImplSignalMs) lastImplSignalMs = ts;
-          if (s.signal === 'impl_test_pass') pass++;
-          if (s.signal === 'impl_test_fail') fail++;
-          if (s.signal === 'impl_peer_approved') approved++;
-          if (s.signal === 'impl_peer_rejected') rejected++;
-        } catch { continue; }
+      for (const s of signals) {
+        if (s.type !== 'impl' || s.agentId !== agentId) continue;
+        const ts = typeof s.timestamp === 'string' || typeof s.timestamp === 'number'
+          ? new Date(s.timestamp).getTime()
+          : 0;
+        if (ts < expiryMs) continue;
+        if (ts > lastImplSignalMs) lastImplSignalMs = ts;
+        if (s.signal === 'impl_test_pass') pass++;
+        if (s.signal === 'impl_test_fail') fail++;
+        if (s.signal === 'impl_peer_approved') approved++;
+        if (s.signal === 'impl_peer_rejected') rejected++;
       }
       const total = pass + fail;
       const peerTotal = approved + rejected;

--- a/tests/orchestrator/performance-reader-reader-torn-warn.test.ts
+++ b/tests/orchestrator/performance-reader-reader-torn-warn.test.ts
@@ -1,0 +1,140 @@
+// @gossip:impact-adjacent:signal-pipeline
+/**
+ * Torn-line warn parity for the raw-JSONL readers migrated to parseJsonlLines:
+ * getRetractedConsensusIds / getRoundRetractions / getImplScore. Before the
+ * migration these silently dropped unparseable lines; now they emit the shared
+ * rate-limited `[performance-reader] dropped N unparseable JSONL line(s)` warn
+ * via parseJsonlLines — same throttling key (this.filePath) as readSignals.
+ *
+ * Fix for consensus 4ee5ced2-b654497a (f4/f10) + 8b23a8f3-2cc348d1 (f16).
+ */
+
+import { writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import {
+  PerformanceReader,
+  __resetWarnRateLimiterForTests,
+} from '../../packages/orchestrator/src/performance-reader';
+
+const TMP = join(__dirname, '..', '..', '.test-tmp-reader-torn-warn');
+const GOSSIP_FILE = join(TMP, '.gossip', 'agent-performance.jsonl');
+
+/** Write raw JSONL lines verbatim — torn lines must survive as written. */
+function writeRaw(lines: string[]): void {
+  mkdirSync(join(TMP, '.gossip'), { recursive: true });
+  writeFileSync(GOSSIP_FILE, lines.join('\n'));
+}
+
+const nowIso = new Date().toISOString();
+
+describe('performance-reader raw-JSONL readers — torn-line warn parity', () => {
+  let warnSpy: jest.SpyInstance;
+
+  function tornWarnCalls(): unknown[][] {
+    return warnSpy.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('unparseable JSONL line(s)'),
+    );
+  }
+
+  beforeEach(() => {
+    __resetWarnRateLimiterForTests();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    try {
+      rmSync(TMP, { recursive: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  it('getRetractedConsensusIds emits the dropped-line warn AND still returns valid tombstones', () => {
+    writeRaw([
+      JSON.stringify({ type: 'consensus', signal: 'consensus_round_retracted', consensus_id: 'abc-123' }),
+      '{ this line is torn',
+      JSON.stringify({ type: 'consensus', signal: 'consensus_round_retracted', consensus_id: 'def-456' }),
+    ]);
+
+    const reader = new PerformanceReader(TMP);
+    const ids = reader.getRetractedConsensusIds();
+
+    // Parsing unchanged: both well-formed tombstones survive the torn line.
+    expect(ids).toEqual(new Set(['abc-123', 'def-456']));
+
+    const warns = tornWarnCalls();
+    expect(warns).toHaveLength(1);
+    expect(warns[0][0]).toContain('dropped 1 unparseable JSONL line(s)');
+    expect(warns[0][0]).toContain('agent-performance.jsonl');
+  });
+
+  it('getRoundRetractions emits the dropped-line warn AND still returns valid retractions', () => {
+    writeRaw([
+      JSON.stringify({
+        type: 'consensus',
+        signal: 'consensus_round_retracted',
+        consensus_id: 'abc-123',
+        reason: 'bad round',
+        retracted_at: nowIso,
+      }),
+      '}{ torn payload',
+      JSON.stringify({
+        type: 'consensus',
+        signal: 'consensus_round_retracted',
+        consensus_id: 'abc-123',
+        reason: 'second reason',
+        retracted_at: nowIso,
+      }),
+    ]);
+
+    const reader = new PerformanceReader(TMP);
+    const out = reader.getRoundRetractions();
+
+    // Duplicates preserved (admin view), torn line dropped.
+    expect(out).toEqual([
+      { consensus_id: 'abc-123', reason: 'bad round', retracted_at: nowIso },
+      { consensus_id: 'abc-123', reason: 'second reason', retracted_at: nowIso },
+    ]);
+
+    const warns = tornWarnCalls();
+    expect(warns).toHaveLength(1);
+    expect(warns[0][0]).toContain('dropped 1 unparseable JSONL line(s)');
+  });
+
+  it('getImplScore emits the dropped-line warn AND still computes the score from valid impl signals', () => {
+    writeRaw([
+      JSON.stringify({ type: 'impl', agentId: 'opus-implementer', signal: 'impl_test_pass', timestamp: nowIso }),
+      'not valid json at all',
+      JSON.stringify({ type: 'impl', agentId: 'opus-implementer', signal: 'impl_test_fail', timestamp: nowIso }),
+      JSON.stringify({ type: 'impl', agentId: 'opus-implementer', signal: 'impl_test_pass', timestamp: nowIso }),
+    ]);
+
+    const reader = new PerformanceReader(TMP);
+    const score = reader.getImplScore('opus-implementer');
+
+    // 2 pass + 1 fail → passRate 2/3; parsing unchanged despite the torn line.
+    expect(score).not.toBeNull();
+    expect(score!.passRate).toBeCloseTo(2 / 3, 5);
+
+    const warns = tornWarnCalls();
+    expect(warns).toHaveLength(1);
+    expect(warns[0][0]).toContain('dropped 1 unparseable JSONL line(s)');
+  });
+
+  it('rate-limits across readers sharing the same file — one warn total within the window', () => {
+    writeRaw([
+      JSON.stringify({ type: 'consensus', signal: 'consensus_round_retracted', consensus_id: 'abc-123' }),
+      '{ torn',
+      JSON.stringify({ type: 'impl', agentId: 'opus-implementer', signal: 'impl_test_pass', timestamp: nowIso }),
+    ]);
+
+    const reader = new PerformanceReader(TMP);
+    // Two reads of the same torn file via different readers, same window.
+    reader.getImplScore('opus-implementer');
+    reader.getRetractedConsensusIds();
+
+    // Shared this.filePath rate-limit key ⇒ the second read is suppressed.
+    expect(tornWarnCalls()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes consensus findings `4ee5ced2-b654497a:f4/f10` and `8b23a8f3-2cc348d1:f16` (LOW, observability): the last three raw-JSON.parse readers in `performance-reader.ts` silently dropped torn JSONL lines.

## Changes

- **`getRetractedConsensusIds`, `getRoundRetractions`, `getImplScore`** migrated to the shared `parseJsonlLines` helper — torn lines now emit the rate-limited `[performance-reader] dropped N unparseable JSONL line(s)` warn (one per file per 60s window, shared key with `readSignals`). Behavior identical for well-formed lines; outer fail-soft wrappers preserved.
- **Timestamp guards tightened** (strict typing, no casts): malformed truthy non-string/non-number timestamps previously produced `NaN` that bypassed the expiry comparison in `getImplScore`; they now map to 0 and are skipped, consistent with how missing timestamps were always handled. Writer only emits ISO strings, so this class is corruption-only.
- **New integration suite** `tests/orchestrator/performance-reader-reader-torn-warn.test.ts`: warn emission per reader, parse results unchanged alongside torn lines, cross-reader rate-limit sharing.

## Review

Mirror-of-pattern change — the `parseJsonlLines` migration pattern was consensus-reviewed in rounds `4ee5ced2-b654497a` and `8b23a8f3-2cc348d1` (whose f16 prescribed exactly this migration), so per the impact-adjacency mirror exception no fresh full round was run. Orchestrator verified behavior-equivalence classes, dropped-guard redundancy, test soundness, and all 6 consumer call sites (all value-readers). A single fable-reviewer verification dispatch stalled (watchdog) and was replaced by direct orchestrator verification.

consensus-id: 8b23a8f3-2cc348d1

Verification: full `npm run build` clean; `npx jest tests/orchestrator/performance-reader` → 128/128 (11 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)