### PR TITLE
feat(hooks): activity-mirror v2 hooks layer (UserPromptSubmit/Stop/PostToolUse)

### DIFF
--- a/apps/cli/src/hook-argv.ts
+++ b/apps/cli/src/hook-argv.ts
@@ -6,10 +6,26 @@
  * return `'usage'` — fix MEDIUM f2 from consensus d88f27db-c0454640
  * (previously, undefined fell through and silently fired the hook).
  *
+ * Activity-mirror v2 (spec §Component 1) adds three mirror subcommands:
+ *   - `mirror-prompt` → UserPromptSubmit mirror hook
+ *   - `mirror-stop`   → Stop mirror hook
+ *   - `mirror-tool`   → PostToolUse mirror hook
+ * These are fail-open + non-blocking; unknown subcommands still map to `'usage'`.
+ *
  * Extracted from index.ts so the guard can be unit-tested without
  * spawning the full CLI (importing index.ts runs `main()` on load).
  */
-export function parseHookSubcommand(sub: string | undefined): 'run' | 'usage' {
+export type HookSubcommand =
+  | 'run'
+  | 'mirror-prompt'
+  | 'mirror-stop'
+  | 'mirror-tool'
+  | 'usage';
+
+export function parseHookSubcommand(sub: string | undefined): HookSubcommand {
   if (sub === '--run' || sub === 'run') return 'run';
+  if (sub === 'mirror-prompt') return 'mirror-prompt';
+  if (sub === 'mirror-stop') return 'mirror-stop';
+  if (sub === 'mirror-tool') return 'mirror-tool';
   return 'usage';
 }

--- a/apps/cli/src/hooks/mirror-prompt.ts
+++ b/apps/cli/src/hooks/mirror-prompt.ts
@@ -1,0 +1,78 @@
+/**
+ * `gossipcat hook mirror-prompt` — UserPromptSubmit mirror hook.
+ *
+ * Reads the CC hook payload `{session_id, transcript_path, cwd, prompt}` from
+ * stdin. If the prompt is a DASHBOARD-ORIGIN turn (it carries the channel
+ * wrapper `<channel source="gossipcat" chat_id="…">…</channel>`), we SKIP the
+ * POST — that turn is already shown in the dashboard; re-mirroring it would
+ * duplicate it (probe fact Q1 + sonnet:f10). Otherwise we POST the user's
+ * prompt as a `role:'user'` mirror frame.
+ *
+ * sonnet:f10 — the wrapper match is STRUCTURAL (a leading-tag regex), not a
+ * loose `includes('<channel')` substring, so a prompt that merely *mentions*
+ * the tag in prose is still mirrored, while a genuine dashboard wrapper is
+ * skipped.
+ *
+ * Fail-open: any parse error / missing field → no POST, exit 0.
+ */
+import { readStdin, parsePayload, resolveCwd, postMirror } from './mirror-shared';
+import { scrubSecrets, truncate } from './mirror-scrub';
+
+/** User-prompt size cap (under the relay's MIRROR_MAX_TEXT ≈ 2KB hard bound). */
+const USER_PROMPT_CAP = 1024;
+
+/**
+ * Structural match for a dashboard channel wrapper at the START of the prompt.
+ * Tolerates leading whitespace and arbitrary attribute order, but requires the
+ * `<channel source="gossipcat"` opening token — a structural anchor, not a
+ * substring scan.
+ */
+const CHANNEL_WRAPPER_RE = /^\s*<channel\s+[^>]*\bsource\s*=\s*"gossipcat"/i;
+
+/** Result of inspecting a prompt for the dashboard channel wrapper. */
+export interface PromptChannelMatch {
+  /** True when the prompt is a dashboard-origin (wrapper-bearing) turn. */
+  isDashboardOrigin: boolean;
+}
+
+/**
+ * Inspect a raw prompt string for the dashboard channel wrapper. We only need
+ * the boolean origin verdict — the chat_id is intentionally NOT parsed here:
+ * the relay seeds `mirrorChatIds` from its OWN validated inbound POST, never
+ * from this hook (P1#1). Parsing it then discarding it was a future footgun
+ * (consensus 4a4b2087 f13), so it is removed.
+ */
+export function inspectPrompt(prompt: unknown): PromptChannelMatch {
+  if (typeof prompt !== 'string') return { isDashboardOrigin: false };
+  return { isDashboardOrigin: CHANNEL_WRAPPER_RE.test(prompt) };
+}
+
+/** Hook body. Resolves once the (detached) POST is dispatched or skipped. */
+export async function runMirrorPromptHook(rawStdin?: string): Promise<void> {
+  try {
+    const raw = rawStdin ?? (await readStdin());
+    const payload = parsePayload(raw);
+    if (!payload) return; // fail-open
+
+    const prompt = payload['prompt'];
+    if (typeof prompt !== 'string' || prompt.length === 0) return;
+
+    const match = inspectPrompt(prompt);
+    // Dashboard-origin turns are already rendered — skip (we only learned the
+    // chat_id; the relay seeds mirrorChatIds from its OWN validated inbound POST,
+    // never from this hook — P1#1).
+    if (match.isDashboardOrigin) return;
+
+    const cwd = resolveCwd(payload['cwd']);
+    const sessionId = typeof payload['session_id'] === 'string' ? payload['session_id'] : undefined;
+
+    // User prompts are the human's own words — mirror them readable, but still
+    // secret-scrub defensively (a user might paste a credential) and size-cap
+    // under the relay's MIRROR_MAX_TEXT hard bound.
+    const text = truncate(scrubSecrets(prompt), USER_PROMPT_CAP);
+
+    postMirror({ cwd, sessionId, frames: [{ role: 'user', text }] });
+  } catch {
+    // fail-open: never block a turn.
+  }
+}

--- a/apps/cli/src/hooks/mirror-scrub.ts
+++ b/apps/cli/src/hooks/mirror-scrub.ts
@@ -1,0 +1,138 @@
+/**
+ * Argument scrubbing + role types for the activity-mirror hooks (spec §Security
+ * "Argument scrubbing (P0)" + §Consensus-hardening sonnet:f8).
+ *
+ * The PostToolUse hook forwards a one-liner summary of `tool_input` to the
+ * dashboard — NEVER `tool_response`. That input may contain secrets (a `curl`
+ * with a Bearer token, an `export API_KEY=…`, an inline credential). We scrub
+ * the FULL string FIRST (so a secret near the end isn't missed by an early
+ * truncate), THEN truncate to ~80 chars (sonnet:f8: scrub-then-truncate).
+ */
+
+/** Strict mirror role enum — mirrors the relay's MIRROR_ROLES (api-bridge.ts). */
+export const MIRROR_ROLES = ['user', 'assistant', 'activity'] as const;
+export type MirrorRole = (typeof MIRROR_ROLES)[number];
+
+/** Redaction marker substituted in place of a matched secret. */
+export const REDACTED = '«redacted»';
+
+/** One-liner summary length cap (after scrubbing). */
+export const SCRUB_SUMMARY_MAX = 80;
+
+/**
+ * Secret patterns, applied in order over the FULL string before truncation.
+ * Each replaces the secret token with REDACTED, preserving the surrounding
+ * structure so the activity line still reads sensibly.
+ *
+ *   - Bearer tokens:        `Bearer <token>`
+ *   - --password flags:     `--password <val>` / `--password=<val>`
+ *   - api key assignments:  `api_key=<val>` / `api-key=<val>` / `apikey=<val>`
+ *   - secret env vars:      `FOO_KEY=…` / `FOO_SECRET=…` / `FOO_TOKEN=…` / `FOO_PASSWORD=…`
+ *   - long hex / base64:    a standalone ≥32-char hex or base64-ish run
+ *
+ * Ordering matters: env-var / api-key assignments run before the bare
+ * hex/base64 sweep so the whole `KEY=value` is collapsed to `KEY=«redacted»`
+ * rather than leaving a dangling `KEY=` with the value separately redacted.
+ */
+const SCRUB_PATTERNS: Array<{ re: RegExp; replace: (m: string, ...g: string[]) => string }> = [
+  // Bearer <token>
+  { re: /Bearer\s+\S+/gi, replace: () => `Bearer ${REDACTED}` },
+  // --password <val> or --password=<val>
+  { re: /(--password[=\s]+)\S+/gi, replace: (_m, p1: string) => `${p1.trimEnd()}=${REDACTED}` },
+  // api_key= / api-key= / apikey=  (value to next whitespace)
+  { re: /(api[_-]?key\s*=\s*)\S+/gi, replace: (_m, p1: string) => `${p1}${REDACTED}` },
+  // secret-bearing env-var assignments: NAME_(KEY|SECRET|TOKEN|PASSWORD)=value
+  {
+    re: /([A-Z][A-Z0-9_]*_(?:KEY|SECRET|TOKEN|PASSWORD)\s*=\s*)\S+/g,
+    replace: (_m, p1: string) => `${p1}${REDACTED}`,
+  },
+  // JWTs: three base64url segments joined by dots, header always starts `eyJ`.
+  // MUST run before the ≥32 sweep — each segment can be <32 chars (so the bare
+  // sweep misses it) and the `.` separator is not in that sweep's char class
+  // (consensus 4a4b2087 HIGH: bare-JWT bypass).
+  { re: /\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, replace: () => REDACTED },
+  // Long hex or base64-ish run (≥32 chars) standing alone. Word-bounded so we
+  // don't shred normal prose; the env/api sweeps above already handled
+  // KEY=value cases.
+  { re: /\b[A-Za-z0-9+/=_-]{32,}\b/g, replace: () => REDACTED },
+];
+
+/**
+ * Scrub secrets from `input` (the FULL string) without truncating. Always
+ * returns a single-line string (newlines/whitespace collapsed to single spaces).
+ * This is the load-bearing security primitive: scrubbing the full string means
+ * a secret near the end is redacted BEFORE any caller truncates (sonnet:f8 —
+ * scrub-then-truncate, never truncate-then-scrub).
+ */
+export function scrubSecrets(input: string): string {
+  if (typeof input !== 'string') return '';
+  let s = input;
+  for (const { re, replace } of SCRUB_PATTERNS) {
+    s = s.replace(re, replace as (substring: string, ...args: any[]) => string);
+  }
+  // Collapse whitespace/newlines into single spaces — mirror rows are one line.
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+/** Truncate an already-single-line string to `max` with an ellipsis. */
+export function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + '…';
+}
+
+/**
+ * Scrub secrets from `input`, THEN truncate to `SCRUB_SUMMARY_MAX` (the activity
+ * one-liner cap). Scrub-first is load-bearing — see `scrubSecrets`.
+ */
+export function scrubAndTruncate(input: string): string {
+  return truncate(scrubSecrets(input), SCRUB_SUMMARY_MAX);
+}
+
+/**
+ * Curated PostToolUse allowlist (spec §Component 1 PostToolUse + deepseek:f8 —
+ * NOT every Read/Grep, which would flood the activity stream). Only these tools
+ * produce an activity frame.
+ */
+export const ACTIVITY_TOOL_ALLOWLIST = new Set<string>([
+  'Bash',
+  'Edit',
+  'Write',
+  'mcp__gossipcat__gossip_dispatch',
+  'mcp__gossipcat__gossip_run',
+  'mcp__gossipcat__gossip_collect',
+]);
+
+/**
+ * Build the scrubbed one-liner for an allowlisted tool. Returns null when the
+ * tool is NOT on the allowlist (caller sends nothing). Reads ONLY `tool_input`
+ * — `tool_response` is never touched (§Security: never forward tool_response).
+ */
+export function buildActivityLine(toolName: unknown, toolInput: unknown): string | null {
+  if (typeof toolName !== 'string' || !ACTIVITY_TOOL_ALLOWLIST.has(toolName)) return null;
+  const input = (toolInput && typeof toolInput === 'object') ? (toolInput as Record<string, unknown>) : {};
+
+  switch (toolName) {
+    case 'Bash': {
+      const cmd = typeof input['command'] === 'string' ? input['command'] : '';
+      return `🔧 Bash · ${scrubAndTruncate(cmd)}`;
+    }
+    case 'Edit':
+    case 'Write': {
+      const fp = typeof input['file_path'] === 'string' ? input['file_path'] : '';
+      const verb = toolName === 'Write' ? 'Write' : 'Edit';
+      return `✏️ ${verb} · ${scrubAndTruncate(fp)}`;
+    }
+    case 'mcp__gossipcat__gossip_dispatch':
+    case 'mcp__gossipcat__gossip_run': {
+      // Best-effort agent extraction; never forward the full task text raw.
+      const agent =
+        typeof input['agent_id'] === 'string' ? input['agent_id'] :
+        typeof input['agent'] === 'string' ? (input['agent'] as string) : '';
+      return `📡 dispatch → ${scrubAndTruncate(agent || 'agents')}`;
+    }
+    case 'mcp__gossipcat__gossip_collect':
+      return `📥 collect`;
+    default:
+      return null;
+  }
+}

--- a/apps/cli/src/hooks/mirror-shared.ts
+++ b/apps/cli/src/hooks/mirror-shared.ts
@@ -1,0 +1,254 @@
+/**
+ * Shared library for the three activity-mirror hooks (spec
+ * `docs/specs/2026-06-14-dashboard-cc-activity-mirror-v2.md` §Component 1 +
+ * §Security + §Consensus-hardening P1#4).
+ *
+ * Every helper here is FAIL-OPEN: a missing relay, missing/invalid auth key, or
+ * any thrown error results in a silent no-op (no POST), never a crash. These
+ * hooks run on EVERY user turn / tool call; they must never freeze or fail a
+ * turn (probe fact Q4 — hooks block until exit, so the POST is delegated to a
+ * DETACHED, time-bounded `curl`).
+ */
+import { openSync, fstatSync, readSync, closeSync } from 'fs';
+import { join } from 'path';
+import { spawn } from 'child_process';
+import type { MirrorRole } from './mirror-scrub';
+
+/** Basename of the persisted dashboard-auth file under `.gossip/`. */
+const AUTH_FILE_NAME = 'dashboard-auth.json';
+/** Sticky relay port file under `.gossip/`. */
+const RELAY_PORT_FILE = 'relay.port';
+/** Bound on how much of the auth file we read (it is tiny — key + sessions). */
+const AUTH_MAX_READ = 64 * 1024;
+/** curl wall-clock budget — the POST must never freeze a turn (Q4). */
+const CURL_MAX_TIME = '2';
+
+/** One frame as submitted in the POST body. */
+export interface MirrorFramePayload {
+  role: MirrorRole;
+  text: string;
+}
+
+/**
+ * Read the dashboard auth key from `.gossip/dashboard-auth.json`, P1#4 hardened.
+ *
+ * Hardening (consensus P1#4):
+ *   - SINGLE open()+fstat() — NOT stat-then-read (avoids the TOCTOU window where
+ *     the file is swapped between the stat and the read).
+ *   - Permission check `(mode & 0o077) === 0` — reject any group/other-readable
+ *     file. The key is a bearer credential; if anyone but the owner can read it
+ *     we refuse to use it (fail-open → no POST).
+ *   - Tolerate the atomic-rename race with `DashboardAuth.persist()` (auth.ts
+ *     writes a `.tmp` then renames): any ENOENT / parse failure → fail-open.
+ *
+ * Returns the 32-hex key string, or null on ANY problem (missing file, bad
+ * perms, parse error, unexpected shape). Null means "no POST" — never throw.
+ */
+export function readDashboardKey(cwd: string): string | null {
+  const path = join(cwd, '.gossip', AUTH_FILE_NAME);
+  let fd: number | null = null;
+  try {
+    // Single open — the fd is the stable handle the fstat + read both operate
+    // on, so a rename between the two cannot swap the bytes out from under us.
+    fd = openSync(path, 'r');
+    const st = fstatSync(fd);
+    if (!st.isFile()) return null;
+    // Reject group/other-readable. 0o077 = group+other rwx bits.
+    if ((st.mode & 0o077) !== 0) return null;
+    if (st.size <= 0 || st.size > AUTH_MAX_READ) return null;
+
+    const buf = Buffer.alloc(st.size);
+    const n = readSync(fd, buf, 0, st.size, 0);
+    const raw = buf.toString('utf8', 0, n);
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    const key = (parsed as { key?: unknown }).key;
+    // Key is randomBytes(16).toString('hex') — exactly 32 lowercase hex chars.
+    if (typeof key !== 'string' || !/^[0-9a-f]{32}$/.test(key)) return null;
+    return key;
+  } catch {
+    // ENOENT (no relay ever started, or mid-rename), EACCES, JSON parse error —
+    // all fail-open: no key → no POST.
+    return null;
+  } finally {
+    if (fd !== null) {
+      try { closeSync(fd); } catch { /* best-effort */ }
+    }
+  }
+}
+
+/**
+ * Locate the relay's listening port. Mirrors the sticky-port precedence used by
+ * the rest of the CLI (env wins, else the `.gossip/relay.port` sticky file).
+ * We do NOT probe-bind here (that would race the live relay we are trying to
+ * reach); we just read the recorded port. Returns null when absent/invalid →
+ * fail-open (no relay → no POST).
+ */
+export function readRelayPort(cwd: string): number | null {
+  const envRaw = process.env['GOSSIP_RELAY_PORT'];
+  if (envRaw !== undefined && envRaw !== '') {
+    const n = parseInt(envRaw, 10);
+    if (Number.isFinite(n) && n >= 1 && n <= 65535) return n;
+  }
+  let fd: number | null = null;
+  try {
+    fd = openSync(join(cwd, '.gossip', RELAY_PORT_FILE), 'r');
+    const buf = Buffer.alloc(16);
+    const n = readSync(fd, buf, 0, 16, 0);
+    const v = parseInt(buf.toString('utf8', 0, n).trim(), 10);
+    if (!Number.isFinite(v) || v < 1 || v > 65535) return null;
+    return v;
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) {
+      try { closeSync(fd); } catch { /* best-effort */ }
+    }
+  }
+}
+
+/** Minimal stdin-pipe handle used to feed curl's `--config -` directives. */
+export interface SpawnStdin {
+  write(chunk: string): void;
+  end(): void;
+}
+
+/** Minimal spawned-child handle the seam returns. */
+export interface SpawnChild {
+  unref(): void;
+  /** Writable stdin pipe (present when stdio[0] is 'pipe'). */
+  stdin?: SpawnStdin | null;
+}
+
+export interface PostMirrorOptions {
+  cwd: string;
+  /** Frames to coalesce into a single POST (batching — spec §Batching). */
+  frames: MirrorFramePayload[];
+  /** Optional dashboard chat_id parsed from a channel wrapper. */
+  chatId?: string;
+  /** Optional CC session_id so the relay can resolve a terminal turn's stream. */
+  sessionId?: string;
+  /** Test seam: capture the spawn argv + stdin instead of running curl. */
+  spawnImpl?: (cmd: string, args: string[], opts: SpawnOpts) => SpawnChild;
+}
+
+interface SpawnOpts {
+  detached: boolean;
+  /** stdin piped (config directives), stdout/stderr discarded. */
+  stdio: ['pipe', 'ignore', 'ignore'];
+}
+
+/**
+ * Fire a NON-BLOCKING, time-bounded mirror POST. Spawns `curl --config -` as a
+ * DETACHED, unref'd child so the hook process can exit immediately without
+ * waiting on the HTTP round-trip (Q4 — never freeze a turn). Reads the relay
+ * port + auth key fresh from disk; no-ops silently when either is absent.
+ *
+ * trust_boundaries (consensus 4a4b2087 HIGH): the bearer key is NEVER placed on
+ * curl's argv (argv is world-visible via `ps`/`/proc`). Instead we pipe a curl
+ * config file over the child's STDIN (`--config -`); the Authorization header —
+ * and every other directive — is read from the pipe, so the key lives only in
+ * the in-memory pipe: never argv, never disk.
+ *
+ * Returns true if a POST was dispatched, false if it was a no-op (no relay / no
+ * key / no frames). Never throws.
+ */
+export function postMirror(opts: PostMirrorOptions): boolean {
+  try {
+    if (!opts.frames || opts.frames.length === 0) return false;
+    const port = readRelayPort(opts.cwd);
+    if (port === null) return false;
+    const key = readDashboardKey(opts.cwd);
+    if (key === null) return false;
+
+    const body: { chat_id?: string; session_id?: string; frames: MirrorFramePayload[] } = {
+      frames: opts.frames,
+    };
+    if (opts.chatId) body.chat_id = opts.chatId;
+    if (opts.sessionId) body.session_id = opts.sessionId;
+
+    const url = `http://127.0.0.1:${port}/dashboard/api/bridge/mirror`;
+    // Only safe, non-secret directives go on argv. `--config -` tells curl to
+    // read the rest of its directives (including the bearer header) from stdin.
+    const args = ['--config', '-'];
+
+    const doSpawn = opts.spawnImpl ?? defaultSpawn;
+    const child = doSpawn('curl', args, { detached: true, stdio: ['pipe', 'ignore', 'ignore'] });
+
+    // curl config-file syntax: one `key = "value"` per line. Double-quoted
+    // values let curl handle the JSON body verbatim. Key (32-hex, validated by
+    // readDashboardKey) and url (numeric port) contain no `"` to escape.
+    const config = buildCurlConfig({ url, key, body: JSON.stringify(body) });
+    if (child.stdin) {
+      child.stdin.write(config);
+      child.stdin.end();
+    }
+    // unref so the parent (the hook) can exit without waiting on curl.
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build the curl `--config -` directive block. The bearer key is delivered HERE
+ * (over stdin), never on argv. JSON-encode the body so embedded quotes/newlines
+ * cannot break out of the double-quoted config value.
+ */
+export function buildCurlConfig(input: { url: string; key: string; body: string }): string {
+  return [
+    'silent',
+    'show-error',
+    `max-time = ${CURL_MAX_TIME}`,
+    'request = "POST"',
+    'header = "Content-Type: application/json"',
+    `header = "Authorization: Bearer ${input.key}"`,
+    `data-binary = ${JSON.stringify(input.body)}`,
+    `url = ${JSON.stringify(input.url)}`,
+    '',
+  ].join('\n');
+}
+
+function defaultSpawn(cmd: string, args: string[], opts: SpawnOpts): SpawnChild {
+  return spawn(cmd, args, opts) as unknown as SpawnChild;
+}
+
+/** Resolve the cwd a hook should anchor its `.gossip/` lookups to. */
+export function resolveCwd(payloadCwd: unknown): string {
+  if (typeof payloadCwd === 'string' && payloadCwd.length > 0) return payloadCwd;
+  return process.cwd();
+}
+
+/**
+ * Read all of stdin to a string (the CC hook payload arrives on stdin as JSON).
+ * Resolves to '' on EOF with no data. Never rejects — a read error resolves ''
+ * so the caller fail-opens.
+ */
+export function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    let data = '';
+    try {
+      const stdin = process.stdin;
+      stdin.setEncoding('utf8');
+      stdin.on('data', (chunk) => { data += chunk; });
+      stdin.on('end', () => resolve(data));
+      stdin.on('error', () => resolve(data));
+      // If stdin is a TTY (no piped payload), resolve empty immediately.
+      if (stdin.isTTY) resolve('');
+    } catch {
+      resolve('');
+    }
+  });
+}
+
+/** Parse a hook stdin payload to an object, or null on any error. */
+export function parsePayload(raw: string): Record<string, unknown> | null {
+  try {
+    const v: unknown = JSON.parse(raw);
+    if (typeof v !== 'object' || v === null || Array.isArray(v)) return null;
+    return v as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}

--- a/apps/cli/src/hooks/mirror-stop.ts
+++ b/apps/cli/src/hooks/mirror-stop.ts
@@ -1,0 +1,135 @@
+/**
+ * `gossipcat hook mirror-stop` — Stop mirror hook.
+ *
+ * Reads `{transcript_path, session_id}` from stdin. Opens the transcript JSONL
+ * and scans BACKWARD for the last `assistant` entry that contains a
+ * `type==='text'` content block, then POSTs that text as a `role:'assistant'`
+ * mirror frame.
+ *
+ * Probe fact Q2 + sonnet:f5/f6/f10:
+ *   - Transcript JSONL = one JSON object per line. Assistant entries carry a
+ *     content array of blocks: `text` / `thinking` / `tool_use`. `tool_result`
+ *     lives in `user` entries, so it is naturally excluded by only reading
+ *     `assistant` entries.
+ *   - ALLOWLIST `text` blocks — skip `thinking` (private reasoning) and
+ *     `tool_use` (structured calls). A pure-tool-use / malformed / missing final
+ *     turn → send NOTHING (gemini:f1/f3 — fail-open to silence on parse error).
+ *
+ * Fail-open: any error → no POST, exit 0.
+ */
+import { readFileSync } from 'fs';
+import { readStdin, parsePayload, resolveCwd, postMirror } from './mirror-shared';
+import { scrubSecrets, truncate } from './mirror-scrub';
+
+/** Assistant-text cap (under the relay's MIRROR_MAX_TEXT ≈ 2KB hard bound). */
+const ASSISTANT_TEXT_CAP = 2000;
+/** Don't read transcripts larger than this into memory (bounded fail-open). */
+const TRANSCRIPT_MAX_BYTES = 32 * 1024 * 1024;
+
+/**
+ * Extract the last assistant `text` block from transcript JSONL content.
+ *
+ * Scans lines from the END (the final assistant turn is what the user just saw)
+ * and returns the concatenated `text` blocks of the FIRST `assistant` entry
+ * (walking backward) that has at least one. Returns null when no such entry
+ * exists (pure-tool-use final turn, thinking-only, malformed, or empty).
+ *
+ * Exported for unit testing without disk IO.
+ */
+export function extractLastAssistantText(jsonl: string): string | null {
+  if (typeof jsonl !== 'string' || jsonl.length === 0) return null;
+  const lines = jsonl.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    let entry: unknown;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue; // skip a malformed line, keep scanning backward
+    }
+    if (typeof entry !== 'object' || entry === null) continue;
+    const e = entry as Record<string, unknown>;
+
+    // The role lives either at `.type` (top-level) or `.message.role`
+    // (nested message envelope). Accept both shapes; only `assistant` matters.
+    const role = resolveEntryRole(e);
+    if (role !== 'assistant') continue;
+
+    const content = resolveEntryContent(e);
+    if (!Array.isArray(content)) continue;
+
+    // ALLOWLIST: collect ONLY type==='text' blocks. thinking / tool_use skipped.
+    const texts: string[] = [];
+    for (const block of content) {
+      if (block && typeof block === 'object') {
+        const b = block as Record<string, unknown>;
+        if (b['type'] === 'text' && typeof b['text'] === 'string') {
+          texts.push(b['text']);
+        }
+      }
+    }
+    // No text blocks in this assistant entry (tool-use-only / thinking-only) —
+    // keep scanning backward; an earlier assistant turn may carry the text.
+    if (texts.length === 0) continue;
+    const joined = texts.join('\n').trim();
+    return joined.length > 0 ? joined : null;
+  }
+  return null;
+}
+
+/** Resolve an entry's role across the two known transcript shapes. */
+function resolveEntryRole(e: Record<string, unknown>): string | null {
+  if (typeof e['type'] === 'string' && (e['type'] === 'assistant' || e['type'] === 'user')) {
+    return e['type'];
+  }
+  const msg = e['message'];
+  if (msg && typeof msg === 'object') {
+    const r = (msg as Record<string, unknown>)['role'];
+    if (typeof r === 'string') return r;
+  }
+  const r = e['role'];
+  return typeof r === 'string' ? r : null;
+}
+
+/** Resolve an entry's content-block array across the two known shapes. */
+function resolveEntryContent(e: Record<string, unknown>): unknown {
+  if (Array.isArray(e['content'])) return e['content'];
+  const msg = e['message'];
+  if (msg && typeof msg === 'object') {
+    return (msg as Record<string, unknown>)['content'];
+  }
+  return undefined;
+}
+
+/** Hook body. */
+export async function runMirrorStopHook(rawStdin?: string): Promise<void> {
+  try {
+    const raw = rawStdin ?? (await readStdin());
+    const payload = parsePayload(raw);
+    if (!payload) return;
+
+    const transcriptPath = payload['transcript_path'];
+    if (typeof transcriptPath !== 'string' || transcriptPath.length === 0) return;
+
+    let jsonl: string;
+    try {
+      jsonl = readFileSync(transcriptPath, 'utf8');
+    } catch {
+      return; // missing / unreadable transcript → send nothing
+    }
+    if (jsonl.length > TRANSCRIPT_MAX_BYTES) return; // pathological — fail-open silent
+
+    const text = extractLastAssistantText(jsonl);
+    if (text === null) return; // pure-tool-use / malformed final turn → send nothing
+
+    const cwd = resolveCwd(payload['cwd']);
+    const sessionId = typeof payload['session_id'] === 'string' ? payload['session_id'] : undefined;
+    // Scrub defensively (assistant text could echo a secret it was shown) + cap.
+    const safe = truncate(scrubSecrets(text), ASSISTANT_TEXT_CAP);
+
+    postMirror({ cwd, sessionId, frames: [{ role: 'assistant', text: safe }] });
+  } catch {
+    // fail-open
+  }
+}

