### PR TITLE
fix(cli): make activity-mirror hooks actually fire from the built binary + opt-in mirror_hooks in gossip_setup

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -9,6 +9,9 @@
 import { createWriteStream, mkdirSync } from 'fs';
 import { join } from 'path';
 import { runHook } from './hook-run';
+import { runMirrorPromptHook } from './hooks/mirror-prompt';
+import { runMirrorStopHook } from './hooks/mirror-stop';
+import { runMirrorToolHook } from './hooks/mirror-tool';
 import { parseHookSubcommand } from './hook-argv';
 import { getLastKnownLatest, checkForUpgrade, isUpgradeAvailable } from './upgrade-check';
 
@@ -72,24 +75,32 @@ export function classifyShimSubcommand(
  * shim previously sent every non-usage decision to `runHook()`).
  *
  * The returned shape mirrors index.ts:75-97. 'usage' → exit 2; 'run' → the
- * synchronous bootstrap hook; the mirror kinds → an async handler module +
- * exported function name (dynamic-imported, fail-open).
+ * synchronous bootstrap hook; the mirror kinds → a direct reference to the
+ * async handler fn (statically imported + fail-open).
+ *
+ * The handler is returned as a `run` fn reference — NOT a module path + fn
+ * name string — because this file is the esbuild --bundle entrypoint. A
+ * runtime `await import('./hooks/mirror-prompt')` is left un-inlined by
+ * esbuild and resolves against a non-existent `dist-mcp/hooks/` dir at
+ * runtime, throwing into the fail-open catch{} and silently dropping the
+ * frame. Static top-level imports get bundled, so referencing the fn keeps
+ * the handler body inside the single-file artifact.
  */
 export function resolveHookAction(
   decision: import('./hook-argv').HookSubcommand,
 ):
   | { action: 'usage' }
   | { action: 'run' }
