### PR TITLE
feat(dashboard): activity-mirror v2 phase 3 — interleaved CC-transcript render

### DIFF
--- a/packages/dashboard-v2/src/components/ChatDock.tsx
+++ b/packages/dashboard-v2/src/components/ChatDock.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { navigate } from '@/lib/router';
 import { useBridgeContext } from '@/lib/BridgeContext';
-import { MessageBubble, StatusDot, AwaitingDots } from '@/components/chat/ChatPrimitives';
-import { ChatEmptyState } from '@/components/chat/ChatEmptyState';
+import { StatusDot, AwaitingDots } from '@/components/chat/ChatPrimitives';
+import { Transcript } from '@/components/chat/Transcript';
 
 /**
  * ChatDock — bottom-RIGHT docked conversation panel wired to the LIVE Claude
@@ -141,22 +141,9 @@ export function ChatDock() {
         </button>
       </div>
 
-      {/* Conversation */}
-      <div ref={scrollRef} className="flex-1 space-y-2 overflow-y-auto px-3 py-3">
-        {messages.length === 0 ? (
-          <ChatEmptyState
-            status={status}
-            onChipClick={(text) => {
-              setDraft(text);
-              // Focus the composer after chip click so user can send immediately.
-              requestAnimationFrame(() => inputRef.current?.focus());
-            }}
-            compact={true}
-          />
-        ) : (
-          messages.map((m) => <MessageBubble key={m.id} msg={m} compact={true} />)
-        )}
-
+      {/* Conversation — flowing CC-transcript view (activity-mirror v2) */}
+      <div ref={scrollRef} className="chat-surface flex-1 overflow-y-auto px-3 py-3">
+        <Transcript messages={messages} status={status} />
         {awaitingReply && <AwaitingDots compact={true} />}
       </div>
 

--- a/packages/dashboard-v2/src/components/ChatPage.tsx
+++ b/packages/dashboard-v2/src/components/ChatPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useBridgeContext } from '@/lib/BridgeContext';
-import { MessageBubble, AwaitingDots } from '@/components/chat/ChatPrimitives';
-import { ChatEmptyState } from '@/components/chat/ChatEmptyState';
+import { AwaitingDots } from '@/components/chat/ChatPrimitives';
+import { Transcript } from '@/components/chat/Transcript';
 import { SessionRail } from '@/components/chat/SessionRail';
 
 /**
@@ -61,14 +61,6 @@ export function ChatPage() {
     }
   };
 
-  /** Prefill the composer from an example chip click. */
-  const prefill = (text: string) => {
-    setDraft(text);
-    inputRef.current?.focus();
-  };
-
-  const hasMessages = messages.length > 0;
-
   return (
     /*
      * Outer shell: full viewport height minus topbar (~56px), padded at top.
@@ -117,39 +109,27 @@ export function ChatPage() {
          * the full column height.
          */}
         <div
-          className="flex flex-col"
+          className="chat-surface flex flex-col"
           style={{
             minHeight: 0,
             border: '1px solid var(--border)',
             borderRadius: 'var(--r-lg)',
-            background: 'var(--surface-elev)',
             overflow: 'hidden',
           }}
         >
-          {/* Scrollable transcript */}
+          {/* Scrollable transcript — flowing CC-transcript view (activity-mirror v2) */}
           <div
             ref={scrollRef}
             className="flex-1 overflow-y-auto"
             style={{
               padding: '20px 20px 8px',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '12px',
               // Ensure the scroll region fills the card height so the composer
               // stays pinned at the bottom even when there are few messages.
               minHeight: 0,
             }}
           >
-            {!hasMessages ? (
-              <ChatEmptyState status={status} onChipClick={prefill} />
-            ) : (
-              <>
-                {messages.map((m) => (
-                  <MessageBubble key={m.id} msg={m} compact={false} />
-                ))}
-                {awaitingReply && <AwaitingDots compact={false} />}
-              </>
-            )}
+            <Transcript messages={messages} status={status} />
+            {awaitingReply && <AwaitingDots compact={false} />}
           </div>
 
           {/* Transient send error — sits between transcript and composer */}

