### PR TITLE
fix(consensus): findingId v2 follow-ups — lookups, NEW exemption, consensusId pass-through

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -787,7 +787,19 @@ export async function handleCollect(
           turn++;
         }
         const parsed = engine.parseCrossReviewResponse(p.agentId, response.text, 50);
-        const filtered = parsed.filter((e: any) => e.peerAgentId !== p.agentId && validPeerIds.has(e.peerAgentId));
+        // NEW findings have no peer — skip self-review/peer-validity check for them
+        // (GH #131 parity: relay-cross-review.ts:229 and consensus-engine.ts:919 both exempt NEW).
+        const filtered = parsed.filter((e: any) => e.action === 'new' || (e.peerAgentId !== p.agentId && validPeerIds.has(e.peerAgentId)));
+        // Rewrite NEW findingIds to the consensus-wide form `<consensusId>:new:<agentId>:<counter>`
+        // and clear peerAgentId residue — mirrors relay-cross-review.ts:238-249 so both
+        // collect-driven and relay-driven paths produce consistent NEW entries before synthesize.
+        let newCounter = 0;
+        for (const e of filtered) {
+          if (e.action === 'new') {
+            e.findingId = `${consensusId}:new:${p.agentId}:${++newCounter}`;
+            e.peerAgentId = '';
+          }
+        }
         if (filtered.length === 0) {
           process.stderr.write(`[consensus] ${p.agentId} cross-review produced 0 entries (attempt ${attempt + 1}${capHit ? ', cap-hit recovery path' : ''})\n`);
           relayCrossReviewSkipped.push({

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -205,7 +205,7 @@ export interface ConsensusReport {
   unverified: ConsensusReportFinding[];
   unique: ConsensusReportFinding[];
   insights: ConsensusReportFinding[];
-  newFindings: Array<{ agentId: string; finding: string; evidence: string; confidence: number; findingId?: string }>;
+  newFindings: Array<{ agentId: string; finding: string; evidence: string; confidence: number; findingId?: string; parentFindingId?: string; severity?: 'critical' | 'high' | 'medium' | 'low' }>;
   crossReviewAssignments?: Record<string, string[]>;
   crossReviewCoverage?: Array<{ findingId: string; assigned: number; targetK: number }>;
   /**

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -2591,7 +2591,8 @@ Return only valid JSON.${skillsBlock}`;
         const chainSuffix = f.parentFindingId
           ? ` _(↳ extends ${f.parentFindingId}${f.severity ? `, severity ${f.severity}` : ''})_`
           : '';
-        lines.push(`  ★ [${preset}] "${f.finding}"${chainSuffix}`);
+        const findingIdSuffix = f.findingId ? ` [${f.findingId}]` : '';
+        lines.push(`  ★ [${preset}] "${f.finding}"${chainSuffix}${findingIdSuffix}`);
       }
       lines.push('');
     }
@@ -3032,7 +3033,7 @@ Return only valid JSON.${skillsBlock}`;
     consensusId: string,
     relayCrossReviewSkipped?: Array<{ agentId: string; reason: string }>,
   ): Promise<ConsensusReport> {
-    const report = await this.synthesize(results, crossReviewEntries);
+    const report = await this.synthesize(results, crossReviewEntries, consensusId);
 
     // Capture the auto-generated (internal) consensusId BEFORE overwriting it,
     // so we can also rewrite the formatted summary text. The summary was built

--- a/packages/orchestrator/src/finding-resolver.ts
+++ b/packages/orchestrator/src/finding-resolver.ts
@@ -842,7 +842,7 @@ function findFindingInReport(report: any, taskId: string, findingProse: unknown)
     const arr = report[bucket];
     if (!Array.isArray(arr)) continue;
     for (const f of arr) {
-      if (f && typeof f.id === 'string' && f.id === taskId) return f;
+      if (f && ((typeof f.id === 'string' && f.id === taskId) || (typeof f.findingId === 'string' && f.findingId === taskId))) return f;
     }
   }
   // Pass 2 — fall back to exact prose match (rare but defensive)

--- a/packages/relay/src/dashboard/api-finding.ts
+++ b/packages/relay/src/dashboard/api-finding.ts
@@ -105,7 +105,7 @@ export async function findingHandler(
   let found: any = null;
   let tag: FindingDetail['finding']['tag'] = 'unverified';
   for (const [bucket, tagName] of buckets) {
-    const hit = (report[bucket] || []).find((f: any) => f.id === findingId);
+    const hit = (report[bucket] || []).find((f: any) => f.id === findingId || f.findingId === findingId);
     if (hit) { found = hit; tag = tagName; break; }
   }
   if (!found) throw new Error(`finding ${findingId} not found in ${consensusId}`);

--- a/tests/orchestrator/consensus-engine.test.ts
+++ b/tests/orchestrator/consensus-engine.test.ts
@@ -1480,4 +1480,44 @@ describe('synthesizeWithCrossReview()', () => {
     // 2 agents × 3 findings each = 6 total, minus any semantic dedup.
     expect(total).toBeGreaterThanOrEqual(3);
   });
+
+  it('NEW finding IDs carry the external consensusId directly — no post-hoc rewrite needed', async () => {
+    // FIX 3 regression: synthesizeWithCrossReview called synthesize() without
+    // forwarding consensusId. synthesize() then generated an internal id and
+    // used it for newFindings[].findingId and new_finding signals. The post-hoc
+    // rewrite at :3053-3059 only touched confirmed/disputed/unverified/unique/insights
+    // (not newFindings), so NEW entries kept the wrong internal id.
+    //
+    // Fix: pass consensusId to synthesize(). This test asserts that newFindings
+    // entries already carry the external id WITHOUT needing the post-hoc rewrite.
+    const engine = new ConsensusEngine(baseConfig);
+    const results: TaskEntry[] = [
+      createTaskEntry('agent-a', 'completed', '## Consensus Summary\n<agent_finding type="finding" severity="high">Race condition in db.ts:10</agent_finding>'),
+      createTaskEntry('agent-b', 'completed', '## Consensus Summary\n<agent_finding type="finding" severity="medium">Null deref in router.ts:5</agent_finding>'),
+    ];
+    const externalConsensusId = 'fix3test-newids01';
+    // Provide a NEW cross-review entry (pre-canonicalized as the collect path now does).
+    const crossReviewEntries: CrossReviewEntry[] = [
+      {
+        action: 'new',
+        agentId: 'agent-a',
+        peerAgentId: '',
+        findingId: `${externalConsensusId}:new:agent-a:1`,
+        finding: 'A new issue discovered during cross-review',
+        evidence: 'Spotted at foo.ts:42',
+        confidence: 4,
+      },
+    ];
+
+    const report = await engine.synthesizeWithCrossReview(results, crossReviewEntries, externalConsensusId);
+
+    expect(report.newFindings).toHaveLength(1);
+    // findingId must carry the external consensusId from the start — not an internal id.
+    expect(report.newFindings[0].findingId).toBe(`${externalConsensusId}:new:agent-a:1`);
+    // The new_finding signal must also carry the external consensusId.
+    const newSignal = report.signals.find(s => s.signal === 'new_finding');
+    expect(newSignal).toBeDefined();
+    expect(newSignal!.consensusId).toBe(externalConsensusId);
+    expect(newSignal!.findingId).toBe(`${externalConsensusId}:new:agent-a:1`);
+  });
 });

--- a/tests/orchestrator/skill-engine.test.ts
+++ b/tests/orchestrator/skill-engine.test.ts
@@ -350,6 +350,38 @@ migration_count: 1
     }
   });
 
+  test('small list (<20 findings) — all present, newest first', async () => {
+    // Mirrors the >20 test above but with only 3 findings to verify the slice(-20)
+    // path doesn't corrupt ordering when the list fits entirely within the window.
+    const freshDir = join(tmpdir(), 'gossip-skillfresh-small-' + Date.now());
+    mkdirSync(join(freshDir, '.gossip'), { recursive: true });
+    const tag = (i: number) => `<finding-${String(i).padStart(2, '0')}>`;
+    const signals: object[] = [];
+    for (let i = 0; i < 3; i++) {
+      signals.push({
+        type: 'consensus', signal: 'category_confirmed', agentId: 'agent-small',
+        category: 'concurrency', evidence: tag(i),
+        taskId: `t${i}`, timestamp: '2026-01-01T00:00:00Z',
+      });
+    }
+    writeSignals(freshDir, signals);
+    writeFileSync(join(freshDir, '.gossip', 'bootstrap.md'), '# Small Project\n');
+
+    const gen = new SkillEngine(mockLLM(VALID_SKILL), new PerformanceReader(freshDir), freshDir);
+    try {
+      const { user } = await gen.buildPrompt('agent-small', 'concurrency');
+      // All 3 findings must be present (no truncation for small lists).
+      for (let i = 0; i < 3; i++) {
+        expect(user).toContain(tag(i));
+      }
+      // Newest-first ordering: f2 appears before f1, f1 before f0.
+      expect(user.indexOf(tag(2))).toBeLessThan(user.indexOf(tag(1)));
+      expect(user.indexOf(tag(1))).toBeLessThan(user.indexOf(tag(0)));
+    } finally {
+      rmSync(freshDir, { recursive: true, force: true });
+    }
+  });
+
   test('user prompt instructs the first line of output must be ---', async () => {
     const gen = new SkillEngine(mockLLM(VALID_SKILL), new PerformanceReader(testDir), testDir);
     const { user } = await gen.buildPrompt('agent-a', 'injection_vectors');

--- a/tests/relay/api-finding.test.ts
+++ b/tests/relay/api-finding.test.ts
@@ -108,4 +108,31 @@ describe('findingHandler', () => {
     const res = await findingHandler(root, 'c1-c2', 'c1-c2:f1');
     expect(res.citations).toHaveLength(0);
   });
+
+  it('finds a newFindings entry by findingId (not id field)', async () => {
+    // ConsensusNewFinding carries `findingId`, not `id`. The bucket search must
+    // also check f.findingId so newFindings entries are resolvable via the API.
+    const root = mkdtempSync(join(tmpdir(), 'gossip-test-finding-new-'));
+    mkdirSync(join(root, '.gossip', 'consensus-reports'), { recursive: true });
+    const findingId = 'abc-new:new:agent-a:1';
+
+    writeFileSync(join(root, '.gossip', 'consensus-reports', 'abc-new.json'), JSON.stringify({
+      id: 'abc-new',
+      timestamp: '2026-06-13T10:00:00Z',
+      confirmed: [], disputed: [], unverified: [], unique: [], insights: [],
+      newFindings: [{
+        agentId: 'agent-a',
+        finding: 'A new issue surfaced during cross-review',
+        evidence: 'Found at foo.ts:10',
+        confidence: 4,
+        findingId,
+      }],
+    }));
+
+    writeFileSync(join(root, '.gossip', 'agent-performance.jsonl'), '');
+
+    const res = await findingHandler(root, 'abc-new', findingId);
+    expect(res.finding.tag).toBe('newFinding');
+    expect(res.finding.finding).toContain('A new issue');
+  });
 });


### PR DESCRIPTION
## Summary
Six verified follow-ups from the PR #566/#567 review (consensus 720ea647-5e374952):
- `api-finding.ts:108` + `finding-resolver.ts:845` match newFindings by `findingId` (f13)
- `collect.ts` relay cross-review filter exempts `action === 'new'` (GH #131 parity) and canonicalizes NEW findingIds like `relay-cross-review.ts` (f14)
- `synthesizeWithCrossReview` forwards external `consensusId` into `synthesize` (f15)
- `formatReport` prints `[findingId]` on NEW lines (f16)
- dashboard `newFindings` type fully mirrors `ConsensusNewFinding` (f8/f12)
- small-list (<20) freshness ordering test (f11)

168 tests green across 5 suites; both package typechecks clean.

## Pre-merge consensus (sonnet-reviewer, fable-reviewer, deepseek-challenger)
consensus-id: 79af065f-a8da414e

No blocking defects. The risky interplay was adversarially verified: the post-hoc id-rewrite in `synthesizeWithCrossReview` degrades to a confirmed no-op with the consensusId pass-through (rewrite runs only on the 5 ConsensusFinding buckets — `newFindings` is excluded), the collect.ts NEW counter is closure-scoped per relay agent, and all three NEW-exemption sites are semantically identical. deepseek's HIGH "rewrite destroys NEW findingIds" claim was falsified by direct read (newFindings not in the `allFindings` spread) and recorded as hallucination_caught.

## Non-blocking follow-ups surfaced (deferred)
- LOW: dead/unconditional f.id suffix rewrite is a latent 3-part-id hazard — delete or guard (fable f1)
- LOW: finding-resolver matcher unreachable for NEW ids via the `:f`-based consensusId derivation at `finding-resolver.ts:203`; dashboard twin works (fable f2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)