### PR TITLE
feat(relay): activity-mirror v2 foundation (emitMirror, per-chat ring, /mirror route)

### DIFF
--- a/packages/relay/src/dashboard/api-bridge.ts
+++ b/packages/relay/src/dashboard/api-bridge.ts
@@ -219,6 +219,17 @@ export class BridgeHub {
       if (v === null) {
         return { status: 400, payload: { error: 'invalid chat_id' } };
       }
+      // Reserve the internal provisional sentinel from client input (trust
+      // boundary). CHAT_ID_RE admits a leading `_`, so '_provisional' (and any
+      // other leading-`_` reserved form) would otherwise pass validateChatId.
+      // A client must NOT be able to register a real stream under the sentinel
+      // key: a later backfillProvisional → drainInto('_provisional', other)
+      // would STEAL + DELETE that client's buffered frames. Internal callers
+      // (drainInto / backfillProvisional) pass the constant directly, not
+      // through here, so this only closes the inbound-client path.
+      if (v === BridgeHub.PROVISIONAL_CHAT_ID || v.startsWith('_')) {
+        return { status: 400, payload: { error: 'invalid chat_id' } };
+      }
       chatId = v;
     }
 
@@ -465,6 +476,16 @@ export class BridgeHub {
     this.clients.add(res);
 
     const keepalive = setInterval(() => {
+      // f6 (completion): an OPEN-but-idle stream — no mirror POST, no reconnect —
+      // would still TTL-evict its mirror authorization after CHAT_ID_TTL_MS even
+      // though the socket is live. The connect-time touchMirrorChatId only covers
+      // the open instant; refresh on every keepalive tick (~25s) so an actively
+      // CONNECTED stream stays mirror-authorized for as long as the socket is up.
+      // touchMirrorChatId is fail-closed: it no-ops unless chatId is already a
+      // registered mirror stream, so a never-registered/legacy id is NOT
+      // resurrected. chatId is captured in this closure (null for legacy
+      // live-only consumers → skipped).
+      if (chatId !== null) this.touchMirrorChatId(chatId);
       try { res.write(':keepalive\n\n'); } catch { clearInterval(keepalive); }
     }, KEEPALIVE_MS);
     keepalive.unref?.();

--- a/packages/relay/src/dashboard/api-bridge.ts
+++ b/packages/relay/src/dashboard/api-bridge.ts
@@ -30,6 +30,7 @@
 
 import type { IncomingMessage, ServerResponse } from 'http';
 import { randomUUID } from 'crypto';
+import { MirrorEventStore } from './api-mirror-events';
 
 /**
  * In-process sink the MCP server registers. Returns true when the message was
@@ -41,11 +42,57 @@ export type BridgeSink = (chatId: string, message: string) => boolean;
 
 /** One outbound frame pushed to the dashboard over SSE. */
 interface BridgeReplyFrame {
-  type: 'reply' | 'ack' | 'error';
+  type: 'reply' | 'ack' | 'error' | 'mirror' | 'restart';
   chat_id: string;
   text?: string;
   ts: string;
 }
+
+/**
+ * Strict role enum for mirror frames (spec §5). Anything outside this set is a
+ * 400 at the route boundary, never a silent drop (resolves DISPUTED f21):
+ *   - 'user'      — a terminal prompt the human typed in the CC session.
+ *   - 'assistant' — the orchestrator's reply text block (Stop hook).
+ *   - 'activity'  — a curated, scrubbed tool/dispatch one-liner (PostToolUse).
+ */
+export const MIRROR_ROLES = ['user', 'assistant', 'activity'] as const;
+export type MirrorRole = (typeof MIRROR_ROLES)[number];
+
+/** Type guard for the strict role enum. */
+export function isMirrorRole(v: unknown): v is MirrorRole {
+  return typeof v === 'string' && (MIRROR_ROLES as readonly string[]).includes(v);
+}
+
+/**
+ * One mirror frame pushed to the dashboard over SSE and retained in the
+ * per-chat_id ring (spec §5). `id` is a per-chat_id monotonic counter and `ts`
+ * is SERVER-stamped — both are assigned by MirrorEventStore.push, never taken
+ * from the untrusted hook payload (deepseek:f8 — ignore hook clocks).
+ */
+export interface MirrorFrame {
+  type: 'mirror';
+  chat_id: string;
+  role: MirrorRole;
+  text: string;
+  ts: string; // SERVER-stamped (ISO 8601)
+  id: number; // per-chat_id monotonic
+}
+
+/** One inbound mirror frame as it arrives in the POST body (pre-validation). */
+export interface InboundMirrorFrame {
+  role: unknown;
+  text: unknown;
+}
+
+/**
+ * Per-frame text cap for mirror frames (spec §4). SEPARATE from the route's
+ * BRIDGE/MIRROR_MAX_BODY readBody cap: the body cap bounds the whole batch, this
+ * bounds each individual frame so one giant frame can't dominate a small batch.
+ * ~2 KB is generous for a scrubbed tool one-liner or a short assistant text.
+ */
+export const MIRROR_MAX_TEXT = 2 * 1024;
+/** Max frames accepted in a single mirror POST batch (DoS guard). */
+export const MIRROR_MAX_FRAMES = 64;
 
 // chat_id shape: callers may omit it (we mint one). When supplied it is
 // UNTRUSTED — restrict to a conservative id charset + length so it can't be
@@ -88,9 +135,51 @@ export class BridgeHub {
   private static readonly MAX_KNOWN_CHAT_IDS = 64;
   private static readonly CHAT_ID_TTL_MS = 2 * 60 * 60 * 1000; // 2h, mirror chat-session-store
 
+  // ── Mirror state (spec v2 §3) ──────────────────────────────────────────────
+  // chat_ids eligible to RECEIVE mirror frames. SEPARATE from knownChatIds
+  // (sonnet:f7/f12). P1#1: this set is seeded ONLY from the relay's validated
+  // inbound POST body (handlePost / registerMirrorChatId from a dashboard turn),
+  // NEVER from a hook-extracted wrapper chat_id — a prompt-injected wrapper
+  // could otherwise seed an arbitrary id and address a stream it never opened.
+  // emitReply STILL gates on knownChatIds, so mirroring never widens the
+  // outbound reply boundary (api-bridge.ts emitReply isKnownChatId check).
+  private mirrorChatIds = new Map<string, number>();
+  // Session→chat_id map (P1#5). The relay has no native "active session
+  // chat_id" notion — a no-chat_id inbound POST mints a fresh UUID. We learn the
+  // mapping from the dashboard turn: a turn carries BOTH a chat_id (validated)
+  // and a session_id (the CC session_id the wrapper/hook reports). Terminal
+  // (no-chat_id) mirror POSTs that DO carry a session_id resolve their chat_id
+  // through here. Established only from a validated dashboard inbound POST.
+  private sessionToChatId = new Map<string, { chatId: string; at: number }>();
+  // Per-chat_id mirror rings (bounded FIFO + TTL + proactive sweep).
+  private mirror = new MirrorEventStore();
+  // PROVISIONAL buffer (P1#5 fallback): a purely-terminal mirror POST with no
+  // resolvable chat_id (no body chat_id, no known session mapping) is buffered
+  // under a provisional id so a later observer can backfill it — OR dropped,
+  // per the config flag. The provisional id is a single, fixed, reserved id
+  // (never a real chat_id — it uses a `_` prefix that CHAT_ID_RE forbids at the
+  // route, so it can never collide with or be addressed by a client). Its ring
+  // is bounded + swept by the SAME MirrorEventStore, so MIRROR_RING_MAX caps the
+  // backfill depth and the TTL sweep reclaims it if no observer ever arrives.
+  // Backfill merges provisional frames into the resolved chat_id ring (re-pushed
+  // → re-stamped with that ring's ids), capped by MIRROR_RING_MAX.
+  private static readonly PROVISIONAL_CHAT_ID = '_provisional';
+  private dropUnresolvedMirror = false;
+  // session→chat_id entries share the same 2h TTL ceiling as knownChatIds.
+  private static readonly MAX_SESSION_MAPPINGS = 64;
+
   /** Register (or clear) the in-process inbound sink. Called by RelayServer. */
   registerSink(fn: BridgeSink | null): void {
     this.sink = fn;
+  }
+
+  /**
+   * Config: when true, an unresolvable terminal mirror POST (no chat_id, no
+   * known session mapping) is DROPPED instead of buffered under the provisional
+   * id. Default false (buffer for backfill). Set by the app layer.
+   */
+  setDropUnresolvedMirror(drop: boolean): void {
+    this.dropUnresolvedMirror = drop;
   }
 
   /** True when an MCP-side consumer is wired. */
@@ -105,7 +194,7 @@ export class BridgeHub {
    * the registered sink. Returns the response payload the route should send.
    */
   handlePost(body: unknown): { status: number; payload: Record<string, unknown> } {
-    const b = (body ?? {}) as { chat_id?: unknown; message?: unknown };
+    const b = (body ?? {}) as { chat_id?: unknown; message?: unknown; session_id?: unknown };
 
     const message = b.message;
     if (typeof message !== 'string' || message.trim().length === 0) {
@@ -136,6 +225,13 @@ export class BridgeHub {
     }
 
     this.rememberChatId(chatId);
+    // P1#1: seed the mirror registry ONLY from this validated inbound POST body.
+    // This is the sole trusted seeding path for mirrorChatIds — hooks NEVER seed
+    // it. P1#5: if the dashboard turn reports its CC session_id, record the
+    // session→chat_id mapping so later terminal (no-chat_id) mirror POSTs resolve.
+    this.registerMirrorChatId(chatId);
+    const sessionId = validateChatId(b.session_id);
+    if (sessionId !== null) this.bindSession(sessionId, chatId);
 
     let delivered: boolean;
     try {
@@ -182,9 +278,126 @@ export class BridgeHub {
   }
 
   /**
+   * MIRROR ingress (spec v2 §3). Validates the (already body-capped + role-
+   * checked-at-route) batch a SECOND time at the trust boundary, resolves the
+   * target chat_id, stamps id + ts SERVER-SIDE per frame, retains each in the
+   * per-chat_id ring, and fans out to SSE.
+   *
+   * Returns a route-shaped {status,payload}:
+   *   - 400 — malformed chat_id, bad/oversize frame, empty/oversize batch.
+   *     A bad frame anywhere in the batch rejects the WHOLE batch (reject →
+   *     400, not silent drop — resolves DISPUTED f21). NOTHING is pushed on a
+   *     400, so a partially-validated batch can't half-apply.
+   *   - 202 — accepted; payload reports the resolved chat_id + how many frames.
+   *
+   * Trust boundaries:
+   *   - chat_id (P1#1): an explicit body chat_id must be in mirrorChatIds (seeded
+   *     ONLY from a dashboard inbound POST). A no-chat_id POST resolves through
+   *     the session→chat_id map; if neither resolves, it goes to the provisional
+   *     buffer (or is dropped per config) — it can NEVER seed mirrorChatIds.
+   *   - id + ts are assigned by MirrorEventStore.push (NOT the hook payload —
+   *     deepseek:f8). The InboundMirrorFrame carries only role + text.
+   *   - Does NOT gate on clients.size (deepseek:f10): a mirror frame with no
+   *     current observer is still retained for ring replay. This asymmetry vs
+   *     emitReply is intentional and consensus-verified (sonnet:f12).
+   *
+   * P1#6 turn-ordering: UserPromptSubmit (turn start) and Stop (turn end) are
+   * separate POSTs; the server `ts` is ARRIVAL order, not causal order — if Stop
+   * races ahead of UserPromptSubmit the frames interleave by arrival. Per spec
+   * we ACCEPT arrival-order and document it here rather than adding a per-turn
+   * sequence number now.
+   */
+  emitMirror(
+    rawChatId: string | undefined | null,
+    frames: InboundMirrorFrame[],
+    sessionId?: string | null,
+  ): { status: number; payload: Record<string, unknown> } {
+    if (!Array.isArray(frames) || frames.length === 0) {
+      return { status: 400, payload: { error: 'frames must be a non-empty array' } };
+    }
+    if (frames.length > MIRROR_MAX_FRAMES) {
+      return { status: 400, payload: { error: 'too many frames in batch' } };
+    }
+
+    // Validate EVERY frame BEFORE touching any ring (gemini:f5 — the route's
+    // handlePost only validated a flat {message}; mirror must iterate). A single
+    // bad frame fails the whole batch with 400.
+    const validated: Array<{ role: MirrorRole; text: string }> = [];
+    for (const f of frames) {
+      if (!f || typeof f !== 'object') {
+        return { status: 400, payload: { error: 'each frame must be an object' } };
+      }
+      if (!isMirrorRole((f as InboundMirrorFrame).role)) {
+        return { status: 400, payload: { error: 'invalid frame role' } };
+      }
+      const text = (f as InboundMirrorFrame).text;
+      if (typeof text !== 'string' || text.length === 0) {
+        return { status: 400, payload: { error: 'frame text must be a non-empty string' } };
+      }
+      if (text.length > MIRROR_MAX_TEXT) {
+        return { status: 400, payload: { error: 'frame text too long' } };
+      }
+      validated.push({ role: (f as InboundMirrorFrame).role as MirrorRole, text });
+    }
+
+    // Resolve the target chat_id.
+    let chatId: string;
+    if (rawChatId !== undefined && rawChatId !== null) {
+      const v = validateChatId(rawChatId);
+      if (v === null) {
+        return { status: 400, payload: { error: 'invalid chat_id' } };
+      }
+      // P1#1: an explicit chat_id is only honored if the dashboard already
+      // opened it (seeded via handlePost). A hook-supplied id we've never seen
+      // on a validated inbound POST is rejected — it CANNOT seed mirrorChatIds.
+      if (!this.isMirrorChatId(v)) {
+        return { status: 400, payload: { error: 'unknown chat_id (not an open dashboard stream)' } };
+      }
+      chatId = v;
+    } else {
+      // No chat_id: resolve through the session map (P1#5).
+      const sid = validateChatId(sessionId);
+      const resolved = sid !== null ? this.resolveSession(sid) : null;
+      if (resolved !== null) {
+        chatId = resolved;
+      } else if (this.dropUnresolvedMirror) {
+        // Config: drop purely-terminal frames with no observer/mapping.
+        return { status: 202, payload: { ok: true, chat_id: null, dropped: validated.length } };
+      } else {
+        // Buffer under the reserved provisional id for later backfill. This id
+        // can never be a real chat_id (CHAT_ID_RE forbids the `_` route-side).
+        chatId = BridgeHub.PROVISIONAL_CHAT_ID;
+      }
+    }
+
+    const stamped: MirrorFrame[] = [];
+    for (const { role, text } of validated) {
+      const frame = this.mirror.push(chatId, role, text);
+      stamped.push(frame);
+      // Do NOT gate on clients.size — frame is already retained for replay.
+      this.broadcast(frame);
+    }
+    return {
+      status: 202,
+      payload: { ok: true, chat_id: chatId === BridgeHub.PROVISIONAL_CHAT_ID ? null : chatId, frames: stamped.length },
+    };
+  }
+
+  /**
    * SSE egress endpoint at /dashboard/api/bridge/stream. Auth is verified by the
    * router BEFORE this runs (same contract as handleEventsSSE). Long-lived — the
    * router must NOT route the response through json() afterwards.
+   *
+   * Mirror replay (spec §3 / P1#3): when the URL carries `?chat_id=<id>`, on
+   * connect we replay that chat_id's retained mirror frames where `id > last_id`
+   * THEN go live. We replay ONLY `mirror` frames — never reply/ack (sonnet:f11);
+   * those are live-only outbound control frames with no per-chat_id ring.
+   *
+   * P1#3 restart discontinuity: on a relay restart the per-chat_id counter
+   * resets to 1, so a client holding `last_id=50` requesting `id>50` would
+   * silently starve (our highest id is now < 50). We detect `last_id >
+   * highestId(chat_id)` and emit an explicit `{type:'restart'}` sentinel telling
+   * the client to drop last_id and refetch from 0, then replay the full ring.
    */
   handleStream(req: IncomingMessage, res: ServerResponse): void {
     if (this.clients.size >= MAX_BRIDGE_CLIENTS) {
@@ -198,6 +411,34 @@ export class BridgeHub {
       'Connection': 'keep-alive',
       'X-Accel-Buffering': 'no',
     });
+
+    // Parse ?chat_id + ?last_id (absent in the original bridge — mirror
+    // api-events' ?last_id pattern). Both optional: no chat_id → live-only
+    // (legacy reply/ack consumers); chat_id → replay that ring first.
+    const url = req.url ?? '';
+    const qIdx = url.indexOf('?');
+    const search = qIdx >= 0 ? url.slice(qIdx + 1) : '';
+    const params = new URLSearchParams(search);
+    const chatId = validateChatId(params.get('chat_id'));
+    const lastId = parseInt(params.get('last_id') ?? '0', 10) || 0;
+
+    if (chatId !== null) {
+      const highest = this.mirror.highestId(chatId);
+      if (lastId > highest) {
+        // Restart discontinuity (P1#3): our counter is behind the client's
+        // cursor → a restart reset it. Tell the client to drop last_id, then
+        // replay the entire current ring from the start.
+        this.writeFrame(res, { type: 'restart', chat_id: chatId, ts: new Date().toISOString() });
+        for (const frame of this.mirror.replaySlice(chatId, 0)) {
+          this.writeFrame(res, frame);
+        }
+      } else {
+        for (const frame of this.mirror.replaySlice(chatId, lastId)) {
+          this.writeFrame(res, frame);
+        }
+      }
+    }
+
     this.backpressure.set(res, 0);
     this.clients.add(res);
 
@@ -212,9 +453,22 @@ export class BridgeHub {
     });
   }
 
+  /**
+   * Write one frame to a single SSE response (used during replay, before the
+   * client joins the broadcast set). Mirror frames carry an SSE `id:` line so
+   * the browser EventSource exposes lastEventId for reconnect-cursor reuse.
+   */
+  private writeFrame(res: ServerResponse, frame: BridgeReplyFrame | MirrorFrame): void {
+    const idLine = 'id' in frame && typeof frame.id === 'number' ? `id: ${frame.id}\n` : '';
+    try { res.write(`${idLine}data: ${JSON.stringify(frame)}\n\n`); } catch { /* client gone */ }
+  }
+
   /** Fan out one frame to every connected SSE client, with backpressure eviction. */
-  private broadcast(frame: BridgeReplyFrame): void {
-    const data = `data: ${JSON.stringify(frame)}\n\n`;
+  private broadcast(frame: BridgeReplyFrame | MirrorFrame): void {
+    // Mirror frames carry an SSE `id:` line so the browser EventSource exposes
+    // lastEventId; reply/ack/restart control frames have no per-chat_id id.
+    const idLine = 'id' in frame && typeof (frame as MirrorFrame).id === 'number' ? `id: ${(frame as MirrorFrame).id}\n` : '';
+    const data = `${idLine}data: ${JSON.stringify(frame)}\n\n`;
     for (const res of this.clients) {
       try {
         const ok = res.write(data);
@@ -260,8 +514,114 @@ export class BridgeHub {
     }
   }
 
+  // ── Mirror chat-id registry (SEPARATE from knownChatIds — P1#1/sonnet:f7) ──
+  // Same bounded + TTL eviction discipline as knownChatIds, but a DISTINCT map:
+  // mirrorChatIds gates emitMirror; knownChatIds gates emitReply. Keeping them
+  // separate is the whole point — mirroring must never widen the outbound reply
+  // boundary.
+
+  /**
+   * Seed the mirror registry. Called ONLY from handlePost (a validated
+   * dashboard inbound POST). There is intentionally NO hook-facing path to this
+   * method (P1#1): a hook-extracted wrapper chat_id can never seed it.
+   */
+  private registerMirrorChatId(chatId: string): void {
+    const now = Date.now();
+    this.evictMirrorChatIds(now);
+    if (!this.mirrorChatIds.has(chatId) && this.mirrorChatIds.size >= BridgeHub.MAX_KNOWN_CHAT_IDS) {
+      let oldestKey: string | null = null;
+      let oldest = Infinity;
+      for (const [k, v] of this.mirrorChatIds) {
+        if (v < oldest) { oldest = v; oldestKey = k; }
+      }
+      if (oldestKey !== null) this.mirrorChatIds.delete(oldestKey);
+    }
+    this.mirrorChatIds.set(chatId, now);
+  }
+
+  private isMirrorChatId(chatId: string): boolean {
+    this.evictMirrorChatIds(Date.now());
+    return this.mirrorChatIds.has(chatId);
+  }
+
+  private evictMirrorChatIds(now: number): void {
+    for (const [k, v] of this.mirrorChatIds) {
+      if (now - v > BridgeHub.CHAT_ID_TTL_MS) this.mirrorChatIds.delete(k);
+    }
+  }
+
+  /**
+   * Record a session→chat_id mapping (P1#5). Established ONLY from a validated
+   * dashboard inbound POST (handlePost). Bounded + TTL'd like the other maps.
+   */
+  private bindSession(sessionId: string, chatId: string): void {
+    const now = Date.now();
+    this.evictSessions(now);
+    if (!this.sessionToChatId.has(sessionId) && this.sessionToChatId.size >= BridgeHub.MAX_SESSION_MAPPINGS) {
+      let oldestKey: string | null = null;
+      let oldest = Infinity;
+      for (const [k, v] of this.sessionToChatId) {
+        if (v.at < oldest) { oldest = v.at; oldestKey = k; }
+      }
+      if (oldestKey !== null) this.sessionToChatId.delete(oldestKey);
+    }
+    this.sessionToChatId.set(sessionId, { chatId, at: now });
+  }
+
+  /**
+   * Resolve a session_id to its bound chat_id, or null. Only returns a chat_id
+   * that is STILL an open mirror stream — a session whose chat_id has since been
+   * evicted from mirrorChatIds resolves to null (fail closed) so a stale mapping
+   * can't re-open mirroring on a dead stream.
+   */
+  private resolveSession(sessionId: string): string | null {
+    this.evictSessions(Date.now());
+    const entry = this.sessionToChatId.get(sessionId);
+    if (!entry) return null;
+    if (!this.isMirrorChatId(entry.chatId)) return null;
+    return entry.chatId;
+  }
+
+  private evictSessions(now: number): void {
+    for (const [k, v] of this.sessionToChatId) {
+      if (now - v.at > BridgeHub.CHAT_ID_TTL_MS) this.sessionToChatId.delete(k);
+    }
+  }
+
+  // ── Test/introspection helpers ──────────────────────────────────────────────
+
   /** Test/introspection helper. */
   clientCount(): number {
     return this.clients.size;
+  }
+
+  /** Test helper: is this chat_id an open mirror stream? */
+  hasMirrorChatId(chatId: string): boolean {
+    return this.isMirrorChatId(chatId);
+  }
+
+  /** Test helper: highest retained mirror id for a chat_id (0 if none). */
+  mirrorHighestId(chatId: string): number {
+    return this.mirror.highestId(chatId);
+  }
+
+  /** Test helper: replay slice for a chat_id. */
+  mirrorReplay(chatId: string, lastId = 0): MirrorFrame[] {
+    return this.mirror.replaySlice(chatId, lastId);
+  }
+
+  /** Test helper: force a proactive ring sweep at a given clock. */
+  sweepMirror(now: number): void {
+    this.mirror.sweep(now);
+  }
+
+  /** Test helper: number of live mirror rings. */
+  mirrorRingCount(): number {
+    return this.mirror.ringCount();
+  }
+
+  /** Stop the mirror sweep timer (clean shutdown / tests). */
+  dispose(): void {
+    this.mirror.dispose();
   }
 }

--- a/packages/relay/src/dashboard/api-bridge.ts
+++ b/packages/relay/src/dashboard/api-bridge.ts
@@ -127,6 +127,10 @@ export class BridgeHub {
   private sink: BridgeSink | null = null;
   private clients = new Set<ServerResponse>();
   private backpressure = new WeakMap<ServerResponse, number>();
+  // Per-client keepalive interval (f12). Tracked so broadcast()'s backpressure
+  // eviction can clearInterval too — the req 'close' handler may never fire on
+  // an abrupt res.destroy(), which would otherwise leak the timer.
+  private keepalives = new Map<ServerResponse, ReturnType<typeof setInterval>>();
   // chat_ids we have seen on an INBOUND POST. Outbound replies bind against this
   // set (consensus f5): the live session can only address a stream the dashboard
   // actually opened, never an arbitrary/forged id. Bounded + TTL'd so a long
@@ -423,18 +427,36 @@ export class BridgeHub {
     const lastId = parseInt(params.get('last_id') ?? '0', 10) || 0;
 
     if (chatId !== null) {
+      // f6: serving a chat_id that's an open mirror stream TOUCHES its TTL so an
+      // actively-observed stream isn't deauthorized just because mirror POSTs
+      // paused (the only other TTL bump is registerMirrorChatId, on inbound POST).
+      // An idle-but-OPEN SSE observer keeps its own authorization alive.
+      this.touchMirrorChatId(chatId);
       const highest = this.mirror.highestId(chatId);
       if (lastId > highest) {
         // Restart discontinuity (P1#3): our counter is behind the client's
         // cursor → a restart reset it. Tell the client to drop last_id, then
         // replay the entire current ring from the start.
-        this.writeFrame(res, { type: 'restart', chat_id: chatId, ts: new Date().toISOString() });
-        for (const frame of this.mirror.replaySlice(chatId, 0)) {
-          this.writeFrame(res, frame);
+        if (!this.writeFrame(res, { type: 'restart', chat_id: chatId, ts: new Date().toISOString() })) {
+          // Slow client backed up on the very first frame — abandon replay.
+          // The client reconnects with its last_id and we replay again (f10).
+          return;
         }
+        this.replayWithBackpressure(res, chatId, 0);
       } else {
-        for (const frame of this.mirror.replaySlice(chatId, lastId)) {
-          this.writeFrame(res, frame);
+        // FIFO-overflow gap (f7): the lowest frame we can still serve is past
+        // lastId+1 because the oldest frames were FIFO-evicted. A late observer
+        // would silently lose that history. Detect it and emit the SAME restart
+        // sentinel used for the counter-reset case so the client drops its
+        // cursor and refetches the full retained ring from 0.
+        const slice = this.mirror.replaySlice(chatId, lastId);
+        if (lastId > 0 && slice.length > 0 && slice[0].id > lastId + 1) {
+          if (!this.writeFrame(res, { type: 'restart', chat_id: chatId, ts: new Date().toISOString() })) {
+            return;
+          }
+          this.replayWithBackpressure(res, chatId, 0);
+        } else {
+          if (!this.replayFrames(res, slice)) return;
         }
       }
     }
@@ -446,21 +468,47 @@ export class BridgeHub {
       try { res.write(':keepalive\n\n'); } catch { clearInterval(keepalive); }
     }, KEEPALIVE_MS);
     keepalive.unref?.();
+    // f12: track the interval per client so broadcast()'s backpressure eviction
+    // can clear it too — the req 'close' handler may never fire on an abrupt
+    // socket destroy, leaking the timer.
+    this.keepalives.set(res, keepalive);
 
     req.on('close', () => {
-      clearInterval(keepalive);
+      this.clearKeepalive(res);
       this.clients.delete(res);
     });
+  }
+
+  /**
+   * Replay a chat_id's ring (id > lastId) to a single client, honoring
+   * backpressure (f10): stop the moment a write returns false instead of
+   * silently dropping later frames into a full socket buffer. The client
+   * reconnects with its last SSE id and replay resumes from there. Returns false
+   * when replay was cut short.
+   */
+  private replayWithBackpressure(res: ServerResponse, chatId: string, lastId: number): boolean {
+    return this.replayFrames(res, this.mirror.replaySlice(chatId, lastId));
+  }
+
+  /** Write a pre-fetched frame slice with backpressure, stopping on first false. */
+  private replayFrames(res: ServerResponse, slice: MirrorFrame[]): boolean {
+    for (const frame of slice) {
+      if (!this.writeFrame(res, frame)) return false;
+    }
+    return true;
   }
 
   /**
    * Write one frame to a single SSE response (used during replay, before the
    * client joins the broadcast set). Mirror frames carry an SSE `id:` line so
    * the browser EventSource exposes lastEventId for reconnect-cursor reuse.
+   * Returns the underlying res.write() result so the replay loop can honor
+   * backpressure (f10) — false means the socket buffer is full / the client is
+   * gone, and the caller must stop replaying.
    */
-  private writeFrame(res: ServerResponse, frame: BridgeReplyFrame | MirrorFrame): void {
+  private writeFrame(res: ServerResponse, frame: BridgeReplyFrame | MirrorFrame): boolean {
     const idLine = 'id' in frame && typeof frame.id === 'number' ? `id: ${frame.id}\n` : '';
-    try { res.write(`${idLine}data: ${JSON.stringify(frame)}\n\n`); } catch { /* client gone */ }
+    try { return res.write(`${idLine}data: ${JSON.stringify(frame)}\n\n`); } catch { return false; }
   }
 
   /** Fan out one frame to every connected SSE client, with backpressure eviction. */
@@ -478,14 +526,42 @@ export class BridgeHub {
           const count = (this.backpressure.get(res) ?? 0) + 1;
           this.backpressure.set(res, count);
           if (count > BACKPRESSURE_EVICT_THRESHOLD) {
+            this.clearKeepalive(res); // f12: don't leak the timer on eviction
             res.destroy();
             this.clients.delete(res);
           }
         }
       } catch {
+        this.clearKeepalive(res);
         this.clients.delete(res);
       }
     }
+  }
+
+  /** Clear + drop a client's keepalive interval (f12). Safe if absent. */
+  private clearKeepalive(res: ServerResponse): void {
+    const timer = this.keepalives.get(res);
+    if (timer !== undefined) {
+      clearInterval(timer);
+      this.keepalives.delete(res);
+    }
+  }
+
+  /**
+   * Bump the TTL of an OPEN mirror chat_id (f6) without seeding a new one. Unlike
+   * registerMirrorChatId this NEVER adds an id — it only refreshes the timestamp
+   * of an id that is already an open mirror stream, so an actively-observed SSE
+   * stream stays authorized even when mirror POSTs pause. A chat_id that isn't a
+   * mirror stream (or has already aged out) is left untouched (fail closed).
+   */
+  private touchMirrorChatId(chatId: string): void {
+    const now = Date.now();
+    // Refresh FIRST, then evict: an open SSE stream re-authorizes its own
+    // chat_id even if it had aged past the TTL since the last mirror POST. If we
+    // evicted before refreshing, an idle-but-open stream would be dropped right
+    // before the touch could save it (f6). Other stale ids are still reaped.
+    if (this.mirrorChatIds.has(chatId)) this.mirrorChatIds.set(chatId, now);
+    this.evictMirrorChatIds(now);
   }
 
   private rememberChatId(chatId: string): void {
@@ -528,7 +604,8 @@ export class BridgeHub {
   private registerMirrorChatId(chatId: string): void {
     const now = Date.now();
     this.evictMirrorChatIds(now);
-    if (!this.mirrorChatIds.has(chatId) && this.mirrorChatIds.size >= BridgeHub.MAX_KNOWN_CHAT_IDS) {
+    const isNew = !this.mirrorChatIds.has(chatId);
+    if (isNew && this.mirrorChatIds.size >= BridgeHub.MAX_KNOWN_CHAT_IDS) {
       let oldestKey: string | null = null;
       let oldest = Infinity;
       for (const [k, v] of this.mirrorChatIds) {
@@ -537,6 +614,30 @@ export class BridgeHub {
       if (oldestKey !== null) this.mirrorChatIds.delete(oldestKey);
     }
     this.mirrorChatIds.set(chatId, now);
+    // Provisional backfill (spec §2 / P2 — f1/f7): the FIRST time a stream is
+    // established, drain any frames buffered under the provisional id (terminal
+    // mirror POSTs that arrived before this chat_id existed) into THIS ring,
+    // re-stamped with this ring's monotonic ids + a fresh server ts, capped at
+    // MIRROR_RING_MAX by the ring's own FIFO. Then the provisional ring is
+    // cleared. Only on first-seen so a re-touch of an existing stream doesn't
+    // re-drain (the provisional ring is empty after the first drain anyway, but
+    // guarding on isNew makes the single-shot intent explicit). If dropping is
+    // configured the provisional buffer is never populated, so this is a no-op.
+    if (isNew) this.backfillProvisional(chatId, now);
+  }
+
+  /**
+   * Drain the provisional ring into a newly-established chat_id ring and fan the
+   * re-stamped frames out to any currently-connected SSE client whose cursor is
+   * on this chat_id (they receive them as live frames; a later reconnect replays
+   * them from the ring). Cap is enforced by MirrorEventStore.drainInto's FIFO.
+   */
+  private backfillProvisional(chatId: string, now: number): void {
+    if (chatId === BridgeHub.PROVISIONAL_CHAT_ID) return;
+    const transferred = this.mirror.drainInto(BridgeHub.PROVISIONAL_CHAT_ID, chatId, now);
+    for (const frame of transferred) {
+      this.broadcast(frame);
+    }
   }
 
   private isMirrorChatId(chatId: string): boolean {
@@ -615,13 +716,32 @@ export class BridgeHub {
     this.mirror.sweep(now);
   }
 
+  /**
+   * Test helper (f6): age an open mirror chat_id's last-touch timestamp into the
+   * past by `ms`, so the next TTL check would evict it unless something (an open
+   * SSE stream) touches it first. Returns false if the id isn't an open stream.
+   */
+  ageMirrorChatId(chatId: string, ms: number): boolean {
+    const cur = this.mirrorChatIds.get(chatId);
+    if (cur === undefined) return false;
+    this.mirrorChatIds.set(chatId, cur - ms);
+    return true;
+  }
+
+  /** Test helper: count of live keepalive timers (f12 leak check). */
+  keepaliveCount(): number {
+    return this.keepalives.size;
+  }
+
   /** Test helper: number of live mirror rings. */
   mirrorRingCount(): number {
     return this.mirror.ringCount();
   }
 
-  /** Stop the mirror sweep timer (clean shutdown / tests). */
+  /** Stop the mirror sweep timer + all per-client keepalives (clean shutdown / tests). */
   dispose(): void {
+    for (const timer of this.keepalives.values()) clearInterval(timer);
+    this.keepalives.clear();
     this.mirror.dispose();
   }
 }

--- a/packages/relay/src/dashboard/api-mirror-events.ts
+++ b/packages/relay/src/dashboard/api-mirror-events.ts
@@ -107,8 +107,46 @@ export class MirrorEventStore {
     const ring = this.rings.get(chatId);
     if (!ring) return [];
     ring.touchedAt = now;
+    // lastId<=0: return a defensive COPY (callers iterate while the ring may be
+    // mutated by a concurrent push/FIFO-shift; handing out the live array would
+    // let an in-flight broadcast splice from under the replay loop). f2.
     if (lastId <= 0) return ring.frames.slice();
     return ring.frames.filter((f) => f.id > lastId);
+  }
+
+  /**
+   * Drain every frame currently buffered under `fromChatId` and re-push it into
+   * `toChatId`, re-stamping each frame with the destination ring's own
+   * monotonic id + a fresh server ts (provisional backfill, spec §2 / P2).
+   *
+   * Why re-stamp rather than copy ids: the provisional ring has its OWN id
+   * sequence; merging raw ids into the resolved ring would collide with that
+   * ring's counter and break the `?last_id` cursor. So each transferred frame
+   * goes through push() exactly like a fresh frame — capped at ringMax by the
+   * same FIFO. role + text are preserved; id/ts/chat_id are reassigned.
+   *
+   * The source ring is fully cleared after the drain (frames are write-once;
+   * a partial transfer can't happen because push never throws). Returns the
+   * re-stamped frames in destination-id order so the hub can broadcast exactly
+   * what was retained. A no-op (returns []) when the source ring is absent or
+   * empty, or when from===to (nothing to merge).
+   */
+  drainInto(fromChatId: string, toChatId: string, now: number = Date.now()): MirrorFrame[] {
+    if (fromChatId === toChatId) return [];
+    const src = this.rings.get(fromChatId);
+    if (!src || src.frames.length === 0) {
+      // Still clear an empty source ring so it doesn't linger for TTL sweep.
+      this.rings.delete(fromChatId);
+      return [];
+    }
+    const carried = src.frames.slice();
+    // Clear the source ring entirely — provisional frames live exactly once.
+    this.rings.delete(fromChatId);
+    const transferred: MirrorFrame[] = [];
+    for (const f of carried) {
+      transferred.push(this.push(toChatId, f.role, f.text, now));
+    }
+    return transferred;
   }
 
   /**

--- a/packages/relay/src/dashboard/api-mirror-events.ts
+++ b/packages/relay/src/dashboard/api-mirror-events.ts
@@ -1,0 +1,149 @@
+/**
+ * api-mirror-events.ts — per-chat_id mirror ring buffers (spec v2 §3/§5,
+ * 2026-06-14-dashboard-cc-activity-mirror-v2.md).
+ *
+ * Why a NEW module rather than reusing api-events.ts (haiku:f3/f8): api-events
+ * owns a SINGLE global ring + a SINGLE monotonic counter shared across all SSE
+ * clients. Mirror frames are partitioned PER chat_id — each session needs its
+ * own id sequence so a client's `?last_id` cursor is meaningful within its
+ * stream, and one chat's frames must never evict another's. So this module
+ * keeps a `Map<chatId, MirrorRing>` where each ring has its own FIFO bound, its
+ * own id counter, and its own last-touched timestamp for TTL eviction.
+ *
+ * Eviction is BOTH bounded-FIFO (MIRROR_RING_MAX per chat) AND TTL with a
+ * PROACTIVE periodic sweep (sonnet:f9 / deepseek:f6): knownChatIds' lazy
+ * (touch-time-only) eviction is not enough because a chat_id that goes silent
+ * forever would otherwise retain its ring indefinitely with no future call to
+ * trigger a lazy purge. The sweep timer is unref'd so it never holds the
+ * process open.
+ */
+
+import type { MirrorFrame } from './api-bridge';
+
+/** Max frames retained per chat_id ring (bounded FIFO). Start conservative. */
+export const MIRROR_RING_MAX = 100;
+/** A chat_id ring idle longer than this is swept. Mirrors the 2h chat TTL. */
+export const MIRROR_RING_TTL_MS = 2 * 60 * 60 * 1000;
+/** How often the proactive sweep runs. */
+export const MIRROR_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+interface MirrorRing {
+  /** Bounded FIFO of frames for this chat_id, in id order. */
+  frames: MirrorFrame[];
+  /** Per-chat_id monotonic id counter. Starts at 0; first frame gets id 1. */
+  nextId: number;
+  /** Last push/replay timestamp (ms) — drives TTL eviction. */
+  touchedAt: number;
+}
+
+/**
+ * MirrorEventStore — owns the per-chat_id rings. One instance per BridgeHub.
+ * Process-local; a cold restart clears everything and resets every counter to
+ * 0 (handled by the restart sentinel in api-bridge.handleStream).
+ */
+export class MirrorEventStore {
+  private rings = new Map<string, MirrorRing>();
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly ringMax: number = MIRROR_RING_MAX,
+    private readonly ttlMs: number = MIRROR_RING_TTL_MS,
+    sweepIntervalMs: number = MIRROR_SWEEP_INTERVAL_MS,
+  ) {
+    // Proactive sweep. unref so the timer never keeps node alive (tests, clean
+    // shutdown). A sweepIntervalMs<=0 disables the timer (test injection).
+    if (sweepIntervalMs > 0) {
+      this.sweepTimer = setInterval(() => this.sweep(Date.now()), sweepIntervalMs);
+      this.sweepTimer.unref?.();
+    }
+  }
+
+  /**
+   * Allocate the next id for a chat_id WITHOUT pushing a frame. The hub stamps
+   * id + ts server-side, so it asks the store to mint the id, builds the frame,
+   * then pushes it. Keeping mint+push as one call (push) avoids a torn counter,
+   * so this is internal — callers use push().
+   */
+  private ensureRing(chatId: string, now: number): MirrorRing {
+    let ring = this.rings.get(chatId);
+    if (!ring) {
+      ring = { frames: [], nextId: 0, touchedAt: now };
+      this.rings.set(chatId, ring);
+    }
+    return ring;
+  }
+
+  /**
+   * Push a frame for chat_id, stamping its per-chat_id id + ts server-side. The
+   * caller supplies role + text (already validated); id/ts/type/chat_id are set
+   * here so a hook clock or forged id can never leak in. Returns the stamped
+   * frame so the hub can broadcast the exact object that was retained.
+   */
+  push(chatId: string, role: MirrorFrame['role'], text: string, now: number = Date.now()): MirrorFrame {
+    const ring = this.ensureRing(chatId, now);
+    const id = ++ring.nextId;
+    const frame: MirrorFrame = {
+      type: 'mirror',
+      chat_id: chatId,
+      role,
+      text,
+      ts: new Date(now).toISOString(),
+      id,
+    };
+    ring.frames.push(frame);
+    // Bounded FIFO: drop oldest beyond the cap. Distinct from TTL eviction.
+    while (ring.frames.length > this.ringMax) ring.frames.shift();
+    ring.touchedAt = now;
+    return frame;
+  }
+
+  /**
+   * Replay slice: every retained frame for chat_id with `id > lastId`, in id
+   * order. Returns [] for an unknown chat_id (no ring yet) — a fresh observer
+   * with last_id=0 on a brand-new stream just goes live. Touches the ring so an
+   * actively-observed stream isn't swept out from under a reconnecting client.
+   */
+  replaySlice(chatId: string, lastId: number, now: number = Date.now()): MirrorFrame[] {
+    const ring = this.rings.get(chatId);
+    if (!ring) return [];
+    ring.touchedAt = now;
+    if (lastId <= 0) return ring.frames.slice();
+    return ring.frames.filter((f) => f.id > lastId);
+  }
+
+  /**
+   * The current highest id retained for chat_id (0 if none). Lets handleStream
+   * detect the restart-discontinuity case: a client requesting `id > last_id`
+   * where last_id exceeds our highest id means our counter was reset by a
+   * restart, so the client must drop last_id and refetch (see the restart
+   * sentinel in api-bridge.handleStream).
+   */
+  highestId(chatId: string): number {
+    const ring = this.rings.get(chatId);
+    if (!ring || ring.frames.length === 0) return 0;
+    return ring.frames[ring.frames.length - 1].id;
+  }
+
+  /**
+   * Proactive TTL sweep — evict every ring untouched for longer than ttlMs.
+   * Called by the periodic timer; also callable directly in tests.
+   */
+  sweep(now: number = Date.now()): void {
+    for (const [chatId, ring] of this.rings) {
+      if (now - ring.touchedAt > this.ttlMs) this.rings.delete(chatId);
+    }
+  }
+
+  /** Test/introspection: number of live rings. */
+  ringCount(): number {
+    return this.rings.size;
+  }
+
+  /** Stop the sweep timer (clean shutdown / tests). */
+  dispose(): void {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+  }
+}

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -21,7 +21,7 @@ import { sessionHandler } from './api-session';
 import { logsHandler } from './api-logs';
 import { violationsHandler } from './api-violations';
 import { handleChat } from './api-chat';
-import { BridgeHub, type BridgeSink } from './api-bridge';
+import { BridgeHub, type BridgeSink, type InboundMirrorFrame } from './api-bridge';
 import { ChatConversationStore } from './chat-session-store';
 import type { ChatbotAgent } from '@gossip/orchestrator';
 import { buildCoverageDegradedMessage } from '@gossip/orchestrator';
@@ -156,6 +156,21 @@ const CHAT_MAX_BODY = 64 * 1024; // 64 KB
 // shared cap (consensus f3 — bound the inbound buffer).
 const BRIDGE_MAX_BODY = 64 * 1024; // 64 KB
 
+// Per-route body cap for POST /dashboard/api/bridge/mirror. A batched mirror
+// turn (UserPromptSubmit + several PostToolUse one-liners + the Stop assistant
+// text) can be larger than a single chat message, but is still tightly bounded.
+// SEPARATE from MIRROR_MAX_TEXT (the per-FRAME cap in api-bridge.ts) — this
+// bounds the whole batch buffer, that bounds each frame (consensus f3 posture).
+const MIRROR_MAX_BODY = 64 * 1024; // 64 KB
+
+// Dedicated mirror rate bucket (P1#2). The /mirror route must NOT reuse
+// allowChatTurn(ip) — a single turn fires 5–10 localhost hooks and would 429
+// the human's chat from the same 127.0.0.1. Key the bucket PER-CHAT_ID (all
+// hooks are localhost, so per-IP is meaningless here), with a short min
+// interval that tolerates a hook burst. A bucket-miss is a soft 429, never a
+// data drop — the hook is fail-open and the next turn re-POSTs.
+const MIRROR_MIN_INTERVAL_MS = 200;
+
 // Minimum interval between chat turns from one IP — a simple per-IP throttle so
 // a single client can't fan out concurrent/rapid turns (each turn can run up to
 // maxToolCallsPerTurn tool executions). Mirrors the isIpLockedOut style.
@@ -190,6 +205,11 @@ export class DashboardRouter {
   private chatStore = new ChatConversationStore();
   // Per-IP last-chat-turn timestamp for the min-interval throttle.
   private chatLastTurn = new Map<string, number>();
+  // Per-CHAT_ID last-mirror-POST timestamp (P1#2). DEDICATED bucket — does NOT
+  // touch chatLastTurn / allowChatTurn, so a hook burst never 429s the human's
+  // chat. Keyed by chat_id (or a fixed no-chat_id key) since all hooks are
+  // 127.0.0.1 and per-IP would conflate every session.
+  private mirrorLastTurn = new Map<string, number>();
   // Dashboard ⇄ live-CC bridge transport (P1). Owns the outbound SSE client set
   // and the in-process inbound sink the MCP server registers. Distinct from the
   // dormant chatbot (consensus f14 — no dual-brain; /api/chat stays dormant).
@@ -423,6 +443,27 @@ export class DashboardRouter {
     const last = this.chatLastTurn.get(ip);
     if (last !== undefined && now - last < CHAT_MIN_INTERVAL_MS) return false;
     this.chatLastTurn.set(ip, now);
+    return true;
+  }
+
+  /**
+   * Per-CHAT_ID min-interval throttle for mirror POSTs (P1#2). DEDICATED bucket
+   * — deliberately separate from allowChatTurn so a turn's hook burst never 429s
+   * the human's chat (both arrive from 127.0.0.1). A no-chat_id terminal POST
+   * shares one fixed key (`_nochatid`) so purely-terminal bursts are still
+   * bounded. Same opportunistic pruning posture as allowChatTurn.
+   */
+  private allowMirrorTurn(key: string): boolean {
+    const now = Date.now();
+    if (this.mirrorLastTurn.size > 100) {
+      const staleBefore = MIRROR_MIN_INTERVAL_MS * 10;
+      for (const [k, v] of this.mirrorLastTurn) {
+        if (now - v > staleBefore) this.mirrorLastTurn.delete(k);
+      }
+    }
+    const last = this.mirrorLastTurn.get(key);
+    if (last !== undefined && now - last < MIRROR_MIN_INTERVAL_MS) return false;
+    this.mirrorLastTurn.set(key, now);
     return true;
   }
 
@@ -724,6 +765,40 @@ export class DashboardRouter {
           return true;
         }
         this.bridge.handleStream(req, res);
+        return true;
+      }
+
+      // Mirror INGRESS — /dashboard/api/bridge/mirror (CC hooks → dashboard).
+      // Auth already verified above. P1#2: a DEDICATED per-chat_id rate bucket
+      // (NOT allowChatTurn — a hook burst must never 429 the human chat). A
+      // per-route readBody cap (MIRROR_MAX_BODY, separate from the per-frame
+      // MIRROR_MAX_TEXT cap). Body {chat_id?, session_id?, frames:[{role,text}]};
+      // the hub validates each frame's role/text and stamps id+ts server-side,
+      // rejecting a bad/oversize/malformed batch with 400.
+      if (url === '/dashboard/api/bridge/mirror' && req.method === 'POST') {
+        let body: unknown;
+        try {
+          body = JSON.parse(await readBody(req, MIRROR_MAX_BODY));
+        } catch {
+          this.json(res, 400, { error: 'Invalid JSON body' });
+          return true;
+        }
+        const b = (body ?? {}) as { chat_id?: unknown; session_id?: unknown; frames?: unknown };
+        // Rate-limit key: the supplied chat_id when present (per-stream bucket),
+        // else a fixed no-chat_id key so terminal bursts are still bounded.
+        const bucketKey = typeof b.chat_id === 'string' && b.chat_id.length > 0 ? b.chat_id : '_nochatid';
+        if (!this.allowMirrorTurn(bucketKey)) {
+          this.json(res, 429, { error: 'Too many mirror frames. Slow down.' });
+          return true;
+        }
+        const rawChatId = b.chat_id === undefined || b.chat_id === null ? null : (b.chat_id as string | null);
+        const sessionId = typeof b.session_id === 'string' ? b.session_id : null;
+        const { status, payload } = this.bridge.emitMirror(
+          rawChatId,
+          Array.isArray(b.frames) ? (b.frames as InboundMirrorFrame[]) : [],
+          sessionId,
+        );
+        this.json(res, status, payload);
         return true;
       }
 

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -21,7 +21,7 @@ import { sessionHandler } from './api-session';
 import { logsHandler } from './api-logs';
 import { violationsHandler } from './api-violations';
 import { handleChat } from './api-chat';
-import { BridgeHub, type BridgeSink, type InboundMirrorFrame } from './api-bridge';
+import { BridgeHub, validateChatId, type BridgeSink, type InboundMirrorFrame } from './api-bridge';
 import { ChatConversationStore } from './chat-session-store';
 import type { ChatbotAgent } from '@gossip/orchestrator';
 import { buildCoverageDegradedMessage } from '@gossip/orchestrator';
@@ -170,6 +170,13 @@ const MIRROR_MAX_BODY = 64 * 1024; // 64 KB
 // interval that tolerates a hook burst. A bucket-miss is a soft 429, never a
 // data drop — the hook is fail-open and the next turn re-POSTs.
 const MIRROR_MIN_INTERVAL_MS = 200;
+// Hard cap backstop for the mirrorLastTurn map (f18). The soft >100 prune only
+// drops entries idle past 10x the interval; under a burst of many DISTINCT
+// validated keys (e.g. per-session terminal buckets) the freshest entries are
+// all recent and the soft prune reaps nothing, so the map could grow unbounded.
+// When the map still exceeds this cap after the soft prune, evict the oldest
+// entries (by last-turn timestamp) until back under the cap.
+const MIRROR_LAST_TURN_HARD_CAP = 1000;
 
 // Minimum interval between chat turns from one IP — a simple per-IP throttle so
 // a single client can't fan out concurrent/rapid turns (each turn can run up to
@@ -459,6 +466,19 @@ export class DashboardRouter {
       const staleBefore = MIRROR_MIN_INTERVAL_MS * 10;
       for (const [k, v] of this.mirrorLastTurn) {
         if (now - v > staleBefore) this.mirrorLastTurn.delete(k);
+      }
+      // f18: hard-cap backstop — if the soft prune left the map over the cap
+      // (many distinct fresh keys), evict the oldest-by-timestamp until under it.
+      // Evict down to HARD_CAP-1 so the set() at the end of this call (which may
+      // add a NEW key) leaves the map at HARD_CAP, never above it.
+      if (this.mirrorLastTurn.size >= MIRROR_LAST_TURN_HARD_CAP) {
+        const oldestFirst = [...this.mirrorLastTurn.entries()].sort((a, b) => a[1] - b[1]);
+        let toEvict = this.mirrorLastTurn.size - (MIRROR_LAST_TURN_HARD_CAP - 1);
+        for (const [k] of oldestFirst) {
+          if (toEvict <= 0) break;
+          this.mirrorLastTurn.delete(k);
+          toEvict--;
+        }
       }
     }
     const last = this.mirrorLastTurn.get(key);
@@ -784,19 +804,33 @@ export class DashboardRouter {
           return true;
         }
         const b = (body ?? {}) as { chat_id?: unknown; session_id?: unknown; frames?: unknown };
-        // Rate-limit key: the supplied chat_id when present (per-stream bucket),
-        // else a fixed no-chat_id key so terminal bursts are still bounded.
-        const bucketKey = typeof b.chat_id === 'string' && b.chat_id.length > 0 ? b.chat_id : '_nochatid';
+        // Validate BOTH ids at the route boundary BEFORE deriving the rate bucket
+        // (f15/f16): a malformed/oversize id must never become a bucket key (log/
+        // keyspace injection) and a validated id is what emitMirror keys on too.
+        const chatIdPresent = b.chat_id !== undefined && b.chat_id !== null;
+        const validChatId = chatIdPresent ? validateChatId(b.chat_id) : null;
+        // f13: a present-but-invalid chat_id (including the empty string) is a
+        // hard 400 at the route — it must NOT silently fall back to the no-chat_id
+        // bucket as if it were a terminal POST.
+        if (chatIdPresent && validChatId === null) {
+          this.json(res, 400, { error: 'invalid chat_id' });
+          return true;
+        }
+        const validSessionId = validateChatId(b.session_id);
+        // Rate-limit key (f15/f11/f3): the VALIDATED chat_id (per-stream bucket)
+        // when present; else the VALIDATED session_id so distinct terminal
+        // sessions get independent buckets instead of all sharing one global
+        // '_nochatid' key (one noisy session can't 429 every other session's
+        // terminal frames); else a single fixed key for the truly-anonymous case.
+        const bucketKey = validChatId ?? (validSessionId !== null ? `_sess:${validSessionId}` : '_nochatid');
         if (!this.allowMirrorTurn(bucketKey)) {
           this.json(res, 429, { error: 'Too many mirror frames. Slow down.' });
           return true;
         }
-        const rawChatId = b.chat_id === undefined || b.chat_id === null ? null : (b.chat_id as string | null);
-        const sessionId = typeof b.session_id === 'string' ? b.session_id : null;
         const { status, payload } = this.bridge.emitMirror(
-          rawChatId,
+          validChatId,
           Array.isArray(b.frames) ? (b.frames as InboundMirrorFrame[]) : [],
-          sessionId,
+          validSessionId,
         );
         this.json(res, status, payload);
         return true;

--- a/tests/relay/api-bridge-mirror.test.ts
+++ b/tests/relay/api-bridge-mirror.test.ts
@@ -350,6 +350,89 @@ describe('BridgeHub mirror chat_id TTL kept alive by an open SSE stream (f6)', (
     expect(hub.hasMirrorChatId('ghost')).toBe(false);
     expect(hub.emitMirror('ghost', frames(['activity', 'x'])).status).toBe(400);
   });
+
+  it('an open SSE stream KEEPS its mirror authorization past the TTL on keepalive ticks (f6 completion)', () => {
+    jest.useFakeTimers();
+    try {
+      hub = new BridgeHub();
+      openDashboardStream(hub, 'chatIdle');
+      expect(hub.hasMirrorChatId('chatIdle')).toBe(true);
+
+      // Open an SSE observer on this chat_id, then let it sit idle (no mirror
+      // POST, no reconnect) for longer than the 2h TTL. The connect touch alone
+      // would NOT save it — only the keepalive tick keeps it authorized.
+      const res = mockRes();
+      hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=chatIdle&last_id=0'), res);
+
+      // Advance well past CHAT_ID_TTL_MS (2h) so many keepalive ticks (~25s)
+      // fire. Modern jest fake timers also advance Date.now(), so the TTL math
+      // and the keepalive touch stay on the same clock.
+      const TTL = 2 * 60 * 60 * 1000;
+      jest.advanceTimersByTime(TTL + 60_000);
+
+      // Still authorized — a subsequent mirror POST is NOT 400'd, because the
+      // keepalive ticks kept refreshing the mirror chat_id TTL.
+      expect(hub.hasMirrorChatId('chatIdle')).toBe(true);
+      expect(hub.emitMirror('chatIdle', frames(['activity', 'long-idle'])).status).toBe(202);
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('keepalive ticks do NOT resurrect a never-registered mirror chat_id (fail closed)', () => {
+    jest.useFakeTimers();
+    try {
+      hub = new BridgeHub();
+      // Legacy/ghost id: never opened via a dashboard inbound POST.
+      const res = mockRes();
+      hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=ghost&last_id=0'), res);
+      jest.advanceTimersByTime(60_000); // several keepalive ticks
+      expect(hub.hasMirrorChatId('ghost')).toBe(false);
+      expect(hub.emitMirror('ghost', frames(['activity', 'x'])).status).toBe(400);
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('BridgeHub reserves the provisional sentinel from client input (trust boundary)', () => {
+  let hub: BridgeHub;
+  afterEach(() => hub?.dispose());
+
+  it('rejects an inbound POST chat_id equal to the provisional sentinel with 400', () => {
+    hub = new BridgeHub();
+    hub.registerSink(() => true);
+    const r = hub.handlePost({ chat_id: '_provisional', message: 'steal the buffer' });
+    expect(r.status).toBe(400);
+    expect(r.payload).toMatchObject({ error: 'invalid chat_id' });
+    // No stream was registered under the sentinel key.
+    expect(hub.hasMirrorChatId('_provisional')).toBe(false);
+  });
+
+  it('rejects any leading-underscore reserved chat_id form from a client (defensive)', () => {
+    hub = new BridgeHub();
+    hub.registerSink(() => true);
+    const r = hub.handlePost({ chat_id: '_reserved', message: 'x' });
+    expect(r.status).toBe(400);
+    expect(hub.hasMirrorChatId('_reserved')).toBe(false);
+  });
+
+  it('a client-registered real stream is NOT clobbered by a sentinel POST + backfill', () => {
+    // A client opens a real stream, then an attacker tries to register the
+    // sentinel as a stream. The attacker POST must fail, so a later backfill
+    // (drainInto from '_provisional') can never STEAL the client's frames —
+    // the provisional ring stays an internal-only buffer.
+    hub = new BridgeHub();
+    hub.registerSink(() => true);
+    expect(hub.handlePost({ chat_id: 'realClient', message: 'open' }).status).toBe(202);
+    expect(hub.emitMirror('realClient', frames(['user', 'mine'])).status).toBe(202);
+    // Attacker attempt: rejected at the boundary.
+    expect(hub.handlePost({ chat_id: '_provisional', message: 'hijack' }).status).toBe(400);
+    // The real client's frames are untouched.
+    expect(hub.mirrorReplay('realClient', 0).map((f) => f.text)).toEqual(['mine']);
+  });
 });
 
 describe('BridgeHub keepalive lifecycle (f12)', () => {

--- a/tests/relay/api-bridge-mirror.test.ts
+++ b/tests/relay/api-bridge-mirror.test.ts
@@ -1,0 +1,207 @@
+import { BridgeHub, isMirrorRole, MIRROR_MAX_TEXT, type InboundMirrorFrame } from '@gossip/relay/dashboard/api-bridge';
+import { IncomingMessage, ServerResponse } from 'http';
+import { EventEmitter } from 'events';
+
+function mockReq(url: string): IncomingMessage {
+  const req = new EventEmitter() as any;
+  req.method = 'GET';
+  req.url = url;
+  req.headers = {};
+  return req;
+}
+
+interface SSERes extends ServerResponse {
+  _writes: string[];
+  _status: number;
+}
+
+function mockRes(): SSERes {
+  const res = new EventEmitter() as any;
+  res._writes = [];
+  res._status = 200;
+  res.writeHead = (code: number) => { res._status = code; return res; };
+  res.write = (chunk: string) => { res._writes.push(chunk); return true; };
+  res.end = () => {};
+  res.destroy = () => {};
+  return res;
+}
+
+/** Seed a chat_id into mirrorChatIds via the validated inbound POST path. */
+function openDashboardStream(hub: BridgeHub, chatId: string, sessionId?: string): void {
+  hub.registerSink(() => true);
+  const body: Record<string, unknown> = { chat_id: chatId, message: 'open' };
+  if (sessionId) body.session_id = sessionId;
+  const r = hub.handlePost(body);
+  expect(r.status).toBe(202);
+}
+
+function frames(...roleTexts: Array<[string, string]>): InboundMirrorFrame[] {
+  return roleTexts.map(([role, text]) => ({ role, text }));
+}
+
+describe('isMirrorRole', () => {
+  it('accepts only the strict enum', () => {
+    expect(isMirrorRole('user')).toBe(true);
+    expect(isMirrorRole('assistant')).toBe(true);
+    expect(isMirrorRole('activity')).toBe(true);
+    expect(isMirrorRole('system')).toBe(false);
+    expect(isMirrorRole('reply')).toBe(false);
+    expect(isMirrorRole(undefined)).toBe(false);
+    expect(isMirrorRole(123)).toBe(false);
+  });
+});
+
+describe('BridgeHub.emitMirror', () => {
+  let hub: BridgeHub;
+  afterEach(() => hub?.dispose());
+
+  it('stamps id + ts server-side and retains frames even with NO connected client', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chatA');
+    // No SSE client connected — emitReply would no-op, but emitMirror must NOT
+    // gate on clients.size (deepseek:f10).
+    expect(hub.clientCount()).toBe(0);
+    const r = hub.emitMirror('chatA', frames(['user', 'hi'], ['assistant', 'yo']));
+    expect(r.status).toBe(202);
+    expect(r.payload).toMatchObject({ ok: true, chat_id: 'chatA', frames: 2 });
+    const retained = hub.mirrorReplay('chatA', 0);
+    expect(retained.map((f) => f.id)).toEqual([1, 2]);
+    expect(retained[0].ts).toMatch(/^\d{4}-\d{2}-\d{2}T/); // server ISO ts
+  });
+
+  it('rejects an unknown chat_id (not an open dashboard stream) with 400 — P1#1', () => {
+    hub = new BridgeHub();
+    // Never opened via handlePost → a hook-supplied id can NOT seed mirrorChatIds.
+    const r = hub.emitMirror('hacker-id', frames(['user', 'x']));
+    expect(r.status).toBe(400);
+    expect(hub.mirrorReplay('hacker-id', 0)).toEqual([]);
+  });
+
+  it('rejects an unknown role anywhere in the batch with 400 and pushes NOTHING', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chatA');
+    const r = hub.emitMirror('chatA', [
+      { role: 'user', text: 'ok' },
+      { role: 'system', text: 'bad role' }, // invalid
+    ]);
+    expect(r.status).toBe(400);
+    // No half-apply: the valid first frame must NOT have been retained.
+    expect(hub.mirrorReplay('chatA', 0)).toEqual([]);
+  });
+
+  it('rejects an oversize frame text with 400', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chatA');
+    const big = 'x'.repeat(MIRROR_MAX_TEXT + 1);
+    const r = hub.emitMirror('chatA', [{ role: 'user', text: big }]);
+    expect(r.status).toBe(400);
+  });
+
+  it('rejects an empty or malformed-chat_id batch with 400', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chatA');
+    expect(hub.emitMirror('chatA', []).status).toBe(400);
+    expect(hub.emitMirror('bad id!', frames(['user', 'x'])).status).toBe(400);
+  });
+
+  it('keeps mirrorChatIds ISOLATED from knownChatIds — mirror never widens the emitReply gate', () => {
+    hub = new BridgeHub();
+    // A mirror-only id that was NEVER opened by a dashboard inbound POST must
+    // not be addressable by emitReply, and an emitReply gate must not let an
+    // arbitrary id through emitMirror. Open ONE real stream and confirm a
+    // DIFFERENT id is rejected on BOTH paths.
+    openDashboardStream(hub, 'real');
+    expect(hub.hasMirrorChatId('real')).toBe(true);
+    expect(hub.hasMirrorChatId('other')).toBe(false);
+    // emitMirror on the unopened id → 400 (mirror gate closed).
+    expect(hub.emitMirror('other', frames(['user', 'x'])).status).toBe(400);
+    // emitReply on the unopened id → false (known gate closed). Connect a client
+    // first so clients.size!==0 isn't the reason it's false.
+    const res = mockRes();
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream'), res);
+    expect(hub.emitReply('other', 'sneaky')).toBe(false);
+    // The real id IS known for replies.
+    expect(hub.emitReply('real', 'legit')).toBe(true);
+  });
+});
+
+describe('BridgeHub session→chat_id resolution (P1#5) + provisional buffer', () => {
+  let hub: BridgeHub;
+  afterEach(() => hub?.dispose());
+
+  it('resolves a no-chat_id mirror POST through the session map', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chatA', 'sess-1');
+    const r = hub.emitMirror(null, frames(['activity', 'bash · ls']), 'sess-1');
+    expect(r.status).toBe(202);
+    expect(r.payload).toMatchObject({ chat_id: 'chatA' });
+    expect(hub.mirrorReplay('chatA', 0)).toHaveLength(1);
+  });
+
+  it('buffers an unresolvable terminal POST under the provisional id (default)', () => {
+    hub = new BridgeHub();
+    // No stream opened, no session mapping → provisional buffer.
+    const r = hub.emitMirror(null, frames(['activity', 'early tool']), 'unknown-sess');
+    expect(r.status).toBe(202);
+    expect(r.payload).toMatchObject({ chat_id: null });
+    // Retained under the provisional ring (not addressable as a real chat_id).
+    expect(hub.mirrorReplay('_provisional', 0)).toHaveLength(1);
+    expect(hub.mirrorRingCount()).toBe(1);
+  });
+
+  it('drops an unresolvable terminal POST when dropUnresolvedMirror is set', () => {
+    hub = new BridgeHub();
+    hub.setDropUnresolvedMirror(true);
+    const r = hub.emitMirror(null, frames(['activity', 'x']));
+    expect(r.status).toBe(202);
+    expect(r.payload).toMatchObject({ chat_id: null, dropped: 1 });
+    expect(hub.mirrorRingCount()).toBe(0); // nothing retained
+  });
+});
+
+describe('BridgeHub.handleStream mirror replay (?last_id) + restart sentinel (P1#3)', () => {
+  let hub: BridgeHub;
+  afterEach(() => hub?.dispose());
+
+  it('replays only mirror frames with id > last_id on connect, then goes live', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chatA');
+    hub.emitMirror('chatA', frames(['user', 'a'], ['assistant', 'b'], ['activity', 'c'])); // ids 1,2,3
+    const res = mockRes();
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=chatA&last_id=1'), res);
+    const dataFrames = res._writes
+      .filter((w) => w.includes('data:'))
+      .map((w) => JSON.parse(w.slice(w.indexOf('data: ') + 6).trim()));
+    // Only ids 2 and 3 replayed; all are type:'mirror' (never reply/ack).
+    expect(dataFrames.map((f: any) => f.id)).toEqual([2, 3]);
+    expect(dataFrames.every((f: any) => f.type === 'mirror')).toBe(true);
+    // SSE id: line present so the browser exposes lastEventId.
+    expect(res._writes.some((w) => /^id: 2\n/.test(w))).toBe(true);
+  });
+
+  it('emits a restart sentinel then full replay when last_id exceeds our highest id', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chatA');
+    // Post-restart: counter reset, only 2 frames exist (ids 1,2).
+    hub.emitMirror('chatA', frames(['user', 'a'], ['assistant', 'b']));
+    const res = mockRes();
+    // Client holds last_id=50 from before the restart.
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=chatA&last_id=50'), res);
+    const parsed = res._writes
+      .filter((w) => w.includes('data:'))
+      .map((w) => JSON.parse(w.slice(w.indexOf('data: ') + 6).trim()));
+    expect(parsed[0].type).toBe('restart');
+    expect(parsed[0].chat_id).toBe('chatA');
+    // Then the FULL ring (ids 1,2) is replayed so the client refetches.
+    expect(parsed.slice(1).map((f: any) => f.id)).toEqual([1, 2]);
+  });
+
+  it('no chat_id query → live-only, no replay (legacy reply/ack consumer)', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chatA');
+    hub.emitMirror('chatA', frames(['user', 'a']));
+    const res = mockRes();
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream'), res);
+    expect(res._writes.filter((w) => w.includes('"type":"mirror"'))).toHaveLength(0);
+  });
+});

--- a/tests/relay/api-bridge-mirror.test.ts
+++ b/tests/relay/api-bridge-mirror.test.ts
@@ -19,11 +19,31 @@ function mockRes(): SSERes {
   const res = new EventEmitter() as any;
   res._writes = [];
   res._status = 200;
+  res._destroyed = false;
   res.writeHead = (code: number) => { res._status = code; return res; };
   res.write = (chunk: string) => { res._writes.push(chunk); return true; };
   res.end = () => {};
-  res.destroy = () => {};
+  res.destroy = () => { res._destroyed = true; };
   return res;
+}
+
+/** A mockRes whose res.write() returns false after `okWrites` successful calls,
+ *  simulating a full socket buffer (backpressure). */
+function backpressureRes(okWrites: number): SSERes {
+  const res = mockRes();
+  let n = 0;
+  (res as any).write = (chunk: string) => {
+    res._writes.push(chunk);
+    n++;
+    return n <= okWrites;
+  };
+  return res;
+}
+
+function dataFramesOf(res: SSERes): any[] {
+  return res._writes
+    .filter((w) => w.includes('data:'))
+    .map((w) => JSON.parse(w.slice(w.indexOf('data: ') + 6).trim()));
 }
 
 /** Seed a chat_id into mirrorChatIds via the validated inbound POST path. */
@@ -203,5 +223,162 @@ describe('BridgeHub.handleStream mirror replay (?last_id) + restart sentinel (P1
     const res = mockRes();
     hub.handleStream(mockReq('/dashboard/api/bridge/stream'), res);
     expect(res._writes.filter((w) => w.includes('"type":"mirror"'))).toHaveLength(0);
+  });
+
+  it('FIFO-overflow gap: emits a restart sentinel + full replay when oldest frames were evicted (f7)', () => {
+    // ringMax tiny so early frames FIFO-evict. The hub's MirrorEventStore uses
+    // MIRROR_RING_MAX, so drive the eviction through many pushes instead.
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chatA');
+    // Push past MIRROR_RING_MAX (100) so the oldest are FIFO-evicted; lowest
+    // retained id becomes 110-99=11 (ids 11..110 retained).
+    const batch: InboundMirrorFrame[] = [];
+    for (let i = 0; i < 110; i++) batch.push({ role: 'activity', text: `f${i}` });
+    // emitMirror caps batch at 64 — split into two posts.
+    hub.emitMirror('chatA', batch.slice(0, 55));
+    hub.emitMirror('chatA', batch.slice(55, 110));
+    const lowest = hub.mirrorReplay('chatA', 0)[0].id;
+    expect(lowest).toBeGreaterThan(1); // oldest were evicted
+    // A client whose last_id sits in the EVICTED gap (e.g. 5, below `lowest`)
+    // must get a restart sentinel, not a silently-truncated slice.
+    const res = mockRes();
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=chatA&last_id=5'), res);
+    const parsed = dataFramesOf(res);
+    expect(parsed[0].type).toBe('restart');
+    // Then the full retained ring is replayed from 0.
+    expect(parsed.slice(1)[0].id).toBe(lowest);
+  });
+
+  it('contiguous replay (no gap) does NOT emit a restart sentinel', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chatA');
+    hub.emitMirror('chatA', frames(['user', 'a'], ['assistant', 'b'], ['activity', 'c'])); // 1,2,3
+    const res = mockRes();
+    // last_id=1: lowest replayable is id 2 === lastId+1 → contiguous, no restart.
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=chatA&last_id=1'), res);
+    const parsed = dataFramesOf(res);
+    expect(parsed.some((f) => f.type === 'restart')).toBe(false);
+    expect(parsed.map((f) => f.id)).toEqual([2, 3]);
+  });
+
+  it('replay stops on backpressure instead of silently dropping frames (f10)', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chatA');
+    hub.emitMirror('chatA', frames(['user', 'a'], ['assistant', 'b'], ['activity', 'c'], ['user', 'd']));
+    // Socket accepts 2 writes; the 3rd write succeeds-but-signals-backpressure
+    // (returns false). The frame that triggers false is still flushed, but
+    // replay STOPS there — frame 4 is never shoved into a full buffer.
+    const res = backpressureRes(2);
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=chatA&last_id=0'), res);
+    const parsed = dataFramesOf(res);
+    // Frames 1,2,3 written then replay halted (frame 4 NOT silently dropped into
+    // a full buffer). Client reconnects with its last SSE id (3) and resumes.
+    expect(parsed.map((f) => f.id)).toEqual([1, 2, 3]);
+  });
+});
+
+describe('BridgeHub provisional backfill on stream open (spec §2 / f1/f7)', () => {
+  let hub: BridgeHub;
+  afterEach(() => hub?.dispose());
+
+  it('drains provisional frames into a chat_id ring when its stream is first opened', () => {
+    hub = new BridgeHub();
+    // Terminal POSTs arrive BEFORE any stream is opened → provisional buffer.
+    hub.emitMirror(null, frames(['activity', 'early-1'], ['activity', 'early-2']), 'sess-x');
+    expect(hub.mirrorReplay('_provisional', 0)).toHaveLength(2);
+    // Now the dashboard opens the stream (handlePost → registerMirrorChatId).
+    openDashboardStream(hub, 'chatLate', 'sess-x');
+    // Provisional frames are merged into chatLate, re-stamped onto its counter.
+    const merged = hub.mirrorReplay('chatLate', 0);
+    expect(merged.map((f) => f.text)).toEqual(['early-1', 'early-2']);
+    expect(merged.map((f) => f.id)).toEqual([1, 2]); // chatLate's own ids
+    // Provisional ring drained empty.
+    expect(hub.mirrorReplay('_provisional', 0)).toEqual([]);
+  });
+
+  it('caps backfill at MIRROR_RING_MAX (provisional overflow is FIFO-trimmed into the dest)', () => {
+    hub = new BridgeHub();
+    // Fill the provisional ring beyond MIRROR_RING_MAX (100). Each emitMirror is
+    // capped at 64 frames, so post in chunks.
+    for (let chunk = 0; chunk < 3; chunk++) {
+      const fr: InboundMirrorFrame[] = [];
+      for (let i = 0; i < 50; i++) fr.push({ role: 'activity', text: `p${chunk}-${i}` });
+      hub.emitMirror(null, fr, 'sess-y');
+    }
+    // Provisional ring itself is already FIFO-bounded at MIRROR_RING_MAX.
+    expect(hub.mirrorReplay('_provisional', 0).length).toBeLessThanOrEqual(100);
+    openDashboardStream(hub, 'chatCap', 'sess-y');
+    expect(hub.mirrorReplay('chatCap', 0).length).toBeLessThanOrEqual(100);
+    expect(hub.mirrorReplay('_provisional', 0)).toEqual([]);
+  });
+
+  it('does NOT populate provisional buffer (nothing to backfill) when dropping is configured', () => {
+    hub = new BridgeHub();
+    hub.setDropUnresolvedMirror(true);
+    hub.emitMirror(null, frames(['activity', 'x']), 'sess-z');
+    expect(hub.mirrorReplay('_provisional', 0)).toEqual([]);
+    openDashboardStream(hub, 'chatD', 'sess-z');
+    expect(hub.mirrorReplay('chatD', 0)).toEqual([]);
+  });
+});
+
+describe('BridgeHub mirror chat_id TTL kept alive by an open SSE stream (f6)', () => {
+  let hub: BridgeHub;
+  afterEach(() => hub?.dispose());
+
+  it('an open SSE stream touches the mirror chat_id TTL so it is not deauthorized', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chatLive');
+    expect(hub.hasMirrorChatId('chatLive')).toBe(true);
+    // Age the chat_id's last-touch just past the 2h TTL — the NEXT eviction
+    // pass (triggered by isMirrorChatId/registerMirrorChatId) would drop it.
+    const TTL = 2 * 60 * 60 * 1000;
+    hub.ageMirrorChatId('chatLive', TTL + 1_000);
+    // An SSE observer connects/serves this chat_id: handleStream must touch the
+    // TTL BEFORE any eviction can drop it.
+    const res = mockRes();
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=chatLive&last_id=0'), res);
+    // Still authorized — a subsequent mirror POST is NOT 400'd.
+    expect(hub.hasMirrorChatId('chatLive')).toBe(true);
+    expect(hub.emitMirror('chatLive', frames(['activity', 'after-idle'])).status).toBe(202);
+  });
+
+  it('a chat_id that was NEVER an open stream is not resurrected by handleStream (fail closed)', () => {
+    hub = new BridgeHub();
+    const res = mockRes();
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=ghost&last_id=0'), res);
+    expect(hub.hasMirrorChatId('ghost')).toBe(false);
+    expect(hub.emitMirror('ghost', frames(['activity', 'x'])).status).toBe(400);
+  });
+});
+
+describe('BridgeHub keepalive lifecycle (f12)', () => {
+  let hub: BridgeHub;
+  afterEach(() => hub?.dispose());
+
+  it('clears the keepalive timer when a client is evicted under backpressure', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chatK');
+    // Connect a client that always signals backpressure (write→false).
+    const res = backpressureRes(0);
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream'), res);
+    expect(hub.keepaliveCount()).toBe(1);
+    // Broadcast enough mirror frames to exceed BACKPRESSURE_EVICT_THRESHOLD (2)
+    // → the client is destroyed AND its keepalive cleared (not leaked).
+    hub.emitMirror('chatK', frames(['activity', '1'], ['activity', '2'], ['activity', '3'], ['activity', '4']));
+    expect((res as any)._destroyed).toBe(true);
+    expect(hub.clientCount()).toBe(0);
+    expect(hub.keepaliveCount()).toBe(0);
+  });
+
+  it('clears the keepalive timer on a normal client close', () => {
+    hub = new BridgeHub();
+    const req = mockReq('/dashboard/api/bridge/stream');
+    const res = mockRes();
+    hub.handleStream(req, res);
+    expect(hub.keepaliveCount()).toBe(1);
+    req.emit('close');
+    expect(hub.keepaliveCount()).toBe(0);
+    expect(hub.clientCount()).toBe(0);
   });
 });

--- a/tests/relay/api-mirror-events.test.ts
+++ b/tests/relay/api-mirror-events.test.ts
@@ -84,3 +84,54 @@ describe('MirrorEventStore', () => {
     expect(s.ringCount()).toBe(1);
   });
 });
+
+describe('MirrorEventStore.drainInto (provisional backfill, spec §2)', () => {
+  function store(ringMax = MIRROR_RING_MAX, ttlMs = 1000): MirrorEventStore {
+    return new MirrorEventStore(ringMax, ttlMs, 0);
+  }
+
+  it('re-stamps provisional frames into the destination ring with the dest counter', () => {
+    const s = store();
+    // Provisional frames accumulate under the reserved id with ids 1,2,3.
+    s.push('_provisional', 'activity', 'p0');
+    s.push('_provisional', 'user', 'p1');
+    s.push('_provisional', 'assistant', 'p2');
+    // Destination already has one live frame (id 1).
+    s.push('chatA', 'user', 'live');
+    const moved = s.drainInto('_provisional', 'chatA');
+    // role+text preserved, ids RE-STAMPED onto chatA's counter (continues at 2,3,4).
+    expect(moved.map((f) => f.id)).toEqual([2, 3, 4]);
+    expect(moved.map((f) => [f.role, f.text])).toEqual([
+      ['activity', 'p0'],
+      ['user', 'p1'],
+      ['assistant', 'p2'],
+    ]);
+    // Source ring cleared; destination holds 1 live + 3 backfilled.
+    expect(s.replaySlice('_provisional', 0)).toEqual([]);
+    expect(s.replaySlice('chatA', 0).map((f) => f.id)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('caps the merged ring at ringMax via the destination FIFO', () => {
+    const s = store(3); // ring max 3
+    // The provisional source ring is ALSO FIFO-bounded at ringMax=3, so pushing
+    // 4 leaves it holding only the last 3 (p1,p2,p3) — p0 was already evicted.
+    for (let i = 0; i < 4; i++) s.push('_provisional', 'activity', `p${i}`);
+    expect(s.replaySlice('_provisional', 0)).toHaveLength(3);
+    const moved = s.drainInto('_provisional', 'chatA');
+    // Those 3 transfer into the (empty) dest ring, re-stamped 1,2,3.
+    expect(s.replaySlice('chatA', 0)).toHaveLength(3);
+    expect(s.replaySlice('chatA', 0).map((f) => f.text)).toEqual(['p1', 'p2', 'p3']);
+    // drainInto returns exactly the frames it transferred.
+    expect(moved).toHaveLength(3);
+    expect(moved.map((f) => f.id)).toEqual([1, 2, 3]);
+  });
+
+  it('is a no-op for an empty/absent source and clears the empty source ring', () => {
+    const s = store();
+    expect(s.drainInto('_provisional', 'chatA')).toEqual([]);
+    // from === to short-circuit.
+    s.push('chatA', 'user', 'x');
+    expect(s.drainInto('chatA', 'chatA')).toEqual([]);
+    expect(s.replaySlice('chatA', 0)).toHaveLength(1); // untouched
+  });
+});

--- a/tests/relay/api-mirror-events.test.ts
+++ b/tests/relay/api-mirror-events.test.ts
@@ -1,0 +1,86 @@
+import { MirrorEventStore, MIRROR_RING_MAX } from '@gossip/relay/dashboard/api-mirror-events';
+
+describe('MirrorEventStore', () => {
+  // Disable the periodic sweep timer (last ctor arg = 0) so tests drive sweep()
+  // explicitly and no timer lingers.
+  function store(ringMax = MIRROR_RING_MAX, ttlMs = 1000): MirrorEventStore {
+    return new MirrorEventStore(ringMax, ttlMs, 0);
+  }
+
+  it('stamps a per-chat_id monotonic id starting at 1 and server ts', () => {
+    const s = store();
+    const f1 = s.push('chatA', 'user', 'hello', 1_000);
+    const f2 = s.push('chatA', 'assistant', 'hi', 2_000);
+    expect(f1.id).toBe(1);
+    expect(f2.id).toBe(2);
+    expect(f1.type).toBe('mirror');
+    expect(f1.chat_id).toBe('chatA');
+    expect(f1.ts).toBe(new Date(1_000).toISOString());
+    expect(f2.ts).toBe(new Date(2_000).toISOString());
+  });
+
+  it('keeps INDEPENDENT id counters per chat_id', () => {
+    const s = store();
+    const a1 = s.push('chatA', 'user', 'a1');
+    const b1 = s.push('chatB', 'user', 'b1');
+    const a2 = s.push('chatA', 'user', 'a2');
+    expect(a1.id).toBe(1);
+    expect(b1.id).toBe(1); // chatB's counter is its own — NOT 2
+    expect(a2.id).toBe(2);
+  });
+
+  it('bounds each ring to ringMax via FIFO eviction (oldest dropped)', () => {
+    const s = store(3);
+    for (let i = 0; i < 5; i++) s.push('chatA', 'activity', `f${i}`);
+    const all = s.replaySlice('chatA', 0);
+    expect(all).toHaveLength(3);
+    // ids keep climbing (4,5,6) even though only the last 3 are retained.
+    expect(all.map((f) => f.id)).toEqual([3, 4, 5]);
+    expect(all.map((f) => f.text)).toEqual(['f2', 'f3', 'f4']);
+  });
+
+  it('replaySlice returns only frames with id > lastId', () => {
+    const s = store();
+    for (let i = 0; i < 5; i++) s.push('chatA', 'user', `f${i}`); // ids 1..5
+    expect(s.replaySlice('chatA', 0).map((f) => f.id)).toEqual([1, 2, 3, 4, 5]);
+    expect(s.replaySlice('chatA', 3).map((f) => f.id)).toEqual([4, 5]);
+    expect(s.replaySlice('chatA', 5)).toEqual([]);
+  });
+
+  it('replaySlice on an unknown chat_id returns []', () => {
+    const s = store();
+    expect(s.replaySlice('nope', 0)).toEqual([]);
+  });
+
+  it('highestId reflects the newest retained id, 0 when empty', () => {
+    const s = store(2);
+    expect(s.highestId('chatA')).toBe(0);
+    s.push('chatA', 'user', 'a'); // id 1
+    s.push('chatA', 'user', 'b'); // id 2
+    s.push('chatA', 'user', 'c'); // id 3, evicts id1
+    expect(s.highestId('chatA')).toBe(3);
+  });
+
+  it('proactive sweep evicts rings idle longer than the TTL', () => {
+    const s = store(MIRROR_RING_MAX, 1000);
+    s.push('chatA', 'user', 'a', 10_000);
+    s.push('chatB', 'user', 'b', 10_500);
+    expect(s.ringCount()).toBe(2);
+    // 11_200: chatA idle 1200ms (> ttl) → evicted; chatB idle 700ms → kept.
+    s.sweep(11_200);
+    expect(s.ringCount()).toBe(1);
+    expect(s.replaySlice('chatA', 0)).toEqual([]);
+    expect(s.replaySlice('chatB', 0, 11_200)).toHaveLength(1);
+  });
+
+  it('replaySlice touches the ring so an actively-read stream survives sweep', () => {
+    const s = store(MIRROR_RING_MAX, 1000);
+    s.push('chatA', 'user', 'a', 10_000);
+    // A reconnecting observer reads at 10_900 (within ttl), refreshing touchedAt.
+    s.replaySlice('chatA', 0, 10_900);
+    // Sweep at 11_500: without the touch, idle would be 1500ms > ttl. The
+    // replay touch at 10_900 makes idle only 600ms → survives.
+    s.sweep(11_500);
+    expect(s.ringCount()).toBe(1);
+  });
+});

--- a/tests/relay/dashboard-mirror-route.test.ts
+++ b/tests/relay/dashboard-mirror-route.test.ts
@@ -120,4 +120,62 @@ describe('POST /dashboard/api/bridge/mirror', () => {
     expect(allow('chatA')).toBe(false); // same key, too fast → throttled
     expect(allow('chatB')).toBe(true);  // different key → its own bucket, allowed
   });
+
+  it('rejects an empty-string chat_id with 400, not a silent no-chat_id fallback (f13)', async () => {
+    const res = await post(router, '/dashboard/api/bridge/mirror', {
+      chat_id: '',
+      frames: [{ role: 'activity', text: 'x' }],
+    }, key);
+    expect(res._status).toBe(400);
+    expect(JSON.parse(res._body)).toMatchObject({ error: 'invalid chat_id' });
+  });
+
+  it('rejects a malformed chat_id at the route before bucket derivation (f15/f16)', async () => {
+    const res = await post(router, '/dashboard/api/bridge/mirror', {
+      chat_id: 'bad id!',
+      frames: [{ role: 'activity', text: 'x' }],
+    }, key);
+    expect(res._status).toBe(400);
+  });
+
+  it('derives the rate bucket from the VALIDATED chat_id (f15)', async () => {
+    await openStream('chatA');
+    const spy = jest.spyOn(router as any, 'allowMirrorTurn');
+    await post(router, '/dashboard/api/bridge/mirror', {
+      chat_id: 'chatA',
+      frames: [{ role: 'user', text: 'hi' }],
+    }, key);
+    // The bucket key is the validated chat_id itself, never a raw/coerced value.
+    expect(spy).toHaveBeenCalledWith('chatA');
+    spy.mockRestore();
+  });
+
+  it('keys the bucket by validated session_id when chat_id is absent (f11/f3)', async () => {
+    const spy = jest.spyOn(router as any, 'allowMirrorTurn');
+    await post(router, '/dashboard/api/bridge/mirror', {
+      session_id: 'sess-7',
+      frames: [{ role: 'activity', text: 'terminal' }],
+    }, key);
+    // Distinct sessions get distinct buckets — keyed by the session, not a single
+    // global '_nochatid'.
+    expect(spy).toHaveBeenCalledWith('_sess:sess-7');
+    spy.mockRestore();
+  });
+
+  it('falls back to a single anonymous bucket only when neither id is present', async () => {
+    const spy = jest.spyOn(router as any, 'allowMirrorTurn');
+    await post(router, '/dashboard/api/bridge/mirror', {
+      frames: [{ role: 'activity', text: 'anon' }],
+    }, key);
+    expect(spy).toHaveBeenCalledWith('_nochatid');
+    spy.mockRestore();
+  });
+
+  it('hard-caps the mirrorLastTurn map under a flood of distinct keys (f18)', () => {
+    const allow = (k: string) => (router as any).allowMirrorTurn(k);
+    // Push well past the 1000 hard cap with distinct fresh keys. The soft >100
+    // prune reaps nothing (all fresh), so the hard cap must bound the map.
+    for (let i = 0; i < 1300; i++) allow(`k${i}`);
+    expect((router as any).mirrorLastTurn.size).toBeLessThanOrEqual(1000);
+  });
 });

--- a/tests/relay/dashboard-mirror-route.test.ts
+++ b/tests/relay/dashboard-mirror-route.test.ts
@@ -1,0 +1,123 @@
+import { DashboardRouter } from '@gossip/relay/dashboard/routes';
+import { DashboardAuth } from '@gossip/relay/dashboard/auth';
+import { IncomingMessage, ServerResponse } from 'http';
+import { mkdtempSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { EventEmitter } from 'events';
+
+function mockReq(method: string, url: string, headers: Record<string, string> = {}): IncomingMessage {
+  const req = new EventEmitter() as any;
+  req.method = method;
+  req.url = url;
+  req.headers = headers;
+  req.socket = { remoteAddress: '127.0.0.1' };
+  return req;
+}
+
+function mockRes(): ServerResponse & { _status: number; _headers: Record<string, string>; _body: string } {
+  const res = new EventEmitter() as any;
+  res._status = 200;
+  res._headers = {};
+  res._body = '';
+  res.writeHead = (code: number, headers?: Record<string, string>) => {
+    res._status = code;
+    if (headers) Object.assign(res._headers, headers);
+    return res;
+  };
+  res.setHeader = (k: string, v: string) => { res._headers[k] = v; };
+  res.write = () => true;
+  res.end = (body?: string) => { res._body = body ?? ''; };
+  res.destroy = () => {};
+  return res;
+}
+
+/** POST a JSON body through the router and resolve the response. */
+async function post(router: DashboardRouter, url: string, body: unknown, bearer: string): Promise<ReturnType<typeof mockRes>> {
+  const req = mockReq('POST', url, { authorization: `Bearer ${bearer}` });
+  const res = mockRes();
+  const handled = router.handle(req, res);
+  req.emit('data', Buffer.from(JSON.stringify(body)));
+  req.emit('end');
+  await handled;
+  return res;
+}
+
+describe('POST /dashboard/api/bridge/mirror', () => {
+  let projectRoot: string;
+  let auth: DashboardAuth;
+  let router: DashboardRouter;
+  let key: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'gossip-mirror-'));
+    mkdirSync(join(projectRoot, '.gossip'), { recursive: true });
+    auth = new DashboardAuth();
+    auth.init();
+    key = auth.getKey();
+    router = new DashboardRouter(auth, projectRoot, { agentConfigs: [], relayConnections: 0, connectedAgentIds: [] });
+    // Open a dashboard stream so 'chatA' is a valid mirror target.
+    router.registerBridgeSink(() => true);
+  });
+
+  async function openStream(chatId: string): Promise<void> {
+    const r = await post(router, '/dashboard/api/bridge', { chat_id: chatId, message: 'open' }, key);
+    expect(r._status).toBe(202);
+  }
+
+  it('accepts a valid batch with 202 for an open stream', async () => {
+    await openStream('chatA');
+    const res = await post(router, '/dashboard/api/bridge/mirror', {
+      chat_id: 'chatA',
+      frames: [{ role: 'user', text: 'hi' }, { role: 'activity', text: 'bash · ls' }],
+    }, key);
+    expect(res._status).toBe(202);
+    expect(JSON.parse(res._body)).toMatchObject({ ok: true, chat_id: 'chatA', frames: 2 });
+  });
+
+  it('rejects a single bad frame in an otherwise-valid batch with 400', async () => {
+    await openStream('chatA');
+    const res = await post(router, '/dashboard/api/bridge/mirror', {
+      chat_id: 'chatA',
+      frames: [{ role: 'user', text: 'good' }, { role: 'nope', text: 'bad' }],
+    }, key);
+    expect(res._status).toBe(400);
+  });
+
+  it('requires auth (401 without Bearer/session)', async () => {
+    const req = mockReq('POST', '/dashboard/api/bridge/mirror');
+    const res = mockRes();
+    const handled = router.handle(req, res);
+    req.emit('data', Buffer.from(JSON.stringify({ frames: [] })));
+    req.emit('end');
+    await handled;
+    expect(res._status).toBe(401);
+  });
+
+  it('dedicated mirror bucket does NOT consume the human-chat allowChatTurn bucket (P1#2)', async () => {
+    // The human chat throttle (allowChatTurn) is per-IP with a 1s interval; the
+    // /bridge route uses it. The mirror route uses a SEPARATE per-chat_id bucket.
+    // Spy on allowChatTurn to prove the mirror route never touches it: a hook
+    // burst on /mirror must leave the chat bucket completely uncalled.
+    await openStream('chatA'); // this DOES call allowChatTurn (the /bridge route)
+    const chatSpy = jest.spyOn(router as any, 'allowChatTurn');
+    for (let i = 0; i < 8; i++) {
+      const r = await post(router, '/dashboard/api/bridge/mirror', { chat_id: 'chatA', frames: [{ role: 'activity', text: `t${i}` }] }, key);
+      // Mirror bucket may 429 a too-fast burst, but it must be the MIRROR bucket
+      // doing it — never allowChatTurn.
+      expect([202, 429]).toContain(r._status);
+    }
+    expect(chatSpy).not.toHaveBeenCalled();
+    chatSpy.mockRestore();
+  });
+
+  it('mirror bucket is per-chat_id (P1#2): distinct chat_ids have independent buckets', async () => {
+    // Drive the bucket directly to avoid the unrelated per-IP /bridge open
+    // throttle. allowMirrorTurn is keyed by chat_id: the SAME key throttles on
+    // a rapid second call; a DIFFERENT key does not.
+    const allow = (key: string) => (router as any).allowMirrorTurn(key);
+    expect(allow('chatA')).toBe(true);
+    expect(allow('chatA')).toBe(false); // same key, too fast → throttled
+    expect(allow('chatB')).toBe(true);  // different key → its own bucket, allowed
+  });
+});