--- a/apps/cli/src/hooks/mirror-tool.ts
+++ b/apps/cli/src/hooks/mirror-tool.ts
@@ -1,0 +1,39 @@
+/**
+ * `gossipcat hook mirror-tool` — PostToolUse mirror hook.
+ *
+ * Reads `{tool_name, tool_input, tool_response, session_id}` from stdin and, for
+ * a CURATED allowlist of tools ONLY (Bash, Edit, Write, gossip_dispatch/run/
+ * collect — NOT Read/Grep, deepseek:f8 flood), POSTs a `role:'activity'` mirror
+ * frame containing a scrubbed one-liner derived from `tool_input`.
+ *
+ * Security (§Security P0):
+ *   - NEVER forward `tool_response` (verified arg-exfil risk — the response can
+ *     carry whole file contents / command output).
+ *   - Scrub `tool_input` for secrets (Bearer / --password / api_key= / secret
+ *     env-vars / long hex-base64) BEFORE truncating to ~80 chars.
+ *
+ * Fail-open: any error / non-allowlisted tool → no POST, exit 0.
+ */
+import { readStdin, parsePayload, resolveCwd, postMirror } from './mirror-shared';
+import { buildActivityLine } from './mirror-scrub';
+
+/** Hook body. */
+export async function runMirrorToolHook(rawStdin?: string): Promise<void> {
+  try {
+    const raw = rawStdin ?? (await readStdin());
+    const payload = parsePayload(raw);
+    if (!payload) return;
+
+    // buildActivityLine reads ONLY tool_name + tool_input; tool_response is
+    // never passed in. Non-allowlisted tool → null → no POST.
+    const line = buildActivityLine(payload['tool_name'], payload['tool_input']);
+    if (line === null) return;
+
+    const cwd = resolveCwd(payload['cwd']);
+    const sessionId = typeof payload['session_id'] === 'string' ? payload['session_id'] : undefined;
+
+    postMirror({ cwd, sessionId, frames: [{ role: 'activity', text: line }] });
+  } catch {
+    // fail-open
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -62,18 +62,39 @@ async function main(): Promise<void> {
     }
 
     case 'hook': {
-      // UserPromptSubmit bootstrap hook body. Only valid invocation is
-      // `gossipcat hook --run` (or `gossipcat hook run`). Bare `gossipcat
-      // hook` previously fell through and silently fired the hook — fix
-      // MEDIUM f2 from consensus d88f27db-c0454640.
+      // UserPromptSubmit bootstrap hook body + the activity-mirror v2 hooks.
+      // Valid invocations: `gossipcat hook --run` (bootstrap), `mirror-prompt`,
+      // `mirror-stop`, `mirror-tool`. Bare `gossipcat hook` previously fell
+      // through and silently fired the hook — fix MEDIUM f2 from consensus
+      // d88f27db-c0454640.
       const decision = parseHookSubcommand(args[1]);
       if (decision === 'usage') {
-        process.stderr.write('Usage: gossipcat hook --run\n');
+        process.stderr.write('Usage: gossipcat hook --run | mirror-prompt | mirror-stop | mirror-tool\n');
         process.exit(2);
       }
-      const { runHook } = await import('./hook-run');
-      runHook();
-      return;
+      if (decision === 'run') {
+        const { runHook } = await import('./hook-run');
+        runHook();
+        return;
+      }
+      // Activity-mirror hooks are fail-open + non-blocking: never let a thrown
+      // error or a missing relay propagate to a non-zero exit that would block
+      // the user's turn. exit 0 unconditionally.
+      try {
+        if (decision === 'mirror-prompt') {
+          const { runMirrorPromptHook } = await import('./hooks/mirror-prompt');
+          await runMirrorPromptHook();
+        } else if (decision === 'mirror-stop') {
+          const { runMirrorStopHook } = await import('./hooks/mirror-stop');
+          await runMirrorStopHook();
+        } else if (decision === 'mirror-tool') {
+          const { runMirrorToolHook } = await import('./hooks/mirror-tool');
+          await runMirrorToolHook();
+        }
+      } catch {
+        // fail-open — swallow.
+      }
+      process.exit(0);
     }
 
     case 'help':

--- a/packages/orchestrator/src/hook-installer.ts
+++ b/packages/orchestrator/src/hook-installer.ts
@@ -480,6 +480,95 @@ export function installBootstrapHook(projectRoot: string): BootstrapHookInstallR
   }
 }
 
