### PR TITLE
feat(bridge): P1 backend — dashboard ⇄ live Claude Code channel bridge

### DIFF
--- a/apps/cli/src/cc-bridge.ts
+++ b/apps/cli/src/cc-bridge.ts
@@ -117,6 +117,11 @@ export function createBridgeHost(server: McpServer): BridgeHost {
   }
 
   function deliverBridgeMessage(chatId: string, content: string): boolean {
+    // Retry any messages re-buffered by a prior async send rejection BEFORE
+    // sending the new one, so a transient failure recovers on the next message
+    // instead of lingering until TTL expiry (consensus f7e5bc15 f8 — flush was
+    // never otherwise triggered). flush() is idempotent + bounded.
+    if (buffer.length > 0) flush();
     const msg: BufferedMessage = { chatId, content, queuedAt: Date.now() };
     return send(msg);
   }

--- a/apps/cli/src/cc-bridge.ts
+++ b/apps/cli/src/cc-bridge.ts
@@ -1,0 +1,129 @@
+/**
+ * cc-bridge.ts — MCP-server-side host for the dashboard ⇄ live Claude Code
+ * bridge (P1 backend, spec 2026-06-14-dashboard-cc-channel-bridge.md).
+ *
+ * NAMING (consensus f4): identifiers are bridge-* / ccBridge, NOT "channel" —
+ * packages/relay/src/channels.ts already owns `ChannelManager` (agent pub-sub).
+ * The ONLY literal `claude/channel` string is the Claude Code protocol
+ * capability key + notification method, used verbatim per the CC contract.
+ *
+ * Responsibilities:
+ *   - INBOUND (dashboard → CC): `deliverBridgeMessage(chatId, content)` emits a
+ *     `notifications/claude/channel` notification over the stdio transport. The
+ *     live CC orchestrator receives it as a `<channel source="gossipcat"
+ *     chat_id="…">` event and is instructed to respond via the `reply` tool.
+ *     stdio CAN push server→client notifications (spec "#1 unknown RESOLVED",
+ *     verified against fakechat).
+ *   - The relay registers `deliverBridgeMessage` as its in-process sink (no wire
+ *     protocol — same Node process). See RelayServer.registerBridgeSink.
+ *
+ * Bounded inbound buffer (consensus f3): a message can arrive (relay POST →
+ * sink) before the MCP transport is connected, or while a notification send is
+ * transiently failing. Rather than drop or grow unbounded, buffer up to
+ * MAX_BUFFERED entries with a TTL (mirroring chat-session-store.ts constants)
+ * and flush on the next successful send / connect. This is NOT the CC-side
+ * mid-tool-call queue (CC owns that); it bounds OUR transient-failure window.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+/** The Claude Code channel notification method — protocol name, verbatim. */
+export const CC_CHANNEL_NOTIFICATION = 'notifications/claude/channel';
+
+// Bounded inbound buffer, mirroring chat-session-store.ts posture.
+const MAX_BUFFERED = 20;
+const BUFFER_TTL_MS = 2 * 60 * 60 * 1000; // 2h idle, same as chat-session-store
+
+interface BufferedMessage {
+  chatId: string;
+  content: string;
+  queuedAt: number;
+}
+
+export interface BridgeHost {
+  /**
+   * Deliver a dashboard message to the live CC session. Returns true when the
+   * notification was sent (or buffered for imminent retry), false when it could
+   * be neither sent nor buffered (buffer full of fresh entries). Synchronous
+   * return so the relay sink can answer the dashboard POST immediately; the
+   * actual stdio send is fire-and-forget.
+   */
+  deliverBridgeMessage(chatId: string, content: string): boolean;
+  /** Flush any buffered messages — call after the transport connects. */
+  flush(): void;
+  /** Test/introspection helper. */
+  bufferedCount(): number;
+}
+
+/**
+ * Build the bridge host bound to a constructed McpServer. The notification is
+ * emitted via `server.server.notification` (the underlying Protocol instance —
+ * McpServer exposes it as `.server`). The method name is not in the SDK's
+ * notification schema, so we cast at the boundary.
+ */
+export function createBridgeHost(server: McpServer): BridgeHost {
+  const buffer: BufferedMessage[] = [];
+
+  function evictExpired(now: number): void {
+    // Drop from the front while the oldest entry has aged out. Entries are
+    // appended in arrival order, so once one is fresh enough the rest are too.
+    while (buffer.length > 0 && now - buffer[0].queuedAt > BUFFER_TTL_MS) {
+      buffer.shift();
+    }
+  }
+
+  function send(msg: BufferedMessage): boolean {
+    try {
+      // The underlying Protocol.notification is the documented seam for
+      // server-initiated notifications (McpServer.server). `claude/channel` is a
+      // CC research-preview method outside the SDK schema → cast.
+      void (server.server as unknown as {
+        notification: (n: { method: string; params?: Record<string, unknown> }) => Promise<void>;
+      }).notification({
+        method: CC_CHANNEL_NOTIFICATION,
+        params: { content: msg.content, meta: { chat_id: msg.chatId } },
+      }).catch(() => {
+        // Send rejected after we optimistically returned — re-buffer so a flush
+        // can retry, unless the buffer is already full of fresh entries.
+        bufferMessage(msg);
+      });
+      return true;
+    } catch {
+      return bufferMessage(msg);
+    }
+  }
+
+  function bufferMessage(msg: BufferedMessage): boolean {
+    const now = Date.now();
+    evictExpired(now);
+    if (buffer.length >= MAX_BUFFERED) {
+      // Buffer saturated with fresh entries — drop the OLDEST to bound memory,
+      // preferring the most recent steering message (consensus f3: bounded, not
+      // unbounded; recency matters for steering).
+      buffer.shift();
+    }
+    buffer.push(msg);
+    return true;
+  }
+
+  function flush(): void {
+    if (buffer.length === 0) return;
+    const now = Date.now();
+    evictExpired(now);
+    const pending = buffer.splice(0, buffer.length);
+    for (const msg of pending) {
+      send(msg);
+    }
+  }
+
+  function deliverBridgeMessage(chatId: string, content: string): boolean {
+    const msg: BufferedMessage = { chatId, content, queuedAt: Date.now() };
+    return send(msg);
+  }
+
+  return {
+    deliverBridgeMessage,
+    flush,
+    bufferedCount: () => buffer.length,
+  };
+}

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -255,6 +255,14 @@ export interface McpContext {
   httpMcpPortSource: 'env' | 'sticky' | 'auto' | null;
   booted: boolean;
   /**
+   * Dashboard ⇄ live-CC bridge host (P1, spec 2026-06-14). Created in
+   * createMcpServer (it closes over the McpServer for stdio notifications) and
+   * registered as the relay's in-process inbound sink at boot. Null until the
+   * MCP server is constructed; null when the bridge module is absent. Typed
+   * `any` to avoid a cross-package import cycle (mirrors `relay`/`toolServer`).
+   */
+  bridgeHost: any;
+  /**
    * True when `doBoot()` ran without a config file and synthesized an empty
    * one (fresh-install / degraded-mode). The dashboard boots with 0 agents
    * in this case — subsequent gossip_setup calls refresh it via
@@ -301,6 +309,7 @@ export const ctx: McpContext = {
   relayPortSource: null,
   httpMcpPortSource: null,
   booted: false,
+  bridgeHost: null,
   bootedInDegradedMode: false,
   lastSyncResult: null,
   boot: async () => { throw new Error('boot not initialized'); },

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -181,6 +181,7 @@ if (process.env.GOSSIPCAT_MCP_NO_MAIN !== '1' && !__argvShimHandled) {
 }
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { createBridgeHost } from './cc-bridge';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { z } from 'zod';
@@ -581,6 +582,22 @@ async function doBoot() {
     },
   });
   await ctx.relay.start();
+
+  // Register the dashboard ⇄ live-CC bridge sink now that the relay exists.
+  // createMcpServer builds ctx.bridgeHost, but on the stdio boot path the relay
+  // starts AFTER the server is constructed, so the in-createMcpServer
+  // registration above is a no-op and this is the real wiring point. Idempotent:
+  // re-registering simply replaces the sink. Best-effort — a bridge wiring
+  // failure must not block boot. (spec 2026-06-14, consensus f4/f10)
+  try {
+    if (ctx.bridgeHost) {
+      ctx.relay.registerBridgeSink((chatId: string, message: string) =>
+        ctx.bridgeHost.deliverBridgeMessage(chatId, message),
+      );
+    }
+  } catch (e) {
+    process.stderr.write(`[gossipcat] bridge sink registration failed: ${(e as Error).message}\n`);
+  }
 
   // PID diagnostic — logged once at relay init so we can correlate
   // `.gossip/mcp.log` `RELAY DISCONNECTED` bursts with MCP-host respawns.
@@ -1234,10 +1251,32 @@ export function createMcpServer(): McpServer {
       version: getGossipcatVersion(),
     },
     {
+      // Advertise the Claude Code `claude/channel` capability so a session
+      // launched with `--channels server:gossipcat` activates the dashboard ⇄
+      // live-CC bridge (spec 2026-06-14). Key is the CC protocol name, verbatim.
+      // P3 (`claude/channel/permission`) is intentionally NOT advertised here.
+      capabilities: {
+        experimental: { 'claude/channel': {} },
+      },
       instructions:
-        'gossipcat — multi-agent orchestration. ALWAYS call gossip_status() first when starting work in this project — this is the bootstrap call that returns your orchestrator role, dispatch rules, consensus workflow, sandbox enforcement, agent list, and by default the full operator playbook (docs/HANDBOOK.md inlined; pass slim:true to skip the handbook section on reconnect refreshes). On native dispatches, every signal you record MUST include a finding_id formatted as <consensus_id>:<agent:fN> so dashboard scores are auditable. When resolving backlog items older than the current session, call gossip_verify_memory before acting to avoid stale premises. These rules live in gossip_status output, not this instruction text, so they can update with the server binary without requiring reinstall.',
+        'gossipcat — multi-agent orchestration. ALWAYS call gossip_status() first when starting work in this project — this is the bootstrap call that returns your orchestrator role, dispatch rules, consensus workflow, sandbox enforcement, agent list, and by default the full operator playbook (docs/HANDBOOK.md inlined; pass slim:true to skip the handbook section on reconnect refreshes). On native dispatches, every signal you record MUST include a finding_id formatted as <consensus_id>:<agent:fN> so dashboard scores are auditable. When resolving backlog items older than the current session, call gossip_verify_memory before acting to avoid stale premises. These rules live in gossip_status output, not this instruction text, so they can update with the server binary without requiring reinstall.\n\nDASHBOARD BRIDGE: when channel mode is active, dashboard messages arrive as a user turn wrapped in <channel source="gossipcat" chat_id="..."> — treat the inner text as orchestrator instructions from the human at the dashboard. Respond to the dashboard ONLY by calling the `reply` tool with that exact chat_id; your normal transcript output does NOT reach the dashboard. Pass the chat_id through verbatim. Do NOT confuse `reply` with gossip_relay (that is for native-subagent dispatch results, never the dashboard bridge).',
     }
   );
+
+  // ── Dashboard ⇄ live-CC bridge host (P1, spec 2026-06-14) ─────────────────
+  // Build the bridge host bound to THIS McpServer (it closes over the stdio
+  // transport for `notifications/claude/channel`). Register it as the relay's
+  // in-process inbound sink: a dashboard POST → registered sink →
+  // deliverBridgeMessage → notification over stdio (no wire protocol — same
+  // process, spec "#1 unknown RESOLVED"). The relay may not be booted yet at
+  // this point (boot is async); register here if present AND again at boot end.
+  const bridgeHost = createBridgeHost(server);
+  ctx.bridgeHost = bridgeHost;
+  try {
+    ctx.relay?.registerBridgeSink((chatId: string, message: string) =>
+      bridgeHost.deliverBridgeMessage(chatId, message),
+    );
+  } catch { /* relay not ready — boot will register */ }
 
   // ── Plan: decompose with write-mode classification ────────────────────────
 
