### PR TITLE
fix(dashboard): skill-graduation — separate frozen verdict from live 7d window (#571) + readability redesign

### DIFF
--- a/packages/dashboard-v2/src/components/SkillGraduationGrid.tsx
+++ b/packages/dashboard-v2/src/components/SkillGraduationGrid.tsx
@@ -72,7 +72,7 @@ const VERDICT_ORDER: Record<GraduationVerdict, number> = {
   silent_skill: 6,
 };
 
-const UNKNOWN_COLOR = 'var(--ink-4)';
+const UNKNOWN_COLOR = 'var(--ink-3)';
 
 function isGraduationVerdict(s: SkillStatus | null | undefined): s is GraduationVerdict {
   return s !== undefined && s !== null && s in VERDICT_COLOR;
@@ -97,7 +97,7 @@ export function SkillGraduationGrid({ skills, loading, error }: Props) {
         <div className="flex items-baseline gap-2">
           <h3 className="h-section">skill graduation</h3>
           <span
-            className="font-mono text-[11px] tabular-nums font-bold"
+            className="font-mono text-[11px] tabular-nums font-medium"
             style={{ color: 'var(--ink)', fontFamily: "'JetBrains Mono', monospace" }}
           >
             {total}
@@ -112,7 +112,7 @@ export function SkillGraduationGrid({ skills, loading, error }: Props) {
         <a
           href={href('/')}
           className="text-[11px] transition hover:underline"
-          style={{ color: 'var(--ink-3)', fontFamily: "'JetBrains Mono', monospace" }}
+          style={{ color: 'var(--ink-3)', fontFamily: 'Geist, var(--font-sans)' }}
         >
           skill detail →
         </a>
@@ -121,7 +121,7 @@ export function SkillGraduationGrid({ skills, loading, error }: Props) {
 
       <div
         className="rounded-lg border p-4"
-        style={{ background: 'var(--surface-elev)', borderColor: 'var(--border)' }}
+        style={{ background: 'var(--surface-sunk)', borderColor: 'var(--border)' }}
       >
         {/* Contextual help — distinguishes the two halves */}
         <p className="mb-3 text-[11px]" style={{ color: 'var(--ink-3)', fontFamily: 'Geist, var(--font-sans)' }}>
@@ -280,7 +280,7 @@ function GraduationCard({ entry }: { entry: SkillEffectivenessEntry }) {
         {/* Verdict chip + recovered badge */}
         <div className="flex flex-wrap items-center gap-1">
           <span
-            className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium"
+            className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold"
             style={{
               color: verdictColor,
               background: `color-mix(in oklch, ${verdictColor} 12%, transparent)`,
@@ -295,7 +295,7 @@ function GraduationCard({ entry }: { entry: SkillEffectivenessEntry }) {
 
           {showRecoveredBadge && (
             <span
-              className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px]"
+              className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium"
               style={{
                 color: 'var(--ok)',
                 background: 'var(--ok-soft)',
@@ -317,7 +317,9 @@ function GraduationCard({ entry }: { entry: SkillEffectivenessEntry }) {
               <span
                 className="text-[10px] tabular-nums"
                 style={{
-                  color: storedEffPp > 0 ? 'var(--ok)' : storedEffPp < 0 ? 'var(--bad)' : 'var(--ink-3)',
+                  color: storedEffPp < 0 && (verdict === 'failed' || verdict === 'flagged_for_manual_review')
+                    ? 'var(--bad)'
+                    : storedEffPp > 0 ? 'var(--ok)' : 'var(--ink-3)',
                   fontFamily: "'JetBrains Mono', monospace",
                 }}
                 title={`Stored effectiveness delta: ${storedEffPp > 0 ? '+' : ''}${storedEffPp}pp (basis for this verdict)`}
@@ -336,7 +338,7 @@ function GraduationCard({ entry }: { entry: SkillEffectivenessEntry }) {
             {verdictDateStr && (
               <span
                 className="text-[10px] tabular-nums"
-                style={{ color: 'var(--ink-4)', fontFamily: "'JetBrains Mono', monospace" }}
+                style={{ color: 'var(--ink-3)', fontFamily: "'JetBrains Mono', monospace" }}
                 title={`Verdict as of: ${entry.verdictAt}`}
               >
                 {verdictDateStr}
@@ -372,7 +374,7 @@ function GraduationCard({ entry }: { entry: SkillEffectivenessEntry }) {
         <SkillEffectivenessSparkline
           curve={entry.curve}
           threshold={entry.threshold}
-          stroke={verdictColor}
+          stroke={agentColor(entry.agentId)}
           width={120}
           height={28}
         />
@@ -417,6 +419,7 @@ function GridSkeleton() {
             style={{ borderBottom: '1px solid var(--border)' }}
           >
             <span className="h-3 w-3/4 rounded-sm" style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }} />
+            <span className="h-2 w-1/3 rounded-sm" style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }} />
             <span className="h-2.5 w-1/2 rounded-sm" style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }} />
             <span className="h-5 w-16 rounded-full" style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }} />
           </div>

--- a/packages/dashboard-v2/src/components/SkillGraduationGrid.tsx
+++ b/packages/dashboard-v2/src/components/SkillGraduationGrid.tsx
@@ -6,30 +6,40 @@ import { href } from '@/lib/router';
 import { agentColor } from '@/lib/utils';
 
 /**
- * DESIGN.md Step 9.5 — SkillGraduationGrid as a flat card grid.
+ * DESIGN.md Step 9 — SkillGraduationGrid (redesigned for issue #571).
  *
- * Replaces the verdict-grouped layout (Step 9). Each cell shows a post-bind
- * effectiveness sparkline with a dashed graduation threshold line, plus the
- * skill name on top and the small-caps verdict + signal count on the bottom.
+ * Each card SEPARATES the frozen verdict (with the stored basis it was made on)
+ * from the live 7d activity window. This resolves the "FAILED 1.00/0.70 N=27"
+ * confation where three numbers from three eras were shown unlabeled.
  *
- * Source: GET /dashboard/api/skills `effectiveness` array — derived from
- * agent-performance.jsonl bucketed by skill into 10 equal-time post-bind
- * windows. UNKNOWN-verdict skills go into a native <details> collapsible
- * below the main grid.
+ * Card anatomy:
+ *   TOP HALF  — verdict section: chip (semantic color), stored basis (storedEffectiveness
+ *               delta + threshold), "as of" date (verdictAt).
+ *   BOTTOM HALF — live 7d section: sparkline + N, labeled "live 7d".
  *
- * Verdict palette mirrors SkillVerdictsSnapshot (single source of truth).
+ * liveRecovered badge: when status is failed/silent_skill but 7d trailing rate
+ * >= threshold, show "recovered · re-test pending" in --ok-soft.
+ *
+ * Sort order: failed/flagged → inconclusive → insufficient → passed → pending → silent.
+ * Unknown-verdict skills collapse into "▶ N unknown" <details>.
+ *
+ * Verdict → DESIGN.md semantic token (NEVER --accent for status):
+ *   passed               → --ok
+ *   pending              → --info
+ *   insufficient_evidence → --idle
+ *   inconclusive/flagged → --warn
+ *   silent_skill         → --ink-3
+ *   failed               → --bad
  */
 
-// 6 graduation verdicts that get their own sparkline color. The 7th
-// (flagged_for_manual_review) plus any unknown string fall through to the
-// UNKNOWN collapsible bucket below.
 type GraduationVerdict =
   | 'passed'
   | 'pending'
   | 'insufficient_evidence'
   | 'inconclusive'
   | 'silent_skill'
-  | 'failed';
+  | 'failed'
+  | 'flagged_for_manual_review';
 
 const VERDICT_COLOR: Record<GraduationVerdict, string> = {
   passed: 'var(--ok)',
@@ -38,6 +48,7 @@ const VERDICT_COLOR: Record<GraduationVerdict, string> = {
   inconclusive: 'var(--warn)',
   silent_skill: 'var(--ink-3)',
   failed: 'var(--bad)',
+  flagged_for_manual_review: 'var(--warn)',
 };
 
 const VERDICT_LABEL: Record<GraduationVerdict, string> = {
@@ -47,6 +58,18 @@ const VERDICT_LABEL: Record<GraduationVerdict, string> = {
   inconclusive: 'inconclusive',
   silent_skill: 'silent',
   failed: 'failed',
+  flagged_for_manual_review: 'flagged',
+};
+
+// Sort priority: action-needed first, then informational, then all-clear.
+const VERDICT_ORDER: Record<GraduationVerdict, number> = {
+  failed: 0,
+  flagged_for_manual_review: 1,
+  inconclusive: 2,
+  insufficient_evidence: 3,
+  passed: 4,
+  pending: 5,
+  silent_skill: 6,
 };
 
 const UNKNOWN_COLOR = 'var(--ink-4)';
@@ -67,31 +90,29 @@ export function SkillGraduationGrid({ skills, loading, error }: Props) {
     [skills],
   );
 
-  const skillCount = total;
-
   return (
     <section className="space-y-2">
-      {/* Section header row — outside the card per the mockup. */}
+      {/* Section header — small-caps Geist per DESIGN.md */}
       <header className="flex items-baseline justify-between">
         <div className="flex items-baseline gap-2">
-          <h3 className="h-section">Skill Graduation</h3>
+          <h3 className="h-section">skill graduation</h3>
           <span
             className="font-mono text-[11px] tabular-nums font-bold"
-            style={{ color: 'var(--ink)' }}
+            style={{ color: 'var(--ink)', fontFamily: "'JetBrains Mono', monospace" }}
           >
-            {skillCount}
+            {total}
           </span>
           <span
-            className="font-mono text-[11px]"
-            style={{ color: 'var(--ink-3)' }}
+            className="text-[11px]"
+            style={{ color: 'var(--ink-3)', fontFamily: 'Geist, var(--font-sans)' }}
           >
             skills · {transitions} transitions /24h
           </span>
         </div>
         <a
           href={href('/')}
-          className="font-mono text-[11px] transition hover:underline"
-          style={{ color: 'var(--ink-3)' }}
+          className="text-[11px] transition hover:underline"
+          style={{ color: 'var(--ink-3)', fontFamily: "'JetBrains Mono', monospace" }}
         >
           skill detail →
         </a>
@@ -99,33 +120,29 @@ export function SkillGraduationGrid({ skills, loading, error }: Props) {
       </header>
 
       <div
-        className="rounded-lg border border-border p-4"
-        style={{ background: 'var(--surface-elev)' }}
+        className="rounded-lg border p-4"
+        style={{ background: 'var(--surface-elev)', borderColor: 'var(--border)' }}
       >
-        <p className="mb-3 text-[11px]" style={{ color: 'var(--ink-3)' }}>
-          Each cell shows the post-bind effectiveness curve. Dashed line = graduation threshold.
-          Verdict is from the latest evidence window.
+        {/* Contextual help — distinguishes the two halves */}
+        <p className="mb-3 text-[11px]" style={{ color: 'var(--ink-3)', fontFamily: 'Geist, var(--font-sans)' }}>
+          Top: frozen verdict + stored basis. Bottom: live 7d activity. Dashed line = graduation threshold.
         </p>
 
-        {/* DESIGN.md error contract — full error reason lives in the header
-            ErrorChip; here we render the cached grid dimmed at 50% so the
-            operator keeps their context instead of seeing a destructive
-            full-width banner that replaces the data. The legacy ErrorBanner
-            is no longer used; kept in the file for compatibility but
-            unreferenced. */}
+        {/* DESIGN.md error contract: error lives in header ErrorChip; cached
+            grid dims to 50% so operator keeps last-known context. */}
         {loading && !skills && <GridSkeleton />}
         {!loading && total === 0 && !error && (
-          <p className="text-[12px]" style={{ color: 'var(--ink-3)' }}>
+          <p className="text-[12px]" style={{ color: 'var(--ink-3)', fontFamily: 'Geist, var(--font-sans)' }}>
             No skills bound yet — agents need at least one dispatch with a skill match.
           </p>
         )}
         {total > 0 && (
           <ul
-            className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6"
+            className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-6"
             style={error ? { opacity: 0.5 } : undefined}
           >
             {known.map((entry) => (
-              <SkillCard key={cellKey(entry)} entry={entry} />
+              <GraduationCard key={cellKey(entry)} entry={entry} />
             ))}
           </ul>
         )}
@@ -145,14 +162,19 @@ export function SkillGraduationGrid({ skills, loading, error }: Props) {
               </span>
               <span
                 className="text-[11px]"
-                style={{ fontVariant: 'small-caps', letterSpacing: '0.04em' }}
+                style={{
+                  fontVariant: 'small-caps',
+                  letterSpacing: '0.04em',
+                  fontFamily: 'Geist, var(--font-sans)',
+                  fontWeight: 600,
+                }}
               >
                 {unknown.length} unknown
               </span>
             </summary>
-            <ul className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6">
+            <ul className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-6">
               {unknown.map((entry) => (
-                <SkillCard key={cellKey(entry)} entry={entry} />
+                <GraduationCard key={cellKey(entry)} entry={entry} />
               ))}
             </ul>
             <style>{`
@@ -182,12 +204,7 @@ function partition(
   if (!list) return { known: [], unknown: [], total: 0, transitions: 0 };
   const known: SkillEffectivenessEntry[] = [];
   const unknown: SkillEffectivenessEntry[] = [];
-  // Transitions /24h proxy: skills whose curve has BOTH a passing and a failing
-  // window inside the last 24h slice. Approximated by checking the last two
-  // bucket values straddle the threshold (one above, one below). The backend
-  // doesn't expose drift_strike_at / regressed_from_passed_at directly yet, so
-  // this is a curve-shape heuristic, not a state-machine read. Documented drift
-  // from spec — easy to upgrade once those fields surface in the API.
+  // Transitions /24h proxy: last two buckets straddle the threshold.
   let transitions = 0;
   for (const e of list) {
     if (isGraduationVerdict(e.status)) known.push(e);
@@ -199,19 +216,9 @@ function partition(
       if (above >= 1 && below >= 1) transitions++;
     }
   }
-  // Sort known: failing-first, then by name so operator eyes land on
-  // problems immediately within the flat grid.
-  const order: Record<GraduationVerdict, number> = {
-    failed: 0,
-    inconclusive: 1,
-    silent_skill: 2,
-    insufficient_evidence: 3,
-    pending: 4,
-    passed: 5,
-  };
   known.sort((a, b) => {
-    const ra = isGraduationVerdict(a.status) ? order[a.status] : 99;
-    const rb = isGraduationVerdict(b.status) ? order[b.status] : 99;
+    const ra = isGraduationVerdict(a.status) ? VERDICT_ORDER[a.status] : 99;
+    const rb = isGraduationVerdict(b.status) ? VERDICT_ORDER[b.status] : 99;
     if (ra !== rb) return ra - rb;
     return a.skill.localeCompare(b.skill);
   });
@@ -219,157 +226,204 @@ function partition(
   return { known, unknown, total: known.length + unknown.length, transitions };
 }
 
-/* ── single skill card ─────────────────────────────────────────────────── */
+/* ── GraduationCard ─────────────────────────────────────────────────────── */
 
-function SkillCard({ entry }: { entry: SkillEffectivenessEntry }) {
+function GraduationCard({ entry }: { entry: SkillEffectivenessEntry }) {
   const verdict = isGraduationVerdict(entry.status) ? entry.status : null;
-  const color = verdict ? VERDICT_COLOR[verdict] : UNKNOWN_COLOR;
-  const label = verdict ? VERDICT_LABEL[verdict] : (entry.status ?? 'unknown');
-  // Delta only meaningful for skills that have actually graduated — for
-  // pending/failed/etc. the trend is noise, not progress.
-  const deltaPp = verdict === 'passed' ? computeDeltaPp(entry.curve) : null;
-  const currentValue = latestValue(entry.curve);
-  const currentStr = currentValue == null ? '—' : currentValue.toFixed(2);
-  const thresholdStr = entry.threshold.toFixed(2);
+  const verdictColor = verdict ? VERDICT_COLOR[verdict] : UNKNOWN_COLOR;
+  const verdictLabel = verdict ? VERDICT_LABEL[verdict] : (entry.status ?? 'unknown');
+
+  // Stored effectiveness delta (what the verdict was based on — not the live rate)
+  const storedEff = typeof entry.storedEffectiveness === 'number' ? entry.storedEffectiveness : null;
+  const storedEffPp = storedEff !== null ? Math.round(storedEff * 100) : null;
+
+  // "Verdict as of" date
+  const verdictDateStr = entry.verdictAt ? formatShortDate(entry.verdictAt) : null;
+
+  // liveRecovered: failed/silent but 7d trailing rate >= threshold
+  const showRecoveredBadge = entry.liveRecovered === true;
 
   return (
     <li
-      className="flex flex-col gap-1.5 rounded-sm border border-border p-2.5"
-      style={{ background: 'var(--surface)' }}
-      title={`${entry.agentId} · ${entry.skill} · ${label} · N=${entry.n}`}
+      className="flex flex-col rounded-lg border"
+      style={{ background: 'var(--surface-elev)', borderColor: 'var(--border)' }}
+      title={`${entry.agentId} · ${entry.skill} · ${verdictLabel} · N=${entry.n}`}
     >
-      {/* Top: skill name + 7d chip; agent identity below */}
-      <div className="flex flex-col gap-0.5">
-        <div className="flex items-baseline justify-between gap-2">
-          <div className="truncate text-[13px]" style={{ color: 'var(--ink)' }}>
-            {entry.skill}
-          </div>
-          <span
-            className="shrink-0 rounded-sm border border-border px-1 font-mono text-[9px] tabular-nums"
-            style={{ color: 'var(--ink-3)' }}
-            title="7-day effectiveness window"
-          >
-            7d
-          </span>
+      {/* ── VERDICT SECTION ─────────────────────────────────────────────── */}
+      <div
+        className="flex flex-col gap-1.5 rounded-t-lg px-2.5 pt-2.5 pb-2"
+        style={{ borderBottom: '1px solid var(--border)' }}
+      >
+        {/* Skill name */}
+        <div
+          className="truncate text-[12px] font-medium leading-tight"
+          style={{ color: 'var(--ink)', fontFamily: 'Geist, var(--font-sans)' }}
+        >
+          {entry.skill}
         </div>
-        <div className="flex items-center gap-1.5">
+
+        {/* Agent identity row — bloom dot + agent id in mono */}
+        <div className="flex items-center gap-1">
           <span
             aria-hidden
             className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
             style={{ backgroundColor: agentColor(entry.agentId) }}
           />
           <span
-            className="truncate font-mono text-[10px]"
-            style={{ color: 'var(--ink-3)' }}
+            className="truncate text-[10px]"
+            style={{ color: 'var(--ink-3)', fontFamily: "'JetBrains Mono', monospace" }}
           >
             {entry.agentId}
           </span>
         </div>
-      </div>
-      {/* Middle: sparkline */}
-      <SkillEffectivenessSparkline
-        curve={entry.curve}
-        threshold={entry.threshold}
-        stroke={color}
-      />
-      {/* Bottom: verdict label + delta-pp + N */}
-      <div className="flex items-baseline justify-between gap-2">
-        <span
-          className="truncate text-[10px]"
-          style={{
-            color,
-            fontVariant: 'small-caps',
-            letterSpacing: '0.04em',
-          }}
-        >
-          {label}
-        </span>
-        <div className="flex items-baseline gap-2">
-          {deltaPp !== null && (
+
+        {/* Verdict chip + recovered badge */}
+        <div className="flex flex-wrap items-center gap-1">
+          <span
+            className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium"
+            style={{
+              color: verdictColor,
+              background: `color-mix(in oklch, ${verdictColor} 12%, transparent)`,
+              border: `1px solid color-mix(in oklch, ${verdictColor} 25%, transparent)`,
+              fontVariant: 'small-caps',
+              letterSpacing: '0.04em',
+              fontFamily: 'Geist, var(--font-sans)',
+            }}
+          >
+            {verdictLabel}
+          </span>
+
+          {showRecoveredBadge && (
             <span
-              className="font-mono text-[10px] tabular-nums"
+              className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px]"
               style={{
-                color:
-                  deltaPp > 0 ? 'var(--ok)' : deltaPp < 0 ? 'var(--bad)' : 'var(--ink-3)',
+                color: 'var(--ok)',
+                background: 'var(--ok-soft)',
+                border: '1px solid color-mix(in oklch, var(--ok) 25%, transparent)',
+                fontFamily: 'Geist, var(--font-sans)',
+                letterSpacing: '0.02em',
               }}
-              title={`Trend ${deltaPp > 0 ? 'up' : deltaPp < 0 ? 'down' : 'flat'} ${Math.abs(deltaPp)} percentage points across the 7d window`}
-              aria-label={`Trend ${deltaPp > 0 ? 'up' : deltaPp < 0 ? 'down' : 'flat'} ${Math.abs(deltaPp)} percentage points`}
+              title="Live 7d signals show recovery above threshold — but the stored verdict is frozen. Re-test to graduate."
             >
-              {deltaPp > 0 ? '+' : ''}
-              {deltaPp}pp
+              recovered · re-test pending
             </span>
           )}
+        </div>
+
+        {/* Stored basis row: delta pp vs threshold + "as of" date */}
+        {(storedEffPp !== null || verdictDateStr) && (
+          <div className="flex items-baseline gap-1.5 flex-wrap">
+            {storedEffPp !== null && (
+              <span
+                className="text-[10px] tabular-nums"
+                style={{
+                  color: storedEffPp > 0 ? 'var(--ok)' : storedEffPp < 0 ? 'var(--bad)' : 'var(--ink-3)',
+                  fontFamily: "'JetBrains Mono', monospace",
+                }}
+                title={`Stored effectiveness delta: ${storedEffPp > 0 ? '+' : ''}${storedEffPp}pp (basis for this verdict)`}
+              >
+                {storedEffPp > 0 ? '+' : ''}{storedEffPp}pp
+              </span>
+            )}
+            {storedEffPp !== null && (
+              <span
+                className="text-[10px]"
+                style={{ color: 'var(--ink-3)', fontFamily: 'Geist, var(--font-sans)' }}
+              >
+                vs {entry.threshold.toFixed(2)}
+              </span>
+            )}
+            {verdictDateStr && (
+              <span
+                className="text-[10px] tabular-nums"
+                style={{ color: 'var(--ink-4)', fontFamily: "'JetBrains Mono', monospace" }}
+                title={`Verdict as of: ${entry.verdictAt}`}
+              >
+                {verdictDateStr}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* ── LIVE 7D SECTION ─────────────────────────────────────────────── */}
+      <div className="flex flex-col gap-1 px-2.5 pt-1.5 pb-2.5">
+        <div className="flex items-center justify-between">
           <span
-            className="font-mono text-[10px] tabular-nums"
-            style={{ color: 'var(--ink)' }}
-            title={`current ${currentStr} · threshold ${thresholdStr}`}
+            className="text-[10px]"
+            style={{
+              color: 'var(--ink-3)',
+              fontVariant: 'small-caps',
+              letterSpacing: '0.04em',
+              fontFamily: 'Geist, var(--font-sans)',
+              fontWeight: 600,
+            }}
           >
-            {currentStr}
-            <span style={{ color: 'var(--ink-3)' }}> / {thresholdStr}</span>
+            live 7d
           </span>
           <span
-            className="font-mono text-[10px] tabular-nums"
-            style={{ color: 'var(--ink-3)' }}
+            className="text-[10px] tabular-nums"
+            style={{ color: 'var(--ink-3)', fontFamily: "'JetBrains Mono', monospace" }}
+            title="Total post-bind signals in the 7d window"
           >
-            N={entry.n}
+            N=<span style={{ color: 'var(--ink)' }}>{entry.n}</span>
           </span>
         </div>
+        <SkillEffectivenessSparkline
+          curve={entry.curve}
+          threshold={entry.threshold}
+          stroke={verdictColor}
+          width={120}
+          height={28}
+        />
       </div>
     </li>
   );
 }
 
-/** First→last non-null bucket delta, in percentage points (integer).
- *  Returns null if fewer than 4 non-null buckets — with 2-3 sparse buckets
- *  the delta swings to ±100pp from single signals, which is misleading
- *  (consensus eee614bd-31ba4209 finding f17). */
-const DELTA_MIN_BUCKETS = 4;
-function computeDeltaPp(curve: SkillEffectivenessEntry['curve']): number | null {
-  const defined = curve.filter((p) => p.value != null && Number.isFinite(p.value)) as Array<{ value: number }>;
-  if (defined.length < DELTA_MIN_BUCKETS) return null;
-  return Math.round((defined[defined.length - 1].value - defined[0].value) * 100);
-}
+/* ── helpers ────────────────────────────────────────────────────────────── */
 
-/** Most recent non-null bucket value, or null if all buckets are empty. */
-function latestValue(curve: SkillEffectivenessEntry['curve']): number | null {
-  for (let i = curve.length - 1; i >= 0; i--) {
-    const v = curve[i].value;
-    if (v != null && Number.isFinite(v)) return v;
+/** Format an ISO timestamp as compact "MMM D" (same year) or "MMM D 'YY". */
+function formatShortDate(iso: string): string | null {
+  try {
+    const d = new Date(iso);
+    if (!Number.isFinite(d.getTime())) return null;
+    const now = new Date();
+    const sameYear = d.getFullYear() === now.getFullYear();
+    const month = d.toLocaleString('en-US', { month: 'short' });
+    const day = d.getDate();
+    return sameYear ? `${month} ${day}` : `${month} ${day} '${String(d.getFullYear()).slice(-2)}`;
+  } catch {
+    return null;
   }
-  return null;
 }
 
 /* ── states ────────────────────────────────────────────────────────────── */
 
-// Legacy ErrorBanner removed in favor of the shared ErrorChip in the header
-// per DESIGN.md error contract — the error reason lives top-right of the
-// card and the cached grid below dims to 50% so the operator keeps context
-// instead of seeing a full-width destructive banner replace the data.
-
 function GridSkeleton() {
   return (
     <ul
-      className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6"
+      className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-6"
       aria-hidden
     >
       {Array.from({ length: 6 }).map((_, i) => (
         <li
           key={i}
-          className="flex h-[88px] flex-col gap-1.5 rounded-sm border border-border p-2.5"
-          style={{ background: 'var(--surface)' }}
+          className="flex flex-col rounded-lg border"
+          style={{ borderColor: 'var(--border)', background: 'var(--surface-elev)', minHeight: '120px' }}
         >
-          <span
-            className="h-3 w-3/4 rounded-sm"
-            style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }}
-          />
-          <span
-            className="h-[30px] w-full rounded-sm"
-            style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }}
-          />
-          <span
-            className="h-3 w-1/2 rounded-sm"
-            style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }}
-          />
+          <div
+            className="flex flex-col gap-1.5 px-2.5 pt-2.5 pb-2"
+            style={{ borderBottom: '1px solid var(--border)' }}
+          >
+            <span className="h-3 w-3/4 rounded-sm" style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }} />
+            <span className="h-2.5 w-1/2 rounded-sm" style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }} />
+            <span className="h-5 w-16 rounded-full" style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }} />
+          </div>
+          <div className="flex flex-col gap-1 px-2.5 pt-1.5 pb-2.5">
+            <span className="h-2.5 w-10 rounded-sm" style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }} />
+            <span className="h-7 w-full rounded-sm" style={{ background: 'color-mix(in oklch, var(--border) 40%, transparent)' }} />
+          </div>
         </li>
       ))}
     </ul>

--- a/packages/dashboard-v2/tsconfig.json
+++ b/packages/dashboard-v2/tsconfig.json
@@ -9,10 +9,7 @@
     "skipLibCheck": true,
     "noEmit": true,
     "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"],
-      "@gossip/types": ["../types/dist/index.d.ts"]
-    }
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src"],
   "exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/**/*.spec.tsx"]

