### PR TITLE
fix(consensus): populate findingId on report newFindings entries

### DIFF
--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -205,7 +205,7 @@ export interface ConsensusReport {
   unverified: ConsensusReportFinding[];
   unique: ConsensusReportFinding[];
   insights: ConsensusReportFinding[];
-  newFindings: Array<{ agentId: string; finding: string; evidence: string; confidence: number }>;
+  newFindings: Array<{ agentId: string; finding: string; evidence: string; confidence: number; findingId?: string }>;
   crossReviewAssignments?: Record<string, string[]>;
   crossReviewCoverage?: Array<{ findingId: string; assigned: number; targetK: number }>;
   /**

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -1298,6 +1298,7 @@ Return only valid JSON.${skillsBlock}`;
           finding: sanitize(entry.finding),
           evidence: sanitize(entry.evidence),
           confidence: entry.confidence,
+          findingId: newFindingId,
           parentFindingId: entry.parentFindingId,
           severity: entry.severity,
         });
@@ -2612,7 +2613,7 @@ Return only valid JSON.${skillsBlock}`;
     // This is the same pattern as the utility-task block in gossip_relay — surface the
     // requirement at the moment the orchestrator has the data needed to act on it,
     // not buried in bootstrap rules that decay as the conversation grows.
-    // newFindings are excluded — ConsensusNewFinding has no stable id (not in findingMap)
+    // newFindings are excluded from actionable — they use their own findingId and are not in findingMap
     const actionable = [
       ...confirmed.map(f => ({ kind: 'confirmed' as const, f })),
       ...disputed.map(f => ({ kind: 'disputed' as const, f })),

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -44,6 +44,12 @@ export interface ConsensusNewFinding {
   finding: string;
   evidence: string;
   confidence: number;
+  /**
+   * Stable ID for this new finding in the format `<consensusId>:new:<agentId>:<counter>`.
+   * Always set on newly synthesized reports. Optional for back-compat with reports
+   * persisted before this field was introduced.
+   */
+  findingId?: string;
   /** Peer finding this extends, e.g. "gemini-reviewer:f1". Set only on chained extensions. */
   parentFindingId?: string;
   /** The extension's own severity — may differ from (escalate) the parent's. */

--- a/tests/orchestrator/consensus-engine.test.ts
+++ b/tests/orchestrator/consensus-engine.test.ts
@@ -506,6 +506,57 @@ Summary: 1 agree, 1 disagree.`;
         expect(newSignal!.agentId).toBe('agent-2');
       });
 
+      it('report newFindings entry findingId matches the new_finding signal findingId', async () => {
+        // The report entry and the signal must share the same findingId so the
+        // orchestrator can link report.newFindings[i] back to the emitted signal.
+        const crossReview: CrossReviewEntry[] = [
+          {
+            action: 'new',
+            agentId: 'agent-2',
+            peerAgentId: '',
+            finding: 'Brand new security finding',
+            evidence: 'Found at auth.ts:42',
+            confidence: 4,
+          },
+        ];
+        const report = await engine.synthesize(results, crossReview);
+        expect(report.newFindings).toHaveLength(1);
+        const newSignal = report.signals.find(s => s.signal === 'new_finding');
+        expect(newSignal).toBeDefined();
+        // Both must carry an identical findingId
+        expect(report.newFindings[0].findingId).toBeDefined();
+        expect(report.newFindings[0].findingId).toBe(newSignal!.findingId);
+        // Must follow the canonical `<consensusId>:new:<agentId>:<counter>` form.
+        // synthesize() is called without a consensusId here, so the defensive
+        // fallback generates a UUID-prefixed form; just verify the structural shape.
+        expect(report.newFindings[0].findingId).toMatch(/^[^:]+:new:agent-2:\d+$/);
+      });
+
+      it('report newFindings entry findingId equals pre-rewritten id supplied by agent', async () => {
+        // When the relay handler has already canonicalized the findingId
+        // (entry.findingId is present), synthesize MUST use that exact id on
+        // both the signal AND the report entry — no re-generation.
+        const rewritten = 'deadbeef-1234abcd:new:agent-2:7';
+        const crossReview: CrossReviewEntry[] = [
+          {
+            action: 'new',
+            agentId: 'agent-2',
+            peerAgentId: '',
+            findingId: rewritten,
+            finding: 'NEW with pre-rewritten id',
+            evidence: 'rewritten by relay handler',
+            confidence: 4,
+          },
+        ];
+        const report = await engine.synthesize(results, crossReview);
+        expect(report.newFindings).toHaveLength(1);
+        const newSignal = report.signals.find(s => s.signal === 'new_finding');
+        expect(newSignal).toBeDefined();
+        // Both report entry and signal must use the pre-rewritten id unchanged.
+        expect(report.newFindings[0].findingId).toBe(rewritten);
+        expect(newSignal!.findingId).toBe(rewritten);
+      });
+
       it('populates authorDiagnostics when agent output contains entity-encoded tags', async () => {
         // agent-html is emitting `&lt;agent_finding&gt;` instead of `<agent_finding>`.
         // parseAgentFindingsStrict produces 0 findings (tags invisible), but the

--- a/tests/orchestrator/verified-finding-chaining.test.ts
+++ b/tests/orchestrator/verified-finding-chaining.test.ts
@@ -68,6 +68,31 @@ describe('synthesize — NEW entry verification + field carry', () => {
     expect(report.newFindings[0].severity).toBe('critical');
   });
 
+  it('carries findingId onto the newFindings entry and matching signal', async () => {
+    const eng = new ConsensusEngine({
+      llm: { generate: jest.fn() } as any,
+      registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: id, skills: [] }),
+
+      round: testRound(),
+    } as any);
+    const results = [makeTask('a', 'x'), makeTask('b', 'y')];
+    const prewrittenId = 'cid12345-67890abc:new:b:1';
+    const entries = [{
+      action: 'new' as const, agentId: 'b', peerAgentId: '',
+      findingId: prewrittenId, finding: 'auth bypass at routes.ts:88',
+      evidence: 'routes.ts:88 lacks guard', confidence: 4,
+      parentFindingId: 'a:f1', severity: 'critical' as const,
+    }];
+    const report = await (eng as any).synthesize(results, entries, 'cid12345-67890abc');
+    expect(report.newFindings).toHaveLength(1);
+    // findingId must be set on the report entry
+    expect(report.newFindings[0].findingId).toBe(prewrittenId);
+    // Signal must use the same id so orchestrator can link report entry → signal
+    const newSignal = report.signals.find((s: any) => s.signal === 'new_finding');
+    expect(newSignal).toBeDefined();
+    expect(newSignal.findingId).toBe(prewrittenId);
+  });
+
   it('drops a NEW entry whose citation is fabricated', async () => {
     const eng = new ConsensusEngine({
       llm: { generate: jest.fn() } as any,


### PR DESCRIPTION
## Summary
- `ConsensusNewFinding` gains an optional `findingId` carrying the same canonical `<consensusId>:new:<agentId>:<counter>` id as the entry's `new_finding` signal, closing the report→signal linkage gap at the data layer (`packages/orchestrator/src/consensus-types.ts`, `consensus-engine.ts:1301`)
- Dashboard type mirror updated (`packages/dashboard-v2/src/lib/types.ts:208`); stale comment at `consensus-engine.ts:2616` corrected
- 3 new tests: report/signal findingId parity, pre-rewritten id pass-through, chained-entry carry (85+11 green, typecheck clean)

## Pre-merge consensus (3 agents: sonnet-reviewer, fable-reviewer, deepseek-challenger)
13 confirmed / 3 disputed (all resolved, 1 hallucination penalized) / 0 blocking. Counter-contiguity invariant, report/signal parity, and mutation safety all adversarially verified.

consensus-id: 720ea647-5e374952

## Follow-ups surfaced by review (not in this PR)
- `api-finding.ts:108` + `finding-resolver.ts:845` still match on `f.id` — newFindings detail lookups 404 (MEDIUM, f13)
- `collect.ts:790` missing `action === 'new'` exemption (GH #131 recurrence, pre-existing, f14)
- Pass `consensusId` through at `consensus-engine.ts:3035` (latent drift, f15)
- Print findingId in formatReport NEW lines / include in actionable (f16)
- Dashboard full-shape type mirror (f8/f12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)