### PR TITLE
fix(skill-name): cap normalized form, not raw input (#4 cluster A — f2/f5/f6 were false-positives)

### DIFF
--- a/packages/orchestrator/src/skill-name.ts
+++ b/packages/orchestrator/src/skill-name.ts
@@ -1,10 +1,18 @@
 export function normalizeSkillName(name: string): string {
   if (!name || typeof name !== 'string') return '';
+  // NOTE on the empty-string return: a non-empty input that strips to '' (fully
+  // non-ASCII, all-separator) intentionally yields ''. Callers such as
+  // SkillIndex.bind() use `if (!name) throw 'Invalid skill name'` as a
+  // fail-closed validation gate (skill-index.ts) — so '' is the correct signal
+  // to REJECT a garbage skill name, NOT a hazard to paper over. (Resolver-pass
+  // findings 674baf54:f2/f5/f6 + 9ed8c12f:f5 mischaracterised this; only the
+  // cap-ordering below, f3/f4, was a real bug.)
   return name
-    .slice(0, 128)                    // length cap — prevents DoS via megabyte keys
+    .slice(0, 512)                    // cheap pre-slice to bound regex work on huge inputs
     .toLowerCase()
     .replace(/[_\s]+/g, '-')          // underscores/spaces → hyphens
-    .replace(/[^a-z0-9-]/g, '')       // strip non-alphanumeric
+    .replace(/[^a-z0-9-]/g, '')       // strip non-ASCII and non-alphanumeric
     .replace(/-{2,}/g, '-')           // collapse double hyphens
-    .replace(/^-+|-+$/g, '');         // strip leading/trailing hyphens
+    .replace(/^-+|-+$/g, '')          // strip leading/trailing hyphens
+    .slice(0, 128);                   // final cap on the NORMALIZED form (fix f3/f4: was applied to the raw input)
 }

--- a/tests/orchestrator/skill-name.test.ts
+++ b/tests/orchestrator/skill-name.test.ts
@@ -29,7 +29,10 @@ describe('normalizeSkillName', () => {
     expect(normalizeSkillName('too__many___underscores')).toBe('too-many-underscores');
   });
 
-  it('returns empty for all-special-character input', () => {
+  it('all-special-character input returns "" (rejected as an invalid skill name)', () => {
+    // No surviving [a-z0-9] chars → '' — SkillIndex.bind treats '' as an invalid
+    // skill name and throws (skill-index.ts). Fail-closed rejection is the intended
+    // behavior; these are not bindable skills.
     expect(normalizeSkillName('!!!')).toBe('');
     expect(normalizeSkillName('@#$%^&*')).toBe('');
     expect(normalizeSkillName('...')).toBe('');
@@ -38,6 +41,23 @@ describe('normalizeSkillName', () => {
   it('caps length at 128 characters', () => {
     const long = 'a'.repeat(500);
     expect(normalizeSkillName(long).length).toBeLessThanOrEqual(128);
+  });
+
+  it('caps length at 128 characters on a 2000-char ASCII input', () => {
+    const long = 'abc-'.repeat(500); // 2000 chars, valid ASCII
+    const result = normalizeSkillName(long);
+    expect(result.length).toBeLessThanOrEqual(128);
+  });
+
+  it('applies the 128 cap to the NORMALIZED form, not the raw input', () => {
+    // 150 raw chars with interspersed strippable '!' → 100 surviving [a-z0-9].
+    // The old slice(0,128)-first order would have capped the RAW input at 128
+    // (→ ~85 surviving); the cap now bounds the normalized output, so all 100
+    // survive. Documents the intended behavior change (finding efad8514:f1).
+    const mixed = 'ab!'.repeat(50); // 150 chars; 'ab' survives, '!' stripped
+    const result = normalizeSkillName(mixed);
+    expect(result).toBe('ab'.repeat(50)); // 100 chars, ≤ 128, none truncated
+    expect(result.length).toBeLessThanOrEqual(128);
   });
 
   it('strips leading and trailing hyphens', () => {
@@ -60,5 +80,51 @@ describe('normalizeSkillName', () => {
   it('handles path traversal attempts', () => {
     expect(normalizeSkillName('../../etc/passwd')).toBe('etcpasswd');
     expect(normalizeSkillName('../.env')).toBe('env');
+  });
+
+  // --- ASCII regression tests (byte-identical to original behavior) ---
+
+  it('trust_boundaries → trust-boundaries', () => {
+    expect(normalizeSkillName('trust_boundaries')).toBe('trust-boundaries');
+  });
+
+  it('My  Skill → my-skill (double space collapses)', () => {
+    expect(normalizeSkillName('My  Skill')).toBe('my-skill');
+  });
+
+  it('--foo-- → foo', () => {
+    expect(normalizeSkillName('--foo--')).toBe('foo');
+  });
+
+  it('a.b.c → abc (dots stripped, no hyphens)', () => {
+    expect(normalizeSkillName('a.b.c')).toBe('abc');
+  });
+
+  // --- Non-ASCII / empty-collapse tests ---
+
+  it('fully non-ASCII input returns "" (fail-closed: rejected at the bind gate)', () => {
+    // A name with no surviving [a-z0-9] chars normalizes to '' — SkillIndex.bind
+    // uses `if (!name) throw 'Invalid skill name'`, so '' is the correct signal
+    // to REJECT a garbage skill name (see skill-index.ts). Distinct non-ASCII
+    // names sharing this '' is acceptable: none of them is a bindable skill.
+    expect(normalizeSkillName('日本語')).toBe('');
+    expect(normalizeSkillName('!!!')).toBe('');
+    expect(normalizeSkillName('こんにちは')).toBe('');
+  });
+
+  it('accented latin input (résumé) keeps surviving ASCII letters and is stable', () => {
+    const first = normalizeSkillName('résumé');
+    const second = normalizeSkillName('résumé');
+    // The accented chars (é) are non-ASCII and stripped; the ASCII letters
+    // r,s,u,m survive — so this does NOT hit the hash fallback. Assert the
+    // exact surviving form so a regression that strips all Latin is caught
+    // (finding efad8514:f2). Transliteration is NOT required.
+    expect(first).toBe('rsum');
+    expect(first).toBe(second);
+  });
+
+  it('stability: same non-ASCII input → same output across calls', () => {
+    const input = '中文-skill';
+    expect(normalizeSkillName(input)).toBe(normalizeSkillName(input));
   });
 });


### PR DESCRIPTION
## What

First cluster of the #4 keep-findings backlog — and a useful negative result: **most of cluster A turned out to be false-positives.**

`normalizeSkillName` (packages/orchestrator/src/skill-name.ts):
- **f3/f4 (REAL, fixed):** `.slice(0,128)` was applied to the raw input *before* stripping. Now a cheap `.slice(0,512)` bounds regex work and the final `.slice(0,128)` applies to the **normalized** form. ASCII behavior byte-identical for inputs ≤128 chars (the only inputs that occur in practice — skill names are short category names).
- **f2/f5/f6 (FALSE POSITIVES, not changed):** the "non-ASCII names collapse to `''` → collision hazard" framing is wrong. The `''` return is a **deliberate fail-closed validation signal** — `SkillIndex.bind()` does `if (!name) throw 'Invalid skill name'` (skill-index.ts:281), so `''` correctly **rejects** a garbage/non-bindable skill name. Now documented in-code so the next reader doesn't re-file it.

## Process note (why the force-push)

An earlier revision of this PR added a `skill-<sha256:8>` fallback for stripped-to-empty inputs (the literal reading of f2/f5/f6). The consensus round approved it, but **CI caught** that it broke the `SkillIndex › rejects empty skill name` security-validation test (`bind('agent-a','!!!')` must throw — it sits alongside `__proto__`/`constructor` rejection). That confirmed f2/f5/f6 were false-positives; the fallback was reverted to the safe cap-reorder-only subset (which sonnet's review explicitly called "the intended improvement, not a regression").

## Review

Consensus `efad8514-4d774510` (sonnet-reviewer) reviewed this file and confirmed the cap-reorder is correct (all 5 targets); the shipped diff is the safe subset. deepseek's dispute (claimed only one length-cap test) was refuted + recorded as a hallucination.

## Gates
- `tsc --noEmit -p packages/orchestrator/tsconfig.json` → exit 0
- `jest tests/orchestrator` → 168 suites, 2461 passed, 20 skipped (incl. skill-index, now passing)
- `npm run build:mcp` → exit 0

consensus-id: efad8514-4d774510

🤖 Generated with [Claude Code](https://claude.com/claude-code)