+// ── Activity-mirror v2 hooks (settings.local.json) ───────────────────────────
+
+export interface MirrorHookInstallResult {
+  installed: string[];
+  skipped: string[];
+  reason?: string;
+}
+
+/**
+ * The three activity-mirror hooks (spec
+ * `docs/specs/2026-06-14-dashboard-cc-activity-mirror-v2.md` §Component 1).
+ * Each maps a CC hook event to a `gossipcat hook mirror-*` subcommand.
+ *
+ *   - UserPromptSubmit → mirror the human's terminal prompt (matcher '' = all).
+ *   - Stop            → mirror the orchestrator's final assistant text.
+ *   - PostToolUse     → mirror a curated, scrubbed tool/dispatch one-liner.
+ *
+ * matcher '' (UserPromptSubmit/Stop) matches every event; PostToolUse matches
+ * only the curated tool names so non-allowlisted tools never even spawn the
+ * hook (the hook ALSO re-checks the allowlist defensively).
+ */
+const MIRROR_HOOKS = [
+  { name: 'mirror-prompt', event: 'UserPromptSubmit' as const, matcher: '', command: 'gossipcat hook mirror-prompt' },
+  { name: 'mirror-stop', event: 'Stop' as const, matcher: '', command: 'gossipcat hook mirror-stop' },
+  {
+    name: 'mirror-tool',
+    event: 'PostToolUse' as const,
+    matcher: 'Bash|Edit|Write|mcp__gossipcat__gossip_dispatch|mcp__gossipcat__gossip_run|mcp__gossipcat__gossip_collect',
+    command: 'gossipcat hook mirror-tool',
+  },
+] as const;
+
+/**
+ * Register the three activity-mirror hooks in
+ * `<projectRoot>/.claude/settings.local.json`.
+ *
+ * IMPORTANT: this is NOT called from `gossip_setup` / any auto-enable path —
+ * activation of the activity mirror is a deliberate follow-up after the
+ * orchestrator has verified the relay + dashboard render are ready. Exported
+ * here so that follow-up (and unit tests) can register the hooks idempotently
+ * with the same atomic-write + malformed-skip discipline as the other
+ * installers. Never throws.
+ */
+export function installMirrorHooks(projectRoot: string): MirrorHookInstallResult {
+  const installed: string[] = [];
+  const skipped: string[] = [];
+  try {
+    const settingsPath = join(projectRoot, '.claude', 'settings.local.json');
+    mkdirSync(dirname(settingsPath), { recursive: true });
+
+    let settings: Record<string, any>;
+    try {
+      settings = loadLocalSettings(settingsPath);
+    } catch (err) {
+      process.stderr.write(
+        `[gossipcat] settings.local.json at ${settingsPath} is malformed; skipping mirror hook install. ` +
+        `Fix the file or delete it and re-run.\n`,
+      );
+      return { installed, skipped, reason: (err as Error).message };
+    }
+
+    let anyMutated = false;
+    for (const hook of MIRROR_HOOKS) {
+      const mutated = mergeHookEntry(settings, hook.event, hook.matcher, hook.command);
+      if (mutated) {
+        installed.push(hook.name);
+        anyMutated = true;
+      } else {
+        skipped.push(hook.name);
+      }
+    }
+
+    if (anyMutated) {
+      const tmp = settingsPath + '.tmp.' + process.pid;
+      writeFileSync(tmp, JSON.stringify(settings, null, 2) + '\n');
+      try {
+        renameSync(tmp, settingsPath);
+      } catch (renameErr) {
+        try { unlinkSync(tmp); } catch { /* best-effort */ }
+        throw renameErr;
+      }
+    }
+
+    return { installed, skipped };
+  } catch (err) {
+    return { installed, skipped, reason: (err as Error).message };
+  }
+}
+
 /**
  * Install the v1 orchestrator-discipline hook bundle into
  * `<projectRoot>/.claude/settings.local.json` (personal hooks, gitignored).

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -94,8 +94,8 @@ export {
 export type { StalenessResult } from './dist-mcp-staleness';
 export type { BootstrapResult } from './bootstrap';
 export { findBundledRules, ensureRulesFile, readRulesContent } from './rules-loader';
-export { installWorktreeSandboxHook, findBundledHook, writeOrchestratorRoleMarker, installDisciplineHooks, installBootstrapHook, BOOTSTRAP_HOOK_COMMAND, isWorktreeSandboxHookRegistered } from './hook-installer';
-export type { HookInstallResult, DisciplineHookInstallResult, BootstrapHookInstallResult } from './hook-installer';
+export { installWorktreeSandboxHook, findBundledHook, writeOrchestratorRoleMarker, installDisciplineHooks, installBootstrapHook, installMirrorHooks, BOOTSTRAP_HOOK_COMMAND, isWorktreeSandboxHookRegistered } from './hook-installer';
+export type { HookInstallResult, DisciplineHookInstallResult, BootstrapHookInstallResult, MirrorHookInstallResult } from './hook-installer';
 export { OverlapDetector } from './overlap-detector';
 export { LensGenerator } from './lens-generator';
 export { PerformanceWriter, rotateJsonlIfNeeded, MAX_TELEMETRY_BYTES } from './performance-writer';

--- a/tests/cli/mirror-prompt.test.ts
+++ b/tests/cli/mirror-prompt.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for the UserPromptSubmit mirror hook channel-tag dedup
+ * (apps/cli/src/hooks/mirror-prompt.ts). Spec §Component 1 + sonnet:f10
+ * (structural match, NOT loose substring).
+ */
+import { inspectPrompt } from '../../apps/cli/src/hooks/mirror-prompt';
+
+describe('inspectPrompt — channel-wrapper dedup', () => {
+  it('detects a dashboard-origin wrapper at the start of the prompt', () => {
+    const r = inspectPrompt('<channel source="gossipcat" chat_id="abc123">do X</channel>');
+    expect(r.isDashboardOrigin).toBe(true);
+    // chat_id is intentionally NOT parsed (f13) — the relay seeds mirrorChatIds
+    // from its own validated POST, never from this hook. PromptChannelMatch no
+    // longer carries a chatId field (type-enforced).
+    expect(Object.keys(r)).toEqual(['isDashboardOrigin']);
+  });
+
+  it('tolerates leading whitespace and reordered attributes', () => {
+    const r = inspectPrompt('  \n<channel chat_id="zz" source="gossipcat">y</channel>');
+    expect(r.isDashboardOrigin).toBe(true);
+  });
+
+  it('does NOT match a prompt that merely mentions the tag in prose (substring guard)', () => {
+    const r = inspectPrompt('Please explain what <channel source="gossipcat"> means in our code.');
+    // The tag is mid-sentence, not the structural opening — must be mirrored.
+    expect(r.isDashboardOrigin).toBe(false);
+  });
+
+  it('does NOT match a different-source channel tag', () => {
+    const r = inspectPrompt('<channel source="other" chat_id="x">hi</channel>');
+    expect(r.isDashboardOrigin).toBe(false);
+  });
+
+  it('reports no wrapper for a plain prompt', () => {
+    const r = inspectPrompt('just a normal terminal prompt');
+    expect(r.isDashboardOrigin).toBe(false);
+  });
+
+  it('handles non-string input fail-open', () => {
+    expect(inspectPrompt(undefined).isDashboardOrigin).toBe(false);
+    expect(inspectPrompt(42).isDashboardOrigin).toBe(false);
+  });
+});

