### PR TITLE
fix(skills): develop prompt uses newest findings + frontmatter-first instruction

### DIFF
--- a/packages/orchestrator/src/skill-engine.ts
+++ b/packages/orchestrator/src/skill-engine.ts
@@ -505,7 +505,7 @@ ${projectContext || 'No project context available.'}
 </project_context>
 
 <findings_in_category>
-${findings.length > 0 ? findings.slice(0, 20).map(f => `- [${f.agentId}] ${f.evidence}`).join('\n') : 'No findings yet in this category.'}
+${findings.length > 0 ? findings.slice(-20).reverse().map(f => `- [${f.agentId}] ${f.evidence}`).join('\n') : 'No findings yet in this category.'}
 </findings_in_category>
 
 <agent_performance>
@@ -525,6 +525,7 @@ Output a skill markdown file with this exact structure:
 7. ## Quality Gate — pre-report checklist with checkboxes
 
 Requirements:
+- CRITICAL: Your ENTIRE response must be the skill markdown file itself. The FIRST line of output must be \`---\` (the opening of the YAML frontmatter). No preamble, no explanation, no code fences.
 - Write with authority — MUST, NEVER, NO EXCEPTIONS
 - Keep under 150 lines
 - CRITICAL: Tailor ALL content to the project's actual tech stack (see <tech_stack>). Only include checks relevant to technologies the project uses. If the project has no SQL database, do NOT mention SQL injection. If no HTML rendering, do NOT mention XSS. Generic security checklists waste agent prompt tokens.

--- a/tests/orchestrator/skill-engine.test.ts
+++ b/tests/orchestrator/skill-engine.test.ts
@@ -309,4 +309,51 @@ migration_count: 1
     const tmpArtifacts = entries.filter(name => name.includes('.tmp.'));
     expect(tmpArtifacts).toEqual([]);
   });
+
+  // ─── prompt freshness + output-discipline (FIX 1 / FIX 2) ────────────────
+
+  test('embeds the NEWEST 20 category findings, not the oldest', async () => {
+    // Isolated dir so the >20 findings don't pollute the shared testDir.
+    const freshDir = join(tmpdir(), 'gossip-skillfresh-' + Date.now());
+    mkdirSync(join(freshDir, '.gossip'), { recursive: true });
+    // 25 category_confirmed findings in append (chronological) order: f0 oldest,
+    // f24 newest. The slice(-20) must keep f5..f24 and drop f0..f4.
+    // Zero-padded + delimited evidence so `finding-02` is not a substring of
+    // `finding-20`; required for the exclusion assertions below.
+    const tag = (i: number) => `<finding-${String(i).padStart(2, '0')}>`;
+    const signals: object[] = [];
+    for (let i = 0; i < 25; i++) {
+      signals.push({
+        type: 'consensus', signal: 'category_confirmed', agentId: 'agent-fresh',
+        category: 'concurrency', evidence: tag(i),
+        taskId: `t${i}`, timestamp: '2026-01-01T00:00:00Z',
+      });
+    }
+    writeSignals(freshDir, signals);
+    writeFileSync(join(freshDir, '.gossip', 'bootstrap.md'), '# Fresh Project\n');
+
+    const gen = new SkillEngine(mockLLM(VALID_SKILL), new PerformanceReader(freshDir), freshDir);
+    try {
+      const { user } = await gen.buildPrompt('agent-fresh', 'concurrency');
+      // Oldest five must be excluded.
+      for (let i = 0; i < 5; i++) {
+        expect(user).not.toContain(tag(i));
+      }
+      // Newest twenty must be present.
+      for (let i = 5; i < 25; i++) {
+        expect(user).toContain(tag(i));
+      }
+      // Newest-first ordering: f24 appears before f23.
+      expect(user.indexOf(tag(24))).toBeLessThan(user.indexOf(tag(23)));
+    } finally {
+      rmSync(freshDir, { recursive: true, force: true });
+    }
+  });
+
+  test('user prompt instructs the first line of output must be ---', async () => {
+    const gen = new SkillEngine(mockLLM(VALID_SKILL), new PerformanceReader(testDir), testDir);
+    const { user } = await gen.buildPrompt('agent-a', 'injection_vectors');
+    expect(user).toContain('The FIRST line of output must be `---`');
+    expect(user).toContain('No preamble, no explanation, no code fences.');
+  });
 });


### PR DESCRIPTION
## Summary
- `buildPrompt` now embeds the most recent 20 category findings, newest first (`findings.slice(-20).reverse()` at `packages/orchestrator/src/skill-engine.ts:508`) instead of the oldest 20 — skill development draws on fresh failure patterns
- New CRITICAL first-bullet output instruction: response must begin with the `---` frontmatter line, no preamble/fences — closes the preamble-induced `validateSkillContent` hard-throw (`skill-engine.ts:634`)
- 2 new tests (newest-20 selection + ordering with 25 seeded findings; instruction presence). 13/13 green, orchestrator typecheck clean

## Pre-merge consensus (3 agents: sonnet-reviewer, fable-reviewer, deepseek-challenger)
Branch verified clean by all three reviewers — slice copy semantics proven mutation-safe, ordering verified against `readJsonlWithRotated` chronology, instruction confirmed complementary (not conflicting) with `saveFromRaw` fence-stripping.

consensus-id: 720ea647-5e374952

## Follow-up (non-blocking)
- Add a <20-findings ordering test (sonnet-reviewer f11)
- Optional belt-and-suspenders: strip leading conversational line before the `---` check in `saveFromRaw`

🤖 Generated with [Claude Code](https://claude.com/claude-code)