### PR TITLE
fix(sandbox): kill Layer-3 boundary-escape noise — invert the rotted test-fixture gate

### DIFF
--- a/apps/cli/src/sandbox.ts
+++ b/apps/cli/src/sandbox.ts
@@ -913,122 +913,31 @@ export function buildAuditExclusions(
   // itunescloudd, TemporaryItems) fill up during a dispatch regardless of
   // agent activity. Exclude the well-known prefixes; any other file under
   // tmpdir is still flagged.
+  //
+  // `cursor-sandbox-cache` is UNCONDITIONAL (not test-gated): the Cursor
+  // editor runs during real agent dispatches and churns this dir every few
+  // seconds (1,054 live noise entries pre-fix). It is editor cache, never a
+  // boundary violation, so prune it on every dispatch — same as the OS dirs.
   try {
     const tmp = canonicalize(tmpdir());
-    for (const pat of ['com.apple.*', 'itunescloudd', 'TemporaryItems', 'node-compile-cache']) {
+    for (const pat of ['com.apple.*', 'itunescloudd', 'TemporaryItems', 'node-compile-cache', 'cursor-sandbox-cache']) {
       for (const v of expandTmpVariants(`${tmp}/${pat}`)) excl.add(v);
     }
   } catch { /* tmpdir() failure — best-effort */ }
-  // Test-fixture exclusion — only active under a real test runner.
-  // JEST_WORKER_ID is set by jest (including --runInBand). NODE_ENV=test is
-  // the universal fallback. Neither is settable by a dispatched agent —
-  // agents run in child processes launched via execFileSync / native bridge,
-  // never inside a jest runner. That makes this gate structurally unforgeable.
+  // Test-fixture noise is NO LONGER handled here via a hand-maintained
+  // allowlist. The old TEST_FIXTURE_PREFIXES list (60+ entries) rotted: every
+  // new test that mkdtemp'd a fresh prefix (jest_dx, finding-resolver-,
+  // siblingroots-, monorepo-, skill-engine-status-, …) leaked into
+  // boundary-escapes.jsonl (8,446/8,486 live entries were such tmpdir noise).
   //
-  // Noise accounting (pre-fix): 6,128 / 8,590 = 71% of entries in
-  // .gossip/boundary-escapes.jsonl came from mkdtempSync(join(tmpdir(),
-  // 'gossip-*')) fixtures during `npm test`. Prefix list enumerated by
-  // grepping `mkdtemp.*'gossip-|join\(tmpdir.*'gossip-` — do NOT collapse
-  // to a bare `gossip-*` glob (too broad even when gated).
-  if (process.env.JEST_WORKER_ID !== undefined || process.env.NODE_ENV === 'test') {
-    try {
-      const tmp = canonicalize(tmpdir());
-      const TEST_FIXTURE_PREFIXES = [
-        // Spec'd core set.
-        'gossip-test-',
-        'gossip-wt-',
-        'gossip-verify-',
-        'gossip-native-prompt-',
-        'gossip-mcp-test-',
-        'gossip-signals-val-',
-        'gossip-pipeline-test-',
-        'gossip-relay-duration-test-',
-        'gossip-hook-ns-',
-        'gossip-memory-test-',
-        'sandbox-test-',
-        'perf-writer-',
-        // Observed via grep (mkdtemp*/join(tmpdir()*) — all test-fixture-only.
-        'gossip-empty-',
-        'gossip-no-mem-',
-        'gossip-symlink-',
-        'gossip-outside-',
-        'gossip-bridge-',
-        'gossip-native-consensus-',
-        'gossip-dash-',
-        'gossip-dash-edge-',
-        'gossip-home-',
-        'gossip-consensus-',
-        'gossip-real-',
-        'gossip-skillgen-',
-        'gossip-signal-types-',
-        'gossip-profile-dispatch-',
-        'gossip-ati-integration-',
-        'gossip-skilldev-integ-',
-        'gossip-migration-',
-        'gossip-cat-hook-',
-        'gossip-hook-install-',
-        'gossip-hook-sentinel-',
-        'gossip-wt-test-',
-        'gossip-skill-tools-test-',
-        'gossip-hygiene-seed-test-',
-        'gossip-searcher-test-',
-        'gossip-registry-test-',
-        'gossip-catalog-test-',
-        'gossip-taskgraph-test-',
-        'gossip-memwriter-test-',
-        'gossip-memwriter-edge-test-',
-        'gossip-memreader-edge-test-',
-        'gossip-prefetch-test-',
-        'gossip-bootstrap-test-',
-        'gossip-bootstrap-spec-test-',
-        'gossip-skill-index-test-',
-        'gossip-gap-tracker-test-',
-        'gossip-gap-tracker-fresh-test-',
-        'gossip-gap-tracker-malformed-',
-        'gossip-gap-test-',
-        'gossip-ctx-',
-        'gossip-lru-',
-        'gossip-task-type-',
-        'gossip-cat-boost-',
-        'gossip-status-filter-',
-        'gossip-discovery-e2e-',
-        'gossip-compactor-test-',
-        'gossip-rules-test-',
-        'gossip-audit-roundtrip-',
-        'gossip-remember-validation-',
-        'gossip-skills-test-',
-        'gossip-verify-mem-',
-        'gossip-fullstack-',
-        'gossip-sim-',
-        'gossip-round-retract-',
-        // NOTE: `gossip-l3-`, `gossip-l3-scan-`, `gossip-l3-bin-` are used by
-        // the Layer-3 audit tests THEMSELVES as scan roots — excluding them
-        // would make those tests silently pass without verifying behavior.
-        // They don't appear in real-world boundary-escapes.jsonl noise; they
-        // exist only as in-test isolation directories and are rmSync'd at
-        // teardown. Intentionally omitted.
-        // Non-gossip test prefixes (scoped fixtures).
-        'scope-tracker-',
-        'scope-outside-',
-        'tg-sync-',
-        'findings-cat-',
-        'signals-dedup-',
-        'cer-',
-        'pcr-',
-        'vrr-',
-        'dgw-',
-        'skill-gen-test-',
-        'skill-eff-test-',
-        'skill-migration-test-',
-        'skill-nan-test-',
-        'skill-safename-test-',
-        'collect-eff-test-',
-      ];
-      for (const prefix of TEST_FIXTURE_PREFIXES) {
-        for (const v of expandTmpVariants(`${tmp}/${prefix}`)) excl.add(v + '*');
-      }
-    } catch { /* tmpdir() failure — best-effort */ }
-  }
+  // It is replaced by an INVERTED gate enforced as a post-scan filter
+  // (isLayer3MainNoise, applied to mainSet in auditFilesystemSinceSentinel):
+  // under a real test runner, EVERY immediate tmpdir child is treated as noise
+  // EXCEPT the gossip-l3-* scan-root keep-list the Layer-3 audit tests use.
+  // The gate stays test-only (JEST_WORKER_ID / NODE_ENV=test, neither settable
+  // by a dispatched child process), so outside a test runner real agent writes
+  // to tmpdir are STILL caught. See isLayer3MainNoise for the keep-list and the
+  // always-on Cursor + build-artifact exclusions.
   if (ownWorktree) {
     const wt = canonicalize(ownWorktree);
     for (const v of expandTmpVariants(wt)) excl.add(v);
@@ -1040,6 +949,122 @@ export function buildAuditExclusions(
     for (const v of expandTmpVariants(s)) excl.add(v);
   }
   return Array.from(excl);
+}
+
+/**
+ * Keep-list of tmpdir-child prefixes that MUST stay flagged even under the
+ * inverted test-fixture gate. These are the scan-root / bin / sentinel dirs
+ * the Layer-3 audit tests THEMSELVES create (mkTmp('gossip-l3-scan-'), etc.)
+ * and write deliberate "bypass" files into. Excluding them would make those
+ * tests silently pass without verifying recording behavior.
+ *
+ * `gossip-l3-` is a prefix of every Layer-3 scan-root/bin/sentinel dir the
+ * audit tests create (`gossip-l3-scan-`, `gossip-l3-bin-`, …), so the single
+ * prefix covers them all — the rename-survival justification for listing the
+ * siblings explicitly is void.
+ *
+ * NOTE (test authors): any NEW test that asserts a Layer-3 MAIN-pass RECORDING
+ * must create its tmpdir under a `gossip-l3-*` prefix. Otherwise the inverted
+ * test-fixture gate (Rule A) suppresses that path's violation under the test
+ * runner and the assertion passes vacuously (no recording to observe).
+ */
+const LAYER3_KEEP_TMPDIR_PREFIXES = ['gossip-l3-'];
+
+/** Build the set of canonical tmp-root prefixes (tmpdir() + /tmp + /private/tmp
+ * twins) that a violating path may sit directly under. Lexical-only. */
+function tmpRootPrefixes(): string[] {
+  const roots = new Set<string>();
+  try {
+    for (const v of expandTmpVariants(canonicalize(tmpdir()))) roots.add(v);
+  } catch { /* tmpdir() failure — best-effort */ }
+  for (const r of ['/tmp', '/private/tmp']) roots.add(r);
+  return Array.from(roots);
+}
+
+/**
+ * Return the immediate child segment of `canonPath` under any tmp root, or
+ * null if `canonPath` is not under a tmp root. e.g. under tmpdir()
+ * `/var/folders/xx/T`, the path `/var/folders/xx/T/jest_dx-AB/sub/f.txt`
+ * yields `jest_dx-AB`.
+ */
+function tmpdirChildSegment(canonPath: string, tmpRoots: string[]): string | null {
+  for (const root of tmpRoots) {
+    const prefix = root.replace(/\/+$/, '') + '/';
+    if (canonPath.startsWith(prefix)) {
+      const rest = canonPath.slice(prefix.length);
+      const slash = rest.indexOf('/');
+      return slash === -1 ? rest : rest.slice(0, slash);
+    }
+  }
+  return null;
+}
+
+/**
+ * Decide whether a Layer-3 MAIN-pass violation path is pure noise that must
+ * NOT be recorded. Applied to each canonicalized mainSet entry AFTER the find
+ * scan (the `find -prune` exclusions handle the coarse, always-known dirs; this
+ * post-filter handles the rules that `-path` globs cannot express inline).
+ *
+ * Three rules, in order:
+ *   A. INVERTED test-fixture gate (test-only). Under a real test runner, every
+ *      immediate tmpdir child is noise EXCEPT the gossip-l3-* keep-list. This
+ *      replaces the rotted 60+ TEST_FIXTURE_PREFIXES allowlist. Outside a test
+ *      runner this rule is inert — real agent writes to tmpdir stay flagged.
+ *   B. Cursor churn (always-on). A `cursor-sandbox-cache` tmpdir child is
+ *      editor cache, never a violation. (Also pruned at find time via
+ *      buildAuditExclusions; kept here as defense-in-depth for non-tmpdir
+ *      canonical forms.)
+ *   C. Build artifacts (projectRoot-anchored). A path with a `dist-mcp/` or
+ *      `dist-dashboard/` segment, or ending in `.tsbuildinfo`, is build output
+ *      — but ONLY when it lives under `opts.projectRoot`. Build artifacts only
+ *      ever appear inside the repo; tmpdir() is itself a main-pass scan root
+ *      for worktree/sequential dispatches, so an unanchored Rule C would let an
+ *      agent hide a REAL escape by writing `/tmp/dist-mcp/evil` or
+ *      `/tmp/anything.tsbuildinfo`. Fail-closed: if `projectRoot` is absent we
+ *      do NOT suppress (cannot anchor → must not drop).
+ *
+ * Matches on the canonicalized path (symlink-safe) — never raw input strings.
+ * `opts.projectRoot` MUST be canonicalized by the caller (same canonicalize()
+ * helper used elsewhere). Cursor rule applies even under a kept gossip-l3-*
+ * root; the build-artifact rule is projectRoot-scoped so it cannot fire on a
+ * tmpdir near-miss.
+ */
+export function isLayer3MainNoise(
+  canonPath: string,
+  opts: { inTestRunner?: boolean; tmpRoots?: string[]; projectRoot?: string } = {},
+): boolean {
+  // Rule C: build artifacts — segment-anchored so `dist-mcp` as a filename
+  // substring (e.g. src/dist-mcp-notes.ts) does NOT match, AND projectRoot-
+  // anchored so a tmpdir path like `/tmp/dist-mcp/evil` or `/tmp/x.tsbuildinfo`
+  // (tmpdir is a scan root) can NEVER be suppressed. Fail-closed when
+  // projectRoot is absent — an unanchored match would mask real escapes.
+  if (
+    opts.projectRoot &&
+    canonPath.startsWith(opts.projectRoot + '/') &&
+    (canonPath.includes('/dist-mcp/') ||
+      canonPath.includes('/dist-dashboard/') ||
+      canonPath.endsWith('.tsbuildinfo'))
+  ) {
+    return true;
+  }
+
+  const tmpRoots = opts.tmpRoots ?? tmpRootPrefixes();
+  const child = tmpdirChildSegment(canonPath, tmpRoots);
+
+  // Rule B: Cursor cache — always-on, gate-independent. Exact dir name (the
+  // find -prune in buildAuditExclusions already covers it; this is the exact
+  // canonical-form twin, not a prefix — no churn dir is a superstring of it).
+  if (child === 'cursor-sandbox-cache') {
+    return true;
+  }
+
+  // Rule A: inverted test-fixture gate — test-only.
+  if (opts.inTestRunner && child !== null) {
+    const isKept = LAYER3_KEEP_TMPDIR_PREFIXES.some(p => child.startsWith(p));
+    if (!isKept) return true;
+  }
+
+  return false;
 }
 
 /**
@@ -1293,6 +1318,29 @@ export function auditFilesystemSinceSentinel(
 
   // Dedup: a path in both passes goes to sensitive only (stronger signal).
   for (const p of sensitiveSet) mainSet.delete(p);
+
+  // Main-pass noise filter (allowlist-rot fix). The `find -prune` exclusions
+  // shed the coarse always-known dirs; this post-filter sheds the rules that
+  // `-path` globs cannot express inline: the inverted test-fixture gate, the
+  // always-on Cursor cache, and build artifacts. Sensitive-pass violations are
+  // NEVER filtered here — Pass 2 is a vetted watchlist with zero noise. The
+  // gate is test-only and structurally unforgeable by a dispatched child
+  // process (it cannot set JEST_WORKER_ID / NODE_ENV in the orchestrator).
+  const inTestRunner =
+    process.env.JEST_WORKER_ID !== undefined || process.env.NODE_ENV === 'test';
+  const tmpRoots = tmpRootPrefixes();
+  const canonProjectRoot = canonicalize(projectRoot);
+  for (const p of Array.from(mainSet)) {
+    // Belt-and-suspenders: never filter a sensitive-pass path here even if the
+    // dedup above is ever reordered. Pass 2 is a vetted zero-noise watchlist;
+    // the noise filter is a main-pass-only concern by construction.
+    if (
+      !sensitiveSet.has(p) &&
+      isLayer3MainNoise(p, { inTestRunner, tmpRoots, projectRoot: canonProjectRoot })
+    ) {
+      mainSet.delete(p);
+    }
+  }
 
   const mainViolations = Array.from(mainSet);
   const sensitiveViolations = Array.from(sensitiveSet);

--- a/tests/cli/sandbox.test.ts
+++ b/tests/cli/sandbox.test.ts
@@ -29,6 +29,7 @@ import {
   auditDispatchBoundary,
   DispatchMetadata,
   buildAuditExclusions,
+  isLayer3MainNoise,
   rotateIfNeeded,
   MAX_BOUNDARY_ESCAPE_BYTES,
 } from '../../apps/cli/src/sandbox';
@@ -427,21 +428,34 @@ describe('buildAuditExclusions — test-fixture gate (NODE_ENV / JEST_WORKER_ID)
     else process.env.NODE_ENV = originalNodeEnv;
   });
 
-  it('NODE_ENV=test: gossip-test- prefix IS excluded from the main-pass list', () => {
-    delete process.env.JEST_WORKER_ID;
-    process.env.NODE_ENV = 'test';
-    const excl = buildAuditExclusions(root, undefined, undefined);
-    expect(excl).toContain(`${tmp}/gossip-test-*`);
+  // The hand-maintained TEST_FIXTURE_PREFIXES allowlist was deleted (it rotted
+  // — every new test prefix leaked into boundary-escapes.jsonl). The gate is
+  // now an INVERTED post-scan filter (isLayer3MainNoise): under a test runner,
+  // every tmpdir child is noise EXCEPT the gossip-l3-* keep-list. These tests
+  // verify the new contract; buildAuditExclusions no longer carries the glob
+  // entries (see the worktree-audit-layer3-noise suite for end-to-end coverage).
+
+  it('inverted gate: a gossip-test- tmpdir child is noise under the test gate', () => {
+    const p = join(tmp, 'gossip-test-fixtureXYZ', '.gossip', 'fake.jsonl');
+    expect(isLayer3MainNoise(p, { inTestRunner: true })).toBe(true);
   });
 
-  it('JEST_WORKER_ID set: gossip-test- prefix IS excluded from the main-pass list', () => {
-    delete process.env.NODE_ENV;
-    process.env.JEST_WORKER_ID = '1';
-    const excl = buildAuditExclusions(root, undefined, undefined);
-    expect(excl).toContain(`${tmp}/gossip-test-*`);
+  it('inverted gate: a sandbox-test- / gossip-wt- tmpdir child is noise under the test gate', () => {
+    expect(isLayer3MainNoise(join(tmp, 'sandbox-test-AAA', 'f.txt'), { inTestRunner: true })).toBe(true);
+    expect(isLayer3MainNoise(join(tmp, 'gossip-wt-BBB', 'f.txt'), { inTestRunner: true })).toBe(true);
   });
 
-  it('NODE_ENV and JEST_WORKER_ID both unset: test-fixture prefixes are NOT excluded', () => {
+  it('inverted gate: the gossip-l3-* keep-list survives the gate (regression guard)', () => {
+    expect(isLayer3MainNoise(join(tmp, 'gossip-l3-scan-AAA', 'outside.txt'), { inTestRunner: true })).toBe(false);
+    expect(isLayer3MainNoise(join(tmp, 'gossip-l3-bin-BBB', 'fake-find'), { inTestRunner: true })).toBe(false);
+  });
+
+  it('gate is test-only: the SAME fixture child is NOT noise when the gate is closed', () => {
+    const p = join(tmp, 'gossip-test-fixtureXYZ', 'exfil.txt');
+    expect(isLayer3MainNoise(p, { inTestRunner: false })).toBe(false);
+  });
+
+  it('NODE_ENV and JEST_WORKER_ID both unset: test-fixture prefixes are NOT excluded by buildAuditExclusions', () => {
     delete process.env.JEST_WORKER_ID;
     delete process.env.NODE_ENV;
     const excl = buildAuditExclusions(root, undefined, undefined);
@@ -451,38 +465,17 @@ describe('buildAuditExclusions — test-fixture gate (NODE_ENV / JEST_WORKER_ID)
     expect(excl).not.toContain(`${tmp}/perf-writer-*`);
     // Non-test churn exclusions MUST still be present (baseline behavior).
     expect(excl).toContain(`${tmp}/node-compile-cache`);
+    // cursor-sandbox-cache is now an always-on prune entry (design B).
+    expect(excl).toContain(`${tmp}/cursor-sandbox-cache`);
   });
 
-  it('NODE_ENV=test: gossip-wt- prefix IS excluded (covers worktree-manager tmp dirs)', () => {
+  it('the dead allowlist gloss is gone: buildAuditExclusions emits no gossip-*-* glob entries even under the gate', () => {
     delete process.env.JEST_WORKER_ID;
     process.env.NODE_ENV = 'test';
     const excl = buildAuditExclusions(root, undefined, undefined);
-    expect(excl).toContain(`${tmp}/gossip-wt-*`);
-  });
-
-  it('NODE_ENV=test: sandbox-test- prefix IS excluded', () => {
-    delete process.env.JEST_WORKER_ID;
-    process.env.NODE_ENV = 'test';
-    const excl = buildAuditExclusions(root, undefined, undefined);
-    expect(excl).toContain(`${tmp}/sandbox-test-*`);
-  });
-
-  it('NODE_ENV=test: test-fixture exclusions emit /tmp ↔ /private/tmp twin variants', () => {
-    // If tmpdir() itself resolves to /tmp or /var/folders, expandTmpVariants
-    // may or may not emit a /private twin. But gossip-l3-* under an in-test
-    // /tmp path must be symmetric. Synthesize by asserting both forms
-    // coexist for the /tmp branch if tmpdir is /tmp-shaped. Otherwise skip
-    // the twin assertion — the expansion is already unit-tested upstream.
-    delete process.env.JEST_WORKER_ID;
-    process.env.NODE_ENV = 'test';
-    const excl = buildAuditExclusions(root, undefined, undefined);
-    // Every emitted test-fixture entry MUST end in '*' so `find -path`
-    // matches descendants. Guard against accidentally dropping the suffix.
-    const fixtureEntries = excl.filter(e => e.includes('gossip-test-'));
-    expect(fixtureEntries.length).toBeGreaterThan(0);
-    for (const e of fixtureEntries) {
-      expect(e.endsWith('*')).toBe(true);
-    }
+    expect(excl.some(e => e.endsWith('gossip-test-*'))).toBe(false);
+    expect(excl.some(e => e.endsWith('sandbox-test-*'))).toBe(false);
+    expect(excl.some(e => e.endsWith('gossip-wt-*'))).toBe(false);
   });
 
   it('gate MUST NOT alter buildSensitiveFindArgs (Layer 3 Pass 2 is independent of exclusions)', () => {

--- a/tests/cli/worktree-audit-layer3-noise.test.ts
+++ b/tests/cli/worktree-audit-layer3-noise.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for the Layer-3 main-pass noise filter (allowlist-rot fix).
+ *
+ * Context: .gossip/boundary-escapes.jsonl was flooded with test/environment
+ * noise — 8446/8486 live entries were tmpdir writes from test fixtures whose
+ * prefixes were NOT in the hand-maintained TEST_FIXTURE_PREFIXES allowlist
+ * (jest_dx, finding-resolver-, siblingroots-, …), plus build artifacts
+ * (dist-mcp/, dist-dashboard/, *.tsbuildinfo) and Cursor churn
+ * (cursor-sandbox-cache). The fix replaces the finite allowlist with an
+ * INVERTED gate (exclude every tmpdir child except the gossip-l3-* scan-root
+ * keep-list used by the Layer-3 audit tests themselves), adds an always-on
+ * cursor-sandbox-cache exclusion, and a build-artifact exclusion.
+ */
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  auditFilesystemSinceSentinel,
+  buildAuditExclusions,
+  DispatchMetadata,
+  isLayer3MainNoise,
+  stampTaskSentinel,
+} from '../../apps/cli/src/sandbox';
+
+const itOnPosix = process.platform === 'win32' ? it.skip : it;
+const describeOnPosix = process.platform === 'win32' ? describe.skip : describe;
+
+function mkTmp(prefix = 'gossip-l3-'): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+import { utimesSync } from 'fs';
+function backdateSentinel(path: string, pastMs: number): void {
+  const when = new Date(Date.now() - pastMs);
+  utimesSync(path, when, when);
+}
+
+describeOnPosix('isLayer3MainNoise — inverted test-fixture gate', () => {
+  itOnPosix('inTestRunner: a NON-keep tmpdir child (skill-engine-status-) is noise', () => {
+    const tmp = tmpdir();
+    const p = join(tmp, 'skill-engine-status-AbCd12', '.gossip', 'fake.jsonl');
+    expect(isLayer3MainNoise(p, { inTestRunner: true })).toBe(true);
+  });
+
+  itOnPosix('inTestRunner: jest_dx and finding-resolver- children are noise', () => {
+    const tmp = tmpdir();
+    expect(isLayer3MainNoise(join(tmp, 'jest_dx-XYZ', 'f.txt'), { inTestRunner: true })).toBe(true);
+    expect(isLayer3MainNoise(join(tmp, 'finding-resolver-9TZV2c', 'f.txt'), { inTestRunner: true })).toBe(true);
+  });
+
+  itOnPosix('inTestRunner: gossip-l3-scan- / gossip-l3-bin- / gossip-l3- children are KEPT (regression guard)', () => {
+    const tmp = tmpdir();
+    expect(isLayer3MainNoise(join(tmp, 'gossip-l3-scan-AAA', 'outside.txt'), { inTestRunner: true })).toBe(false);
+    expect(isLayer3MainNoise(join(tmp, 'gossip-l3-bin-BBB', 'fake-find'), { inTestRunner: true })).toBe(false);
+    expect(isLayer3MainNoise(join(tmp, 'gossip-l3-CCC', 'sentinel'), { inTestRunner: true })).toBe(false);
+  });
+
+  itOnPosix('NOT inTestRunner: a non-keep tmpdir child is NOT noise (gate closed)', () => {
+    const tmp = tmpdir();
+    const p = join(tmp, 'skill-engine-status-AbCd12', 'exfil.txt');
+    expect(isLayer3MainNoise(p, { inTestRunner: false })).toBe(false);
+  });
+
+  itOnPosix('a NON-tmpdir path is never noise via the inverted gate', () => {
+    expect(isLayer3MainNoise('/some/project/src/leak.ts', { inTestRunner: true })).toBe(false);
+  });
+
+  itOnPosix('a near-miss tmpdir dir that merely STARTS WITH a keep prefix is still FLAGGED (guards startsWith→equality drift)', () => {
+    // `gossip-l3-evil` literally starts with the `gossip-l3-` keep prefix, so a
+    // naive startsWith keeps it — which is intended (the keep-list is a prefix
+    // match by design, the audit tests mkdtemp `gossip-l3-scan-<rand>` etc.).
+    // What we assert here is the COMPLEMENT: a tmpdir child that does NOT start
+    // with the keep prefix stays flagged, so a future startsWith→equality
+    // refactor of the keep-list can't silently widen suppression. Use a
+    // near-miss that shares a leading substring but not the full prefix.
+    const tmp = tmpdir();
+    const tmpRoots = undefined; // default discovery
+    expect(
+      isLayer3MainNoise(join(tmp, 'gossip-l3evil', 'f.txt'), { inTestRunner: true, tmpRoots }),
+    ).toBe(true);
+    // And a dir that does start with the keep prefix stays KEPT (false).
+    expect(
+      isLayer3MainNoise(join(tmp, 'gossip-l3-evil', 'f.txt'), { inTestRunner: true, tmpRoots }),
+    ).toBe(false);
+  });
+});
+
+describeOnPosix('isLayer3MainNoise — always-on Cursor + build-artifact exclusions', () => {
+  itOnPosix('cursor-sandbox-cache tmpdir child is noise EVEN without the test gate', () => {
+    const tmp = tmpdir();
+    const p = join(tmp, 'cursor-sandbox-cache', 'blob.bin');
+    expect(isLayer3MainNoise(p, { inTestRunner: false })).toBe(true);
+  });
+
+  itOnPosix('dist-mcp/ and dist-dashboard/ build outputs are noise WHEN under projectRoot', () => {
+    const projectRoot = '/Users/x/gossip';
+    expect(isLayer3MainNoise('/Users/x/gossip/dist-mcp/index.js', { inTestRunner: false, projectRoot })).toBe(true);
+    expect(isLayer3MainNoise('/Users/x/gossip/dist-dashboard/assets/a.js', { inTestRunner: false, projectRoot })).toBe(true);
+  });
+
+  itOnPosix('*.tsbuildinfo is noise WHEN under projectRoot', () => {
+    expect(
+      isLayer3MainNoise('/Users/x/gossip/packages/dashboard-v2/tsconfig.tsbuildinfo', {
+        inTestRunner: false,
+        projectRoot: '/Users/x/gossip',
+      }),
+    ).toBe(true);
+  });
+
+  itOnPosix('build-artifact rule FAILS CLOSED when projectRoot is absent (cannot anchor → do not suppress)', () => {
+    // Without projectRoot the build-artifact rule must NOT fire — otherwise an
+    // agent could hide a real escape under a build-artifact-looking name.
+    expect(isLayer3MainNoise('/Users/x/gossip/dist-mcp/index.js', { inTestRunner: false })).toBe(false);
+    expect(isLayer3MainNoise('/Users/x/gossip/x.tsbuildinfo', { inTestRunner: false })).toBe(false);
+  });
+
+  itOnPosix('a tmpdir build-artifact-looking path OUTSIDE projectRoot is FLAGGED (no evasion via /tmp/dist-mcp or /tmp/*.tsbuildinfo)', () => {
+    const tmp = tmpdir();
+    const projectRoot = '/Users/x/gossip'; // distinct from tmpdir
+    // tmpdir is itself a main-pass scan root; these must NOT be suppressed.
+    expect(
+      isLayer3MainNoise(join(tmp, 'dist-mcp', 'evil.js'), { inTestRunner: false, projectRoot }),
+    ).toBe(false);
+    expect(
+      isLayer3MainNoise(join(tmp, 'anything.tsbuildinfo'), { inTestRunner: false, projectRoot }),
+    ).toBe(false);
+    expect(
+      isLayer3MainNoise(join(tmp, 'dist-dashboard', 'a.js'), { inTestRunner: false, projectRoot }),
+    ).toBe(false);
+  });
+
+  itOnPosix('a sibling real source path is NOT noise even alongside build artifacts', () => {
+    const projectRoot = '/Users/x/gossip';
+    expect(isLayer3MainNoise('/Users/x/gossip/apps/cli/src/sandbox.ts', { inTestRunner: false, projectRoot })).toBe(false);
+    // dist-mcp as a substring of a filename (not a path segment) must NOT match.
+    expect(isLayer3MainNoise('/Users/x/gossip/src/dist-mcp-notes.ts', { inTestRunner: false, projectRoot })).toBe(false);
+  });
+});
+
+describeOnPosix('buildAuditExclusions — cursor-sandbox-cache always-on prune', () => {
+  itOnPosix('adds cursor-sandbox-cache to the always-on tmpdir prune list (not test-gated)', () => {
+    const excl = buildAuditExclusions('/tmp/projectroot', undefined);
+    const tmp = tmpdir();
+    expect(excl).toContain(`${tmp}/cursor-sandbox-cache`);
+  });
+
+  itOnPosix('no longer emits the dead TEST_FIXTURE_PREFIXES glob entries', () => {
+    // Under the jest gate (JEST_WORKER_ID is set), the old code added ~60
+    // `<tmp>/gossip-*-*` glob entries. The inversion deletes them.
+    const excl = buildAuditExclusions('/tmp/projectroot', undefined);
+    expect(excl.some(e => e.endsWith('gossip-test-*'))).toBe(false);
+    expect(excl.some(e => e.endsWith('sandbox-test-*'))).toBe(false);
+  });
+});
+
+describeOnPosix('auditFilesystemSinceSentinel — end-to-end noise suppression (gate ON under jest)', () => {
+  itOnPosix('a non-keep tmpdir fixture write is EXCLUDED from violations', () => {
+    // jest sets JEST_WORKER_ID, so the inverted gate is active.
+    const projectRoot = mkTmp();
+    const fixtureDir = mkdtempSync(join(tmpdir(), `skill-engine-status-${Date.now()}-`));
+    try {
+      const sentinel = stampTaskSentinel(projectRoot, 'noise-1')!;
+      backdateSentinel(sentinel, 5000);
+      const inner = join(fixtureDir, 'sub');
+      mkdirSync(inner, { recursive: true });
+      writeFileSync(join(inner, 'fixture.jsonl'), '{"x":1}\n');
+
+      const meta: DispatchMetadata = {
+        taskId: 'noise-1',
+        agentId: 'opus-implementer',
+        writeMode: 'worktree',
+        timestamp: Date.now(),
+        sentinelPath: sentinel,
+      };
+      const res = auditFilesystemSinceSentinel(projectRoot, meta, {
+        scanRoots: [tmpdir()],
+        logFailures: false,
+      });
+      expect(res.violations.some(v => v.includes('fixture.jsonl'))).toBe(false);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  itOnPosix('a gossip-l3-scan- write IS still recorded under the gate (regression guard)', () => {
+    const projectRoot = mkTmp();
+    const scanRoot = mkTmp('gossip-l3-scan-');
+    try {
+      const sentinel = stampTaskSentinel(projectRoot, 'keep-1')!;
+      backdateSentinel(sentinel, 5000);
+      writeFileSync(join(scanRoot, 'outside.txt'), 'exfil');
+
+      const meta: DispatchMetadata = {
+        taskId: 'keep-1',
+        agentId: 'opus-implementer',
+        writeMode: 'worktree',
+        timestamp: Date.now(),
+        sentinelPath: sentinel,
+      };
+      const res = auditFilesystemSinceSentinel(projectRoot, meta, {
+        scanRoots: [scanRoot],
+        logFailures: false,
+      });
+      expect(res.violations.some(v => v.endsWith('outside.txt'))).toBe(true);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(scanRoot, { recursive: true, force: true });
+    }
+  });
+
+  itOnPosix('a build-artifact-looking write under a tmpdir scan root (NOT under projectRoot) is FLAGGED — closes the /tmp/dist-mcp + /tmp/*.tsbuildinfo evasion', () => {
+    // Rule C is projectRoot-anchored. tmpdir is itself a main-pass scan root for
+    // worktree/sequential dispatches, so an UNanchored Rule C would let an agent
+    // hide a real escape as `/tmp/dist-mcp/evil` or `/tmp/x.tsbuildinfo`. Here
+    // projectRoot and the scan root are DISTINCT tmp dirs, so these build-artifact
+    // names land OUTSIDE projectRoot and must surface as violations.
+    const projectRoot = mkTmp();
+    const scanRoot = mkTmp('gossip-l3-scan-');
+    try {
+      const sentinel = stampTaskSentinel(projectRoot, 'evasion-1')!;
+      backdateSentinel(sentinel, 5000);
+      const distMcpDir = join(scanRoot, 'dist-mcp');
+      mkdirSync(distMcpDir, { recursive: true });
+      writeFileSync(join(distMcpDir, 'evil.js'), 'exfil');
+      writeFileSync(join(scanRoot, 'anything.tsbuildinfo'), '{}');
+
+      const meta: DispatchMetadata = {
+        taskId: 'evasion-1',
+        agentId: 'opus-implementer',
+        writeMode: 'worktree',
+        timestamp: Date.now(),
+        sentinelPath: sentinel,
+      };
+      const res = auditFilesystemSinceSentinel(projectRoot, meta, {
+        scanRoots: [scanRoot],
+        logFailures: false,
+      });
+      // Both build-artifact-looking tmpdir paths are now FLAGGED (no evasion).
+      expect(res.violations.some(v => v.endsWith('evil.js'))).toBe(true);
+      expect(res.violations.some(v => v.endsWith('.tsbuildinfo'))).toBe(true);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(scanRoot, { recursive: true, force: true });
+    }
+  });
+
+  itOnPosix('a *.tsbuildinfo / dist-mcp write GENUINELY under projectRoot IS excluded (real build output)', () => {
+    // The legitimate case: build artifacts live inside the repo. When the
+    // scan surfaces a path under projectRoot, Rule C suppresses it.
+    const projectRoot = mkTmp();
+    try {
+      const sentinel = stampTaskSentinel(projectRoot, 'build-real-1')!;
+      backdateSentinel(sentinel, 5000);
+      const distMcpDir = join(projectRoot, 'dist-mcp');
+      mkdirSync(distMcpDir, { recursive: true });
+      writeFileSync(join(distMcpDir, 'index.js'), 'build');
+      writeFileSync(join(projectRoot, 'tsconfig.tsbuildinfo'), '{}');
+      writeFileSync(join(projectRoot, 'real-source.ts'), 'leak');
+
+      const meta: DispatchMetadata = {
+        taskId: 'build-real-1',
+        agentId: 'opus-implementer',
+        writeMode: 'worktree',
+        timestamp: Date.now(),
+        sentinelPath: sentinel,
+      };
+      // Scan projectRoot itself so the build artifacts surface as candidates.
+      const res = auditFilesystemSinceSentinel(projectRoot, meta, {
+        scanRoots: [projectRoot],
+        logFailures: false,
+      });
+      expect(res.violations.some(v => v.endsWith('.tsbuildinfo'))).toBe(false);
+      expect(res.violations.some(v => v.endsWith('dist-mcp/index.js') || v.includes('/dist-mcp/'))).toBe(false);
+      // A real source path under projectRoot is NOT a build artifact — it must
+      // still surface (projectRoot is the scan root here, so anything under it
+      // that isn't a build artifact or excluded dir is a candidate violation).
+      expect(res.violations.some(v => v.endsWith('real-source.ts'))).toBe(true);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`.gossip/boundary-escapes.jsonl` (the Layer-3 post-dispatch audit log) was 99.5% noise. Measured on the live file: **8446/8486** entries were tmpdir test writes, and all **40** "real-repo" hits were build artifacts (`dist-mcp/`, `dist-dashboard/`, `tsconfig.tsbuildinfo`) — **zero** real boundary escapes. The detector gave ~0 signal-to-noise for spotting an actual engagement gap.

**Root cause: allowlist rot.** The hand-maintained 60+ entry `TEST_FIXTURE_PREFIXES` list never kept up with new test `mkdtemp` prefixes (`jest_dx`, `finding-resolver-`, `cursor-sandbox-cache`, `siblingroots-`, `skill-engine-status-`, and a ~25-prefix long tail).

## Fix

Delete the allowlist; replace with `isLayer3MainNoise()` — an **inverted gate**:

- **Rule A (test-only):** under a test runner, every immediate `tmpdir()` child is noise **except** the `gossip-l3-*` scan-root keep-list the Layer-3 audit tests depend on. Permanently kills the rot. The gate is test-only (`JEST_WORKER_ID`/`NODE_ENV=test`) and structurally unforgeable by a dispatched child process.
- **Rule B (always-on):** prune `cursor-sandbox-cache` editor churn.
- **Rule C (always-on, projectRoot-anchored):** drop `/dist-mcp/`, `/dist-dashboard/`, `*.tsbuildinfo` build artifacts — but **only under `projectRoot`**, fail-closed when absent, so an agent can't hide a real escape behind `/tmp/dist-mcp/evil` or `/tmp/x.tsbuildinfo` (tmpdir is itself a main-pass scan root).

Applied to `mainSet` only, after the sensitive-pass dedup, with a structural `!sensitiveSet.has(p)` guard so Pass-2 watchlist hits can never be suppressed even if the dedup is reordered. **Layer-2 `recordBoundaryEscape` is untouched.**

## Review

Reviewed via gossipcat consensus (`sonnet-reviewer` + `deepseek-challenger`) — **2 confirmed, 0 disputed**. deepseek-challenger caught an unconditional-Rule-C evasion (f1/f3); fixed here by the projectRoot anchor + fail-closed guard. f12 (drop-observability counter) deferred as a follow-up.

consensus-id: 2edcfb6c-e21e4c47

## Test plan

- `npx tsc --noEmit -p apps/cli/tsconfig.json` → exit 0
- `worktree-audit-layer3`, `-sensitive`, `-noise`, `sandbox` suites: **156/156 pass** (incl. new negative test that `gossip-l3-evil` near-miss stays flagged, and that a `/tmp/dist-mcp/evil`-style tmpdir path is flagged while a real `projectRoot` build artifact is excluded)
- Full `tests/cli`: **1152 passed, 8 skipped, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)