@@ -1794,6 +1833,50 @@ export function createMcpServer(): McpServer {
     async ({ consensus_id, agent_id, result }) => {
       const { handleRelayCrossReview } = await import('./handlers/relay-cross-review');
       return handleRelayCrossReview(consensus_id, agent_id, result);
+    },
+  );
+
+  // ── Dashboard bridge: reply to the live-CC channel (P1, spec 2026-06-14) ───
+  // Invariant-#4 mitigation (consensus f8): this tool is the ONLY output path
+  // from the live CC session back to the dashboard. It is deliberately scoped
+  // and named so it can't be mistaken for gossip_relay during native dispatch —
+  // gossip_relay closes a native-subagent task; `reply` sends conversational
+  // text to a dashboard chat stream. It no-ops with a clear error when no bridge
+  // session is active (chat_id never opened, or dashboard disabled), so a
+  // mis-fired call during a native-dispatch turn can't silently spoof a relay.
+  server.tool(
+    'reply',
+    'Dashboard bridge ONLY: send a conversational reply to the dashboard chat stream identified by chat_id. Use this — and ONLY this — to respond to a <channel source="gossipcat" chat_id="..."> dashboard message; your transcript output never reaches the dashboard. Pass the chat_id through verbatim. This is NOT gossip_relay: it does not close native-subagent tasks. Returns an error (no side effect) when no matching dashboard bridge stream is open.',
+    {
+      chat_id: z.string().describe('The chat_id verbatim from the <channel ... chat_id="..."> dashboard message.'),
+      text: z.string().describe('The reply text to stream to the dashboard.'),
+    },
+    async ({ chat_id, text }) => {
+      // Trust boundary: chat_id + text are model-supplied. The relay hub
+      // re-validates the chat_id shape and binds it to a stream the dashboard
+      // actually opened (consensus f5) — a forged/never-opened id is rejected.
+      if (typeof chat_id !== 'string' || chat_id.trim().length === 0) {
+        return { content: [{ type: 'text' as const, text: 'reply error: chat_id is required.' }], isError: true };
+      }
+      if (typeof text !== 'string') {
+        return { content: [{ type: 'text' as const, text: 'reply error: text must be a string.' }], isError: true };
+      }
+      if (!ctx.relay) {
+        return { content: [{ type: 'text' as const, text: 'reply error: no dashboard bridge is active (relay not started).' }], isError: true };
+      }
+      let delivered = false;
+      try {
+        delivered = ctx.relay.emitBridgeReply(chat_id, text) === true;
+      } catch {
+        delivered = false;
+      }
+      if (!delivered) {
+        return {
+          content: [{ type: 'text' as const, text: `reply error: no open dashboard bridge stream for chat_id "${chat_id}". This tool only sends to the dashboard channel — if you meant to close a native-subagent task, use gossip_relay instead.` }],
+          isError: true,
+        };
+      }
+      return { content: [{ type: 'text' as const, text: `Sent reply to dashboard (chat_id ${chat_id}).` }] };
     },
   );
 

