### PR TITLE
feat(sandbox): f12 — observability for Layer-3 main-pass noise drops

### DIFF
--- a/apps/cli/src/sandbox.ts
+++ b/apps/cli/src/sandbox.ts
@@ -1330,6 +1330,13 @@ export function auditFilesystemSinceSentinel(
     process.env.JEST_WORKER_ID !== undefined || process.env.NODE_ENV === 'test';
   const tmpRoots = tmpRootPrefixes();
   const canonProjectRoot = canonicalize(projectRoot);
+  // Observability (f12): the noise filter could in principle over-suppress and
+  // silently mask a real escape. Record HOW MANY paths it discarded plus a
+  // bounded sample (same slice(0, 20) cap as the violation logging below) so a
+  // sudden spike in drops is auditable. Pure instrumentation — the set of paths
+  // actually deleted from mainSet is byte-for-byte identical with or without it.
+  let droppedCount = 0;
+  const droppedSample: string[] = [];
   for (const p of Array.from(mainSet)) {
     // Belt-and-suspenders: never filter a sensitive-pass path here even if the
     // dedup above is ever reordered. Pass 2 is a vetted zero-noise watchlist;
@@ -1339,7 +1346,20 @@ export function auditFilesystemSinceSentinel(
       isLayer3MainNoise(p, { inTestRunner, tmpRoots, projectRoot: canonProjectRoot })
     ) {
       mainSet.delete(p);
+      droppedCount += 1;
+      if (droppedSample.length < 20) droppedSample.push(p);
     }
+  }
+  // These are EXPECTED drops (build artifacts / Cursor cache / test fixtures),
+  // NOT violations — debug surface only, never a ⚠ warning, never JSONL, never a
+  // score-affecting signal. Gated behind the same logFailures flag as the
+  // violation logging.
+  if (droppedCount > 0 && logFailures) {
+    process.stderr.write(
+      `[gossipcat] Layer 3 main-pass noise filter discarded ${droppedCount} path(s) (sample):\n` +
+        droppedSample.map(v => `    ${v}`).join('\n') +
+        '\n',
+    );
   }
 
   const mainViolations = Array.from(mainSet);


### PR DESCRIPTION
## What

Closes **f12** from the next-session ledger: add dropped-path observability to the Layer-3 main-pass noise filter in `apps/cli/src/sandbox.ts`.

## Why

The noise filter loop at `sandbox.ts:1333` silently `mainSet.delete(p)`'d every suppressed path (build artifacts, Cursor cache, test fixtures) with **zero record** of how many or which. Over-suppression — a genuinely-violating path wrongly classified as noise — would mask a real boundary escape with no audit trail.

## Change (additive only)

- `droppedCount` + bounded `droppedSample` (`slice(0,20)` cap, matching the existing violation-logging convention at line 1354).
- One debug `stderr` line, gated behind the existing `logFailures` flag, emitted only when `droppedCount > 0`. Plain `[gossipcat]` prefix — **NOT** a ⚠ warning (these are *expected* drops), **no** `boundary-escapes.jsonl` write, **no** score-affecting signal.

Suppression logic (`isLayer3MainNoise` condition + `mainSet.delete`) is **byte-for-byte unchanged** — the set deleted from `mainSet` is identical with or without this patch. Pure instrumentation.

## Verification

- `npx tsc --noEmit -p apps/cli/tsconfig.json` → exit 0, clean.
- `npx jest tests/cli/sandbox.test.ts tests/cli/worktree-audit-layer3.test.ts tests/cli/worktree-audit-layer3-noise.test.ts` → **131 passed, 0 failed**, no test updates needed (confirms suppression behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)