### PR TITLE
feat(dashboard): multi-conversation chat tabs

### DIFF
--- a/packages/dashboard-v2/src/components/ChatPage.tsx
+++ b/packages/dashboard-v2/src/components/ChatPage.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
-import { useBridgeContext } from '@/lib/BridgeContext';
+import { useBridgeStore } from '@/lib/BridgeContext';
 import { AwaitingDots } from '@/components/chat/ChatPrimitives';
 import { Transcript } from '@/components/chat/Transcript';
 import { SessionRail } from '@/components/chat/SessionRail';
+import { ChatTabs } from '@/components/chat/ChatTabs';
 
 /**
  * ChatPage — operator command surface for the dashboard ⇄ Claude Code bridge.
@@ -11,11 +12,13 @@ import { SessionRail } from '@/components/chat/SessionRail';
  * Only the transcript region and the rail's activity feed scroll internally.
  *
  * Two-column on lg+:
- *   LEFT  — chat card: compact info-bar + transcript (flex-1, overflow-y:auto) + composer
+ *   LEFT  — chat card: compact info-bar + TAB STRIP + transcript (flex-1) + composer
  *   RIGHT — SessionRail: ~288px — working agents + activity feed
  *
- * Shares the SAME bridge conversation as the bottom-right launcher via
- * BridgeContext (single useBridge() instance).
+ * MULTI-CONVERSATION: a browser-tab-style strip (ChatTabs) sits under the info-bar.
+ * Each tab is an INDEPENDENT conversation (own chat_id, history, SSE) managed by
+ * the multi-conversation BridgeContext store (useBridgeStore). The bottom-right
+ * launcher (ChatDock) mirrors whichever tab is ACTIVE via useBridgeContext().
  *
  * DESIGN.md conformance (2026-06-15 dark carve-out):
  *   - .chat-surface scoped dark warm-charcoal tokens inside the card.
@@ -29,22 +32,39 @@ import { SessionRail } from '@/components/chat/SessionRail';
  */
 
 export function ChatPage() {
-  const { messages, status, awaitingReply, chatId, send, sendError } = useBridgeContext();
+  const {
+    conversations,
+    activeId,
+    active,
+    sendError,
+    send,
+    newConversation,
+    closeConversation,
+    switchConversation,
+    canAddTab,
+  } = useBridgeStore();
   const [draft, setDraft] = useState('');
+
+  // Active conversation slice (always present — store guarantees ≥1 tab).
+  const messages = active?.messages ?? [];
+  const status = active?.status ?? 'connecting';
+  const awaitingReply = active?.awaitingReply ?? false;
+  const chatId = active?.chatId ?? null;
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
-  // Auto-scroll to newest turn when conversation grows or awaiting indicator toggles.
+  // Auto-scroll to newest turn when the conversation grows, the awaiting
+  // indicator toggles, OR the active tab changes (jump to that tab's latest).
   useEffect(() => {
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [messages, awaitingReply]);
+  }, [messages, awaitingReply, activeId]);
 
