### PR TITLE
fix(quota): spend-cap 429s get 24h cooldown + honest banner states

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1898,12 +1898,22 @@ export function createMcpServer(): McpServer {
         const { readFileSync } = await import('fs');
         const quotaPath = join(process.cwd(), '.gossip', 'quota-state.json');
         const quotaRaw = readFileSync(quotaPath, 'utf8');
-        const quotaState: Record<string, { exhaustedUntil?: number }> = JSON.parse(quotaRaw);
+        const quotaState: Record<string, { exhaustedUntil?: number; reason?: string; consecutive429s?: number }> = JSON.parse(quotaRaw);
         for (const [provider, state] of Object.entries(quotaState)) {
           const now = Date.now();
-          if (state.exhaustedUntil && state.exhaustedUntil > now) {
-            const cooldownSec = Math.ceil((state.exhaustedUntil - now) / 1000);
+          const cooling = !!state.exhaustedUntil && state.exhaustedUntil > now;
+          const consecutive = state.consecutive429s ?? 0;
+          if (cooling && state.reason === 'spend_cap') {
+            // Monthly spend cap: a cooldown timer is meaningless to the user —
+            // it only recovers when they raise the cap or the month rolls over.
+            lines.push(`  Quota: ${provider} — EXHAUSTED (monthly spend cap — manage at https://ai.studio/spend)`);
+          } else if (cooling) {
+            const cooldownSec = Math.ceil((state.exhaustedUntil! - now) / 1000);
             lines.push(`  Quota: ${provider} — EXHAUSTED (${cooldownSec}s cooldown)`);
+          } else if (consecutive >= 5) {
+            // Cooldown expired but a long run of 429s preceded it and no
+            // successful call has since reset the counter — do NOT claim OK.
+            lines.push(`  Quota: ${provider} — SUSPECT (${consecutive} consecutive 429s before cooldown expiry — verify with a real call)`);
           } else {
             lines.push(`  Quota: ${provider} — OK`);
           }

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -123,8 +123,8 @@ class QuotaTracker {
     try {
       const state: QuotaStateFile = JSON.parse(readFileSync(this.statePath, 'utf-8'));
       if (state[this.provider]) {
-        this.exhaustedUntil = state[this.provider].exhaustedUntil;
-        this.consecutive429s = state[this.provider].consecutive429s;
+        this.exhaustedUntil = state[this.provider].exhaustedUntil ?? 0;
+        this.consecutive429s = state[this.provider].consecutive429s ?? 0;
         this.reason = state[this.provider].reason ?? 'quota';
       }
     } catch { /* start fresh */ }

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -86,7 +86,14 @@ export class QuotaExhaustedException extends Error {
   }
 }
 
-type CooldownReason = 'quota' | 'unavailable';
+type CooldownReason = 'quota' | 'unavailable' | 'spend_cap';
+
+// A monthly spend cap (Google) cannot recover via a short rate-limit cooldown —
+// it clears only when the user raises the cap or the billing month rolls over.
+// Use a 24h cooldown re-armed on every subsequent spend-cap 429 so the banner
+// stops lying about "OK" the instant a short cooldown would have expired.
+const SPEND_CAP_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+const SPEND_CAP_RE = /spend(?:ing)?\s+cap/i;
 
 interface QuotaProviderState {
   exhaustedUntil: number;
@@ -140,7 +147,10 @@ class QuotaTracker {
   checkBeforeRequest(): void {
     if (this.exhaustedUntil > Date.now()) {
       const remainingMs = this.exhaustedUntil - Date.now();
-      const label = this.reason === 'unavailable' ? 'service unavailable' : 'quota exhausted';
+      const label =
+        this.reason === 'unavailable' ? 'service unavailable'
+        : this.reason === 'spend_cap' ? 'monthly spend cap reached'
+        : 'quota exhausted';
       _log(this.provider, `${label}, ${Math.round(remainingMs / 1000)}s cooldown remaining`);
       throw new QuotaExhaustedException({
         message: `${this.provider} ${label} — ${Math.round(remainingMs / 1000)}s cooldown remaining`,
@@ -153,6 +163,24 @@ class QuotaTracker {
   /** Handle a 429 response. Parses Retry-After, sets cooldown, persists, throws. */
   handle429(res: Response, errBody: string): never {
     this.consecutive429s++;
+    // A monthly spend-cap 429 (Google) is NOT a transient rate limit: a short
+    // Retry-After cooldown would expire while calls keep failing, so the banner
+    // would flip back to "OK". Detect it from the error body and arm a long
+    // cooldown re-armed on every subsequent spend-cap 429. Ordinary quota 429s
+    // keep the existing exponential-backoff behaviour.
+    const isSpendCap = SPEND_CAP_RE.test(errBody);
+    if (isSpendCap) {
+      this.reason = 'spend_cap';
+      const cooldownMs = SPEND_CAP_COOLDOWN_MS;
+      this.exhaustedUntil = Date.now() + cooldownMs;
+      this.persist();
+      _log(this.provider, `429 monthly spend cap (${this.consecutive429s}x) — cooling down ${cooldownMs / 1000}s`);
+      throw new QuotaExhaustedException({
+        message: `${this.provider} monthly spend cap reached (429 #${this.consecutive429s}): ${errBody}`,
+        provider: this.provider,
+        retryAfterMs: cooldownMs,
+      });
+    }
     this.reason = 'quota';
     const retryAfter = this.parseRetryAfter(res);
     const cooldownMs = retryAfter ?? Math.min(60_000 * Math.pow(2, this.consecutive429s - 1), 300_000);

--- a/tests/orchestrator/llm-client.test.ts
+++ b/tests/orchestrator/llm-client.test.ts
@@ -792,3 +792,81 @@ describe('Multimodal message formatting', () => {
     expect(sentBody.messages[0].content).toBe('plain text');
   });
 });
+
+describe('QuotaTracker spend-cap detection (429)', () => {
+  let projectRoot: string;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'quota-spend-cap-'));
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  const read429State = () =>
+    JSON.parse(readFileSync(join(projectRoot, '.gossip', 'quota-state.json'), 'utf-8')).google;
+
+  it('a spend-cap 429 persists reason "spend_cap" with a 24h cooldown', async () => {
+    const before = Date.now();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Map([['retry-after', '30']]) as any, // short header must be IGNORED for spend cap
+      text: async () =>
+        'You exceeded its monthly spending cap. Manage at https://ai.studio/spend',
+    }) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider('ai-test', 'gemini-pro', projectRoot);
+    await expect(provider.generate([{ role: 'user', content: 'hi' }]))
+      .rejects.toThrow(/monthly spend cap/i);
+
+    const state = read429State();
+    expect(state.reason).toBe('spend_cap');
+    expect(state.consecutive429s).toBe(1);
+    // 24h cooldown, NOT the 30s Retry-After header.
+    const remaining = state.exhaustedUntil - before;
+    expect(remaining).toBeGreaterThan(23 * 60 * 60 * 1000);
+    expect(remaining).toBeLessThanOrEqual(24 * 60 * 60 * 1000 + 5_000);
+  });
+
+  it('matches "spend cap" without the -ing as well (case-insensitive)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Map() as any,
+      text: async () => 'PROJECT SPEND CAP EXCEEDED',
+    }) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider('ai-test', 'gemini-pro', projectRoot);
+    await expect(provider.generate([{ role: 'user', content: 'hi' }]))
+      .rejects.toThrow(/monthly spend cap/i);
+
+    expect(read429State().reason).toBe('spend_cap');
+  });
+
+  it('an ordinary quota 429 is unchanged — reason "quota", honours Retry-After', async () => {
+    const before = Date.now();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Map([['retry-after', '45']]) as any,
+      text: async () => 'Resource has been exhausted (e.g. check quota).',
+    }) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider('ai-test', 'gemini-pro', projectRoot);
+    await expect(provider.generate([{ role: 'user', content: 'hi' }]))
+      .rejects.toThrow(/quota exhausted/i);
+
+    const state = read429State();
+    expect(state.reason).toBe('quota');
+    expect(state.consecutive429s).toBe(1);
+    // Retry-After 45s is honoured; nowhere near the 24h spend-cap window.
+    const remaining = state.exhaustedUntil - before;
+    expect(remaining).toBeGreaterThan(40_000);
+    expect(remaining).toBeLessThan(60_000);
+  });
+});

