### PR TITLE
fix(resolver): wire resolverLineAnchored + ENOENT resolution + skip-reason observability

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -62,6 +62,14 @@ export interface GossipConfig {
      * git-common-dir + worktree-list gates, never the other security gates.
      */
     siblingRoots?: string[];
+    /**
+     * Enable the line-anchored staleness heuristic in the findings resolver.
+     * When true, a finding whose cited identifier is still present in the file
+     * but NOT at the cited line (present_elsewhere) is auto-resolved as
+     * `stale_anchor`. Default false (opt-in) per the rollout plan — do NOT
+     * flip to true until the false-resolve safety brake is implemented.
+     */
+    resolverLineAnchored?: boolean;
   };
   agents?: Record<string, {
     provider: string;
@@ -190,6 +198,12 @@ export function validateConfig(raw: any): GossipConfig {
       typeof raw.consensus.worktreeAutoRevert !== 'boolean'
     ) {
       throw new Error('Config "consensus.worktreeAutoRevert" must be a boolean');
+    }
+    if (
+      raw.consensus.resolverLineAnchored !== undefined &&
+      typeof raw.consensus.resolverLineAnchored !== 'boolean'
+    ) {
+      throw new Error('Config "consensus.resolverLineAnchored" must be a boolean');
     }
     if (raw.consensus.orchestratorOwnedGlobs !== undefined) {
       const globs = raw.consensus.orchestratorOwnedGlobs;

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -1133,7 +1133,7 @@ export async function handleCollect(
       const autoResolveEnabled = cfgPathAr?.consensus?.autoResolveOnRoundClose !== false;
       if (autoResolveEnabled) {
         const { resolveFindings: rf } = await import('@gossip/orchestrator');
-        const resolveResult = await rf(process.cwd());
+        const resolveResult = await rf(process.cwd(), { lineAnchored: cfgPathAr?.consensus?.resolverLineAnchored ?? false });
         if (resolveResult.ok) {
           if (resolveResult.resolved > 0) {
             process.stderr.write(

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -3879,7 +3879,8 @@ export function createMcpServer(): McpServer {
       await boot();
       try {
         const { resolveFindings } = await import('@gossip/orchestrator');
-        const result = await resolveFindings(process.cwd(), { full, sinceSha });
+        const cfg = (() => { try { const { findConfigPath, loadConfig } = require('./config'); const p = findConfigPath(process.cwd()); return p ? loadConfig(p) : null; } catch { return null; } })();
+        const result = await resolveFindings(process.cwd(), { full, sinceSha, lineAnchored: cfg?.consensus?.resolverLineAnchored ?? false });
         if (!result.ok) {
           return { content: [{ type: 'text' as const, text: `Resolver skipped: ${result.reason} (another resolver run in progress; try again in a moment).` }] };
         }
@@ -3895,6 +3896,16 @@ export function createMcpServer(): McpServer {
         }
         lines.push(`  head_sha: ${result.headSha ?? '(none)'}`);
         lines.push(`  watermark_advanced: ${result.watermarkAdvanced}`);
+        // Diagnostic: surface non-zero skip-reason counts. `lineAnchoredOff` is
+        // the headline explanation for a resolved:0 run when the line-anchored
+        // staleness heuristic is disabled (consensus.resolverLineAnchored).
+        const nonZeroSkips = Object.entries(result.skipReasons ?? {}).filter(([, n]) => n > 0);
+        if (nonZeroSkips.length > 0) {
+          lines.push(`  skipped: ${nonZeroSkips.map(([k, n]) => `${k}=${n}`).join(', ')}`);
+          if ((result.skipReasons?.lineAnchoredOff ?? 0) > 0) {
+            lines.push(`  (lineAnchoredOff: enable consensus.resolverLineAnchored to resolve present-elsewhere findings as stale_anchor)`);
+          }
+        }
         return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
       } catch (err) {
         return { content: [{ type: 'text' as const, text: `Failed to run resolver: ${(err as Error).message}` }] };

--- a/packages/orchestrator/src/finding-resolver.ts
+++ b/packages/orchestrator/src/finding-resolver.ts
@@ -94,6 +94,16 @@ export interface ResolveResult {
    * `'lock_contended'` when the lock could not be acquired in time.
    */
   watermarkAdvanced: boolean;
+  /**
+   * Per-reason counts of open findings that were scanned but NOT resolved,
+   * keyed by the `continue` site that skipped them. Always an object (callers
+   * can read it unconditionally). The diagnostic-critical key is
+   * `lineAnchoredOff`: findings that would resolve as `stale_anchor` but are
+   * held open because `opts.lineAnchored` is false — this is what explains a
+   * `resolved: 0` run when the line-anchored heuristic is disabled. Other
+   * keys: `noCite`, `notTouched`, `readError`, `insight`, `pathRejected`.
+   */
+  skipReasons?: Record<string, number>;
 }
 
 export interface ResolveSkipped {
@@ -178,6 +188,21 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
   let resolvedCount = 0;
   let pathRejections = 0;
   const resolvedFindingIds: string[] = [];
+  // Per-`continue`-site diagnostic counters (spec: observability). Initialized
+  // to a stable key set so the shape is predictable; `lineAnchoredOff` is the
+  // headline diagnostic for resolved:0 runs with the heuristic disabled.
+  const skipReasons: Record<string, number> = {
+    noCite: 0,
+    notTouched: 0,
+    lineAnchoredOff: 0,
+    readError: 0,
+    insight: 0,
+    pathRejected: 0,
+    // An absent cite (deleted file or absent_everywhere symbol) that would
+    // resolve on its own but is held open by a present sibling cite under the
+    // multi-cite strict-AND. Diagnoses "deleted file + still-alive cite → open".
+    absentBlockedBySibling: 0,
+  };
 
   // Per-consensus-report cache for backfill lookups. Loading the same JSON
   // file once per row would be wasteful when 20+ findings share a round.
@@ -247,14 +272,14 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
         entry._legacyBackfill = true; // auditable in audit-log
       }
     }
-    if (entry.type === 'insight') continue;
+    if (entry.type === 'insight') { skipReasons.insight++; continue; }
     // tag === 'unverified' is still resolvable when its cited symbol is gone;
     // tag-level filtering is the cross-review verdict, not the bug-vs-insight
     // axis. Spec §Heuristic safety #3.
 
     const findingText = String(entry.finding ?? '');
     const cites = parseCites(findingText);
-    if (cites.fileCites.length === 0) continue; // no anchor, nothing to check
+    if (cites.fileCites.length === 0) { skipReasons.noCite++; continue; } // no anchor, nothing to check
 
     // Bucket B — skip findings citing auto-memory paths (not source code).
     // These are ~/.claude/projects/<encoded-cwd>/memory/ files. They are
@@ -304,7 +329,7 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
       }
       safeFileCites.push({ ...fc, absPath: validation.absPath });
     }
-    if (rejected) continue;
+    if (rejected) { skipReasons.pathRejected++; continue; }
 
     // multi-cite AND: every cite must be in the touched set (Path A).
     // Bug 2: use realpath of gitRoot (not projectRoot) as the base for
@@ -321,7 +346,7 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
           break;
         }
       }
-      if (!touchedAll) continue;
+      if (!touchedAll) { skipReasons.notTouched++; continue; }
     }
 
     // file-scoped symbol-presence check, AND across all cites
@@ -335,7 +360,7 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
       const inferred = inferLeadIdentifier(findingText);
       if (inferred) symbolsToCheck.add(inferred);
     }
-    if (symbolsToCheck.size === 0) continue;
+    if (symbolsToCheck.size === 0) { skipReasons.noCite++; continue; }
 
     // Three-state classification per (cite, symbol) pair.
     // Spec §Heuristic — three-state evaluation. We aggregate at the
@@ -348,10 +373,63 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
     let sawPresentAtAnchor = false;
     let sawCiteWithoutLine = false;
     let readFailure = false;
+    let readErrorCode = '';
     for (const fc of safeFileCites) {
       let body: string;
-      try { body = fs.readFileSync(fc.absPath, 'utf8'); }
-      catch { readFailure = true; break; }
+      try {
+        body = fs.readFileSync(fc.absPath, 'utf8');
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'ENOENT') {
+          // A read miss is treated as "the cited code is definitively gone"
+          // (→ absent_everywhere → commit:<sha>, flag-independent) ONLY for a
+          // GENUINE DELETION. Two guards separate a real deletion from a
+          // false-positive (consensus da8f1aa1 f2 — without these, a `full`
+          // run bypasses the touched-set gate and a never-tracked citation
+          // would false-resolve):
+          //   1. lstat must ALSO fail — if the path entry still exists (a
+          //      dangling symlink whose target is gone), it is not a deletion.
+          //   2. git must show the path was once tracked — a never-tracked
+          //      citation (typo, fabricated, sibling-repo path) is not a
+          //      deletion. A genuine deletion appears in `git log -- <path>`.
+          let entryGone = false;
+          try { fs.lstatSync(fc.absPath); } catch { entryGone = true; }
+          // A deleted file can't be realpath'd, so fc.absPath keeps its
+          // pre-symlink-resolution form (e.g. /var/... vs realGitRoot's
+          // /private/var/... on macOS). Realpath the EXISTING parent dir and
+          // rejoin the basename so the git-relative path matches realGitRoot
+          // — otherwise path.relative yields a `../`-prefixed path and the
+          // tracked check fails for genuine deletions.
+          let relForGit: string;
+          try {
+            relForGit = path.relative(
+              realGitRoot,
+              path.join(fs.realpathSync(path.dirname(fc.absPath)), path.basename(fc.absPath)),
+            );
+          } catch {
+            relForGit = path.relative(realGitRoot, fc.absPath);
+          }
+          if (entryGone && wasTrackedInGit(gitRoot, relForGit)) {
+            // Genuine deletion of a once-tracked file. Treat this cite as
+            // absent_everywhere; continue the inner loop so it feeds the
+            // strict-AND aggregate. Any present sibling cite still blocks.
+            sawAbsentEverywhere = true;
+            continue;
+          }
+          // Dangling symlink (entry still present) or a never-tracked path →
+          // cannot be called a deletion. Skip the finding with an audit entry
+          // rather than false-resolving.
+          readFailure = true;
+          readErrorCode = entryGone ? 'ENOENT_UNTRACKED' : 'ENOENT_DANGLING';
+          break;
+        }
+        // Present-but-unreadable (EPERM/EISDIR/etc.) cannot be classified →
+        // keep skipping the whole finding, but record an audit entry so the
+        // skip is not silent.
+        readFailure = true;
+        readErrorCode = code ?? 'unknown';
+        break;
+      }
       const stripped = stripJsTsComments(body);
       for (const sym of symbolsToCheck) {
         const presence = classifyPresence(
@@ -374,7 +452,22 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
         }
       }
     }
-    if (readFailure) continue;
+    if (readFailure) {
+      // Present-but-unreadable cite → auditable skip (mirrors the
+      // skipAsMemory / path_validation_rejected audit-call pattern above).
+      try {
+        appendChainedEntry(projectRoot, {
+          ts: new Date().toISOString(),
+          finding_id: String(entry.taskId ?? entry.findingId ?? ''),
+          action: 'skipped',
+          after_check: 'read_error',
+          operator: 'auto',
+          reason: `cited file unreadable (errno ${readErrorCode})`,
+        });
+      } catch { /* best-effort */ }
+      skipReasons.readError++;
+      continue;
+    }
 
     // Aggregate per spec §Heuristic decision matrix.
     const allAbsentEverywhere =
@@ -393,6 +486,17 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
     if (!allAbsentEverywhere && !(opts.lineAnchored && allPresentElsewhere)) {
       // Mixed state, any present_at_anchor, any cite without line, or
       // line-anchored heuristic disabled → leave open.
+      // Diagnostic: a finding that WOULD resolve as stale_anchor but is held
+      // open purely because opts.lineAnchored is false. This is the headline
+      // explanation for a `resolved: 0` run — surface it distinctly.
+      if (!allAbsentEverywhere && allPresentElsewhere && !opts.lineAnchored) {
+        skipReasons.lineAnchoredOff++;
+      }
+      // Diagnostic: an absent cite (deleted file / absent_everywhere symbol)
+      // held open because a sibling cite is still present (strict-AND block).
+      if (sawAbsentEverywhere && (sawPresentElsewhere || sawPresentAtAnchor)) {
+        skipReasons.absentBlockedBySibling++;
+      }
       continue;
     }
 
@@ -499,6 +603,7 @@ function runUnderLock(projectRoot: string, opts: ResolveOptions): ResolveResult 
     pathRejections,
     headSha,
     watermarkAdvanced,
+    skipReasons,
   };
 }
 