### PR DESCRIPTION
Piece **1 of 3** of activity-mirror v2 (spec `docs/specs/2026-06-14-dashboard-cc-activity-mirror-v2.md`, §Sequencing). Hooks (`apps/cli`) and dashboard render (`packages/dashboard-v2`) follow in separate PRs. Backend-only; fully unit-tested in isolation.

consensus-id: a417fd85-f84243c5

## What this adds (Components §3/§4/§5 + P1 hardening 1-6)
- **Frame schema**: `'mirror'`/`'restart'` added to the `BridgeReplyFrame` union; `MirrorFrame` with strict `role` enum (`user|assistant|activity`), server-stamped `ts`+`id`.
- **`api-mirror-events.ts`** (new): `MirrorEventStore` — `Map<chatId, MirrorRing>`, per-chat_id monotonic id, bounded FIFO (`MIRROR_RING_MAX=100`), TTL + proactive unref'd sweep, `drainInto` for provisional backfill.
- **`mirrorChatIds`** registry, SEPARATE from `knownChatIds`, seeded ONLY from validated inbound POST (P1#1); `emitReply`'s `knownChatIds` boundary untouched.
- **`sessionToChatId`** map (P1#5); terminal frames resolve through it, fail-closed on eviction; provisional buffer + **backfill** on first stream-establish.
- **`emitMirror`**: whole-batch validate before any ring write (bad frame → 400, no half-apply), server-side id+ts, no `clients.size` gate.
- **`handleStream`**: `?chat_id`+`?last_id` replay (mirror frames only), restart sentinel on id discontinuity (counter-reset AND FIFO-overflow gap), backpressure-aware replay.
- **`POST /dashboard/api/bridge/mirror`**: `DashboardAuth` + 64KB body cap + **dedicated** per-chat_id `allowMirrorTurn` bucket (P1#2, separate from `allowChatTurn`); per-frame validation, `MIRROR_MAX_TEXT` 2KB.

## Review trail
- **Consensus `a417fd85-f84243c5`** (sonnet-reviewer + gemini-reviewer + deepseek-challenger, 2 rounds): 14 confirmed. All trust-boundary points passed. Fix commit `5e6741e5` resolved every HIGH/MED: **provisional backfill implemented** (was documented-but-absent), mirrorChatIds TTL no longer deauthorizes a live stream, SSE replay honors backpressure, FIFO-gap restart sentinel, rate-bucket hardening (validate-first, session_id keying, `''`→400, hard cap), keepalive timer-leak fix.
- **Focused delta review** (deepseek, adversarial on the new backfill/broadcast logic): no HIGH/critical; #547-class hang explicitly cleared (partial-replay reconnect cursor resumes correctly). Micro-fix `7c09e44b` closed two residuals: reserve the `_provisional` sentinel from client input, and **complete f6** (keepalive touches the TTL so a long-idle-but-open stream stays authorized).

## Verification
- `tsc --noEmit -p packages/relay` → 0 errors
- `jest tests/relay/{api-mirror-events,api-bridge-mirror,dashboard-mirror-route,dashboard-routes,dashboard-api}.test.ts` → **130 passed**

## Deliberately NOT in this PR (documented, non-blocking)
- `readBody req.destroy()` on oversize → unreachable 400 (deepseek f8) — **pre-existing shared helper**, all-route blast radius. Separate fix.
- `/dashboard/api/bridge/stream` reuses `allowChatTurn` (deepseek f9) — **pre-existing, intentional** per prior consensus `f7e5bc15`.
- Capacity-LRU can evict an open stream's chat_id — bounded by `MAX_BRIDGE_CLIENTS=20`; narrow, noted.
- Partial-replay "incomplete" sentinel — reconnect works; UX polish, follow-up.
- Relates to gh issue #547 (SSE hang) — this PR's restart-sentinel + backpressure handling reduce that class on the mirror path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)