--- a/packages/relay/src/dashboard/api-bridge.ts
+++ b/packages/relay/src/dashboard/api-bridge.ts
@@ -159,6 +159,10 @@ export class BridgeHub {
     const chatId = validateChatId(rawChatId);
     if (chatId === null) return false;
     if (!this.isKnownChatId(chatId)) return false;
+    // No connected SSE client → the reply cannot be delivered. Return false so
+    // the MCP `reply` tool surfaces an honest "no open stream" error instead of
+    // reporting a success that silently vanished (consensus f7e5bc15 f5).
+    if (this.clients.size === 0) return false;
     this.broadcast({ type: 'reply', chat_id: chatId, text, ts: new Date().toISOString() });
     return true;
   }
@@ -172,6 +176,7 @@ export class BridgeHub {
     const chatId = validateChatId(rawChatId);
     if (chatId === null) return false;
     if (!this.isKnownChatId(chatId)) return false;
+    if (this.clients.size === 0) return false;
     this.broadcast({ type: 'ack', chat_id: chatId, ts: new Date().toISOString() });
     return true;
   }

--- a/packages/relay/src/dashboard/api-bridge.ts
+++ b/packages/relay/src/dashboard/api-bridge.ts
@@ -1,0 +1,262 @@
+/**
+ * api-bridge.ts — relay-side transport for the dashboard ⇄ live Claude Code
+ * bridge (P1 backend, spec 2026-06-14-dashboard-cc-channel-bridge.md).
+ *
+ * NAMING (consensus f4): this is the "bridge", NOT a "channel" — packages/relay/
+ * src/channels.ts already owns `ChannelManager` (agent pub-sub), a different
+ * concept. The only place the literal `claude/channel` string appears is the MCP
+ * capability key / notification method (the Claude Code protocol name, verbatim);
+ * every identifier here is bridge-*.
+ *
+ * Two directions:
+ *   - INBOUND  (dashboard → CC): the dashboard POSTs to /dashboard/api/bridge.
+ *     The router calls the registered in-process sink (set by the MCP server via
+ *     RelayServer.registerBridgeSink). The relay and the MCP server share one
+ *     Node process (spec "#1 unknown RESOLVED"), so this is a direct callback —
+ *     there is NO wire protocol / pending queue between them.
+ *   - OUTBOUND (CC → dashboard): the MCP `reply` tool calls
+ *     RelayServer.emitBridgeReply → BridgeHub.emitReply, which fans out an SSE
+ *     frame to every connected dashboard bridge-stream client.
+ *
+ * Security posture (consensus f5/f10/f12/f13 — security in P1, not P4):
+ *   - The POST route is gated by the EXISTING DashboardAuth + allowChatTurn
+ *     rate-limit + a per-route readBody cap in routes.ts BEFORE this module runs.
+ *   - chat_id is validated/bound on BOTH directions (untrusted on inbound POST,
+ *     re-validated on outbound reply so an injected LLM can't address an
+ *     arbitrary/forged stream id).
+ *   - Every reply path guarantees a terminal/ack frame so push-into-idle never
+ *     silently no-ops when Claude omits reply().
+ */
+
+import type { IncomingMessage, ServerResponse } from 'http';
+import { randomUUID } from 'crypto';
+
+/**
+ * In-process sink the MCP server registers. Returns true when the message was
+ * accepted for delivery to the live CC session, false when no bridge consumer
+ * is wired (MCP server not booted / not registered) — the router surfaces that
+ * to the dashboard rather than silently dropping.
+ */
+export type BridgeSink = (chatId: string, message: string) => boolean;
+
+/** One outbound frame pushed to the dashboard over SSE. */
+interface BridgeReplyFrame {
+  type: 'reply' | 'ack' | 'error';
+  chat_id: string;
+  text?: string;
+  ts: string;
+}
+
+// chat_id shape: callers may omit it (we mint one). When supplied it is
+// UNTRUSTED — restrict to a conservative id charset + length so it can't be
+// used for SSE header/log injection or to bloat the client keyspace. UUIDs and
+// short opaque tokens both satisfy this.
+const CHAT_ID_RE = /^[a-zA-Z0-9_-]{1,128}$/;
+// Upper bound on a single inbound message. The route also enforces a readBody
+// cap; this is the post-parse semantic guard (mirror CHAT message sizing).
+const MAX_MESSAGE_LENGTH = 32 * 1024;
+const MAX_BRIDGE_CLIENTS = 20;
+const KEEPALIVE_MS = 25_000;
+/** Consecutive failed writes before a client is evicted (mirror api-events). */
+const BACKPRESSURE_EVICT_THRESHOLD = 2;
+
+/**
+ * Validate an untrusted chat_id. Returns the trimmed id when well-formed, or
+ * null when absent/malformed. Callers decide whether null means "mint a fresh
+ * one" (inbound) or "reject" (outbound bind).
+ */
+export function validateChatId(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const v = raw.trim();
+  if (!CHAT_ID_RE.test(v)) return null;
+  return v;
+}
+
+/**
+ * BridgeHub — owns the outbound SSE client set and the registered inbound sink.
+ * One instance per DashboardRouter. Process-local; a cold restart clears it.
+ */
+export class BridgeHub {
+  private sink: BridgeSink | null = null;
+  private clients = new Set<ServerResponse>();
+  private backpressure = new WeakMap<ServerResponse, number>();
+  // chat_ids we have seen on an INBOUND POST. Outbound replies bind against this
+  // set (consensus f5): the live session can only address a stream the dashboard
+  // actually opened, never an arbitrary/forged id. Bounded + TTL'd so a long
+  // run can't grow it unbounded.
+  private knownChatIds = new Map<string, number>();
+  private static readonly MAX_KNOWN_CHAT_IDS = 64;
+  private static readonly CHAT_ID_TTL_MS = 2 * 60 * 60 * 1000; // 2h, mirror chat-session-store
+
+  /** Register (or clear) the in-process inbound sink. Called by RelayServer. */
+  registerSink(fn: BridgeSink | null): void {
+    this.sink = fn;
+  }
+
+  /** True when an MCP-side consumer is wired. */
+  hasSink(): boolean {
+    return this.sink !== null;
+  }
+
+  /**
+   * INBOUND: deliver an untrusted dashboard message to the live CC session.
+   * Body is already JSON-parsed by the route. Validates {chat_id?, message},
+   * mints a chat_id when absent, records it for outbound binding, then invokes
+   * the registered sink. Returns the response payload the route should send.
+   */
+  handlePost(body: unknown): { status: number; payload: Record<string, unknown> } {
+    const b = (body ?? {}) as { chat_id?: unknown; message?: unknown };
+
+    const message = b.message;
+    if (typeof message !== 'string' || message.trim().length === 0) {
+      return { status: 400, payload: { error: 'message must be a non-empty string' } };
+    }
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      return { status: 400, payload: { error: 'message too long' } };
+    }
+
+    // chat_id is optional. A supplied value must be well-formed; a malformed one
+    // is rejected (fail closed) rather than silently coerced, so a client can't
+    // smuggle junk that later fails outbound binding. Absent → mint.
+    let chatId: string;
+    if (b.chat_id === undefined || b.chat_id === null) {
+      chatId = randomUUID();
+    } else {
+      const v = validateChatId(b.chat_id);
+      if (v === null) {
+        return { status: 400, payload: { error: 'invalid chat_id' } };
+      }
+      chatId = v;
+    }
+
+    if (!this.sink) {
+      // No live CC session wired (MCP server not booted, or bridge not active).
+      // Tell the dashboard explicitly instead of pretending it was delivered.
+      return { status: 503, payload: { error: 'No live Claude Code bridge session is active', chat_id: chatId } };
+    }
+
+    this.rememberChatId(chatId);
+
+    let delivered: boolean;
+    try {
+      delivered = this.sink(chatId, message);
+    } catch {
+      delivered = false;
+    }
+    if (!delivered) {
+      return { status: 503, payload: { error: 'Bridge sink rejected the message', chat_id: chatId } };
+    }
+    return { status: 202, payload: { ok: true, chat_id: chatId } };
+  }
+
+  /**
+   * OUTBOUND: the MCP `reply` tool forwards CC's reply here. Binds chat_id
+   * (consensus f5) — drops a reply addressed to a stream the dashboard never
+   * opened. Always fans out a `reply` frame on success. Returns whether the id
+   * was bound (so the MCP tool can no-op honestly when it wasn't).
+   */
+  emitReply(rawChatId: string, text: string): boolean {
+    const chatId = validateChatId(rawChatId);
+    if (chatId === null) return false;
+    if (!this.isKnownChatId(chatId)) return false;
+    this.broadcast({ type: 'reply', chat_id: chatId, text, ts: new Date().toISOString() });
+    return true;
+  }
+
+  /**
+   * Emit a terminal ack frame for a chat_id (consensus f12). Used to guarantee a
+   * closing frame + visible "working…/done" state so push-into-idle never
+   * silently no-ops when Claude omits reply(). Bound the same way as emitReply.
+   */
+  emitAck(rawChatId: string): boolean {
+    const chatId = validateChatId(rawChatId);
+    if (chatId === null) return false;
+    if (!this.isKnownChatId(chatId)) return false;
+    this.broadcast({ type: 'ack', chat_id: chatId, ts: new Date().toISOString() });
+    return true;
+  }
+
+  /**
+   * SSE egress endpoint at /dashboard/api/bridge/stream. Auth is verified by the
+   * router BEFORE this runs (same contract as handleEventsSSE). Long-lived — the
+   * router must NOT route the response through json() afterwards.
+   */
+  handleStream(req: IncomingMessage, res: ServerResponse): void {
+    if (this.clients.size >= MAX_BRIDGE_CLIENTS) {
+      res.writeHead(503, { 'Content-Type': 'text/plain', 'Retry-After': '5' });
+      res.end('Too many bridge SSE clients — retry after 5s');
+      return;
+    }
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
+    this.backpressure.set(res, 0);
+    this.clients.add(res);
+
+    const keepalive = setInterval(() => {
+      try { res.write(':keepalive\n\n'); } catch { clearInterval(keepalive); }
+    }, KEEPALIVE_MS);
+    keepalive.unref?.();
+
+    req.on('close', () => {
+      clearInterval(keepalive);
+      this.clients.delete(res);
+    });
+  }
+
+  /** Fan out one frame to every connected SSE client, with backpressure eviction. */
+  private broadcast(frame: BridgeReplyFrame): void {
+    const data = `data: ${JSON.stringify(frame)}\n\n`;
+    for (const res of this.clients) {
+      try {
+        const ok = res.write(data);
+        if (ok) {
+          this.backpressure.set(res, 0);
+        } else {
+          const count = (this.backpressure.get(res) ?? 0) + 1;
+          this.backpressure.set(res, count);
+          if (count > BACKPRESSURE_EVICT_THRESHOLD) {
+            res.destroy();
+            this.clients.delete(res);
+          }
+        }
+      } catch {
+        this.clients.delete(res);
+      }
+    }
+  }
+
+  private rememberChatId(chatId: string): void {
+    const now = Date.now();
+    this.evictChatIds(now);
+    if (!this.knownChatIds.has(chatId) && this.knownChatIds.size >= BridgeHub.MAX_KNOWN_CHAT_IDS) {
+      // Drop the oldest-seen id to make room (capacity pressure).
+      let oldestKey: string | null = null;
+      let oldest = Infinity;
+      for (const [k, v] of this.knownChatIds) {
+        if (v < oldest) { oldest = v; oldestKey = k; }
+      }
+      if (oldestKey !== null) this.knownChatIds.delete(oldestKey);
+    }
+    this.knownChatIds.set(chatId, now);
+  }
+
+  private isKnownChatId(chatId: string): boolean {
+    this.evictChatIds(Date.now());
+    return this.knownChatIds.has(chatId);
+  }
+
+  private evictChatIds(now: number): void {
+    for (const [k, v] of this.knownChatIds) {
+      if (now - v > BridgeHub.CHAT_ID_TTL_MS) this.knownChatIds.delete(k);
+    }
+  }
+
+  /** Test/introspection helper. */
+  clientCount(): number {
+    return this.clients.size;
+  }
+}