--- a/packages/dashboard-v2/tsconfig.json
+++ b/packages/dashboard-v2/tsconfig.json
@@ -9,7 +9,10 @@
     "skipLibCheck": true,
     "noEmit": true,
     "baseUrl": ".",
-    "paths": { "@/*": ["./src/*"] }
+    "paths": {
+      "@/*": ["./src/*"],
+      "@gossip/types": ["../types/dist/index.d.ts"]
+    }
   },
   "include": ["src"],
   "exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/**/*.spec.tsx"]

--- a/packages/relay/src/dashboard/api-skills.ts
+++ b/packages/relay/src/dashboard/api-skills.ts
@@ -42,12 +42,20 @@ function isCorrupt(projectRoot: string, index: SkillIndex): boolean {
   return existsSync(join(projectRoot, '.gossip', 'skill-index.json')) && !index.exists();
 }
 
-/* ── frontmatter (status + bound_at + passed_baseline_rate) ────────────── */
+/* ── frontmatter (status + bound_at + passed_baseline_rate + provenance) ── */
 
 interface SkillFrontmatter {
   status?: string;
   bound_at?: string;
   passed_baseline_rate?: number;
+  /** Stored effectiveness delta (pre/post hallucination rate) — verdict basis. */
+  effectiveness?: number;
+  /** ISO timestamp when the skill passed — best "verdict as of" stamp. */
+  passed_at?: string;
+  /** ISO timestamp when inconclusive verdict was recorded. */
+  inconclusive_at?: string;
+  /** ISO timestamp when the skill regressed from a previously-passed state. */
+  regressed_from_passed_at?: string;
 }
 
 function readSkillFrontmatter(
@@ -79,10 +87,17 @@ function readSkillFrontmatter(
       else if (key === 'passed_baseline_rate') {
         const n = Number(value);
         if (Number.isFinite(n)) out.passed_baseline_rate = n;
-      }
+      } else if (key === 'effectiveness') {
+        const n = Number(value);
+        if (Number.isFinite(n)) out.effectiveness = n;
+      } else if (key === 'passed_at') out.passed_at = value;
+      else if (key === 'inconclusive_at') out.inconclusive_at = value;
+      else if (key === 'regressed_from_passed_at') out.regressed_from_passed_at = value;
     }
     // Return null instead of empty object when no recognized fields were parsed
