### PR TITLE
fix(build): self-contained MCP bundle (v0.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ## [Unreleased]
 
+## [0.6.2] — 2026-06-14
+
+Patch release. Makes the published MCP server binary **self-contained** so it
+runs regardless of the consumer's `node_modules` state.
+
+### Fixed
+
+- **Published `dist-mcp/mcp-server.js` is now self-contained.** `build:mcp`
+  previously externalized `ws` and `@modelcontextprotocol/sdk`, so the binary
+  depended on npm resolving those at runtime — a normal `npm i -g gossipcat`
+  worked, but the bin could not run standalone and was fragile to broken /
+  partially-hoisted / version-mismatched `node_modules` on upgrade. The bundler
+  now inlines both (only `ws`'s optional native addons `bufferutil` /
+  `utf-8-validate` stay external, matching `ws`'s own graceful fallback), so the
+  binary boots with zero installed dependencies. Bundle grows ~2.3MB → ~3.0MB.
+  Verified: standalone MCP `initialize` handshake succeeds with no
+  `node_modules` present.
+
 ## [0.6.1] — 2026-06-14
 
 Patch release. Headline fix: `gossipcat code` now actually works from the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gossipcat",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gossipcat",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossipcat",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
   "mcpName": "io.github.ataberk-xyz/gossipcat",
   "repository": {
@@ -33,7 +33,7 @@
     "test": "jest --config jest.config.base.js",
     "clean": "rm -rf packages/*/dist apps/*/dist dist-mcp/ dist-dashboard/",
     "postinstall": "node scripts/postinstall.js",
-    "build:mcp": "rm -rf dist-mcp && npx esbuild apps/cli/src/mcp-server-sdk.ts --bundle --platform=node --target=node22 --outfile=dist-mcp/mcp-server.js --external:ws --external:@modelcontextprotocol/sdk --tsconfig=tsconfig.json && cp -r packages/orchestrator/src/default-skills dist-mcp/default-skills && cp -r packages/orchestrator/src/default-rules dist-mcp/default-rules && cp -r assets dist-mcp/assets && mkdir -p dist-mcp/data && cp data/archetypes.json dist-mcp/data/archetypes.json && chmod +x dist-mcp/mcp-server.js && chmod +x dist-mcp/assets/hooks/worktree-sandbox.sh && chmod +x dist-mcp/assets/hooks/discipline/*.sh",
+    "build:mcp": "rm -rf dist-mcp && npx esbuild apps/cli/src/mcp-server-sdk.ts --bundle --platform=node --target=node22 --outfile=dist-mcp/mcp-server.js --external:bufferutil --external:utf-8-validate --tsconfig=tsconfig.json && cp -r packages/orchestrator/src/default-skills dist-mcp/default-skills && cp -r packages/orchestrator/src/default-rules dist-mcp/default-rules && cp -r assets dist-mcp/assets && mkdir -p dist-mcp/data && cp data/archetypes.json dist-mcp/data/archetypes.json && chmod +x dist-mcp/mcp-server.js && chmod +x dist-mcp/assets/hooks/worktree-sandbox.sh && chmod +x dist-mcp/assets/hooks/discipline/*.sh",
     "build:dashboard": "cd packages/dashboard-v2 && npx vite build --outDir ../../dist-dashboard --emptyOutDir",
     "prepublishOnly": "npm run build:all && npm run build:mcp && npm run build:dashboard",
     "gossipcat": "npx ts-node -r tsconfig-paths/register -P tsconfig.json apps/cli/src/index.ts",


### PR DESCRIPTION
## Problem

The published `dist-mcp/mcp-server.js` externalized `ws` and `@modelcontextprotocol/sdk` (`build:mcp` used `--external:ws --external:@modelcontextprotocol/sdk`), so the binary relied on npm resolving those at **runtime**.

A clean `npm i -g gossipcat` works (both are declared `dependencies`), but the bin **cannot run standalone** and is fragile on upgrade against broken / partially-hoisted / version-mismatched `node_modules`. It also made release verification misleading — running the bundle from an extracted tarball throws a module-loader error that looks like a broken publish but is just missing peer deps.

## Fix

`build:mcp` now **inlines** `ws` + `@modelcontextprotocol/sdk` into the bundle. Only `ws`'s optional native addons (`bufferutil`, `utf-8-validate`) stay external — matching `ws`'s own `try/catch` fallback (it works in pure-JS mode without them). The published binary is now fully self-contained and boots with **zero installed dependencies**.

`ws` / `@modelcontextprotocol/sdk` remain in `dependencies` for the source / ts-node dev path and library consumers — bundling is belt-and-suspenders, not a removal.

## Verification

- `npm run build:mcp` — clean; bundle 2.3MB → 3.0MB
- Bundle contains **no external `require("ws")` / `require("@modelcontextprotocol/sdk")`**
- **Standalone boot with zero `node_modules`:** MCP `initialize` handshake returns a valid response (`claude/channel` capability present), `help` shows `gossipcat code`, `code` routes to code-launch — no module-loader errors
- `npx jest tests/cli` — 90 suites, 1172 passed, 8 skipped, 0 failed

Bumps version 0.6.1 → 0.6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)