### PR TITLE
fix(status): skip truly-empty rounds in the Signals-pending detector

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -1978,7 +1978,7 @@ export function createMcpServer(): McpServer {
       // Mirrors the existing gossip_status reconnect-recovery pattern for
       // pendingConsensusRounds re-surfacing.
       try {
-        const { readdirSync, statSync } = await import('fs');
+        const { readdirSync, statSync, readFileSync } = await import('fs');
         const { readJsonlWithRotated: readJsonlRotated1506 } = await import('@gossip/orchestrator');
         const reportsDir = join(process.cwd(), '.gossip', 'consensus-reports');
         const perfPath = join(process.cwd(), '.gossip', 'agent-performance.jsonl');
@@ -1993,6 +1993,22 @@ export function createMcpServer(): McpServer {
             const fpath = join(reportsDir, fname);
             const st = statSync(fpath);
             if (now - st.mtimeMs > WINDOW_MS) continue;
+            // Skip TRULY-empty rounds (zero findings across every bucket). They can
+            // never be "covered" because there are no findings to attribute a signal
+            // to, so they would otherwise be flagged as pending forever until they
+            // age out of the 24h window — a false positive. Fail toward surfacing:
+            // any read/parse failure falls through to flagging the round (push below).
+            try {
+              const report = JSON.parse(readFileSync(fpath, 'utf8'));
+              const isEmpty =
+                (report.confirmed?.length ?? 0) === 0 &&
+                (report.disputed?.length ?? 0) === 0 &&
+                (report.unverified?.length ?? 0) === 0 &&
+                (report.unique?.length ?? 0) === 0 &&
+                (report.newFindings?.length ?? 0) === 0 &&
+                (report.insights?.length ?? 0) === 0;
+              if (isEmpty) continue;
+            } catch { /* unreadable/malformed report — fall through and flag it (fail toward surfacing) */ }
             recentReports.push({ id: fname.replace(/\.json$/, ''), mtimeMs: st.mtimeMs });
           }
         } catch { /* reports dir missing — no rounds yet */ }


### PR DESCRIPTION
## What

The "Signals pending" detector in `apps/cli/src/mcp-server-sdk.ts` flagged every consensus report from the last 24h whose id had no manually-recorded signal. But a round that produced **zero findings** (all of `confirmed`/`disputed`/`unverified`/`unique`/`newFindings`/`insights` empty) can never be "covered" — there is no finding to attribute a signal to — so it was flagged as pending **forever** until it aged out of the 24h window.

A quota-degraded session (gemini 429s + `roots_empty_after_validation`) produced **12 empty `Audit` rounds** that were stuck in the warning, with `bulk_from_consensus` unable to clear them (nothing to record).

## Fix

Skip truly-empty rounds in the `recentReports` loop: read + `JSON.parse` each report and `continue` past it only when **every** finding bucket is empty/absent (`?.length ?? 0`). Defensive — a malformed/unreadable report falls through to flagging (fail toward surfacing, not hiding). The `covered`-set logic, 24h window, and display code are untouched; purely additive.

## Verification

- `npx tsc --noEmit -p apps/cli/tsconfig.json` → exit 0, clean.
- No existing test covers this inline detector (it lives in the `gossip_status` handler with `await import('fs')` and direct fs reads — no isolated unit seam). Noted as a follow-up rather than bolting on a fixture harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)