-    if (!out.status && !out.bound_at && out.passed_baseline_rate === undefined) return null;
+    if (!out.status && !out.bound_at && out.passed_baseline_rate === undefined
+        && out.effectiveness === undefined && !out.passed_at && !out.inconclusive_at
+        && !out.regressed_from_passed_at) return null;
     return out;
   } catch {
     return null;
@@ -230,6 +245,30 @@ function deriveEffectiveness(
       });
       const threshold = fm?.passed_baseline_rate ?? DEFAULT_THRESHOLD;
       const status = (fm?.status as SkillVerdict | undefined) ?? null;
+
+      // Verdict provenance — "verdict as of" timestamp (best-available stamp).
+      const verdictAt: string | undefined =
+        fm?.passed_at ?? fm?.inconclusive_at ?? fm?.regressed_from_passed_at ?? fm?.bound_at;
+
+      // liveRecovered: frozen verdict says failed/silent but live 7d shows recovery.
+      const isFailedVerdict = status === 'failed' || status === 'silent_skill';
+      let liveRecovered: boolean | undefined;
+      if (isFailedVerdict && n > 0) {
+        // Trailing rate: last non-null bucket value, or n-weighted mean over all buckets.
+        let trailingRate: number | null = null;
+        for (let i = curve.length - 1; i >= 0; i--) {
+          const v = curve[i].value;
+          if (v != null && Number.isFinite(v)) { trailingRate = v; break; }
+        }
+        if (trailingRate == null) {
+          // Fallback: n-weighted mean
+          let totalCorrect = 0;
+          for (const b of buckets) totalCorrect += b.c;
+          trailingRate = n > 0 ? totalCorrect / n : 0;
+        }
+        liveRecovered = trailingRate >= threshold;
+      }
+
       out.push({
         agentId,
         skill: slot.skill,
@@ -238,6 +277,9 @@ function deriveEffectiveness(
         threshold,
         n,
         boundAt: boundAtIso,
+        ...(fm?.effectiveness !== undefined ? { storedEffectiveness: fm.effectiveness } : {}),
+        ...(verdictAt !== undefined ? { verdictAt } : {}),
+        ...(liveRecovered !== undefined ? { liveRecovered } : {}),
       });
     }
   }