--- a/packages/dashboard-v2/src/components/chat/SessionRail.tsx
+++ b/packages/dashboard-v2/src/components/chat/SessionRail.tsx
@@ -224,7 +224,7 @@ export function SessionRail({ status, chatId }: SessionRailProps) {
             >
               <span
                 className="text-[11px]"
-                style={{ color: 'var(--ink-4)', fontVariant: 'small-caps', letterSpacing: '0.04em' }}
+                style={{ color: 'var(--ink-3)', fontVariant: 'small-caps', letterSpacing: '0.04em' }}
               >
                 working dir
               </span>
@@ -241,7 +241,7 @@ export function SessionRail({ status, chatId }: SessionRailProps) {
           <div style={{ display: 'flex', alignItems: 'baseline', gap: '6px' }}>
             <span
               className="text-[11px]"
-              style={{ color: 'var(--ink-4)', fontVariant: 'small-caps', letterSpacing: '0.04em' }}
+              style={{ color: 'var(--ink-3)', fontVariant: 'small-caps', letterSpacing: '0.04em' }}
             >
               tasks
             </span>
@@ -259,7 +259,7 @@ export function SessionRail({ status, chatId }: SessionRailProps) {
               <div style={{ display: 'flex', alignItems: 'baseline', gap: '6px' }}>
                 <span
                   className="text-[11px]"
-                  style={{ color: 'var(--ink-4)', fontVariant: 'small-caps', letterSpacing: '0.04em' }}
+                  style={{ color: 'var(--ink-3)', fontVariant: 'small-caps', letterSpacing: '0.04em' }}
                 >
                   signals
                 </span>
@@ -333,7 +333,7 @@ export function SessionRail({ status, chatId }: SessionRailProps) {
                 </span>
                 <span
                   className="font-mono text-[10px]"
-                  style={{ color: 'var(--ink-4)' }}
+                  style={{ color: 'var(--ink-3)' }}
                   aria-hidden
                 >
                   {timeShortFromTs(e.ts)}

--- a/packages/dashboard-v2/src/components/chat/Transcript.tsx
+++ b/packages/dashboard-v2/src/components/chat/Transcript.tsx
@@ -1,0 +1,140 @@
+import type { BridgeMessage, BridgeStatus } from '@/lib/useBridge';
+import { UserTurn, ProseBody, ActivityRow, AckRow, ErrorRow } from './transcript-parts';
+
+/**
+ * Transcript — the activity-mirror v2 "CC-transcript" render: a flowing,
+ * chronological thread (NOT chat bubbles) of user / assistant / activity / reply
+ * turns under one session chat_id (spec 2026-06-14-dashboard-cc-activity-mirror-v2.md
+ * §6, mockup docs/specs/mockups/chat-transcript-dark.html).
+ *
+ * Ordering: messages arrive pre-interleaved by server-stamped `ts` from
+ * useBridge.insertByTs, so this just maps them to turn rows.
+ *
+ * Look (scoped dark warm-charcoal — applied by the `.chat-surface` wrapper the
+ * caller renders this inside):
+ *   - user        → `›` --accent gutter + Geist body
+ *   - assistant   → `●` --ink-3 bullet + markdown prose (untrusted → renderer)
+ *   - activity    → muted system row, small-caps LABEL only
+ *   - ack/error   → status rows
+ * The `●` anchor is suppressed for assistant turns whose only body is an
+ * activity row (the row carries its own glyph) — design-review dedup.
+ *
+ * States (DESIGN.md State Coverage): loading=skeleton rows (no spinner);
+ * empty="No activity yet — terminal session idle"; error=chip-bad + last frames
+ * dimmed. `state` is derived by the caller from connection status + message count.
+ */
+
+interface TranscriptProps {
+  messages: readonly BridgeMessage[];
+  status: BridgeStatus;
+}
+
+/** Render one message as its transcript turn. */
+function Turn({ msg }: { msg: BridgeMessage }) {
+  switch (msg.role) {
+    case 'user':
+      return <UserTurn msg={msg} />;
+    case 'activity':
+      // Activity rows carry their own glyph → suppress the gutter ● anchor.
+      return (
+        <div className="cx-turn assistant">
+          <div className="cx-row">
+            <div className="cx-bullet" aria-hidden />
+            <div className="cx-body">
+              <ActivityRow text={msg.text} />
+            </div>
+          </div>
+        </div>
+      );
+    case 'ack':
+      return (
+        <div className="cx-turn assistant">
+          <div className="cx-row">
+            <div className="cx-bullet" aria-hidden />
+            <div className="cx-body">
+              <AckRow text={msg.text} />
+            </div>
+          </div>
+        </div>
+      );
+    case 'error':
+      return (
+        <div className="cx-turn assistant">
+          <div className="cx-row">
+            <div className="cx-bullet" aria-hidden />
+            <div className="cx-body">
+              <ErrorRow text={msg.text} />
+            </div>
+          </div>
+        </div>
+      );
+    case 'assistant':
+    default:
+      return (
+        <div className="cx-turn assistant">
+          <div className="cx-row">
+            <div className="cx-bullet" aria-hidden>
+              ●
+            </div>
+            <div className="cx-body">
+              <ProseBody text={msg.text} />
+            </div>
+          </div>
+        </div>
+      );
+  }
+}
+
+/** Loading skeleton — three shimmer rows, no spinner (DESIGN.md). */
+function LoadingState() {
+  return (
+    <div aria-busy="true" aria-label="Loading transcript">
+      <div className="cx-skel" style={{ width: '46%' }} />
+      <div className="cx-skel" style={{ width: '72%' }} />
+      <div className="cx-skel" style={{ width: '38%' }} />
+    </div>
+  );
+}
+
+/** Empty state — keep the frame, idle copy. */
+function EmptyState() {
+  return (
+    <div className="cx-state">
+      <span aria-hidden>○</span>
+      <span>No activity yet — terminal session idle</span>
+    </div>
+  );
+}
+
+export function Transcript({ messages, status }: TranscriptProps) {
+  const hasMessages = messages.length > 0;
+
+  // Loading: connecting with nothing to show yet → skeleton (no spinner).
+  if (!hasMessages && status === 'connecting') {
+    return <LoadingState />;
+  }
+
+  // Empty: connected/closed with no frames → idle copy, keep the frame.
+  if (!hasMessages) {
+    return <EmptyState />;
+  }
+
+  // Error: relay down → dim the last-known frames + a disconnect chip.
+  const dimmed = status === 'error';
+
+  return (
+    <div>
+      {dimmed && (
+        <div className="cx-state err" role="status">
+          <span className="cx-chip-bad">relay disconnected</span>
+          <span className="cx-dimmed">showing last-known frames</span>
+        </div>
+      )}
+      <div className={dimmed ? 'cx-dimmed' : undefined}>
+        {messages.map((m) => (
+          <Turn key={m.id} msg={m} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard-v2/src/components/chat/transcript-parts.tsx
+++ b/packages/dashboard-v2/src/components/chat/transcript-parts.tsx
@@ -1,0 +1,127 @@
+import { renderFindingMarkdown } from '@/lib/utils';
+import type { BridgeMessage } from '@/lib/useBridge';
+
+/**
+ * transcript-parts — render atoms for the activity-mirror v2 "CC-transcript"
+ * view (spec 2026-06-14-dashboard-cc-activity-mirror-v2.md §6, mockup
+ * docs/specs/mockups/chat-transcript-dark.html).
+ *
+ * SECURITY: mirror `text` is untrusted (spec P2 / security §). It is ALWAYS
+ * routed through renderFindingMarkdown (HTML-escapes first, then re-applies a
+ * fixed safe-tag allowlist) — never injected as raw HTML. Code fences render via
+ * that renderer's existing plain `<pre class="md-code-block">` path; syntax
+ * highlighting is intentionally OUT OF SCOPE for this PR (no tokenizer dep).
+ */
+
+/** A user turn: `›` gutter glyph in --accent + Geist body, no bubble chrome. */
+export function UserTurn({ msg }: { msg: BridgeMessage }) {
+  return (
+    <div className="cx-turn user">
+      <div className="cx-gutter" aria-hidden>
+        &rsaquo;
+      </div>
+      <div className="cx-body whitespace-pre-wrap break-words">{msg.text}</div>
+    </div>
+  );
+}
+
+/**
+ * ProseBody — assistant / mirrored prose rendered through the markdown renderer.
+ * Untrusted text is escaped by renderFindingMarkdown before any tag is re-applied.
+ */
+export function ProseBody({ text }: { text: string }) {
+  return (
+    <div
+      className="cx-prose finding-md"
+      // eslint-disable-next-line react/no-danger -- renderFindingMarkdown escapes
+      // all HTML first, then re-applies a fixed safe-tag allowlist (no raw passthrough).
+      dangerouslySetInnerHTML={{ __html: renderFindingMarkdown(text) }}
+    />
+  );
+}
+
+/**
+ * Parsed shape of a curated activity one-liner from the PostToolUse hook, e.g.
+ *   "🔧 Bash · npm run build:dashboard"  → { icon, label:'bash ·', cmd:'npm run …' }
+ *   "📡 dispatch → sonnet-reviewer"       → { icon, label:'dispatch →', agent:'sonnet-…' }
+ * Falls back to the raw text in `cmd` when it doesn't match either shape.
+ */
+export interface ParsedActivity {
+  icon: string;
+  label: string;
+  cmd?: string;
+  agent?: string;
+}
+
+const LEADING_ICON = /^([\p{Emoji_Presentation}\p{Extended_Pictographic}🔧📡🗒]+)\s*/u;
+
+export function parseActivity(text: string): ParsedActivity {
+  let icon = '';
+  let rest = text.trim();
+  const iconMatch = rest.match(LEADING_ICON);
+  if (iconMatch) {
+    icon = iconMatch[1];
+    rest = rest.slice(iconMatch[0].length).trim();
+  }
+
+  // dispatch / relay form: "<label> → <agent>"
+  const arrowIdx = rest.indexOf('→');
+  if (arrowIdx >= 0) {
+    const label = rest.slice(0, arrowIdx + 1).trim(); // keep the arrow in the label
+    const agent = rest.slice(arrowIdx + 1).trim();
+    return { icon, label, agent };
+  }
+
+  // tool form: "<label> · <command>"
+  const dotIdx = rest.indexOf('·');
+  if (dotIdx >= 0) {
+    const label = rest.slice(0, dotIdx + 1).trim(); // keep the middot in the label
+    const cmd = rest.slice(dotIdx + 1).trim();
+    return { icon, label, cmd };
+  }
+
+  // Unstructured fallback — show the whole thing as a command.
+  return { icon, label: '', cmd: rest };
+}
+
+/**
+ * ActivityRow — muted system row. The LABEL (`bash ·`, `dispatch →`) is
+ * small-caps --idle; the command (--ink-2) and agent (--info) stay normal-case
+ * JetBrains Mono per the design-review correction (small-caps the label only).
+ */
+export function ActivityRow({ text }: { text: string }) {
+  const { icon, label, cmd, agent } = parseActivity(text);
+  return (
+    <div className="cx-activity">
+      {icon && (
+        <span className="cx-ic" aria-hidden>
+          {icon}
+        </span>
+      )}
+      {label && <span className="cx-label">{label}</span>}
+      {agent && <span className="cx-agent">{agent}</span>}
+      {cmd && <span className={!label && !agent ? 'cx-cmd cx-cmd-bare' : 'cx-cmd'}>{cmd}</span>}
+    </div>
+  );
+}
+
+/** AckRow — dashboard "received — working…" status, muted. The row already
+ * sits under an empty gutter, so it carries no label glyph (small-caps is for
+ * labels only, not a bare separator). */
+export function AckRow({ text }: { text: string }) {
+  return (
+    <div className="cx-activity">
+      <span className="cx-cmd cx-cmd-bare">{text}</span>
+    </div>
+  );
+}
+
+/** ErrorRow — session error, --bad chip + message. */
+export function ErrorRow({ text }: { text: string }) {
+  return (
+    <div className="cx-state err" role="alert">
+      <span className="cx-chip-bad">session error</span>
+      <span>{text}</span>
+    </div>
+  );
+}

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -330,7 +330,7 @@
   --info: #7CC1C7;
   --info-soft: #1A2729;
   --severity-medium: #6E9BD4;
-  --cite-file: #6674C2;
+  --cite-file: #7A8ED6; /* AA on dark surfaces — bumped from #6674C2 (2026-06-15 a11y pass) */
   --cite-fn: #7A6FBA;
   --idle: #807A71;
   --idle-soft: #2A2722;
@@ -733,3 +733,196 @@ html[data-theme="dark"]::after {
   padding: 0;
   font-size: inherit;
 }
+
+/* ════════════════════════════════════════════════════════════════════════
+   Chat surface — activity-mirror v2 "CC-transcript" look
+   ────────────────────────────────────────────────────────────────────────
+   SCOPED dark warm-charcoal carve-out (DESIGN.md 2026-06-15 rows + spec
+   2026-06-14-dashboard-cc-activity-mirror-v2.md §6). These tokens override the
+   app theme ONLY inside `.chat-surface`; they do NOT leak app-wide. Values are
+   the AA-corrected mockup tokens (docs/specs/mockups/chat-transcript-dark.html).
+   ════════════════════════════════════════════════════════════════════════ */
+.chat-surface {
+  --bg: #14120F;
+  --surface: #1C1A16;
+  --surface-2: #232019;
+  --ink: #F2EDE3;
+  --ink-2: #B8B2A6;
+  --ink-3: #8A857B; /* AA text min (≈5.3:1 on --bg #14120F) — line numbers, hints, meta */
+  --ink-4: #6B6862; /* NON-TEXT only — gutter borders, decorative glyphs */
+  --border: #2A2620;
+  --border-strong: #3A3429;
+  --accent: #D58267;
+  --ok: #4FA97D;
+  --ok-soft: rgba(79, 169, 125, 0.13);
+  --bad: #D2697A;
+  --bad-soft: rgba(210, 105, 122, 0.13);
+  --warn: #D6A04E;
+  --info: #5FB0AA;
+  --idle: #8A867E;
+  --cite-file: #7A8ED6;
+  --cite-fn: #7A6FBA;
+  /* syntax palette — derived from chart/cite tokens, NEVER --accent */
+  --sx-keyword: #9D72A8;
+  --sx-string: #4FA97D;
+  --sx-number: #C99A52;
+  --sx-fn: #7A6FBA;
+  --sx-type: #5FB0AA;
+  --sx-comment: #9B958D;
+  --sx-punc: #B8B2A6;
+  --r-md: 8px;
+  --r-lg: 12px;
+
+  background: var(--bg);
+  color: var(--ink);
+  background-image: radial-gradient(120% 80% at 50% -10%, #1a1713 0%, #14120f 60%);
+}
+
+/* ── transcript turns ── */
+.cx-turn { margin: 0 0 22px; }
+.cx-turn + .cx-turn {
+  border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  padding-top: 18px;
+}
+.cx-turn.user { display: flex; gap: 11px; align-items: flex-start; }
+.cx-turn.user .cx-gutter {
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.4;
+  flex: none;
+  padding-top: 1px;
+}
+.cx-turn.user .cx-body { color: var(--ink-2); }
+.cx-row { display: flex; gap: 11px; align-items: flex-start; }
+.cx-bullet {
+  flex: none;
+  width: 14px;
+  text-align: center;
+  color: var(--ink-3);
+  font-size: 9px;
+  line-height: 1.9;
+  user-select: none;
+}
+.cx-body { flex: 1; min-width: 0; }
+
+/* prose (markdown) inside an assistant/mirror turn */
+.cx-prose { color: var(--ink); }
+.cx-prose p, .cx-prose { margin: 0 0 10px; }
+.cx-prose :last-child { margin-bottom: 0; }
+.cx-prose strong { color: var(--ink); font-weight: 600; }
+.cx-prose a {
+  color: var(--info);
+  text-decoration: none;
+  border-bottom: 1px solid color-mix(in srgb, var(--info) 40%, transparent);
+}
+.cx-prose code.md-inline-code,
+.cx-prose code.cite-fn {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  color: var(--ink);
+}
+.cx-prose code.cite-file {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--cite-file);
+  background: color-mix(in srgb, var(--cite-file) 12%, transparent);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+.cx-prose ul.md-list { list-style: disc; padding-left: 1.1rem; margin: 0.25rem 0; }
+.cx-prose h1.md-h1, .cx-prose h2.md-h2, .cx-prose h3.md-h3 {
+  color: var(--ink);
+  font-weight: 600;
+  margin: 0.4rem 0 0.2rem;
+}
+
+/* code fence (plain — NO syntax highlighting in this PR) */
+.cx-prose pre.md-code-block {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.6;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 10px 12px;
+  margin: 4px 0 12px;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--ink);
+}
+.cx-prose pre.md-code-block code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}
+
+/* ── activity row (curated tool/dispatch mirror) ── */
+.cx-activity {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 12.5px;
+  color: var(--ink-3);
+  margin: 0 0 9px;
+}
+.cx-activity .cx-label {
+  font-variant: small-caps;
+  letter-spacing: 0.02em;
+  color: var(--idle);
+}
+.cx-activity .cx-agent {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--info);
+}
+.cx-activity .cx-cmd {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--ink-2);
+}
+/* Unstructured / ack one-liners that parsed no label or agent — de-emphasize so
+ * they don't read as equal-weight body copy next to semantic activity rows. */
+.cx-activity .cx-cmd-bare {
+  color: var(--ink-3);
+}
+/* Emoji icon must not inherit small-caps from any future parent change. */
+.cx-activity .cx-ic {
+  font-variant: normal;
+}
+
+/* ── states ── */
+.cx-state {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 14px 12px;
+  border: 1px dashed var(--border);
+  border-radius: var(--r-md);
+  color: var(--ink-3);
+  font-size: 13px;
+  margin: 4px 0;
+}
+.cx-state.err { border-style: solid; }
+.cx-chip-bad {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  background: var(--bad-soft);
+  color: var(--bad);
+  font-family: var(--font-mono);
+}
+.cx-skel {
+  height: 11px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--border) 40%, transparent);
+  margin: 6px 0;
+}
+.cx-dimmed { opacity: 0.5; }

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -766,7 +766,7 @@ html[data-theme="dark"]::after {
   --sx-keyword: #9D72A8;
   --sx-string: #4FA97D;
   --sx-number: #C99A52;
-  --sx-fn: #7A6FBA;
+  --sx-fn: #7e72c0; /* AA on code-block surface --surface-sunk #131210 (was #7A6FBA, 4.29:1) */
   --sx-type: #5FB0AA;
   --sx-comment: #9B958D;
   --sx-punc: #B8B2A6;

--- a/packages/dashboard-v2/src/lib/__tests__/useBridge.test.tsx
+++ b/packages/dashboard-v2/src/lib/__tests__/useBridge.test.tsx
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useBridge } from '../useBridge';
+
+/**
+ * useBridge — activity-mirror v2 frame handling.
+ *
+ * Covers the new mirror/restart/last_id behavior on the SHARED bridge SSE stream
+ * (spec 2026-06-14-dashboard-cc-activity-mirror-v2.md §3/§6):
+ *   - mirror frame → appends a turn carrying role/text/ts/serverId
+ *   - chat_id filter still applies to mirror frames
+ *   - highest mirror id seen drives ?last_id on (re)connect
+ *   - restart frame → reset last_id to 0 and reconnect
+ *   - unknown frame type silently ignored (forward-compat)
+ */
+
+// ── Mock EventSource ────────────────────────────────────────────────────────
+const instances: MockEventSource[] = [];
+
+class MockEventSource {
+  url: string;
+  onopen: ((this: EventSource, ev: Event) => unknown) | null = null;
+  onmessage: ((this: EventSource, ev: MessageEvent) => unknown) | null = null;
+  onerror: ((this: EventSource, ev: Event) => unknown) | null = null;
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    instances.push(this);
+  }
+  close() {
+    this.closed = true;
+  }
+  /** Test helper: deliver a frame as an SSE message. */
+  emit(frame: unknown) {
+    this.onmessage?.call(this as unknown as EventSource, { data: JSON.stringify(frame) } as MessageEvent);
+  }
+  open() {
+    this.onopen?.call(this as unknown as EventSource, new Event('open'));
+  }
+}
+
+/** Read the last_id query param off a stream URL. */
+function lastIdOf(url: string): string {
+  return new URL(url, 'http://localhost').searchParams.get('last_id') ?? '';
+}
+
+let realEventSource: unknown;
+
+beforeEach(() => {
+  instances.length = 0;
+  // Patch ONLY window.EventSource on the real jsdom window — replacing the whole
+  // window would break @testing-library/react's render (needs jsdom document).
+  realEventSource = (window as unknown as { EventSource?: unknown }).EventSource;
+  (window as unknown as { EventSource: unknown }).EventSource = MockEventSource;
+  // POST is only exercised to mint a chat_id; stub fetch so send() resolves.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      status: 202,
+      json: async () => ({ ok: true, chat_id: 'chat-1' }),
+    })) as unknown as typeof fetch
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  (window as unknown as { EventSource: unknown }).EventSource = realEventSource;
+});
+
+/** Mount the hook and adopt chat_id 'chat-1' via a send() so frames pass the filter. */
+async function mountWithChat() {
+  const hook = renderHook(() => useBridge());
+  // The mount effect opens the first EventSource.
+  await waitFor(() => expect(instances.length).toBeGreaterThan(0));
+  act(() => instances[0].open());
+  await act(async () => {
+    await hook.result.current.send('hello');
+  });
+  await waitFor(() => expect(hook.result.current.chatId).toBe('chat-1'));
+  return hook;
+}
+
+describe('useBridge — ?last_id plumbing', () => {
+  it('opens the stream with last_id=0 on first connect', async () => {
+    renderHook(() => useBridge());
+    await waitFor(() => expect(instances.length).toBe(1));
+    expect(lastIdOf(instances[0].url)).toBe('0');
+  });
+});
+
+describe('useBridge — mirror frames', () => {
+  it('appends a mirror frame as a turn carrying role/text/ts/serverId', async () => {
+    const hook = await mountWithChat();
+    act(() => {
+      instances[0].emit({
+        type: 'mirror',
+        chat_id: 'chat-1',
+        role: 'assistant',
+        text: 'live answer',
+        ts: '2026-06-15T10:00:00.000Z',
+        id: 7,
+      });
+    });
+    await waitFor(() => {
+      const turns = hook.result.current.messages;
+      const mirror = turns.find((m) => m.text === 'live answer');
+      expect(mirror).toBeTruthy();
+      expect(mirror!.role).toBe('assistant');
+      expect(mirror!.serverId).toBe(7);
+    });
+  });
+
+  it('appends an activity-role mirror frame', async () => {
+    const hook = await mountWithChat();
+    act(() => {
+      instances[0].emit({
+        type: 'mirror',
+        chat_id: 'chat-1',
+        role: 'activity',
+        text: '🔧 bash · npm run build',
+        ts: '2026-06-15T10:00:01.000Z',
+        id: 8,
+      });
+    });
+    await waitFor(() =>
+      expect(hook.result.current.messages.some((m) => m.role === 'activity')).toBe(true)
+    );
+  });
+
+  it('drops a mirror frame whose chat_id does not match the active chat', async () => {
+    const hook = await mountWithChat();
+    const before = hook.result.current.messages.length;
+    act(() => {
+      instances[0].emit({
+        type: 'mirror',
+        chat_id: 'other-chat',
+        role: 'assistant',
+        text: 'should be filtered',
+        ts: '2026-06-15T10:00:02.000Z',
+        id: 99,
+      });
+    });
+    // No new turn should appear.
+    expect(hook.result.current.messages.length).toBe(before);
+    expect(hook.result.current.messages.some((m) => m.text === 'should be filtered')).toBe(false);
+  });
+
+  it('ignores an unknown frame type without throwing', async () => {
+    const hook = await mountWithChat();
+    const before = hook.result.current.messages.length;
+    act(() => {
+      instances[0].emit({ type: 'future-kind', chat_id: 'chat-1', text: 'x', ts: '2026-06-15T10:00:03.000Z' });
+    });
+    expect(hook.result.current.messages.length).toBe(before);
+  });
+
+  it('coerces a non-string text to empty instead of crashing the render', async () => {
+    const hook = await mountWithChat();
+    act(() => {
+      // Malformed relay payload: text is an object, not a string. The guard must
+      // coerce to '' so downstream .trim()/.replace() renderers don't throw.
+      instances[0].emit({
+        type: 'mirror',
+        chat_id: 'chat-1',
+        role: 'assistant',
+        text: { not: 'a string' },
+        ts: '2026-06-15T10:00:06.000Z',
+        id: 13,
+      });
+    });
+    await waitFor(() => {
+      const mirror = hook.result.current.messages.find((m) => m.serverId === 13);
+      expect(mirror).toBeTruthy();
+      expect(mirror!.text).toBe('');
+    });
+  });
+
+  it('ignores a mirror frame with an unknown role', async () => {
+    const hook = await mountWithChat();
+    const before = hook.result.current.messages.length;
+    act(() => {
+      instances[0].emit({
+        type: 'mirror',
+        chat_id: 'chat-1',
+        role: 'system',
+        text: 'unknown role',
+        ts: '2026-06-15T10:00:04.000Z',
+        id: 12,
+      });
+    });
+    expect(hook.result.current.messages.length).toBe(before);
+  });
+});
+
+describe('useBridge — last_id high-water mark', () => {
+  it('reconnects with ?last_id set to the highest mirror id seen', async () => {
+    await mountWithChat();
+    act(() => {
+      instances[0].emit({
+        type: 'mirror',
+        chat_id: 'chat-1',
+        role: 'assistant',
+        text: 'a',
+        ts: '2026-06-15T10:00:00.000Z',
+        id: 5,
+      });
+      instances[0].emit({
+        type: 'mirror',
+        chat_id: 'chat-1',
+        role: 'assistant',
+        text: 'b',
+        ts: '2026-06-15T10:00:01.000Z',
+        id: 9,
+      });
+    });
+    // Trigger a reconnect via onerror — the retry is scheduled behind a backoff
+    // timer, so drive it with fake timers to reach the second connect deterministically.
+    vi.useFakeTimers();
+    act(() => instances[0].onerror?.call(instances[0] as unknown as EventSource, new Event('error')));
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    vi.useRealTimers();
+    expect(instances.length).toBe(2);
+    expect(lastIdOf(instances[1].url)).toBe('9');
+  });
+});
+
+describe('useBridge — restart frame', () => {
+  it('resets last_id to 0 and reconnects on a restart frame', async () => {
+    await mountWithChat();
+    act(() => {
+      instances[0].emit({
+        type: 'mirror',
+        chat_id: 'chat-1',
+        role: 'assistant',
+        text: 'a',
+        ts: '2026-06-15T10:00:00.000Z',
+        id: 42,
+      });
+    });
+    // Restart → relay counter reset; client must drop last_id and refetch from 0.
+    act(() => {
+      instances[0].emit({ type: 'restart', chat_id: 'chat-1', ts: '2026-06-15T10:00:05.000Z' });
+    });
+    await waitFor(() => expect(instances.length).toBe(2));
+    expect(lastIdOf(instances[1].url)).toBe('0');
+    expect(instances[0].closed).toBe(true);
+  });
+});

