### PR TITLE
chore(release): v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ## [Unreleased]
 
+## [0.6.4] — 2026-06-16
+
+Patch release. Makes the dashboard ⇄ live-Claude-Code **activity mirror
+actually render** in the chat surface.
+
+### Fixed
+
+- **Dashboard chat now emits live activity.** Terminal activity-mirror frames
+  never reached the dashboard chat — it appeared to "emit no messages". Mirror
+  hooks POST `{frames, session_id}` with no `chat_id`, and the relay could only
+  map `session_id → chat_id` from a field the browser cannot supply, so every
+  terminal frame fell into the internal `_provisional` buffer and was filtered
+  out client-side. `emitMirror()` now routes an unresolvable terminal frame to
+  the most-recently-registered active mirror chat_id instead of `_provisional`.
+  The trust boundary is unchanged: the target is only ever a relay-seeded
+  chat_id (hooks cannot seed it), and the outbound `reply` gate is untouched.
+  Known limitation: with multiple concurrent dashboard tabs only the
+  most-recent tab receives unresolved activity (a strict improvement over the
+  prior behaviour where every tab saw nothing).
+
 ## [0.6.2] — 2026-06-14
 
 Patch release. Makes the published MCP server binary **self-contained** so it

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gossipcat",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gossipcat",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossipcat",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
   "mcpName": "io.github.ataberk-xyz/gossipcat",
   "repository": {


### PR DESCRIPTION
Version bump for v0.6.4. After merging this PR, run `./scripts/release.sh` (no args) from master to build, tag, and publish the GitHub release.