### PR TITLE
feat(bridge): per-client server-side chat_id filter + multi-observer fanout

### DIFF
--- a/packages/dashboard-v2/src/lib/__tests__/useBridge.test.tsx
+++ b/packages/dashboard-v2/src/lib/__tests__/useBridge.test.tsx
@@ -196,8 +196,14 @@ describe('useBridge — mirror frames', () => {
 describe('useBridge — last_id high-water mark', () => {
   it('reconnects with ?last_id set to the highest mirror id seen', async () => {
     await mountWithChat();
+    // After mountWithChat(), setChat('chat-1') triggers an immediate reconnect
+    // so the server can subscribe this client to the correct ring (?chat_id=chat-1).
+    // instances[0] = initial (no chat_id); instances[1] = reconnect with ?chat_id.
+    // Wait for the chat_id reconnect to settle before emitting mirror frames.
+    await waitFor(() => expect(instances.length).toBeGreaterThanOrEqual(2));
+    const active = instances[instances.length - 1]; // most-recently-opened stream
     act(() => {
-      instances[0].emit({
+      active.emit({
         type: 'mirror',
         chat_id: 'chat-1',
         role: 'assistant',
@@ -205,7 +211,7 @@ describe('useBridge — last_id high-water mark', () => {
         ts: '2026-06-15T10:00:00.000Z',
         id: 5,
       });
-      instances[0].emit({
+      active.emit({
         type: 'mirror',
         chat_id: 'chat-1',
         role: 'assistant',
@@ -215,23 +221,28 @@ describe('useBridge — last_id high-water mark', () => {
       });
     });
     // Trigger a reconnect via onerror — the retry is scheduled behind a backoff
-    // timer, so drive it with fake timers to reach the second connect deterministically.
+    // timer, so drive it with fake timers to reach the next connect deterministically.
+    const countBefore = instances.length;
     vi.useFakeTimers();
-    act(() => instances[0].onerror?.call(instances[0] as unknown as EventSource, new Event('error')));
+    act(() => active.onerror?.call(active as unknown as EventSource, new Event('error')));
     act(() => {
       vi.advanceTimersByTime(1_000);
     });
     vi.useRealTimers();
-    expect(instances.length).toBe(2);
-    expect(lastIdOf(instances[1].url)).toBe('9');
+    expect(instances.length).toBe(countBefore + 1);
+    // The newly-opened stream should carry last_id=9 (the highest mirror id seen).
+    expect(lastIdOf(instances[instances.length - 1].url)).toBe('9');
   });
 });
 
 describe('useBridge — restart frame', () => {
   it('resets last_id to 0 and reconnects on a restart frame', async () => {
     await mountWithChat();
+    // Wait for the setChat-triggered reconnect to settle.
+    await waitFor(() => expect(instances.length).toBeGreaterThanOrEqual(2));
+    const active = instances[instances.length - 1];
     act(() => {
-      instances[0].emit({
+      active.emit({
         type: 'mirror',
         chat_id: 'chat-1',
         role: 'assistant',
@@ -240,12 +251,13 @@ describe('useBridge — restart frame', () => {
         id: 42,
       });
     });
+    const countBefore = instances.length;
     // Restart → relay counter reset; client must drop last_id and refetch from 0.
     act(() => {
-      instances[0].emit({ type: 'restart', chat_id: 'chat-1', ts: '2026-06-15T10:00:05.000Z' });
+      active.emit({ type: 'restart', chat_id: 'chat-1', ts: '2026-06-15T10:00:05.000Z' });
     });
-    await waitFor(() => expect(instances.length).toBe(2));
-    expect(lastIdOf(instances[1].url)).toBe('0');
-    expect(instances[0].closed).toBe(true);
+    await waitFor(() => expect(instances.length).toBe(countBefore + 1));
+    expect(lastIdOf(instances[instances.length - 1].url)).toBe('0');
+    expect(active.closed).toBe(true);
   });
 });

--- a/packages/dashboard-v2/src/lib/useBridge.ts
+++ b/packages/dashboard-v2/src/lib/useBridge.ts
@@ -18,9 +18,12 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  * Backend contract (do NOT change — fixed by api-bridge.ts):
  *   POST /dashboard/api/bridge {chat_id?, message}
  *     → 202 {ok:true, chat_id} | 400 | 429 | 503
- *   GET  /dashboard/api/bridge/stream[?last_id=N]  (SSE)
- *     Frames arriving on the SHARED stream (activity-mirror v2, spec
- *     2026-06-14-dashboard-cc-activity-mirror-v2.md §5/§6):
+ *   GET  /dashboard/api/bridge/stream[?last_id=N][&chat_id=ID]  (SSE)
+ *     The stream is PER-chat_id: the relay filters server-side and delivers only
+ *     frames whose chat_id matches the ?chat_id this stream subscribed with. A
+ *     stream opened without ?chat_id (before the first send) receives NOTHING
+ *     until setChat reconnects it with the minted id. Frame kinds (activity-mirror
+ *     v2, spec 2026-06-14-dashboard-cc-activity-mirror-v2.md §5/§6):
  *       {type:'reply'|'ack'|'error', chat_id, text?, ts}      — dashboard-typed turns
  *       {type:'mirror', chat_id, role, text, ts, id}          — live CC-session mirror
  *           role ∈ 'user'|'assistant'|'activity'; id is a per-chat_id monotonic
@@ -152,8 +155,24 @@ export function useBridge(): UseBridgeResult {
   // latest value without re-opening the stream on every chat_id change.
   const chatIdRef = useRef<string | null>(null);
   const setChat = useCallback((id: string) => {
+    const prev = chatIdRef.current;
     chatIdRef.current = id;
     setChatId(id);
+    // When the chat_id transitions null→value (or changes), reconnect the
+    // EventSource so the server subscribes this client to the correct chat_id
+    // ring (server-side filtering requires the ?chat_id query param to be
+    // present on the stream URL). The reconnect also triggers ring replay for
+    // any mirror frames that arrived before the client connected with its id.
+    //
+    // Race note: a reply to the very first turn could theoretically arrive in
+    // the brief window between the send() returning a chat_id and the
+    // reconnect completing. In practice the reply lands seconds later (CC
+    // processing time), so the window is negligible. reply/ack frames are
+    // live-only (not ring-retained), so an extremely fast reply in this window
+    // would be missed — acceptable for the first-turn case.
+    if (prev !== id) {
+      reconnectRef.current?.();
+    }
   }, []);
 
   // Highest mirror `id` seen for the active chat. Read on each (re)connect to
@@ -183,7 +202,14 @@ export function useBridge(): UseBridgeResult {
       // only the gap (id > lastSeen), per spec §3 / P1#3. ?last_id mirrors the
       // working pattern in useEventStream.ts.
       const lastId = lastMirrorIdRef.current;
-      es = new window!.EventSource(`${STREAM_PATH}?last_id=${lastId}`);
+      // Include ?chat_id when we have one so the server subscribes this client
+      // to the correct ring and delivers only matching frames (server-side
+      // filter). Before the first send chatIdRef is null; we open without
+      // ?chat_id and receive no frames until setChat triggers a reconnect.
+      const chatIdParam = chatIdRef.current
+        ? `&chat_id=${encodeURIComponent(chatIdRef.current)}`
+        : '';
+      es = new window!.EventSource(`${STREAM_PATH}?last_id=${lastId}${chatIdParam}`);
 
       es.onopen = () => {
         if (destroyed) return;

--- a/packages/relay/src/dashboard/api-bridge.ts
+++ b/packages/relay/src/dashboard/api-bridge.ts
@@ -131,6 +131,13 @@ export class BridgeHub {
   // eviction can clearInterval too — the req 'close' handler may never fire on
   // an abrupt res.destroy(), which would otherwise leak the timer.
   private keepalives = new Map<ServerResponse, ReturnType<typeof setInterval>>();
+  // Per-client subscribed chat_id (null = no ?chat_id supplied = live-only legacy
+  // consumer). Set when the client is added to this.clients in handleStream.
+  // Server-side filtering in broadcast() uses this: each frame is only delivered
+  // to the client(s) whose subscribed chat_id matches frame.chat_id. A null-
+  // subscribed client receives nothing — the old "shared broadcast to all"
+  // behaviour is intentionally replaced with per-client routing.
+  private clientChatId = new Map<ServerResponse, string | null>();
   // chat_ids we have seen on an INBOUND POST. Outbound replies bind against this
   // set (consensus f5): the live session can only address a stream the dashboard
   // actually opened, never an arbitrary/forged id. Bounded + TTL'd so a long
@@ -148,19 +155,6 @@ export class BridgeHub {
   // emitReply STILL gates on knownChatIds, so mirroring never widens the
   // outbound reply boundary (api-bridge.ts emitReply isKnownChatId check).
   private mirrorChatIds = new Map<string, number>();
-  // The most-recently-registered active mirror chat_id (set in
-  // registerMirrorChatId, cleared/recomputed when that id is TTL-evicted).
-  // Used by emitMirror to route unresolved terminal frames to a live observer
-  // instead of the provisional buffer when one exists (fix: mirror frames
-  // previously fell into _provisional and were dropped by the dashboard client
-  // because bindSession never ran — the browser cannot send a session_id it
-  // doesn't know). SECURITY: only ever a chat_id already in mirrorChatIds.
-  // KNOWN LIMITATION (consensus 96350953-8ce94428): single-pointer, so with
-  // multiple concurrent dashboard tabs only the most-recently-registered one
-  // receives unresolved terminal frames; earlier tabs see no live activity until
-  // they send again. Accepted tradeoff — a strict improvement over the prior
-  // behaviour where the frames went to _provisional and EVERY tab saw nothing.
-  private latestMirrorChatId: string | null = null;
   // Session→chat_id map (P1#5). The relay has no native "active session
   // chat_id" notion — a no-chat_id inbound POST mints a fresh UUID. We learn the
   // mapping from the dashboard turn: a turn carries BOTH a chat_id (validated)
@@ -391,23 +385,39 @@ export class BridgeHub {
       } else if (this.dropUnresolvedMirror) {
         // Config: drop purely-terminal frames with no observer/mapping.
         return { status: 202, payload: { ok: true, chat_id: null, dropped: validated.length } };
-      } else if (
-        this.latestMirrorChatId !== null &&
-        this.isMirrorChatId(this.latestMirrorChatId)
-      ) {
-        // Fix: route to the most-recently-registered active mirror chat_id.
-        // The browser cannot send a session_id it doesn't know, so bindSession
-        // never runs and resolveSession always returns null. Without this branch
-        // every terminal mirror frame fell into the provisional ring, which the
-        // dashboard client filtered out (it gates on the active chat_id). We
-        // only ever route to a chat_id already in mirrorChatIds (relay-seeded
-        // from a validated dashboard inbound POST), so the trust boundary is
-        // unchanged: hook values CANNOT seed mirrorChatIds and cannot arrive here.
-        chatId = this.latestMirrorChatId;
       } else {
-        // Buffer under the reserved provisional id for later backfill. This id
-        // can never be a real chat_id (CHAT_ID_RE forbids the `_` route-side).
-        chatId = BridgeHub.PROVISIONAL_CHAT_ID;
+        // UNRESOLVED: no explicit chat_id AND no session-map hit.
+        // Run an eviction pass first so only live ids are targeted.
+        this.evictMirrorChatIds(Date.now());
+        const liveIds = Array.from(this.mirrorChatIds.keys());
+        if (liveIds.length > 0) {
+          // Multi-observer fanout: push a per-ring copy to EVERY live mirror
+          // chat_id. This replaces the single-pointer latestMirrorChatId
+          // heuristic (consensus 96350953) — every active dashboard tab receives
+          // the terminal frame instead of only the most-recently-registered one.
+          // Per-ring id counters are independent and correct by design.
+          // SECURITY: only chat_ids already in mirrorChatIds are targeted — that
+          // map is seeded ONLY from validated inbound POSTs (handlePost). Hooks
+          // cannot seed it.
+          let totalFrames = 0;
+          for (const id of liveIds) {
+            for (const { role, text } of validated) {
+              const frame = this.mirror.push(id, role, text);
+              // Do NOT gate on clients.size — frame is retained for replay.
+              this.broadcast(frame);
+              totalFrames++;
+            }
+          }
+          return {
+            status: 202,
+            payload: { ok: true, chat_id: null, fanout: liveIds.length, frames: totalFrames },
+          };
+        } else {
+          // No live mirror chat_ids → buffer under the reserved provisional id
+          // for later backfill. This id can never be a real chat_id (CHAT_ID_RE
+          // forbids the `_` route-side).
+          chatId = BridgeHub.PROVISIONAL_CHAT_ID;
+        }
       }
     }
 
@@ -462,6 +472,14 @@ export class BridgeHub {
     const params = new URLSearchParams(search);
     const chatId = validateChatId(params.get('chat_id'));
     const lastId = parseInt(params.get('last_id') ?? '0', 10) || 0;
+    // FORWARD-HARDENING (consensus 8c396aee, deferred): ?chat_id is shape-validated
+    // but NOT gated against knownChatIds/mirrorChatIds, so an authenticated client
+    // may subscribe to any chat_id it names. Not exploitable in the current
+    // single-auth-principal model (one dashboard key, server-minted random-UUID
+    // chat_ids) and strictly better than the prior broadcast-to-all. A gate here
+    // would have to preserve post-restart replay/re-register recovery (a naive
+    // null-store breaks it, since the client reuses its chat_id on resend without
+    // reconnecting) — implement carefully before any multi-user auth model.
 
     if (chatId !== null) {
       // f6: serving a chat_id that's an open mirror stream TOUCHES its TTL so an
@@ -500,6 +518,9 @@ export class BridgeHub {
 
     this.backpressure.set(res, 0);
     this.clients.add(res);
+    // Track which chat_id this client is subscribed to for server-side filtering
+    // in broadcast(). null means no ?chat_id (legacy live-only consumer).
+    this.clientChatId.set(res, chatId);
 
     const keepalive = setInterval(() => {
       // f6 (completion): an OPEN-but-idle stream — no mirror POST, no reconnect —
@@ -523,6 +544,7 @@ export class BridgeHub {
     req.on('close', () => {
       this.clearKeepalive(res);
       this.clients.delete(res);
+      this.clientChatId.delete(res);
     });
   }
 
@@ -558,13 +580,30 @@ export class BridgeHub {
     try { return res.write(`${idLine}data: ${JSON.stringify(frame)}\n\n`); } catch { return false; }
   }
 
-  /** Fan out one frame to every connected SSE client, with backpressure eviction. */
+  /**
+   * Fan out one frame to matching connected SSE clients (server-side filter),
+   * with backpressure eviction.
+   *
+   * Each frame carries a chat_id. Only the client(s) subscribed to that
+   * chat_id receive the write — clients subscribed to a different chat_id or
+   * with a null subscription (legacy live-only consumer) are skipped. This
+   * eliminates the prior behaviour of broadcasting EVERY frame to ALL clients
+   * (the bandwidth/confidentiality gap noted in the multi-tab fix spec).
+   */
   private broadcast(frame: BridgeReplyFrame | MirrorFrame): void {
     // Mirror frames carry an SSE `id:` line so the browser EventSource exposes
     // lastEventId; reply/ack/restart control frames have no per-chat_id id.
     const idLine = 'id' in frame && typeof (frame as MirrorFrame).id === 'number' ? `id: ${(frame as MirrorFrame).id}\n` : '';
     const data = `${idLine}data: ${JSON.stringify(frame)}\n\n`;
     for (const res of this.clients) {
+      // Server-side chat_id filter: only deliver to clients whose subscribed
+      // chat_id matches this frame's chat_id. A null-subscribed (legacy) client
+      // receives nothing — it never supplied a ?chat_id so the server has no
+      // basis to route to it. The dashboard client-side filter in useBridge.ts
+      // remains as defense-in-depth.
+      const subscribedChatId = this.clientChatId.get(res) ?? null;
+      if (subscribedChatId === null || subscribedChatId !== frame.chat_id) continue;
+
       try {
         const ok = res.write(data);
         if (ok) {
@@ -576,11 +615,13 @@ export class BridgeHub {
             this.clearKeepalive(res); // f12: don't leak the timer on eviction
             res.destroy();
             this.clients.delete(res);
+            this.clientChatId.delete(res); // clean up subscription on eviction
           }
         }
       } catch {
         this.clearKeepalive(res);
         this.clients.delete(res);
+        this.clientChatId.delete(res); // clean up subscription on exception
       }
     }
   }
@@ -661,11 +702,6 @@ export class BridgeHub {
       if (oldestKey !== null) this.mirrorChatIds.delete(oldestKey);
     }
     this.mirrorChatIds.set(chatId, now);
-    // Track the most-recently-registered mirror chat_id so emitMirror can route
-    // unresolved terminal frames to a live observer instead of the provisional
-    // buffer (fix: the browser can't know the CC session_id so bindSession never
-    // runs; latestMirrorChatId fills that gap without widening any trust boundary).
-    this.latestMirrorChatId = chatId;
     // Provisional backfill (spec §2 / P2 — f1/f7): the FIRST time a stream is
     // established, drain any frames buffered under the provisional id (terminal
     // mirror POSTs that arrived before this chat_id existed) into THIS ring,
@@ -698,21 +734,10 @@ export class BridgeHub {
   }
 
   private evictMirrorChatIds(now: number): void {
-    let evictedLatest = false;
     for (const [k, v] of this.mirrorChatIds) {
       if (now - v > BridgeHub.CHAT_ID_TTL_MS) {
         this.mirrorChatIds.delete(k);
-        if (k === this.latestMirrorChatId) evictedLatest = true;
       }
-    }
-    if (evictedLatest) {
-      // Recompute to the newest remaining entry (highest timestamp), or null.
-      let newestKey: string | null = null;
-      let newest = -Infinity;
-      for (const [k, v] of this.mirrorChatIds) {
-        if (v > newest) { newest = v; newestKey = k; }
-      }
-      this.latestMirrorChatId = newestKey;
     }
   }
 

--- a/tests/relay/api-bridge-mirror.test.ts
+++ b/tests/relay/api-bridge-mirror.test.ts
@@ -277,7 +277,7 @@ describe('BridgeHub.handleStream mirror replay (?last_id) + restart sentinel (P1
   });
 });
 
-describe('BridgeHub.emitMirror — latestMirrorChatId fallback (terminal frame routing fix)', () => {
+describe('BridgeHub.emitMirror — multi-observer fanout for unresolved terminal frames', () => {
   let hub: BridgeHub;
   afterEach(() => hub?.dispose());
 
@@ -292,19 +292,19 @@ describe('BridgeHub.emitMirror — latestMirrorChatId fallback (terminal frame r
     expect(hub.mirrorRingCount()).toBe(1);
   });
 
-  it('(b) after registerMirrorChatId via handlePost, unresolved terminal POST routes to that chat_id', () => {
+  it('(b) single registered mirror chat_id → unresolved frame fans out to that chat_id', () => {
     hub = new BridgeHub();
     // Simulated inbound dashboard POST (the ONLY trusted seeding path).
     openDashboardStream(hub, 'uuid-A');
-    // Connect a SSE client so we can verify broadcast.
+    // Connect a SSE client subscribed to uuid-A so we can verify broadcast.
     const res = mockRes();
     hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=uuid-A'), res);
 
     // Terminal mirror POST with no chat_id and an UNBOUND session_id.
     const r = hub.emitMirror(null, frames(['activity', 'tool dispatch']), 'unbound-session');
     expect(r.status).toBe(202);
-    // Resolved to the latest mirror chat_id, NOT provisional.
-    expect(r.payload).toMatchObject({ ok: true, chat_id: 'uuid-A', frames: 1 });
+    // Single-id fanout: payload reports fanout=1, chat_id=null.
+    expect(r.payload).toMatchObject({ ok: true, chat_id: null, fanout: 1, frames: 1 });
 
     // Retained in uuid-A's ring.
     const ring = hub.mirrorReplay('uuid-A', 0);
@@ -322,53 +322,67 @@ describe('BridgeHub.emitMirror — latestMirrorChatId fallback (terminal frame r
     expect(hub.mirrorReplay('_provisional', 0)).toHaveLength(0);
   });
 
-  it('(c) dropUnresolvedMirror=true still drops even when latestMirrorChatId is set', () => {
+  it('(c) dropUnresolvedMirror=true still drops even when mirrorChatIds are registered', () => {
     hub = new BridgeHub();
     hub.setDropUnresolvedMirror(true);
     openDashboardStream(hub, 'uuid-B');
     const r = hub.emitMirror(null, frames(['activity', 'x']), 'unbound');
     expect(r.status).toBe(202);
     expect(r.payload).toMatchObject({ chat_id: null, dropped: 1 });
-    // Nothing retained anywhere.
+    // Nothing retained anywhere (the registered chat_id ring stays empty too).
+    expect(hub.mirrorReplay('uuid-B', 0)).toHaveLength(0);
     expect(hub.mirrorRingCount()).toBe(0);
   });
 
-  it('(d) multi-tab: unresolved frames route to the MOST-RECENTLY-registered chat_id, not earlier ones', () => {
+  it('(d) multi-tab FANOUT: unresolved frames are delivered to ALL registered chat_ids, not just the most-recent', () => {
     hub = new BridgeHub();
-    // Two dashboard tabs register in sequence (consensus 96350953-8ce94428:f1/f4).
+    // Two dashboard tabs register in sequence.
     openDashboardStream(hub, 'uuid-A');
-    openDashboardStream(hub, 'uuid-B'); // latest is now uuid-B
+    openDashboardStream(hub, 'uuid-B');
+
+    // Connect a SSE client subscribed to each tab's chat_id.
+    const resA = mockRes();
+    const resB = mockRes();
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=uuid-A'), resA);
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=uuid-B'), resB);
 
     const r = hub.emitMirror(null, frames(['activity', 'tool dispatch']), 'unbound-session');
     expect(r.status).toBe(202);
-    // Routes to the most-recent tab (uuid-B), NOT the earlier uuid-A.
-    expect(r.payload).toMatchObject({ ok: true, chat_id: 'uuid-B', frames: 1 });
+    // Fanout payload: chat_id=null, fanout=2 (both tabs), frames=2 (1 frame × 2 rings).
+    expect(r.payload).toMatchObject({ ok: true, chat_id: null, fanout: 2, frames: 2 });
 
+    // BOTH rings receive a copy.
+    expect(hub.mirrorReplay('uuid-A', 0)).toHaveLength(1);
     expect(hub.mirrorReplay('uuid-B', 0)).toHaveLength(1);
-    // Known limitation: the earlier tab's ring stays empty (documented tradeoff —
-    // a strict improvement over the pre-fix behaviour where ALL tabs got nothing).
-    expect(hub.mirrorReplay('uuid-A', 0)).toHaveLength(0);
+    expect(hub.mirrorReplay('uuid-A', 0)[0].text).toBe('tool dispatch');
+    expect(hub.mirrorReplay('uuid-B', 0)[0].text).toBe('tool dispatch');
+
+    // BOTH connected clients received the broadcast.
+    expect(dataFramesOf(resA)).toHaveLength(1);
+    expect(dataFramesOf(resB)).toHaveLength(1);
+    expect(dataFramesOf(resA)[0].chat_id).toBe('uuid-A');
+    expect(dataFramesOf(resB)[0].chat_id).toBe('uuid-B');
+
+    // Provisional ring stays empty.
     expect(hub.mirrorReplay('_provisional', 0)).toHaveLength(0);
   });
 
-  it('recomputes latestMirrorChatId to the newest survivor after the latest id is TTL-evicted', () => {
+  it('after all mirror chat_ids age out, an unresolved frame falls back to _provisional', () => {
     hub = new BridgeHub();
     openDashboardStream(hub, 'chatA');
-    openDashboardStream(hub, 'chatB'); // latest is chatB
+    openDashboardStream(hub, 'chatB');
     const TTL = 2 * 60 * 60 * 1000;
 
-    // Age chatB past the TTL, then trigger an eviction pass (hasMirrorChatId →
-    // evictMirrorChatIds). latestMirrorChatId must recompute to chatA.
-    hub.ageMirrorChatId('chatB', TTL + 1_000);
-    expect(hub.hasMirrorChatId('chatB')).toBe(false); // evicted
-    const afterB = hub.emitMirror(null, frames(['activity', 'after-B']), 'unbound');
-    expect(afterB.payload).toMatchObject({ chat_id: 'chatA', frames: 1 });
-
-    // Age chatA out too → no survivors → latest recomputes to null → provisional.
+    // Age both past the TTL, then trigger an eviction pass.
     hub.ageMirrorChatId('chatA', TTL + 1_000);
+    hub.ageMirrorChatId('chatB', TTL + 1_000);
     expect(hub.hasMirrorChatId('chatA')).toBe(false);
-    const afterA = hub.emitMirror(null, frames(['activity', 'after-A']), 'unbound');
-    expect(afterA.payload).toMatchObject({ chat_id: null });
+    expect(hub.hasMirrorChatId('chatB')).toBe(false);
+
+    // No live ids → falls back to provisional.
+    const r = hub.emitMirror(null, frames(['activity', 'after-eviction']), 'unbound');
+    expect(r.status).toBe(202);
+    expect(r.payload).toMatchObject({ chat_id: null });
     expect(hub.mirrorReplay('_provisional', 0)).toHaveLength(1);
   });
 });
@@ -538,9 +552,11 @@ describe('BridgeHub keepalive lifecycle (f12)', () => {
   it('clears the keepalive timer when a client is evicted under backpressure', () => {
     hub = new BridgeHub();
     openDashboardStream(hub, 'chatK');
-    // Connect a client that always signals backpressure (write→false).
+    // Connect a client subscribed to chatK that always signals backpressure.
+    // The client must subscribe to chatK so broadcast() actually delivers frames
+    // to it (server-side filter skips null-subscribed legacy clients).
     const res = backpressureRes(0);
-    hub.handleStream(mockReq('/dashboard/api/bridge/stream'), res);
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=chatK'), res);
     expect(hub.keepaliveCount()).toBe(1);
     // Broadcast enough mirror frames to exceed BACKPRESSURE_EVICT_THRESHOLD (2)
     // → the client is destroyed AND its keepalive cleared (not leaked).
@@ -559,5 +575,72 @@ describe('BridgeHub keepalive lifecycle (f12)', () => {
     req.emit('close');
     expect(hub.keepaliveCount()).toBe(0);
     expect(hub.clientCount()).toBe(0);
+  });
+});
+
+describe('BridgeHub.broadcast — server-side per-client chat_id filter', () => {
+  let hub: BridgeHub;
+  afterEach(() => hub?.dispose());
+
+  it('a mirror frame for chat_id A is delivered only to the A-subscribed client, NOT to the B-subscribed client', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chat-A');
+    openDashboardStream(hub, 'chat-B');
+
+    // Two clients: one subscribed to chat-A, one to chat-B.
+    const resA = mockRes();
+    const resB = mockRes();
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=chat-A'), resA);
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=chat-B'), resB);
+    expect(hub.clientCount()).toBe(2);
+
+    // Emit a mirror frame explicitly for chat-A.
+    const r = hub.emitMirror('chat-A', frames(['activity', 'hello A']));
+    expect(r.status).toBe(202);
+
+    // resA received the frame; resB received nothing.
+    const framesA = dataFramesOf(resA);
+    const framesB = dataFramesOf(resB);
+    expect(framesA).toHaveLength(1);
+    expect(framesA[0].chat_id).toBe('chat-A');
+    expect(framesB).toHaveLength(0);
+  });
+
+  it('a reply frame for chat_id A reaches only the A-subscribed client, not B', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chat-A');
+    openDashboardStream(hub, 'chat-B');
+
+    const resA = mockRes();
+    const resB = mockRes();
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=chat-A'), resA);
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream?chat_id=chat-B'), resB);
+
+    // emitReply targets chat-A (known from handlePost above).
+    const ok = hub.emitReply('chat-A', 'reply text');
+    expect(ok).toBe(true);
+
+    const framesA = dataFramesOf(resA);
+    const framesB = dataFramesOf(resB);
+    expect(framesA).toHaveLength(1);
+    expect(framesA[0].type).toBe('reply');
+    expect(framesA[0].chat_id).toBe('chat-A');
+    expect(framesB).toHaveLength(0);
+  });
+
+  it('a null-subscribed (legacy no-?chat_id) client receives NO frames', () => {
+    hub = new BridgeHub();
+    openDashboardStream(hub, 'chat-A');
+
+    // Legacy client: no ?chat_id in URL.
+    const resLegacy = mockRes();
+    hub.handleStream(mockReq('/dashboard/api/bridge/stream'), resLegacy);
+    expect(hub.clientCount()).toBe(1);
+
+    hub.emitMirror('chat-A', frames(['activity', 'something']));
+
+    // Legacy client gets nothing — it supplied no chat_id so there is nothing
+    // to match against.
+    expect(dataFramesOf(resLegacy)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## What
Full multi-tab fix for the dashboard activity-mirror, replacing the single-pointer `latestMirrorChatId` stopgap from 0.6.4.

**Server (`packages/relay/src/dashboard/api-bridge.ts`)**
- `broadcast()` filters **server-side**: a frame reaches only the SSE client(s) whose subscribed `chat_id` (new `clientChatId` map, set in `handleStream` from `?chat_id`) equals `frame.chat_id`. Null-subscribed clients get nothing. Closes the prior broadcast-to-all bandwidth/confidentiality gap; client-side filter kept as defense-in-depth.
- `emitMirror()` unresolved branch **fans out** an unresolvable terminal frame to **every** live mirror chat_id (per-ring copy + broadcast) instead of one `latestMirrorChatId` — so every open dashboard tab sees the live session activity. Empty `mirrorChatIds` → `_provisional` fallback unchanged. `latestMirrorChatId` field + eviction-recompute removed.
- `clientChatId` cleaned on all client-removal paths (close, backpressure eviction, exception).

**Client (`packages/dashboard-v2/src/lib/useBridge.ts`)**
- SSE URL appends `&chat_id` once known; `setChat` reconnects on chat_id adoption so the server subscribes the stream. First-turn reply race documented.

## Review
Consensus **8c396aee-3f104110** (sonnet-reviewer + gemini-reviewer + deepseek-challenger, 2 rounds): **17 confirmed, 2 disputed**.
- Filter verified type-safe + injection-hardened (`encodeURIComponent` + anchored `CHAT_ID_RE`); fanout bounded (`mirrorChatIds ≤ 64`) and targets only relay-seeded ids (hooks cannot seed); `latestMirrorChatId` removal clean.
- The fanout "confidentiality regression" and `touchMirrorChatId` "side-channel" findings were verified as **misframed** (single-auth-principal; the fanout is the intended "every tab sees the one live session" behavior) and recorded as `hallucination_caught`.

## Deferred (documented in-code)
`?chat_id` on the SSE stream is shape-validated but **not gated** against `knownChatIds`. Confirmed by review but **not exploitable in the single-auth-principal model** (one dashboard key, server-minted random-UUID chat_ids), and strictly better than the prior broadcast-to-all. A naive gate **breaks post-restart reconnect recovery** (the client reuses its chat_id on resend without reconnecting), so it's left as a forward-hardening item for any future multi-user auth model.

## Tests
- `tests/relay/api-bridge-mirror.test.ts`: multi-tab fanout + server-side-filter cases → **36/36 pass**
- `useBridge.test.tsx` updated for the reconnect → **9/9 pass**
- relay + dashboard `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)