-  // Focus composer on page mount.
+  // Focus composer on page mount and when switching tabs.
   useEffect(() => {
     inputRef.current?.focus();
-  }, []);
+  }, [activeId]);
 
   const submit = () => {
     const text = draft.trim();
@@ -184,6 +204,16 @@ export function ChatPage() {
               cc transcript
             </span>
           </div>
+
+          {/* Tab strip — one tab per independent conversation, directly under the info-bar */}
+          <ChatTabs
+            conversations={conversations}
+            activeId={activeId}
+            canAddTab={canAddTab}
+            onSwitch={switchConversation}
+            onClose={closeConversation}
+            onNew={newConversation}
+          />
 
           {/* Scrollable transcript — fills remaining card height */}
           <div

--- a/packages/dashboard-v2/src/components/chat/ChatTabs.tsx
+++ b/packages/dashboard-v2/src/components/chat/ChatTabs.tsx
@@ -1,0 +1,122 @@
+import { useRef } from 'react';
+import type { ConversationView } from '@/lib/BridgeContext';
+
+/**
+ * ChatTabs — browser-tab-style strip for the multi-conversation ChatPage.
+ *
+ * Each tab is an INDEPENDENT conversation (own chat_id, history, SSE). The strip
+ * sits directly under the compact info-bar, scrolls horizontally when crowded,
+ * and ends with a `+` new-chat button (disabled at MAX_TABS).
+ *
+ * a11y: role=tablist / role=tab + aria-selected; ArrowLeft/ArrowRight roving
+ * focus; close buttons carry aria-labels; prefers-reduced-motion honored via the
+ * .cx-tab CSS (no transition under reduce).
+ *
+ * DESIGN.md (dark chat carve-out):
+ *   - Active tab: subtle --surface fill + 2px --ink-2 bottom indicator.
+ *   - Inactive: transparent, --ink-3, hover wash.
+ *   - Unread dot: --info teal (NEVER --accent — terracotta is Send-CTA only).
+ *   - Label = Geist; chat_id fallback label = JetBrains Mono.
+ *   - Hairline borders, no shadows, --r-md radius.
+ */
+
+interface ChatTabsProps {
+  conversations: ConversationView[];
+  activeId: string;
+  canAddTab: boolean;
+  onSwitch: (key: string) => void;
+  onClose: (key: string) => void;
+  onNew: () => void;
+}
+
+export function ChatTabs({
+  conversations,
+  activeId,
+  canAddTab,
+  onSwitch,
+  onClose,
+  onNew,
+}: ChatTabsProps) {
+  const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+
+  const onKeyNav = (e: React.KeyboardEvent, idx: number) => {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+    e.preventDefault();
+    const dir = e.key === 'ArrowRight' ? 1 : -1;
+    const next = conversations[(idx + dir + conversations.length) % conversations.length];
+    // Manual activation (ARIA tabs): arrows move FOCUS only — they must not
+    // call onSwitch, which would fire a full conversation switch (SSE reconnect,
+    // auto-scroll, draft reset) on every keystroke. The native <button> click
+    // handler activates on Enter/Space/click.
+    if (next) tabRefs.current[next.key]?.focus();
+  };
+
+  return (
+    <div
+      className="cx-tabstrip shrink-0"
+      role="tablist"
+      aria-label="Conversations"
+    >
+      <div className="cx-tabstrip-scroll">
+        {conversations.map((c, idx) => {
+          const isActive = c.key === activeId;
+          // chat_id-derived labels (6-char short ids) render in mono; prose
+          // snippets / "new chat" render in Geist.
+          const isIdLabel = !!c.chatId && c.label === c.chatId.slice(0, 6);
+          const showUnread = !isActive && c.unread > 0;
+          return (
+            <div
+              key={c.key}
+              className={`cx-tab ${isActive ? 'is-active' : ''}`}
+            >
+              <button
+                ref={(el) => {
+                  tabRefs.current[c.key] = el;
+                }}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                tabIndex={isActive ? 0 : -1}
+                className="cx-tab-btn"
+                onClick={() => onSwitch(c.key)}
+                onKeyDown={(e) => onKeyNav(e, idx)}
+                title={c.chatId ?? 'new conversation'}
+                aria-label={`${c.label}${showUnread ? `, ${c.unread} unread` : ''}`}
+              >
+                {showUnread && (
+                  <span className="cx-tab-unread" aria-hidden="true" />
+                )}
+                <span className={isIdLabel ? 'cx-tab-label font-mono' : 'cx-tab-label'}>
+                  {c.label}
+                </span>
+              </button>
+              <button
+                type="button"
+                className="cx-tab-close"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClose(c.key);
+                }}
+                aria-label={`Close conversation ${c.label}`}
+                title="Close conversation"
+              >
+                ×
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      <button
+        type="button"
+        className="cx-tab-new shrink-0"
+        onClick={onNew}
+        disabled={!canAddTab}
+        aria-label="New conversation"
+        title={canAddTab ? 'New conversation' : 'Maximum conversations open'}
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/packages/dashboard-v2/src/globals.css
+++ b/packages/dashboard-v2/src/globals.css
@@ -963,6 +963,153 @@ html[data-theme="dark"]::after {
 }
 .cx-dimmed { opacity: 0.5; }
 
+/* ── conversation tab strip (multi-conversation ChatPage) ────────────────────
+   Rendered inside the .chat-surface left card, so all var() tokens resolve to
+   the dark carve-out values. Active = subtle --surface fill + 2px --ink-2 bottom
+   indicator; inactive = transparent / --ink-3 + hover wash. Unread dot is --info
+   teal (NEVER --accent — terracotta is the Send CTA only). */
+.cx-tabstrip {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+  padding: 0 8px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 50%, var(--bg));
+  min-height: 34px;
+}
+.cx-tabstrip-scroll {
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  flex: 1;
+  min-width: 0;
+  scrollbar-width: thin;
+}
+.cx-tab {
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+  min-width: 80px;
+  max-width: 180px;
+  border-radius: var(--r-md) var(--r-md) 0 0;
+  border-bottom: 3px solid transparent;
+  transition: background 100ms ease-out, border-color 100ms ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cx-tab { transition: none; }
+}
+.cx-tab:hover {
+  background: color-mix(in srgb, var(--surface) 70%, transparent);
+}
+.cx-tab.is-active {
+  background: var(--surface);
+  border-bottom-color: var(--ink-2); /* 3px from .cx-tab above — more visible than hairline */
+}
+.cx-tab-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: 152px;
+  padding: 7px 4px 7px 10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--ink-3);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  line-height: 1.2;
+}
+.cx-tab.is-active .cx-tab-btn { color: var(--ink); }
+.cx-tab-btn:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--info) 60%, transparent);
+  outline-offset: 1px; /* positive offset keeps ring fully visible above the 3px active indicator */
+  border-radius: var(--r-sm);
+}
+.cx-tab-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.cx-tab-label.font-mono {
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+.cx-tab-unread {
+  flex: none;
+  width: 6px;
+  height: 6px;
+  border-radius: 9999px;
+  background: var(--info);
+}
+.cx-tab-close {
+  flex: none;
+  width: 24px;  /* WCAG 2.2 AA 24×24 minimum hit area */
+  height: 24px;
+  margin-right: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  color: var(--ink-3); /* interactive glyph — must meet AA min (--ink-3), not non-text-only --ink-4 */
+  font-size: 14px;
+  line-height: 1;
+  opacity: 0;
+  transition: opacity 100ms ease-out, color 100ms ease-out, background 100ms ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cx-tab-close { transition: none; }
+}
+.cx-tab:hover .cx-tab-close,
+.cx-tab.is-active .cx-tab-close { opacity: 1; }
+.cx-tab-close:hover {
+  color: var(--ink-2);
+  background: color-mix(in srgb, var(--ink-4) 22%, transparent);
+}
+.cx-tab-close:focus-visible {
+  opacity: 1;
+  outline: 2px solid color-mix(in srgb, var(--info) 60%, transparent);
+  outline-offset: -1px;
+}
+.cx-tab-new {
+  flex: none;
+  align-self: center;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  border-left: 1px solid var(--border); /* separator anchors + button; prevents it from floating */
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  color: var(--ink-3);
+  font-size: 16px;
+  line-height: 1;
+  padding-left: 8px;
+  margin-left: 4px;
+  transition: background 100ms ease-out, color 100ms ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cx-tab-new { transition: none; }
+}
+.cx-tab-new:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--surface) 80%, transparent);
+  color: var(--ink);
+}
+.cx-tab-new:disabled { opacity: 0.4; cursor: not-allowed; }
+.cx-tab-new:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--info) 60%, transparent);
+  outline-offset: -1px;
+}
+
 /* ── highlight.js token mapping ──────────────────────────────────────────────
    Scoped under .md-code-block so highlight.js's emitted .hljs-* classes pick up
    the --sx-* tokens. Base .hljs gets NO color override (inherits the surrounding

--- a/packages/dashboard-v2/src/lib/BridgeContext.tsx
+++ b/packages/dashboard-v2/src/lib/BridgeContext.tsx
@@ -1,35 +1,452 @@
-import { createContext, useContext, type ReactNode } from 'react';
-import { useBridge, type UseBridgeResult } from '@/lib/useBridge';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { useBridge, type BridgeMessage, type BridgeStatus } from '@/lib/useBridge';
 
 /**
- * BridgeContext — wraps the ONE useBridge() instance so both the launcher
- * popover (ChatDock) and the full ChatPage share the same SSE stream, the same
- * chat_id, and the same message history.
+ * BridgeContext — MULTI-CONVERSATION store for the dashboard ⇄ LIVE Claude Code
+ * bridge. Drives the ChatPage tab strip: several INDEPENDENT conversations, each
+ * with its own chat_id, message history, SSE stream, and status. The bottom-right
+ * ChatDock launcher mirrors whichever conversation is ACTIVE.
  *
- * Architecture rule: useBridge() opens its OWN EventSource + its OWN
- * messages/chatId state per call-site. If the popover and ChatPage each called
- * useBridge() independently they would become two separate streams with
- * diverging messages and two different chat_ids (each first-send mints its
- * own). This provider calls useBridge() EXACTLY ONCE; both consumers call
- * useBridgeContext() to read from the shared result.
+ * ── Why one hook per conversation, not one multiplexed stream ──
+ * Post-#610 the relay filters the SSE server-side by ?chat_id, so a single
+ * EventSource only receives ITS chat_id's frames. To keep every open tab live
+ * (so an inactive tab can accrue an `unread` marker when a reply/mirror lands),
+ * each open conversation runs its OWN useBridge() instance — ONE SSE per tab.
+ * React's Rules of Hooks forbid calling useBridge() in a dynamic-length loop, so
+ * we mount one headless <ConversationController> per tab; each calls useBridge()
+ * and reports its live slice up into the store's `views` map.
+ *
+ * ── Persistence ──
+ * Open tabs (chat_id + label + active) persist to localStorage under
+ * `gossipcat_chat_tabs`. On load each persisted conversation reopens with
+ * ?last_id=0 to replay the server ring. A never-sent (chat_id=null) tab is NOT
+ * persisted — there is nothing to reattach to. Reads/writes are try/caught and
+ * capped so corrupt or oversized storage degrades to a single fresh tab.
  */
 
