### PR TITLE
fix(bridge): route unresolved mirror frames to active chat_id, not _provisional

### DIFF
--- a/packages/relay/src/dashboard/api-bridge.ts
+++ b/packages/relay/src/dashboard/api-bridge.ts
@@ -148,6 +148,19 @@ export class BridgeHub {
   // emitReply STILL gates on knownChatIds, so mirroring never widens the
   // outbound reply boundary (api-bridge.ts emitReply isKnownChatId check).
   private mirrorChatIds = new Map<string, number>();
+  // The most-recently-registered active mirror chat_id (set in
+  // registerMirrorChatId, cleared/recomputed when that id is TTL-evicted).
+  // Used by emitMirror to route unresolved terminal frames to a live observer
+  // instead of the provisional buffer when one exists (fix: mirror frames
+  // previously fell into _provisional and were dropped by the dashboard client
+  // because bindSession never ran — the browser cannot send a session_id it
+  // doesn't know). SECURITY: only ever a chat_id already in mirrorChatIds.
+  // KNOWN LIMITATION (consensus 96350953-8ce94428): single-pointer, so with
+  // multiple concurrent dashboard tabs only the most-recently-registered one
+  // receives unresolved terminal frames; earlier tabs see no live activity until
+  // they send again. Accepted tradeoff — a strict improvement over the prior
+  // behaviour where the frames went to _provisional and EVERY tab saw nothing.
+  private latestMirrorChatId: string | null = null;
   // Session→chat_id map (P1#5). The relay has no native "active session
   // chat_id" notion — a no-chat_id inbound POST mints a fresh UUID. We learn the
   // mapping from the dashboard turn: a turn carries BOTH a chat_id (validated)
@@ -378,6 +391,19 @@ export class BridgeHub {
       } else if (this.dropUnresolvedMirror) {
         // Config: drop purely-terminal frames with no observer/mapping.
         return { status: 202, payload: { ok: true, chat_id: null, dropped: validated.length } };
+      } else if (
+        this.latestMirrorChatId !== null &&
+        this.isMirrorChatId(this.latestMirrorChatId)
+      ) {
+        // Fix: route to the most-recently-registered active mirror chat_id.
+        // The browser cannot send a session_id it doesn't know, so bindSession
+        // never runs and resolveSession always returns null. Without this branch
+        // every terminal mirror frame fell into the provisional ring, which the
+        // dashboard client filtered out (it gates on the active chat_id). We
+        // only ever route to a chat_id already in mirrorChatIds (relay-seeded
+        // from a validated dashboard inbound POST), so the trust boundary is
+        // unchanged: hook values CANNOT seed mirrorChatIds and cannot arrive here.
+        chatId = this.latestMirrorChatId;
       } else {
         // Buffer under the reserved provisional id for later backfill. This id
         // can never be a real chat_id (CHAT_ID_RE forbids the `_` route-side).
@@ -635,6 +661,11 @@ export class BridgeHub {
       if (oldestKey !== null) this.mirrorChatIds.delete(oldestKey);
     }
     this.mirrorChatIds.set(chatId, now);
+    // Track the most-recently-registered mirror chat_id so emitMirror can route
+    // unresolved terminal frames to a live observer instead of the provisional
+    // buffer (fix: the browser can't know the CC session_id so bindSession never
+    // runs; latestMirrorChatId fills that gap without widening any trust boundary).
+    this.latestMirrorChatId = chatId;
     // Provisional backfill (spec §2 / P2 — f1/f7): the FIRST time a stream is
     // established, drain any frames buffered under the provisional id (terminal
     // mirror POSTs that arrived before this chat_id existed) into THIS ring,
@@ -667,8 +698,21 @@ export class BridgeHub {
   }
 
   private evictMirrorChatIds(now: number): void {
+    let evictedLatest = false;
     for (const [k, v] of this.mirrorChatIds) {
-      if (now - v > BridgeHub.CHAT_ID_TTL_MS) this.mirrorChatIds.delete(k);
+      if (now - v > BridgeHub.CHAT_ID_TTL_MS) {
+        this.mirrorChatIds.delete(k);
+        if (k === this.latestMirrorChatId) evictedLatest = true;
+      }
+    }
+    if (evictedLatest) {
+      // Recompute to the newest remaining entry (highest timestamp), or null.
+      let newestKey: string | null = null;
+      let newest = -Infinity;
+      for (const [k, v] of this.mirrorChatIds) {
+        if (v > newest) { newest = v; newestKey = k; }
+      }
+      this.latestMirrorChatId = newestKey;
     }
   }
 

--- a/tests/relay/api-bridge-mirror.test.ts
+++ b/tests/relay/api-bridge-mirror.test.ts
@@ -277,6 +277,102 @@ describe('BridgeHub.handleStream mirror replay (?last_id) + restart sentinel (P1
   });
 });
 
