### PR TITLE
feat(bridge): P1 frontend + `gossipcat code` wrapper (completes P1)

### DIFF
--- a/apps/cli/src/code-launch.ts
+++ b/apps/cli/src/code-launch.ts
@@ -1,0 +1,174 @@
+/**
+ * `gossipcat code` — launch wrapper for Claude Code with the gossipcat channel.
+ *
+ * Execs `claude` with either:
+ *   --channels server:<name>                        (when channel.allowlisted=true in .gossip/config.json)
+ *   --dangerously-load-development-channels server:<name>  (default until allowlisted)
+ *
+ * The server <name> is resolved by inspecting .mcp.json (cwd) and ~/.claude.json mcpServers,
+ * looking for the entry whose command runs the gossipcat mcp-serve binary. Falls back to
+ * "gossipcat" with a printed note.
+ *
+ * All remaining argv are passed through to claude verbatim.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { spawn } from 'child_process';
+
+/** Safe charset for MCP server names: alphanumeric, hyphens, underscores, dots. */
+const SAFE_SERVER_NAME_RE = /^[a-zA-Z0-9._-]{1,64}$/;
+
+interface McpServersMap {
+  [key: string]: {
+    command?: string;
+    args?: unknown[];
+    [k: string]: unknown;
+  };
+}
+
+/**
+ * Parse a JSON file at `filePath`, catching all errors.
+ * Returns null on any failure (missing file, bad JSON, wrong type).
+ */
+function safeReadJson(filePath: string): unknown {
+  try {
+    if (!existsSync(filePath)) return null;
+    const raw = readFileSync(filePath, 'utf-8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return true if the mcpServers entry looks like a gossipcat mcp-serve invocation.
+ * Checks both the command itself and the args array.
+ */
+function isGossipMcpEntry(entry: { command?: string; args?: unknown[] }): boolean {
+  const cmd = entry.command ?? '';
+  const args = Array.isArray(entry.args) ? entry.args : [];
+
+  // Direct invocation: command is the gossipcat binary
+  if (typeof cmd === 'string' && /gossipcat/i.test(cmd)) return true;
+
+  // node dist-mcp/mcp-server.js pattern (the canonical form in .mcp.json)
+  if (args.some(a => typeof a === 'string' && /mcp-server\.(js|ts)$/.test(a))) return true;
+
+  // npx gossipcat mcp-serve
+  if (typeof cmd === 'string' && /npx/i.test(cmd)) {
+    if (args.some(a => typeof a === 'string' && /gossipcat/i.test(a))) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Detect the MCP server name for gossipcat by reading .mcp.json and/or ~/.claude.json.
+ * Returns [serverName, usingFallback].
+ */
+function detectServerName(cwd: string): [string, boolean] {
+  const candidates: [string, unknown][] = [
+    [join(cwd, '.mcp.json'), safeReadJson(join(cwd, '.mcp.json'))],
+    [join(homedir(), '.claude.json'), safeReadJson(join(homedir(), '.claude.json'))],
+  ];
+
+  for (const [filePath, data] of candidates) {
+    if (!data || typeof data !== 'object') continue;
+    const root = data as Record<string, unknown>;
+
+    // .mcp.json top-level { mcpServers: { <name>: {...} } }
+    // ~/.claude.json nested: { mcpServers: { <name>: {...} } }
+    const mcpServers = root['mcpServers'];
+    if (!mcpServers || typeof mcpServers !== 'object') continue;
+
+    const servers = mcpServers as McpServersMap;
+    for (const [name, entry] of Object.entries(servers)) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (isGossipMcpEntry(entry)) {
+        // Validate the name before returning it (it will be passed to spawn args)
+        if (SAFE_SERVER_NAME_RE.test(name)) {
+          return [name, false];
+        }
+        // Name is present but unsafe — log and fall through
+        process.stderr.write(
+          `[gossipcat code] Warning: found gossipcat MCP entry in ${filePath} but server name "${name}" ` +
+          `contains unsafe characters; falling back to "gossipcat".\n`
+        );
+      }
+    }
+  }
+
+  return ['gossipcat', true];
+}
+
+/**
+ * Read the channel.allowlisted flag from .gossip/config.json.
+ * Defaults to false on any read/parse/type error.
+ */
+function isChannelAllowlisted(cwd: string): boolean {
+  const configPath = join(cwd, '.gossip', 'config.json');
+  try {
+    const data = safeReadJson(configPath);
+    if (!data || typeof data !== 'object') return false;
+    const channel = (data as Record<string, unknown>)['channel'];
+    if (!channel || typeof channel !== 'object') return false;
+    const allowlisted = (channel as Record<string, unknown>)['allowlisted'];
+    return allowlisted === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Main entry point for `gossipcat code`.
+ * @param argv - process.argv.slice(3) (everything after "gossipcat code")
+ */
+export function runCodeCommand(argv: string[]): void {
+  const cwd = process.cwd();
+
+  const [serverName, usingFallback] = detectServerName(cwd);
+  if (usingFallback) {
+    process.stderr.write(
+      `[gossipcat code] Note: could not detect gossipcat MCP server name from .mcp.json or ~/.claude.json; ` +
+      `using "gossipcat". If your server has a different name, ensure .mcp.json is present.\n`
+    );
+  }
+
+  const allowlisted = isChannelAllowlisted(cwd);
+
+  let claudeArgs: string[];
+  if (allowlisted) {
+    claudeArgs = ['--channels', `server:${serverName}`, ...argv];
+  } else {
+    process.stderr.write(
+      `[gossipcat code] Note: using --dangerously-load-development-channels (custom channels are not yet ` +
+      `on Anthropic's allowlist). Set channel.allowlisted=true in .gossip/config.json once allowlisted ` +
+      `to switch to --channels.\n`
+    );
+    claudeArgs = ['--dangerously-load-development-channels', `server:${serverName}`, ...argv];
+  }
+
+  const child = spawn('claude', claudeArgs, { stdio: 'inherit' });
+
+  child.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'ENOENT') {
+      process.stderr.write(
+        `[gossipcat code] Error: "claude" is not on your PATH. ` +
+        `Install Claude Code (https://claude.ai/download) and ensure the CLI is accessible.\n`
+      );
+    } else {
+      process.stderr.write(`[gossipcat code] Error launching claude: ${err.message}\n`);
+    }
+    process.exit(1);
+  });
+
+  child.on('exit', (code: number | null, signal: string | null) => {
+    if (signal) {
+      process.kill(process.pid, signal as NodeJS.Signals);
+    } else {
+      process.exit(code ?? 0);
+    }
+  });
+}

--- a/apps/cli/src/hook-run.ts
+++ b/apps/cli/src/hook-run.ts
@@ -27,6 +27,14 @@ const NO_BOOTSTRAP_HINT =
 const SUPPRESSED_LINE =
   '[gossipcat: bootstrap already loaded — call gossip_status() if you need a refresh]';
 
+/**
+ * One-line nudge appended after the bootstrap when the dashboard channel is
+ * not active. Suppressed when CLAUDE_CHANNEL_ID is set (CC injects it when a
+ * channel is live) or when GOSSIPCAT_CHANNEL_ACTIVE=1 is set manually.
+ */
+const CHANNEL_NUDGE =
+  '[gossipcat] 💬 Drive me from the dashboard: run `gossipcat code` to launch with the channel active.';
+
 export interface HookRunOptions {
   /** Override `process.cwd()` for tests. */
   cwd?: string;
@@ -90,6 +98,12 @@ export function runHook(opts: HookRunOptions = {}): void {
     }
     write(content);
     if (!content.endsWith('\n')) write('\n');
+
+    // Append channel nudge only when the CC channel is not already active.
+    // CLAUDE_CHANNEL_ID is injected by Claude Code when --channels is in effect.
+    if (!process.env['CLAUDE_CHANNEL_ID'] && !process.env['GOSSIPCAT_CHANNEL_ACTIVE']) {
+      write(CHANNEL_NUDGE + '\n');
+    }
 
     // Update sentinel best-effort (any failure is silent).
     if (currentMtime !== null && sentinelPath) {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -32,6 +32,12 @@ async function main(): Promise<void> {
       await createTeam(args.slice(1).join(' ') || undefined);
       return;
 
+    case 'code': {
+      const { runCodeCommand } = await import('./code-launch');
+      runCodeCommand(process.argv.slice(3));
+      return;
+    }
+
     case 'mcp-serve':
       // Run MCP server via stdio — used by Claude Code / Cursor / any MCP client
       await import('./mcp-server-sdk');
@@ -202,6 +208,7 @@ function printHelp(): void {
     gossipcat sync             Sync task history to Supabase
     gossipcat sync --setup     Configure Supabase connection
     gossipcat sync --status    Show sync status
+    gossipcat code [args...]   Launch Claude Code with gossipcat channel active
     gossipcat mcp-serve        Start MCP server (for Claude Code / Cursor)
     gossipcat hook --run       Run UserPromptSubmit bootstrap hook (internal)
     gossipcat help             Show this help

--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -19,6 +19,7 @@ import { useDashboardData } from '@/hooks/useDashboardData';
 import { timeAgo } from '@/lib/utils';
 import { getBenchBadgeKind, needsAttention } from '@/lib/bench';
 import { NotificationStack } from '@/components/NotificationStack';
+import { ChatDock } from '@/components/ChatDock';
 import { useSeverityCounts } from '@/hooks/useSeverityCounts';
 import { AgentCardBig } from '@/components/AgentCardBig';
 import type { DashboardEvent, AgentData, ConsensusReportsData, FleetTrendResponse, FleetTrendPoint } from '@/lib/types';
@@ -640,6 +641,7 @@ export function App() {
     <>
       <Dashboard onUnauthorized={recheck} />
       <NotificationStack />
+      <ChatDock />
     </>
   );
 }

--- a/packages/dashboard-v2/src/components/ChatDock.tsx
+++ b/packages/dashboard-v2/src/components/ChatDock.tsx
@@ -82,13 +82,13 @@ function MessageBubble({ msg }: { msg: BridgeMessage }) {
         style={bubbleStyle}
       >
         {isError && (
-          <span className="mb-0.5 block font-mono text-[10px]" style={{ fontVariant: 'small-caps', letterSpacing: '0.04em' }}>
+          <span className="h-section mb-0.5 block" style={{ color: 'var(--bad)' }}>
             session error
           </span>
         )}
         {msg.text}
       </div>
-      <span className="px-1 font-mono text-[9px]" style={{ color: 'var(--text-faint)' }}>
+      <span className="px-1 font-mono text-[11px]" style={{ color: 'var(--text-dim)' }}>
         {timeShort(msg.ts)}
       </span>
     </div>
@@ -96,12 +96,13 @@ function MessageBubble({ msg }: { msg: BridgeMessage }) {
 }
 
 function StatusDot({ status }: { status: ReturnType<typeof useBridge>['status'] }) {
-  const map = {
+  const map: Record<string, { color: string; label: string }> = {
     open: { color: 'var(--ok)', label: 'live' },
     connecting: { color: 'var(--warn)', label: 'connecting' },
     closed: { color: 'var(--idle)', label: 'offline' },
-  } as const;
-  const { color, label } = map[status];
+    error: { color: 'var(--bad)', label: 'relay down' },
+  };
+  const { color, label } = map[status] ?? map['closed'];
   return (
     <span className="inline-flex items-center gap-1.5">
       <span
@@ -189,7 +190,7 @@ export function ChatDock() {
             <span className="h-section">live claude code</span>
             <StatusDot status={status} />
           </div>
-          <div className="mt-0.5 truncate font-mono text-[10px]" style={{ color: 'var(--text-faint)' }}>
+          <div className="mt-0.5 truncate font-mono text-[10px]" style={{ color: 'var(--text-dim)' }}>
             {chatId ? `chat ${chatId.slice(0, 8)}` : 'same session as your terminal'}
           </div>
         </div>
@@ -208,7 +209,7 @@ export function ChatDock() {
       <div ref={scrollRef} className="flex-1 space-y-2 overflow-y-auto px-3 py-3">
         {messages.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center px-4 text-center">
-            <div className="font-mono text-xs" style={{ color: 'var(--text-dim)' }}>
+            <div className="text-xs" style={{ color: 'var(--text-dim)' }}>
               {status === 'connecting' ? 'connecting to the live session…' : 'no messages yet'}
             </div>
             <div className="mt-1 text-[11px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 70%, transparent)' }}>
@@ -224,7 +225,7 @@ export function ChatDock() {
             <span className="inline-flex gap-1" aria-hidden>
               <span className="h-1.5 w-1.5 animate-pulse rounded-full" style={{ background: 'var(--text-faint)' }} />
             </span>
-            <span className="font-mono text-[10px]" style={{ color: 'var(--text-dim)' }}>
+            <span className="text-[10px]" style={{ color: 'var(--text-dim)' }}>
               working…
             </span>
           </div>

--- a/packages/dashboard-v2/src/components/ChatDock.tsx
+++ b/packages/dashboard-v2/src/components/ChatDock.tsx
@@ -1,0 +1,278 @@
+import { useEffect, useRef, useState } from 'react';
+import { useBridge, type BridgeMessage } from '@/lib/useBridge';
+
+/**
+ * ChatDock — bottom-right docked conversation panel wired to the LIVE Claude
+ * Code orchestrator session over the P1 bridge (spec
+ * 2026-06-14-dashboard-cc-channel-bridge.md).
+ *
+ * This is the SAME session running in the terminal — typing here reaches the
+ * live orchestrator; its replies stream back over SSE. It is explicitly NOT the
+ * dormant ChatbotAgent /api/chat brain (never wired here).
+ *
+ * DESIGN.md conformance:
+ *   - Terracotta --accent is reserved for the send CTA + the collapsed launcher
+ *     (a primary action), NEVER on chat chrome / bubbles / status.
+ *   - Status is semantic: --ok (open), --warn (connecting), --bad (error),
+ *     --idle (closed). Connection chip + error turns use these only.
+ *   - Section label uses the small-caps Geist .h-section signature.
+ *   - Hairline --border, --r-lg card, NO drop shadow (the dock floats with the
+ *     project's existing --shadow-card token, consistent with NotificationStack).
+ *   - JetBrains Mono (--font-mono) for the chat_id + timestamps; Geist body for
+ *     message text.
+ *
+ * Placement: fixed bottom-right launcher that expands into a panel, mirroring
+ * NotificationStack's fixed bottom-right anchor (it sits to the LEFT of the
+ * toast lane so the two don't overlap). Alternative considered: a persistent
+ * right rail — rejected because the dashboard's hero/grid already owns full
+ * width and a rail would force a layout reflow on every route. A collapsible
+ * dock is non-invasive and matches the "complements the terminal" intent.
+ */
+
+function timeShort(ts: string): string {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function MessageBubble({ msg }: { msg: BridgeMessage }) {
+  const isUser = msg.role === 'user';
+  const isError = msg.role === 'error';
+  const isAck = msg.role === 'ack';
+
+  // Ack is a centered system note, not a bubble.
+  if (isAck) {
+    return (
+      <div className="flex justify-center py-0.5">
+        <span
+          className="rounded-full px-2 py-0.5 font-mono text-[10px]"
+          style={{
+            color: 'var(--idle)',
+            background: 'color-mix(in oklch, var(--idle) 12%, transparent)',
+          }}
+        >
+          {msg.text}
+        </span>
+      </div>
+    );
+  }
+
+  const bubbleStyle = isError
+    ? {
+        color: 'var(--bad)',
+        background: 'color-mix(in oklch, var(--bad) 10%, transparent)',
+        border: '1px solid color-mix(in oklch, var(--bad) 30%, transparent)',
+      }
+    : isUser
+      ? {
+          color: 'var(--text)',
+          background: 'var(--surface-sunk)',
+          border: '1px solid var(--border)',
+        }
+      : {
+          color: 'var(--text)',
+          background: 'var(--surface-elev)',
+          border: '1px solid var(--border)',
+        };
+
+  return (
+    <div className={`flex flex-col ${isUser ? 'items-end' : 'items-start'} gap-0.5`}>
+      <div
+        className="max-w-[85%] whitespace-pre-wrap break-words rounded-lg px-3 py-2 text-[13px] leading-snug"
+        style={bubbleStyle}
+      >
+        {isError && (
+          <span className="mb-0.5 block font-mono text-[10px]" style={{ fontVariant: 'small-caps', letterSpacing: '0.04em' }}>
+            session error
+          </span>
+        )}
+        {msg.text}
+      </div>
+      <span className="px-1 font-mono text-[9px]" style={{ color: 'var(--text-faint)' }}>
+        {timeShort(msg.ts)}
+      </span>
+    </div>
+  );
+}
+
+function StatusDot({ status }: { status: ReturnType<typeof useBridge>['status'] }) {
+  const map = {
+    open: { color: 'var(--ok)', label: 'live' },
+    connecting: { color: 'var(--warn)', label: 'connecting' },
+    closed: { color: 'var(--idle)', label: 'offline' },
+  } as const;
+  const { color, label } = map[status];
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span
+        className={`inline-block h-1.5 w-1.5 rounded-full ${status === 'connecting' ? 'animate-pulse' : ''}`}
+        style={{ background: color }}
+        aria-hidden
+      />
+      <span className="font-mono text-[10px]" style={{ color: 'var(--text-dim)' }}>
+        {label}
+      </span>
+    </span>
+  );
+}
+
+export function ChatDock() {
+  const [openPanel, setOpenPanel] = useState(false);
+  const [draft, setDraft] = useState('');
+  const { messages, status, awaitingReply, chatId, send, sendError } = useBridge();
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Auto-scroll to the newest turn whenever the conversation grows or the
+  // working indicator toggles.
+  useEffect(() => {
+    if (!openPanel) return;
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages, awaitingReply, openPanel]);
+
+  useEffect(() => {
+    if (openPanel) inputRef.current?.focus();
+  }, [openPanel]);
+
+  const submit = () => {
+    const text = draft.trim();
+    if (!text) return;
+    void send(text);
+    setDraft('');
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Enter sends; Shift+Enter inserts a newline (multi-line steering prompts).
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  // ── Collapsed launcher ──
+  if (!openPanel) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpenPanel(true)}
+        className="fixed bottom-4 left-4 z-50 flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-colors"
+        style={{ background: 'var(--accent)', color: 'var(--accent-foreground, #fff)' }}
+        aria-label="Open live Claude Code chat"
+        data-tooltip="Talk to the live Claude Code session"
+        data-tooltip-pos="right"
+      >
+        <span aria-hidden>◎</span>
+        <span>Live session</span>
+      </button>
+    );
+  }
+
+  // ── Expanded panel ──
+  return (
+    <div
+      className="fixed bottom-4 left-4 z-50 flex w-[360px] max-w-[calc(100vw-2rem)] flex-col rounded-xl"
+      style={{
+        height: 'min(560px, calc(100vh - 2rem))',
+        background: 'var(--surface-elev)',
+        border: '1px solid var(--border)',
+        boxShadow: 'var(--shadow-card)',
+      }}
+      role="region"
+      aria-label="Live Claude Code session chat"
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 border-b px-4 py-3" style={{ borderColor: 'var(--border)' }}>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="h-section">live claude code</span>
+            <StatusDot status={status} />
+          </div>
+          <div className="mt-0.5 truncate font-mono text-[10px]" style={{ color: 'var(--text-faint)' }}>
+            {chatId ? `chat ${chatId.slice(0, 8)}` : 'same session as your terminal'}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpenPanel(false)}
+          className="shrink-0 rounded px-2 py-1 text-sm leading-none transition-colors hover:[background:var(--surface-sunk)]"
+          style={{ color: 'var(--text-dim)' }}
+          aria-label="Collapse chat dock"
+        >
+          –
+        </button>
+      </div>
+
+      {/* Conversation */}
+      <div ref={scrollRef} className="flex-1 space-y-2 overflow-y-auto px-3 py-3">
+        {messages.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center px-4 text-center">
+            <div className="font-mono text-xs" style={{ color: 'var(--text-dim)' }}>
+              {status === 'connecting' ? 'connecting to the live session…' : 'no messages yet'}
+            </div>
+            <div className="mt-1 text-[11px]" style={{ color: 'color-mix(in oklch, var(--text-dim) 70%, transparent)' }}>
+              Type below to steer or start work. This reaches the same Claude Code session running in your terminal.
+            </div>
+          </div>
+        ) : (
+          messages.map((m) => <MessageBubble key={m.id} msg={m} />)
+        )}
+
+        {awaitingReply && (
+          <div className="flex items-center gap-2 px-1 py-1">
+            <span className="inline-flex gap-1" aria-hidden>
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full" style={{ background: 'var(--text-faint)' }} />
+            </span>
+            <span className="font-mono text-[10px]" style={{ color: 'var(--text-dim)' }}>
+              working…
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Transient send error */}
+      {sendError && (
+        <div
+          role="alert"
+          className="mx-3 mb-1 rounded-sm px-2 py-1 font-mono text-[10px]"
+          style={{
+            color: 'var(--bad)',
+            background: 'color-mix(in oklch, var(--bad) 10%, transparent)',
+            border: '1px solid color-mix(in oklch, var(--bad) 30%, transparent)',
+          }}
+        >
+          {sendError}
+        </div>
+      )}
+
+      {/* Composer */}
+      <div className="flex items-end gap-2 border-t px-3 py-3" style={{ borderColor: 'var(--border)' }}>
+        <textarea
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={onKeyDown}
+          rows={1}
+          placeholder="Message the live session…  (Enter to send)"
+          className="max-h-28 min-h-[36px] flex-1 resize-none rounded-md border px-3 py-2 text-[13px] focus:outline-none"
+          style={{
+            background: 'var(--surface)',
+            color: 'var(--text)',
+            borderColor: 'var(--border)',
+          }}
+        />
+        <button
+          type="button"
+          onClick={submit}
+          disabled={draft.trim().length === 0}
+          className="shrink-0 rounded-md px-3 py-2 text-sm font-medium transition-opacity disabled:opacity-40"
+          style={{ background: 'var(--accent)', color: 'var(--accent-foreground, #fff)' }}
+          aria-label="Send message"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -214,6 +214,7 @@
 @media (prefers-reduced-motion: reduce) {
   /* Respect motion sensitivity: easter egg still fires but instantly. */
   [style*="orch-smile-pop"], [style*="orch-ripple"] { animation: none !important; opacity: 0; }
+  .animate-pulse { animation: none; }
 }
 
 /* DESIGN.md section header signature (small-caps Geist).

--- a/packages/dashboard-v2/src/lib/useBridge.ts
+++ b/packages/dashboard-v2/src/lib/useBridge.ts
@@ -51,7 +51,7 @@ export interface BridgeMessage {
 }
 
 /** Connection lifecycle of the SSE stream. */
-export type BridgeStatus = 'connecting' | 'open' | 'closed';
+export type BridgeStatus = 'connecting' | 'open' | 'closed' | 'error';
 
 export interface UseBridgeResult {
   messages: BridgeMessage[];
@@ -70,6 +70,8 @@ export interface UseBridgeResult {
 const BACKOFF_MIN_MS = 1_000;
 const BACKOFF_MAX_MS = 5_000;
 const STREAM_PATH = '/dashboard/api/bridge/stream';
+/** After this many consecutive onerror events with no successful onopen, surface 'error' status. */
+const ERROR_AFTER_FAILURES = 4;
 const POST_PATH = '/dashboard/api/bridge';
 const POST_TIMEOUT_MS = 30_000;
 
@@ -118,6 +120,7 @@ export function useBridge(): UseBridgeResult {
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     let backoff = BACKOFF_MIN_MS;
     let destroyed = false;
+    let consecutiveFailures = 0;
 
     function open(): void {
       if (destroyed) return;
@@ -126,6 +129,7 @@ export function useBridge(): UseBridgeResult {
 
       es.onopen = () => {
         if (destroyed) return;
+        consecutiveFailures = 0;
         setStatus('open');
         backoff = BACKOFF_MIN_MS;
       };
@@ -164,7 +168,12 @@ export function useBridge(): UseBridgeResult {
           es = null;
         }
         if (destroyed) return;
-        setStatus('connecting');
+        consecutiveFailures += 1;
+        if (consecutiveFailures >= ERROR_AFTER_FAILURES) {
+          setStatus('error');
+        } else {
+          setStatus('connecting');
+        }
         retryTimer = setTimeout(() => open(), backoff);
         backoff = Math.min(backoff * 2, BACKOFF_MAX_MS);
       };

--- a/packages/dashboard-v2/src/lib/useBridge.ts
+++ b/packages/dashboard-v2/src/lib/useBridge.ts
@@ -1,0 +1,242 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * useBridge — frontend hook for the dashboard ⇄ LIVE Claude Code session bridge
+ * (P1 backend, spec 2026-06-14-dashboard-cc-channel-bridge.md).
+ *
+ * Mirrors the useEventStream SSE pattern: open an EventSource, parse frames,
+ * manual reconnect with backoff, cleanup-on-unmount. Adds the conversational
+ * layer the bridge needs:
+ *   - send(text): POST to /dashboard/api/bridge. Omits chat_id on the first
+ *     send; the server mints + returns one, which we reuse for the conversation.
+ *   - Frames are filtered to the active chat_id so a stray/forged stream id
+ *     (or a different tab's conversation) can't bleed into this view.
+ *
+ * IMPORTANT: this wires the LIVE Claude Code orchestrator session, NOT the
+ * dormant ChatbotAgent /api/chat brain. The two must never be conflated.
+ *
+ * Backend contract (do NOT change — fixed by api-bridge.ts):
+ *   POST /dashboard/api/bridge {chat_id?, message}
+ *     → 202 {ok:true, chat_id} | 400 | 429 | 503
+ *   GET  /dashboard/api/bridge/stream  (SSE)
+ *     → frames {type:'reply'|'ack'|'error', chat_id, text?, ts}
+ */
+
+// Minimal window surface — mirrors useEventStream so node/jsdom test envs that
+// lack a full lib.dom EventSource don't trip the import.
+declare const window:
+  | {
+      EventSource: typeof EventSource;
+    }
+  | undefined;
+
+/** A single inbound SSE frame from the bridge. */
+export interface BridgeFrame {
+  type: 'reply' | 'ack' | 'error';
+  chat_id: string;
+  text?: string;
+  ts: string;
+}
+
+/** Role of a rendered conversation turn. */
+export type BridgeRole = 'user' | 'assistant' | 'ack' | 'error';
+
+/** One rendered turn in the conversation view. */
+export interface BridgeMessage {
+  /** Stable client-side id (monotonic) for React keys. */
+  id: number;
+  role: BridgeRole;
+  text: string;
+  ts: string;
+}
+
+/** Connection lifecycle of the SSE stream. */
+export type BridgeStatus = 'connecting' | 'open' | 'closed';
+
+export interface UseBridgeResult {
+  messages: BridgeMessage[];
+  /** SSE connection status. */
+  status: BridgeStatus;
+  /** True between a send() and the next reply/ack/error frame for this chat. */
+  awaitingReply: boolean;
+  /** True once the server has minted (or we have adopted) a chat_id. */
+  chatId: string | null;
+  /** POST a user message to the live CC session. No-op for empty input. */
+  send: (text: string) => Promise<void>;
+  /** Last transient send error (network / HTTP), cleared on the next send. */
+  sendError: string | null;
+}
+
+const BACKOFF_MIN_MS = 1_000;
+const BACKOFF_MAX_MS = 5_000;
+const STREAM_PATH = '/dashboard/api/bridge/stream';
+const POST_PATH = '/dashboard/api/bridge';
+const POST_TIMEOUT_MS = 30_000;
+
+/** HTTP status → human-readable send error, matching backend semantics. */
+function postErrorMessage(status: number): string {
+  switch (status) {
+    case 400:
+      return 'message rejected — invalid or empty';
+    case 429:
+      return 'rate limited — slow down';
+    case 503:
+      return 'no live Claude Code session — start `gossipcat code`';
+    case 401:
+      return 'session expired — reload to re-authenticate';
+    default:
+      return `send failed — HTTP ${status}`;
+  }
+}
+
+let nextMessageId = 1;
+function makeMessage(role: BridgeRole, text: string, ts?: string): BridgeMessage {
+  return { id: nextMessageId++, role, text, ts: ts ?? new Date().toISOString() };
+}
+
+export function useBridge(): UseBridgeResult {
+  const [messages, setMessages] = useState<BridgeMessage[]>([]);
+  const [status, setStatus] = useState<BridgeStatus>('connecting');
+  const [awaitingReply, setAwaitingReply] = useState(false);
+  const [chatId, setChatId] = useState<string | null>(null);
+  const [sendError, setSendError] = useState<string | null>(null);
+
+  // chat_id is read inside the EventSource onmessage closure (created once in the
+  // mount effect) and written by send(). A ref keeps the frame filter reading the
+  // latest value without re-opening the stream on every chat_id change.
+  const chatIdRef = useRef<string | null>(null);
+  const setChat = useCallback((id: string) => {
+    chatIdRef.current = id;
+    setChatId(id);
+  }, []);
+
+  // ── SSE stream: open once, manual reconnect, filter frames to active chat ──
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.EventSource === 'undefined') return;
+
+    let es: EventSource | null = null;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let backoff = BACKOFF_MIN_MS;
+    let destroyed = false;
+
+    function open(): void {
+      if (destroyed) return;
+      setStatus('connecting');
+      es = new window!.EventSource(STREAM_PATH);
+
+      es.onopen = () => {
+        if (destroyed) return;
+        setStatus('open');
+        backoff = BACKOFF_MIN_MS;
+      };
+
+      es.onmessage = (evt: MessageEvent) => {
+        let frame: BridgeFrame;
+        try {
+          frame = JSON.parse(evt.data);
+        } catch {
+          return; // malformed frame — skip
+        }
+        // Filter to the active conversation. Before our first send chatIdRef is
+        // null and we have no stream to claim, so ignore frames until then.
+        const active = chatIdRef.current;
+        if (!active || frame.chat_id !== active) return;
+
+        if (frame.type === 'reply') {
+          setAwaitingReply(false);
+          setMessages((prev) => [...prev, makeMessage('assistant', frame.text ?? '', frame.ts)]);
+        } else if (frame.type === 'ack') {
+          // Ack means "received / working" — keep the awaiting indicator on but
+          // record a discrete ack turn so the user sees the session is alive.
+          setMessages((prev) => [...prev, makeMessage('ack', 'received — working…', frame.ts)]);
+        } else if (frame.type === 'error') {
+          setAwaitingReply(false);
+          setMessages((prev) => [
+            ...prev,
+            makeMessage('error', frame.text ?? 'the live session reported an error', frame.ts),
+          ]);
+        }
+      };
+
+      es.onerror = () => {
+        if (es) {
+          es.close();
+          es = null;
+        }
+        if (destroyed) return;
+        setStatus('connecting');
+        retryTimer = setTimeout(() => open(), backoff);
+        backoff = Math.min(backoff * 2, BACKOFF_MAX_MS);
+      };
+    }
+
+    open();
+
+    return () => {
+      destroyed = true;
+      setStatus('closed');
+      if (retryTimer !== null) clearTimeout(retryTimer);
+      if (es) {
+        es.close();
+        es = null;
+      }
+    };
+  }, []);
+
+  const send = useCallback(
+    async (raw: string): Promise<void> => {
+      const text = raw.trim();
+      if (text.length === 0) return;
+
+      setSendError(null);
+      // Optimistically render the user's turn immediately.
+      setMessages((prev) => [...prev, makeMessage('user', text)]);
+      setAwaitingReply(true);
+
+      // Reuse the conversation's chat_id once minted; omit on the first send so
+      // the server mints one and returns it.
+      const existing = chatIdRef.current;
+      const body: { message: string; chat_id?: string } = { message: text };
+      if (existing) body.chat_id = existing;
+
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), POST_TIMEOUT_MS);
+      try {
+        const res = await fetch(POST_PATH, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+
+        // The backend returns chat_id on 202 AND on 503 (so a retry can reuse
+        // the same conversation). Adopt it whenever present.
+        let payload: { ok?: boolean; chat_id?: string; error?: string } = {};
+        try {
+          payload = await res.json();
+        } catch {
+          /* non-JSON body — fall through to status-based handling */
+        }
+        if (typeof payload.chat_id === 'string' && payload.chat_id.length > 0 && !chatIdRef.current) {
+          setChat(payload.chat_id);
+        }
+
+        if (res.status === 202) return;
+
+        // Non-2xx: surface the error, stop the awaiting indicator.
+        setAwaitingReply(false);
+        setSendError(payload.error ?? postErrorMessage(res.status));
+      } catch (err) {
+        setAwaitingReply(false);
+        const aborted = err instanceof Error && err.name === 'AbortError';
+        setSendError(aborted ? 'send timed out — relay unreachable' : 'send failed — relay unreachable');
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+    [setChat]
+  );
+
+  return { messages, status, awaitingReply, chatId, send, sendError };
+}


### PR DESCRIPTION
## What
Completes P1 of the dashboard⇄live-Claude-Code bridge on top of the backend (PR #585): the dashboard becomes a usable surface for the **live orchestrator conversation**, launchable with one command.

**2a — chat dock** (`packages/dashboard-v2`): `useBridge` SSE hook + `ChatDock` (collapsible bottom-left, DESIGN.md-conformant) wired to `/api/bridge` + `/api/bridge/stream`. No `/api/chat` (ChatbotAgent stays dormant — no dual-brain).

**2b — `gossipcat code`** (`apps/cli`): one-command launch — detects the gossipcat MCP server name, reads the `channel.allowlisted` guard, execs `claude --channels server:<name>` (or `--dangerously-load-development-channels` until allowlisted) with stdio inherit; bootstrap nudge when no channel is active.

## Gate (consensus-id: 75e3e6ba-a1444e24)
Design + correctness/security consensus (sonnet-designer + sonnet-reviewer, 2 rounds). **No critical/high; spawn shell-free + validated; useBridge no-leak/no-XSS.** 7 confirmed findings fixed (error-state escalation, prose→Geist, `.h-section` label, 11px timestamp, reduced-motion guard, `--text-dim` swap); 2 designer claims refuted on cross-review (`rounded-xl`=12px; `--text-faint`≠`--ink-4`).

Deferred follow-ups (LOW, non-blocking): mark optimistic message failed on send-error (f9); document argv passthrough; `process.ppid` Windows sentinel quirk (pre-existing).

## Verification
tsc clean (dashboard-v2 + apps/cli); dashboard build clean; tests/cli 1152, dashboard 12/12, hook-run 6/6.

## Launch
`gossipcat code` → `claude --dangerously-load-development-channels server:gossipcat` (auto-switches to `--channels` once `channel.allowlisted=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)