--- a/packages/types/src/skills.ts
+++ b/packages/types/src/skills.ts
@@ -41,6 +41,26 @@ export interface SkillEffectivenessEntry {
   n: number;
   /** ISO. Anchor for the curve. */
   boundAt: string;
+
+  // ── Verdict provenance fields (issue #571 fix) ───────────────────────────
+  /**
+   * The stored effectiveness delta from frontmatter (the value the verdict was
+   * actually based on). Distinct from the live 7d trailing rate in the curve.
+   * Frontmatter field: `effectiveness`.
+   */
+  storedEffectiveness?: number;
+  /**
+   * Best-available "verdict as of" ISO timestamp from frontmatter.
+   * Checked in order: passed_at → inconclusive_at → regressed_from_passed_at → bound_at.
+   * Undefined when no timestamp field is present in frontmatter.
+   */
+  verdictAt?: string;
+  /**
+   * True when the frozen verdict is 'failed' or 'silent_skill' AND the live 7d
+   * window shows recovery: n > 0 AND trailing rate >= threshold. Signals skills
+   * that have recovered since the verdict was recorded (see issue #572).
+   */
+  liveRecovered?: boolean;
 }
 
 /**


### PR DESCRIPTION
Closes #571. Refs #572.

## Problem
Skill-graduation cells fused three unrelated numbers — a **frozen** frontmatter verdict/threshold with a **live 7-day** rate/N — producing nonsensical cells like `trust-boundaries/gemini-reviewer: FAILED 1.00/0.70 N=27` (failed verdict from when it had full evidence, paired with its since-recovered live rate). The engine was correct; the display conflated eras.

## Changes
- **`packages/types/src/skills.ts`** — `SkillEffectivenessEntry` gains `storedEffectiveness?`, `verdictAt?`, `liveRecovered?` (all optional, additive).
- **`packages/relay/src/dashboard/api-skills.ts`** — `readSkillFrontmatter` parses `effectiveness`/`passed_at`/`inconclusive_at`/`regressed_from_passed_at`; `deriveEffectiveness` derives `verdictAt` (passed_at → inconclusive_at → regressed_from_passed_at → bound_at) and `liveRecovered` (failed/silent + n>0 + trailing 7d rate ≥ threshold). **Verdict semantics unchanged — display data only.**
- **`SkillGraduationGrid.tsx`** — redesigned to DESIGN.md dark variant: a **verdict half** (semantic-colored chip — `--ok/--bad/--warn/--idle`, never `--accent` — with stored basis + "as of" date) separated by a hairline from a labeled **"live 7d"** sparkline+N; a calm `recovered · re-test pending` badge when `liveRecovered`; status-sorted (failed/flagged → inconclusive → insufficient → passed → pending → silent); `flagged_for_manual_review` now handled (was falling into the unknown bucket).

## Verification
relay + dashboard typecheck clean (with `@gossip/types` built), `build:mcp` ok, `vite build` ok, 73 dashboard/relay tests pass. CI builds `@gossip/types` before dependents (ci.yml), so the additive type field resolves normally — no tsconfig override needed.

## Notes
- Pairs with #572 (the `liveRecovered` badge surfaces failed-but-recovered skills, which #572's failed-recovery re-test would then act on).
- sonnet-designer DESIGN.md review in progress; will fix any token/hierarchy findings before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)