+describe('BridgeHub.emitMirror — latestMirrorChatId fallback (terminal frame routing fix)', () => {
+  let hub: BridgeHub;
+  afterEach(() => hub?.dispose());
+
+  it('(a) no registered mirror chat_id → unresolved frames go to _provisional (unchanged behaviour)', () => {
+    hub = new BridgeHub();
+    // No dashboard stream opened → no mirrorChatId registered.
+    const r = hub.emitMirror(null, frames(['activity', 'orphan']), 'unknown-session');
+    expect(r.status).toBe(202);
+    expect(r.payload).toMatchObject({ chat_id: null });
+    // Retained under the provisional ring, NOT under a real chat_id ring.
+    expect(hub.mirrorReplay('_provisional', 0)).toHaveLength(1);
+    expect(hub.mirrorRingCount()).toBe(1);
+  });
+
+  it('(b) after registerMirrorChatId via handlePost, unresolved terminal POST routes to that chat_id', () => {
+    hub = new BridgeHub();
+    // Simulated inbound dashboard POST (the ONLY trusted seeding path).
+    openDashboardStream(hub, 'uuid-A');
+    // Connect a SSE client so we can verify broadcast.
+    const res = mockRes();
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=uuid-A'), res);
+
+    // Terminal mirror POST with no chat_id and an UNBOUND session_id.
+    const r = hub.emitMirror(null, frames(['activity', 'tool dispatch']), 'unbound-session');
+    expect(r.status).toBe(202);
+    // Resolved to the latest mirror chat_id, NOT provisional.
+    expect(r.payload).toMatchObject({ ok: true, chat_id: 'uuid-A', frames: 1 });
+
+    // Retained in uuid-A's ring.
+    const ring = hub.mirrorReplay('uuid-A', 0);
+    expect(ring).toHaveLength(1);
+    expect(ring[0].text).toBe('tool dispatch');
+    expect(ring[0].chat_id).toBe('uuid-A');
+
+    // Broadcast reached the connected client with chat_id = 'uuid-A'.
+    const live = dataFramesOf(res);
+    expect(live).toHaveLength(1);
+    expect(live[0].chat_id).toBe('uuid-A');
+    expect(live[0].type).toBe('mirror');
+
+    // Provisional ring is empty — frames did NOT land there.
+    expect(hub.mirrorReplay('_provisional', 0)).toHaveLength(0);
+  });
+
+  it('(c) dropUnresolvedMirror=true still drops even when latestMirrorChatId is set', () => {
+    hub = new BridgeHub();
+    hub.setDropUnresolvedMirror(true);
+    openDashboardStream(hub, 'uuid-B');
+    const r = hub.emitMirror(null, frames(['activity', 'x']), 'unbound');
+    expect(r.status).toBe(202);
+    expect(r.payload).toMatchObject({ chat_id: null, dropped: 1 });
+    // Nothing retained anywhere.
+    expect(hub.mirrorRingCount()).toBe(0);
+  });
+
+  it('(d) multi-tab: unresolved frames route to the MOST-RECENTLY-registered chat_id, not earlier ones', () => {
+    hub = new BridgeHub();
+    // Two dashboard tabs register in sequence (consensus 96350953-8ce94428:f1/f4).
+    openDashboardStream(hub, 'uuid-A');
+    openDashboardStream(hub, 'uuid-B'); // latest is now uuid-B
+
+    const r = hub.emitMirror(null, frames(['activity', 'tool dispatch']), 'unbound-session');
+    expect(r.status).toBe(202);
+    // Routes to the most-recent tab (uuid-B), NOT the earlier uuid-A.
+    expect(r.payload).toMatchObject({ ok: true, chat_id: 'uuid-B', frames: 1 });
+
+    expect(hub.mirrorReplay('uuid-B', 0)).toHaveLength(1);
+    // Known limitation: the earlier tab's ring stays empty (documented tradeoff —
+    // a strict improvement over the pre-fix behaviour where ALL tabs got nothing).
+    expect(hub.mirrorReplay('uuid-A', 0)).toHaveLength(0);
+    expect(hub.mirrorReplay('_provisional', 0)).toHaveLength(0);
+  });
+
+  it('recomputes latestMirrorChatId to the newest survivor after the latest id is TTL-evicted', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chatA');
+    openDashboardStream(hub, 'chatB'); // latest is chatB
+    const TTL = 2 * 60 * 60 * 1000;
+
+    // Age chatB past the TTL, then trigger an eviction pass (hasMirrorChatId →
+    // evictMirrorChatIds). latestMirrorChatId must recompute to chatA.
+    hub.ageMirrorChatId('chatB', TTL + 1_000);
+    expect(hub.hasMirrorChatId('chatB')).toBe(false); // evicted
+    const afterB = hub.emitMirror(null, frames(['activity', 'after-B']), 'unbound');
+    expect(afterB.payload).toMatchObject({ chat_id: 'chatA', frames: 1 });
+
+    // Age chatA out too → no survivors → latest recomputes to null → provisional.
+    hub.ageMirrorChatId('chatA', TTL + 1_000);
+    expect(hub.hasMirrorChatId('chatA')).toBe(false);
+    const afterA = hub.emitMirror(null, frames(['activity', 'after-A']), 'unbound');
+    expect(afterA.payload).toMatchObject({ chat_id: null });
+    expect(hub.mirrorReplay('_provisional', 0)).toHaveLength(1);
+  });
+});
+
 describe('BridgeHub provisional backfill on stream open (spec §2 / f1/f7)', () => {
   let hub: BridgeHub;
   afterEach(() => hub?.dispose());


### PR DESCRIPTION
## Problem
The dashboard chat **emitted no messages** — terminal activity-mirror frames never reached the client.

Mirror hooks POST `{frames, session_id}` with no `chat_id`. The relay can only map `session_id → chat_id` via `bindSession`, which only runs when the **inbound dashboard POST carries `session_id`** — but the browser can't know the CC session_id. So `bindSession` never ran, `resolveSession` always returned `null`, and every terminal frame fell into `PROVISIONAL_CHAT_ID`. The dashboard client filters SSE frames to its active `chat_id`, so all `_provisional` frames were dropped. Net: zero activity rendered.

## Fix
`emitMirror()` now routes an unresolvable terminal frame to the most-recently-registered active mirror chat_id (`latestMirrorChatId`) instead of `_provisional`, when one exists.

- Field set **only** in private `registerMirrorChatId()` (the auth-gated `handlePost` path).
- Recomputed in `evictMirrorChatIds()` when the tracked id is TTL-evicted.
- Double-checked with `isMirrorChatId()` at the use site.

## Security
Trust boundary unchanged (consensus-verified): `latestMirrorChatId` can only ever be a relay-seeded chat_id; hooks cannot seed it; `emitReply`'s `knownChatIds` outbound gate and the `_provisional`/leading-`_` reservation in `handlePost` are untouched.

## Verification
- **Live end-to-end** (browser): sent message + live `🔧 Bash` activity frames + reply all render; 4/4 frames carried the real chat_id, 0 `_provisional`.
- **Consensus `96350953-8ce94428`** (sonnet-reviewer + gemini-reviewer + deepseek-challenger, 2 rounds): 9 confirmed, 1 disputed (deepseek's HIGH severity downgraded to MEDIUM — not a regression). Security boundary intact.
- **Tests:** +2 (multi-tab routing, TTL-recompute) → **33/33 pass**; `tsc` clean.

## Known limitation (accepted tradeoff)
Single-pointer design: with multiple concurrent dashboard tabs, only the most-recently-registered tab receives unresolved terminal frames. This is a **strict improvement** over the prior behaviour (all tabs saw nothing) and is documented in-code. Follow-ups noted: server-side per-client chat_id filtering in `broadcast()` (pre-existing), and multi-observer fanout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)