### PR TITLE
fix(tools): cap file_read output to prevent WS MESSAGE_TOO_BIG (1009)

### DIFF
--- a/packages/tools/src/tool-server.ts
+++ b/packages/tools/src/tool-server.ts
@@ -75,6 +75,15 @@ function truncateAtLine(text: string, maxLength: number): string {
   return text.slice(0, cut !== -1 ? cut : maxLength);
 }
 
+/**
+ * Cap for file_read results. Must stay comfortably under the relay WS
+ * maxPayload (1 MB, packages/relay/src/server.ts:107) even after JSON-envelope
+ * escaping (~2x worst case) AND when multiple file_reads land in the same turn.
+ * 256 KB × 2 (escaping) × 2 (two reads) = 1 MB — right at the limit, so the
+ * cap itself provides the safety margin.
+ */
+const MAX_FILE_READ_CHARS = 256 * 1024;
+
 export class ToolServer {
   private agent: GossipAgent;
   private fileTools: FileTools;
@@ -336,7 +345,13 @@ export class ToolServer {
             throw new Error(`Read blocked: "${args.path}" is outside scope "${readScope}"`);
           }
         }
-        return this.fileTools.fileRead(args as { path: string; startLine?: number; endLine?: number }, agentRoot);
+        let fileContent = await this.fileTools.fileRead(args as { path: string; startLine?: number; endLine?: number }, agentRoot);
+        if (fileContent.length > MAX_FILE_READ_CHARS) {
+          const originalLength = fileContent.length;
+          fileContent = truncateAtLine(fileContent, MAX_FILE_READ_CHARS)
+            + `\n\n[file_read truncated: file is ${originalLength} chars (cap ${MAX_FILE_READ_CHARS}); read a specific range with startLine/endLine]`;
+        }
+        return fileContent;
       }
       case 'file_write': {
         // Check cap BEFORE write to avoid write-success-with-false-error

--- a/tests/tools/tool-server-file-read-cap.test.ts
+++ b/tests/tools/tool-server-file-read-cap.test.ts
@@ -1,0 +1,108 @@
+import { jest } from '@jest/globals';
+const vi = jest;
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ToolServer } from '../../packages/tools/src/tool-server';
+
+// MAX_FILE_READ_CHARS is 256 * 1024 = 262144. Mirror the constant here so
+// the tests are self-documenting without importing internals.
+const MAX_FILE_READ_CHARS = 256 * 1024;
+
+// Mock GossipAgent to avoid actual relay connection
+vi.mock('@gossip/client', () => ({
+  GossipAgent: class {
+    agentId = 'tool-server';
+    async connect() {}
+    async disconnect() {}
+    on() {}
+    async sendEnvelope() {}
+  },
+}));
+
+describe('ToolServer file_read cap (MESSAGE_TOO_BIG guard)', () => {
+  let server: ToolServer;
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gossip-file-read-cap-'));
+    server = new ToolServer({
+      relayUrl: 'ws://localhost:0',
+      projectRoot,
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('truncates a file larger than MAX_FILE_READ_CHARS and appends notice', async () => {
+    // Write a file that is clearly over the cap once line-annotated.
+    // fileRead prepends line numbers ("N\t") which adds overhead.
+    // Use enough lines to ensure annotated output > MAX_FILE_READ_CHARS.
+    // Each line: "a".repeat(79) + "\n" = 80 raw chars.
+    // After annotation: "N\t" + "a".repeat(79) = 82-87 chars per line.
+    // 3500 such lines = ~285 KB annotated → safely above the 256 KB cap.
+    const lineCount = 3500;
+    const lineContent = 'a'.repeat(79);
+    const bigContent = (lineContent + '\n').repeat(lineCount);
+    const bigPath = path.join(projectRoot, 'big.txt');
+    fs.writeFileSync(bigPath, bigContent);
+
+    const result = await server.executeTool('file_read', { path: 'big.txt' }, undefined);
+
+    expect(typeof result).toBe('string');
+    const resultStr = result as string;
+
+    // Total length must not exceed cap + notice length (notice is ~150 chars max)
+    expect(resultStr.length).toBeLessThanOrEqual(MAX_FILE_READ_CHARS + 200);
+
+    // Must end with the truncation notice
+    expect(resultStr).toContain('[file_read truncated:');
+    // Notice must report original (annotated) length as a number
+    expect(resultStr).toMatch(/file is \d+ chars/);
+    expect(resultStr).toContain(`cap ${MAX_FILE_READ_CHARS}`);
+    expect(resultStr).toContain('startLine/endLine');
+  });
+
+  it('returns small file content unchanged (no notice appended)', async () => {
+    const smallContent = 'const x = 1;\nconst y = 2;\n';
+    fs.writeFileSync(path.join(projectRoot, 'small.ts'), smallContent);
+
+    const result = await server.executeTool('file_read', { path: 'small.ts' }, undefined);
+
+    expect(typeof result).toBe('string');
+    const resultStr = result as string;
+    // fileRead annotates with line numbers — just check no notice and content present
+    expect(resultStr).toContain('const x = 1;');
+    expect(resultStr).toContain('const y = 2;');
+    expect(resultStr).not.toContain('[file_read truncated:');
+    // Small file well under cap
+    expect(resultStr.length).toBeLessThan(MAX_FILE_READ_CHARS);
+  });
+
+  it('ranged read (startLine/endLine) of a large file returns small slice without truncation notice', async () => {
+    // Write a large file with numbered lines so we can pin the range.
+    // 10 000 lines × ~50 chars = ~500 KB raw — but we only read 5 lines.
+    const lines: string[] = [];
+    for (let i = 1; i <= 10000; i++) {
+      lines.push(`line ${i}: ${'x'.repeat(40)}`);
+    }
+    const largeContent = lines.join('\n') + '\n';
+    fs.writeFileSync(path.join(projectRoot, 'lines.txt'), largeContent);
+
+    // Read only lines 1–5 — the annotated slice is tiny regardless of file size
+    const result = await server.executeTool(
+      'file_read',
+      { path: 'lines.txt', startLine: 1, endLine: 5 },
+      undefined,
+    );
+
+    expect(typeof result).toBe('string');
+    const resultStr = result as string;
+    expect(resultStr).toContain('line 1:');
+    expect(resultStr).toContain('line 5:');
+    // The slice is well under the cap — no notice should appear
+    expect(resultStr).not.toContain('[file_read truncated:');
+  });
+});


### PR DESCRIPTION
## Problem
The `file_read` worker tool returned file contents **uncapped**. A large file (observed 654,350 chars) once JSON-enveloped (~1.5–2× escaping) plus a second `file_read` in the same turn exceeded the relay WebSocket `maxPayload` (1 MB, `packages/relay/src/server.ts:107`), closing the worker socket with close code **1009 (MESSAGE_TOO_BIG)** and losing the in-flight turn.

`file_read` was the only read-tool with no output cap — `git_diff` (`truncateAtLine(…, 3000)`), `shell_exec` (last 4000 chars), and `run_tests` already truncate.

## Fix
Cap `file_read` at `MAX_FILE_READ_CHARS` (256 KB) in `packages/tools/src/tool-server.ts` via the existing `truncateAtLine` helper, appending a truncation notice pointing to `startLine`/`endLine`. Scope/symlink boundary checks unchanged; WS `maxPayload` untouched.

## Tests
`tests/tools/tool-server-file-read-cap.test.ts` — large file → truncated + notice reporting original length; small file → unchanged; ranged read → not spuriously truncated. Full tools suite: **8 suites / 106 tests pass** (3 new). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)