--- a/tests/cli/mirror-scrub.test.ts
+++ b/tests/cli/mirror-scrub.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the activity-mirror arg scrubber + PostToolUse allowlist
+ * (apps/cli/src/hooks/mirror-scrub.ts). Spec §Security P0 + sonnet:f8.
+ */
+import {
+  scrubSecrets,
+  scrubAndTruncate,
+  truncate,
+  buildActivityLine,
+  REDACTED,
+  SCRUB_SUMMARY_MAX,
+} from '../../apps/cli/src/hooks/mirror-scrub';
+
+describe('scrubSecrets', () => {
+  it('redacts Bearer tokens', () => {
+    const out = scrubSecrets('curl -H "Authorization: Bearer sk-abc123def456" https://x');
+    expect(out).toContain(`Bearer ${REDACTED}`);
+    expect(out).not.toContain('sk-abc123def456');
+  });
+
+  it('redacts --password values', () => {
+    expect(scrubSecrets('mysql --password hunter2 db')).not.toContain('hunter2');
+    expect(scrubSecrets('mysql --password=hunter2 db')).not.toContain('hunter2');
+  });
+
+  it('redacts api_key / api-key assignments', () => {
+    expect(scrubSecrets('api_key=ABCDEF1234')).toBe(`api_key=${REDACTED}`);
+    expect(scrubSecrets('api-key=ABCDEF1234')).toBe(`api-key=${REDACTED}`);
+  });
+
+  it('redacts secret-bearing env-var assignments', () => {
+    expect(scrubSecrets('export OPENAI_API_KEY=sk-xyz')).toContain(`OPENAI_API_KEY=${REDACTED}`);
+    expect(scrubSecrets('GITHUB_TOKEN=ghp_aaa bbb')).toContain(`GITHUB_TOKEN=${REDACTED}`);
+    expect(scrubSecrets('DB_PASSWORD=p4ss')).toContain(`DB_PASSWORD=${REDACTED}`);
+    expect(scrubSecrets('STRIPE_SECRET=zzz')).toContain(`STRIPE_SECRET=${REDACTED}`);
+  });
+
+  it('redacts standalone long hex/base64 runs (>=32 chars)', () => {
+    const hex = 'a'.repeat(40);
+    expect(scrubSecrets(`token ${hex} end`)).toBe(`token ${REDACTED} end`);
+    // A short hex run is left intact.
+    expect(scrubSecrets('short abc123 end')).toBe('short abc123 end');
+  });
+
+  it('collapses newlines/whitespace to a single line', () => {
+    expect(scrubSecrets('a\n  b\t c')).toBe('a b c');
+  });
+
+  it('returns empty string for non-string input', () => {
+    expect(scrubSecrets(undefined as unknown as string)).toBe('');
+  });
+});
+
+describe('scrubAndTruncate (scrub THEN truncate — sonnet:f8)', () => {
+  it('redacts a secret near the END before truncation drops it', () => {
+    // A long benign prefix then a secret at the tail. Truncate-first would
+    // chop the secret out of VIEW but it would still have ridden through; the
+    // contract is the secret is REDACTED regardless of position.
+    const prefix = 'x'.repeat(SCRUB_SUMMARY_MAX);
+    const out = scrubAndTruncate(`${prefix} Bearer sk-tailsecret`);
+    expect(out).not.toContain('sk-tailsecret');
+    expect(out.length).toBeLessThanOrEqual(SCRUB_SUMMARY_MAX);
+  });
+
+  it('truncates to SCRUB_SUMMARY_MAX with an ellipsis', () => {
+    // Use short space-separated words so the long-hex/base64 sweep doesn't
+    // collapse the whole thing to a single «redacted» token.
+    const out = scrubAndTruncate('word '.repeat(60));
+    expect(out.length).toBeLessThanOrEqual(SCRUB_SUMMARY_MAX);
+    expect(out.endsWith('…')).toBe(true);
+  });
+});
+
+describe('truncate', () => {
+  it('leaves short strings intact', () => {
+    expect(truncate('abc', 80)).toBe('abc');
+  });
+  it('truncates and ellipsizes', () => {
+    expect(truncate('abcdef', 4)).toBe('abc…');
+  });
+});
+
+describe('buildActivityLine — allowlist + scrub', () => {
+  it('returns null for non-allowlisted tools (Read/Grep flood guard)', () => {
+    expect(buildActivityLine('Read', { file_path: '/etc/passwd' })).toBeNull();
+    expect(buildActivityLine('Grep', { pattern: 'x' })).toBeNull();
+    expect(buildActivityLine('WebFetch', {})).toBeNull();
+  });
+
+  it('builds a scrubbed Bash one-liner', () => {
+    const line = buildActivityLine('Bash', { command: 'curl -H "Authorization: Bearer sk-secret123456"' });
+    expect(line).not.toBeNull();
+    expect(line).toContain('🔧 Bash');
+    expect(line).not.toContain('sk-secret123456');
+  });
+
+  it('builds Edit/Write file-path lines', () => {
+    expect(buildActivityLine('Edit', { file_path: '/a/b.ts' })).toContain('/a/b.ts');
+    expect(buildActivityLine('Write', { file_path: '/a/c.ts' })).toContain('Write');
+  });
+
+  it('builds a dispatch line with the agent id', () => {
+    expect(buildActivityLine('mcp__gossipcat__gossip_dispatch', { agent_id: 'opus-implementer' }))
+      .toContain('opus-implementer');
+    expect(buildActivityLine('mcp__gossipcat__gossip_run', { agent: 'sonnet-reviewer' }))
+      .toContain('sonnet-reviewer');
+  });
+
+  it('builds a collect line', () => {
+    expect(buildActivityLine('mcp__gossipcat__gossip_collect', {})).toContain('collect');
+  });
+
+  it('NEVER includes tool_response (it is not even an input to the builder)', () => {
+    // The function signature has no tool_response param — this asserts the
+    // contract at the type+behavior level: even a malicious tool_input cannot
+    // smuggle a response field into the line beyond its own scrubbed value.
+    const line = buildActivityLine('Bash', { command: 'echo hi', tool_response: 'SECRET-OUTPUT' });
+    expect(line).not.toContain('SECRET-OUTPUT');
+  });
+});

