### PR TITLE
fix(tools): byte-based file_read cap at 512KB (correct the msgpack budget)

### DIFF
--- a/packages/tools/src/tool-server.ts
+++ b/packages/tools/src/tool-server.ts
@@ -76,13 +76,39 @@ function truncateAtLine(text: string, maxLength: number): string {
 }
 
 /**
- * Cap for file_read results. Must stay comfortably under the relay WS
- * maxPayload (1 MB, packages/relay/src/server.ts:107) even after JSON-envelope
- * escaping (~2x worst case) AND when multiple file_reads land in the same turn.
- * 256 KB × 2 (escaping) × 2 (two reads) = 1 MB — right at the limit, so the
- * cap itself provides the safety margin.
+ * Truncate text so its UTF-8 byte length stays <= maxBytes, without splitting
+ * a multi-byte character. Prefers cutting at the last newline in the second
+ * half of the slice so the returned string ends at a clean line boundary.
  */
-const MAX_FILE_READ_CHARS = 256 * 1024;
+function truncateToBytes(text: string, maxBytes: number): string {
+  if (Buffer.byteLength(text, 'utf8') <= maxBytes) return text;
+  // Slice to maxBytes, then decode — the subarray may end mid-char, but
+  // TextDecoder with fatal:false replaces the incomplete sequence with U+FFFD.
+  let slice = Buffer.from(text, 'utf8').subarray(0, maxBytes).toString('utf8');
+  // Strip any trailing replacement character left by the incomplete sequence.
+  // Use the � escape (not a literal char) so a build/encoding transform
+  // can't silently break the strip and let the result exceed maxBytes.
+  slice = slice.replace(/\uFFFD$/, '');
+  // Prefer cutting at a newline in the latter half of the slice to avoid
+  // dropping a large chunk of content due to an early newline.
+  const midpoint = Math.floor(slice.length / 2);
+  const lastNl = slice.lastIndexOf('\n');
+  if (lastNl > midpoint) slice = slice.slice(0, lastNl);
+  return slice;
+}
+
+/**
+ * Cap for file_read results (byte-based). Each file_read response is its own WS
+ * message bounded by the relay maxPayload of 1 MB (packages/relay/src/server.ts:107)
+ * — reads are NOT batched into one frame. The envelope is MessagePack-encoded
+ * (Codec in @gossip/client / @msgpack/msgpack), NOT JSON: a string costs its raw
+ * UTF-8 bytes + a ≤5-byte length prefix, with no per-character escaping. So a
+ * 512 KB result is ~512 KB on the wire (~half the limit), plus a small msgpack
+ * envelope and the ~100-byte truncation notice — comfortable headroom, no
+ * JSON-style 2× escaping factor. The cap is also a sane content ceiling: agents
+ * should range-read (startLine/endLine) rather than dump near-MB files.
+ */
+const MAX_FILE_READ_BYTES = 512 * 1024;
 
 export class ToolServer {
   private agent: GossipAgent;
@@ -346,10 +372,10 @@ export class ToolServer {
           }
         }
         let fileContent = await this.fileTools.fileRead(args as { path: string; startLine?: number; endLine?: number }, agentRoot);
-        if (fileContent.length > MAX_FILE_READ_CHARS) {
-          const originalLength = fileContent.length;
-          fileContent = truncateAtLine(fileContent, MAX_FILE_READ_CHARS)
-            + `\n\n[file_read truncated: file is ${originalLength} chars (cap ${MAX_FILE_READ_CHARS}); read a specific range with startLine/endLine]`;
+        if (Buffer.byteLength(fileContent, 'utf8') > MAX_FILE_READ_BYTES) {
+          const originalBytes = Buffer.byteLength(fileContent, 'utf8');
+          fileContent = truncateToBytes(fileContent, MAX_FILE_READ_BYTES)
+            + `\n\n[file_read truncated: ${originalBytes} bytes (cap ${MAX_FILE_READ_BYTES}); read a specific range with startLine/endLine]`;
         }
         return fileContent;
       }

