### PR TITLE
feat(relay): durable write-through chat history (survives restart, fixes ghost tabs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ## [Unreleased]
 
+### Added
+
+- **Durable dashboard chat history.** Mirror chat transcripts now persist to
+  `.gossip/chat/<chat_id>.jsonl` via a write-through `ChatStore` seam, so chat
+  history survives a relay restart and is no longer capped at the 100-frame
+  in-memory ring. On a cold ring, `MirrorEventStore` hydrates from disk and
+  continues the per-chat id sequence, so a reconnecting tab replays its history
+  instead of showing an empty transcript ("ghost tab"). Persistence is
+  best-effort and read-side only — the inbound `reply`/answer trust gates are
+  unchanged. Transcripts are written as plaintext under the gitignored
+  `.gossip/` dir; the store re-validates every `chat_id` against the id charset
+  before any path op (path-traversal defense-in-depth), bounds each file via
+  amortized truncation, writes truncations atomically (tmp→rename), skips
+  internal `_`-prefixed sentinels, and caps per-line length before parse.
+
 ## [0.6.5] — 2026-06-17
 
 Dashboard chat: multi-conversation tabs, a redesign, and dashboard-answerable

--- a/packages/relay/src/dashboard/api-bridge.ts
+++ b/packages/relay/src/dashboard/api-bridge.ts
@@ -30,7 +30,8 @@
 
 import type { IncomingMessage, ServerResponse } from 'http';
 import { randomUUID } from 'crypto';
-import { MirrorEventStore } from './api-mirror-events';
+import { MirrorEventStore, MIRROR_RING_MAX, MIRROR_RING_TTL_MS } from './api-mirror-events';
+import { FileChatStore, NullChatStore } from './chat-store';
 
 /**
  * In-process sink the MCP server registers. Returns true when the message was
@@ -283,6 +284,12 @@ export function validateChatId(raw: unknown): string | null {
   return v;
 }
 
+/** Optional configuration for BridgeHub. */
+export interface BridgeHubOpts {
+  /** When provided, mirror history is persisted under this directory. */
+  chatDir?: string;
+}
+
 /**
  * BridgeHub — owns the outbound SSE client set and the registered inbound sink.
  * One instance per DashboardRouter. Process-local; a cold restart clears it.
@@ -337,7 +344,8 @@ export class BridgeHub {
   // through here. Established only from a validated dashboard inbound POST.
   private sessionToChatId = new Map<string, { chatId: string; at: number }>();
   // Per-chat_id mirror rings (bounded FIFO + TTL + proactive sweep).
-  private mirror = new MirrorEventStore();
+  // Constructed with a FileChatStore when chatDir is provided, else NullChatStore.
+  private mirror: MirrorEventStore;
   // PROVISIONAL buffer (P1#5 fallback): a purely-terminal mirror POST with no
   // resolvable chat_id (no body chat_id, no known session mapping) is buffered
   // under a provisional id so a later observer can backfill it — OR dropped,
@@ -352,6 +360,13 @@ export class BridgeHub {
   private dropUnresolvedMirror = false;
   // session→chat_id entries share the same 2h TTL ceiling as knownChatIds.
   private static readonly MAX_SESSION_MAPPINGS = 64;
+
+  constructor(opts: BridgeHubOpts = {}) {
+    const store = opts.chatDir
+      ? new FileChatStore(opts.chatDir)
+      : new NullChatStore();
+    this.mirror = new MirrorEventStore(MIRROR_RING_MAX, MIRROR_RING_TTL_MS, undefined, store);
+  }
 
   /** Register (or clear) the in-process inbound sink. Called by RelayServer. */
   registerSink(fn: BridgeSink | null): void {

--- a/packages/relay/src/dashboard/api-mirror-events.ts
+++ b/packages/relay/src/dashboard/api-mirror-events.ts
@@ -19,6 +19,7 @@
  */
 
 import type { MirrorFrame } from './api-bridge';
+import { NullChatStore, type ChatStore } from './chat-store';
 
 /** Max frames retained per chat_id ring (bounded FIFO). Start conservative. */
 export const MIRROR_RING_MAX = 100;
@@ -40,16 +41,24 @@ interface MirrorRing {
  * MirrorEventStore — owns the per-chat_id rings. One instance per BridgeHub.
  * Process-local; a cold restart clears everything and resets every counter to
  * 0 (handled by the restart sentinel in api-bridge.handleStream).
+ *
+ * When a ChatStore is injected, rings are lazily hydrated from disk on first
+ * access (push/replaySlice/highestId) so post-restart replays and restart-
+ * sentinel checks see persisted frames and the id sequence continues across
+ * restarts (stopping false restart-sentinels).
  */
 export class MirrorEventStore {
   private rings = new Map<string, MirrorRing>();
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
+  private store: ChatStore;
 
   constructor(
     private readonly ringMax: number = MIRROR_RING_MAX,
     private readonly ttlMs: number = MIRROR_RING_TTL_MS,
     sweepIntervalMs: number = MIRROR_SWEEP_INTERVAL_MS,
+    store: ChatStore = new NullChatStore(),
   ) {
+    this.store = store;
     // Proactive sweep. unref so the timer never keeps node alive (tests, clean
     // shutdown). A sweepIntervalMs<=0 disables the timer (test injection).
     if (sweepIntervalMs > 0) {
@@ -59,17 +68,45 @@ export class MirrorEventStore {
   }
 
   /**
-   * Allocate the next id for a chat_id WITHOUT pushing a frame. The hub stamps
-   * id + ts server-side, so it asks the store to mint the id, builds the frame,
-   * then pushes it. Keeping mint+push as one call (push) avoids a torn counter,
-   * so this is internal — callers use push().
+   * Allocate or hydrate a ring for a chat_id. On first access when the ring is
+   * not in memory, loads persisted frames from the ChatStore so post-restart
+   * reads see durable history and the id sequence continues (preventing false
+   * restart-sentinels). Returns null when neither an in-memory ring exists NOR
+   * any persisted frames were found — callers treat null as "no data."
+   *
+   * Renamed from `ensureRing` to `getOrHydrate` to reflect the new semantics.
+   * push() uses a variant that always creates the ring (even if empty), since a
+   * push always establishes a new ring. replaySlice/highestId use this
+   * conditional form so they don't pollute ringCount() with empty rings on miss.
+   */
+  private getOrHydrate(chatId: string, now: number): MirrorRing | null {
+    const existing = this.rings.get(chatId);
+    if (existing) return existing;
+    // Not in memory — try to load from the persistent store.
+    const persisted = this.store.load(chatId, this.ringMax);
+    if (persisted.length === 0) return null;
+    const ring: MirrorRing = {
+      frames: persisted.slice(),
+      // Continue the id sequence from the highest persisted id so push() does
+      // not reset to 1 after a restart (preventing the false restart-sentinel).
+      nextId: persisted[persisted.length - 1].id,
+      touchedAt: now,
+    };
+    this.rings.set(chatId, ring);
+    return ring;
+  }
+
+  /**
+   * Ensure a ring exists for a chat_id, creating it from persisted data or
+   * fresh. Always returns a ring (never null). Used only by push() since a
+   * push always establishes a ring.
    */
   private ensureRing(chatId: string, now: number): MirrorRing {
-    let ring = this.rings.get(chatId);
-    if (!ring) {
-      ring = { frames: [], nextId: 0, touchedAt: now };
-      this.rings.set(chatId, ring);
-    }
+    const hydrated = this.getOrHydrate(chatId, now);
+    if (hydrated) return hydrated;
+    // No persisted data — fresh ring.
+    const ring: MirrorRing = { frames: [], nextId: 0, touchedAt: now };
+    this.rings.set(chatId, ring);
     return ring;
   }
 
@@ -94,6 +131,8 @@ export class MirrorEventStore {
     // Bounded FIFO: drop oldest beyond the cap. Distinct from TTL eviction.
     while (ring.frames.length > this.ringMax) ring.frames.shift();
     ring.touchedAt = now;
+    // Write-through to durable store (NullChatStore is a no-op).
+    this.store.append(chatId, frame);
     return frame;
   }
 
@@ -104,7 +143,7 @@ export class MirrorEventStore {
    * actively-observed stream isn't swept out from under a reconnecting client.
    */
   replaySlice(chatId: string, lastId: number, now: number = Date.now()): MirrorFrame[] {
-    const ring = this.rings.get(chatId);
+    const ring = this.getOrHydrate(chatId, now);
     if (!ring) return [];
     ring.touchedAt = now;
     // lastId<=0: return a defensive COPY (callers iterate while the ring may be
@@ -142,6 +181,9 @@ export class MirrorEventStore {
     const carried = src.frames.slice();
     // Clear the source ring entirely — provisional frames live exactly once.
     this.rings.delete(fromChatId);
+    // Drop the provisional file from disk — re-stamped frames persist via
+    // push() into the destination ring.
+    this.store.drop(fromChatId);
     const transferred: MirrorFrame[] = [];
     for (const f of carried) {
       transferred.push(this.push(toChatId, f.role, f.text, now));
@@ -157,7 +199,7 @@ export class MirrorEventStore {
    * sentinel in api-bridge.handleStream).
    */
   highestId(chatId: string): number {
-    const ring = this.rings.get(chatId);
+    const ring = this.getOrHydrate(chatId, Date.now());
     if (!ring || ring.frames.length === 0) return 0;
     return ring.frames[ring.frames.length - 1].id;
   }

--- a/packages/relay/src/dashboard/chat-store.ts
+++ b/packages/relay/src/dashboard/chat-store.ts
@@ -1,0 +1,190 @@
+/**
+ * chat-store.ts — durable write-through store for mirror chat history
+ * (spec 2026-06-17-chat-write-through-store.md).
+ *
+ * ChatStore is a thin seam between the in-memory MirrorEventStore ring and a
+ * persistent backend. The default (NullChatStore) is a no-op and preserves all
+ * existing behavior. FileChatStore writes append-only JSONL under
+ * <chatDir>/<chatId>.jsonl, one frame per line, with amortized truncation to
+ * PERSIST_CAP lines to prevent unbounded disk growth.
+ *
+ * Security: FileChatStore re-validates every chatId against CHAT_ID_RE before
+ * ANY path operation — defense-in-depth against path traversal even if the
+ * caller is already validating. An invalid id is always a no-op (append/drop)
+ * or returns [] (load). Never throws into the live bridge.
+ *
+ * Underscore-prefixed ids (e.g. '_provisional') are internal sentinels and are
+ * NEVER persisted by append() or maybeRetain(). load() and drop() still work on
+ * them so pre-existing sentinel files can be drained and cleaned up.
+ */
+
+import { appendFileSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import type { MirrorFrame } from './api-bridge';
+
+/** Same pattern as CHAT_ID_RE in api-bridge.ts — defense-in-depth re-check. */
+const CHAT_ID_RE = /^[a-zA-Z0-9_-]{1,128}$/;
+
+/**
+ * Approximate max lines retained per .jsonl file. When a file exceeds 2× this
+ * on append, it is truncated to the last PERSIST_CAP lines (amortized rewrite
+ * — one rewrite per 2×PERSIST_CAP appends, not one per append).
+ */
+export const PERSIST_CAP = 1000;
+
+/**
+ * Maximum byte length of a single JSONL line that load() will parse.
+ * Lines exceeding this are skipped (with a console.warn) as a defense-in-depth
+ * guard against corrupted or adversarial oversized lines.
+ */
+const MAX_LINE_BYTES = 256 * 1024; // 256 KiB
+
+export interface ChatStore {
+  /** Durable write-through. Best-effort: MUST NOT throw into the live path. */
+  append(chatId: string, frame: MirrorFrame): void;
+  /** Hydrate a cold ring. Returns up to `max` most-recent frames in id order. */
+  load(chatId: string, max: number): MirrorFrame[];
+  /** Delete persisted history (provisional cleanup after drainInto). */
+  drop(chatId: string): void;
+  dispose(): void;
+}
+
+/** Default no-op — preserves current behavior + all existing tests. */
+export class NullChatStore implements ChatStore {
+  append(_chatId: string, _frame: MirrorFrame): void {}
+  load(_chatId: string, _max: number): MirrorFrame[] { return []; }
+  drop(_chatId: string): void {}
+  dispose(): void {}
+}
+
+/** True when `obj` has the minimal shape of a MirrorFrame. */
+function isMirrorFrameShaped(obj: unknown): obj is MirrorFrame {
+  if (!obj || typeof obj !== 'object') return false;
+  const f = obj as Record<string, unknown>;
+  return (
+    f.type === 'mirror' &&
+    typeof f.chat_id === 'string' &&
+    typeof f.role === 'string' &&
+    typeof f.text === 'string' &&
+    typeof f.ts === 'string' &&
+    typeof f.id === 'number'
+  );
+}
+
+/** Append-only JSONL per chat under <chatDir>/<chatId>.jsonl */
+export class FileChatStore implements ChatStore {
+  /**
+   * Per-chat append counter. Used to gate maybeRetain() calls so we do not
+   * read the file on every append (O(1) amortized instead of O(N)):
+   *   - First append for a chatId in this process: one-time retention check
+   *     (bounds a large pre-existing file from a prior run).
+   *   - Subsequent appends: only call maybeRetain every PERSIST_CAP writes.
+   */
+  private readonly appendCounters = new Map<string, number>();
+
+  constructor(private readonly chatDir: string) {}
+
+  private isValidChatId(chatId: string): boolean {
+    return CHAT_ID_RE.test(chatId);
+  }
+
+  private filePath(chatId: string): string {
+    return join(this.chatDir, `${chatId}.jsonl`);
+  }
+
+  append(chatId: string, frame: MirrorFrame): void {
+    if (!this.isValidChatId(chatId)) return;
+    // Underscore-prefixed ids are internal sentinels (e.g. '_provisional') —
+    // never persist them. load() / drop() may still operate on existing files.
+    if (chatId.startsWith('_')) return;
+    try {
+      mkdirSync(this.chatDir, { recursive: true });
+      const line = JSON.stringify(frame) + '\n';
+      appendFileSync(this.filePath(chatId), line, 'utf8');
+
+      // Amortized retention gate: avoid reading the file on every append.
+      // On first append for this chatId (counter not yet set), do a one-time
+      // check to bound any large pre-existing file from a prior process run.
+      // After that, check every PERSIST_CAP appends.
+      const prev = this.appendCounters.get(chatId);
+      const count = (prev ?? 0) + 1;
+      this.appendCounters.set(chatId, count);
+      const isFirst = prev === undefined;
+      if (isFirst || count % PERSIST_CAP === 0) {
+        this.maybeRetain(chatId);
+      }
+    } catch (err) {
+      // Disk/IO error — log once and swallow. Must never propagate into the live bridge.
+      console.warn(`[chat-store] append failed for chatId=${chatId}:`, err);
+    }
+  }
+
+  private maybeRetain(chatId: string): void {
+    // Underscore-prefixed ids are internal sentinels — never persist them.
+    if (chatId.startsWith('_')) return;
+    try {
+      const fp = this.filePath(chatId);
+      const content = readFileSync(fp, 'utf8');
+      const lines = content.split('\n').filter((l) => l.length > 0);
+      if (lines.length < 2 * PERSIST_CAP) return;
+      // Truncate to last PERSIST_CAP lines using an atomic tmp→rename so a
+      // crash mid-write never corrupts the live file.
+      const kept = lines.slice(lines.length - PERSIST_CAP);
+      const tmp = fp + '.tmp';
+      writeFileSync(tmp, kept.join('\n') + '\n', 'utf8');
+      renameSync(tmp, fp);
+    } catch (err) {
+      // Retention is best-effort; log so a persistent failure is observable.
+      console.warn(`[chat-store] retain failed for chatId=${chatId}`, err);
+    }
+  }
+
+  load(chatId: string, max: number): MirrorFrame[] {
+    if (!this.isValidChatId(chatId)) return [];
+    let content: string;
+    try {
+      content = readFileSync(this.filePath(chatId), 'utf8');
+    } catch (err: any) {
+      if (err?.code === 'ENOENT') return [];
+      console.warn(`[chat-store] load failed for chatId=${chatId}:`, err);
+      return [];
+    }
+    const lines = content.split('\n').filter((l) => l.length > 0);
+    const frames: MirrorFrame[] = [];
+    for (const line of lines) {
+      // Defense-in-depth: skip lines that are unreasonably long before parsing.
+      if (line.length > MAX_LINE_BYTES) {
+        console.warn(`[chat-store] skipping oversized line (${line.length} bytes) for chatId=${chatId}`);
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(line);
+        if (isMirrorFrameShaped(parsed)) {
+          frames.push(parsed as MirrorFrame);
+        } else {
+          console.warn(`[chat-store] skipping malformed frame line for chatId=${chatId}`);
+        }
+      } catch {
+        console.warn(`[chat-store] skipping unparseable line for chatId=${chatId}`);
+      }
+    }
+    // Return the last `max` frames in id order (file is already in append order,
+    // so slicing the tail keeps id-order correct).
+    if (frames.length <= max) return frames;
+    return frames.slice(frames.length - max);
+  }
+
+  drop(chatId: string): void {
+    if (!this.isValidChatId(chatId)) return;
+    try {
+      unlinkSync(this.filePath(chatId));
+    } catch (err: any) {
+      if (err?.code !== 'ENOENT') {
+        console.warn(`[chat-store] drop failed for chatId=${chatId}:`, err);
+      }
+      // ENOENT is fine — already gone.
+    }
+  }
+
+  dispose(): void {}
+}

--- a/packages/relay/src/dashboard/chat-store.ts
+++ b/packages/relay/src/dashboard/chat-store.ts
@@ -135,12 +135,34 @@ export class FileChatStore implements ChatStore {
       renameSync(tmp, fp);
     } catch (err) {
       // Retention is best-effort; log so a persistent failure is observable.
+      // Best-effort: remove our own tmp if the rename (not a crash) failed, so a
+      // failed retain does not leave an orphan behind.
+      this.cleanupStaleTmp(chatId);
       console.warn(`[chat-store] retain failed for chatId=${chatId}`, err);
+    }
+  }
+
+  /**
+   * Best-effort removal of a stale `<chatId>.jsonl.tmp` left by a crash between
+   * maybeRetain's writeFileSync and renameSync (the live .jsonl is always
+   * intact; only the tmp orphans). Called on cold load() so orphans from a
+   * prior process run are reclaimed when the chat is next hydrated, and from
+   * maybeRetain's catch. ENOENT (the normal case) is silent.
+   */
+  private cleanupStaleTmp(chatId: string): void {
+    try {
+      unlinkSync(this.filePath(chatId) + '.tmp');
+    } catch (err: any) {
+      if (err?.code !== 'ENOENT') {
+        console.warn(`[chat-store] stale .tmp cleanup failed for chatId=${chatId}:`, err);
+      }
     }
   }
 
   load(chatId: string, max: number): MirrorFrame[] {
     if (!this.isValidChatId(chatId)) return [];
+    // Reclaim any orphan tmp from a prior process run when a chat is hydrated.
+    this.cleanupStaleTmp(chatId);
     let content: string;
     try {
       content = readFileSync(this.filePath(chatId), 'utf8');
@@ -162,7 +184,7 @@ export class FileChatStore implements ChatStore {
         if (isMirrorFrameShaped(parsed)) {
           frames.push(parsed as MirrorFrame);
         } else {
-          console.warn(`[chat-store] skipping malformed frame line for chatId=${chatId}`);
+          console.warn(`[chat-store] skipping line with valid JSON but wrong MirrorFrame shape for chatId=${chatId}`);
         }
       } catch {
         console.warn(`[chat-store] skipping unparseable line for chatId=${chatId}`);

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -220,7 +220,9 @@ export class DashboardRouter {
   // Dashboard ⇄ live-CC bridge transport (P1). Owns the outbound SSE client set
   // and the in-process inbound sink the MCP server registers. Distinct from the
   // dormant chatbot (consensus f14 — no dual-brain; /api/chat stays dormant).
-  private bridge = new BridgeHub();
+  // Constructed in the constructor body (not as a field initializer) so it can
+  // receive the chatDir option derived from projectRoot.
+  private bridge: BridgeHub;
 
   constructor(
     private auth: DashboardAuth,
@@ -228,6 +230,9 @@ export class DashboardRouter {
     private ctx: DashboardContext,
   ) {
     this.dashboardRoot = resolveDashboardRoot(projectRoot);
+    // Wire the chat write-through store: persist mirror frames under
+    // <projectRoot>/.gossip/chat/<chatId>.jsonl so history survives relay restart.
+    this.bridge = new BridgeHub({ chatDir: join(projectRoot, '.gossip', 'chat') });
   }
 
   /**

--- a/tests/relay/api-mirror-events.test.ts
+++ b/tests/relay/api-mirror-events.test.ts
@@ -1,4 +1,8 @@
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { MirrorEventStore, MIRROR_RING_MAX } from '@gossip/relay/dashboard/api-mirror-events';
+import { FileChatStore } from '@gossip/relay/dashboard/chat-store';
 
 describe('MirrorEventStore', () => {
   // Disable the periodic sweep timer (last ctor arg = 0) so tests drive sweep()
@@ -133,5 +137,114 @@ describe('MirrorEventStore.drainInto (provisional backfill, spec §2)', () => {
     s.push('chatA', 'user', 'x');
     expect(s.drainInto('chatA', 'chatA')).toEqual([]);
     expect(s.replaySlice('chatA', 0)).toHaveLength(1); // untouched
+  });
+});
+
+// ── Hydration + write-through (FileChatStore integration) ────────────────────
+
+describe('MirrorEventStore — hydration from FileChatStore', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'mirror-store-hydration-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function storeWithFile(ringMax = MIRROR_RING_MAX): MirrorEventStore {
+    return new MirrorEventStore(ringMax, 60_000, 0, new FileChatStore(dir));
+  }
+
+  it('write-through: pushed frames are persisted to disk', () => {
+    const s = storeWithFile();
+    s.push('chatA', 'user', 'hello', 1000);
+    s.push('chatA', 'assistant', 'world', 2000);
+    s.dispose();
+    // New store instance over same dir: load from disk.
+    const s2 = storeWithFile();
+    const loaded = s2.replaySlice('chatA', 0);
+    expect(loaded).toHaveLength(2);
+    expect(loaded.map((f) => f.text)).toEqual(['hello', 'world']);
+    s2.dispose();
+  });
+
+  it('hydration restores frames and nextId — id sequence CONTINUES across restart', () => {
+    const s = storeWithFile();
+    s.push('chatA', 'user', 'f1', 1000);
+    s.push('chatA', 'user', 'f2', 2000);
+    // ids are 1, 2
+    s.dispose();
+    // Simulated restart: new store instance, same chatDir.
+    const s2 = storeWithFile();
+    // Push a new frame — id should continue at 3, not reset to 1.
+    const f3 = s2.push('chatA', 'user', 'f3', 3000);
+    expect(f3.id).toBe(3);
+    s2.dispose();
+  });
+
+  it('highestId hydrates from disk when ring is cold', () => {
+    const s = storeWithFile();
+    s.push('chatA', 'user', 'a', 1000);
+    s.push('chatA', 'user', 'b', 2000);
+    s.dispose();
+    // New instance: highestId must trigger hydration, not return 0.
+    const s2 = storeWithFile();
+    expect(s2.highestId('chatA')).toBe(2);
+    s2.dispose();
+  });
+
+  it('replaySlice hydrates and returns persisted frames on first access', () => {
+    const s = storeWithFile();
+    for (let i = 1; i <= 5; i++) s.push('chatA', 'user', `f${i}`, i * 1000);
+    s.dispose();
+    const s2 = storeWithFile();
+    const slice = s2.replaySlice('chatA', 2);
+    expect(slice.map((f) => f.id)).toEqual([3, 4, 5]);
+    s2.dispose();
+  });
+
+  it('NullChatStore default: existing ring tests still pass (no regression)', () => {
+    // Verify the NullChatStore default is intact — the store ctor with no arg
+    // uses NullChatStore so replaySlice on an unknown ring returns [] as before.
+    const s = new MirrorEventStore(MIRROR_RING_MAX, 60_000, 0);
+    expect(s.replaySlice('unknown', 0)).toEqual([]);
+    expect(s.highestId('unknown')).toBe(0);
+    s.push('chatA', 'user', 'hi');
+    expect(s.ringCount()).toBe(1);
+    s.dispose();
+  });
+
+  it('drainInto persists to destination and drops the provisional file', () => {
+    const s = storeWithFile();
+    // Provisional frames.
+    s.push('_provisional', 'activity', 'p0', 1000);
+    s.push('_provisional', 'activity', 'p1', 2000);
+    s.drainInto('_provisional', 'chatA');
+    s.dispose();
+    // New instance: chatA should have the drained frames.
+    const s2 = storeWithFile();
+    const loaded = s2.replaySlice('chatA', 0);
+    expect(loaded).toHaveLength(2);
+    expect(loaded.map((f) => f.text)).toEqual(['p0', 'p1']);
+    // Provisional file should be gone.
+    const { existsSync } = require('fs');
+    expect(existsSync(join(dir, '_provisional.jsonl'))).toBe(false);
+    s2.dispose();
+  });
+
+  it('hydrates only the ringMax tail — does not overflow the ring', () => {
+    const ringMax = 3;
+    const s = storeWithFile(ringMax);
+    // Push 6 frames — ring holds only the last 3 in memory, file holds 6.
+    for (let i = 1; i <= 6; i++) s.push('chatA', 'user', `f${i}`, i * 1000);
+    s.dispose();
+    // New instance with same ringMax: hydrate only the last ringMax frames.
+    const s2 = storeWithFile(ringMax);
+    const slice = s2.replaySlice('chatA', 0);
+    expect(slice).toHaveLength(ringMax);
+    expect(slice.map((f) => f.id)).toEqual([4, 5, 6]);
+    s2.dispose();
   });
 });

--- a/tests/relay/chat-store.test.ts
+++ b/tests/relay/chat-store.test.ts
@@ -297,4 +297,17 @@ describe('FileChatStore', () => {
     const loaded = s.load('my-chat_id-123', 100);
     expect(loaded).toHaveLength(1);
   });
+
+  it('load() reclaims a stale .tmp orphan left by a prior-run crash', () => {
+    const s = store();
+    s.append('chat1', makeFrame(1));
+    // Simulate an orphan tmp left by a crash between writeFileSync and rename.
+    const orphan = join(dir, 'chat1.jsonl.tmp');
+    writeFileSync(orphan, 'garbage\n', 'utf8');
+    expect(existsSync(orphan)).toBe(true);
+    // Hydrating the chat cleans the orphan and still returns the real frames.
+    const loaded = s.load('chat1', 100);
+    expect(loaded).toHaveLength(1);
+    expect(existsSync(orphan)).toBe(false);
+  });
 });

--- a/tests/relay/chat-store.test.ts
+++ b/tests/relay/chat-store.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for chat-store.ts — NullChatStore + FileChatStore (spec 2026-06-17).
+ */
+
+import { mkdtempSync, rmSync, existsSync, writeFileSync, appendFileSync as fsAppend } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { NullChatStore, FileChatStore, PERSIST_CAP } from '@gossip/relay/dashboard/chat-store';
+import type { MirrorFrame } from '@gossip/relay/dashboard/api-bridge';
+
+function makeFrame(id: number, chatId = 'chat1', text = `text-${id}`): MirrorFrame {
+  return {
+    type: 'mirror',
+    chat_id: chatId,
+    role: 'user',
+    text,
+    ts: new Date(1000 * id).toISOString(),
+    id,
+  };
+}
+
+describe('NullChatStore', () => {
+  it('append is a no-op', () => {
+    const s = new NullChatStore();
+    expect(() => s.append('chat1', makeFrame(1))).not.toThrow();
+  });
+
+  it('load always returns []', () => {
+    const s = new NullChatStore();
+    s.append('chat1', makeFrame(1));
+    expect(s.load('chat1', 100)).toEqual([]);
+  });
+
+  it('drop is a no-op', () => {
+    const s = new NullChatStore();
+    expect(() => s.drop('chat1')).not.toThrow();
+  });
+
+  it('dispose is a no-op', () => {
+    const s = new NullChatStore();
+    expect(() => s.dispose()).not.toThrow();
+  });
+});
+
+describe('FileChatStore', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chat-store-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function store() {
+    return new FileChatStore(dir);
+  }
+
+  // ── append + load round-trip ─────────────────────────────────────────────
+
+  it('append + load round-trip preserves all frame fields', () => {
+    const s = store();
+    const f = makeFrame(1, 'chat1', 'hello world');
+    s.append('chat1', f);
+    const loaded = s.load('chat1', 100);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toEqual(f);
+  });
+
+  it('appends multiple frames and loads in id order', () => {
+    const s = store();
+    for (let i = 1; i <= 5; i++) s.append('chat1', makeFrame(i));
+    const loaded = s.load('chat1', 100);
+    expect(loaded).toHaveLength(5);
+    expect(loaded.map((f) => f.id)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('load returns only the last `max` frames in id order', () => {
+    const s = store();
+    for (let i = 1; i <= 10; i++) s.append('chat1', makeFrame(i));
+    const loaded = s.load('chat1', 3);
+    expect(loaded).toHaveLength(3);
+    expect(loaded.map((f) => f.id)).toEqual([8, 9, 10]);
+  });
+
+  it('load returns [] for ENOENT (chat never written)', () => {
+    const s = store();
+    expect(s.load('nonexistent', 100)).toEqual([]);
+  });
+
+  it('separate chatIds are stored independently', () => {
+    const s = store();
+    s.append('chatA', makeFrame(1, 'chatA', 'a1'));
+    s.append('chatB', makeFrame(1, 'chatB', 'b1'));
+    s.append('chatA', makeFrame(2, 'chatA', 'a2'));
+    expect(s.load('chatA', 100).map((f) => f.id)).toEqual([1, 2]);
+    expect(s.load('chatB', 100).map((f) => f.id)).toEqual([1]);
+  });
+
+  // ── malformed line skip ──────────────────────────────────────────────────
+
+  it('skips malformed JSON lines without throwing', () => {
+    const s = store();
+    // Write one valid, one garbage, one valid frame directly to the file.
+    const { appendFileSync } = require('fs');
+    const path = join(dir, 'chat1.jsonl');
+    appendFileSync(path, JSON.stringify(makeFrame(1)) + '\n');
+    appendFileSync(path, 'not-json-at-all\n');
+    appendFileSync(path, JSON.stringify(makeFrame(2)) + '\n');
+    const loaded = s.load('chat1', 100);
+    expect(loaded).toHaveLength(2);
+    expect(loaded.map((f) => f.id)).toEqual([1, 2]);
+  });
+
+  it('skips JSON lines that are not MirrorFrame-shaped', () => {
+    const s = store();
+    const { appendFileSync } = require('fs');
+    const path = join(dir, 'chat1.jsonl');
+    appendFileSync(path, JSON.stringify(makeFrame(1)) + '\n');
+    appendFileSync(path, JSON.stringify({ type: 'reply', chat_id: 'chat1', ts: 'x' }) + '\n'); // missing role/text/id
+    appendFileSync(path, JSON.stringify(makeFrame(2)) + '\n');
+    const loaded = s.load('chat1', 100);
+    expect(loaded).toHaveLength(2);
+  });
+
+  // ── retention / truncation ───────────────────────────────────────────────
+
+  it('truncates to last PERSIST_CAP lines when file reaches 2*PERSIST_CAP', () => {
+    const s = store();
+    // Write exactly 2*PERSIST_CAP frames. The retention check fires at
+    // count=2*PERSIST_CAP (gated counter) and at that point there are exactly
+    // 2*PERSIST_CAP lines — above the < 2*PERSIST_CAP skip threshold — so
+    // the file is truncated to PERSIST_CAP lines.
+    for (let i = 1; i <= 2 * PERSIST_CAP; i++) s.append('chat1', makeFrame(i));
+    const loaded = s.load('chat1', PERSIST_CAP + 500);
+    // After truncation, exactly PERSIST_CAP frames remain.
+    expect(loaded.length).toBe(PERSIST_CAP);
+    // The retained frames should be the most recent ones.
+    const ids = loaded.map((f) => f.id);
+    expect(ids[0]).toBeGreaterThan(PERSIST_CAP);
+    expect(ids[ids.length - 1]).toBe(2 * PERSIST_CAP);
+  });
+
+  it('retention still works across > 2*PERSIST_CAP appends (gated counter path)', () => {
+    const s = store();
+    // Append exactly 3*PERSIST_CAP frames. Retention checks fire at count=1,
+    // count=PERSIST_CAP, count=2*PERSIST_CAP (triggers truncation to PERSIST_CAP),
+    // and count=3*PERSIST_CAP (triggers another truncation — 2*PERSIST_CAP → PERSIST_CAP).
+    // After all appends, the file is bounded to exactly PERSIST_CAP lines.
+    const total = 3 * PERSIST_CAP;
+    for (let i = 1; i <= total; i++) s.append('chat1', makeFrame(i));
+    const loaded = s.load('chat1', total + 1000);
+    // File must be bounded to PERSIST_CAP lines.
+    expect(loaded.length).toBeLessThanOrEqual(PERSIST_CAP);
+    // The last frame must be the very last appended.
+    const ids = loaded.map((f) => f.id);
+    expect(ids[ids.length - 1]).toBe(total);
+  });
+
+  it('after truncation file has exactly PERSIST_CAP lines, is valid JSONL, no .tmp left', () => {
+    const s = store();
+    // Trigger truncation by appending exactly 2*PERSIST_CAP frames (retention
+    // check fires at count=2*PERSIST_CAP which is the gated PERSIST_CAP boundary).
+    for (let i = 1; i <= 2 * PERSIST_CAP; i++) s.append('chat1', makeFrame(i));
+
+    // Verify no .tmp file remains.
+    const tmpPath = join(dir, 'chat1.jsonl.tmp');
+    expect(existsSync(tmpPath)).toBe(false);
+
+    // Load and confirm exactly PERSIST_CAP frames.
+    const loaded = s.load('chat1', PERSIST_CAP + 9999);
+    expect(loaded).toHaveLength(PERSIST_CAP);
+
+    // All frames must parse as valid MirrorFrame (load already does this, but
+    // double-check by confirming every id is a number > 0).
+    expect(loaded.every((f) => typeof f.id === 'number' && f.id > 0)).toBe(true);
+  });
+
+  // ── _provisional / underscore sentinel guard ─────────────────────────────
+
+  it('_provisional append writes NO file', () => {
+    const s = store();
+    s.append('_provisional', makeFrame(1, '_provisional'));
+    const path = join(dir, '_provisional.jsonl');
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it('other underscore-prefixed ids write NO file', () => {
+    const s = store();
+    s.append('_internal', makeFrame(1, '_internal'));
+    const path = join(dir, '_internal.jsonl');
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it('load on a pre-seeded _provisional.jsonl returns frames (drain path)', () => {
+    // Simulate a file written by a prior process version before the fix.
+    const path = join(dir, '_provisional.jsonl');
+    writeFileSync(path, JSON.stringify(makeFrame(1, '_provisional')) + '\n');
+    writeFileSync(path, JSON.stringify(makeFrame(2, '_provisional')) + '\n', { flag: 'a' });
+    const s = store();
+    const loaded = s.load('_provisional', 100);
+    expect(loaded).toHaveLength(2);
+  });
+
+  it('drop still deletes a pre-seeded _provisional.jsonl', () => {
+    const path = join(dir, '_provisional.jsonl');
+    writeFileSync(path, JSON.stringify(makeFrame(1, '_provisional')) + '\n');
+    expect(existsSync(path)).toBe(true);
+    const s = store();
+    s.drop('_provisional');
+    expect(existsSync(path)).toBe(false);
+  });
+
+  // ── oversized line guard (MAX_LINE_BYTES) ────────────────────────────────
+
+  it('load skips oversized lines and still returns surrounding well-formed frames', () => {
+    const path = join(dir, 'chat1.jsonl');
+    // A valid frame before the oversized line.
+    fsAppend(path, JSON.stringify(makeFrame(1)) + '\n');
+    // An oversized line (> 256 KiB).
+    const bigLine = 'x'.repeat(256 * 1024 + 1);
+    fsAppend(path, bigLine + '\n');
+    // A valid frame after the oversized line.
+    fsAppend(path, JSON.stringify(makeFrame(2)) + '\n');
+
+    const s = store();
+    const loaded = s.load('chat1', 100);
+    expect(loaded).toHaveLength(2);
+    expect(loaded.map((f) => f.id)).toEqual([1, 2]);
+  });
+
+  // ── drop ─────────────────────────────────────────────────────────────────
+
+  it('drop removes the file', () => {
+    const s = store();
+    s.append('chat1', makeFrame(1));
+    const path = join(dir, 'chat1.jsonl');
+    expect(existsSync(path)).toBe(true);
+    s.drop('chat1');
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it('drop is a no-op when file does not exist (ENOENT)', () => {
+    const s = store();
+    expect(() => s.drop('nonexistent')).not.toThrow();
+  });
+
+  // ── chatId re-validation (path-traversal defense) ────────────────────────
+
+  it('rejects chatId with ../ (path traversal) — append is no-op', () => {
+    const s = store();
+    s.append('../evil', makeFrame(1)); // must not create a file outside dir
+    // No file should be created anywhere in dir.
+    const { readdirSync } = require('fs');
+    expect(readdirSync(dir)).toHaveLength(0);
+  });
+
+  it('rejects chatId with ../ — load returns []', () => {
+    const s = store();
+    expect(s.load('../evil', 100)).toEqual([]);
+  });
+
+  it('rejects chatId with leading / — append is no-op', () => {
+    // CHAT_ID_RE requires alphanumeric/dash/underscore only, so '/' fails.
+    const s = store();
+    s.append('/etc/passwd', makeFrame(1));
+    const { readdirSync } = require('fs');
+    expect(readdirSync(dir)).toHaveLength(0);
+  });
+
+  it('rejects empty chatId', () => {
+    const s = store();
+    s.append('', makeFrame(1));
+    expect(s.load('', 100)).toEqual([]);
+    const { readdirSync } = require('fs');
+    expect(readdirSync(dir)).toHaveLength(0);
+  });
+
+  it('rejects chatId longer than 128 characters', () => {
+    const s = store();
+    const longId = 'a'.repeat(129);
+    s.append(longId, makeFrame(1));
+    expect(s.load(longId, 100)).toEqual([]);
+    const { readdirSync } = require('fs');
+    expect(readdirSync(dir)).toHaveLength(0);
+  });
+
+  it('drop is no-op for invalid chatId', () => {
+    const s = store();
+    expect(() => s.drop('../evil')).not.toThrow();
+  });
+
+  it('accepts valid chatId with dashes and underscores', () => {
+    const s = store();
+    s.append('my-chat_id-123', makeFrame(1, 'my-chat_id-123'));
+    const loaded = s.load('my-chat_id-123', 100);
+    expect(loaded).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Problem

Dashboard chat tabs persist their **identity + label** in the browser indefinitely, but message **history** lived only in the relay's in-memory `MirrorEventStore` ring (100 frames/chat, 2h idle TTL, **wiped on every relay restart**). Result:

- **Ghost tabs** — after a relay restart (rebuild, `gossip_reload`, CC restart, reboot) a persisted tab reopens with `?last_id=0`, the ring is empty, replay returns nothing → label intact, transcript gone.
- **Head truncation** — conversations past 100 frames silently dropped their start.

## Change

A **write-through file store** behind a swappable `ChatStore` interface (forward-compatible with the planned Local Postgres migration — swap the backend, keep the seam):

- `NullChatStore` (default, no-op) — existing behavior + all existing tests unchanged.
- `FileChatStore` — append-only JSONL at `.gossip/chat/<chat_id>.jsonl`.
- `MirrorEventStore` hydrates a cold ring from disk on first access (`push`/`replaySlice`/`highestId`) and **continues the per-chat id sequence** (`nextId = last persisted id`), so the restart-sentinel no longer false-fires and the `?last_id` cursor survives a restart. This is what cures the ghost-tab + 100-frame-truncation pair.
- `BridgeHub` accepts `{ chatDir? }`; `DashboardRouter` wires `.gossip/chat`.

Persistence is **best-effort + read-side only** — the inbound `reply`/answer trust gates are untouched.

## Review

Consensus cross-review `2b1f6582-c25c4ba0` (gemini-reviewer + deepseek-challenger): **6 confirmed, 1 hallucination caught**. All 6 confirmed findings hardened:

| Finding | Fix |
|---|---|
| retention read whole file every append (O(n²)) | amortized O(1) via per-chat append counter |
| non-atomic truncation rewrite | atomic `tmp → rename` |
| silent retain errors | `console.warn` on failure |
| `_provisional` sentinel persisted | skip `_`-prefixed ids on write |
| no line-length cap before `JSON.parse` | 256 KiB per-line cap |
| path traversal via `chat_id` filename | `chat_id` re-validated against the id charset before every path op |

The one HIGH "duplicate-id after restart" finding was a **hallucination** (its own body self-refuted; `++ring.nextId` pre-increment makes the first post-hydrate id = `lastId + 1`).

## Tests

- NEW `tests/relay/chat-store.test.ts` — round-trip, tail, malformed/oversized-line skip, retention truncation, `chat_id` traversal rejection, `_`-prefix skip, atomic rewrite (no `.tmp` left).
- `tests/relay/api-mirror-events.test.ts` — hydration suite incl. id-sequence continuation across a simulated restart.
- `jest tests/relay` = **35 suites, 379 passed, 1 pre-existing skip**; relay `tsc --noEmit` clean.

## Notes

Transcripts are plaintext under the gitignored `.gossip/` dir; mirror frames can carry tool args — an opt-out/scrub is a sensible follow-up. Scope here is the file store only; session-id accounting UI + Postgres are deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)