--- a/tests/orchestrator/llm-client.test.ts
+++ b/tests/orchestrator/llm-client.test.ts
@@ -1,5 +1,5 @@
 import { createProvider, createProviderForAgent, resolveAgentProvider, AnthropicProvider, OpenAIProvider, GeminiProvider, OllamaProvider } from '@gossip/orchestrator';
-import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync, mkdirSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -868,5 +868,31 @@ describe('QuotaTracker spend-cap detection (429)', () => {
     const remaining = state.exhaustedUntil - before;
     expect(remaining).toBeGreaterThan(40_000);
     expect(remaining).toBeLessThan(60_000);
+  });
+
+  it('loading an OLD quota-state.json missing consecutive429s does not corrupt the counter to NaN', async () => {
+    // Simulate a state file written before the consecutive429s field existed:
+    // only exhaustedUntil present (already expired), no consecutive429s, no reason.
+    mkdirSync(join(projectRoot, '.gossip'), { recursive: true });
+    writeFileSync(
+      join(projectRoot, '.gossip', 'quota-state.json'),
+      JSON.stringify({ google: { exhaustedUntil: 1 } }),
+    );
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Map([['retry-after', '45']]) as any,
+      text: async () => 'Resource has been exhausted (e.g. check quota).',
+    }) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider('ai-test', 'gemini-pro', projectRoot);
+    await expect(provider.generate([{ role: 'user', content: 'hi' }]))
+      .rejects.toThrow(/quota exhausted/i);
+
+    // The missing field must default to 0, so the first 429 increments to 1 — NOT NaN.
+    const state = read429State();
+    expect(state.consecutive429s).toBe(1);
+    expect(Number.isNaN(state.consecutive429s)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
A Google monthly spend-cap 429 was treated as a transient rate limit — the short cooldown expired and the banner flipped back to `Quota: OK` while every call kept failing (observed live: 30 consecutive 429s with an OK banner). Now:
- `QuotaTracker` detects spend-cap error bodies (`SPEND_CAP_RE = /spend(?:ing)?\s+cap/i`) → `reason: 'spend_cap'`, 24h re-armed cooldown ignoring Retry-After
- `gossip_status` banner renders `EXHAUSTED (monthly spend cap — manage at https://ai.studio/spend)` / `SUSPECT (n consecutive 429s)` / `OK`
- **Fixup (consensus-caught):** `QuotaTracker.load()` now guards `consecutive429s`/`exhaustedUntil` with `?? 0` — an old `quota-state.json` predating the field yielded `undefined → NaN` on increment, corrupting the SUSPECT threshold. Backcompat test added.

56 tests green (llm-client suite); orchestrator + apps/cli typechecks clean.

## Pre-merge consensus (sonnet-reviewer, fable-reviewer, deepseek-challenger)
consensus-id: 79af065f-a8da414e

The NaN-on-load bug (sonnet `f1`, MEDIUM) was the one blocker — fixed in this PR before merge. Spend-cap detection verified cross-provider-safe (no phrase collision with OpenAI/Anthropic/DeepSeek transient 429 bodies), and `onSuccess` self-heals counter+cooldown+reason on the next successful call.

## Non-blocking (deferred)
- Retry-After ignored for spend-cap is by-design; `!cooling && reason === 'spend_cap'` could also render SUSPECT (fable suggestion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)