--- a/tests/tools/tool-server-file-read-cap.test.ts
+++ b/tests/tools/tool-server-file-read-cap.test.ts
@@ -5,9 +5,11 @@ import * as os from 'os';
 import * as path from 'path';
 import { ToolServer } from '../../packages/tools/src/tool-server';
 
-// MAX_FILE_READ_CHARS is 256 * 1024 = 262144. Mirror the constant here so
-// the tests are self-documenting without importing internals.
-const MAX_FILE_READ_CHARS = 256 * 1024;
+// MAX_FILE_READ_BYTES is 512 * 1024 = 524288. Mirror the constant here so
+// the tests are self-documenting without importing internals. The cap is
+// BYTE-based (the WS maxPayload limit is in bytes), so a multi-byte file can
+// exceed it with far fewer chars.
+const MAX_FILE_READ_BYTES = 512 * 1024;
 
 // Mock GossipAgent to avoid actual relay connection
 vi.mock('@gossip/client', () => ({
@@ -36,14 +38,13 @@ describe('ToolServer file_read cap (MESSAGE_TOO_BIG guard)', () => {
     fs.rmSync(projectRoot, { recursive: true, force: true });
   });
 
-  it('truncates a file larger than MAX_FILE_READ_CHARS and appends notice', async () => {
-    // Write a file that is clearly over the cap once line-annotated.
+  it('truncates a file larger than MAX_FILE_READ_BYTES and appends notice', async () => {
+    // Write a file that is clearly over the byte cap once line-annotated.
     // fileRead prepends line numbers ("N\t") which adds overhead.
-    // Use enough lines to ensure annotated output > MAX_FILE_READ_CHARS.
-    // Each line: "a".repeat(79) + "\n" = 80 raw chars.
-    // After annotation: "N\t" + "a".repeat(79) = 82-87 chars per line.
-    // 3500 such lines = ~285 KB annotated → safely above the 256 KB cap.
-    const lineCount = 3500;
+    // Each line: "a".repeat(79) + "\n" = 80 raw bytes (ASCII).
+    // After annotation: "N\t" + "a".repeat(79) = 82-87 bytes per line.
+    // 7000 such lines = ~580 KB annotated → above the 512 KB cap.
+    const lineCount = 7000;
     const lineContent = 'a'.repeat(79);
     const bigContent = (lineContent + '\n').repeat(lineCount);
     const bigPath = path.join(projectRoot, 'big.txt');
@@ -54,15 +55,38 @@ describe('ToolServer file_read cap (MESSAGE_TOO_BIG guard)', () => {
     expect(typeof result).toBe('string');
     const resultStr = result as string;
 
-    // Total length must not exceed cap + notice length (notice is ~150 chars max)
-    expect(resultStr.length).toBeLessThanOrEqual(MAX_FILE_READ_CHARS + 200);
+    // Total UTF-8 bytes must not exceed cap + the small notice (~100 bytes).
+    expect(Buffer.byteLength(resultStr, 'utf8')).toBeLessThanOrEqual(MAX_FILE_READ_BYTES + 300);
+    // The truncated BODY (before the notice) must be bounded to the cap itself.
+    const body = resultStr.split('\n\n[file_read truncated:')[0];
+    expect(Buffer.byteLength(body, 'utf8')).toBeLessThanOrEqual(MAX_FILE_READ_BYTES);
 
-    // Must end with the truncation notice
+    // Must end with the byte-reporting truncation notice
     expect(resultStr).toContain('[file_read truncated:');
-    // Notice must report original (annotated) length as a number
-    expect(resultStr).toMatch(/file is \d+ chars/);
-    expect(resultStr).toContain(`cap ${MAX_FILE_READ_CHARS}`);
+    expect(resultStr).toMatch(/\d+ bytes \(cap/);
+    expect(resultStr).toContain(`cap ${MAX_FILE_READ_BYTES}`);
     expect(resultStr).toContain('startLine/endLine');
+  });
+
+  it('truncates a multi-byte file that exceeds the BYTE cap with fewer chars (emoji)', async () => {
+    // Each 😀 is 4 UTF-8 bytes. 100 per line + "\n" = ~401 bytes/line; line-number
+    // annotation adds a few more. 1500 lines ≈ 610 KB bytes but only ~150K chars —
+    // the OLD char cap (256K chars) would have MISSED this; the byte cap catches it.
+    const emojiLine = '😀'.repeat(100) + '\n';
+    const content = Array.from({ length: 1500 }, () => emojiLine).join('');
+    fs.writeFileSync(path.join(projectRoot, 'emoji.txt'), content);
+
+    const result = await server.executeTool('file_read', { path: 'emoji.txt' }, undefined);
+    const resultStr = result as string;
+
+    expect(resultStr).toContain('[file_read truncated:');
+    expect(resultStr).toMatch(/\d+ bytes \(cap/);
+    expect(resultStr).toContain(`cap ${MAX_FILE_READ_BYTES}`);
+    // Byte-bounded, no split multi-byte char (no U+FFFD) in the body before the notice.
+    expect(Buffer.byteLength(resultStr, 'utf8')).toBeLessThanOrEqual(MAX_FILE_READ_BYTES + 300);
+    const body = resultStr.split('\n\n[file_read truncated:')[0];
+    expect(Buffer.byteLength(body, 'utf8')).toBeLessThanOrEqual(MAX_FILE_READ_BYTES);
+    expect(body).not.toMatch(/�/);
   });
 
   it('returns small file content unchanged (no notice appended)', async () => {
@@ -78,7 +102,7 @@ describe('ToolServer file_read cap (MESSAGE_TOO_BIG guard)', () => {
     expect(resultStr).toContain('const y = 2;');
     expect(resultStr).not.toContain('[file_read truncated:');
     // Small file well under cap
-    expect(resultStr.length).toBeLessThan(MAX_FILE_READ_CHARS);
+    expect(Buffer.byteLength(resultStr, 'utf8')).toBeLessThan(MAX_FILE_READ_BYTES);
   });
 
   it('ranged read (startLine/endLine) of a large file returns small slice without truncation notice', async () => {


### PR DESCRIPTION
Follow-up to #594 (which added a 256KB **char**-based `file_read` cap to prevent WS `MESSAGE_TOO_BIG (1009)` disconnects). Two corrections, both surfaced while answering "why 400KB and not 512KB?".

## 1 — Byte-based, not char-based
The WS `maxPayload` (1 MB) is in **bytes**, but the old cap was in **chars**. A multi-byte file (CJK/emoji, up to 4 bytes/char) could exceed the byte budget at far fewer chars and still trigger the 1009 disconnect. New helper `truncateToBytes()`:
- caps on `Buffer.byteLength`,
- never splits a multi-byte char (strips a trailing U+FFFD left by a mid-sequence cut — uses the `�` escape so a build transform can't break it),
- prefers a line boundary,
- **guarantees `byteLength <= maxBytes`** (reviewer-verified across all cut positions).

## 2 — 256KB → 512KB, and the rationale corrected
#594's comment justified the cap with "×2 JSON-escape worst case." But the envelope is **MessagePack-encoded** (`Codec` / `@msgpack/msgpack` at `gossip-agent.ts:205`, decoded at `relay/server.ts:390`), **not JSON** — only the auth handshake is JSON. msgpack stores a string as **raw UTF-8 bytes + a ≤5-byte length prefix**, with no per-char escaping. So:
- a 512KB result is **~512KB on the wire** (~half the 1MB limit) + a small envelope + ~100B notice — comfortable headroom,
- the "×2" factor that drove 256KB (and a transitional 400KB) was a **false JSON premise**,
- 512KB is safe and a saner content ceiling (agents should range-read near-MB files rather than dump them).

## Review
A focused resource-safety review (sonnet-reviewer) confirmed the `truncateToBytes` invariant (`byteLength <= maxBytes` on every path), confirmed `file_grep`/`file_write`/scope-check are untouched, and **independently flagged the msgpack-vs-JSON correction** — folded in here, along with its suggestion to assert body-only `byteLength` separately from the +notice total.

## Verification
- `tsc --noEmit` clean; **jest 4/4** — over-cap ASCII (~580KB), multi-byte emoji over-cap (~610KB; under the old 256K char cap, over the byte cap), under-cap unchanged, ranged read no-truncate. Body-only `byteLength <= cap` asserted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)