--- a/packages/relay/src/dashboard/index.ts
+++ b/packages/relay/src/dashboard/index.ts
@@ -4,3 +4,4 @@ export { DashboardWs, type DashboardEvent } from './ws';
 export { emitDashboardEvent, type DashboardEventEntry } from './api-events';
 export { ChatConversationStore } from './chat-session-store';
 export { handleChat, type ChatRequestBody, type HandleChatDeps } from './api-chat';
+export { BridgeHub, validateChatId, type BridgeSink } from './api-bridge';

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -20,6 +20,7 @@ import { activeTasksHandler } from './api-active-tasks';
 import { logsHandler } from './api-logs';
 import { violationsHandler } from './api-violations';
 import { handleChat } from './api-chat';
+import { BridgeHub, type BridgeSink } from './api-bridge';
 import { ChatConversationStore } from './chat-session-store';
 import type { ChatbotAgent } from '@gossip/orchestrator';
 import { buildCoverageDegradedMessage } from '@gossip/orchestrator';
@@ -148,6 +149,12 @@ export function normalizeLegacyDegradedFields(report: any): any {
 // readBody, don't bump the shared cap).
 const CHAT_MAX_BODY = 64 * 1024; // 64 KB
 
+// Per-route body cap for POST /dashboard/api/bridge (dashboard → live CC). A
+// steering message can be a paragraph, but is tightly bounded as a DoS guard —
+// same posture as CHAT_MAX_BODY, parametrizing readBody rather than bumping the
+// shared cap (consensus f3 — bound the inbound buffer).
+const BRIDGE_MAX_BODY = 64 * 1024; // 64 KB
+
 // Minimum interval between chat turns from one IP — a simple per-IP throttle so
 // a single client can't fan out concurrent/rapid turns (each turn can run up to
 // maxToolCallsPerTurn tool executions). Mirrors the isIpLockedOut style.
@@ -182,6 +189,10 @@ export class DashboardRouter {
   private chatStore = new ChatConversationStore();
   // Per-IP last-chat-turn timestamp for the min-interval throttle.
   private chatLastTurn = new Map<string, number>();
+  // Dashboard ⇄ live-CC bridge transport (P1). Owns the outbound SSE client set
+  // and the in-process inbound sink the MCP server registers. Distinct from the
+  // dormant chatbot (consensus f14 — no dual-brain; /api/chat stays dormant).
+  private bridge = new BridgeHub();
 
   constructor(
     private auth: DashboardAuth,
@@ -198,6 +209,27 @@ export class DashboardRouter {
    */
   setChatbot(agent: ChatbotAgent | null): void {
     this.chatbot = agent;
+  }
+
+  /**
+   * Register (or clear) the in-process bridge sink that delivers dashboard
+   * messages to the live Claude Code session. Called by the app layer via
+   * RelayServer.registerBridgeSink once the MCP server is constructed. The relay
+   * and MCP server share one process (no wire protocol), so this is a direct
+   * callback — see api-bridge.ts.
+   */
+  registerBridgeSink(fn: BridgeSink | null): void {
+    this.bridge.registerSink(fn);
+  }
+
+  /**
+   * Forward a reply from the live CC session (MCP `reply` tool) to the dashboard
+   * over SSE. chat_id is re-validated + bound inside the hub (consensus f5).
+   * Returns false when the id was unbound / malformed so the caller can no-op
+   * honestly.
+   */
+  emitBridgeReply(chatId: string, text: string): boolean {
+    return this.bridge.emitReply(chatId, text);
   }
 
   /** Update live context (call when agents connect/disconnect) */
@@ -647,6 +679,37 @@ export class DashboardRouter {
           return true;
         }
         await handleChat(req, res, body, { chatbot: this.chatbot, store: this.chatStore });
+        return true;
+      }
+
+      // Bridge INBOUND — /dashboard/api/bridge (dashboard → live CC session).
+      // Auth already verified above. Reuse the SAME per-IP rate-limit the chat
+      // route uses (consensus f13), a per-route readBody cap (consensus f3), then
+      // hand the parsed body to the bridge hub, which validates {chat_id?,
+      // message} and invokes the in-process sink.
+      if (url === '/dashboard/api/bridge' && req.method === 'POST') {
+        const ip = req.socket?.remoteAddress || 'unknown';
+        if (!this.allowChatTurn(ip)) {
+          this.json(res, 429, { error: 'Too many bridge requests. Slow down.' });
+          return true;
+        }
+        let body: unknown;
+        try {
+          body = JSON.parse(await readBody(req, BRIDGE_MAX_BODY));
+        } catch {
+          this.json(res, 400, { error: 'Invalid JSON body' });
+          return true;
+        }
+        const { status, payload } = this.bridge.handlePost(body);
+        this.json(res, status, payload);
+        return true;
+      }
+
+      // Bridge OUTBOUND SSE — /dashboard/api/bridge/stream (live CC → dashboard).
+      // Auth already verified above. Long-lived: handleStream takes over the
+      // response and must NOT go through json().
+      if (url === '/dashboard/api/bridge/stream' && req.method === 'GET') {
+        this.bridge.handleStream(req, res);
         return true;
       }
 

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -706,9 +706,16 @@ export class DashboardRouter {
       }
 
       // Bridge OUTBOUND SSE — /dashboard/api/bridge/stream (live CC → dashboard).
-      // Auth already verified above. Long-lived: handleStream takes over the
-      // response and must NOT go through json().
+      // Auth already verified above. Per-IP throttle on connection opens too
+      // (consensus f7e5bc15 f2 — defense-in-depth so a leaked key can't churn
+      // SSE slots; the MAX_BRIDGE_CLIENTS cap still bounds concurrency). Long-
+      // lived: handleStream takes over the response and must NOT go through json().
       if (url === '/dashboard/api/bridge/stream' && req.method === 'GET') {
+        const ip = req.socket?.remoteAddress || 'unknown';
+        if (!this.allowChatTurn(ip)) {
+          this.json(res, 429, { error: 'Too many bridge stream opens. Slow down.' });
+          return true;
+        }
         this.bridge.handleStream(req, res);
         return true;
       }

--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -15,6 +15,7 @@ import { AgentConnection, livenessMap } from './agent-connection';
 import { DashboardAuth } from './dashboard/auth';
 import { DashboardRouter } from './dashboard/routes';
 import { DashboardWs } from './dashboard/ws';
+import type { BridgeSink } from './dashboard/api-bridge';
 import type { ChatbotAgent } from '@gossip/orchestrator';
 
 export interface DashboardConfig {
@@ -468,5 +469,28 @@ export class RelayServer {
    */
   setChatbot(agent: ChatbotAgent | null): void {
     this.dashboardRouter?.setChatbot(agent);
+  }
+
+  /**
+   * Register the in-process bridge sink (dashboard → live Claude Code session).
+   * Called by the app layer (mcp-server-sdk.ts) after the MCP server is
+   * constructed: the dashboard POST handler invokes this callback, which emits
+   * a `notifications/claude/channel` notification over stdio. The relay and MCP
+   * server share one process (spec "#1 unknown RESOLVED") — no wire protocol.
+   * No-op if the dashboard is disabled. Pass null to clear.
+   */
+  registerBridgeSink(fn: BridgeSink | null): void {
+    this.dashboardRouter?.registerBridgeSink(fn);
+  }
+
+  /**
+   * Forward a reply from the live CC session (MCP `reply` tool) out to the
+   * dashboard over SSE. chat_id is re-validated + bound to a stream the
+   * dashboard actually opened (consensus f5). Returns false when the dashboard
+   * is disabled or the chat_id is unbound/malformed so the caller can no-op
+   * honestly rather than claiming a delivery.
+   */
+  emitBridgeReply(chatId: string, text: string): boolean {
+    return this.dashboardRouter?.emitBridgeReply(chatId, text) ?? false;
   }
 }


### PR DESCRIPTION
## What
P1 **backend core** of the dashboard ⇄ live Claude Code bridge: fold a Claude Code "channel" into the existing gossipcat MCP server so the dashboard drives the **same live orchestrator conversation**. Server-side round-trip only.

- **Inbound** (dashboard → CC): `POST /dashboard/api/bridge` → in-process sink → `notifications/claude/channel` over stdio → live CC session sees `<channel source="gossipcat" chat_id="…">`.
- **Outbound** (CC → dashboard): bridge-scoped `reply` MCP tool → `GET /dashboard/api/bridge/stream` (SSE).
- **In-process**: relay + MCP server share one Node process — no wire protocol (design consensus confirmed).

## Scope
P1 backend only. **Out of scope:** P2 activity-mirror, P3 permission relay (`claude/channel/permission` omitted), dashboard-v2 UI, `gossipcat code` wrapper. ChatbotAgent left dormant (no dual-brain).

## Security (consensus moved P4 → P1)
Auth (`DashboardAuth`) + `allowChatTurn` rate-limit + readBody cap at the enqueue boundary; `chat_id` validated both directions + outbound binding (cap+TTL); bounded inbound buffer; fail-closed; `reply` no-ops with a "not gossip_relay" error when no stream is open (invariant #4 mitigation).

## Verification
- `tsc --noEmit` clean: `apps/cli` + `packages/relay`
- `tests/relay`: 262 passed, 0 failed
- Diff reviewed line-by-line by orchestrator

## Design review
consensus-id: 91609233-7ac94056 (4 confirmed, 18 unique; in-process transport confirmed, all security findings folded in)

## Known residuals (follow-up, non-blocking)
- `cc-bridge.ts` `flush()` not yet wired to a transport-connect trigger (retry buffer partially inert; happy path unaffected)
- `reply` tool globally visible (guarded by no-op)

## Launch note
Requires `--channels server:gossipcat` (or `--dangerously-load-development-channels` until allowlisted) at CC launch. The `gossipcat code` wrapper that hides this is step 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)