### PR TITLE
feat(provider): first-class grok (xAI) provider

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -125,7 +125,7 @@ export function loadConfig(configPath: string): GossipConfig {
 // enabled". Drift between these two lists means some values pass schema but
 // fail validateConfig (or vice versa) — that is a hard-to-diagnose user-facing
 // bug. If you change one, change the other.
-export const VALID_PROVIDERS = ['anthropic', 'openai', 'deepseek', 'openclaw', 'google', 'local', 'native', 'none'];
+export const VALID_PROVIDERS = ['anthropic', 'openai', 'deepseek', 'grok', 'openclaw', 'google', 'local', 'native', 'none'];
 
 // Upper bound for per-agent maxToolTurns. Enforced both here (validateConfig,
 // runtime load of .gossip/config.json) and in the gossip_setup Zod schema

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -838,7 +838,7 @@ export async function resolveAgentProvider(
 // tests/cli/config.test.ts asserts this matches VALID_MAIN_PROVIDERS in
 // apps/cli/src/config.ts so a provider can never pass schema validation but
 // fail at runtime (or vice versa).
-export const CREATE_PROVIDER_CASES = ['anthropic', 'openai', 'deepseek', 'openclaw', 'google', 'local', 'none'] as const;
+export const CREATE_PROVIDER_CASES = ['anthropic', 'openai', 'deepseek', 'grok', 'openclaw', 'google', 'local', 'none'] as const;
 
 export function createProvider(provider: string, model: string, apiKey?: string, projectRoot?: string, baseUrl?: string, authSlot?: string): ILLMProvider {
   switch (provider) {
@@ -854,6 +854,17 @@ export function createProvider(provider: string, model: string, apiKey?: string,
       apiKey ?? '', model, projectRoot,
       baseUrl ?? 'https://api.deepseek.com/v1',
       'deepseek', 600_000, 'DeepSeek', authSlot,
+    );
+    // xAI's Grok is OpenAI-wire-compatible at api.x.ai/v1 — reuse OpenAIProvider.
+    // Default the base_url to https://api.x.ai/v1 (an explicit base_url still
+    // overrides), give it a 'grok' quota slot, and a 'Grok' label so 401/403 auth
+    // errors name Grok instead of the generic "OpenAI-compatible".
+    // 600s timeout (like deepseek): grok-4 is a long-streaming reasoning model
+    // and the 120s default would terminate it mid-stream.
+    case 'grok': return new OpenAIProvider(
+      apiKey ?? '', model, projectRoot,
+      baseUrl ?? 'https://api.x.ai/v1',
+      'grok', 600_000, 'Grok', authSlot,
     );
     // OpenClaw is a remote agentic LLM with its own server-side tool chain
     // (web_fetch, exec, browser, etc.). Its wallclock regularly exceeds the

--- a/tests/orchestrator/create-provider-timeout.test.ts
+++ b/tests/orchestrator/create-provider-timeout.test.ts
@@ -14,3 +14,20 @@ describe('createProvider — deepseek timeout (regression: #522 missed the long 
     expect(p.timeoutMs).toBe(120_000);
   });
 });
+
+describe('createProvider — grok (xAI) provider arm', () => {
+  it('returns an OpenAIProvider pointed at the xAI endpoint with the Grok label', () => {
+    const p = createProvider('grok', 'grok-4', 'sk-test') as any;
+    expect(p.constructor.name).toBe('OpenAIProvider');
+    expect(p.baseUrl).toBe('https://api.x.ai/v1');
+    expect(p.providerLabel).toBe('Grok');
+  });
+  it('gives grok the 600s timeout (grok-4 is a long-streaming reasoning model)', () => {
+    const p = createProvider('grok', 'grok-4', 'sk-test') as any;
+    expect(p.timeoutMs).toBe(600_000);
+  });
+  it('honours an explicit base_url override', () => {
+    const p = createProvider('grok', 'grok-4', 'sk-test', undefined, 'https://proxy.example/v1') as any;
+    expect(p.baseUrl).toBe('https://proxy.example/v1');
+  });
+});


### PR DESCRIPTION
Adds **Grok (xAI)** as a first-class provider. xAI's API is OpenAI-wire-compatible at `https://api.x.ai/v1`, so this mirrors the existing `deepseek` arm — a validated pattern, no new abstraction.

## Changes
- **`packages/orchestrator/src/llm-client.ts`** — `case 'grok'` in `createProvider()` → `OpenAIProvider` with `base_url https://api.x.ai/v1`, quota slot `grok`, `'Grok'` error label, 600s timeout (grok-4 is a long-streaming reasoning model, like deepseek-reasoner). Added `'grok'` to `CREATE_PROVIDER_CASES`.
- **`apps/cli/src/config.ts`** — added `'grok'` to `VALID_PROVIDERS` (`VALID_MAIN_PROVIDERS` inherits it via `.filter`).
- **`tests/orchestrator/create-provider-timeout.test.ts`** — 3 tests: `createProvider('grok','grok-4')` → `OpenAIProvider`, `base_url` `https://api.x.ai/v1`, label `Grok`, 600s timeout, base_url override.

## Usage
A custom agent uses `provider: "grok"`, `model: "grok-4"`, and `key_ref` pointing at the OS-keychain service holding the xAI key (this operator stored it under service `xai`, so `key_ref: "xai"`).

## Verification
- `tsc --noEmit` → 0 errors (orchestrator + cli)
- `jest tests/cli/config.test.ts tests/orchestrator/create-provider-timeout.test.ts` → **52 passed**, incl. the `CREATE_PROVIDER_CASES` ↔ `VALID_MAIN_PROVIDERS` parity test (the gate that keeps schema-validation and runtime in sync)

## Note
Independent of the activity-mirror v2 PRs (#596 merged, #597 open) — different files, no stacking. After merge: `npm run build:mcp` + `/mcp` reconnect so the running relay picks up `case 'grok'`, then `gossip_setup` a grok agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)