### PR TITLE
fix(signals): scope late-relay retraction + once-per-task auto-signal dedup (6eed37aa:f9)

### DIFF
--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -316,16 +316,17 @@ export function cancelTimeoutWatcher(taskId: string): void {
 function recordTimeoutSignal(taskId: string, agentId: string): void {
   try {
     const { emitConsensusSignals } = require('@gossip/orchestrator');
-    // PR 4 Part A: operational disagreement — no finding context exists because
-    // the agent never produced a review verdict to tag. Intentionally written
-    // without `category` so the Part B no-op guard in
-    // performance-reader.ts:computeScores treats this as a transport/lifecycle
-    // event rather than a finding-evaluation signal. Routing to the dedicated
-    // task_timeout stream is tracked separately in PR 5.
+    // Operational timeout — no finding context exists because the agent never
+    // produced a review verdict to tag. Emitted as `task_timeout` (a scoring
+    // no-op, like the collect-time row at collect.ts) so the late-relay scoped
+    // tombstone (retractedSignal: 'task_timeout') covers BOTH timeout rows.
+    // Intentionally written without `category`. Previously this was a
+    // categoryless `disagreement` (also a scoring no-op via the Part B guard),
+    // which the scoped tombstone could not reach — consensus f7d8b67a (f9).
     emitConsensusSignals(process.cwd(), [{
       type: 'consensus' as const,
       taskId,
-      signal: 'disagreement' as const,
+      signal: 'task_timeout' as const,
       agentId,
       evidence: 'Native agent timed out — no gossip_relay call received',
       timestamp: new Date().toISOString(),
@@ -582,7 +583,9 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
             signal: 'signal_retracted' as const,
             agentId: taskInfo.agentId,
             taskId: task_id,
-            // Scoped tombstone (PR #557): void ONLY the timeout signal, not the
+            // Scoped tombstone (PR #557): void ONLY the timeout rows — both the
+            // watcher's task_timeout (recordTimeoutSignal above) and any
+            // collect-time task_timeout share this name+agent+taskId — not the
             // fresh auto-signals (impl_test_pass, task_completed, format_compliance)
             // re-emitted later in this same handler. Without retractedSignal the
             // reader treats this as a wildcard and zeroes ALL scoring credit for

--- a/apps/cli/src/handlers/native-tasks.ts
+++ b/apps/cli/src/handlers/native-tasks.ts
@@ -582,6 +582,12 @@ export async function handleNativeRelay(task_id: string, result: string, error?:
             signal: 'signal_retracted' as const,
             agentId: taskInfo.agentId,
             taskId: task_id,
+            // Scoped tombstone (PR #557): void ONLY the timeout signal, not the
+            // fresh auto-signals (impl_test_pass, task_completed, format_compliance)
+            // re-emitted later in this same handler. Without retractedSignal the
+            // reader treats this as a wildcard and zeroes ALL scoring credit for
+            // the late-completing agent (performance-reader.ts:714-722).
+            retractedSignal: 'task_timeout',
             evidence: 'Late relay arrived — agent completed successfully after timeout',
             timestamp: new Date().toISOString(),
           }]);

--- a/packages/orchestrator/src/auto-signal-dedup.ts
+++ b/packages/orchestrator/src/auto-signal-dedup.ts
@@ -30,7 +30,14 @@ function tripleKey(agentId: string, taskId: string, signal: string): string {
  *
  * Returns the signals that should actually be written, plus the skipped count.
  * Fail-open: if the read throws, returns the input batch unchanged (better to
- * risk a rare double-count than to silently drop a real signal).
+ * risk a rare double-count than to silently drop a real signal); the failure
+ * is logged to stderr so an inert dedup is diagnosable.
+ *
+ * Key constraints (consensus f7d8b67a f14): the triple omits `counterpartId`,
+ * so a future multi-peer batch caller would collapse distinct peers' signals —
+ * do not route multi-peer batches through this. It also ignores retraction
+ * tombstones, so a retracted signal type can never be legitimately re-emitted
+ * via the deduped emitters — do not route retractable consensus signals here.
  */
 export function dedupeOncePerTaskSignals<T extends PerformanceSignal>(
   projectRoot: string,
@@ -68,7 +75,10 @@ export function dedupeOncePerTaskSignals<T extends PerformanceSignal>(
       kept.push(s);
     }
     return { kept, skipped };
-  } catch {
+  } catch (err) {
+    process.stderr.write(
+      `[gossipcat] auto-signal dedup read failed (fail-open, batch passes undeduped): ${(err as Error).message}\n`,
+    );
     return { kept: [...signals], skipped: 0 };
   }
 }

--- a/packages/orchestrator/src/auto-signal-dedup.ts
+++ b/packages/orchestrator/src/auto-signal-dedup.ts
@@ -1,0 +1,74 @@
+/**
+ * auto-signal-dedup.ts — append-time dedup for once-per-task auto-signals.
+ *
+ * Audit 6eed37aa f9. Both pipeline emitters (emitCompletionSignals in
+ * completion-signals.ts and emitImplSignals in signal-helpers.ts) fire a fixed
+ * set of signals exactly once per task. A crash/retry between the signal append
+ * and `nativeTaskMap.delete(task_id)` (apps/cli/src/handlers/native-tasks.ts)
+ * re-runs the whole emission for the same task, double-counting it in scoring.
+ * The MCP record/bulk paths already dedup by findingId; these auto-emissions
+ * had no guard.
+ *
+ * This lives in its own module (not inside completion-signals.ts) so the
+ * helper depends ONLY on performance-reader's read helpers — keeping it out of
+ * the completion-signals ↔ dispatch-pipeline import cycle.
+ */
+import { join } from 'path';
+import { readJsonlWithRotated, parseJsonlLines } from './performance-reader';
+import type { PerformanceSignal } from './consensus-types';
+
+function tripleKey(agentId: string, taskId: string, signal: string): string {
+  return `${agentId} ${taskId} ${signal}`;
+}
+
+/**
+ * Drop any signal whose (agentId, taskId, signal) triple already exists on disk
+ * (or repeats within the incoming batch). Intentionally NOT pushed into
+ * WRITER_INTERNAL.appendSignals — consensus-type signals legitimately repeat
+ * per finding and are deduped elsewhere by findingId. Per-task emission
+ * frequency is low, so an O(file) read per emit is acceptable (no index built).
+ *
+ * Returns the signals that should actually be written, plus the skipped count.
+ * Fail-open: if the read throws, returns the input batch unchanged (better to
+ * risk a rare double-count than to silently drop a real signal).
+ */
+export function dedupeOncePerTaskSignals<T extends PerformanceSignal>(
+  projectRoot: string,
+  signals: readonly T[],
+): { kept: T[]; skipped: number } {
+  if (signals.length === 0) return { kept: [], skipped: 0 };
+  try {
+    const filePath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+    const raw = readJsonlWithRotated(filePath);
+    const existing = new Set<string>();
+    if (raw) {
+      const lines = raw.trim().split('\n').filter(Boolean);
+      const rows = parseJsonlLines<PerformanceSignal>(lines, filePath);
+      for (const r of rows) {
+        if (
+          r &&
+          typeof r.agentId === 'string' &&
+          typeof r.taskId === 'string' &&
+          typeof r.signal === 'string'
+        ) {
+          existing.add(tripleKey(r.agentId, r.taskId, r.signal));
+        }
+      }
+    }
+    const seenInBatch = new Set<string>();
+    const kept: T[] = [];
+    let skipped = 0;
+    for (const s of signals) {
+      const key = tripleKey(s.agentId, s.taskId, s.signal);
+      if (existing.has(key) || seenInBatch.has(key)) {
+        skipped++;
+        continue;
+      }
+      seenInBatch.add(key);
+      kept.push(s);
+    }
+    return { kept, skipped };
+  } catch {
+    return { kept: [...signals], skipped: 0 };
+  }
+}

--- a/packages/orchestrator/src/completion-signals.ts
+++ b/packages/orchestrator/src/completion-signals.ts
@@ -105,8 +105,6 @@ export function emitCompletionSignals(projectRoot: string, input: CompletionSign
         timestamp: now,
         source: 'auto',
       };
-      const writer = new PerformanceWriter(projectRoot);
-      writer[WRITER_INTERNAL].appendSignal(transportSignal, 'completion-signals-helper');
       // Still emit task_completed (duration telemetry is valid) but skip format_compliance
       // and finding_dropped_format — those metrics are meaningless for placeholder responses.
       const durationValue = elapsedMs !== null ? elapsedMs : 0;
@@ -122,7 +120,20 @@ export function emitCompletionSignals(projectRoot: string, input: CompletionSign
         metadata: metadataEntries,
         timestamp: now,
       };
-      writer[WRITER_INTERNAL].appendSignal(completedSignal, 'completion-signals-helper');
+      // Route through the same once-per-task dedup as the main path so a
+      // crash-retry cannot double-append transport_failure/task_completed
+      // (consensus f7d8b67a f13). transport_failure is consensus-type but
+      // never retracted and strictly once-per-task, so the dedup constraints
+      // documented in auto-signal-dedup.ts hold.
+      const placeholderBatch = [transportSignal, completedSignal];
+      const placeholderDedup = dedupeOncePerTaskSignals(projectRoot, placeholderBatch);
+      if (placeholderDedup.skipped > 0) {
+        process.stderr.write(`[gossipcat] skipped ${placeholderDedup.skipped} duplicate auto-signal(s) for task ${taskId}\n`);
+      }
+      if (placeholderDedup.kept.length > 0) {
+        const writer = new PerformanceWriter(projectRoot);
+        writer[WRITER_INTERNAL].appendSignals(placeholderDedup.kept, 'completion-signals-helper');
+      }
       return;
     }
 

--- a/packages/orchestrator/src/completion-signals.ts
+++ b/packages/orchestrator/src/completion-signals.ts
@@ -20,6 +20,7 @@ import { PerformanceWriter } from './performance-writer';
 import { WRITER_INTERNAL } from './_writer-internal';
 import { detectFormatCompliance } from './dispatch-pipeline';
 import { PROVIDER_PLACEHOLDER_RE } from './llm-client';
+import { dedupeOncePerTaskSignals } from './auto-signal-dedup';
 import type { ConsensusSignal, MetaSignal, PipelineSignal } from './consensus-types';
 
 export interface CompletionSignalInput {
@@ -210,8 +211,16 @@ export function emitCompletionSignals(projectRoot: string, input: CompletionSign
       } as PipelineSignal);
     }
 
+    // Append-time dedup (audit 6eed37aa f9): a crash/retry between this append
+    // and nativeTaskMap.delete(task_id) re-runs emission for the same task.
+    // Skip any (agentId, taskId, signal) triple already on disk.
+    const { kept, skipped } = dedupeOncePerTaskSignals(projectRoot, signals);
+    if (skipped > 0) {
+      process.stderr.write(`[gossipcat] skipped ${skipped} duplicate auto-signal(s) for task ${taskId}\n`);
+    }
+    if (kept.length === 0) return;
     const writer = new PerformanceWriter(projectRoot);
-    writer[WRITER_INTERNAL].appendSignals(signals, 'completion-signals-helper');
+    writer[WRITER_INTERNAL].appendSignals(kept, 'completion-signals-helper');
   } catch (err) {
     process.stderr.write(`[gossipcat] emitCompletionSignals failed: ${(err as Error).message}\n`);
   }