--- a/packages/dashboard-v2/src/lib/useBridge.ts
+++ b/packages/dashboard-v2/src/lib/useBridge.ts
@@ -18,8 +18,19 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  * Backend contract (do NOT change — fixed by api-bridge.ts):
  *   POST /dashboard/api/bridge {chat_id?, message}
  *     → 202 {ok:true, chat_id} | 400 | 429 | 503
- *   GET  /dashboard/api/bridge/stream  (SSE)
- *     → frames {type:'reply'|'ack'|'error', chat_id, text?, ts}
+ *   GET  /dashboard/api/bridge/stream[?last_id=N]  (SSE)
+ *     Frames arriving on the SHARED stream (activity-mirror v2, spec
+ *     2026-06-14-dashboard-cc-activity-mirror-v2.md §5/§6):
+ *       {type:'reply'|'ack'|'error', chat_id, text?, ts}      — dashboard-typed turns
+ *       {type:'mirror', chat_id, role, text, ts, id}          — live CC-session mirror
+ *           role ∈ 'user'|'assistant'|'activity'; id is a per-chat_id monotonic
+ *           counter, ts is server-stamped ISO. On connect the relay replays this
+ *           chat_id's ring where id > ?last_id, then goes live.
+ *       {type:'restart', chat_id, ts}                          — relay restarted; the
+ *           per-chat_id counter reset to 1, so a client holding last_id=N would
+ *           starve waiting for id>N. Drop last_id and reconnect with ?last_id=0.
+ *   Forward-compat: any unknown frame `type` is silently ignored so a newer relay
+ *   can add frame kinds without breaking an older dashboard build.
  */
 
 // Minimal window surface — mirrors useEventStream so node/jsdom test envs that