-  | { action: 'mirror'; module: string; fn: string } {
+  | { action: 'mirror'; run: () => Promise<void> } {
   switch (decision) {
     case 'run':
       return { action: 'run' };
     case 'mirror-prompt':
-      return { action: 'mirror', module: './hooks/mirror-prompt', fn: 'runMirrorPromptHook' };
+      return { action: 'mirror', run: runMirrorPromptHook };
     case 'mirror-stop':
-      return { action: 'mirror', module: './hooks/mirror-stop', fn: 'runMirrorStopHook' };
+      return { action: 'mirror', run: runMirrorStopHook };
     case 'mirror-tool':
-      return { action: 'mirror', module: './hooks/mirror-tool', fn: 'runMirrorToolHook' };
+      return { action: 'mirror', run: runMirrorToolHook };
     case 'usage':
     default:
       return { action: 'usage' };
@@ -119,11 +130,10 @@ const __argvShimHandled = (() => {
     // async work keeps the event loop alive and exits when done. A thrown error
     // or missing relay must never propagate to a non-zero exit that would block
     // the user's turn.
-    const { module: mirrorModule, fn: mirrorFn } = hookAction;
+    const mirrorRun = hookAction.run;
     void (async () => {
       try {
-        const mod = (await import(mirrorModule)) as Record<string, () => Promise<void>>;
-        await mod[mirrorFn]();
+        await mirrorRun();
       } catch {
         // fail-open — swallow.
       }

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -138,7 +138,13 @@ const __argvShimHandled = (() => {
         // fail-open — swallow.
       }
       process.exit(0);
-    })();
+    })().catch(() => {
+      // Defense-in-depth backstop, parity with the key/code branches. The inner
+      // try/catch already covers handler throws; this guards a future edit that
+      // introduces an await before the try. Mirror hooks are fail-open and must
+      // NEVER block a turn, so swallow and exit 0 (NOT exit 1 like key/code).
+      process.exit(0);
+    });
     return true; // async handler owns the process; do NOT boot the MCP server
   }
   if (kind === 'help') {
@@ -148,6 +154,7 @@ const __argvShimHandled = (() => {
       'Usage:\n' +
       '  gossipcat                Start MCP server (for Claude Code / Cursor)\n' +
       '  gossipcat hook --run     Run UserPromptSubmit bootstrap hook (internal)\n' +
+      '  gossipcat hook mirror-prompt|mirror-stop|mirror-tool   Activity-mirror hooks (internal; opt-in via gossip_setup mirror_hooks)\n' +
       '  gossipcat key set <provider>   Store an API key in the OS keychain (service: gossip-mesh)\n' +
       '  gossipcat key list             Show which providers have a stored key\n' +
       '  gossipcat code [args...]       Launch Claude Code with the gossipcat channel active\n' +

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -63,6 +63,39 @@ export function classifyShimSubcommand(
   return 'unknown';
 }
 
+/**
+ * Map a `parseHookSubcommand` decision to the dist-mcp shim's action.
+ *
+ * Exported so unit tests can assert routing without spawning the bundle: each
+ * mirror decision must dispatch its matching async handler module, never fall
+ * through to the synchronous bootstrap `runHook()` (the bug this fixes — the
+ * shim previously sent every non-usage decision to `runHook()`).
+ *
+ * The returned shape mirrors index.ts:75-97. 'usage' → exit 2; 'run' → the
+ * synchronous bootstrap hook; the mirror kinds → an async handler module +
+ * exported function name (dynamic-imported, fail-open).
+ */
+export function resolveHookAction(
+  decision: import('./hook-argv').HookSubcommand,
+):
+  | { action: 'usage' }
+  | { action: 'run' }
+  | { action: 'mirror'; module: string; fn: string } {
+  switch (decision) {
+    case 'run':
+      return { action: 'run' };
+    case 'mirror-prompt':
+      return { action: 'mirror', module: './hooks/mirror-prompt', fn: 'runMirrorPromptHook' };
+    case 'mirror-stop':
+      return { action: 'mirror', module: './hooks/mirror-stop', fn: 'runMirrorStopHook' };
+    case 'mirror-tool':
+      return { action: 'mirror', module: './hooks/mirror-tool', fn: 'runMirrorToolHook' };
+    case 'usage':
+    default:
+      return { action: 'usage' };
+  }
+}
+
 const __argvShimHandled = (() => {
   const argv = process.argv.slice(2);
   const sub = argv[0];
@@ -70,12 +103,33 @@ const __argvShimHandled = (() => {
 
   if (kind === 'hook') {
     const decision = parseHookSubcommand(argv[1]);
-    if (decision === 'usage') {
-      process.stderr.write('Usage: gossipcat hook --run\n');
+    const hookAction = resolveHookAction(decision);
+    if (hookAction.action === 'usage') {
+      process.stderr.write('Usage: gossipcat hook --run | mirror-prompt | mirror-stop | mirror-tool\n');
       process.exit(2);
     }
-    runHook();
-    process.exit(0);
+    if (hookAction.action === 'run') {
+      runHook();
+      process.exit(0);
+    }
+    // Activity-mirror hooks (mirror-prompt|mirror-stop|mirror-tool) are async,
+    // fail-open + non-blocking — mirrors index.ts:80-97. The shim is a
+    // synchronous IIFE, so we must NOT exit(0) before the async handler
+    // resolves: spawn it and `return true` (like the key/code branches) so the
+    // async work keeps the event loop alive and exits when done. A thrown error
+    // or missing relay must never propagate to a non-zero exit that would block
+    // the user's turn.
+    const { module: mirrorModule, fn: mirrorFn } = hookAction;
+    void (async () => {
+      try {
+        const mod = (await import(mirrorModule)) as Record<string, () => Promise<void>>;
+        await mod[mirrorFn]();
+      } catch {
+        // fail-open — swallow.
+      }
+      process.exit(0);
+    })();
+    return true; // async handler owns the process; do NOT boot the MCP server
   }
   if (kind === 'help') {
     process.stdout.write(
@@ -2449,6 +2503,8 @@ export function createMcpServer(): McpServer {
       instruction_agent_ids: z.union([z.string(), z.array(z.string())]).optional().describe('Agent IDs for instruction update'),
       instruction_update: z.string().optional().describe('Instruction text to append/replace'),
       instruction_mode: z.enum(['append', 'replace']).optional().describe('How to apply instruction update'),
+      mirror_hooks: z.boolean().default(false)
+        .describe('Opt-in (default false): install the activity-mirror hooks (UserPromptSubmit/Stop/PostToolUse) into .claude/settings.local.json so the live CC session is mirrored into the dashboard. OFF by default because these hooks mirror tool I/O externally — only enable after verifying the relay + dashboard render are ready.'),
       agents: z.array(z.object({
         id: z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/, 'Agent ID must be alphanumeric with hyphens/underscores — path separators and ".." are rejected').describe('Agent ID (lowercase, hyphens). e.g. "claude-reviewer", "gemini-impl"'),
         type: z.enum(['native', 'custom']).describe(
@@ -2485,7 +2541,7 @@ export function createMcpServer(): McpServer {
           .describe(`Per-agent tool-turn budget override (integer in [1, ${MAX_TOOL_TURNS_CEILING}]). Defaults to 15 when omitted. Useful for slow-reasoning agents (e.g. deepseek-reasoner) that need more turns per cross-review. NOTE: re-declaring an existing agent replaces its whole config entry (even in merge mode) — omitting this field on a re-declare resets the agent to the default.`),
       })).describe('Array of agents to create'),
     },
-    async ({ main_provider, main_model, mode, agents, instruction_agent_ids, instruction_update, instruction_mode }) => {
+    async ({ main_provider, main_model, mode, agents, instruction_agent_ids, instruction_update, instruction_mode, mirror_hooks }) => {
       if (mode === 'update_instructions') {
         if (!instruction_agent_ids || !instruction_update) {
           return { content: [{ type: 'text' as const, text: 'Error: update_instructions mode requires instruction_agent_ids and instruction_update' }] };
@@ -2779,6 +2835,37 @@ export function createMcpServer(): McpServer {
         process.stderr.write(`[gossipcat] gossip_setup: discipline hook install failed: ${e}\n`);
       }
 
+      // Activity-mirror hooks — OPT-IN ONLY (default OFF). These mirror the live
+      // CC session's tool I/O into the dashboard, so they are never auto-enabled:
+      // installMirrorHooks runs only when the caller passes mirror_hooks:true.
+      let mirrorSummary = '';
+      if (mirror_hooks === true) {
+        try {
+          process.stderr.write(
+            '[gossipcat] Installing activity-mirror hooks into .claude/settings.local.json ' +
+            '(UserPromptSubmit/Stop/PostToolUse). Opt-in: mirrors tool I/O to the dashboard. ' +
+            'To skip: omit mirror_hooks or delete the entries after install.\n',
+          );
+          const { installMirrorHooks } = require('@gossip/orchestrator') as typeof import('@gossip/orchestrator');
+          const mirrorResult = installMirrorHooks(root);
+          if (mirrorResult.reason) {
+            mirrorSummary = `Mirror hooks: skipped (${mirrorResult.reason})`;
+          } else if (mirrorResult.installed.length > 0) {
+            mirrorSummary = `Mirror hooks: installed [${mirrorResult.installed.join(', ')}]`;
+            if (mirrorResult.skipped.length > 0) {
+              mirrorSummary += `, already present [${mirrorResult.skipped.join(', ')}]`;
+            }
+          } else {
+            mirrorSummary = 'Mirror hooks: already present (no changes)';
+          }
+        } catch (e) {
+          mirrorSummary = `Mirror hooks: skipped (${(e as Error).message})`;
+          process.stderr.write(`[gossipcat] gossip_setup: mirror hook install failed: ${e}\n`);
+        }
+      } else {
+        mirrorSummary = 'Mirror hooks: not enabled (opt-in — pass mirror_hooks:true to install)';
+      }
+
       // Bootstrap UserPromptSubmit hook (mtime-keyed sentinel) — spec
       // 2026-05-07-bootstrap-hook-trim. Idempotent: upgrades legacy
       // `cat .gossip/bootstrap.md` hooks, no-ops if already current, leaves
@@ -2877,6 +2964,9 @@ export function createMcpServer(): McpServer {
       }
       if (disciplineSummary) {
         lines.push(disciplineSummary);
+      }
+      if (mirrorSummary) {
+        lines.push(mirrorSummary);
       }
       lines.push('Agents will connect to relay on first gossip_dispatch() call.');
       if (nativeCreated.length > 0) {

--- a/tests/cli/mirror-hooks-setup-optin.test.ts
+++ b/tests/cli/mirror-hooks-setup-optin.test.ts
@@ -1,0 +1,144 @@
+/**
+ * gossip_setup handler — activity-mirror hooks are OPT-IN (default OFF).
+ *
+ * The activity-mirror hooks (UserPromptSubmit/Stop/PostToolUse) mirror the live
+ * CC session's tool I/O into the dashboard. They are NEVER auto-enabled:
+ * installMirrorHooks runs only when the caller passes `mirror_hooks: true`.
+ *
+ * Like mcp-server-setup-dashboard.test.ts, we test the gating logic layer
+ * (mirroring the block in mcp-server-sdk.ts) rather than the full HTTP handler,
+ * which requires a live relay + agent config. The source-text assertions below
+ * lock the structural invariants of the real handler so the simulation cannot
+ * silently diverge.
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+interface MirrorHookInstallResult {
+  installed: string[];
+  skipped: string[];
+  reason?: string;
+}
+
+/**
+ * Mirrors the mirror-hooks gating block from the gossip_setup handler:
+ * installMirrorHooks(root) runs ONLY when mirror_hooks === true; otherwise the
+ * settings file is never touched and an opt-in advisory line is appended.
+ */
+function buildMirrorSummary(opts: {
+  mirror_hooks: boolean | undefined;
+  install: () => MirrorHookInstallResult;
+}): string {
+  let mirrorSummary = '';
+  if (opts.mirror_hooks === true) {
+    try {
+      const mirrorResult = opts.install();
+      if (mirrorResult.reason) {
+        mirrorSummary = `Mirror hooks: skipped (${mirrorResult.reason})`;
+      } else if (mirrorResult.installed.length > 0) {
+        mirrorSummary = `Mirror hooks: installed [${mirrorResult.installed.join(', ')}]`;
+        if (mirrorResult.skipped.length > 0) {
+          mirrorSummary += `, already present [${mirrorResult.skipped.join(', ')}]`;
+        }
+      } else {
+        mirrorSummary = 'Mirror hooks: already present (no changes)';
+      }
+    } catch (e) {
+      mirrorSummary = `Mirror hooks: skipped (${(e as Error).message})`;
+    }
+  } else {
+    mirrorSummary = 'Mirror hooks: not enabled (opt-in — pass mirror_hooks:true to install)';
+  }
+  return mirrorSummary;
+}
+
+describe('gossip_setup — mirror hooks opt-in gating', () => {
+  it('mirror_hooks:true → installMirrorHooks IS invoked', () => {
+    let called = 0;
+    const summary = buildMirrorSummary({
+      mirror_hooks: true,
+      install: () => {
+        called += 1;
+        return { installed: ['mirror-prompt', 'mirror-stop', 'mirror-tool'], skipped: [] };
+      },
+    });
+    expect(called).toBe(1);
+    expect(summary).toContain('Mirror hooks: installed [mirror-prompt, mirror-stop, mirror-tool]');
+  });
+
+  it('mirror_hooks:false → installMirrorHooks NOT invoked, no settings mutation', () => {
+    let called = 0;
+    const summary = buildMirrorSummary({
+      mirror_hooks: false,
+      install: () => {
+        called += 1;
+        return { installed: [], skipped: [] };
+      },
+    });
+    expect(called).toBe(0);
+    expect(summary).toContain('not enabled (opt-in');
+  });
+
+  it('mirror_hooks absent (undefined) → installMirrorHooks NOT invoked (default OFF)', () => {
+    let called = 0;
+    const summary = buildMirrorSummary({
+      mirror_hooks: undefined,
+      install: () => {
+        called += 1;
+        return { installed: [], skipped: [] };
+      },
+    });
+    expect(called).toBe(0);
+    expect(summary).toContain('not enabled (opt-in');
+  });
+
+  it('mirror_hooks:true with all already present → "already present (no changes)"', () => {
+    const summary = buildMirrorSummary({
+      mirror_hooks: true,
+      install: () => ({ installed: [], skipped: ['mirror-prompt', 'mirror-stop', 'mirror-tool'] }),
+    });
+    expect(summary).toBe('Mirror hooks: already present (no changes)');
+  });
+
+  it('mirror_hooks:true with a malformed-settings reason → skipped (reason)', () => {
+    const summary = buildMirrorSummary({
+      mirror_hooks: true,
+      install: () => ({ installed: [], skipped: [], reason: 'settings.local.json is malformed' }),
+    });
+    expect(summary).toBe('Mirror hooks: skipped (settings.local.json is malformed)');
+  });
+
+  it('mirror_hooks:true install throw → fail-soft skipped summary (no propagation)', () => {
+    const summary = buildMirrorSummary({
+      mirror_hooks: true,
+      install: () => { throw new Error('boom'); },
+    });
+    expect(summary).toBe('Mirror hooks: skipped (boom)');
+  });
+});
+
+// ── Source-text assertions — lock the real handler's gating invariants ───────
+describe('gossip_setup source — mirror_hooks opt-in invariants', () => {
+  const SRC: string = readFileSync(
+    resolve(__dirname, '..', '..', 'apps', 'cli', 'src', 'mcp-server-sdk.ts'),
+    'utf-8',
+  );
+
+  it('declares a mirror_hooks boolean flag defaulting to false', () => {
+    expect(SRC).toMatch(/mirror_hooks:\s*z\.boolean\(\)\.default\(false\)/);
+  });
+
+  it('destructures mirror_hooks in the handler args', () => {
+    expect(SRC).toMatch(/instruction_mode,\s*mirror_hooks\s*\}/);
+  });
+
+  it('installMirrorHooks is gated behind mirror_hooks === true', () => {
+    // The install call must sit inside the `mirror_hooks === true` branch.
+    expect(SRC).toMatch(/if \(mirror_hooks === true\)[\s\S]*?installMirrorHooks\(root\)/);
+  });
+
+  it('the else branch never installs (opt-in advisory only)', () => {
+    expect(SRC).toMatch(/not enabled \(opt-in/);
+  });
+});

--- a/tests/cli/shim-subcommand-classify.test.ts
+++ b/tests/cli/shim-subcommand-classify.test.ts
@@ -138,7 +138,10 @@ describe('classifyShimSubcommand', () => {
 describe('resolveHookAction', () => {
   let resolveAction: (
     decision: string,
-  ) => { action: string; module?: string; fn?: string };
+  ) => { action: string; run?: () => Promise<void> };
+  let mirrorPrompt: { runMirrorPromptHook: () => Promise<void> };
+  let mirrorStop: { runMirrorStopHook: () => Promise<void> };
+  let mirrorTool: { runMirrorToolHook: () => Promise<void> };
 
   beforeAll(() => {
     const savedArgv = process.argv;
@@ -149,6 +152,14 @@ describe('resolveHookAction', () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const mod = require('../../apps/cli/src/mcp-server-sdk') as typeof import('../../apps/cli/src/mcp-server-sdk');
       resolveAction = mod.resolveHookAction as typeof resolveAction;
+      // Same module instances the shim statically imports — identity comparison
+      // below proves resolveHookAction returns the bundled handler references.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      mirrorPrompt = require('../../apps/cli/src/hooks/mirror-prompt');
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      mirrorStop = require('../../apps/cli/src/hooks/mirror-stop');
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      mirrorTool = require('../../apps/cli/src/hooks/mirror-tool');
     });
     process.argv = savedArgv;
     if (savedEnv === undefined) {
@@ -167,27 +178,21 @@ describe('resolveHookAction', () => {
   });
 
   it('maps "mirror-prompt" → async runMirrorPromptHook (NOT runHook)', () => {
-    expect(resolveAction('mirror-prompt')).toEqual({
-      action: 'mirror',
-      module: './hooks/mirror-prompt',
-      fn: 'runMirrorPromptHook',
-    });
+    const a = resolveAction('mirror-prompt');
+    expect(a.action).toBe('mirror');
+    expect(a.run).toBe(mirrorPrompt.runMirrorPromptHook);
   });
 
   it('maps "mirror-stop" → async runMirrorStopHook (NOT runHook)', () => {
-    expect(resolveAction('mirror-stop')).toEqual({
-      action: 'mirror',
-      module: './hooks/mirror-stop',
-      fn: 'runMirrorStopHook',
-    });
+    const a = resolveAction('mirror-stop');
+    expect(a.action).toBe('mirror');
+    expect(a.run).toBe(mirrorStop.runMirrorStopHook);
   });
 
   it('maps "mirror-tool" → async runMirrorToolHook (NOT runHook)', () => {
-    expect(resolveAction('mirror-tool')).toEqual({
-      action: 'mirror',
-      module: './hooks/mirror-tool',
-      fn: 'runMirrorToolHook',
-    });
+    const a = resolveAction('mirror-tool');
+    expect(a.action).toBe('mirror');
+    expect(a.run).toBe(mirrorTool.runMirrorToolHook);
   });
 
   it('no mirror decision resolves to the bootstrap run action (the bug)', () => {
@@ -222,8 +227,20 @@ describe('argv shim source — hook branch mirror dispatch', () => {
   it("the hook branch's mirror path returns true so the async handler owns the process", () => {
     // The mirror dispatch must `return true` (like code/key) so the synchronous
     // IIFE does NOT exit(0) before the async handler resolves. We anchor on the
-    // dynamic-import of the resolved mirror module followed by `return true`.
-    expect(SRC).toMatch(/await import\(mirrorModule\)[\s\S]*?return true;/);
+    // direct call of the resolved handler fn followed by `return true`.
+    expect(SRC).toMatch(/await mirrorRun\(\)[\s\S]*?return true;/);
+  });
+
+  it('the mirror handlers are STATIC top-level imports (so esbuild bundles them)', () => {
+    // The bug this fixes: a runtime `await import('./hooks/mirror-*')` is left
+    // un-inlined by esbuild --bundle and resolves against a non-existent
+    // dist-mcp/hooks/ dir → throws into fail-open catch{} → no frame. Static
+    // imports get bundled into the single-file artifact.
+    expect(SRC).toMatch(/import \{ runMirrorPromptHook \} from '\.\/hooks\/mirror-prompt';/);
+    expect(SRC).toMatch(/import \{ runMirrorStopHook \} from '\.\/hooks\/mirror-stop';/);
+    expect(SRC).toMatch(/import \{ runMirrorToolHook \} from '\.\/hooks\/mirror-tool';/);
+    // No runtime dynamic import of the mirror modules survives in the shim.
+    expect(SRC).not.toMatch(/await import\(mirrorModule\)/);
   });
 
   it('usage message lists the mirror subcommands', () => {

--- a/tests/cli/shim-subcommand-classify.test.ts
+++ b/tests/cli/shim-subcommand-classify.test.ts
@@ -129,3 +129,104 @@ describe('classifyShimSubcommand', () => {
     expect(classify('setup')).toBe('unknown');
   });
 });
+
+// ── resolveHookAction unit tests ────────────────────────────────────────────
+// The dist-mcp shim's `hook` branch must dispatch each mirror decision to its
+// async handler module — NOT fall through to the synchronous bootstrap
+// runHook(). This regression-tests the bug where the bundled binary sent every
+// non-usage decision (incl. mirror-prompt|mirror-stop|mirror-tool) to runHook().
+describe('resolveHookAction', () => {
+  let resolveAction: (
+    decision: string,
+  ) => { action: string; module?: string; fn?: string };
+
+  beforeAll(() => {
+    const savedArgv = process.argv;
+    const savedEnv = process.env.GOSSIPCAT_MCP_NO_MAIN;
+    process.argv = ['node', 'mcp-server.js'];
+    process.env.GOSSIPCAT_MCP_NO_MAIN = '1';
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mod = require('../../apps/cli/src/mcp-server-sdk') as typeof import('../../apps/cli/src/mcp-server-sdk');
+      resolveAction = mod.resolveHookAction as typeof resolveAction;
+    });
+    process.argv = savedArgv;
+    if (savedEnv === undefined) {
+      delete process.env.GOSSIPCAT_MCP_NO_MAIN;
+    } else {
+      process.env.GOSSIPCAT_MCP_NO_MAIN = savedEnv;
+    }
+  });
+
+  it('maps "run" → synchronous bootstrap hook', () => {
+    expect(resolveAction('run')).toEqual({ action: 'run' });
+  });
+
+  it('maps "usage" → usage', () => {
+    expect(resolveAction('usage')).toEqual({ action: 'usage' });
+  });
+
+  it('maps "mirror-prompt" → async runMirrorPromptHook (NOT runHook)', () => {
+    expect(resolveAction('mirror-prompt')).toEqual({
+      action: 'mirror',
+      module: './hooks/mirror-prompt',
+      fn: 'runMirrorPromptHook',
+    });
+  });
+
+  it('maps "mirror-stop" → async runMirrorStopHook (NOT runHook)', () => {
+    expect(resolveAction('mirror-stop')).toEqual({
+      action: 'mirror',
+      module: './hooks/mirror-stop',
+      fn: 'runMirrorStopHook',
+    });
+  });
+
+  it('maps "mirror-tool" → async runMirrorToolHook (NOT runHook)', () => {
+    expect(resolveAction('mirror-tool')).toEqual({
+      action: 'mirror',
+      module: './hooks/mirror-tool',
+      fn: 'runMirrorToolHook',
+    });
+  });
+
+  it('no mirror decision resolves to the bootstrap run action (the bug)', () => {
+    for (const d of ['mirror-prompt', 'mirror-stop', 'mirror-tool']) {
+      expect(resolveAction(d).action).toBe('mirror');
+      expect(resolveAction(d).action).not.toBe('run');
+    }
+  });
+});
+
+// ── Source-text assertions — hook branch dispatches mirror subcommands ───────
+// Locks the dist-mcp shim's `hook` branch structure so the async/fail-open
+// lifecycle (return true, no premature exit) cannot silently regress.
+describe('argv shim source — hook branch mirror dispatch', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const fs = require('fs');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const pathMod = require('path');
+  const SRC: string = fs.readFileSync(
+    pathMod.resolve(__dirname, '..', '..', 'apps', 'cli', 'src', 'mcp-server-sdk.ts'),
+    'utf-8',
+  );
+
+  it('exports resolveHookAction', () => {
+    expect(SRC).toMatch(/export function resolveHookAction/);
+  });
+
+  it('the hook branch derives its action from resolveHookAction', () => {
+    expect(SRC).toMatch(/if \(kind === 'hook'\)[\s\S]{0,400}resolveHookAction\(decision\)/);
+  });
+
+  it("the hook branch's mirror path returns true so the async handler owns the process", () => {
+    // The mirror dispatch must `return true` (like code/key) so the synchronous
+    // IIFE does NOT exit(0) before the async handler resolves. We anchor on the
+    // dynamic-import of the resolved mirror module followed by `return true`.
+    expect(SRC).toMatch(/await import\(mirrorModule\)[\s\S]*?return true;/);
+  });
+
+  it('usage message lists the mirror subcommands', () => {
+    expect(SRC).toMatch(/Usage: gossipcat hook --run \| mirror-prompt \| mirror-stop \| mirror-tool/);
+  });
+});


### PR DESCRIPTION
## Summary

Activity-mirror v2 (#596/#597/#599/#600) shipped the relay, dashboard render, and hook *handlers* — but the hooks **never actually fired from a built binary**. This PR fixes two stacked latent bugs and wires the feature into `gossip_setup` as an opt-in.

### Bug 1 — the dist-mcp shim never dispatched the mirror subcommands
`build:mcp` bundles `apps/cli/src/mcp-server-sdk.ts` as the published `gossipcat` binary. Its `hook` argv branch only handled `--run`/`usage` and sent **everything else** (including `mirror-prompt|mirror-stop|mirror-tool`) to the bootstrap `runHook()`. The real mirror dispatch existed only in `apps/cli/src/index.ts`, which is **not** bundled. So `gossipcat hook mirror-*` ran the bootstrap hook, never the mirror hook.

**Fix:** extracted `resolveHookAction(decision)` and routed each mirror kind to its handler via the same async-IIFE + `return true` lifecycle the `key`/`code` branches use (fail-open, never blocks a turn).

### Bug 2 — the handlers weren't bundled
The first fix used `await import('./hooks/mirror-*')`. esbuild (`--bundle --outfile`, no splitting) does **not** inline runtime dynamic imports — it left the literal path as a runtime resolve against a non-existent `dist-mcp/hooks/`, which threw into the fail-open `catch{}` → silent no-op (`grep -c postMirror dist-mcp/mcp-server.js` = 0).

**Fix:** static top-level imports of the three handlers. Bundle now inlines them (`postMirror` = 4).

### Feature — `mirror_hooks` opt-in in `gossip_setup`
New `mirror_hooks: z.boolean().default(false)`. When `true`, `installMirrorHooks(root)` registers the 3 hooks in `.claude/settings.local.json` (modeled on the existing `installDisciplineHooks` block). **Default OFF** — these hooks mirror tool I/O (Bash/Edit/Write + gossip dispatch/run/collect) to the dashboard every turn, so enabling is deliberate.

## Verification
- 48 unit tests (routing, opt-in gating, static-import + no-dynamic-import source invariants)
- Real `installMirrorHooks` integration: writes correct idempotent hook entries (closes the mocked-callback test gap)
- **Live end-to-end on-machine**: relinked the global binary to this build, enabled `mirror_hooks`, and confirmed real CC turns auto-fire `mirror-tool` and land frames in the relay/dashboard (no reconnect needed). Then reverted the test artifacts.
- `npm run build:mcp` exit 0 · `npx tsc -p apps/cli/tsconfig.json` clean

## Review
Pre-merge consensus (3 agents, 2 rounds): 13 confirmed, 1 disputed. The lone HIGH (deepseek-challenger: "`require('@gossip/orchestrator')` MODULE_NOT_FOUND in bundle") was a **hallucination** — `build:mcp` externalizes only `bufferutil`/`utf-8-validate`; the module is inlined (`installMirrorHooks` = 4 in bundle, 0 runtime requires). Cross-review agreed. Two low nits fixed (`.catch()` parity + help text); one (postMirror no-op logging) noted as a follow-up (out of scope — touches the hook handlers).

consensus-id: f9a77639-5a2342e5

🤖 Generated with [Claude Code](https://claude.com/claude-code)