### PR TITLE
fix(consensus): robust finding-id rewrite + resolver NEW-id reachability (#568/#569 v2 LOWs)

### DIFF
--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -3050,12 +3050,20 @@ Return only valid JSON.${skillsBlock}`;
     for (const signal of report.signals) {
       signal.consensusId = consensusId;
     }
-    // Also update finding IDs to use the provided consensusId
-    const allFindings = [...report.confirmed, ...report.disputed, ...report.unverified, ...report.unique, ...(report.insights || [])];
-    for (const f of allFindings) {
-      if (f.id) {
-        const suffix = f.id.split(':').pop() || f.id;
-        f.id = `${consensusId}:${suffix}`;
+    // Also update finding IDs to use the provided consensusId. Guard on a real
+    // prefix mismatch (mirrors the summary rewrite below): synthesize() is now
+    // called with the external consensusId, so finding ids already carry it and
+    // this loop is a no-op in the common path. When a mismatch does exist,
+    // replace ONLY the consensusId prefix — the previous `split(':').pop()`
+    // kept just the final segment, which silently dropped the agentId from a
+    // 3-part `<cid>:<agent>:fN` id and corrupted the finding_id.
+    if (internalConsensusId && internalConsensusId !== consensusId) {
+      const allFindings = [...report.confirmed, ...report.disputed, ...report.unverified, ...report.unique, ...(report.insights || [])];
+      const internalPrefix = `${internalConsensusId}:`;
+      for (const f of allFindings) {
+        if (f.id && f.id.startsWith(internalPrefix)) {
+          f.id = `${consensusId}:${f.id.slice(internalPrefix.length)}`;
+        }
       }
     }
 

--- a/packages/orchestrator/src/finding-resolver.ts
+++ b/packages/orchestrator/src/finding-resolver.ts
@@ -200,9 +200,23 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
     // risk treating an insight as a bug-fix.
     if (entry.type === undefined || entry.type === null) {
       const taskId = String(entry.taskId ?? entry.findingId ?? '');
-      const colonIdx = taskId.lastIndexOf(':f');
-      if (colonIdx > 0) {
-        const consensusId = taskId.slice(0, colonIdx);
+      // `<cid>:f<N>` ids derive the consensusId from the `:f` suffix. NEW-format
+      // ids (`<cid>:new:<agent>:<n>`) have no `:f` segment, so derive the
+      // consensusId from the `:new:` separator instead — otherwise the report
+      // lookup (whose findFindingInReport scans the `newFindings` bucket) is
+      // unreachable for them and a NEW *insight* in a legacy row would fall to
+      // the tentative-'finding' backfill below and risk being auto-resolved as
+      // a bug-fix.
+      // Index-search direction is deliberately asymmetric: `:f` is a terminal
+      // suffix (`:fN`), so lastIndexOf is safest against a stray `:f` inside an
+      // agent name; `:new:` is an INTERIOR separator whose FIRST occurrence is
+      // the protocol boundary, so indexOf is correct — lastIndexOf would
+      // misparse an agent literally named `new` (`<cid>:new:new:<n>` → `<cid>:new`).
+      const fIdx = taskId.lastIndexOf(':f');
+      const newIdx = taskId.indexOf(':new:');
+      const consensusId =
+        fIdx > 0 ? taskId.slice(0, fIdx) : newIdx > 0 ? taskId.slice(0, newIdx) : null;
+      if (consensusId) {
         let report: any | null;
         if (consensusReportCache.has(consensusId)) {
           report = consensusReportCache.get(consensusId) ?? null;

--- a/tests/orchestrator/finding-resolver.test.ts
+++ b/tests/orchestrator/finding-resolver.test.ts
@@ -555,6 +555,59 @@ describe('finding-resolver — resolveFindings', () => {
     expect(findings[0].status).toBe('open');
   });
 
+  test('NEW-format id (<cid>:new:<agent>:<n>) without `type`, report shows insight → skip', async () => {
+    // Regression for fable f2 (consensus 79af065f): NEW-format ids have no `:f`
+    // segment, so deriving the consensusId via lastIndexOf(':f') failed and the
+    // row fell to the tentative-'finding' backfill — wrongly auto-resolving a
+    // NEW *insight*. The `:new:` separator must derive the consensusId so the
+    // report lookup (newFindings bucket) reaches the real `insight` type.
+    const { root } = setupGitFixture();
+    fs.mkdirSync(path.join(root, '.gossip', 'consensus-reports'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, '.gossip', 'consensus-reports', 'eeee5555-ffff6666.json'),
+      JSON.stringify({
+        id: 'eeee5555-ffff6666',
+        newFindings: [
+          { findingId: 'eeee5555-ffff6666:new:gemini-reviewer:1', findingType: 'insight', finding: 'x' },
+        ],
+      }),
+    );
+    writeFinding(root, {
+      taskId: 'eeee5555-ffff6666:new:gemini-reviewer:1',
+      finding: 'Note: `Math.min` no longer used <cite tag="file">src/foo.ts:1</cite>',
+      tag: 'unique',
+      // no `type` — must backfill from the newFindings bucket, NOT the legacy path
+      status: 'open',
+    });
+    const result = await resolveFindings(root, { full: true });
+    if (!result.ok) throw new Error();
+    expect(result.resolved).toBe(0);
+    expect(readFindings(root)[0].status).toBe('open');
+  });
+
+  test('NEW-format id without `type`, report shows finding → resolves', async () => {
+    const { root } = setupGitFixture();
+    fs.mkdirSync(path.join(root, '.gossip', 'consensus-reports'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, '.gossip', 'consensus-reports', 'dddd7777-eeee8888.json'),
+      JSON.stringify({
+        id: 'dddd7777-eeee8888',
+        newFindings: [
+          { findingId: 'dddd7777-eeee8888:new:sonnet-reviewer:2', findingType: 'finding', finding: 'x' },
+        ],
+      }),
+    );
+    writeFinding(root, {
+      taskId: 'dddd7777-eeee8888:new:sonnet-reviewer:2',
+      finding: 'Bad `Math.min` <cite tag="file">src/foo.ts:1</cite>',
+      tag: 'unique',
+      status: 'open',
+    });
+    const result = await resolveFindings(root, { full: true });
+    if (!result.ok) throw new Error();
+    expect(result.resolved).toBe(1);
+  });
+
   test('PR-299 Bug A: row without `type`, no consensus report → conservative skip', async () => {
     const { root } = setupGitFixture();
     writeFinding(root, {


### PR DESCRIPTION
## What

Two LOW follow-ups deferred from consensus `79af065f` (fable f1/f2) on the #568/#569 newFindings findingId work.

### f1 — finding-id rewrite robustness (consensus-engine.ts `synthesizeWithCrossReview`)
The post-hoc finding-id rewrite used `f.id.split(':').pop()`, keeping only the last `:`-segment. Since `synthesize()` is now called with the external consensusId (the #568 f15 fix), finding ids already carry it and the loop is a **no-op today** — but `pop()` would silently strip the agentId from a 3-part `<cid>:<agent>:fN` id if the id scheme ever changed. Now **guarded on a real prefix mismatch** (mirrors the summary rewrite right below it) and does **prefix-replacement**, preserving any middle segments. Behavior-identical in the common path; robust against the latent corruption.

### f2 — resolver NEW-id reachability (finding-resolver.ts type-backfill)
NEW-format ids `<cid>:new:<agent>:<n>` have no `:f` segment, so deriving the consensusId via `lastIndexOf(':f')` failed and the row fell to the tentative-`'finding'` legacy backfill — **wrongly auto-resolving a NEW *insight* as a bug-fix**. Now derives the consensusId from the `:new:` separator so the report lookup (`findFindingInReport`'s `newFindings` bucket, matched by `findingId`) is reachable and the real insight/finding type is honoured.

`indexOf` (first match) is correct for the interior `:new:` boundary — a comment documents why it's intentionally asymmetric with `lastIndexOf(':f')` (a terminal suffix).

## Tests
Two NEW-id resolver cases: `insight→skip` and `finding→resolves`. The `insight→skip` case is **mutation-verified** — breaking the `:new:` separator turns it red (the insight wrongly resolves), confirming it guards the regression.

## Review
Consensus `aae29ca0-4030493d` (sonnet-reviewer + deepseek-challenger): **both fixes confirmed correct, 0 disputed.** deepseek adversarially challenged every attack vector and refuted them all. Its one suggestion — swap `indexOf(':new:')` → `lastIndexOf(':new:')` "for symmetry" — was **rejected**: it breaks for an agent literally named `new` (`<cid>:new:new:<n>` → `<cid>:new`). The documentation half of the suggestion was adopted (the asymmetry comment).

One pre-existing MEDIUM noted (not introduced here): consensus reports written before the findingId-stamping PR lack `findingId` on `newFindings` entries, so they fall to the exact-prose Pass-2 fallback in `findFindingInReport` — and crucially this fix degrades **safely** there (null → conservative skip, vs the old wrongly-resolve).

## Gates
- `tsc --noEmit -p packages/orchestrator/tsconfig.json` → exit 0
- `jest tests/orchestrator` → 168 suites, 2449 passed, 20 skipped
- `npm run build:mcp` → exit 0

consensus-id: aae29ca0-4030493d

🤖 Generated with [Claude Code](https://claude.com/claude-code)