### PR TITLE
fix(cli): route `gossipcat code` from the published binary

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -49,7 +49,8 @@ import { getLastKnownLatest, checkForUpgrade, isUpgradeAvailable } from './upgra
  * Classify the first argv token for the published binary's dispatch shim.
  *
  * Exported so unit tests can assert routing without spawning the bundle.
- * The IIFE below is the sole consumer at runtime.
+ * The IIFE below consumes this helper — all top-level routing decisions
+ * are derived from the kind it returns, not from re-testing raw `sub` strings.
  */
 export function classifyShimSubcommand(
   sub: string | undefined,
@@ -65,7 +66,9 @@ export function classifyShimSubcommand(
 const __argvShimHandled = (() => {
   const argv = process.argv.slice(2);
   const sub = argv[0];
-  if (sub === 'hook') {
+  const kind = classifyShimSubcommand(sub);
+
+  if (kind === 'hook') {
     const decision = parseHookSubcommand(argv[1]);
     if (decision === 'usage') {
       process.stderr.write('Usage: gossipcat hook --run\n');
@@ -74,7 +77,7 @@ const __argvShimHandled = (() => {
     runHook();
     process.exit(0);
   }
-  if (sub === 'help' || sub === '--help' || sub === '-h') {
+  if (kind === 'help') {
     process.stdout.write(
       'gossipcat — Multi-Agent Orchestration\n' +
       '\n' +
@@ -93,7 +96,7 @@ const __argvShimHandled = (() => {
     );
     process.exit(0);
   }
-  if (sub === 'key') {
+  if (kind === 'key') {
     // Terminal-only credential bootstrap for the published binary. Deliberately
     // NOT an MCP tool: a secret must never traverse the LLM tool layer.
     void (async () => {
@@ -119,7 +122,7 @@ const __argvShimHandled = (() => {
     });
     return true; // async handler owns the process; do NOT boot the MCP server
   }
-  if (sub === 'code') {
+  if (kind === 'code') {
     // Launch Claude Code with the gossipcat channel active.
     // `argv` is process.argv.slice(2), so argv.slice(1) drops 'code' and passes
     // the remaining tokens to runCodeCommand — matching process.argv.slice(3).
@@ -133,15 +136,13 @@ const __argvShimHandled = (() => {
     });
     return true; // async handler owns the process; do NOT boot the MCP server
   }
-  // `mcp` is a back-compat alias for no-args; legacy `.mcp.json` files written
-  // by older `gossip_setup` invocations pass `"args": ["mcp"]`. Without this
-  // exemption v0.4.29 broke every such user with a -32000 MCP handshake error.
-  // Intentionally NOT advertised in help — new configs should use no args.
-  if (sub !== undefined && sub !== 'mcp') {
+  if (kind === 'unknown') {
+    // `mcp` alias is classified as 'server' so it falls through; only truly
+    // unrecognised tokens reach here.
     process.stderr.write(`gossipcat: unknown subcommand '${sub}'. Try 'gossipcat help'.\n`);
     process.exit(2);
   }
-  // No args (or `mcp` alias) → fall through; the MCP server boots below.
+  // kind === 'server': no args or `mcp` alias → fall through; MCP server boots below.
   return false;
 })();
 

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -26,6 +26,7 @@ import { getLastKnownLatest, checkForUpgrade, isUpgradeAvailable } from './upgra
 //   - `gossipcat hook --run` or `gossipcat hook run` → execute hook body, exit 0
 //   - `gossipcat hook` or `gossipcat hook <unknown>` → usage to stderr, exit 2
 //   - `gossipcat help|--help|-h`                     → usage to stdout, exit 0
+//   - `gossipcat code [args...]`                     → launch Claude Code with channel, exit via child
 //   - `gossipcat <unknown>`                          → error to stderr, exit 2
 //   - no args                                        → fall through, boot MCP server
 //   - `gossipcat mcp`                                → back-compat alias for no-args;
@@ -39,10 +40,28 @@ import { getLastKnownLatest, checkForUpgrade, isUpgradeAvailable } from './upgra
 // See memory `project_bootstrap_hook_command_dispatch_bug.md` for the
 // full diagnosis and the dist-mcp-only build context.
 //
-// Wrapped in an IIFE (not a bare block) so the `key` branch can `return` after
-// spawning its async handler — the async work keeps the event loop alive and
+// Wrapped in an IIFE (not a bare block) so the `key` / `code` branches can
+// `return` after spawning their async handler — the async work keeps the event
+// loop alive and
 // calls process.exit(code) when done, while the synchronous `return` prevents
 // fall-through to the MCP server boot below.
+/**
+ * Classify the first argv token for the published binary's dispatch shim.
+ *
+ * Exported so unit tests can assert routing without spawning the bundle.
+ * The IIFE below is the sole consumer at runtime.
+ */
+export function classifyShimSubcommand(
+  sub: string | undefined,
+): 'hook' | 'key' | 'code' | 'help' | 'server' | 'unknown' {
+  if (sub === 'hook') return 'hook';
+  if (sub === 'key') return 'key';
+  if (sub === 'code') return 'code';
+  if (sub === 'help' || sub === '--help' || sub === '-h') return 'help';
+  if (sub === undefined || sub === 'mcp') return 'server';
+  return 'unknown';
+}
+
 const __argvShimHandled = (() => {
   const argv = process.argv.slice(2);
   const sub = argv[0];
@@ -64,11 +83,13 @@ const __argvShimHandled = (() => {
       '  gossipcat hook --run     Run UserPromptSubmit bootstrap hook (internal)\n' +
       '  gossipcat key set <provider>   Store an API key in the OS keychain (service: gossip-mesh)\n' +
       '  gossipcat key list             Show which providers have a stored key\n' +
+      '  gossipcat code [args...]       Launch Claude Code with the gossipcat channel active\n' +
       '  gossipcat help           Show this help\n' +
       '\n' +
       'The published binary is the MCP server bundle. The full CLI\n' +
       '(setup wizard, create-agent, chat, etc.) lives in apps/cli/src/index.ts\n' +
-      'and is available via `npm start` / `npx ts-node` in the source repo.\n'
+      'and is available via `npm start` / `npx ts-node` in the source repo.\n' +
+      'The `code` subcommand is available in the published binary.\n'
     );
     process.exit(0);
   }
@@ -94,6 +115,20 @@ const __argvShimHandled = (() => {
       // raw stack trace. Surface a clean message and a non-zero exit instead.
       const msg = err instanceof Error ? err.message : String(err);
       process.stderr.write(`gossipcat key: ${msg}\n`);
+      process.exit(1);
+    });
+    return true; // async handler owns the process; do NOT boot the MCP server
+  }
+  if (sub === 'code') {
+    // Launch Claude Code with the gossipcat channel active.
+    // `argv` is process.argv.slice(2), so argv.slice(1) drops 'code' and passes
+    // the remaining tokens to runCodeCommand — matching process.argv.slice(3).
+    void (async () => {
+      const { runCodeCommand } = await import('./code-launch');
+      runCodeCommand(argv.slice(1));
+    })().catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`gossipcat code: ${msg}\n`);
       process.exit(1);
     });
     return true; // async handler owns the process; do NOT boot the MCP server

--- a/tests/cli/mcp-server-code-dispatch.test.ts
+++ b/tests/cli/mcp-server-code-dispatch.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Behavioral tests for the `gossipcat code` argv-dispatch branch in
+ * `apps/cli/src/mcp-server-sdk.ts` — specifically the code path that
+ * launches Claude Code via `runCodeCommand`.
+ *
+ * Spawns the built bundle (`dist-mcp/mcp-server.js`) with `node`, just like
+ * `mcp-server-argv-dispatch.test.ts` does, so we test the exact artifact
+ * users install from npm.
+ *
+ * If the bundle is missing the test is skipped with a hint to run
+ * `npm run build:mcp` first.
+ *
+ * Coverage goals:
+ *   (a) `gossipcat code` does NOT print "unknown subcommand 'code'" and does NOT exit 2.
+ *   (b) The code-launch handler is reached: stderr contains "[gossipcat code]"
+ *       and/or "is not on your PATH" (because `claude` is removed from PATH),
+ *       and the process exits non-zero from the code-launch path, NOT the unknown path.
+ *   (c) The MCP server does NOT boot on the `code` path: no .gossip/mcp.log side-effect.
+ */
+import { spawn } from 'child_process';
+import { existsSync, mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { join, resolve, dirname } from 'path';
+import { tmpdir } from 'os';
+
+const BUNDLE_PATH = resolve(__dirname, '..', '..', 'dist-mcp', 'mcp-server.js');
+
+interface RunResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Spawn the bundle with a stripped PATH so `claude` is not available —
+ * this forces the code-launch handler to hit its "not on PATH" error path,
+ * which surfaces `[gossipcat code]` on stderr and exits non-zero.
+ *
+ * `PATH` is set to just the node bin directory so `node` itself is still
+ * resolvable (required for dynamic imports inside the bundle) but `claude`
+ * is absent.
+ */
+function runBundleNoClaudePath(
+  args: string[],
+  opts: { cwd?: string; timeoutMs?: number } = {},
+): Promise<RunResult> {
+  return new Promise((resolveP, reject) => {
+    // Keep only the directory that contains the `node` binary so the bundle
+    // can still spawn child processes via node, but `claude` is invisible.
+    const nodeBinDir = dirname(process.execPath);
+    const child = spawn(process.execPath, [BUNDLE_PATH, ...args], {
+      cwd: opts.cwd ?? process.cwd(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        PATH: nodeBinDir,
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (b) => { stdout += b.toString(); });
+    child.stderr.on('data', (b) => { stderr += b.toString(); });
+    // Close stdin so the bundle doesn't hang reading MCP stdio.
+    child.stdin.end();
+
+    const timeoutMs = opts.timeoutMs ?? 15_000;
+    const hardTimer = setTimeout(() => {
+      try { child.kill('SIGKILL'); } catch { /* */ }
+      reject(new Error(`bundle did not exit within ${timeoutMs}ms (args=${args.join(' ')})`));
+    }, timeoutMs);
+
+    child.on('exit', (code, signal) => {
+      clearTimeout(hardTimer);
+      resolveP({ code, signal, stdout, stderr });
+    });
+    child.on('error', (err) => {
+      clearTimeout(hardTimer);
+      reject(err);
+    });
+  });
+}
+
+const describeOrSkip = existsSync(BUNDLE_PATH) ? describe : describe.skip;
+
+describeOrSkip('dist-mcp/mcp-server.js — `code` subcommand dispatch', () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    while (created.length) {
+      const dir = created.pop()!;
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ }
+    }
+  });
+
+  it('(a) does NOT print "unknown subcommand \'code\'" and does NOT exit 2', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossipcat-code-dispatch-'));
+    created.push(root);
+
+    const res = await runBundleNoClaudePath(['code'], { cwd: root });
+
+    expect(res.code).not.toBe(2);
+    expect(res.stderr).not.toContain("unknown subcommand 'code'");
+  });
+
+  it('(b) reaches the code-launch handler: stderr contains [gossipcat code] and/or PATH error', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossipcat-code-dispatch-'));
+    created.push(root);
+
+    const res = await runBundleNoClaudePath(['code'], { cwd: root });
+
+    // The code-launch handler in code-launch.ts emits "[gossipcat code]" on stderr
+    // whenever it starts up (for notes/warnings) and on the PATH error path.
+    // With `claude` absent from PATH the "is not on your PATH" branch fires.
+    const reachedCodeLaunch =
+      res.stderr.includes('[gossipcat code]') ||
+      res.stderr.includes('is not on your PATH');
+    expect(reachedCodeLaunch).toBe(true);
+  });
+
+  it('(b) exits non-zero from the code-launch path (not the unknown-subcommand path)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossipcat-code-dispatch-'));
+    created.push(root);
+
+    const res = await runBundleNoClaudePath(['code'], { cwd: root });
+
+    // Must exit non-zero (claude not on PATH → error)...
+    expect(res.code).not.toBe(0);
+    // ...but NOT via the unknown-subcommand exit-2 path.
+    expect(res.stderr).not.toContain("unknown subcommand 'code'");
+  });
+
+  it('(c) MCP server does NOT boot on the code path — no .gossip/mcp.log side-effect', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gossipcat-code-dispatch-'));
+    created.push(root);
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+
+    await runBundleNoClaudePath(['code'], { cwd: root });
+
+    // The MCP server boot path writes .gossip/mcp.log as its first side-effect.
+    // The `code` branch returns `true` from the IIFE, so the server never starts.
+    expect(existsSync(join(root, '.gossip', 'mcp.log'))).toBe(false);
+  });
+});

--- a/tests/cli/shim-subcommand-classify.test.ts
+++ b/tests/cli/shim-subcommand-classify.test.ts
@@ -24,14 +24,18 @@ describe('argv shim source — code branch present', () => {
     'utf-8',
   );
 
-  it('contains a `code` branch in the IIFE', () => {
-    expect(SRC).toMatch(/if \(sub === 'code'\)/);
+  it('IIFE derives route from classifyShimSubcommand (no duplicate raw-string routing)', () => {
+    // After the refactor the IIFE uses `const kind = classifyShimSubcommand(sub)`
+    // and branches on `kind`, not on raw `sub` strings — ensuring the helper is
+    // the single source of routing truth and cannot silently diverge.
+    expect(SRC).toMatch(/classifyShimSubcommand\(sub\)/);
+    // The kind-based code branch must be present in the IIFE.
+    expect(SRC).toMatch(/if \(kind === 'code'\)/);
   });
 
   it('the `code` branch returns true so the async handler owns the process', () => {
     // "return true" must appear in the code branch context.
-    // The comment "async handler owns the process" appears after return true on the same line.
-    expect(SRC).toMatch(/if \(sub === 'code'\)[\s\S]{0,800}return true;/);
+    expect(SRC).toMatch(/if \(kind === 'code'\)[\s\S]{0,800}return true;/);
   });
 
   it('the `code` branch imports code-launch and calls runCodeCommand', () => {
@@ -47,8 +51,8 @@ describe('argv shim source — code branch present', () => {
     expect(SRC).toMatch(/gossipcat code \[args\.\.\.\]/);
   });
 
-  it('`code` branch appears BEFORE the unknown-subcommand rejection', () => {
-    const codeIdx = SRC.indexOf("if (sub === 'code')");
+  it('`code` kind-branch appears BEFORE the unknown-subcommand rejection in the IIFE', () => {
+    const codeIdx = SRC.indexOf("if (kind === 'code')");
     const unknownIdx = SRC.indexOf("unknown subcommand");
     expect(codeIdx).toBeGreaterThan(-1);
     expect(unknownIdx).toBeGreaterThan(-1);

--- a/tests/cli/shim-subcommand-classify.test.ts
+++ b/tests/cli/shim-subcommand-classify.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for `classifyShimSubcommand` — the pure routing helper exported
+ * from apps/cli/src/mcp-server-sdk.ts.
+ *
+ * These tests verify that the published binary's argv shim correctly routes
+ * `code` to the code-launch handler (rather than the unknown-subcommand
+ * rejection at exit 2) without spawning the actual bundle.
+ *
+ * Covers the bug where PR #586's `gossipcat code` wrapper was unreachable for
+ * every npm-installed user because mcp-server-sdk.ts had no `code` branch.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { readFileSync } = require('fs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { resolve } = require('path');
+
+// ── Source-text assertions (no module import needed) ────────────────────────
+// Same pattern as key-shim-boot-gate.test.ts — read the source directly to
+// lock in structural invariants without triggering the IIFE side-effects.
+describe('argv shim source — code branch present', () => {
+  const SRC: string = readFileSync(
+    resolve(__dirname, '..', '..', 'apps', 'cli', 'src', 'mcp-server-sdk.ts'),
+    'utf-8',
+  );
+
+  it('contains a `code` branch in the IIFE', () => {
+    expect(SRC).toMatch(/if \(sub === 'code'\)/);
+  });
+
+  it('the `code` branch returns true so the async handler owns the process', () => {
+    // "return true" must appear in the code branch context.
+    // The comment "async handler owns the process" appears after return true on the same line.
+    expect(SRC).toMatch(/if \(sub === 'code'\)[\s\S]{0,800}return true;/);
+  });
+
+  it('the `code` branch imports code-launch and calls runCodeCommand', () => {
+    expect(SRC).toMatch(/runCodeCommand/);
+    expect(SRC).toMatch(/['"]\.\/code-launch['"]/);
+  });
+
+  it('exports classifyShimSubcommand', () => {
+    expect(SRC).toMatch(/export function classifyShimSubcommand/);
+  });
+
+  it('help text includes gossipcat code [args...]', () => {
+    expect(SRC).toMatch(/gossipcat code \[args\.\.\.\]/);
+  });
+
+  it('`code` branch appears BEFORE the unknown-subcommand rejection', () => {
+    const codeIdx = SRC.indexOf("if (sub === 'code')");
+    const unknownIdx = SRC.indexOf("unknown subcommand");
+    expect(codeIdx).toBeGreaterThan(-1);
+    expect(unknownIdx).toBeGreaterThan(-1);
+    expect(codeIdx).toBeLessThan(unknownIdx);
+  });
+});
+
+// ── classifyShimSubcommand unit tests ───────────────────────────────────────
+// The IIFE in mcp-server-sdk.ts runs at module load time and reads
+// process.argv, potentially calling process.exit. We use jest.isolateModules
+// with a safe argv fixture so the IIFE falls through harmlessly (no-args →
+// return false) while we still get access to the exported helper.
+describe('classifyShimSubcommand', () => {
+  let classify: (sub: string | undefined) => string;
+
+  beforeAll(() => {
+    const savedArgv = process.argv;
+    const savedEnv = process.env.GOSSIPCAT_MCP_NO_MAIN;
+    // Patch argv to a safe no-subcommand state BEFORE the module is loaded,
+    // so the IIFE falls through (no-args → return false, no process.exit).
+    // Set GOSSIPCAT_MCP_NO_MAIN=1 to prevent main() from booting the MCP server.
+    process.argv = ['node', 'mcp-server.js'];
+    process.env.GOSSIPCAT_MCP_NO_MAIN = '1';
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mod = require('../../apps/cli/src/mcp-server-sdk') as typeof import('../../apps/cli/src/mcp-server-sdk');
+      classify = mod.classifyShimSubcommand;
+    });
+    process.argv = savedArgv;
+    if (savedEnv === undefined) {
+      delete process.env.GOSSIPCAT_MCP_NO_MAIN;
+    } else {
+      process.env.GOSSIPCAT_MCP_NO_MAIN = savedEnv;
+    }
+  });
+
+  it('routes "code" → "code" (not "unknown")', () => {
+    expect(classify('code')).toBe('code');
+  });
+
+  it('routes undefined → "server" (MCP boot)', () => {
+    expect(classify(undefined)).toBe('server');
+  });
+
+  it('routes "mcp" alias → "server" (back-compat)', () => {
+    expect(classify('mcp')).toBe('server');
+  });
+
+  it('routes "hook" → "hook"', () => {
+    expect(classify('hook')).toBe('hook');
+  });
+
+  it('routes "key" → "key"', () => {
+    expect(classify('key')).toBe('key');
+  });
+
+  it('routes "help" → "help"', () => {
+    expect(classify('help')).toBe('help');
+  });
+
+  it('routes "--help" → "help"', () => {
+    expect(classify('--help')).toBe('help');
+  });
+
+  it('routes "-h" → "help"', () => {
+    expect(classify('-h')).toBe('help');
+  });
+
+  it('routes bogus subcommand → "unknown"', () => {
+    expect(classify('bogus')).toBe('unknown');
+  });
+
+  it('routes "setup" → "unknown" (source-only command)', () => {
+    expect(classify('setup')).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Problem

`gossipcat code` was unreachable for **every npm-installed user**. The user reported it as `no such command`.

PR #586 ("P1 COMPLETE") wired the `code` subcommand only into `apps/cli/src/index.ts` — the dev-only CLI run via `npm start` / `ts-node`. But the published npm `bin` is `dist-mcp/mcp-server.js`, built by esbuild from **`apps/cli/src/mcp-server-sdk.ts`**, whose argv shim routed only `hook` / `key` / `help` / `mcp` and **actively rejected** everything else:

```
gossipcat: unknown subcommand 'code'. Try 'gossipcat help'.   # exit 2
```

So the channel wrapper never actually shipped to published users, despite the "P1 COMPLETE" claim.

## Fix

- Add a `code` branch to the `__argvShimHandled` IIFE in `mcp-server-sdk.ts`, **before** the unknown-subcommand rejection — mirroring the existing `key` branch: async-import `code-launch`, call `runCodeCommand(argv.slice(1))` (≡ `process.argv.slice(3)`), `return true` so the MCP server does not boot.
- Update the `help` text to document `gossipcat code [args...]`.
- Extract a pure, exported `classifyShimSubcommand()` helper so subcommand routing is unit-testable without spawning the bundle.

`index.ts` and `code-launch.ts` are untouched.

## Verification

- `npx tsc --noEmit -p apps/cli/tsconfig.json` — clean
- `npm run build:mcp` — clean; built bundle:
  - `node dist-mcp/mcp-server.js code` → reaches `code-launch` (hits the `claude not on PATH` path), **not** the unknown-subcommand rejection
  - `node dist-mcp/mcp-server.js bogus` → still correctly rejected with exit 2
- Tests: 26/26 pass across `shim-subcommand-classify` (new, 16), `mcp-server-argv-dispatch` (existing, no regression), `key-shim-boot-gate` (existing)

## Notes

- Built via a `sonnet-implementer` dispatch; orchestrator independently re-verified the diff, typecheck, tests, and live bundle routing. Signal relay could not be recorded — the gossipcat MCP server disconnected mid-session.
- Follow-up (separate): correct `project_dashboard_cc_channel_bridge.md`, which claims the wrapper shipped to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)