--- a/packages/orchestrator/src/signal-helpers.ts
+++ b/packages/orchestrator/src/signal-helpers.ts
@@ -21,6 +21,7 @@
 
 import { PerformanceWriter } from './performance-writer';
 import { WRITER_INTERNAL } from './_writer-internal';
+import { dedupeOncePerTaskSignals } from './auto-signal-dedup';
 import type { PerformanceSignal } from './consensus-types';
 
 // ── Helper 1: emitConsensusSignals ────────────────────────────────────────────
@@ -107,8 +108,18 @@ export function emitImplSignals(
         `[${[...new Set(signals.map(s => s.type))].join(', ')}]`
       );
     }
+    // Append-time dedup (audit 6eed37aa f9): impl_test_pass / impl_test_fail are
+    // emitted once per write-mode task. A crash/retry before nativeTaskMap.delete
+    // re-runs emission for the same task; skip any (agentId, taskId, signal)
+    // triple already on disk.
+    const { kept, skipped } = dedupeOncePerTaskSignals(projectRoot, signals);
+    if (skipped > 0) {
+      const taskId = signals[0]?.taskId ?? 'unknown';
+      process.stderr.write(`[gossipcat] skipped ${skipped} duplicate auto-signal(s) for task ${taskId}\n`);
+    }
+    if (kept.length === 0) return;
     const writer = new PerformanceWriter(projectRoot);