-const BridgeContext = createContext<UseBridgeResult | null>(null);
+const STORAGE_KEY = 'gossipcat_chat_tabs';
+/** Hard ceiling on open tabs (well under server MAX_BRIDGE_CLIENTS=20). */
+export const MAX_TABS = 8;
+/** Label snippet length from the first user message. */
+const LABEL_SNIPPET_LEN = 18;
+
+/** Persistent tab metadata (the store's source of truth). */
+interface TabMeta {
+  /** Stable client-side key for React + active selection. Survives chat_id mint. */
+  key: string;
+  /** Server chat_id once minted/adopted; null for a brand-new never-sent tab. */
+  chatId: string | null;
+  /** Display label (first-message snippet, else short id, else "new chat"). */
+  label: string;
+}
+
+/** Live per-conversation slice reported up by a ConversationController. */
+export interface ConversationView {
+  key: string;
+  chatId: string | null;
+  label: string;
+  messages: BridgeMessage[];
+  status: BridgeStatus;
+  awaitingReply: boolean;
+  unread: number;
+  /** Last transient send error on this conversation (null when clear). */
+  sendError: string | null;
+}
+
+/** Imperative handle a ConversationController registers so the store can drive it. */
+interface ConversationHandle {
+  send: (text: string) => Promise<void>;
+  markRead: () => void;
+}
+
+export interface BridgeStoreValue {
+  /** All open conversations, in tab order, merged meta + live state. */
+  conversations: ConversationView[];
+  /** Key of the active (visible) conversation. */
+  activeId: string;
+  /** The active conversation's live slice (always present — never zero tabs). */
+  active: ConversationView | null;
+  /** Last transient send error on the ACTIVE conversation. */
+  sendError: string | null;
+  /** POST a message to the ACTIVE conversation. */
+  send: (text: string) => Promise<void>;
+  /** Open a fresh conversation tab and switch to it. No-op at MAX_TABS. */
+  newConversation: () => void;
+  /** Close a tab; activates a neighbor. Closing the last leaves one fresh tab. */
+  closeConversation: (key: string) => void;
+  /** Switch the active tab (clears its unread). */
+  switchConversation: (key: string) => void;
+  /** True when another tab can be opened. */
+  canAddTab: boolean;
+}
+
+const BridgeStore = createContext<BridgeStoreValue | null>(null);
+
+// ── id generation ───────────────────────────────────────────────────────────
+
+let keyCounter = 0;
+function freshKey(): string {
+  keyCounter += 1;
+  return `tab-${Date.now().toString(36)}-${keyCounter}`;
+}
+
+// ── label derivation ─────────────────────────────────────────────────────────
+
+/**
+ * Derive a tab label: first USER-message snippet (~18 chars), else short chat_id
+ * (first 6), else "new chat". Collapses whitespace + ellipsizes.
+ */
+function deriveLabel(messages: readonly BridgeMessage[], chatId: string | null): string {
+  const firstUser = messages.find((m) => m.role === 'user' && m.text.trim().length > 0);
+  if (firstUser) {
+    const snippet = firstUser.text.trim().replace(/\s+/g, ' ');
+    return snippet.length > LABEL_SNIPPET_LEN ? `${snippet.slice(0, LABEL_SNIPPET_LEN)}…` : snippet;
+  }
+  if (chatId && chatId.length > 0) return chatId.slice(0, 6);
+  return 'new chat';
+}
+
+// ── persistence ──────────────────────────────────────────────────────────────
+
+interface PersistShape {
+  tabs: { chatId: string; label: string }[];
+  activeChatId: string | null;
+}
+
+function loadPersisted(): { tabs: TabMeta[]; activeKey: string } | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw || raw.length > 64_000) return null; // cap against oversized/corrupt storage
+    const parsed = JSON.parse(raw) as PersistShape;
+    if (!parsed || !Array.isArray(parsed.tabs)) return null;
+    const tabs: TabMeta[] = [];
+    for (const t of parsed.tabs) {
+      if (!t || typeof t.chatId !== 'string' || t.chatId.length === 0) continue;
+      const label = typeof t.label === 'string' && t.label.length > 0 ? t.label.slice(0, 64) : t.chatId.slice(0, 6);
+      tabs.push({ key: freshKey(), chatId: t.chatId, label });
+      if (tabs.length >= MAX_TABS) break;
+    }
+    if (tabs.length === 0) return null;
+    const activeFromStore = tabs.find((t) => t.chatId === parsed.activeChatId);
+    return { tabs, activeKey: (activeFromStore ?? tabs[0]).key };
+  } catch {
+    return null; // corrupt JSON / blocked storage → fresh start
+  }
+}
+
+function persist(tabs: readonly TabMeta[], activeKey: string): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    // Only persist conversations that have a server chat_id (reattachable).
+    const persistable = tabs.filter((t): t is TabMeta & { chatId: string } => typeof t.chatId === 'string');
+    const active = tabs.find((t) => t.key === activeKey);
+    const shape: PersistShape = {
+      tabs: persistable.map((t) => ({ chatId: t.chatId, label: t.label })),
+      activeChatId: active?.chatId ?? null,
+    };
+    if (shape.tabs.length === 0) {
+      localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(shape));
+  } catch {
+    /* storage full / blocked — non-fatal, tabs still work in-memory */
+  }
+}
+
+// ── ConversationController ────────────────────────────────────────────────────
+
+/**
+ * Headless per-conversation host. Mounts ONE useBridge() instance, reports its
+ * live slice up to the store via onState, and registers an imperative handle
+ * (send/markRead) so the store can drive the active conversation. Renders
+ * nothing — purely a hook host (Rules-of-Hooks-safe N instances).
+ */
+function ConversationController({
+  meta,
+  active,
+  onState,
+  onChatIdMinted,
+  registerHandle,
+}: {
+  meta: TabMeta;
+  active: boolean;
+  onState: (view: ConversationView) => void;
+  onChatIdMinted: (key: string, chatId: string, label: string) => void;
+  registerHandle: (key: string, handle: ConversationHandle | null) => void;
+}) {
+  const bridge = useBridge({ initialChatId: meta.chatId, active });
+
+  // Register/unregister this conversation's imperative handle.
+  useEffect(() => {
+    registerHandle(meta.key, { send: bridge.send, markRead: bridge.markRead });
+    return () => registerHandle(meta.key, null);
+  }, [meta.key, bridge.send, bridge.markRead, registerHandle]);
+
+  // Report the live slice up whenever any displayed field changes. The label is
+  // derived from messages so it updates from "new chat" → first-message snippet.
+  const label = deriveLabel(bridge.messages, bridge.chatId);
+  useEffect(() => {
+    onState({
+      key: meta.key,
+      chatId: bridge.chatId,
+      label,
+      messages: bridge.messages,
+      status: bridge.status,
+      awaitingReply: bridge.awaitingReply,
+      unread: bridge.unread,
+      sendError: bridge.sendError,
+    });
+  }, [
+    meta.key,
+    bridge.chatId,
+    label,
+    bridge.messages,
+    bridge.status,
+    bridge.awaitingReply,
+    bridge.unread,
+    bridge.sendError,
+    onState,
+  ]);
+
+  // When this conversation mints its first chat_id, tell the store so it persists
+  // + records the id against the stable tab key.
+  const prevChatId = useRef<string | null>(meta.chatId);
+  useEffect(() => {
+    if (bridge.chatId && bridge.chatId !== prevChatId.current) {
+      prevChatId.current = bridge.chatId;
+      onChatIdMinted(meta.key, bridge.chatId, label);
+    }
+  }, [meta.key, bridge.chatId, label, onChatIdMinted]);
+
+  return null;
+}
+
+// ── Provider ──────────────────────────────────────────────────────────────────
 
 export function BridgeProvider({ children }: { children: ReactNode }) {
-  // The single source-of-truth bridge instance.
-  const bridge = useBridge();
-  return <BridgeContext.Provider value={bridge}>{children}</BridgeContext.Provider>;
+  // Restore once: loadPersisted() mints fresh keys, so calling it twice would
+  // produce mismatched tab/active keys. A single lazy initializer keeps them in
+  // sync. (useState initializers run once; a useRef-cached value is overkill.)
+  const initial = useRef<{ tabs: TabMeta[]; activeKey: string }>(undefined as never);
+  if (initial.current === (undefined as never)) {
+    const restored = loadPersisted();
+    initial.current = restored ?? (() => {
+      const tab = { key: freshKey(), chatId: null, label: 'new chat' };
+      return { tabs: [tab], activeKey: tab.key };
+    })();
+  }
+
+  // Tab metadata = source of truth for which conversations exist + their ids.
+  const [tabs, setTabs] = useState<TabMeta[]>(() => initial.current.tabs);
+  const [activeKey, setActiveKey] = useState<string>(() => initial.current.activeKey);
+
+  // Defensive: keep activeKey pointing at a real tab.
+  useEffect(() => {
+    if (!tabs.some((t) => t.key === activeKey) && tabs.length > 0) {
+      setActiveKey(tabs[0].key);
+    }
+  }, [tabs, activeKey]);
+
+  // Live per-conversation slices, keyed by tab key. Updated by controllers.
+  const [views, setViews] = useState<Record<string, ConversationView>>({});
+
+  // Imperative handles per conversation (send/markRead), kept in a ref (not state)
+  // so registering one doesn't re-render the whole store.
+  const handlesRef = useRef<Record<string, ConversationHandle>>({});
+
+  const registerHandle = useCallback((key: string, handle: ConversationHandle | null) => {
+    if (handle) handlesRef.current[key] = handle;
+    else delete handlesRef.current[key];
+  }, []);
+
+  const onState = useCallback((view: ConversationView) => {
+    setViews((prev) => {
+      const existing = prev[view.key];
+      if (
+        existing &&
+        existing.chatId === view.chatId &&
+        existing.label === view.label &&
+        existing.messages === view.messages &&
+        existing.status === view.status &&
+        existing.awaitingReply === view.awaitingReply &&
+        existing.unread === view.unread &&
+        existing.sendError === view.sendError
+      ) {
+        return prev; // no change — avoid a needless re-render
+      }
+      return { ...prev, [view.key]: view };
+    });
+  }, []);
+
+  const onChatIdMinted = useCallback((key: string, chatId: string, label: string) => {
+    setTabs((prev) => prev.map((t) => (t.key === key ? { ...t, chatId, label } : t)));
+  }, []);
+
+  // Persist whenever tabs (with chat_ids) or the active selection changes.
+  useEffect(() => {
+    persist(tabs, activeKey);
+  }, [tabs, activeKey]);
+
+  // ── tab operations ──
+  const newConversation = useCallback(() => {
+    setTabs((prev) => {
+      if (prev.length >= MAX_TABS) return prev;
+      const key = freshKey();
+      setActiveKey(key);
+      return [...prev, { key, chatId: null, label: 'new chat' }];
+    });
+  }, []);
+
+  const switchConversation = useCallback((key: string) => {
+    setActiveKey(key);
+    handlesRef.current[key]?.markRead();
+  }, []);
+
+  const closeConversation = useCallback((key: string) => {
+    setTabs((prev) => {
+      const idx = prev.findIndex((t) => t.key === key);
+      if (idx < 0) return prev;
+      const next = prev.filter((t) => t.key !== key);
+
+      // Never zero tabs: closing the last leaves one fresh "new chat".
+      if (next.length === 0) {
+        const freshTab = { key: freshKey(), chatId: null, label: 'new chat' };
+        setActiveKey(freshTab.key);
+        return [freshTab];
+      }
+
+      // Closing the active tab → activate a neighbor (prefer the one to the left,
+      // else the new tab now at the same index).
+      setActiveKey((curActive) => {
+        if (curActive !== key) return curActive;
+        const neighbor = next[Math.max(0, idx - 1)] ?? next[0];
+        // Switching surfaces the neighbor's content → clear its unread.
+        handlesRef.current[neighbor.key]?.markRead();
+        return neighbor.key;
+      });
+      return next;
+    });
+    // Drop the closed conversation's cached view so it stops rendering.
+    setViews((prev) => {
+      if (!(key in prev)) return prev;
+      const { [key]: _gone, ...rest } = prev;
+      return rest;
+    });
+  }, []);
+
+  const send = useCallback(
+    (text: string): Promise<void> => {
+      const handle = handlesRef.current[activeKey];
+      if (!handle) return Promise.resolve();
+      return handle.send(text);
+    },
+    [activeKey]
+  );
+
+  // Build the ordered, merged conversation list (tab order + live slice).
+  const conversations = useMemo<ConversationView[]>(
+    () =>
+      tabs.map(
+        (t) =>
+          views[t.key] ?? {
+            key: t.key,
+            chatId: t.chatId,
+            label: t.label,
+            messages: [],
+            status: 'connecting' as BridgeStatus,
+            awaitingReply: false,
+            unread: 0,
+            sendError: null,
+          }
+      ),
+    [tabs, views]
+  );
+
+  const active = conversations.find((c) => c.key === activeKey) ?? conversations[0] ?? null;
+  // sendError tracks the ACTIVE conversation (matches the old single-bridge API).
+  const sendError = active?.sendError ?? null;
+
+  const value = useMemo<BridgeStoreValue>(
+    () => ({
+      conversations,
+      activeId: activeKey,
+      active,
+      sendError,
+      send,
+      newConversation,
+      closeConversation,
+      switchConversation,
+      canAddTab: tabs.length < MAX_TABS,
+    }),
+    [conversations, activeKey, active, sendError, send, newConversation, closeConversation, switchConversation, tabs.length]
+  );
+
+  return (
+    <BridgeStore.Provider value={value}>
+      {/* One headless hook host per open conversation — keeps every tab streaming. */}
+      {tabs.map((t) => (
+        <ConversationController
+          key={t.key}
+          meta={t}
+          active={t.key === activeKey}
+          onState={onState}
+          onChatIdMinted={onChatIdMinted}
+          registerHandle={registerHandle}
+        />
+      ))}
+      {children}
+    </BridgeStore.Provider>
+  );
 }
 
 /**
- * useBridgeContext — consume the shared bridge state.
+ * useBridgeStore — consume the multi-conversation store.
  * Throws if called outside <BridgeProvider>.
  */
