### PR TITLE
fix(dashboard): Overview 'Actionable' = resolution-aware open-findings count

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2802,7 +2802,7 @@ export function createMcpServer(): McpServer {
         const seedResult = seedMemoryHygiene(root);
         const msg = seedResult.action === 'appended' ? 'appended'
           : seedResult.action === 'already-present' ? 'already present'
-          : seedResult.action === 'skipped-no-claude-md' ? 'skipped (no CLAUDE.md)'
+          : seedResult.action === 'skipped-no-claude-md' ? 'no CLAUDE.md to annotate — rules shipped via .claude/rules/gossipcat.md'
           : `error (${(seedResult as { error: string }).error})`;
         process.stderr.write(`[gossipcat] gossip_setup: memory hygiene — ${msg}\n`);
       } catch (e) {

--- a/packages/relay/src/dashboard/api-open-findings.ts
+++ b/packages/relay/src/dashboard/api-open-findings.ts
@@ -11,6 +11,39 @@
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
+/** Returns true if the entry should be skipped because it is an insight (not actionable). */
+function isInsightEntry(entry: any): boolean {
+  return entry.type === 'insight';
+}
+
+/** Returns true if the entry counts as open (not resolved). */
+function isOpenEntry(entry: any): boolean {
+  return entry.status !== 'resolved';
+}
+
+/**
+ * Count open, non-insight findings in implementation-findings.jsonl.
+ * Returns 0 when the file is missing or unreadable.
+ * This is the single authoritative definition of "actionable open findings".
+ */
+export function countOpenActionableFindings(projectRoot: string): number {
+  const findingsPath = join(projectRoot, '.gossip', 'implementation-findings.jsonl');
+  if (!existsSync(findingsPath)) return 0;
+  let raw: string;
+  try { raw = readFileSync(findingsPath, 'utf-8'); }
+  catch { return 0; }
+  let count = 0;
+  for (const line of raw.split('\n').filter(Boolean)) {
+    let entry: any;
+    try { entry = JSON.parse(line); } catch { continue; }
+    const findingId = String(entry.taskId ?? entry.findingId ?? entry.id ?? '');
+    if (!findingId) continue;
+    if (isInsightEntry(entry)) continue;
+    if (isOpenEntry(entry)) count++;
+  }
+  return count;
+}
+
 export interface OpenFindingRow {
   finding_id: string;
   state: 'open' | 'resolved' | 'stale-anchor';
@@ -52,9 +85,9 @@ export async function openFindingsHandler(projectRoot: string): Promise<OpenFind
     if (!findingId) continue;
     // Skip insight rows — they pollute the actionable findings count.
     // type:null legacy rows are preserved (spec §Design cheap variant).
-    if (entry.type === 'insight') continue;
+    if (isInsightEntry(entry)) continue;
     let state: 'open' | 'resolved' | 'stale-anchor';
-    if (entry.status === 'resolved') {
+    if (!isOpenEntry(entry)) {
       state = entry.resolvedBy === 'stale_anchor' ? 'stale-anchor' : 'resolved';
     } else {
       state = 'open';

--- a/packages/relay/src/dashboard/api-overview.ts
+++ b/packages/relay/src/dashboard/api-overview.ts
@@ -2,6 +2,7 @@ import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { readJsonlWithRotated } from '@gossip/orchestrator';
 import { isUtilityAgent } from './utility-agents';
+import { countOpenActionableFindings } from './api-open-findings';
 
 interface AgentConfigLike {
   id: string;
@@ -212,7 +213,6 @@ export async function overviewHandler(projectRoot: string, ctx: OverviewContext)
   let totalFindings = 0;
   let confirmedFindings = 0;
   let lastConsensusTimestamp = '';
-  let actionableFindings = 0;
   // Per-run buckets for the consensus-runs count: mirror api-consensus.ts:98's
   // "real consensus run" definition (≥2 agents, ≥3 signals). Without this filter,
   // SystemPulse.consensusRuns counts manual/singleton signal recordings and
@@ -264,10 +264,8 @@ export async function overviewHandler(projectRoot: string, ctx: OverviewContext)
             confirmedFindings++;
           } else if (entry.signal === 'disagreement' || entry.signal === 'hallucination_caught') {
             totalFindings++;
-            actionableFindings++;
           } else if (entry.signal === 'new_finding') {
             totalFindings++;
-            actionableFindings++;
           } else if (entry.signal === 'unverified' || entry.signal === 'unique_unconfirmed') {
             totalFindings++;
           }
@@ -279,6 +277,10 @@ export async function overviewHandler(projectRoot: string, ctx: OverviewContext)
   for (const bucket of runBuckets.values()) {
     if (bucket.agents.size >= 2 && bucket.signalCount >= 3) consensusRuns++;
   }
+
+  // Resolution-aware open-findings count: read implementation-findings.jsonl once.
+  // Uses the shared predicate from api-open-findings so the two endpoints can never drift.
+  const actionableFindings = countOpenActionableFindings(projectRoot);
 
   const avgDurationMs = durationCount > 0 ? Math.round(totalDuration / durationCount) : 0;
 

--- a/tests/relay/api-overview-extras.test.ts
+++ b/tests/relay/api-overview-extras.test.ts
@@ -1,5 +1,5 @@
 import { overviewHandler } from '../../packages/relay/src/dashboard/api-overview';
-import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -8,6 +8,8 @@ function setupRoot(): string {
   mkdirSync(join(root, '.gossip'), { recursive: true });
   return root;
 }
+
+function emptyCtx() { return { agentConfigs: [], relayConnections: 0, connectedAgentIds: [] }; }
 
 describe('overviewHandler extras', () => {
   it('skillVerdictSummary counts bucketed statuses across skill files', async () => {
@@ -55,5 +57,80 @@ describe('overviewHandler extras', () => {
     expect(data.droppedFindingTypeCounts).toBeDefined();
     expect(data.droppedFindingTypeCounts!.approval).toBe(5);
     expect(data.droppedFindingTypeCounts!.concern).toBe(1);
+  });
+});
+
+describe('overviewHandler — actionableFindings (resolution-aware)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'gossip-test-af-'));
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function writeFindings(lines: object[]): void {
+    writeFileSync(
+      join(root, '.gossip', 'implementation-findings.jsonl'),
+      lines.map(l => JSON.stringify(l)).join('\n') + '\n',
+    );
+  }
+
+  function writePerfSignals(signals: string[]): void {
+    writeFileSync(
+      join(root, '.gossip', 'agent-performance.jsonl'),
+      signals.map(s => JSON.stringify({ type: 'consensus', signal: s, agentId: 'agent-x', consensusId: 'c1', timestamp: new Date().toISOString() })).join('\n') + '\n',
+    );
+  }
+
+  it('(a) counts open non-insight findings', async () => {
+    writeFindings([
+      { taskId: 'f1', type: 'finding', status: 'open' },
+      { taskId: 'f2', type: 'finding', status: 'open' },
+      { taskId: 'f3', type: null, status: 'open' }, // legacy null-type: counts
+    ]);
+    const data = await overviewHandler(root, emptyCtx());
+    expect(data.actionableFindings).toBe(3);
+  });
+
+  it('(b) excludes resolved findings (status:resolved)', async () => {
+    writeFindings([
+      { taskId: 'f1', type: 'finding', status: 'open' },
+      { taskId: 'f2', type: 'finding', status: 'resolved' },
+      { taskId: 'f3', type: 'finding', status: 'resolved', resolvedBy: 'stale_anchor' },
+    ]);
+    const data = await overviewHandler(root, emptyCtx());
+    expect(data.actionableFindings).toBe(1);
+  });
+
+  it('(c) excludes insight-type findings', async () => {
+    writeFindings([
+      { taskId: 'f1', type: 'insight', status: 'open' },
+      { taskId: 'f2', type: 'finding', status: 'open' },
+    ]);
+    const data = await overviewHandler(root, emptyCtx());
+    expect(data.actionableFindings).toBe(1);
+  });
+
+  it('(d) does NOT change when disagreement/hallucination_caught/new_finding signals are added', async () => {
+    writeFindings([
+      { taskId: 'f1', type: 'finding', status: 'open' },
+    ]);
+    const dataWithoutSignals = await overviewHandler(root, emptyCtx());
+    expect(dataWithoutSignals.actionableFindings).toBe(1);
+
+    // Now add a batch of signals that previously pumped actionableFindings
+    writePerfSignals(['disagreement', 'disagreement', 'hallucination_caught', 'new_finding', 'new_finding']);
+    const dataWithSignals = await overviewHandler(root, emptyCtx());
+    expect(dataWithSignals.actionableFindings).toBe(1); // must be unchanged
+  });
+
+  it('returns 0 when implementation-findings.jsonl is absent', async () => {
+    // No findings file written
+    const data = await overviewHandler(root, emptyCtx());
+    expect(data.actionableFindings).toBe(0);
   });
 });


### PR DESCRIPTION
## Why

The Overview **Actionable** stat showed **479** locally — a number that only ever grows and counts already-settled items. Root cause: it was computed from `agent-performance.jsonl` signal history, incrementing on every `disagreement` (280) + `hallucination_caught` (123) + `new_finding` (76) signal, lifetime-cumulative across rotated logs, with **no resolution awareness**. A caught hallucination needs no action, yet it inflated the "to-do" count. The real open backlog is **64** (the resolution-aware `/open-findings` total).

## What

**1. `fix(dashboard)` — redefine `actionableFindings`** (`de5544bb`)
- Now the resolution-aware open-findings count (`type !== 'insight' && status !== 'resolved'`), read from `implementation-findings.jsonl`.
- Extracted a single shared predicate (`isOpenEntry` / `isInsightEntry`) + `countOpenActionableFindings()` helper in `api-open-findings.ts`, reused by both the Overview stat and the `/open-findings` endpoint so they **can never drift**.
- Removed the three signal-loop increments. `totalFindings` / `confirmedFindings` (separate signal-derived metrics) are **untouched**.

**2. `chore(setup)` — clarify the memory-hygiene skip log** (`818ccac0`)
- `skipped (no CLAUDE.md)` read like a failure. The mandatory rules (incl. the memory-hygiene status convention) ship via `.claude/rules/gossipcat.md` in every `gossip_setup`; the CLAUDE.md seed is only a human-facing annotation. Reworded so the log reflects nothing is missing.

## Verification
- `npx jest tests/relay/api-overview-extras.test.ts tests/relay/dashboard-open-findings-insight-filter.test.ts` → **9/9 pass**
- New cases: open counted · resolved excluded · insight excluded · signal-history does NOT move it · missing file => 0
- `tsc --noEmit` clean for relay + apps/cli packages

## Consensus review
consensus-id: 1bd98b48-b8224987

3 agents (sonnet-reviewer, gemini-reviewer, deepseek-challenger), 2 rounds → **11 confirmed, 0 disputed, 0 unverified**. No critical/high. Two LOW (non-blocking) notes:
- `isOpenEntry` used as `!isOpenEntry(entry)` is a readability nit (logic provably equivalent to the old `status === 'resolved'`; no behavioral bug).
- Neither `countOpenActionableFindings` nor `openFindingsHandler` reads the rotated `.jsonl.1` sibling — a **pre-existing** limitation inherited without regression.

## Notes
- Read-only metric aggregation; no `@gossip:impact-adjacent` annotation on these files, so the impact-adjacency gate is not triggered.
- Unrelated local `.claude/settings.local.json` env change intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)