-    writer[WRITER_INTERNAL].appendSignals(signals, 'signal-helpers-impl');
+    writer[WRITER_INTERNAL].appendSignals(kept, 'signal-helpers-impl');
   } catch (err) {
     process.stderr.write(`[gossipcat] emitImplSignals failed: ${(err as Error).message}\n`);
   }

--- a/tests/orchestrator/auto-signal-dedup-and-scoped-retraction.test.ts
+++ b/tests/orchestrator/auto-signal-dedup-and-scoped-retraction.test.ts
@@ -26,6 +26,7 @@ import {
   emitConsensusSignals,
   PerformanceReader,
 } from '@gossip/orchestrator';
+import { __resetWarnRateLimiterForTests } from '../../packages/orchestrator/src/performance-reader';
 import type { ConsensusSignal } from '../../packages/orchestrator/src/consensus-types';
 
 const JSONL = '.gossip/agent-performance.jsonl';
@@ -42,11 +43,30 @@ function readRows(dir: string): any[] {
     .filter(r => r && typeof r.signal === 'string' && typeof r.agentId === 'string');
 }
 
+const tmpDirs: string[] = [];
+
 function makeTmpDir(label: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), `gossip-${label}-`));
   fs.mkdirSync(path.join(dir, '.gossip'), { recursive: true });