-export function useBridgeContext(): UseBridgeResult {
-  const ctx = useContext(BridgeContext);
+export function useBridgeStore(): BridgeStoreValue {
+  const ctx = useContext(BridgeStore);
   if (ctx === null) {
-    throw new Error('useBridgeContext must be used inside <BridgeProvider>');
+    throw new Error('useBridgeStore must be used inside <BridgeProvider>');
   }
   return ctx;
+}
+
+/** Active-conversation slice in the legacy single-bridge shape. */
+export interface ActiveBridge {
+  messages: BridgeMessage[];
+  status: BridgeStatus;
+  awaitingReply: boolean;
+  chatId: string | null;
+  sendError: string | null;
+  send: (text: string) => Promise<void>;
+}
+
+/**
+ * useBridgeContext — backward-compatible accessor for the ACTIVE conversation,
+ * shaped like the original single-bridge result. ChatDock + ChatPrimitives use
+ * this so the launcher always mirrors whichever tab is active without knowing
+ * about the multi-conversation store.
+ */
+export function useBridgeContext(): ActiveBridge {
+  const store = useBridgeStore();
+  const a = store.active;
+  return {
+    messages: a?.messages ?? [],
+    status: a?.status ?? 'connecting',
+    awaitingReply: a?.awaitingReply ?? false,
+    chatId: a?.chatId ?? null,
+    sendError: store.sendError,
+    send: store.send,
+  };
 }

--- a/packages/dashboard-v2/src/lib/__tests__/BridgeContext.test.tsx
+++ b/packages/dashboard-v2/src/lib/__tests__/BridgeContext.test.tsx
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, act, waitFor, screen } from '@testing-library/react';
+import { BridgeProvider, useBridgeStore, MAX_TABS } from '../BridgeContext';
+
+/**
+ * BridgeContext — multi-conversation tab store.
+ *
+ * Covers the ChatPage tab strip contract:
+ *   - newConversation / switchConversation / closeConversation
+ *   - localStorage persistence round-trip (open chat_ids + active id + labels)
+ *   - unread accrues on an INACTIVE conversation, clears on switch
+ *   - closing the ACTIVE tab activates a neighbor
+ *   - closing the LAST tab leaves exactly one fresh "new chat" (never zero)
+ *   - first-message snippet labels; new tab capped at MAX_TABS
+ */
+
+const STORAGE_KEY = 'gossipcat_chat_tabs';
+
+// ── Mock EventSource ─────────────────────────────────────────────────────────
+const instances: MockEventSource[] = [];
+
+class MockEventSource {
+  url: string;
+  onopen: ((this: EventSource, ev: Event) => unknown) | null = null;
+  onmessage: ((this: EventSource, ev: MessageEvent) => unknown) | null = null;
+  onerror: ((this: EventSource, ev: Event) => unknown) | null = null;
+  closed = false;
+  constructor(url: string) {
+    this.url = url;
+    instances.push(this);
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(frame: unknown) {
+    this.onmessage?.call(this as unknown as EventSource, { data: JSON.stringify(frame) } as MessageEvent);
+  }
+  /** Find the most-recently-opened stream subscribed to a given chat_id. */
+  static lastForChat(chatId: string): MockEventSource | undefined {
+    for (let i = instances.length - 1; i >= 0; i--) {
+      if (new URL(instances[i].url, 'http://localhost').searchParams.get('chat_id') === chatId) {
+        return instances[i];
+      }
+    }
+    return undefined;
+  }
+}
+
+// fetch mints a fresh incrementing chat_id per send so each first-send gets its own.
+let mintCounter = 0;
+function stubFetchMinting() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      mintCounter += 1;
+      const id = `chat-${mintCounter}`;
+      return { status: 202, json: async () => ({ ok: true, chat_id: id }) };
+    }) as unknown as typeof fetch
+  );
+}
+
+let realEventSource: unknown;
+
+beforeEach(() => {
+  instances.length = 0;
+  mintCounter = 0;
+  localStorage.clear();
+  realEventSource = (window as unknown as { EventSource?: unknown }).EventSource;
+  (window as unknown as { EventSource: unknown }).EventSource = MockEventSource;
+  stubFetchMinting();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  (window as unknown as { EventSource: unknown }).EventSource = realEventSource;
+  localStorage.clear();
+});
+
+// ── Test harness: exposes the store via window for imperative driving ─────────
+let store: ReturnType<typeof useBridgeStore>;
+function Capture() {
+  store = useBridgeStore();
+  return (
+    <div data-testid="tabs">
+      {store.conversations.map((c) => (
+        <span key={c.key} data-active={c.key === store.activeId} data-unread={c.unread}>
+          {c.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+function renderStore() {
+  return render(
+    <BridgeProvider>
+      <Capture />
+    </BridgeProvider>
+  );
+}
+
+describe('BridgeContext — initial state', () => {
+  it('starts with exactly one fresh "new chat" tab, active', async () => {
+    renderStore();
+    await waitFor(() => expect(store.conversations.length).toBe(1));
+    expect(store.conversations[0].label).toBe('new chat');
+    expect(store.activeId).toBe(store.conversations[0].key);
+  });
+});
+
+describe('BridgeContext — new / switch / close', () => {
+  it('opens a new tab and switches to it', async () => {
+    renderStore();
+    await waitFor(() => expect(store.conversations.length).toBe(1));
+    const first = store.conversations[0].key;
+    act(() => store.newConversation());
+    await waitFor(() => expect(store.conversations.length).toBe(2));
+    const second = store.conversations[1].key;
+    expect(store.activeId).toBe(second);
+
+    act(() => store.switchConversation(first));
+    await waitFor(() => expect(store.activeId).toBe(first));
+  });
+
+  it('caps new tabs at MAX_TABS', async () => {
+    renderStore();
+    await waitFor(() => expect(store.conversations.length).toBe(1));
+    for (let i = 0; i < MAX_TABS + 3; i++) {
+      act(() => store.newConversation());
+    }
+    await waitFor(() => expect(store.conversations.length).toBe(MAX_TABS));
+    expect(store.canAddTab).toBe(false);
+  });
+
+  it('closing the active tab activates a neighbor', async () => {
+    renderStore();
+    await waitFor(() => expect(store.conversations.length).toBe(1));
+    act(() => store.newConversation());
+    act(() => store.newConversation());
+    await waitFor(() => expect(store.conversations.length).toBe(3));
+    const [a, b] = store.conversations.map((c) => c.key);
+    const c = store.conversations[2].key;
+    // active is the third (last opened); close it → neighbor (b) becomes active.
+    expect(store.activeId).toBe(c);
+    act(() => store.closeConversation(c));
+    await waitFor(() => expect(store.conversations.length).toBe(2));
+    expect(store.activeId).toBe(b);
+    // closing a non-active tab leaves active unchanged.
+    act(() => store.closeConversation(a));
+    await waitFor(() => expect(store.conversations.length).toBe(1));
+    expect(store.activeId).toBe(b);
+  });
+
+  it('closing the last tab leaves exactly one fresh "new chat" (never zero)', async () => {
+    renderStore();
+    await waitFor(() => expect(store.conversations.length).toBe(1));
+    const only = store.conversations[0].key;
+    act(() => store.closeConversation(only));
+    await waitFor(() => expect(store.conversations.length).toBe(1));
+    // A brand-new tab with a different key + "new chat" label.
+    expect(store.conversations[0].key).not.toBe(only);
+    expect(store.conversations[0].label).toBe('new chat');
+    expect(store.activeId).toBe(store.conversations[0].key);
+  });
+});
+
+describe('BridgeContext — labels from first message', () => {
+  it('labels a tab with the first user-message snippet after send', async () => {
+    renderStore();
+    await waitFor(() => expect(store.conversations.length).toBe(1));
+    await act(async () => {
+      await store.send('deploy the staging build now please');
+    });
+    await waitFor(() =>
+      expect(store.conversations[0].label).toBe('deploy the staging…')
+    );
+    // chat_id minted + adopted.
+    await waitFor(() => expect(store.conversations[0].chatId).toBe('chat-1'));
+  });
+});
+
+describe('BridgeContext — unread on inactive tab', () => {
+  it('accrues unread on an inactive conversation and clears on switch', async () => {
+    renderStore();
+    await waitFor(() => expect(store.conversations.length).toBe(1));
+    // Send on tab 1 to mint chat-1, then open + switch to a fresh tab 2.
+    await act(async () => {
+      await store.send('first');
+    });
+    await waitFor(() => expect(store.conversations[0].chatId).toBe('chat-1'));
+    act(() => store.newConversation()); // switches to tab 2; tab 1 now inactive
+    await waitFor(() => expect(store.conversations.length).toBe(2));
+    const tab1Key = store.conversations[0].key;
+
+    // A reply lands on chat-1 while tab 1 is inactive → unread bumps.
+    const es = MockEventSource.lastForChat('chat-1');
+    expect(es).toBeTruthy();
+    act(() => {
+      es!.emit({
+        type: 'mirror',
+        chat_id: 'chat-1',
+        role: 'assistant',
+        text: 'background reply',
+        ts: '2026-06-16T11:00:00.000Z',
+        id: 2,
+      });
+    });
+    await waitFor(() => {
+      const tab1 = store.conversations.find((c) => c.key === tab1Key);
+      expect(tab1?.unread).toBe(1);
+    });
+
+    // Switch back to tab 1 → its unread clears.
+    act(() => store.switchConversation(tab1Key));
+    await waitFor(() => {
+      const tab1 = store.conversations.find((c) => c.key === tab1Key);
+      expect(tab1?.unread).toBe(0);
+    });
+  });
+});
+
+describe('BridgeContext — persistence round-trip', () => {
+  it('persists open chat_ids + active id, restores them on remount', async () => {
+    const { unmount } = renderStore();
+    await waitFor(() => expect(store.conversations.length).toBe(1));
+    await act(async () => {
+      await store.send('alpha');
+    });
+    await waitFor(() => expect(store.conversations[0].chatId).toBe('chat-1'));
+    act(() => store.newConversation());
+    await waitFor(() => expect(store.conversations.length).toBe(2));
+    await act(async () => {
+      await store.send('beta');
+    });
+    await waitFor(() => expect(store.conversations[1].chatId).toBe('chat-2'));
+
+    // localStorage should now hold both chat_ids; active = chat-2 (tab 2).
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.tabs.map((t: { chatId: string }) => t.chatId)).toEqual(['chat-1', 'chat-2']);
+    expect(parsed.activeChatId).toBe('chat-2');
+
+    unmount();
+    instances.length = 0;
+
+    // Remount: tabs restore from storage; streams reopen subscribed to the ids.
+    renderStore();
+    await waitFor(() => expect(store.conversations.length).toBe(2));
+    expect(store.conversations.map((c) => c.chatId)).toEqual(['chat-1', 'chat-2']);
+    expect(store.active?.chatId).toBe('chat-2');
+    // Each restored conversation opened a stream subscribed to its chat_id.
+    await waitFor(() => {
+      expect(MockEventSource.lastForChat('chat-1')).toBeTruthy();
+      expect(MockEventSource.lastForChat('chat-2')).toBeTruthy();
+    });
+  });
+
+  it('falls back to a single fresh tab when storage is corrupt', async () => {
+    localStorage.setItem(STORAGE_KEY, '{not valid json');
+    renderStore();
+    await waitFor(() => expect(store.conversations.length).toBe(1));
+    expect(store.conversations[0].label).toBe('new chat');
+    expect(store.conversations[0].chatId).toBeNull();
+  });
+
+  it('does NOT persist a never-sent (chat_id=null) conversation', async () => {
+    renderStore();
+    await waitFor(() => expect(store.conversations.length).toBe(1));
+    act(() => store.newConversation()); // two empty tabs, neither sent
+    await waitFor(() => expect(store.conversations.length).toBe(2));
+    // No chat_ids minted → storage stays empty (removeItem path).
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe('BridgeContext — render integration', () => {
+  it('renders one tab element per conversation', async () => {
+    renderStore();
+    await waitFor(() => expect(store.conversations.length).toBe(1));
+    act(() => store.newConversation());
+    await waitFor(() => {
+      const spans = screen.getByTestId('tabs').querySelectorAll('span');
+      expect(spans.length).toBe(2);
+    });
+  });
+});

--- a/packages/dashboard-v2/src/lib/__tests__/useBridge.test.tsx
+++ b/packages/dashboard-v2/src/lib/__tests__/useBridge.test.tsx
@@ -235,6 +235,73 @@ describe('useBridge — last_id high-water mark', () => {
   });
 });
 
+describe('useBridge — unread (inactive conversation)', () => {
+  it('increments unread when an inbound frame lands while inactive, markRead clears it', async () => {
+    const hook = renderHook(({ active }) => useBridge({ active }), {
+      initialProps: { active: false },
+    });
+    await waitFor(() => expect(instances.length).toBeGreaterThan(0));
+    act(() => instances[0].open());
+    await act(async () => {
+      await hook.result.current.send('hello');
+    });
+    await waitFor(() => expect(hook.result.current.chatId).toBe('chat-1'));
+    await waitFor(() => expect(instances.length).toBeGreaterThanOrEqual(2));
+    const active = instances[instances.length - 1];
+
+    act(() => {
+      active.emit({
+        type: 'mirror',
+        chat_id: 'chat-1',
+        role: 'assistant',
+        text: 'reply while hidden',
+        ts: '2026-06-16T10:00:00.000Z',
+        id: 3,
+      });
+    });
+    await waitFor(() => expect(hook.result.current.unread).toBe(1));
+
+    act(() => hook.result.current.markRead());
+    expect(hook.result.current.unread).toBe(0);
+  });
+
+  it('does NOT increment unread when the conversation is active', async () => {
+    const hook = renderHook(() => useBridge({ active: true }));
+    await waitFor(() => expect(instances.length).toBeGreaterThan(0));
+    act(() => instances[0].open());
+    await act(async () => {
+      await hook.result.current.send('hi');
+    });
+    await waitFor(() => expect(hook.result.current.chatId).toBe('chat-1'));
+    await waitFor(() => expect(instances.length).toBeGreaterThanOrEqual(2));
+    const active = instances[instances.length - 1];
+    act(() => {
+      active.emit({
+        type: 'mirror',
+        chat_id: 'chat-1',
+        role: 'assistant',
+        text: 'visible reply',
+        ts: '2026-06-16T10:00:01.000Z',
+        id: 4,
+      });
+    });
+    await waitFor(() =>
+      expect(hook.result.current.messages.some((m) => m.text === 'visible reply')).toBe(true)
+    );
+    expect(hook.result.current.unread).toBe(0);
+  });
+});
+
+describe('useBridge — initialChatId', () => {
+  it('opens the stream subscribed to a restored chat_id and replays the ring (last_id=0)', async () => {
+    renderHook(() => useBridge({ initialChatId: 'restored-chat' }));
+    await waitFor(() => expect(instances.length).toBe(1));
+    const url = new URL(instances[0].url, 'http://localhost');
+    expect(url.searchParams.get('chat_id')).toBe('restored-chat');
+    expect(url.searchParams.get('last_id')).toBe('0');
+  });
+});
+
 describe('useBridge — restart frame', () => {
   it('resets last_id to 0 and reconnects on a restart frame', async () => {
     await mountWithChat();

--- a/packages/dashboard-v2/src/lib/useBridge.ts
+++ b/packages/dashboard-v2/src/lib/useBridge.ts
@@ -1,16 +1,25 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
- * useBridge — frontend hook for the dashboard ⇄ LIVE Claude Code session bridge
- * (P1 backend, spec 2026-06-14-dashboard-cc-channel-bridge.md).
+ * useBridge — frontend hook for ONE conversation on the dashboard ⇄ LIVE Claude
+ * Code session bridge (P1 backend, spec 2026-06-14-dashboard-cc-channel-bridge.md).
+ *
+ * Each call to useBridge() is an INDEPENDENT conversation: it opens its OWN
+ * EventSource, keeps its OWN message list / status / awaitingReply, and mints (or
+ * adopts) its OWN chat_id. The multi-conversation tab store (BridgeContext) mounts
+ * one useBridge() instance per open tab via a headless ConversationController so
+ * inactive tabs keep streaming and accrue an `unread` marker.
  *
  * Mirrors the useEventStream SSE pattern: open an EventSource, parse frames,
  * manual reconnect with backoff, cleanup-on-unmount. Adds the conversational
  * layer the bridge needs:
  *   - send(text): POST to /dashboard/api/bridge. Omits chat_id on the first
  *     send; the server mints + returns one, which we reuse for the conversation.
- *   - Frames are filtered to the active chat_id so a stray/forged stream id
- *     (or a different tab's conversation) can't bleed into this view.
+ *   - Frames are filtered to this conversation's chat_id so a stray/forged stream
+ *     id (or a different tab's conversation) can't bleed into this view.
+ *   - unread: increments when a reply/mirror/error frame arrives while this
+ *     conversation is INACTIVE (options.active === false). markRead() clears it
+ *     (called by the store when the tab becomes active).
  *
  * IMPORTANT: this wires the LIVE Claude Code orchestrator session, NOT the
  * dormant ChatbotAgent /api/chat brain. The two must never be conflated.
@@ -82,6 +91,23 @@ export interface BridgeMessage {
 /** Connection lifecycle of the SSE stream. */
 export type BridgeStatus = 'connecting' | 'open' | 'closed' | 'error';
 
+/** Options for a single-conversation bridge instance. */
+export interface UseBridgeOptions {
+  /**
+   * Initial chat_id to (re)attach to — a persisted/restored conversation. When
+   * provided the stream opens immediately subscribed to this id and replays the
+   * server ring (?last_id=0). null/undefined = a brand-new, never-sent
+   * conversation that mints its id on first send.
+   */
+  initialChatId?: string | null;
+  /**
+   * Whether this conversation is the ACTIVE (visible) tab. Inbound reply/mirror/
+   * error frames that arrive while inactive increment `unread`. Defaults true so
+   * a bare useBridge() (no store) behaves like the old single-conversation hook.
+   */
+  active?: boolean;
+}
+
 export interface UseBridgeResult {
   messages: BridgeMessage[];
   /** SSE connection status. */
@@ -90,10 +116,14 @@ export interface UseBridgeResult {
   awaitingReply: boolean;
   /** True once the server has minted (or we have adopted) a chat_id. */
   chatId: string | null;
+  /** Count of inbound turns since this conversation was last marked read. */
+  unread: number;
   /** POST a user message to the live CC session. No-op for empty input. */
   send: (text: string) => Promise<void>;
   /** Last transient send error (network / HTTP), cleared on the next send. */
   sendError: string | null;
+  /** Clear the unread counter (called when the tab becomes active). */
+  markRead: () => void;
 }
 
 const BACKOFF_MIN_MS = 1_000;
@@ -143,17 +173,33 @@ function insertByTs(prev: readonly BridgeMessage[], msg: BridgeMessage): BridgeM
   return [...prev.slice(0, idx), msg, ...prev.slice(idx)];
 }
 
-export function useBridge(): UseBridgeResult {
+export function useBridge(options: UseBridgeOptions = {}): UseBridgeResult {
+  const { initialChatId = null, active = true } = options;
+
   const [messages, setMessages] = useState<BridgeMessage[]>([]);
   const [status, setStatus] = useState<BridgeStatus>('connecting');
   const [awaitingReply, setAwaitingReply] = useState(false);
-  const [chatId, setChatId] = useState<string | null>(null);
+  const [chatId, setChatId] = useState<string | null>(initialChatId);
   const [sendError, setSendError] = useState<string | null>(null);
+  const [unread, setUnread] = useState(0);
+
+  // `active` is read inside the onmessage closure; a ref keeps it current without
+  // re-opening the stream when the active tab changes.
+  const activeRef = useRef(active);
+  activeRef.current = active;
+
+  const markRead = useCallback(() => setUnread(0), []);
+
+  // Bump the unread counter only when this conversation is NOT the active tab.
+  const bumpUnreadIfInactive = useCallback(() => {
+    if (!activeRef.current) setUnread((n) => n + 1);
+  }, []);
 
   // chat_id is read inside the EventSource onmessage closure (created once in the
   // mount effect) and written by send(). A ref keeps the frame filter reading the
-  // latest value without re-opening the stream on every chat_id change.
-  const chatIdRef = useRef<string | null>(null);
+  // latest value without re-opening the stream on every chat_id change. Seeded
+  // with the restored initialChatId so a persisted conversation streams at once.
+  const chatIdRef = useRef<string | null>(initialChatId);
   const setChat = useCallback((id: string) => {
     const prev = chatIdRef.current;
     chatIdRef.current = id;
@@ -225,15 +271,16 @@ export function useBridge(): UseBridgeResult {
         } catch {
           return; // malformed frame — skip
         }
-        // Filter to the active conversation. Before our first send chatIdRef is
+        // Filter to this conversation. Before our first send chatIdRef is
         // null and we have no stream to claim, so ignore frames until then.
         // Mirror frames carry chat_id too — the same filter applies.
-        const active = chatIdRef.current;
-        if (!active || frame.chat_id !== active) return;
+        const activeChat = chatIdRef.current;
+        if (!activeChat || frame.chat_id !== activeChat) return;
 
         if (frame.type === 'reply') {
           setAwaitingReply(false);
           setMessages((prev) => insertByTs(prev, makeMessage('assistant', frame.text ?? '', frame.ts)));
+          bumpUnreadIfInactive();
         } else if (frame.type === 'ack') {
           // Ack means "received / working" — keep the awaiting indicator on but
           // record a discrete ack turn so the user sees the session is alive.
@@ -243,6 +290,7 @@ export function useBridge(): UseBridgeResult {
           setMessages((prev) =>
             insertByTs(prev, makeMessage('error', frame.text ?? 'the live session reported an error', frame.ts))
           );
+          bumpUnreadIfInactive();
         } else if (frame.type === 'mirror') {
           handleMirrorFrame(frame);
         } else if (frame.type === 'restart') {
@@ -293,6 +341,7 @@ export function useBridge(): UseBridgeResult {
       // and the frame interleaves near "now" instead of at an arbitrary position.
       const ts = typeof frame.ts === 'string' && /^\d{4}-\d{2}-\d{2}T/.test(frame.ts) ? frame.ts : undefined;
       setMessages((prev) => insertByTs(prev, makeMessage(role, text, ts, frame.id)));
+      bumpUnreadIfInactive();
     }
 
     /** Close + reopen the stream immediately (used by the `restart` frame). */
@@ -323,7 +372,7 @@ export function useBridge(): UseBridgeResult {
         es = null;
       }
     };
-  }, []);
+  }, [bumpUnreadIfInactive]);
 
   const send = useCallback(
     async (raw: string): Promise<void> => {
@@ -380,5 +429,5 @@ export function useBridge(): UseBridgeResult {
     [setChat]
   );
 
-  return { messages, status, awaitingReply, chatId, send, sendError };
+  return { messages, status, awaitingReply, chatId, unread, send, sendError, markRead };
 }


### PR DESCRIPTION
Browser-tab-style strip in the Chat page to run several independent chat conversations and switch between them. Frontend only.

## What
- **`useBridge.ts`** — generalized to a per-conversation controller (`UseBridgeOptions {initialChatId?, active?}`, `unread`, `markRead`). Each conversation runs its **own** `EventSource(?chat_id=…)`, kept alive when inactive so it accrues unread. Backward-compatible; forward-compatible with the #610 per-client SSE filter.
- **`BridgeContext.tsx`** — multi-conversation store (`conversations[]`, `activeId`, `send`→active, `new/close/switchConversation`, `canAddTab`). One headless `ConversationController` per tab (Rules-of-Hooks-safe N independent SSE hooks). **localStorage persistence** (`gossipcat_chat_tabs`, try/caught + 64KB cap, never-sent not persisted, MAX_TABS=8). `useBridgeContext()` kept as a backward-compat active accessor so the **bottom-right launcher mirrors the active tab** unchanged.
- **`ChatTabs.tsx`** (new) — `role=tablist/tab` + `aria-selected`, roving Arrow focus with **manual activation** (Enter/Space/click; arrows don't switch), per-tab unread dot + 24×24 close, `+` new-chat. Closing the active tab activates the neighbor; closing the last leaves one fresh tab (never zero).
- **`ChatPage.tsx`** — renders the strip under the info-bar; active slice drives transcript/composer.
- **`globals.css`** — `.cx-tabstrip/.cx-tab*`: active = `--surface` + 3px `--ink-2` indicator; inactive transparent/`--ink-3` + hover wash; unread `--info` teal (never `--accent`); JBMono id labels; hairline, no shadow, focus rings, reduced-motion guards.

## Design QA (sonnet-designer `f516303c`) — 11 findings, all applied
- **HIGH:** close `×` off non-text `--ink-4` → `--ink-3` (AA); removed `role="presentation"` wrapper that orphaned `role=tab` from the tablist a11y tree (verified: 0 presentation divs, 2 role=tab); manual tab activation so arrow-browsing doesn't fire SSE reconnect per keystroke.
- **MED/LOW:** 3px active indicator, 24×24 close hit area, min-width + `+` separator, dead CSS selector removed, focus-ring offset, unread surfaced to AT.

> Note: the design-fix agent stalled on a 500 mid-task — CSS fixes had landed; the orchestrator finished the component fixes (F2/F3/F10) and re-verified.

## Verification
- tsc clean · `build:dashboard` clean · **vitest 55 passed** (11 new BridgeContext + 3 new useBridge)
- live in-browser: add/switch/close/snippet-labels/unread confirmed; a11y `role=tab=2, presentationDivs=0, close=24px`; **page fits (no scroll)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)