--- a/tests/cli/mirror-shared.test.ts
+++ b/tests/cli/mirror-shared.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for the activity-mirror shared lib
+ * (apps/cli/src/hooks/mirror-shared.ts): auth-key read fail-open (P1#4) +
+ * non-blocking detached/unref'd curl spawn (Q4). No real network.
+ */
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readDashboardKey, readRelayPort, postMirror } from '../../apps/cli/src/hooks/mirror-shared';
+
+const VALID_KEY = 'a'.repeat(32);
+
+function freshProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'mirror-shared-'));
+  // .gossip dir
+  require('fs').mkdirSync(join(dir, '.gossip'), { recursive: true });
+  return dir;
+}
+
+function writeAuth(dir: string, body: string, mode = 0o600): void {
+  const p = join(dir, '.gossip', 'dashboard-auth.json');
+  writeFileSync(p, body, { mode });
+  chmodSync(p, mode);
+}
+
+describe('readDashboardKey — P1#4 hardening', () => {
+  let dir: string;
+  beforeEach(() => { dir = freshProject(); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('reads a valid 0600 key', () => {
+    writeAuth(dir, JSON.stringify({ version: 1, key: VALID_KEY, sessions: [] }), 0o600);
+    expect(readDashboardKey(dir)).toBe(VALID_KEY);
+  });
+
+  it('fails open (null) when the file is missing', () => {
+    expect(readDashboardKey(dir)).toBeNull();
+  });
+
+  it('fails open when the file is group/other-readable (reject (mode & 0o077) !== 0)', () => {
+    writeAuth(dir, JSON.stringify({ version: 1, key: VALID_KEY, sessions: [] }), 0o644);
+    expect(readDashboardKey(dir)).toBeNull();
+  });
+
+  it('fails open on a parse error', () => {
+    writeAuth(dir, '{ not valid json', 0o600);
+    expect(readDashboardKey(dir)).toBeNull();
+  });
+
+  it('fails open when the key is not 32-hex', () => {
+    writeAuth(dir, JSON.stringify({ version: 1, key: 'TOO-SHORT', sessions: [] }), 0o600);
+    expect(readDashboardKey(dir)).toBeNull();
+  });
+});
+
+describe('readRelayPort', () => {
+  let dir: string;
+  beforeEach(() => { dir = freshProject(); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('reads a valid sticky port', () => {
+    writeFileSync(join(dir, '.gossip', 'relay.port'), '63007');
+    expect(readRelayPort(dir)).toBe(63007);
+  });
+
+  it('returns null when absent', () => {
+    expect(readRelayPort(dir)).toBeNull();
+  });
+
+  it('returns null for an out-of-range value', () => {
+    writeFileSync(join(dir, '.gossip', 'relay.port'), '99999');
+    expect(readRelayPort(dir)).toBeNull();
+  });
+});
+
+describe('postMirror — non-blocking detached spawn (Q4)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = freshProject();
+    writeFileSync(join(dir, '.gossip', 'relay.port'), '63007');
+    writeAuth(dir, JSON.stringify({ version: 1, key: VALID_KEY, sessions: [] }), 0o600);
+  });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('spawns curl --config - detached+unref, stdin piped (never freezes a turn)', () => {
+    let spawned: { cmd: string; args: string[]; opts: any } | null = null;
+    let unrefed = false;
+    let stdinChunks = '';
+    let stdinEnded = false;
+    const ok = postMirror({
+      cwd: dir,
+      frames: [{ role: 'user', text: 'hello' }],
+      spawnImpl: (cmd, args, opts) => {
+        spawned = { cmd, args, opts };
+        return {
+          unref: () => { unrefed = true; },
+          stdin: { write: (c: string) => { stdinChunks += c; }, end: () => { stdinEnded = true; } },
+        };
+      },
+    });
+    expect(ok).toBe(true);
+    expect(spawned).not.toBeNull();
+    expect(spawned!.cmd).toBe('curl');
+    // Only safe directives on argv — `--config -` reads the rest from stdin.
+    expect(spawned!.args).toEqual(['--config', '-']);
+    expect(spawned!.opts.detached).toBe(true);
+    expect(spawned!.opts.stdio).toEqual(['pipe', 'ignore', 'ignore']);
+    expect(unrefed).toBe(true);
+    expect(stdinEnded).toBe(true);
+    // max-time directive lives in the piped config, not argv.
+    expect(stdinChunks).toContain('max-time = 2');
+  });
+
+  it('delivers the bearer key ONLY via stdin config — never on argv (HIGH 4a4b2087)', () => {
+    let args: string[] = [];
+    let stdinChunks = '';
+    postMirror({
+      cwd: dir,
+      frames: [{ role: 'user', text: 'hi' }],
+      spawnImpl: (_c, a) => {
+        args = a;
+        return { unref() {}, stdin: { write: (c: string) => { stdinChunks += c; }, end() {} } };
+      },
+    });
+    // The key (and the literal 'Bearer') must NOT appear anywhere in argv.
+    const argvJoined = args.join(' ');
+    expect(argvJoined).not.toContain(VALID_KEY);
+    expect(argvJoined).not.toContain('Bearer');
+    // The key is delivered over the stdin config pipe instead.
+    expect(stdinChunks).toContain(`header = "Authorization: Bearer ${VALID_KEY}"`);
+    // Body carries the frames (also piped, not on argv).
+    const m = stdinChunks.match(/data-binary = (".*")/);
+    expect(m).not.toBeNull();
+    const body = JSON.parse(JSON.parse(m![1]));
+    expect(body.frames[0]).toEqual({ role: 'user', text: 'hi' });
+  });
+
+  it('no-ops (no spawn) when there is no relay port', () => {
+    rmSync(join(dir, '.gossip', 'relay.port'));
+    let called = false;
+    const ok = postMirror({
+      cwd: dir,
+      frames: [{ role: 'user', text: 'x' }],
+      spawnImpl: () => { called = true; return { unref() {} }; },
+    });
+    expect(ok).toBe(false);
+    expect(called).toBe(false);
+  });
+
+  it('no-ops when there is no auth key', () => {
+    rmSync(join(dir, '.gossip', 'dashboard-auth.json'));
+    let called = false;
+    const ok = postMirror({
+      cwd: dir,
+      frames: [{ role: 'user', text: 'x' }],
+      spawnImpl: () => { called = true; return { unref() {} }; },
+    });
+    expect(ok).toBe(false);
+    expect(called).toBe(false);
+  });
+
+  it('no-ops on an empty frame list', () => {
+    let called = false;
+    const ok = postMirror({
+      cwd: dir,
+      frames: [],
+      spawnImpl: () => { called = true; return { unref() {} }; },
+    });
+    expect(ok).toBe(false);
+    expect(called).toBe(false);
+  });
+
+  it('includes chat_id and session_id in the body when provided', () => {
+    let stdinChunks = '';
+    postMirror({
+      cwd: dir,
+      chatId: 'cid',
+      sessionId: 'sid',
+      frames: [{ role: 'activity', text: '🔧 Bash · ls' }],
+      spawnImpl: () => ({ unref() {}, stdin: { write: (c: string) => { stdinChunks += c; }, end() {} } }),
+    });
+    const m = stdinChunks.match(/data-binary = (".*")/);
+    const body = JSON.parse(JSON.parse(m![1]));
+    expect(body.chat_id).toBe('cid');
+    expect(body.session_id).toBe('sid');
+  });
+});

--- a/tests/cli/mirror-stop.test.ts
+++ b/tests/cli/mirror-stop.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the Stop hook transcript parser
+ * (apps/cli/src/hooks/mirror-stop.ts). Spec §Component 1 + Q2 + sonnet:f5/f6/f10.
+ */
+import { extractLastAssistantText } from '../../apps/cli/src/hooks/mirror-stop';
+
+/** Build a JSONL transcript from entry objects. */
+function jsonl(entries: unknown[]): string {
+  return entries.map((e) => JSON.stringify(e)).join('\n');
+}
+
+describe('extractLastAssistantText', () => {
+  it('extracts the last assistant text block (top-level shape)', () => {
+    const t = jsonl([
+      { type: 'user', content: [{ type: 'text', text: 'hi' }] },
+      { type: 'assistant', content: [{ type: 'text', text: 'hello there' }] },
+    ]);
+    expect(extractLastAssistantText(t)).toBe('hello there');
+  });
+
+  it('extracts from the nested message envelope shape', () => {
+    const t = jsonl([
+      { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'nested reply' }] } },
+    ]);
+    expect(extractLastAssistantText(t)).toBe('nested reply');
+  });
+
+  it('concatenates multiple text blocks in one entry', () => {
+    const t = jsonl([
+      { type: 'assistant', content: [{ type: 'text', text: 'line1' }, { type: 'text', text: 'line2' }] },
+    ]);
+    expect(extractLastAssistantText(t)).toBe('line1\nline2');
+  });
+
+  it('skips thinking and tool_use blocks (allowlist text only)', () => {
+    const t = jsonl([
+      {
+        type: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'secret reasoning' },
+          { type: 'tool_use', name: 'Bash', input: { command: 'ls' } },
+          { type: 'text', text: 'the answer' },
+        ],
+      },
+    ]);
+    const out = extractLastAssistantText(t);
+    expect(out).toBe('the answer');
+    expect(out).not.toContain('secret reasoning');
+    expect(out).not.toContain('ls');
+  });
+
+  it('returns null for a pure-tool-use final turn (send nothing)', () => {
+    const t = jsonl([
+      { type: 'assistant', content: [{ type: 'text', text: 'earlier' }] },
+      { type: 'assistant', content: [{ type: 'tool_use', name: 'Bash', input: {} }] },
+    ]);
+    // The LAST assistant entry is tool-use only → walk backward → returns the
+    // earlier text turn (an assistant text DID exist in the transcript).
+    expect(extractLastAssistantText(t)).toBe('earlier');
+  });
+
+  it('returns null when no assistant text exists at all', () => {
+    const t = jsonl([
+      { type: 'user', content: [{ type: 'text', text: 'q' }] },
+      { type: 'assistant', content: [{ type: 'tool_use', name: 'Bash', input: {} }] },
+    ]);
+    expect(extractLastAssistantText(t)).toBeNull();
+  });
+
+  it('returns null for a thinking-only assistant turn with no text', () => {
+    const t = jsonl([
+      { type: 'assistant', content: [{ type: 'thinking', thinking: 'hmm' }] },
+    ]);
+    expect(extractLastAssistantText(t)).toBeNull();
+  });
+
+  it('skips a malformed JSONL line and keeps scanning backward', () => {
+    const t = [
+      JSON.stringify({ type: 'assistant', content: [{ type: 'text', text: 'good' }] }),
+      '{ this is not valid json',
+    ].join('\n');
+    expect(extractLastAssistantText(t)).toBe('good');
+  });
+
+  it('returns null for empty / missing input', () => {
+    expect(extractLastAssistantText('')).toBeNull();
+    expect(extractLastAssistantText(undefined as unknown as string)).toBeNull();
+  });
+
+  it('ignores tool_result that lives in user entries', () => {
+    const t = jsonl([
+      { type: 'user', content: [{ type: 'tool_result', content: 'OUTPUT LEAK' }] },
+      { type: 'assistant', content: [{ type: 'text', text: 'done' }] },
+    ]);
+    const out = extractLastAssistantText(t);
+    expect(out).toBe('done');
+    expect(out).not.toContain('OUTPUT LEAK');
+  });
+});