@@ -873,6 +978,26 @@ function findFindingInReport(report: any, taskId: string, findingProse: unknown)
 }
 
 // ─── git helpers ──────────────────────────────────────────────────────────
+
+/**
+ * True if `relPath` (relative to gitRoot) was ever tracked in git history —
+ * i.e. `git log -- <path>` returns at least one commit. Used to distinguish a
+ * GENUINE DELETION (tracked-then-removed → safe to treat a missing file as
+ * absent_everywhere) from a never-tracked citation path (typo / fabricated /
+ * sibling-repo), which must NOT auto-resolve. Fail-closed: any error or an
+ * escaping relPath returns false (do not resolve on uncertainty).
+ */
+function wasTrackedInGit(gitRoot: string, relPath: string): boolean {
+  if (!relPath || relPath.startsWith('..') || path.isAbsolute(relPath)) return false;
+  try {
+    const out = execFileSync('git', ['log', '--max-count=1', '--format=%H', '--', relPath], {
+      cwd: gitRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return out.length > 0;
+  } catch { return false; }
+}
 
 function readHeadSha(projectRoot: string): string | null {
   try {

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -413,3 +413,28 @@ describe('maxToolTurns config plumbing (fix/per-agent-turn-cap)', () => {
     expect(configToAgentConfigs(cfg).find(a => a.id === 'x')?.maxToolTurns).toBeUndefined();
   });
 });
+
+describe('consensus.resolverLineAnchored validation', () => {
+  it('accepts a boolean value', () => {
+    const cfg = validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      consensus: { resolverLineAnchored: true },
+    });
+    expect(cfg.consensus?.resolverLineAnchored).toBe(true);
+  });
+
+  it('accepts an omitted value (default path)', () => {
+    const cfg = validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      consensus: {},
+    });
+    expect(cfg.consensus?.resolverLineAnchored).toBeUndefined();
+  });
+
+  it('rejects a non-boolean value', () => {
+    expect(() => validateConfig({
+      main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      consensus: { resolverLineAnchored: 'yes' as any },
+    })).toThrow(/consensus\.resolverLineAnchored/);
+  });
+});

