### PR TITLE
chore(release): v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ## [Unreleased]
 
+## [0.6.1] — 2026-06-14
+
+Patch release. Headline fix: `gossipcat code` now actually works from the
+published npm binary. Also lands the dashboard ⇄ Claude Code channel bridge
+(P1, experimental) and a dependency security bump. 7 commits since 0.6.0.
+
+### Fixed
+
+- **`gossipcat code` now reachable from the published binary.** The subcommand was wired only into the dev CLI (`apps/cli/src/index.ts`), but the published `bin` is `dist-mcp/mcp-server.js` (built from `apps/cli/src/mcp-server-sdk.ts`), whose argv shim rejected every unknown subcommand — so `gossipcat code` exited with `unknown subcommand 'code'` for all npm users. The published entry now routes `code` through the shared `classifyShimSubcommand` classifier (single source of truth), with a spawn-based behavioral regression test (#587).
+- **Sandbox Layer-3 boundary-escape noise** — inverted a rotted test-fixture gate that was flooding the boundary-escape log (#582); empty consensus rounds no longer trip the Signals-pending status detector (#584).
+
+### Added
+
+- **Dashboard ⇄ Claude Code channel bridge (P1, experimental).** The web dashboard can now drive the *same* live Claude Code orchestrator session — start and steer work from a chat dock — via a channel folded into the gossipcat MCP server (in-process; no headless SDK). Launch with the new `gossipcat code` wrapper. Still requires `--dangerously-load-development-channels` until gossipcat's channel is on Anthropic's allowlist; P2 (activity mirror) and P3 (per-request permission relay) are not yet shipped (#585, #586).
+- **Sandbox Layer-3 main-pass observability** — diagnostics for main-pass noise drops (#583).
+
+### Security
+
+- **esbuild `^0.27.4` → `^0.28.1`** (dev dependency), clearing Dependabot `GHSA-gv7w-rqvm-qjhr` (High) and `GHSA-g7r4-m6w7-qqqr` (Low). Build-time only; never shipped to npm users (#588).
+
 ## [0.6.0] — 2026-06-13
 
 Adds several consensus-pipeline and resolver capabilities, a per-agent tool-turn

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gossipcat",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gossipcat",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossipcat",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
   "mcpName": "io.github.ataberk-xyz/gossipcat",
   "repository": {


### PR DESCRIPTION
Stage 1 of the release flow (`scripts/release.sh`) — version bump + CHANGELOG for **v0.6.1**.

Bumps `package.json` 0.6.0 → 0.6.1 and documents the 7 commits unreleased since the `v0.6.0` tag.

### What's in 0.6.1
**Fixed**
- `gossipcat code` now reachable from the published binary — it was wired only into the dev CLI, never the published `mcp-server-sdk.ts` entry, so npm users hit `unknown subcommand 'code'` (#587).
- Sandbox Layer-3 boundary-escape noise + empty-round Signals-pending detector (#582, #584).

**Added (experimental)**
- Dashboard ⇄ Claude Code channel bridge P1 — drive the live CC session from the dashboard chat dock via `gossipcat code` (still behind `--dangerously-load-development-channels`; P2/P3 not yet shipped) (#585, #586).
- Sandbox Layer-3 main-pass observability (#583).

**Security**
- esbuild `^0.27.4` → `^0.28.1`, clearing Dependabot GHSA-gv7w-rqvm-qjhr (High) + GHSA-g7r4-m6w7-qqqr (Low) (#588).

### After merge (Stage 2 — the actual publish)
```
git checkout master && git pull --ff-only
./scripts/release.sh        # no args: build, pack, tag v0.6.1, GH release, npm publish
```
Then verify: `npm view gossipcat version` → `0.6.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)