--- a/tests/cli/mirror-tool.test.ts
+++ b/tests/cli/mirror-tool.test.ts
@@ -1,0 +1,106 @@
+/**
+ * End-to-end unit tests for the PostToolUse mirror hook
+ * (apps/cli/src/hooks/mirror-tool.ts → runMirrorToolHook). Spec §Component 1 +
+ * consensus 4a4b2087 HIGH (mirror-tool untested).
+ *
+ * Seam: we mock `mirror-shared`'s `postMirror` so we can assert WHAT frame the
+ * hook would POST without any real network/spawn — the same injection seam the
+ * sibling mirror tests use (capture-the-call, no I/O). `readStdin` etc. are
+ * irrelevant here because the hook accepts an injected `rawStdin` argument.
+ */
+
+const postMirrorMock = jest.fn<boolean, [unknown]>(() => true);
+
+jest.mock('../../apps/cli/src/hooks/mirror-shared', () => {
+  const actual = jest.requireActual('../../apps/cli/src/hooks/mirror-shared');
+  return {
+    ...actual,
+    // Only override the network-facing primitive; keep resolveCwd/parsePayload real.
+    postMirror: (opts: unknown) => postMirrorMock(opts),
+  };
+});
+
+import { runMirrorToolHook } from '../../apps/cli/src/hooks/mirror-tool';
+
+/** The shape postMirror receives. */
+interface PostArg {
+  cwd: string;
+  sessionId?: string;
+  frames: Array<{ role: string; text: string }>;
+}
+
+function lastFrame(): { role: string; text: string } {
+  const arg = postMirrorMock.mock.calls.at(-1)![0] as PostArg;
+  return arg.frames[0];
+}
+
+describe('runMirrorToolHook — PostToolUse mirror', () => {
+  beforeEach(() => { postMirrorMock.mockClear(); });
+
+  it('(a) allowlisted Bash → ONE activity frame with a scrubbed one-liner', async () => {
+    await runMirrorToolHook(JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'ls -la /tmp' },
+      cwd: '/proj',
+      session_id: 'sid-1',
+    }));
+    expect(postMirrorMock).toHaveBeenCalledTimes(1);
+    const arg = postMirrorMock.mock.calls[0][0] as PostArg;
+    expect(arg.frames).toHaveLength(1);
+    expect(arg.frames[0].role).toBe('activity');
+    expect(arg.frames[0].text).toBe('🔧 Bash · ls -la /tmp');
+    expect(arg.sessionId).toBe('sid-1');
+    expect(arg.cwd).toBe('/proj');
+  });
+
+  it('(b) tool_response in stdin is NEVER present in the posted frame', async () => {
+    await runMirrorToolHook(JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'cat /etc/hosts' },
+      tool_response: 'SENSITIVE-RESPONSE-CONTENTS-LEAK',
+      cwd: '/proj',
+    }));
+    expect(postMirrorMock).toHaveBeenCalledTimes(1);
+    expect(lastFrame().text).not.toContain('SENSITIVE-RESPONSE-CONTENTS-LEAK');
+    expect(lastFrame().text).toBe('🔧 Bash · cat /etc/hosts');
+  });
+
+  it('(c) non-allowlisted tools (Read / Grep) → no POST', async () => {
+    await runMirrorToolHook(JSON.stringify({
+      tool_name: 'Read',
+      tool_input: { file_path: '/secret' },
+      cwd: '/proj',
+    }));
+    await runMirrorToolHook(JSON.stringify({
+      tool_name: 'Grep',
+      tool_input: { pattern: 'token' },
+      cwd: '/proj',
+    }));
+    expect(postMirrorMock).not.toHaveBeenCalled();
+  });
+
+  it('(d) malformed / empty stdin → no POST, no throw', async () => {
+    await expect(runMirrorToolHook('{ not json')).resolves.toBeUndefined();
+    await expect(runMirrorToolHook('')).resolves.toBeUndefined();
+    await expect(runMirrorToolHook('[]')).resolves.toBeUndefined(); // array → parsePayload null
+    expect(postMirrorMock).not.toHaveBeenCalled();
+  });
+
+  it('(e) secrets in tool_input (Bearer / api_key / JWT) are redacted in the posted text', async () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.dBjftJeZ4CVPmB92K27uhbUJU1p1r';
+    await runMirrorToolHook(JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: {
+        command: `curl -H "Authorization: Bearer sk-abc123secret" --data api_key=topsecretvalue ${jwt}`,
+      },
+      cwd: '/proj',
+    }));
+    expect(postMirrorMock).toHaveBeenCalledTimes(1);
+    const text = lastFrame().text;
+    expect(text).not.toContain('sk-abc123secret');
+    expect(text).not.toContain('topsecretvalue');
+    expect(text).not.toContain(jwt);
+    // The redaction marker is present.
+    expect(text).toContain('«redacted»');
+  });
+});

