### PR TITLE
fix(dashboard): brighten skill-graduation sparkline curve in dark mode

### DIFF
--- a/packages/dashboard-v2/src/components/SkillEffectivenessSparkline.tsx
+++ b/packages/dashboard-v2/src/components/SkillEffectivenessSparkline.tsx
@@ -87,6 +87,7 @@ export function SkillEffectivenessSparkline({
           return (
             <circle
               key={i}
+              className="skill-spark-curve"
               cx={xFor(idx)}
               cy={yFor(value)}
               r={1.4}
@@ -100,6 +101,7 @@ export function SkillEffectivenessSparkline({
         return (
           <path
             key={i}
+            className="skill-spark-curve"
             d={d}
             fill="none"
             stroke={stroke}

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -373,6 +373,15 @@ body {
    Dark activates via [data-theme="dark"] from useTheme.ts.
    Tokens live in the :root + [data-theme="dark"] blocks above. ───── */
 
+/* Skill-graduation sparkline — lift the agent-hued curve on the dark canvas.
+   agentColor() returns fixed spec hexes (not --a-* tokens), so dim hues
+   (slate/plum/sage) wash out on the #252320 card. Opacity is already 1; the
+   lever is brightness + a hair more weight. Light mode is untouched. */
+[data-theme="dark"] .skill-spark-curve {
+  filter: brightness(1.3) saturate(1.1);
+  stroke-width: 1.85px;
+}
+
 /* Subtle vignette — dark theme only (washes out the warm light palette).
    z-index 1 keeps it above body content but below dialogs/drawers (z-50) and
    notification stacks. The earlier z-index 9998 obscured modals once the


### PR DESCRIPTION
Follow-up polish on #573 (skill-graduation redesign).

## Problem
The per-skill sparkline curve washed out on the dark canvas. Root cause: `agentColor()` returns fixed spec hexes (not `--a-*` CSS tokens), and the `[data-theme=dark]` block doesn't override those tokens — so dim agent hues (slate `#6B7A85`, plum `#8C5E97`, sage `#2F7D5B`) drew at full saturation but low contrast on the `#252320` card. Curve opacity was already 1.0, so opacity wasn't the lever — brightness was.

## Change (display-only, dark-scoped)
- `SkillEffectivenessSparkline.tsx`: add `className="skill-spark-curve"` to the curve `<path>` and the single-point `<circle>` (threshold line + empty-state untouched).
- `globals.css`: `[data-theme="dark"] .skill-spark-curve { filter: brightness(1.3) saturate(1.1); stroke-width: 1.85px; }`

Light mode is unchanged (scoped to dark). Verified in a headless dark-mode screenshot — the plum/teal curves now read clearly without going garish; threshold dashed line stays subtle.

dashboard-v2 typecheck clean; `build:dashboard` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)