+  tmpDirs.push(dir);
   return dir;
 }
+
+beforeEach(() => {
+  // The dedup read path goes through parseJsonlLines, whose torn-line warn
+  // rate-limiter is module-level state — reset like the sibling suites do.
+  __resetWarnRateLimiterForTests();
+});
+
+afterAll(() => {
+  for (const dir of tmpDirs) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+});
 
 // ──────────────────────────────────────────────────────────────────────────
 // FIX A — scoped late-relay retraction (reader-side semantics, writer-side fix)
@@ -169,12 +189,15 @@ describe('FIX A — late-relay scoped retraction', () => {
     // task_timeout consensus signal: late-agent has no surviving consensus
     // scoring signal, so getScores yields no penalising timeout entry.
     const scores = reader.getScores();
+    // Unconditional (consensus f7d8b67a f15/f20 follow-up): an acc entry DOES
+    // exist for late-agent (execution disproved the round's "unreachable
+    // branch" claim — the impl task seeds an entry), so assert the retraction
+    // semantics directly: zero surviving consensus signals, and specifically
+    // no timeout-derived penalty rows.
     const late = scores.get('late-agent');
-    // Either no consensus signals survived (timeout retracted) or, if present,
-    // none is the retracted task_timeout.
-    if (late) {
-      expect(late.totalSignals ?? 0).toBe(0);
-    }
+    expect(late?.totalSignals ?? 0).toBe(0);
+    expect(late?.disagreements ?? 0).toBe(0);
+    expect(late?.hallucinations ?? 0).toBe(0);
   });
 });
 