@@ -30,16 +41,25 @@ declare const window:
     }
   | undefined;
 
-/** A single inbound SSE frame from the bridge. */
+/** A single inbound SSE frame from the bridge (known frame kinds only). */
 export interface BridgeFrame {
-  type: 'reply' | 'ack' | 'error';
+  type: 'reply' | 'ack' | 'error' | 'mirror' | 'restart';
   chat_id: string;
   text?: string;
   ts: string;
+  /** Present on `mirror` frames: 'user'|'assistant'|'activity'. */
+  role?: string;
+  /** Present on `mirror` frames: per-chat_id monotonic server counter. */
+  id?: number;
 }
 
-/** Role of a rendered conversation turn. */
-export type BridgeRole = 'user' | 'assistant' | 'ack' | 'error';
+/**
+ * Role of a rendered conversation turn.
+ *   user/assistant — typed turns AND mirrored CC-session prose
+ *   activity       — mirrored curated tool/dispatch row (v2)
+ *   ack/error      — dashboard-typed status frames
+ */
+export type BridgeRole = 'user' | 'assistant' | 'activity' | 'ack' | 'error';
 
 /** One rendered turn in the conversation view. */
 export interface BridgeMessage {
@@ -48,6 +68,12 @@ export interface BridgeMessage {
   role: BridgeRole;
   text: string;
   ts: string;
+  /**
+   * Server-assigned per-chat_id id for `mirror`-sourced turns (undefined for
+   * locally-minted user echoes and dashboard reply/ack/error turns). Used to
+   * track the high-water mark for ?last_id replay.
+   */
+  serverId?: number;
 }
 
 /** Connection lifecycle of the SSE stream. */
@@ -92,8 +118,26 @@ function postErrorMessage(status: number): string {
 }
 
 let nextMessageId = 1;
-function makeMessage(role: BridgeRole, text: string, ts?: string): BridgeMessage {
-  return { id: nextMessageId++, role, text, ts: ts ?? new Date().toISOString() };
+function makeMessage(role: BridgeRole, text: string, ts?: string, serverId?: number): BridgeMessage {
+  return { id: nextMessageId++, role, text, ts: ts ?? new Date().toISOString(), serverId };
+}
+
+/**
+ * Insert a message keeping the list ordered by server-stamped `ts` (ascending).
+ * Mirror frames and dashboard reply/ack/error frames arrive on the same stream
+ * but are not guaranteed to be globally ordered, so we interleave by ts.
+ *
+ * Optimistic local user echoes (no serverId, ts = client clock) are appended in
+ * arrival order: we only reorder when the incoming frame's ts is strictly older
+ * than the last turn, so a normal forward-moving stream stays append-only.
+ */
+function insertByTs(prev: readonly BridgeMessage[], msg: BridgeMessage): BridgeMessage[] {
+  const last = prev[prev.length - 1];
+  if (!last || msg.ts >= last.ts) return [...prev, msg];
+  // Out-of-order arrival: find the first turn strictly newer than msg and splice before it.
+  const idx = prev.findIndex((m) => m.ts > msg.ts);
+  if (idx < 0) return [...prev, msg];
+  return [...prev.slice(0, idx), msg, ...prev.slice(idx)];
 }
 
 export function useBridge(): UseBridgeResult {
@@ -112,6 +156,16 @@ export function useBridge(): UseBridgeResult {
     setChatId(id);
   }, []);
 
+  // Highest mirror `id` seen for the active chat. Read on each (re)connect to
+  // build ?last_id (mirrors useEventStream's read-on-open pattern so a reconnect
+  // replays only the gap). Reset to 0 on a `restart` frame (server counter reset)
+  // and a manual reconnect is triggered so the client doesn't starve on id>N.
+  const lastMirrorIdRef = useRef(0);
+  // Set by a `restart` frame to ask the open EventSource to close + reopen with
+  // ?last_id=0. Read by onerror's reconnect path is not enough (no error fires),
+  // so restart calls the captured reconnect() directly.
+  const reconnectRef = useRef<(() => void) | null>(null);
+
   // ── SSE stream: open once, manual reconnect, filter frames to active chat ──
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.EventSource === 'undefined') return;
@@ -125,7 +179,11 @@ export function useBridge(): UseBridgeResult {
     function open(): void {
       if (destroyed) return;
       setStatus('connecting');
-      es = new window!.EventSource(STREAM_PATH);
+      // Re-read the high-water mark on each (re)connect so a reconnect replays
+      // only the gap (id > lastSeen), per spec §3 / P1#3. ?last_id mirrors the
+      // working pattern in useEventStream.ts.
+      const lastId = lastMirrorIdRef.current;
+      es = new window!.EventSource(`${STREAM_PATH}?last_id=${lastId}`);
 
       es.onopen = () => {
         if (destroyed) return;
@@ -143,23 +201,31 @@ export function useBridge(): UseBridgeResult {
         }
         // Filter to the active conversation. Before our first send chatIdRef is
         // null and we have no stream to claim, so ignore frames until then.
+        // Mirror frames carry chat_id too — the same filter applies.
         const active = chatIdRef.current;
         if (!active || frame.chat_id !== active) return;
 
         if (frame.type === 'reply') {
           setAwaitingReply(false);
-          setMessages((prev) => [...prev, makeMessage('assistant', frame.text ?? '', frame.ts)]);
+          setMessages((prev) => insertByTs(prev, makeMessage('assistant', frame.text ?? '', frame.ts)));
         } else if (frame.type === 'ack') {
           // Ack means "received / working" — keep the awaiting indicator on but
           // record a discrete ack turn so the user sees the session is alive.
-          setMessages((prev) => [...prev, makeMessage('ack', 'received — working…', frame.ts)]);
+          setMessages((prev) => insertByTs(prev, makeMessage('ack', 'received — working…', frame.ts)));
         } else if (frame.type === 'error') {
           setAwaitingReply(false);
-          setMessages((prev) => [
-            ...prev,
-            makeMessage('error', frame.text ?? 'the live session reported an error', frame.ts),
-          ]);
+          setMessages((prev) =>
+            insertByTs(prev, makeMessage('error', frame.text ?? 'the live session reported an error', frame.ts))
+          );
+        } else if (frame.type === 'mirror') {
+          handleMirrorFrame(frame);
+        } else if (frame.type === 'restart') {
+          // Relay restarted → per-chat_id counter reset to 1. Drop our high-water
+          // mark and reconnect with ?last_id=0 so we don't starve on id>previous.
+          lastMirrorIdRef.current = 0;
+          reconnectRef.current?.();
         }
+        // Forward-compat: any other frame.type is silently ignored (staged rollout).
       };
 
       es.onerror = () => {
@@ -179,10 +245,46 @@ export function useBridge(): UseBridgeResult {
       };
     }
 
+    /** Append a `mirror` frame as a turn, tracking the high-water id. */
+    function handleMirrorFrame(frame: BridgeFrame): void {
+      const role = frame.role;
+      if (role !== 'user' && role !== 'assistant' && role !== 'activity') {
+        return; // unknown mirror role — ignore (forward-compat with future roles)
+      }
+      if (typeof frame.id === 'number' && frame.id > lastMirrorIdRef.current) {
+        lastMirrorIdRef.current = frame.id;
+      }
+      // An assistant mirror frame is the live session answering — clear the
+      // awaiting indicator so a typed turn's spinner doesn't linger.
+      if (role === 'assistant') setAwaitingReply(false);
+      // Coerce text defensively: a malformed relay payload could carry a
+      // non-string `text` (object/number), which would throw in the downstream
+      // .trim()/.replace() renderers. `?? ''` only guards null/undefined.
+      const text = typeof frame.text === 'string' ? frame.text : '';
+      setMessages((prev) => insertByTs(prev, makeMessage(role, text, frame.ts, frame.id)));
+    }
+
+    /** Close + reopen the stream immediately (used by the `restart` frame). */
+    function reconnect(): void {
+      if (destroyed) return;
+      if (retryTimer !== null) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+      if (es) {
+        es.close();
+        es = null;
+      }
+      backoff = BACKOFF_MIN_MS;
+      open();
+    }
+    reconnectRef.current = reconnect;
+
     open();
 
     return () => {
       destroyed = true;
+      reconnectRef.current = null;
       setStatus('closed');
       if (retryTimer !== null) clearTimeout(retryTimer);
       if (es) {


### PR DESCRIPTION
## What

Phase 3 (the final unbuilt piece) of the **activity-mirror v2** pipeline. Relay foundation (#596) and hooks (#597) are already merged; this renders the live Claude Code session as one chronological **interleaved transcript** in the dashboard chat surface.

**This is PR-A: the render pipeline only.** Syntax highlighting is intentionally deferred to a follow-up PR (PR-B) because its tokenizer needs a dependency-approval decision per CLAUDE.md. Code fences keep rendering via the existing `renderFindingMarkdown` plain `<pre>` path; **no new dependency is added.**

Spec: `docs/specs/2026-06-14-dashboard-cc-activity-mirror-v2.md` §6

## Changes

**`useBridge.ts`** — extend the SHARED bridge SSE stream handling:
- `mirror` frames → append a turn (role `user`/`assistant`/`activity`, text, ts, server id)
- `restart` frame → reset the high-water id to 0 + synchronous reconnect (`?last_id=0`)
- `?last_id=N` plumbed onto the stream URL (highest mirror id seen, re-read per connect)
- ts-ordered interleave via `insertByTs`; unknown frame type / role silently ignored (forward-compat)
- defensive: coerce non-string `frame.text` to `''` (malformed-payload DoS guard — from security review)

**`components/chat/Transcript.tsx` + `transcript-parts.tsx`** (new) — flowing CC-transcript (not bubbles): `›` user gutter, `●` assistant anchor (suppressed on activity-only turns), muted small-caps activity LABEL only, loading/empty/error states. Untrusted mirror text routed through `renderFindingMarkdown` (HTML-escaped, never raw).

**`globals.css`** — `.chat-surface`-scoped warm-charcoal dark tokens (AA-corrected, no app-wide leak).

**Pre-existing #592 a11y fixes folded in** (they're on the chat surface this PR activates):
- `SessionRail` text labels + timestamps `--ink-4` → `--ink-3` (were the wrong NON-TEXT-ONLY token)
- `[data-theme=dark] --cite-file` `#6674C2` → `#7A8ED6` (completes the 2026-06-15 a11y pass)

## Review

Pre-merge consensus (3 agents, 2 rounds): **13 confirmed / 1 disputed / 5 unique**.
- **Security**: no XSS — `renderFindingMarkdown` escape-first ordering confirmed safe for `dangerouslySetInnerHTML`. One LOW input-validation gap (non-string `frame.text`) — **fixed** + regression test added.
- **SSE correctness**: `insertByTs` ordering, `?last_id` high-water, restart reconnect + cleanup, forward-compat — all confirmed correct.
- **Design/a11y**: all actionable findings fixed; the 1 disputed finding (`.cx-ic` reset) was correctly refuted (defensive-only) and added anyway as harmless hardening.

consensus-id: 60c6fb12-37064c1a

## Verification

- `tsc --noEmit` clean; **vitest 21/21** (9 new useBridge + 12 existing)
- Visually verified live on `:63007/dashboard/chat` (gstack browse): page loads, dark `#14120F` chat surface, empty state renders exact copy "No activity yet — terminal session idle", skeleton loading state, SSE stream `?last_id=0 → 200`, SessionRail labels now AA-readable (`--ink-3`).

## Follow-ups (not in this PR)

- **PR-B**: syntax highlighting (needs a dependency decision — highlight.js subset / Shiki-at-build / hand-rolled)
- Wire `installMirrorHooks()` on (deliberately not auto-enabled) to feed live mirror frames
- `dot-ok` glow on `StatusDot` (touches pre-existing shared primitive)
- Error-state temporal qualifier ("last update Xm ago" — needs prop plumbing)
- Remove orphaned `MessageBubble`/`ChatEmptyState`
- **Pre-existing bug observed during browse:** `SessionRail` fetches `/dashboard/api/dashboard/api/session` (doubled prefix) → 404; the session rail stays in "connecting". Not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)