--- a/tests/orchestrator/finding-resolver-line-anchored.test.ts
+++ b/tests/orchestrator/finding-resolver-line-anchored.test.ts
@@ -336,5 +336,113 @@ describe('finding-resolver — line-anchored staleness (resolveFindings)', () =>
     // No stale_anchor audit entries either.
     const audit = readAuditEntries(root);
     expect(audit.find(e => e.resolved_by === 'stale_anchor')).toBeUndefined();
+    // Diagnostic counter: the finding was held open purely by the disabled
+    // line-anchored gate, so skipReasons.lineAnchoredOff must record it. This
+    // is the headline explanation for a resolved:0 run.
+    expect(result.skipReasons?.lineAnchoredOff).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── Case 9: deleted-file cite (ENOENT) → commit:<sha>, flag-independent ─
+  test('case 9: cited file no longer exists on disk → resolves as commit:<sha>', async () => {
+    const root = makeTempProject();
+    initGit(root);
+    const abs = path.join(root, 'src/gone.ts');
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, 'export const removeMe = () => 1;\n');
+    commit(root, 'init');
+    // Delete the file and commit the removal.
+    fs.rmSync(abs);
+    fs.writeFileSync(path.join(root, '.gossip', '_marker'), Date.now().toString());
+    const headSha = commit(root, 'delete gone.ts');
+
+    writeFinding(root, {
+      taskId: 'case9:f1',
+      finding: 'Issue in `removeMe` <cite tag="file">src/gone.ts:1</cite>',
+      tag: 'finding',
+      type: 'finding',
+      status: 'open',
+    });
+
+    // lineAnchored NOT passed — deleted-file resolution is flag-independent.
+    const result = await resolveFindings(root, { full: true });
+    if (!result.ok) throw new Error('lock contended');
+    expect(result.resolved).toBe(1);
+    const findings = readFindings(root);
+    expect(findings[0].status).toBe('resolved');
+    expect(findings[0].resolvedBy).toBe(`commit:${headSha}`);
+    // Audit entry records the absent fastpath, not stale_anchor.
+    const audit = readAuditEntries(root);
+    const resolveEntry = audit.find(e => e.action === 'resolve' && e.finding_id === 'case9:f1');
+    expect(resolveEntry).toBeDefined();
+    expect(resolveEntry.after_check).toBe('absent');
+  });
+
+  // ── Case 10: NEVER-tracked cite path (ENOENT but not a deletion) → NOT
+  //    resolved. Guards the full-mode false-resolve (consensus da8f1aa1 f2):
+  //    in full mode the touched-set gate is bypassed, so a typo'd/fabricated
+  //    citation path reaches readFileSync → ENOENT. It must NOT be treated as
+  //    a deletion because git never tracked it.
+  test('case 10: never-tracked cite path is NOT resolved (full mode)', async () => {
+    const root = makeTempProject();
+    initGit(root);
+    // Commit a real file so HEAD exists, but the cited path was NEVER tracked.
+    fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'src/real.ts'), 'export const real = 1;\n');
+    commit(root, 'init');
+
+    writeFinding(root, {
+      taskId: 'case10:f1',
+      finding: 'Issue in `neverWas` <cite tag="file">src/never-existed.ts:1</cite>',
+      tag: 'finding',
+      type: 'finding',
+      status: 'open',
+    });
+
+    const result = await resolveFindings(root, { full: true });
+    if (!result.ok) throw new Error('lock contended');
+    expect(result.resolved).toBe(0);
+    expect(readFindings(root)[0].status).toBe('open');
+    // The never-tracked ENOENT routes through the auditable read-error skip.
+    expect((result.skipReasons?.readError ?? 0)).toBeGreaterThanOrEqual(1);
+    const audit = readAuditEntries(root);
+    const skip = audit.find(e => e.action === 'skipped' && e.finding_id === 'case10:f1');
+    expect(skip).toBeDefined();
+    expect(skip.after_check).toBe('read_error');
+  });
+
+  // ── Case 11: multi-cite deleted-file (ENOENT→absent) + present sibling →
+  //    strict-AND blocks resolution (the most important safety property).
+  test('case 11: deleted cite + present sibling cite → NOT resolved', async () => {
+    const root = makeTempProject();
+    initGit(root);
+    fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+    // A tracked file that we will delete.
+    fs.writeFileSync(path.join(root, 'src/gone.ts'), 'export const removeMe = () => 1;\n');
+    // A present file whose symbol sits AT the cited line (present_at_anchor).
+    fs.writeFileSync(path.join(root, 'src/alive.ts'), buildFileWithSymbolAt(20, 'stillHere', [10]));
+    commit(root, 'init');
+    fs.rmSync(path.join(root, 'src/gone.ts'));
+    commit(root, 'delete gone.ts');
+
+    // Lead identifier is `stillHere` (the symbol checked against ALL cited
+    // files): present_at_anchor in alive.ts:10, and absent from the deleted
+    // gone.ts (which is ENOENT→absent regardless of symbol). The present
+    // sibling must block the deleted cite's absence under strict-AND.
+    writeFinding(root, {
+      taskId: 'case11:f1',
+      finding:
+        'Cross-file issue with `stillHere` <cite tag="file">src/alive.ts:10</cite> <cite tag="file">src/gone.ts:1</cite>',
+      tag: 'finding',
+      type: 'finding',
+      status: 'open',
+    });
+
+    const result = await resolveFindings(root, { full: true });
+    if (!result.ok) throw new Error('lock contended');
+    // Deleted cite sets sawAbsentEverywhere, but the present sibling sets
+    // sawPresentAtAnchor → allAbsentEverywhere is false → finding stays OPEN.
+    expect(result.resolved).toBe(0);
+    expect(readFindings(root)[0].status).toBe('open');
+    expect((result.skipReasons?.absentBlockedBySibling ?? 0)).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## What

`gossip_resolve_findings` resolved **0 findings in practice** — investigation consensus `75b99e95-30ba409d` traced it to a half-shipped feature (PR #310): the `stale_anchor` resolution path is gated behind an `opts.lineAnchored` flag that **no production caller passes**, the `consensus.resolverLineAnchored` config flag the spec intended was **never added**, deleted-file cites **silently skip**, and the 5% safety brake is an unimplemented stub. This wires the feature up (default-OFF), makes deleted files resolve safely, and makes `resolved:0` diagnosable.

## Changes

- **`config.ts`** — add `consensus.resolverLineAnchored?: boolean` + `validateConfig` boolean check. Default false (opt-in) per the spec rollout plan.
- **`mcp-server-sdk.ts` + `collect.ts`** — wire `cfg.consensus.resolverLineAnchored → opts.lineAnchored` (both `?? false`). The `stale_anchor` path (the common "code moved off the cited line" signature) is now reachable when an operator opts in.
- **`finding-resolver.ts` — ENOENT resolution, guarded.** A deleted cited file now resolves via the flag-independent `absent_everywhere → commit:<sha>` path — but **only for a genuine deletion**: the path entry must be truly gone (`lstat` fails — not a dangling symlink) **AND** git must show it was once tracked (`wasTrackedInGit`). A never-tracked / typo'd / sibling-repo citation is **not** treated as a deletion. This closes the false-resolve that fix-consensus `da8f1aa1-4c6f4716` (f2) found: in `full:true` mode the touched-set gate is bypassed, so without the guard a never-existed citation path would auto-close a finding. Non-ENOENT read errors and untracked/dangling-ENOENT skip with a chained `read_error` audit entry (no longer silent).
- **`finding-resolver.ts` — observability.** `ResolveResult.skipReasons` counters (`lineAnchoredOff`, `readError`, `absentBlockedBySibling`, …) surfaced in the MCP output so a `resolved:0` run explains itself (e.g. "all present_elsewhere, lineAnchored disabled").

## Review

- **Investigation consensus `75b99e95-30ba409d`** (sonnet + deepseek): diagnosed root cause, 0 disputed.
- **Fix consensus `da8f1aa1-4c6f4716`** (sonnet + deepseek) on the diff: implementation correct; the multi-cite strict-AND blocking, no-accidental-default-on, and audit-chain integrity all confirmed. deepseek's f2 (false-resolve) was real → hardened here with a git-tracked guard (deepseek's `existsSync` fix was rejected — it would also block legitimate deleted-file resolutions; sonnet's n1 caught this). One reviewer test-gap claim was a hallucination (Case 9 already existed) and recorded as such.

### Deferred (follow-up)
The 5% false-resolve **safety brake** (`flag_for_review` pivot) is still unimplemented — the `resolverLineAnchored` default must stay **false** until it lands. Enabling the `stale_anchor` path by default before then risks auto-closing moved-but-not-fixed findings.

## Gates
- `tsc --noEmit -p packages/orchestrator/tsconfig.json` → exit 0
- `jest tests/orchestrator` → 168 suites, 2452 passed, 20 skipped
- `npm run build:mcp` → exit 0
- Case 10 (never-tracked → not resolved) mutation-verified against the `wasTrackedInGit` guard.

consensus-id: da8f1aa1-4c6f4716

🤖 Generated with [Claude Code](https://claude.com/claude-code)