--- a/tests/orchestrator/auto-signal-dedup-and-scoped-retraction.test.ts
+++ b/tests/orchestrator/auto-signal-dedup-and-scoped-retraction.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for audit 6eed37aa-dfba43ca f9 (append-time auto-signal dedup) plus the
+ * orchestrator-discovered late-relay self-voiding retraction bug.
+ *
+ * FIX A — late-relay scoped retraction:
+ *   apps/cli/src/handlers/native-tasks.ts emits a `signal_retracted` tombstone
+ *   when a late relay overwrites a timed_out result. Previously the tombstone
+ *   carried no `retractedSignal`, so the reader treated it as a WILDCARD and
+ *   voided every consensus signal for that agent+task — not just task_timeout.
+ *   The fix scopes the tombstone to `retractedSignal: 'task_timeout'`.
+ *
+ * FIX B — append-time dedup:
+ *   emitCompletionSignals (completion-signals.ts) and emitImplSignals
+ *   (signal-helpers.ts) re-run their full emission on a crash/retry between the
+ *   signal append and nativeTaskMap.delete(task_id), double-counting the same
+ *   task. dedupeOncePerTaskSignals (auto-signal-dedup.ts) skips any
+ *   (agentId, taskId, signal) triple already on disk.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  emitCompletionSignals,
+  emitImplSignals,
+  emitConsensusSignals,
+  PerformanceReader,
+} from '@gossip/orchestrator';
+import type { ConsensusSignal } from '../../packages/orchestrator/src/consensus-types';
+
+const JSONL = '.gossip/agent-performance.jsonl';
+
+function readRows(dir: string): any[] {
+  const p = path.join(dir, JSONL);
+  if (!fs.existsSync(p)) return [];
+  return fs
+    .readFileSync(p, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line))
+    // Drop round-counter bump meta-records — only signal rows matter here.
+    .filter(r => r && typeof r.signal === 'string' && typeof r.agentId === 'string');
+}
+
+function makeTmpDir(label: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `gossip-${label}-`));
+  fs.mkdirSync(path.join(dir, '.gossip'), { recursive: true });
+  return dir;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// FIX A — scoped late-relay retraction (reader-side semantics, writer-side fix)
+// ──────────────────────────────────────────────────────────────────────────
+describe('FIX A — late-relay scoped retraction', () => {
+  function makeConsensus(over: Partial<ConsensusSignal>): ConsensusSignal {
+    return {
+      type: 'consensus',
+      taskId: 'late-task',
+      signal: 'task_timeout',
+      agentId: 'late-agent',
+      timestamp: new Date().toISOString(),
+      evidence: '',
+      ...over,
+    } as ConsensusSignal;
+  }
+
+  it('scoped retraction voids ONLY task_timeout, leaving other consensus signals for the same agent+task intact', () => {
+    const reader = new PerformanceReader('');
+    // The late-relay flow: a timeout signal, then a SCOPED retraction, then the
+    // agent ALSO has a legitimate consensus signal under the same task id.
+    const signals: ConsensusSignal[] = [
+      makeConsensus({ signal: 'task_timeout', taskId: 'late-task' }),
+      makeConsensus({ signal: 'agreement', category: 'concurrency', taskId: 'late-task' }),
+      makeConsensus({
+        signal: 'signal_retracted',
+        taskId: 'late-task',
+        retractedSignal: 'task_timeout', // ← the fix
+      }),
+    ];
+    const scores = (reader as any).computeScores(signals);
+    const score = scores.get('late-agent');
+    expect(score).toBeDefined();
+    // task_timeout retracted → does not count. agreement survives → 1 scoring signal.
+    expect(score.totalSignals).toBe(1);
+    expect(score.agreements).toBe(1);
+  });
+
+  it('UNSCOPED (legacy) retraction still voids ALL consensus signals for that agent+task — back-compat preserved', () => {
+    const reader = new PerformanceReader('');
+    const signals: ConsensusSignal[] = [
+      makeConsensus({ signal: 'task_timeout', taskId: 'legacy-task' }),
+      makeConsensus({ signal: 'agreement', category: 'concurrency', taskId: 'legacy-task' }),
+      makeConsensus({
+        signal: 'signal_retracted',
+        taskId: 'legacy-task',
+        // no retractedSignal → wildcard, the historical behaviour
+      }),
+    ];
+    const scores = (reader as any).computeScores(signals);
+    const score = scores.get('late-agent');
+    // Wildcard voids both task_timeout AND agreement for this agent+task.
+    expect(score?.totalSignals ?? 0).toBe(0);
+  });
+
+  it('a different agent+task is unaffected by an unscoped retraction (no cross-task leakage)', () => {
+    const reader = new PerformanceReader('');
+    const signals: ConsensusSignal[] = [
+      makeConsensus({ signal: 'agreement', category: 'concurrency', taskId: 'other-task' }),
+      makeConsensus({ signal: 'signal_retracted', taskId: 'legacy-task' }), // wildcard, different task
+    ];
+    const scores = (reader as any).computeScores(signals);
+    const score = scores.get('late-agent');
+    // The retraction is keyed to legacy-task; other-task's agreement survives.
+    expect(score.totalSignals).toBe(1);
+    expect(score.agreements).toBe(1);
+  });
+
+  it('end-to-end on disk: task_timeout + scoped retraction + re-emitted impl_test_pass → timeout excluded, impl counted exactly once', () => {
+    const dir = makeTmpDir('fixA-e2e');
+    // Timeout fires (consensus).
+    emitConsensusSignals(dir, [{
+      type: 'consensus',
+      signal: 'task_timeout',
+      agentId: 'late-agent',
+      taskId: 'late-task',
+      evidence: 'timed out',
+      timestamp: new Date().toISOString(),
+    }]);
+    // Late relay arrives → scoped retraction of task_timeout.
+    emitConsensusSignals(dir, [{
+      type: 'consensus',
+      signal: 'signal_retracted',
+      agentId: 'late-agent',
+      taskId: 'late-task',
+      retractedSignal: 'task_timeout',
+      evidence: 'late relay',
+      timestamp: new Date().toISOString(),
+    }]);
+    // Re-emitted auto-signals (FIRST emission for these triples → not deduped).
+    emitImplSignals(dir, [{
+      type: 'impl',
+      signal: 'impl_test_pass',
+      agentId: 'late-agent',
+      taskId: 'late-task',
+      source: 'auto',
+      timestamp: new Date().toISOString(),
+    }]);
+    emitCompletionSignals(dir, {
+      agentId: 'late-agent',
+      taskId: 'late-task',
+      result: '<agent_finding type="finding" severity="low">ok</agent_finding>',
+      elapsedMs: 1000,
+    });
+
+    const rows = readRows(dir);
+    // The on-disk timeout row + the impl_test_pass row both physically exist...
+    expect(rows.some(r => r.signal === 'task_timeout')).toBe(true);
+    expect(rows.filter(r => r.signal === 'impl_test_pass')).toHaveLength(1);
+    expect(rows.filter(r => r.signal === 'task_completed')).toHaveLength(1);
+
+    // ...but the reader excludes the retracted timeout and counts the impl pass.
+    // getImplScore reflects exactly one pass and zero fails (passRate === 1).
+    const reader = new PerformanceReader(dir);
+    const impl = reader.getImplScore('late-agent');
+    expect(impl).not.toBeNull();
+    expect(impl!.passRate).toBe(1);
+
+    // And the scoring path (computeScores via getScores) excludes the retracted
+    // task_timeout consensus signal: late-agent has no surviving consensus
+    // scoring signal, so getScores yields no penalising timeout entry.
+    const scores = reader.getScores();
+    const late = scores.get('late-agent');
+    // Either no consensus signals survived (timeout retracted) or, if present,
+    // none is the retracted task_timeout.
+    if (late) {
+      expect(late.totalSignals ?? 0).toBe(0);
+    }
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// FIX B — append-time dedup for once-per-task auto-signals
+// ──────────────────────────────────────────────────────────────────────────
+describe('FIX B — emitCompletionSignals append-time dedup', () => {
+  it('calling emitCompletionSignals twice for the same task appends only one set', () => {
+    const dir = makeTmpDir('fixB-completion');
+    const input = {
+      agentId: 'agent-b',
+      taskId: 'task-dup',
+      result: 'plain result with no findings',
+      elapsedMs: 2000,
+    };
+    emitCompletionSignals(dir, input);
+    const firstCount = readRows(dir).length;
+    expect(firstCount).toBeGreaterThan(0);
+
+    // Second call — the crash/retry scenario. Should be fully deduped.
+    emitCompletionSignals(dir, input);
+    const secondRows = readRows(dir);
+
+    expect(secondRows.filter(r => r.signal === 'task_completed')).toHaveLength(1);
+    expect(secondRows.filter(r => r.signal === 'format_compliance')).toHaveLength(1);
+    // No new signal rows after the second call.
+    expect(secondRows.length).toBe(firstCount);
+  });
+
+  it('a distinct task is NOT blocked by another task\'s prior emission', () => {
+    const dir = makeTmpDir('fixB-distinct');
+    emitCompletionSignals(dir, { agentId: 'agent-b', taskId: 'task-1', result: 'x', elapsedMs: 1 });
+    emitCompletionSignals(dir, { agentId: 'agent-b', taskId: 'task-2', result: 'x', elapsedMs: 1 });
+    const rows = readRows(dir);
+    expect(rows.filter(r => r.signal === 'task_completed' && r.taskId === 'task-1')).toHaveLength(1);
+    expect(rows.filter(r => r.signal === 'task_completed' && r.taskId === 'task-2')).toHaveLength(1);
+  });
+});
+
+describe('FIX B — emitImplSignals append-time dedup', () => {
+  it('calling emitImplSignals twice for the same task appends only one impl signal', () => {
+    const dir = makeTmpDir('fixB-impl');
+    const sig = {
+      type: 'impl' as const,
+      signal: 'impl_test_pass' as const,
+      agentId: 'agent-b',
+      taskId: 'impl-dup',
+      source: 'auto' as const,
+      timestamp: new Date().toISOString(),
+    };
+    emitImplSignals(dir, [sig]);
+    emitImplSignals(dir, [{ ...sig, timestamp: new Date(Date.now() + 5).toISOString() }]);
+
+    const rows = readRows(dir);
+    expect(rows.filter(r => r.signal === 'impl_test_pass')).toHaveLength(1);
+  });
+
+  it('impl_test_fail for the same task+agent is a distinct triple and is NOT deduped against impl_test_pass', () => {
+    const dir = makeTmpDir('fixB-impl-distinct-signal');
+    emitImplSignals(dir, [{
+      type: 'impl', signal: 'impl_test_pass', agentId: 'agent-b', taskId: 'impl-x',
+      source: 'auto', timestamp: new Date().toISOString(),
+    }]);
+    emitImplSignals(dir, [{
+      type: 'impl', signal: 'impl_test_fail', agentId: 'agent-b', taskId: 'impl-x',
+      source: 'auto', timestamp: new Date().toISOString(),
+    }]);
+    const rows = readRows(dir);
+    expect(rows.filter(r => r.signal === 'impl_test_pass')).toHaveLength(1);
+    expect(rows.filter(r => r.signal === 'impl_test_fail')).toHaveLength(1);
+  });
+
+  it('collapses a self-duplicated batch (same triple twice in one call) to a single write', () => {
+    const dir = makeTmpDir('fixB-impl-batch');
+    const sig = {
+      type: 'impl' as const,
+      signal: 'impl_test_pass' as const,
+      agentId: 'agent-b',
+      taskId: 'impl-batch',
+      source: 'auto' as const,
+      timestamp: new Date().toISOString(),
+    };
+    emitImplSignals(dir, [sig, { ...sig }]);
+    const rows = readRows(dir);
+    expect(rows.filter(r => r.signal === 'impl_test_pass')).toHaveLength(1);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// FIX A × FIX B interaction — dedup must NOT block the late-relay re-emission
+// ──────────────────────────────────────────────────────────────────────────
+describe('FIX A × FIX B — dedup does not block late-relay re-emission', () => {
+  it('after a prior task_timeout + scoped retraction, the re-emitted impl/completion signals are FIRST emissions and land', () => {
+    const dir = makeTmpDir('fixAB-interaction');
+    // Timeout path emits ONLY task_timeout (no impl/completion signals).
+    emitConsensusSignals(dir, [{
+      type: 'consensus',
+      signal: 'task_timeout',
+      agentId: 'late-agent',
+      taskId: 'late-task',
+      evidence: 'timed out',
+      timestamp: new Date().toISOString(),
+    }]);
+    emitConsensusSignals(dir, [{
+      type: 'consensus',
+      signal: 'signal_retracted',
+      agentId: 'late-agent',
+      taskId: 'late-task',
+      retractedSignal: 'task_timeout',
+      evidence: 'late relay',
+      timestamp: new Date().toISOString(),
+    }]);
+
+    // The late relay now emits the once-per-task auto-signals for the FIRST time
+    // for these (agentId, taskId, signal) triples — dedup must let them through.
+    emitImplSignals(dir, [{
+      type: 'impl', signal: 'impl_test_pass', agentId: 'late-agent', taskId: 'late-task',
+      source: 'auto', timestamp: new Date().toISOString(),
+    }]);
+    emitCompletionSignals(dir, {
+      agentId: 'late-agent', taskId: 'late-task', result: 'done', elapsedMs: 1500,
+    });
+
+    const rows = readRows(dir);
+    expect(rows.filter(r => r.signal === 'impl_test_pass')).toHaveLength(1);
+    expect(rows.filter(r => r.signal === 'task_completed')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes audit finding `6eed37aa-dfba43ca:f9` (auto-signal append-time dedup) plus an orchestrator-discovered scoring bug found while scoping it.

## Fix A — late-relay self-voiding retraction
The late-relay-wins path emitted `signal_retracted` without `retractedSignal`; the reader treats that as a wildcard (`agent:task:*`) in an order-unaware filter, so the round's own retraction voided every consensus signal for that agent+task. Now scoped to `retractedSignal: 'task_timeout'` (the #557 scoped-tombstone support this inline site never adopted). The fixup also renames the native timeout watcher's emission from categoryless `disagreement` to `task_timeout` (implementing the routing its own comment tracked as 'PR 5'), so the scoped tombstone covers both timeout rows.

## Fix B — once-per-task auto-signal dedup
New `packages/orchestrator/src/auto-signal-dedup.ts` — `dedupeOncePerTaskSignals` drops `(agentId, taskId, signal)` triples already on disk (or repeated in-batch), fail-open with a stderr line. Wired into `emitCompletionSignals` (including the provider-placeholder branch) and `emitImplSignals` only — consensus signals keep findingId-based dedup elsewhere; key constraints documented in the module header.

## Review
Full pre-merge consensus `f7d8b67a-7e1745d4` (fable-reviewer, sonnet-reviewer, deepseek-challenger; 2 rounds): 8 confirmed / 4 disputed-refuted / 8 unique; 20 signals + 1 corrective retraction recorded. Cross-review refuted deepseek's CRITICAL TOCTOU claim (path is fully synchronous; cited concurrent caller pair serves disjoint task populations), a self-refuted HIGH, a wrong test count, and a wrong rotated-data premise. One reviewer claim was itself falsified by execution during fixups (the 'vacuous assertion' was reachable — an acc entry exists) and the signal record was corrected via scoped retraction.

consensus-id: f7d8b67a-7e1745d4

Verification: 277 tests green across signal/reader/writer/completion suites incl. 10 new; full `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)