### PR TITLE
fix(tools): Windows path-separator bug in Sandbox — relay file_read rejects every in-project path

### DIFF
--- a/packages/tools/src/sandbox.ts
+++ b/packages/tools/src/sandbox.ts
@@ -1,4 +1,4 @@
-import { resolve, dirname } from 'path';
+import { resolve, dirname, sep } from 'path';
 import { existsSync, realpathSync } from 'fs';
 
 /**
@@ -15,13 +15,18 @@ function fold(p: string): string {
 }
 
 /**
- * Canonical trailing-slash form for the root side of a prefix comparison.
+ * Canonical trailing-separator form for the root side of a prefix comparison.
  * Blocks sibling-prefix bypass: e.g. a root of `/tmp/gossip-wt-AB` must not
- * accept `/tmp/gossip-wt-ABXYZ/file.txt`. A filesystem root (`/`) is left
- * as-is since it already ends in `/`.
+ * accept `/tmp/gossip-wt-ABXYZ/file.txt`.
+ *
+ * Uses the platform path separator (`path.sep`). On Windows, `realpathSync`
+ * and `resolve` yield back-slash paths, so appending a hard-coded `/` here
+ * made the `startsWith` containment check below fail for EVERY in-root path
+ * — every relay-agent file_read got "resolves outside project root". A path
+ * that already ends in the separator (e.g. a filesystem root) is left as-is.
  */
 function rootWithSlash(p: string): string {
-  return p.endsWith('/') ? p : p + '/';
+  return p.endsWith(sep) ? p : p + sep;
 }
 
 export class Sandbox {


### PR DESCRIPTION
## Summary
On Windows, a relay (custom-provider) agent's `file_read` of **any** path inside the project root fails with `Path "..." resolves outside project root`. Native (host) agents are unaffected because they don't go through the relay `Sandbox`.

## Root cause
`packages/tools/src/sandbox.ts` → `rootWithSlash()` appends a hard-coded forward slash:
```ts
function rootWithSlash(p) { return p.endsWith('/') ? p : p + '/'; }
```
On Windows `realpathSync`/`resolve` return back-slash paths, so the Sandbox root becomes `C:\proj/` while the resolved file is `C:\proj\file.ts`. The containment check `foldedFull.startsWith(rootWithSlash(foldedRoot))` then compares `c:\proj\file.ts`.startsWith(`c:\proj/`) → **false** → every in-project path is rejected. The exact-match branch only passes when the path *is* the root.

## Impact
Any provider that runs as a relay worker (Gemini / OpenAI / DeepSeek / local) cannot read project files on Windows — so they can't review code, only emit on non-file tasks. Native Claude Code agents (host file tools) are unaffected.

## Fix
Use the platform separator (`path.sep`) for the trailing-separator canonical form. Containment + sibling-prefix protection are preserved (on POSIX `sep === '/'`, behavior is unchanged).

## Verification
The existing `tests/tools/sandbox.test.ts` already covers this — it just never runs on a Windows CI. On Windows:
- **Before:** `allows paths within project root` and `allows file_write to non-existent path within root` → FAIL (`resolves outside project root`).
- **After:** both PASS (7/8; the 8th, `blocks symlinks pointing outside project`, is an unrelated Windows symlink-privilege/test-env artifact that fails before and after this change).

Repro of the containment check in isolation (Windows): root `C:\proj` + file `C:\proj\VERSION` → `startsWith('C:\proj/')` = false (reject); with `path.sep` → `startsWith('C:\proj\')` = true (allow).

---
*Disclaimer: this PR description and the code change in this PR were drafted by @kloud-ai under human review and approval. Human in the loop: GravyaDev.*