--- a/tests/orchestrator/hook-installer-mirror.test.ts
+++ b/tests/orchestrator/hook-installer-mirror.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for installMirrorHooks (packages/orchestrator/src/hook-installer.ts).
+ * Spec §Component 1 settings wiring. NOT auto-enabled — this exercises the
+ * explicit installer fn that a follow-up activation step would call.
+ */
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { installMirrorHooks } from '../../packages/orchestrator/src/hook-installer';
+
+function freshProject(): string {
+  return mkdtempSync(join(tmpdir(), 'mirror-installer-'));
+}
+
+function readSettings(dir: string): any {
+  return JSON.parse(readFileSync(join(dir, '.claude', 'settings.local.json'), 'utf-8'));
+}
+
+describe('installMirrorHooks', () => {
+  let dir: string;
+  beforeEach(() => { dir = freshProject(); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('registers all three mirror hooks on a fresh project', () => {
+    const r = installMirrorHooks(dir);
+    expect(r.installed.sort()).toEqual(['mirror-prompt', 'mirror-stop', 'mirror-tool']);
+    expect(r.skipped).toEqual([]);
+    const s = readSettings(dir);
+    expect(s.hooks.UserPromptSubmit.some((e: any) =>
+      e.hooks.some((h: any) => h.command === 'gossipcat hook mirror-prompt'))).toBe(true);
+    expect(s.hooks.Stop.some((e: any) =>
+      e.hooks.some((h: any) => h.command === 'gossipcat hook mirror-stop'))).toBe(true);
+    expect(s.hooks.PostToolUse.some((e: any) =>
+      e.hooks.some((h: any) => h.command === 'gossipcat hook mirror-tool'))).toBe(true);
+  });
+
+  it('scopes the PostToolUse matcher to the curated allowlist', () => {
+    installMirrorHooks(dir);
+    const s = readSettings(dir);
+    const entry = s.hooks.PostToolUse.find((e: any) =>
+      e.hooks.some((h: any) => h.command === 'gossipcat hook mirror-tool'));
+    expect(entry.matcher).toContain('Bash');
+    expect(entry.matcher).toContain('mcp__gossipcat__gossip_dispatch');
+    expect(entry.matcher).not.toContain('Read');
+  });
+
+  it('is idempotent — a second call skips all three', () => {
+    installMirrorHooks(dir);
+    const r2 = installMirrorHooks(dir);
+    expect(r2.installed).toEqual([]);
+    expect(r2.skipped.sort()).toEqual(['mirror-prompt', 'mirror-stop', 'mirror-tool']);
+  });
+
+  it('preserves pre-existing unrelated settings', () => {
+    const dotClaude = join(dir, '.claude');
+    require('fs').mkdirSync(dotClaude, { recursive: true });
+    writeFileSync(join(dotClaude, 'settings.local.json'),
+      JSON.stringify({ permissions: { allow: ['Edit'] } }, null, 2));
+    installMirrorHooks(dir);
+    const s = readSettings(dir);
+    expect(s.permissions.allow).toEqual(['Edit']);
+    expect(s.hooks.UserPromptSubmit).toBeDefined();
+  });
+
+  it('does NOT clobber a malformed settings.local.json', () => {
+    const dotClaude = join(dir, '.claude');
+    require('fs').mkdirSync(dotClaude, { recursive: true });
+    const p = join(dotClaude, 'settings.local.json');
+    writeFileSync(p, '{ not json');
+    const r = installMirrorHooks(dir);
+    expect(r.reason).toMatch(/malformed/i);
+    // File left untouched.
+    expect(readFileSync(p, 'utf-8')).toBe('{ not json');
+  });
+
+  it('never throws (returns a result even on a bad path)', () => {
+    // A path whose .claude cannot be created (file in the way) still returns.
+    const filePath = join(dir, 'afile');
+    writeFileSync(filePath, 'x');
+    const r = installMirrorHooks(filePath);
+    expect(r).toHaveProperty('installed');
+    expect(r).toHaveProperty('skipped');
+  });
+
+  it('leaves no .tmp file behind after a successful write', () => {
+    installMirrorHooks(dir);
+    const dotClaude = join(dir, '.claude');
+    const leftover = require('fs').readdirSync(dotClaude).filter((f: string) => f.includes('.tmp'));
+    expect(leftover).toEqual([]);
+    expect(existsSync(join(dotClaude, 'settings.local.json'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Phase **2 of 3** of activity-mirror v2 (spec `docs/specs/2026-06-14-dashboard-cc-activity-mirror-v2.md` §Component 1 + §Security + §P1#4). Phase 1 (relay) shipped in #596 (`5cde01fb`); phase 3 (dashboard render) follows. These hooks POST terminal activity to the `/dashboard/api/bridge/mirror` route #596 added.

consensus-id: 4a4b2087-01e049f1

## What this adds
Three `gossipcat hook mirror-*` subcommands (all **fail-open, exit 0, non-blocking**, no-op when no relay/auth):
- **`mirror-prompt`** (UserPromptSubmit) — POSTs the user prompt; structurally skips dashboard-origin turns (`^<channel source="gossipcat"`); never seeds a chat_id into the relay (P1#1).
- **`mirror-stop`** (Stop) — backward transcript scan for the last assistant `text` block; fail-open on tool-only/thinking-only/malformed/missing.
- **`mirror-tool`** (PostToolUse) — curated allowlist (Bash/Edit/Write/gossip dispatch-run-collect); scrubbed one-liner; **never forwards `tool_response`**.

Shared lib (`mirror-shared.ts`): **P1#4-hardened auth read** (single `openSync`+`fstatSync`, rejects `(mode & 0o077)!==0`, fail-open), and a **detached non-blocking POST** that pipes the Bearer header via `curl --config -` **stdin** — the key is never on argv or disk.

Settings installer `installMirrorHooks()` is included but **deliberately NOT auto-enabled** (these fire every turn; activation is a follow-up after live verification).

## Review trail
- **Consensus `4a4b2087-01e049f1`** (sonnet-reviewer + gemini-reviewer + deepseek-challenger, 2 rounds): **13 confirmed, 0 disputed**. Security core (auth read, scrub-then-truncate, `tool_response` exclusion, channel-tag match, fail-open dispatch) passed.
- **3 HIGH found and fixed before this PR:**
  - **Bearer key in `curl` argv** (`ps`/`/proc`-visible) → moved off argv to `curl --config -` stdin (kept detached/non-blocking; in-process `http` was rejected because it'd cut the request when the hook exits).
  - **JWT scrubber bypass** (bare JWT segments each <32 chars) → added `eyJ…\.eyJ…\.…` pattern.
  - **`mirror-tool` orchestration untested** → new `tests/cli/mirror-tool.test.ts` (allowlist, `tool_response` excluded, secret-redaction, malformed → no-op).
  - Plus 2 cheap lows: removed dead `chatId` extraction (future trust-boundary footgun), `Buffer.allocUnsafe`→`Buffer.alloc`.

## Verification
- `tsc --noEmit` → 0 errors (apps/cli + orchestrator)
- `jest` mirror suites → **59 passed / 6 suites** (incl. new `mirror-tool.test.ts`)

## Deferred (documented, non-blocking)
- Lowercase-prefixed short env-var secrets (`pwd=abc`) escape the scrubber — accepted limit of pattern-based best-effort scrubbing.
- `process.exit` asymmetry vs the bootstrap hook — cosmetic.
- Cross-process batching (one turn's hooks → one POST) — `postMirror` already accepts `frames[]`; a future batcher needs no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)