### PR TITLE
feat(skill-engine): failed-skill recovery re-test — symmetric inverse of drift (#572)

### DIFF
--- a/packages/orchestrator/src/check-effectiveness.ts
+++ b/packages/orchestrator/src/check-effectiveness.ts
@@ -102,6 +102,27 @@ export interface SkillSnapshot {
    * of the spec's α² (≈0.000625).
    */
   drift_strike_at?: string;
+  // ── Failed-skill recovery fields (symmetric inverse of drift) ─────────
+  /**
+   * ISO. Set when a skill first transitions to `failed`. Anchor for the
+   * recovery detection window — the recovery Wilson test compares signals
+   * since failed_at against RECOVERY_FLOOR. Mirrors `passed_at`'s role for
+   * drift, on the opposite (failed) population.
+   */
+  failed_at?: string;
+  /** 0 or 1. K=2 requires one prior confirming recovery window before lifting suppression. */
+  recovery_strikes?: number;
+  /**
+   * ISO. Set when recovery_strikes increments 0→1; cleared on transition to
+   * pending (recovery succeeds) and on reset (a non-confirming window). Anchors
+   * the strike-2 recovery Wilson window via getCountersSince(recovery_strike_at)
+   * so the two K=2 windows are independent — mirrors drift_strike_at exactly.
+   * Without this the strike-2 window includes strike-1's signals and the
+   * false-promote rate is α instead of α².
+   */
+  recovery_strike_at?: string;
+  /** ISO. Set when recovery flips a failed skill back to `pending`. Diagnostic provenance. */
+  recovered_at?: string;
 }
 
 /**
@@ -114,6 +135,15 @@ export const DRIFT_WINDOW_SIZE = MIN_EVIDENCE;
 export const DRIFT_DEMOTE_STRIKES = 2;
 /** Floor used in the hybrid first-window test for backfilled passed skills. */
 const HYBRID_BACKFILL_FLOOR = 0.75;
+/**
+ * Floor used by the failed-skill recovery gate. Mirrors HYBRID_BACKFILL_FLOOR
+ * (0.75) — a recovered skill must demonstrate accuracy confidently ABOVE the
+ * graduation floor before suppression is lifted. Recovery only lifts
+ * suppression (failed → pending); the skill still must clear the normal
+ * MIN_EVIDENCE=80 Wilson graduation afterward to reach `passed`. Setting the
+ * recovery bar at the same 0.75 floor keeps the two gates symmetric.
+ */
+const RECOVERY_FLOOR = 0.75;
 
 export interface VerdictResult {
   status: VerdictStatus;
@@ -208,7 +238,7 @@ export function resolveVerdict(
   snapshot: SkillSnapshot,
   delta: CategoryCounters,
   nowMs: number,
-  opts?: { role?: string; agentAccuracy?: number; driftDelta?: CategoryCounters },
+  opts?: { role?: string; agentAccuracy?: number; driftDelta?: CategoryCounters; recoveryDelta?: CategoryCounters },
 ): VerdictResult {
   // Terminal states short-circuit
   if (opts?.role === 'implementer') {
@@ -218,7 +248,7 @@ export function resolveVerdict(
     return { status: 'flagged_for_manual_review', shouldUpdate: false };
   }
   if (snapshot.status === 'failed') {
-    return { status: 'failed', shouldUpdate: false };
+    return resolveFailedRecovery(snapshot, opts?.recoveryDelta, nowMs);
   }
   if (snapshot.status === 'passed') {
     return resolvePassedDrift(snapshot, opts?.driftDelta, nowMs);
@@ -370,7 +400,18 @@ export function resolveVerdict(
         zScore,
         verdict_method: oneSampleMethod,
         shouldUpdate: true,
-        newSnapshotFields: { status: 'failed', verdict_method: oneSampleMethod },
+        newSnapshotFields: {
+          status: 'failed',
+          verdict_method: oneSampleMethod,
+          // Stamp the recovery-window anchor at fail time (symmetric inverse of
+          // passed_at). resolveFailedRecovery uses this to measure the recovery
+          // window. Without it the recovery clock never starts.
+          failed_at: new Date(nowMs).toISOString(),
+          // Clear any recovered_at from a prior recovery — this is a fresh
+          // failure, so a stale "recovered at" timestamp would be misleading in
+          // the frontmatter. (Write-only diagnostic field; no logic reads it.)
+          recovered_at: undefined,
+        },
       };
     }
     // CI straddles prior — inconclusive, fall through to strikes logic below.
@@ -451,7 +492,17 @@ export function resolveVerdict(
       zScore,
       verdict_method: verdictMethod,
       shouldUpdate: true,
-      newSnapshotFields: { status: 'failed', verdict_method: verdictMethod },
+      newSnapshotFields: {
+        status: 'failed',
+        verdict_method: verdictMethod,
+        // Stamp the recovery-window anchor at fail time (symmetric inverse of
+        // passed_at) — starts the recovery clock for resolveFailedRecovery.
+        failed_at: new Date(nowMs).toISOString(),
+        // Clear any recovered_at from a prior recovery — this is a fresh
+        // failure, so a stale "recovered at" timestamp would be misleading in
+        // the frontmatter. (Write-only diagnostic field; no logic reads it.)
+        recovered_at: undefined,
+      },
     };
   }
 
@@ -614,6 +665,128 @@ function resolvePassedDrift(
       drift_strikes: 0,
       drift_strike_at: undefined,
       passed_backfilled: undefined,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Recovery detection — failed-skill re-test (symmetric inverse of drift).
+//
+// Pipeline gate: a skill that reached `failed` is suppressed from injection
+// forever by skill-loader.ts. This gate gives it a path back: re-tested every
+// N=80 fresh signals since `failed_at`. Two consecutive Wilson lower-bound
+// CONFIRMATIONS above RECOVERY_FLOOR (K=2) lift suppression by transitioning
+// the skill to `pending` with `recovered_at` stamped. The combined K=2
+// false-promote rate is α² = 0.000625 — symmetric with drift's false-demote
+// rate, with latency bounded by 2 × DRIFT_WINDOW_SIZE.
+//
+// DISJOINT POPULATION: the recovery window anchors on failed_at /
+// recovery_strike_at, while drift anchors on passed_at / drift_strike_at. A
+// skill is never simultaneously failed and passed, so the two gates spend
+// their α budgets on non-overlapping signal populations — no α-leakage (same
+// argument as HANDBOOK invariant #11). Recovery → pending (NOT passed):
+// recovered skills still must clear the normal MIN_EVIDENCE=80 Wilson
+// graduation. Recovery only LIFTS SUPPRESSION.
+//
+// PAUSED state: when no recoveryDelta is supplied (caller couldn't compute a
+// window — e.g. failed_at not yet stamped on the first observation), recovery
+// is disabled until a window materializes. The skill stays `failed`.
+// ---------------------------------------------------------------------------
+
+function wilsonLowerBoundConfirmsAbove(
+  delta: CategoryCounters,
+  postTotal: number,
+  floor: number,
+): boolean {
+  if (postTotal <= 0) return false;
+  // Fast-skip when the post sample rate is at or below the floor — recovery is
+  // by definition "post window is ABOVE floor." Symmetric inverse of
+  // wilsonLowerBoundFailsAgainst's postP >= baseline fast-skip.
+  const postP = delta.correct / postTotal;
+  if (postP <= floor) return false;
+  // Use sparse-current α (calibrated one-sample target) — the SAME α the drift
+  // test uses. The recovery test is conceptually identical: one observed
+  // accuracy CI compared against a fixed prior, just on the other side.
+  const alpha = WILSON_SCHEDULE['sparse-current'];
+  const postCI = wilsonScoreInterval(delta.correct, postTotal, alpha);
+  // Recovery = the lower end of the post window's CI lies ABOVE the floor.
+  // Equivalent to "we can confidently say post is ABOVE floor at level α."
+  return postCI.lower > floor;
+}
+
+function resolveFailedRecovery(
+  snapshot: SkillSnapshot,
+  recoveryDelta: CategoryCounters | undefined,
+  nowMs: number,
+): VerdictResult {
+  // PAUSED: no recovery delta supplied (caller couldn't compute a window) →
+  // recovery detection disabled, skill stays failed.
+  if (!recoveryDelta) {
+    return { status: 'failed', shouldUpdate: false };
+  }
+  // Start the clock: a failed skill with no failed_at anchor stamps one now.
+  // This handles legacy `failed` snapshots written before the recovery fields
+  // existed — the recovery window can only be measured from a known anchor.
+  if (snapshot.failed_at == null) {
+    return {
+      status: 'failed',
+      shouldUpdate: true,
+      newSnapshotFields: { status: 'failed', failed_at: new Date(nowMs).toISOString() },
+    };
+  }
+  const postTotal = recoveryDelta.correct + recoveryDelta.hallucinated;
+  if (postTotal < DRIFT_WINDOW_SIZE) {
+    // Window not full yet — stay suppressed, no transition.
+    return { status: 'failed', shouldUpdate: false };
+  }
+
+  const confirm = wilsonLowerBoundConfirmsAbove(recoveryDelta, postTotal, RECOVERY_FLOOR);
+
+  if (confirm) {
+    const nextStrikes = (snapshot.recovery_strikes ?? 0) + 1;
+    if (nextStrikes >= DRIFT_DEMOTE_STRIKES) {
+      // K=2 confirming windows → lift suppression. Transition to pending (NOT
+      // passed): the skill resumes injection and must clear normal graduation.
+      const nowIso = new Date(nowMs).toISOString();
+      return {
+        status: 'pending',
+        shouldUpdate: true,
+        newSnapshotFields: {
+          status: 'pending',
+          recovered_at: nowIso,
+          failed_at: undefined,
+          recovery_strikes: 0,
+          recovery_strike_at: undefined,
+          verdict_method: undefined,
+        },
+      };
+    }
+    // First confirming window — stamp recovery_strike_at so the strike-2 Wilson
+    // window anchors here (independent from strike-1's window). Required for the
+    // α² K=2 false-promote guarantee (symmetric with drift_strike_at).
+    return {
+      status: 'failed',
+      shouldUpdate: true,
+      newSnapshotFields: {
+        status: 'failed',
+        recovery_strikes: nextStrikes,
+        recovery_strike_at: new Date(nowMs).toISOString(),
+      },
+    };
+  }
+
+  // Non-confirming window → reset strikes. No prior strike means steady-state
+  // (nothing to write); a prior strike must be cleared.
+  if ((snapshot.recovery_strikes ?? 0) === 0) {
+    return { status: 'failed', shouldUpdate: false };
+  }
+  return {
+    status: 'failed',
+    shouldUpdate: true,
+    newSnapshotFields: {
+      status: 'failed',
+      recovery_strikes: 0,
+      recovery_strike_at: undefined,
     },
   };
 }

--- a/packages/orchestrator/src/skill-engine.ts
+++ b/packages/orchestrator/src/skill-engine.ts
@@ -932,6 +932,16 @@ ${inputs.join('\n')}
           : undefined,
       drift_strike_at:
         typeof frontmatter.drift_strike_at === 'string' ? frontmatter.drift_strike_at : undefined,
+      failed_at:
+        typeof frontmatter.failed_at === 'string' ? frontmatter.failed_at : undefined,
+      recovery_strikes:
+        frontmatter.recovery_strikes != null && Number.isFinite(Number(frontmatter.recovery_strikes))
+          ? Number(frontmatter.recovery_strikes)
+          : undefined,
+      recovery_strike_at:
+        typeof frontmatter.recovery_strike_at === 'string' ? frontmatter.recovery_strike_at : undefined,
+      recovered_at:
+        typeof frontmatter.recovered_at === 'string' ? frontmatter.recovered_at : undefined,
     };
 
     const anchorMs = snapshot.inconclusive_at
@@ -973,10 +983,31 @@ ${inputs.join('\n')}
       }
     }
 
+    // Recovery delta: counters since failed_at (for the failed-status recovery
+    // gate). Symmetric inverse of the drift block above, on the DISJOINT failed
+    // population. When strike-1 has fired, anchor the next window at
+    // recovery_strike_at (not failed_at) so the two K=2 windows are independent
+    // — without this the strike-2 window includes strike-1's signals and the
+    // false-promote rate is α (≈0.025) instead of α² (≈0.000625). Falls back to
+    // bound_at when failed_at is absent (legacy snapshot — resolveFailedRecovery
+    // will stamp failed_at on this pass).
+    let recoveryDelta: ReturnType<PerformanceReader['getCountersSince']> | undefined;
+    if (snapshot.status === 'failed') {
+      const anchorIso =
+        (snapshot.recovery_strikes ?? 0) >= 1 && snapshot.recovery_strike_at
+          ? snapshot.recovery_strike_at
+          : (snapshot.failed_at ?? snapshot.bound_at);
+      const anchorAtMs = new Date(anchorIso).getTime();
+      if (!isNaN(anchorAtMs)) {
+        recoveryDelta = this.perfReader.getCountersSince(agentId, category, anchorAtMs);
+      }
+    }
+
     const verdictOpts: Parameters<typeof resolveVerdict>[3] = {
       ...(opts ?? {}),
       ...(agentScore != null ? { agentAccuracy: agentScore.accuracy } : {}),
       ...(driftDelta ? { driftDelta } : {}),
+      ...(recoveryDelta ? { recoveryDelta } : {}),
     };
     const verdict = resolveVerdict(snapshot, delta, nowMs, verdictOpts);
 

--- a/tests/orchestrator/recovery-detection.test.ts
+++ b/tests/orchestrator/recovery-detection.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Failed-skill recovery detection — unit tests.
+ *
+ * GitHub issue #572. Symmetric inverse of the passed-skill drift gate
+ * (drift-detection.test.ts): a `failed` skill whose accuracy recovers gets a
+ * path back via two consecutive Wilson lower-bound confirmations above
+ * RECOVERY_FLOOR (K=2), transitioning to `pending` (NOT `passed` — the skill
+ * still must clear normal MIN_EVIDENCE=80 graduation; recovery only lifts
+ * suppression).
+ *
+ * Statistical invariant: recovery anchors on failed_at / recovery_strike_at,
+ * drift anchors on passed_at / drift_strike_at — DISJOINT signal populations,
+ * each spends its own α (HANDBOOK invariant #11). K=2 independent windows →
+ * α² false-promote.
+ */
+
+import {
+  resolveVerdict,
+  DRIFT_DEMOTE_STRIKES,
+  type SkillSnapshot,
+} from '../../packages/orchestrator/src/check-effectiveness';
+
+const NOW = Date.parse('2026-06-13T12:00:00Z');
+
+function failedSnapshot(overrides: Partial<SkillSnapshot> = {}): SkillSnapshot {
+  return {
+    baseline_accuracy_correct: 70,
+    baseline_accuracy_hallucinated: 30,
+    bound_at: new Date(NOW - 60 * 86400_000).toISOString(),
+    status: 'failed',
+    migration_count: 3,
+    failed_at: new Date(NOW - 20 * 86400_000).toISOString(),
+    ...overrides,
+  };
+}
+
+// Recovery gate ------------------------------------------------------------
+
+describe('Recovery gate — failed snapshot', () => {
+  it('PAUSED when no recoveryDelta supplied', () => {
+    const snap = failedSnapshot();
+    const v = resolveVerdict(snap, { correct: 0, hallucinated: 0 }, NOW, {});
+    expect(v.status).toBe('failed');
+    expect(v.shouldUpdate).toBe(false);
+    expect(v.newSnapshotFields).toBeUndefined();
+  });
+
+  it('failed with NO failed_at → stamps failed_at, stays failed', () => {
+    const snap = failedSnapshot({ failed_at: undefined });
+    const v = resolveVerdict(
+      snap,
+      { correct: 0, hallucinated: 0 },
+      NOW,
+      { recoveryDelta: { correct: 80, hallucinated: 0 } }, // would otherwise confirm
+    );
+    expect(v.status).toBe('failed');
+    expect(v.shouldUpdate).toBe(true);
+    expect(v.newSnapshotFields?.status).toBe('failed');
+    expect(v.newSnapshotFields?.failed_at).toBe(new Date(NOW).toISOString());
+    // No strike progress yet — clock just started.
+    expect(v.newSnapshotFields?.recovery_strikes).toBeUndefined();
+  });
+
+  it('window not full (< 80 fresh signals) stays failed without writeback', () => {
+    const snap = failedSnapshot();
+    const v = resolveVerdict(
+      snap,
+      { correct: 0, hallucinated: 0 },
+      NOW,
+      { recoveryDelta: { correct: 50, hallucinated: 10 } }, // 60 < 80
+    );
+    expect(v.status).toBe('failed');
+    expect(v.shouldUpdate).toBe(false);
+  });
+
+  it('sparse window below floor stays failed (no confirmation)', () => {
+    const snap = failedSnapshot({ recovery_strikes: 0 });
+    // 80 signals at 60% — below the 0.75 floor; Wilson lower bound < 0.75.
+    const v = resolveVerdict(
+      snap,
+      { correct: 0, hallucinated: 0 },
+      NOW,
+      { recoveryDelta: { correct: 48, hallucinated: 32 } },
+    );
+    expect(v.status).toBe('failed');
+    expect(v.shouldUpdate).toBe(false);
+  });
+
+  it('K=2: first confirming window stays failed, increments recovery_strikes', () => {
+    const snap = failedSnapshot({ recovery_strikes: 0 });
+    // 80 signals at 100% — well above the 0.75 floor; Wilson lower bound > 0.75.
+    const v = resolveVerdict(
+      snap,
+      { correct: 0, hallucinated: 0 },
+      NOW,
+      { recoveryDelta: { correct: 80, hallucinated: 0 } },
+    );
+    expect(v.status).toBe('failed');
+    expect(v.shouldUpdate).toBe(true);
+    expect(v.newSnapshotFields?.status).toBe('failed');
+    expect(v.newSnapshotFields?.recovery_strikes).toBe(1);
+    expect(v.newSnapshotFields?.recovery_strike_at).toBe(new Date(NOW).toISOString());
+  });
+
+  it(`K=${DRIFT_DEMOTE_STRIKES}: second confirming window → pending, clears recovery fields`, () => {
+    const snap = failedSnapshot({
+      recovery_strikes: 1,
+      recovery_strike_at: new Date(NOW - 60 * 60_000).toISOString(),
+    });
+    const v = resolveVerdict(
+      snap,
+      { correct: 0, hallucinated: 0 },
+      NOW,
+      { recoveryDelta: { correct: 80, hallucinated: 0 } },
+    );
+    expect(v.status).toBe('pending');
+    expect(v.shouldUpdate).toBe(true);
+    expect(v.newSnapshotFields?.status).toBe('pending');
+    expect(v.newSnapshotFields?.recovered_at).toBe(new Date(NOW).toISOString());
+    expect(v.newSnapshotFields?.failed_at).toBeUndefined();
+    expect(v.newSnapshotFields?.recovery_strikes).toBe(0);
+    expect(v.newSnapshotFields?.recovery_strike_at).toBeUndefined();
+    expect(v.newSnapshotFields?.verdict_method).toBeUndefined();
+  });
+
+  it('confirming-then-NON-confirming → recovery_strikes reset to 0', () => {
+    const snap = failedSnapshot({
+      recovery_strikes: 1,
+      recovery_strike_at: new Date(NOW - 60 * 60_000).toISOString(),
+    });
+    // 80 signals at 50% — below floor; Wilson lower bound < 0.75 → not confirming.
+    const v = resolveVerdict(
+      snap,
+      { correct: 0, hallucinated: 0 },
+      NOW,
+      { recoveryDelta: { correct: 40, hallucinated: 40 } },
+    );
+    expect(v.status).toBe('failed');
+    expect(v.shouldUpdate).toBe(true);
+    expect(v.newSnapshotFields?.status).toBe('failed');
+    expect(v.newSnapshotFields?.recovery_strikes).toBe(0);
+    expect(v.newSnapshotFields?.recovery_strike_at).toBeUndefined();
+  });
+
+  it('non-confirming window with no prior strike → no writeback (steady state)', () => {
+    const snap = failedSnapshot({ recovery_strikes: 0 });
+    const v = resolveVerdict(
+      snap,
+      { correct: 0, hallucinated: 0 },
+      NOW,
+      { recoveryDelta: { correct: 40, hallucinated: 40 } }, // 50% below floor
+    );
+    expect(v.status).toBe('failed');
+    expect(v.shouldUpdate).toBe(false);
+  });
+
+  it('two consecutive confirming windows (independent anchors) → pending', () => {
+    // Strike-1: confirming window since failed_at.
+    const snap = failedSnapshot({ recovery_strikes: 0 });
+    const v1 = resolveVerdict(
+      snap,
+      { correct: 0, hallucinated: 0 },
+      NOW,
+      { recoveryDelta: { correct: 78, hallucinated: 2 } }, // ~97.5%, confirms
+    );
+    expect(v1.newSnapshotFields?.recovery_strikes).toBe(1);
+    expect(v1.newSnapshotFields?.recovery_strike_at).toBe(new Date(NOW).toISOString());
+
+    // Strike-2: fresh window anchored at recovery_strike_at (independent).
+    const snap2 = failedSnapshot({
+      recovery_strikes: 1,
+      recovery_strike_at: v1.newSnapshotFields!.recovery_strike_at as string,
+    });
+    const v2 = resolveVerdict(
+      snap2,
+      { correct: 0, hallucinated: 0 },
+      NOW + 80 * 60_000,
+      { recoveryDelta: { correct: 78, hallucinated: 2 } }, // fresh 80, confirms
+    );
+    expect(v2.status).toBe('pending');
+    expect(v2.newSnapshotFields?.recovered_at).toBeDefined();
+    expect(v2.newSnapshotFields?.failed_at).toBeUndefined();
+    expect(v2.newSnapshotFields?.recovery_strike_at).toBeUndefined();
+  });
+});
+
+// Regression — drift gate unaffected, fresh failing skill still graduates path
+// -------------------------------------------------------------------------
+
+describe('Recovery gate — regression guards', () => {
+  it('passed skill still drifts (resolvePassedDrift unaffected)', () => {
+    const passedSnap: SkillSnapshot = {
+      baseline_accuracy_correct: 70,
+      baseline_accuracy_hallucinated: 30,
+      bound_at: new Date(NOW - 30 * 86400_000).toISOString(),
+      status: 'passed',
+      migration_count: 3,
+      passed_at: new Date(NOW - 10 * 86400_000).toISOString(),
+      passed_baseline_rate: 0.85,
+      drift_strikes: 1,
+    };
+    const v = resolveVerdict(
+      passedSnap,
+      { correct: 0, hallucinated: 0 },
+      NOW,
+      { driftDelta: { correct: 40, hallucinated: 40 } }, // 50% fails vs 0.85
+    );
+    expect(v.status).toBe('inconclusive');
+    expect(v.newSnapshotFields?.regressed_from_passed_at).toBeDefined();
+  });
+
+  it('fresh pending skill below MIN_EVIDENCE still returns pending', () => {
+    const pendingSnap: SkillSnapshot = {
+      baseline_accuracy_correct: 70,
+      baseline_accuracy_hallucinated: 30,
+      bound_at: new Date(NOW - 1 * 86400_000).toISOString(),
+      status: 'pending',
+      migration_count: 0,
+    };
+    const v = resolveVerdict(
+      pendingSnap,
+      { correct: 30, hallucinated: 10 }, // 40 < 80
+      NOW,
+    );
+    expect(v.status).toBe('pending');
+    expect(v.shouldUpdate).toBe(false);
+  });
+
+  it('re-failing after a prior recovery clears stale recovered_at and re-stamps failed_at', () => {
+    // A skill that previously recovered (failed→pending) carries a recovered_at
+    // stamp. If it now fails again, the new failed snapshot must start a fresh
+    // recovery clock (failed_at) and NOT carry the stale recovered_at forward.
+    const reFailingSnap: SkillSnapshot = {
+      baseline_accuracy_correct: 70,
+      baseline_accuracy_hallucinated: 30,
+      bound_at: new Date(NOW - 30 * 86400_000).toISOString(),
+      status: 'pending',
+      migration_count: 3,
+      recovered_at: new Date(NOW - 5 * 86400_000).toISOString(),
+    };
+    const v = resolveVerdict(
+      reFailingSnap,
+      { correct: 20, hallucinated: 60 }, // 25% over 80 samples → Wilson failed
+      NOW,
+    );
+    expect(v.status).toBe('failed');
+    expect(v.newSnapshotFields?.failed_at).toBeDefined();
+    // Stale recovered_at must be cleared on re-fail (write-only diagnostic).
+    expect(v.newSnapshotFields).toHaveProperty('recovered_at', undefined);
+  });
+});


### PR DESCRIPTION
## What

Closes #572. Adds a **recovery re-test** for skills that reached terminal `failed` status — the symmetric inverse of the existing `resolvePassedDrift` gate. Until now, a `failed` skill was suppressed from injection forever (skill-loader.ts:228) with no path back, even after the agent's accuracy in that category recovered.

A failed skill is now re-tested every `N=80` fresh signals since `failed_at`. **Two consecutive** Wilson lower-bound confirmations above `RECOVERY_FLOOR=0.75` (K=2) lift suppression by transitioning `failed → pending` (not `passed` — the skill must re-earn graduation through the normal `MIN_EVIDENCE=80` path).

## How

- **`check-effectiveness.ts`** — `resolveFailedRecovery` (exact structural mirror of `resolvePassedDrift`), `wilsonLowerBoundConfirmsAbove` (symmetric inverse of `wilsonLowerBoundFailsAgainst`, same `WILSON_SCHEDULE['sparse-current']` α; CI test `postCI.lower > floor` vs drift's `postCI.upper < baseline`), `RECOVERY_FLOOR`, new `SkillSnapshot` fields (`failed_at`/`recovery_strikes`/`recovery_strike_at`/`recovered_at`), `:251` wiring, `failed_at` stamps at both fail branches.
- **`skill-engine.ts`** — frontmatter parse of the new fields + `recoveryDelta` anchoring: `failed_at`, then `recovery_strike_at` after strike 1 so the two K=2 windows are **disjoint** (→ α² false-promote rate, matching drift). Gated on `status==='failed'` (zero hot-path cost otherwise).
- **`recovered_at`** is cleared on re-fail (previously left stale; write-only diagnostic field, no logic reads it).

## Statistical contract

Recovery and drift operate on **disjoint signal populations** (recovery anchors `failed_at`/`recovery_strike_at`; drift anchors `passed_at`/`drift_strike_at`). A skill is never simultaneously `failed` and `passed`, so the two gates spend their α budgets on non-overlapping populations — no leakage. K=2 independent windows → α²≈0.000625 false-promote.

## Review

Consensus `ed784c4e-3cd246f1` (sonnet-reviewer native + deepseek-challenger relay) + opus out-of-band edge-case pass. **Zero correctness bugs.** deepseek's CRITICAL "recovery structurally unreachable" claim was **refuted** (−1): signal category is derived from finding *text* (`extractCategories` at consensus-engine.ts:1121, `resolveSignalCategory`/`inferCategory`), **not** from injected skills — so a suppressed skill's agent keeps accumulating category-tagged signals every round and the recovery window fills normally. Confirmed by sonnet cross-review (confidence 5) and direct code read of `getCountersSince` (performance-reader.ts:659-680).

### Deferred follow-ups (legitimate, non-blocking)
- **Coverage (MEDIUM):** no integration test drives the `skill-engine.ts:997` anchor-switch through `SkillEngine`/`getCountersSince` (the 11→12 unit tests inject `recoveryDelta` pre-computed). A regression at `:997` would slip past them.
- **Observability (LOW):** findings whose text uses non-canonical vocabulary get `category: undefined` and are excluded from `getCountersSince` — a narrow under-count of the recovery window (pre-existing category-inference characteristic, not a deadlock).

## Gates
- `tsc --noEmit -p packages/orchestrator/tsconfig.json` → exit 0
- `jest tests/orchestrator` → 167 suites, 2444 passed, 20 skipped
- `npm run build:mcp` → exit 0

consensus-id: ed784c4e-3cd246f1

🤖 Generated with [Claude Code](https://claude.com/claude-code)