### PR TITLE
fix: post-cross-review items — grok gossip_setup enums (#598) + dashboard cleanup

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -144,7 +144,7 @@ const KEY_REF_PATTERN = /^[a-zA-Z0-9_-]{1,32}$/;
 // from the agent's own provider is very likely an operator typo (the agent would
 // authenticate with the wrong key), so validateConfig WARNS — not a hard error,
 // because a shared custom service name across providers is a legitimate use. #522
-const WELL_KNOWN_KEY_SERVICES = ['anthropic', 'openai', 'deepseek', 'openclaw', 'google'];
+const WELL_KNOWN_KEY_SERVICES = ['anthropic', 'openai', 'deepseek', 'grok', 'openclaw', 'google'];
 
 // Subset for `main_agent.provider`: 'native' is excluded because the main
 // agent must be able to invoke a real LLM (the orchestrator that dispatches
@@ -157,6 +157,17 @@ const WELL_KNOWN_KEY_SERVICES = ['anthropic', 'openai', 'deepseek', 'openclaw', 
 // throw "Unknown provider: native" at boot. 'native' remains valid for
 // `utility_model.provider` and `agents[*].provider` where it's design-correct.
 export const VALID_MAIN_PROVIDERS = VALID_PROVIDERS.filter(p => p !== 'native');
+
+// Provider enums for the gossip_setup MCP tool's intake schema
+// (apps/cli/src/mcp-server-sdk.ts). z.enum requires a literal tuple, so these
+// cannot be derived from VALID_PROVIDERS at runtime — the parity test in
+// tests/cli/config.test.ts asserts they stay in lockstep. This closes the gap
+// that shipped grok in #598 (added to VALID_PROVIDERS + createProvider) but left
+// it unsettable via gossip_setup because the Zod enums were not updated.
+//   MCP_MAIN_PROVIDER_ENUM   ≡ VALID_MAIN_PROVIDERS (orchestrator LLM; no 'native')
+//   MCP_CUSTOM_PROVIDER_ENUM ≡ VALID_PROVIDERS minus 'native' and 'none' (custom agents)
+export const MCP_MAIN_PROVIDER_ENUM = ['anthropic', 'openai', 'deepseek', 'grok', 'openclaw', 'google', 'local', 'none'] as const;
+export const MCP_CUSTOM_PROVIDER_ENUM = ['anthropic', 'openai', 'deepseek', 'grok', 'openclaw', 'google', 'local'] as const;
 
 const CLAUDE_MODEL_MAP: Record<string, { provider: string; model: string }> = {
   opus:   { provider: 'anthropic', model: 'claude-opus-4-6' },

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -226,7 +226,7 @@ import { createServer as createHttpServer, IncomingMessage, ServerResponse } fro
 
 // ── Extracted modules ────────────────────────────────────────────────────
 import { ctx, NATIVE_TASK_TTL_MS } from './mcp-context';
-import { MAX_TOOL_TURNS_CEILING } from './config';
+import { MAX_TOOL_TURNS_CEILING, MCP_MAIN_PROVIDER_ENUM, MCP_CUSTOM_PROVIDER_ENUM } from './config';
 import { getGossipcatVersion } from './version';
 import { captureGitStatus, checkUnexpectedChanges } from './utility-guard';
 import { buildUtilityAgentPrompt, getUncategorizedStatusLine, checkDistMcpStaleness, logStalenessToMcpLog, isValidCategory, seedPermanentDefaults, GLOBAL_PERMANENT_DEFAULTS, IMPLEMENTER_PERMANENT_DEFAULTS, RESEARCHER_REVIEWER_PERMANENT_DEFAULTS } from '@gossip/orchestrator';
@@ -2440,7 +2440,7 @@ export function createMcpServer(): McpServer {
       // lens generator, gossip publisher all call createProvider on this value),
       // and createProvider has no 'native' branch. 'native' remains valid for
       // utility_model and per-agent overrides.
-      main_provider: z.enum(['anthropic', 'openai', 'deepseek', 'openclaw', 'google', 'local', 'none']).default('google')
+      main_provider: z.enum(MCP_MAIN_PROVIDER_ENUM).default('google')
         .describe('Provider for the orchestrator LLM. Use "none" when no API key is available — features degrade gracefully to profile-based. Note: "native" is not valid here (use it only for utility_model or per-agent overrides).'),
       main_model: z.string().default('gemini-2.5-pro')
         .describe('Model ID for orchestrator (e.g. gemini-2.5-pro, claude-sonnet-4-6, gpt-4o)'),
@@ -2463,7 +2463,7 @@ export function createMcpServer(): McpServer {
         instructions: z.string().optional()
           .describe('For native agents: full instructions (markdown body of .claude/agents/*.md)'),
         // Custom agent fields
-        provider: z.enum(['anthropic', 'openai', 'deepseek', 'openclaw', 'google', 'local']).optional()
+        provider: z.enum(MCP_CUSTOM_PROVIDER_ENUM).optional()
           .describe('For custom agents: LLM provider'),
         custom_model: z.string().optional()
           .describe('For custom agents: model ID (e.g. gemini-2.5-pro, gpt-4o, claude-sonnet-4-6)'),

--- a/packages/dashboard-v2/src/components/chat/transcript-parts.tsx
+++ b/packages/dashboard-v2/src/components/chat/transcript-parts.tsx
@@ -13,7 +13,16 @@ import type { BridgeMessage } from '@/lib/useBridge';
  * highlighting is intentionally OUT OF SCOPE for this PR (no tokenizer dep).
  */
 
-/** A user turn: `›` gutter glyph in --accent + Geist body, no bubble chrome. */
+/**
+ * A user turn: `›` gutter glyph in --accent + Geist body, no bubble chrome.
+ *
+ * `msg.text` is rendered as a React text child (NOT through renderFindingMarkdown)
+ * — INTENTIONALLY. User/terminal-prompt mirror frames are plain text, and React
+ * auto-escapes the string so this is XSS-safe. Do NOT "upgrade" this to
+ * dangerouslySetInnerHTML / renderFindingMarkdown to get markdown styling without
+ * re-auditing the trust boundary: this text crosses the same untrusted hook→relay
+ * →SSE path as assistant frames.
+ */
 export function UserTurn({ msg }: { msg: BridgeMessage }) {
   return (
     <div className="cx-turn user">

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -837,11 +837,10 @@ html[data-theme="dark"]::after {
 .cx-prose p, .cx-prose { margin: 0 0 10px; }
 .cx-prose :last-child { margin-bottom: 0; }
 .cx-prose strong { color: var(--ink); font-weight: 600; }
-.cx-prose a {
-  color: var(--info);
-  text-decoration: none;
-  border-bottom: 1px solid color-mix(in srgb, var(--info) 40%, transparent);
-}
+/* No `.cx-prose a` rule: renderFindingMarkdown emits no <a> tags (untrusted
+ * mirror text). If a markdown-link pass is ever added, the renderer MUST validate
+ * the URL scheme (reject javascript:/data:) and set rel="noopener noreferrer"
+ * before any link styling is reintroduced here. */
 .cx-prose code.md-inline-code,
 .cx-prose code.cite-fn {
   font-family: var(--font-mono);

--- a/packages/dashboard-v2/src/lib/useBridge.ts
+++ b/packages/dashboard-v2/src/lib/useBridge.ts
@@ -261,7 +261,12 @@ export function useBridge(): UseBridgeResult {
       // non-string `text` (object/number), which would throw in the downstream
       // .trim()/.replace() renderers. `?? ''` only guards null/undefined.
       const text = typeof frame.text === 'string' ? frame.text : '';
-      setMessages((prev) => insertByTs(prev, makeMessage(role, text, frame.ts, frame.id)));
+      // Guard the ts too: insertByTs orders by lexicographic string compare, so a
+      // malformed/empty ts from a relay bug would mis-sort (e.g. '' jumps to the
+      // top). Drop a non-ISO ts to undefined so makeMessage stamps the local clock
+      // and the frame interleaves near "now" instead of at an arbitrary position.
+      const ts = typeof frame.ts === 'string' && /^\d{4}-\d{2}-\d{2}T/.test(frame.ts) ? frame.ts : undefined;
+      setMessages((prev) => insertByTs(prev, makeMessage(role, text, ts, frame.id)));
     }
 
     /** Close + reopen the stream immediately (used by the `restart` frame). */

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { validateConfig, findConfigPath, configToAgentConfigs, loadClaudeSubagents, VALID_MAIN_PROVIDERS } from '../../apps/cli/src/config';
+import { validateConfig, findConfigPath, configToAgentConfigs, loadClaudeSubagents, VALID_MAIN_PROVIDERS, VALID_PROVIDERS, MCP_MAIN_PROVIDER_ENUM, MCP_CUSTOM_PROVIDER_ENUM } from '../../apps/cli/src/config';
 import { CREATE_PROVIDER_CASES } from '../../packages/orchestrator/src/llm-client';
 
 describe('Config Validation', () => {
@@ -121,6 +121,22 @@ describe('Config Validation', () => {
       const config = validateConfig({ main_agent: { provider: p, model: 'x' } });
       expect(config.main_agent.provider).toBe(p);
     }
+  });
+
+  // Guards the #598 drift: grok was added to VALID_PROVIDERS + createProvider but
+  // NOT to the gossip_setup Zod enums, so operators couldn't create a Grok agent.
+  // The enums must be supersettable from the canonical lists, so a new provider
+  // can't reach VALID_PROVIDERS without also reaching the MCP intake schema.
+  it('gossip_setup provider Zod enums stay in lockstep with VALID_PROVIDERS', () => {
+    const sorted = (a: readonly string[]) => [...a].sort();
+    // main_provider intake ≡ VALID_MAIN_PROVIDERS (orchestrator LLM; excludes 'native')
+    expect(sorted(MCP_MAIN_PROVIDER_ENUM)).toEqual(sorted(VALID_MAIN_PROVIDERS));
+    // per-agent custom provider ≡ VALID_PROVIDERS minus 'native' and 'none'
+    const customExpected = VALID_PROVIDERS.filter((p) => p !== 'native' && p !== 'none');
+    expect(sorted(MCP_CUSTOM_PROVIDER_ENUM)).toEqual(sorted(customExpected));
+    // grok specifically must be settable both ways (the exact #598 gap).
+    expect(MCP_MAIN_PROVIDER_ENUM).toContain('grok');
+    expect(MCP_CUSTOM_PROVIDER_ENUM).toContain('grok');
   });
 });
 


### PR DESCRIPTION
Findings from the **post-merge cross-review of the last 5 PRs** (#598–#602). Only #598 had a real defect; the rest were confirmed sound, so this also folds in the few worthwhile low-hanging items.

## #598 — MEDIUM (real, verified): grok unreachable via `gossip_setup`
`grok` was added to `VALID_PROVIDERS` + `createProvider`, but **not** to the two Zod intake enums in `mcp-server-sdk.ts` (`mcp-server-sdk.ts` had zero mentions of `grok`). So `gossip_setup` rejected creating a Grok agent or setting Grok as the orchestrator — the documented operator path (`provider:'grok'`) was dead. CI missed it because the parity test only checked `VALID_PROVIDERS ⊆ CREATE_PROVIDER_CASES`, not the enums.

**Drift-proof fix:**
- Export `MCP_MAIN_PROVIDER_ENUM` / `MCP_CUSTOM_PROVIDER_ENUM` (as-const tuples) from `config.ts` and use them in both `z.enum()` sites, so the intake schema can't drift from the canonical lists again.
- New parity test asserts the enums set-equal `VALID_MAIN_PROVIDERS` / `VALID_PROVIDERS\{native,none}` and that `grok` is settable — locks the exact gap that shipped.

## #598 — LOW
`grok` added to `WELL_KNOWN_KEY_SERVICES`, so a `key_ref:'anthropic'` typo on a grok agent **warns** instead of silently authenticating against `api.x.ai` and 401-ing.

## #599 low-hanging (render cross-review)
- **Removed the dead `.cx-prose a` rule** — `renderFindingMarkdown` emits no `<a>` tags; left a comment that any future link pass must validate the URL scheme (reject `javascript:`/`data:`) + add `rel="noopener noreferrer"`. (A latent link-injection trap, gone.)
- **Guard malformed `frame.ts`** in `handleMirrorFrame` — a non-ISO `ts` from a relay bug is dropped to `undefined` so `makeMessage` stamps now (insertByTs sorts lexicographically; `''` would otherwise jump to the top).
- **Documented `UserTurn`'s intentional plain-text render** (React auto-escapes user mirror text — XSS-safe; the comment warns against "upgrading" it to `renderFindingMarkdown` without re-auditing the boundary).

## Confirmed sound (no changes needed)
- **#600/#601**: the nested-fence truncation in #600 was already fixed by #601 (deepseek adversarial pass: all 3 fixes correct, no regressions).
- **#602**: `truncateToBytes` invariant fuzz-confirmed across all cut positions; msgpack budget correct.

## Verification
`tests/cli/config.test.ts` **47/47** (incl. new parity test + grok acceptance), `apps/cli` tsc clean, dashboard tsc + **vitest 41/41**, `build:mcp` clean (grok present in the bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)