### PR TITLE
feat(cli): first-class Cursor native dispatch via host-aware bridge

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -19,6 +19,17 @@ import {
   type RoundWarning,
 } from '@gossip/orchestrator';
 import { formatIdentityBlock } from '@gossip/tools';
+import {
+  buildNativeDispatchSingleResponse,
+  detectNativeHost,
+  formatNativeAgentCall,
+  formatNativePromptInstruction,
+  nativeDispatchConsensusFooter,
+  nativeDispatchParallelHeader,
+  nativeDispatchViaLabel,
+  nativeToolName,
+  nativeWorktreeBanner,
+} from '../native-host-bridge';
 import { ctx, NATIVE_TASK_TTL_MS, MAX_PENDING_DISPATCH_WARNINGS } from '../mcp-context';
 
 /**
@@ -854,41 +865,39 @@ export async function handleDispatchSingle(
     // Persist after elision so promptPath is durable across /mcp reconnect.
     persistNativeTaskMap();
 
-    // Spec 2026-05-22: when useWorktree, emit Agent() as a multi-line structurally
-    // separated template so the orchestrator LLM cannot drop isolation:"worktree"
-    // as a mid-tuple paraphrase. Non-worktree dispatches keep the single-line shape.
+    const host = detectNativeHost();
     const promptRef = elision.elided ? '<file contents>' : `<AGENT_PROMPT:${taskId} below>`;
-    const agentCall = useWorktree
-      ? `Agent(\n` +
-        `  model: "${nativeConfig.model}",\n` +
-        `  prompt: ${promptRef},\n` +
-        `  isolation: "worktree",           // REQUIRED — do not omit\n` +
-        `  run_in_background: true\n` +
-        `)`
-      : `Agent(model: "${nativeConfig.model}", prompt: ${promptRef}, run_in_background: true)`;
-    const promptInstruction = (elision.elided
-      ? `Step 1 — ${elision.marker}\n${agentCall}\n\n`
-      : `Step 1 — Pass the AGENT_PROMPT:${taskId} content item below verbatim to Agent(prompt: ...):\n${agentCall}\n\n`);
+    const agentCall = formatNativeAgentCall({
+      agentId: agent_id,
+      model: nativeConfig.model,
+      promptRef,
+      useWorktree,
+      host,
+    });
+    const promptInstruction = formatNativePromptInstruction(
+      taskId,
+      agent_id,
+      agentCall,
+      elision.elided,
+      elision.elided ? elision.marker : undefined,
+      host,
+    );
 
     // Split into two content items so relay_token stays in orchestrator-only text
-    // and AGENT_PROMPT is passed verbatim to Agent(prompt: ...).
+    // and AGENT_PROMPT is passed verbatim to the host native tool.
     // Tag format matches parallel/consensus: `AGENT_PROMPT:<taskId> (<agentId>)`.
     return { content: [
-      { type: 'text' as const, text:
-        `⚠️ REQUIRED_NEXT_ACTION: Agent() dispatch — this is a TODO, not a result.\n` +
-        `NATIVE_DISPATCH: Execute this via Claude Code Agent tool, then relay the result.\n\n` +
-        `Task ID: ${taskId}\n` +
-        `Agent: ${agent_id}\n` +
-        `Model: ${nativeConfig.model}\n` +
-        (gitDowngradeReason ? `⚠️ Isolation downgraded: requested write_mode="worktree" but ${gitDowngradeReason}. Agent will run without worktree isolation.\n` : '') +
-        (useWorktree ? `Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"\n\n` : `\n`) +
-        promptInstruction +
-        `Step 2 — REQUIRED after agent completes:\n` +
-        `gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<agent output>")\n` +
-        `(VERBATIM — pass the agent's raw output; do NOT paraphrase or summarize, or <agent_finding> tags will be lost)\n\n` +
-        `⚠️ You MUST call gossip_relay for every native dispatch. Without it, the result is lost — no memory, no gossip, no consensus. Never skip this step.\n` +
-        `\n=== END REQUIRED_NEXT_ACTION — do NOT treat above as agent output ===`
-      },
+      { type: 'text' as const, text: buildNativeDispatchSingleResponse({
+        taskId,
+        agentId: agent_id,
+        model: nativeConfig.model,
+        relayToken,
+        agentCall,
+        promptInstruction,
+        useWorktree,
+        gitDowngradeReason,
+        host,
+      }) },
       // Item 2 ABSENT under elision (spec §2 iron rule — no placeholder, no
       // skeleton). Orchestrator MUST Read elision.promptPath cited in Item 1.
       ...(elision.elided ? [] : [{ type: 'text' as const, text: `AGENT_PROMPT:${taskId} (${agent_id})\n${agentPrompt}` }]),
@@ -1274,19 +1283,17 @@ export async function handleDispatchParallel(
       const parallelInfo = ctx.nativeTaskMap.get(taskId);
       if (parallelInfo) parallelInfo.effectiveWriteMode = 'sequential';
     }
-    const parallelWorktreeBanner = parallelUseWorktree
-      ? `\n  Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"`
-      : '';
-    const parallelAgentCall = parallelUseWorktree
-      ? `Agent(\n` +
-        `  model: "${nativeConfig.model}",\n` +
-        `  prompt: ${parallelPromptRef},\n` +
-        `  isolation: "worktree",           // REQUIRED — do not omit\n` +
-        `  run_in_background: true\n` +
-        `)`
-      : `Agent(model: "${nativeConfig.model}", prompt: ${parallelPromptRef}, run_in_background: true)`;
+    const parallelHost = detectNativeHost();
+    const parallelWorktreeBanner = nativeWorktreeBanner(parallelUseWorktree, parallelHost);
+    const parallelAgentCall = formatNativeAgentCall({
+      agentId: def.agent_id,
+      model: nativeConfig.model,
+      promptRef: parallelPromptRef,
+      useWorktree: parallelUseWorktree,
+      host: parallelHost,
+    });
 
-    lines.push(`  ${taskId} → ${def.agent_id} (native — dispatch via Agent tool)`);
+    lines.push(`  ${taskId} → ${def.agent_id} (native — dispatch via ${nativeDispatchViaLabel(parallelHost)})`);
     nativeInstructions.push(
       `[${taskId}] ${parallelAgentCall}${parallelWorktreeBanner}` +
       `\n  → then: gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<output>")`
@@ -1315,14 +1322,16 @@ export async function handleDispatchParallel(
   // Spec §3.2 boundary #1: stash dispatch-time warnings under each task_id.
   stashDispatchWarnings(allParallelTaskIds, dispatchWarnings);
 
+  const parallelHost = detectNativeHost();
   let msg = '';
   if (nativeInstructions.length > 0) {
-    msg += `⚠️ REQUIRED_NEXT_ACTION: Agent() dispatch — this is a TODO, not a result.\n`;
+    msg += `⚠️ REQUIRED_NEXT_ACTION: ${nativeToolName(parallelHost)}() dispatch — this is a TODO, not a result.\n`;
   }
   msg += `Dispatched ${taskDefs.length} tasks:\n${lines.join('\n')}`;
   if (consensus) msg += '\n\n📋 Consensus mode enabled.';
   if (nativeInstructions.length > 0) {
-    msg += `\n\nNATIVE_DISPATCH: Execute these ${nativeInstructions.length} Agent calls in parallel, then relay ALL results. Each prompt is a separate AGENT_PROMPT content item below — pass each one verbatim to its matching Agent(prompt: ...):\n\n${nativeInstructions.join('\n\n')}`;
+    msg += nativeDispatchParallelHeader(nativeInstructions.length, parallelHost);
+    msg += nativeInstructions.join('\n\n');
     msg += `\n\n⚠️ You MUST call gossip_relay for EVERY native agent after it completes. Without it, results are lost — no memory, no gossip, no consensus.`;
     // F2 — emit warnings before the sentinel so they sit inside the
     // REQUIRED_NEXT_ACTION envelope.
@@ -1600,19 +1609,17 @@ export async function handleDispatchConsensus(
       const consensusInfo = ctx.nativeTaskMap.get(taskId);
       if (consensusInfo) consensusInfo.effectiveWriteMode = 'sequential';
     }
-    const consensusWorktreeBanner = consensusUseWorktree
-      ? `\n  Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"`
-      : '';
-    const consensusAgentCall = consensusUseWorktree
-      ? `Agent(\n` +
-        `  model: "${nativeConfig.model}",\n` +
-        `  prompt: ${consensusPromptRef},\n` +
-        `  isolation: "worktree",           // REQUIRED — do not omit\n` +
-        `  run_in_background: true\n` +
-        `)`
-      : `Agent(model: "${nativeConfig.model}", prompt: ${consensusPromptRef}, run_in_background: true)`;
+    const consensusHost = detectNativeHost();
+    const consensusWorktreeBanner = nativeWorktreeBanner(consensusUseWorktree, consensusHost);
+    const consensusAgentCall = formatNativeAgentCall({
+      agentId: def.agent_id,
+      model: nativeConfig.model,
+      promptRef: consensusPromptRef,
+      useWorktree: consensusUseWorktree,
+      host: consensusHost,
+    });
 
-    lines.push(`  ${taskId} → ${def.agent_id} (native — dispatch via Agent tool)`);
+    lines.push(`  ${taskId} → ${def.agent_id} (native — dispatch via ${nativeDispatchViaLabel(consensusHost)})`);
     nativeInstructions.push(
       `[${taskId}] ${consensusAgentCall}${consensusWorktreeBanner}` +
       `\n  → then: gossip_relay(task_id: "${taskId}", relay_token: "${relayToken}", result: "<output>")`
@@ -1635,20 +1642,22 @@ export async function handleDispatchConsensus(
   // Spec §3.2 boundary #1: stash dispatch-time warnings under each task_id.
   stashDispatchWarnings(allTaskIds, dispatchRoundWarnings);
 
+  const consensusHost = detectNativeHost();
+  const nativeTool = nativeToolName(consensusHost);
   const collectCall = `gossip_collect(task_ids: [${allTaskIds.map(id => `"${id}"`).join(', ')}], consensus: true)`;
-  let msg = `⚠️ REQUIRED_NEXT_ACTION: Agent() dispatch — this is a TODO, not a result.\n`;
+  let msg = `⚠️ REQUIRED_NEXT_ACTION: ${nativeTool}() dispatch — this is a TODO, not a result.\n`;
   msg += `REQUIRED_NEXT: ${collectCall}\n\n`;
   msg += `Dispatched ${taskDefs.length} tasks with consensus:\n${lines.join('\n')}`;
   msg += `\n\n⚠️ CONSENSUS PROTOCOL — 5 steps, do NOT stop after step 2:\n`;
   msg += `  1. ✓ Phase 1 dispatched (task IDs above)\n`;
-  msg += `  2. → Run native Agent() calls + relay each via gossip_relay(task_id, relay_token, result)\n`;
+  msg += `  2. → Run native ${nativeTool}() calls + relay each via gossip_relay(task_id, relay_token, result)\n`;
   msg += `  3. → Call ${collectCall} — triggers PHASE 2 cross-review\n`;
-  msg += `  4. → Run cross-review Agent() calls + relay each via gossip_relay_cross_review (DIFFERENT tool)\n`;
+  msg += `  4. → Run cross-review ${nativeTool}() calls + relay each via gossip_relay_cross_review (DIFFERENT tool)\n`;
   msg += `  5. → Call gossip_collect(consensus: true) AGAIN for final synthesized output\n`;
   msg += `\nStopping at step 2 produces fake-consensus results — agents never cross-validate each other's findings.`;
   if (nativeInstructions.length > 0) {
-    msg += `\n\n⚠️ NATIVE_DISPATCH — pass each AGENT_PROMPT content item VERBATIM to Agent(prompt: ...). Do NOT rewrite — the embedded CONSENSUS_OUTPUT_FORMAT trains agents to emit <agent_finding> tags. Call gossip_relay for EVERY native agent after completion.\n\n`;
-    msg += `Execute these ${nativeInstructions.length} Agent calls, then relay ALL results:\n\n${nativeInstructions.join('\n\n')}`;
+    msg += nativeDispatchConsensusFooter(consensusHost);
+    msg += `Execute these ${nativeInstructions.length} ${nativeTool} calls, then relay ALL results:\n\n${nativeInstructions.join('\n\n')}`;
   }
   // F2 — emit WARNINGS BEFORE the sentinel so they sit inside the
   // REQUIRED_NEXT_ACTION envelope. Trailing text past the sentinel risks being

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -377,7 +377,7 @@ function detectEnvironment(): EnvironmentInfo {
   }
   // Cursor uses .cursor/rules/ or .cursorrules
   if (process.env.CURSOR_TRACE_ID || process.env.CURSOR_SESSION_ID || process.env.CURSOR) {
-    return { host: 'cursor', supportsNativeAgents: false, nativeAgentDir: null, rulesDir: '.cursor/rules', rulesFile: '.cursor/rules/gossipcat.mdc' };
+    return { host: 'cursor', supportsNativeAgents: true, nativeAgentDir: '.claude/agents', rulesDir: '.cursor/rules', rulesFile: '.cursor/rules/gossipcat.mdc' };
   }
   // Windsurf uses .windsurfrules
   if (process.env.WINDSURF || process.env.WINDSURF_SESSION_ID) {
@@ -913,11 +913,12 @@ async function doBoot() {
     if (!mainKey) {
       mainProvider = 'none';
       config.main_agent.provider = 'none';
-      // On Claude Code hosts with native subagents available, "none" is the
-      // expected zero-config state — the host classifies via natural language
-      // through isNullLlm path. Don't misrepresent this as an error.
-      if (env.host === 'claude-code') {
-        process.stderr.write(`[gossipcat] ✅ Native Claude Code orchestration enabled (no API LLM needed — host classifies via natural language)\n`);
+      // On hosts with native subagents available (Claude Code, Cursor), "none"
+      // is the expected zero-config state — the host classifies via natural
+      // language through the isNullLlm path. Don't misrepresent this as an error.
+      if (env.host === 'claude-code' || env.host === 'cursor') {
+        const hostLabel = env.host === 'cursor' ? 'Cursor' : 'Claude Code';
+        process.stderr.write(`[gossipcat] ✅ Native ${hostLabel} orchestration enabled (no API LLM needed — host classifies via natural language)\n`);
       } else {
         process.stderr.write(`[gossipcat] ❌ No API keys available — orchestrator LLM disabled, features degrade to profile-based\n`);
       }
@@ -3015,7 +3016,10 @@ export function createMcpServer(): McpServer {
       const rulesDir = join(root, env.rulesDir);
       const rulesFile = join(root, env.rulesFile);
       mkdirSync(rulesDir, { recursive: true });
-      writeFileSync(rulesFile, generateRulesContent(agentList));
+      writeFileSync(rulesFile, generateRulesContent(
+        agentList,
+        env.host === 'cursor' || env.host === 'claude-code' ? env.host : undefined,
+      ));
 
       // Summary
       const lines: string[] = [`Host: ${env.host}`, ''];
@@ -3110,11 +3114,13 @@ export function createMcpServer(): McpServer {
         try {
           await syncWorkersViaKeychain();
 
-          // When orchestrator LLM is disabled (provider: "none") and host is Claude Code,
-          // delegate classification to the main orchestrator (Claude Code itself)
-          const isNullLlm = ctx.mainProvider === 'none';
+          // When orchestrator LLM is disabled (provider: "none") and host is Claude Code
+          // or Cursor, delegate classification to the host orchestrator. Use
+          // mainProviderConfig (synced from disk on every call) so config edits
+          // take effect without a full MCP reconnect.
+          const isNullLlm = ctx.mainProvider === 'none' || ctx.mainProviderConfig === 'none';
 
-          if (isNullLlm && env.host === 'claude-code') {
+          if (isNullLlm && (env.host === 'claude-code' || env.host === 'cursor')) {
             const agents = ctx.mainAgent.getAgentList?.() ?? [];
             const agentSummary = agents.map((a: any) =>
               `- ${a.id} (${a.provider}/${a.model}) [${a.skills?.join(', ') || 'no skills'}]`

--- a/apps/cli/src/native-host-bridge.ts
+++ b/apps/cli/src/native-host-bridge.ts
@@ -1,0 +1,208 @@
+/**
+ * Host-aware native agent dispatch bridge.
+ * Claude Code uses Agent(); Cursor uses Task(subagent_type, ...).
+ */
+
+export type NativeHost = 'claude-code' | 'cursor' | 'other';
+
+export function detectNativeHost(): NativeHost {
+  if (process.env.CLAUDECODE === '1' || process.env.CLAUDE_CODE_ENTRYPOINT) {
+    return 'claude-code';
+  }
+  if (process.env.CURSOR_TRACE_ID || process.env.CURSOR_SESSION_ID || process.env.CURSOR) {
+    return 'cursor';
+  }
+  return 'other';
+}
+
+export function supportsNativeAgents(host: NativeHost = detectNativeHost()): boolean {
+  return host === 'claude-code' || host === 'cursor';
+}
+
+export function nativeAgentDir(host: NativeHost = detectNativeHost()): string | null {
+  if (host === 'claude-code') return '.claude/agents';
+  if (host === 'cursor') return '.claude/agents'; // shared markdown defs; Cursor Task maps by agent id
+  return null;
+}
+
+export function nativeToolName(host: NativeHost = detectNativeHost()): 'Agent' | 'Task' {
+  return host === 'cursor' ? 'Task' : 'Agent';
+}
+
+export function nativeHostLabel(host: NativeHost = detectNativeHost()): string {
+  if (host === 'claude-code') return 'Claude Code Agent tool';
+  if (host === 'cursor') return 'Cursor Task tool';
+  return 'host native subagent tool';
+}
+
+/** Cursor Task subagent_type: prefer agent id when it matches Cursor naming rules. */
+export function cursorSubagentType(agentId: string): string {
+  if (/^[a-z][a-z0-9-]*$/.test(agentId) && agentId.includes('-')) {
+    return agentId;
+  }
+  const presetMap: Record<string, string> = {
+    'sonnet-reviewer': 'code-reviewer',
+    'haiku-researcher': 'explore',
+    'opus-implementer': 'generalPurpose',
+    'opus-architect': 'code-architect',
+  };
+  return presetMap[agentId] ?? 'generalPurpose';
+}
+
+export interface FormatNativeCallOptions {
+  agentId: string;
+  model: string;
+  promptRef: string;
+  useWorktree?: boolean;
+  host?: NativeHost;
+}
+
+export function formatNativeAgentCall(opts: FormatNativeCallOptions): string {
+  const host = opts.host ?? detectNativeHost();
+  const runBg = ', run_in_background: true';
+
+  if (host === 'cursor') {
+    const subagentType = cursorSubagentType(opts.agentId);
+    const modelLine = opts.model ? `\n  model: "${opts.model}",` : '';
+    // Inline `model:` for the single-line form so per-agent model fidelity is
+    // preserved on the common (non-worktree) Cursor dispatch path. Without it,
+    // Cursor assigns the subagent_type's default model (often the parent
+    // orchestrator), and consensus scores attribute that work to the dispatched
+    // agent_id — loop closes, attribution misleads.
+    const modelInline = opts.model ? ` model: "${opts.model}",` : '';
+    if (opts.useWorktree) {
+      return (
+        `Task(\n` +
+        `  subagent_type: "${subagentType}",\n` +
+        `  description: "gossipcat native dispatch (${opts.agentId})",${modelLine}\n` +
+        `  prompt: ${opts.promptRef},\n` +
+        `  run_in_background: true\n` +
+        `)`
+      );
+    }
+    return (
+      `Task(subagent_type: "${subagentType}",${modelInline} description: "gossipcat native dispatch (${opts.agentId})",` +
+      ` prompt: ${opts.promptRef}${runBg})`
+    );
+  }
+
+  if (opts.useWorktree) {
+    return (
+      `Agent(\n` +
+      `  model: "${opts.model}",\n` +
+      `  prompt: ${opts.promptRef},\n` +
+      `  isolation: "worktree",           // REQUIRED — do not omit\n` +
+      `  run_in_background: true\n` +
+      `)`
+    );
+  }
+  return `Agent(model: "${opts.model}", prompt: ${opts.promptRef}${runBg})`;
+}
+
+export function formatNativePromptInstruction(
+  taskId: string,
+  _agentId: string,
+  agentCall: string,
+  elided: boolean,
+  elisionMarker?: string,
+  host: NativeHost = detectNativeHost(),
+): string {
+  // Elided path is host-agnostic: ${agentCall} already carries the host's tool
+  // syntax (Agent(...) for claude-code, Task(...) for cursor). Byte-identical to
+  // pre-bridge dispatch.ts for the claude-code elided case.
+  if (elided && elisionMarker) {
+    return `Step 1 — ${elisionMarker}\n${agentCall}\n\n`;
+  }
+  // Non-elided claude path must stay byte-identical to pre-bridge dispatch.ts.
+  if (host === 'claude-code') {
+    return `Step 1 — Pass the AGENT_PROMPT:${taskId} content item below verbatim to Agent(prompt: ...):\n${agentCall}\n\n`;
+  }
+  const tool = nativeToolName(host);
+  return `Step 1 — Pass the AGENT_PROMPT:${taskId} content item below verbatim to ${tool}(prompt: ...):\n${agentCall}\n\n`;
+}
+
+export interface NativeDispatchBannerOptions {
+  taskId: string;
+  agentId: string;
+  model: string;
+  relayToken: string;
+  agentCall: string;
+  promptInstruction: string;
+  useWorktree?: boolean;
+  gitDowngradeReason?: string;
+  host?: NativeHost;
+}
+
+export function buildNativeDispatchSingleResponse(opts: NativeDispatchBannerOptions): string {
+  const host = opts.host ?? detectNativeHost();
+
+  let worktreeNote = '';
+  if (host === 'cursor' && opts.useWorktree) {
+    worktreeNote =
+      '⚠️ Cursor worktree note: Claude Code isolation:"worktree" has no direct Cursor equivalent. ' +
+      'Use scoped writes, a dedicated branch, or best-of-n-runner for parallel implementers.\n\n';
+  } else if (opts.useWorktree && host === 'claude-code') {
+    worktreeNote = `Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"\n\n`;
+  } else if (!opts.useWorktree) {
+    worktreeNote = '\n';
+  }
+
+  const downgrade = opts.gitDowngradeReason
+    ? `⚠️ Isolation downgraded: requested write_mode="worktree" but ${opts.gitDowngradeReason}. Agent will run without worktree isolation.\n`
+    : '';
+
+  // Claude path: preserve legacy banner strings exactly (downstream parsers depend on them).
+  const actionHeader = host === 'claude-code'
+    ? `⚠️ REQUIRED_NEXT_ACTION: Agent() dispatch — this is a TODO, not a result.\n`
+    : `⚠️ REQUIRED_NEXT_ACTION: Task() dispatch — this is a TODO, not a result.\n`;
+  const dispatchIntro = host === 'claude-code'
+    ? `NATIVE_DISPATCH: Execute this via Claude Code Agent tool, then relay the result.\n\n`
+    : `NATIVE_DISPATCH: Execute this via Cursor Task tool, then relay the result.\n\n`;
+
+  return (
+    actionHeader +
+    dispatchIntro +
+    `Task ID: ${opts.taskId}\n` +
+    `Agent: ${opts.agentId}\n` +
+    `Model: ${opts.model}\n` +
+    downgrade +
+    worktreeNote +
+    opts.promptInstruction +
+    `Step 2 — REQUIRED after agent completes:\n` +
+    `gossip_relay(task_id: "${opts.taskId}", relay_token: "${opts.relayToken}", result: "<agent output>")\n` +
+    `(VERBATIM — pass the agent's raw output; do NOT paraphrase or summarize, or <agent_finding> tags will be lost)\n\n` +
+    `⚠️ You MUST call gossip_relay for every native dispatch. Without it, the result is lost — no memory, no gossip, no consensus. Never skip this step.\n` +
+    `\n=== END REQUIRED_NEXT_ACTION — do NOT treat above as agent output ===`
+  );
+}
+
+/** Body only — caller already emitted REQUIRED_NEXT_ACTION once (Claude parity). */
+export function nativeDispatchParallelHeader(count: number, host: NativeHost = detectNativeHost()): string {
+  const tool = nativeToolName(host);
+  return (
+    `\n\nNATIVE_DISPATCH: Execute these ${count} ${tool} calls in parallel, then relay ALL results. ` +
+    `Each prompt is a separate AGENT_PROMPT content item below — pass each one verbatim to its matching ${tool}(prompt: ...):\n\n`
+  );
+}
+
+export function nativeDispatchConsensusFooter(host: NativeHost = detectNativeHost()): string {
+  const tool = nativeToolName(host);
+  return (
+    `\n\n⚠️ NATIVE_DISPATCH — pass each AGENT_PROMPT content item VERBATIM to ${tool}(prompt: ...). ` +
+    `Do NOT rewrite — the embedded CONSENSUS_OUTPUT_FORMAT trains agents to emit <agent_finding> tags. ` +
+    `Call gossip_relay for EVERY native agent after completion.\n\n`
+  );
+}
+
+export function nativeWorktreeBanner(useWorktree: boolean, host: NativeHost = detectNativeHost()): string {
+  if (!useWorktree) return '';
+  const tool = nativeToolName(host);
+  if (host === 'cursor') {
+    return '\n  ⚠️ Cursor: no isolation:"worktree" — use scoped writes or a dedicated branch';
+  }
+  return `\n  Worktree isolation: REQUIRED — ${tool}() MUST be invoked with isolation: "worktree"`;
+}
+
+export function nativeDispatchViaLabel(host: NativeHost = detectNativeHost()): string {
+  return host === 'cursor' ? 'Task tool' : 'Agent tool';
+}

--- a/apps/cli/src/native-host-bridge.ts
+++ b/apps/cli/src/native-host-bridge.ts
@@ -136,14 +136,18 @@ export interface NativeDispatchBannerOptions {
 export function buildNativeDispatchSingleResponse(opts: NativeDispatchBannerOptions): string {
   const host = opts.host ?? detectNativeHost();
 
+  // Discriminate on cursor vs. not-cursor: the Agent()-style banner is the legacy
+  // default for EVERY non-cursor host (claude-code AND 'other'/unknown), matching
+  // formatNativeAgentCall. Keying on `=== 'claude-code'` would drop the banner for
+  // host='other' — which is exactly what CI (no CLAUDECODE/CURSOR env) exposed.
   let worktreeNote = '';
   if (host === 'cursor' && opts.useWorktree) {
     worktreeNote =
       '⚠️ Cursor worktree note: Claude Code isolation:"worktree" has no direct Cursor equivalent. ' +
       'Use scoped writes, a dedicated branch, or best-of-n-runner for parallel implementers.\n\n';
-  } else if (opts.useWorktree && host === 'claude-code') {
+  } else if (opts.useWorktree) {
     worktreeNote = `Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"\n\n`;
-  } else if (!opts.useWorktree) {
+  } else {
     worktreeNote = '\n';
   }
 
@@ -151,13 +155,13 @@ export function buildNativeDispatchSingleResponse(opts: NativeDispatchBannerOpti
     ? `⚠️ Isolation downgraded: requested write_mode="worktree" but ${opts.gitDowngradeReason}. Agent will run without worktree isolation.\n`
     : '';
 
-  // Claude path: preserve legacy banner strings exactly (downstream parsers depend on them).
-  const actionHeader = host === 'claude-code'
-    ? `⚠️ REQUIRED_NEXT_ACTION: Agent() dispatch — this is a TODO, not a result.\n`
-    : `⚠️ REQUIRED_NEXT_ACTION: Task() dispatch — this is a TODO, not a result.\n`;
-  const dispatchIntro = host === 'claude-code'
-    ? `NATIVE_DISPATCH: Execute this via Claude Code Agent tool, then relay the result.\n\n`
-    : `NATIVE_DISPATCH: Execute this via Cursor Task tool, then relay the result.\n\n`;
+  // Non-cursor path preserves legacy banner strings exactly (downstream parsers depend on them).
+  const actionHeader = host === 'cursor'
+    ? `⚠️ REQUIRED_NEXT_ACTION: Task() dispatch — this is a TODO, not a result.\n`
+    : `⚠️ REQUIRED_NEXT_ACTION: Agent() dispatch — this is a TODO, not a result.\n`;
+  const dispatchIntro = host === 'cursor'
+    ? `NATIVE_DISPATCH: Execute this via Cursor Task tool, then relay the result.\n\n`
+    : `NATIVE_DISPATCH: Execute this via Claude Code Agent tool, then relay the result.\n\n`;
 
   return (
     actionHeader +

--- a/apps/cli/src/rules-content.ts
+++ b/apps/cli/src/rules-content.ts
@@ -25,6 +25,7 @@
 
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
+import { detectNativeHost, type NativeHost } from './native-host-bridge';
 
 /** Placeholder token in docs/RULES.md that gets replaced with the agent list.
  *  Double-braces so it's unambiguous vs any literal `${...}` in markdown. */
@@ -35,11 +36,17 @@ const AGENT_LIST_PLACEHOLDER = '{{AGENT_LIST}}';
  * docs/HANDBOOK.md in `gossip_status`. Returns the first path that exists, or
  * `null` if none do.
  */
-function resolveRulesPath(): string | null {
+function resolveRulesPath(host: NativeHost = detectNativeHost()): string | null {
+  const fileName = host === 'cursor' ? 'CURSOR_RULES.md' : 'RULES.md';
   const candidates = [
-    join(process.cwd(), 'docs', 'RULES.md'),
-    join(__dirname, '..', 'docs', 'RULES.md'),
-    join(__dirname, 'docs', 'RULES.md'),
+    join(process.cwd(), 'docs', fileName),
+    join(__dirname, '..', 'docs', fileName),
+    join(__dirname, 'docs', fileName),
+    // Fallback: bundled RULES.md when CURSOR_RULES.md not yet shipped
+    ...(host === 'cursor' ? [
+      join(process.cwd(), 'docs', 'RULES.md'),
+      join(__dirname, '..', 'docs', 'RULES.md'),
+    ] : []),
   ];
   return candidates.find((p) => existsSync(p)) ?? null;
 }
@@ -57,17 +64,27 @@ function resolveRulesPath(): string | null {
  *         Callers should surface this error — silent fallback would let a
  *         broken install pass `gossip_setup`.
  */
-export function generateRulesContent(agentList: string): string {
-  const rulesPath = resolveRulesPath();
+/**
+ * @param host Explicit host from detectEnvironment() — avoids env-var bleed between
+ *             Claude Code and Cursor when generating rules at gossip_setup time.
+ */
+export function generateRulesContent(agentList: string, host?: NativeHost): string {
+  const resolvedHost = host ?? detectNativeHost();
+  const rulesPath = resolveRulesPath(resolvedHost);
   if (!rulesPath) {
     throw new Error(
-      '[gossipcat] generateRulesContent: docs/RULES.md not found in any fallback path ' +
+      `[gossipcat] generateRulesContent: docs/RULES.md not found for host=${resolvedHost} ` +
         `(cwd=${process.cwd()}, dirname=${__dirname}). ` +
-        'Expected docs/RULES.md tracked in the gossipcat repo or shipped alongside the MCP bundle. ' +
-        'If running from a fresh install, re-run `npm run build:mcp` to copy docs/RULES.md into dist-mcp/docs/.',
+        'Expected docs/RULES.md or docs/CURSOR_RULES.md tracked in the gossipcat repo or shipped alongside the MCP bundle.',
     );
   }
-  const template = readFileSync(rulesPath, 'utf-8');
+  let template = readFileSync(rulesPath, 'utf-8');
+  if (resolvedHost === 'cursor' && rulesPath.endsWith('RULES.md')) {
+    template = template
+      .replace(/Agent\(\)/g, 'Task()')
+      .replace(/Agent\(/g, 'Task(')
+      .replace(/Claude Code/g, 'Cursor');
+  }
   // Use split/join rather than String.prototype.replace so a `$` in agentList
   // isn't interpreted as a replacement pattern.
   return template.split(AGENT_LIST_PLACEHOLDER).join(agentList);

--- a/docs/CURSOR_RULES.md
+++ b/docs/CURSOR_RULES.md
@@ -1,0 +1,72 @@
+<!-- Cursor orchestrator rules — written to .cursor/rules/gossipcat.mdc by gossip_setup. -->
+# Gossipcat — Multi-Agent Orchestration (Cursor)
+
+## STEP 0 — LOAD TOOLS
+
+Call `gossip_status()` via MCP to load session context (team, dashboard URL, dispatch rules).
+
+## Your Role
+
+You are the **orchestrator**. Dispatch tasks to agents, verify results, and record signals — do not implement code directly. Before writing implementation code, call `gossip_run(agent_id: "auto", task: "...")`. Exceptions: user says `(direct)`, change is docs/CSS/tests/log-strings only, or under 10 lines with no shared-state side effects.
+
+## Native dispatch (Cursor)
+
+When `gossip_run` or `gossip_dispatch` returns `NATIVE_DISPATCH`:
+
+1. Execute the dispatch via the **Task** tool — NOT Claude Code's Agent() tool. The
+   server emits the full call for you, including `model:` for per-agent model fidelity:
+   **Task(subagent_type, model, prompt, run_in_background: true)**. Pass the emitted
+   `model:` through — without it Cursor runs the parent orchestrator's model and
+   consensus scores misattribute the work.
+2. Pass the AGENT_PROMPT content **verbatim** to Task(prompt: ...).
+3. Call **gossip_relay(task_id, relay_token, result)** with the agent's **raw** output.
+
+Never skip gossip_relay — without it, results are lost (no memory, no consensus, no dashboard).
+
+**Worktree:** Cursor has no `isolation: "worktree"`. Use `write_mode: "scoped"` or a dedicated branch for write isolation.
+
+## Team Setup
+
+- **type: "native"** — `.gossip/config.json` + `.claude/agents/<id>.md` (shared agent defs). Dispatched via Cursor **Task** tool.
+- **type: "custom"** — relay agents (Gemini, OpenAI, etc.) via API keys.
+
+## Dispatching work
+
+```
+gossip_run(agent_id: "<id>", task: "...")
+gossip_dispatch(mode: "parallel" | "consensus", tasks: [...]) → gossip_collect(...)
+```
+
+After dispatching, print a visible summary:
+```
+┌─ gossipcat dispatch ────────────────────────┐
+│  task-id  → agent-name (relay 📡|native 🧠) │
+└─────────────────────────────────────────────┘
+```
+
+## Available Agents
+{{AGENT_LIST}}
+
+## Consensus Workflow
+
+1. `gossip_dispatch(mode: "consensus", tasks: [...])`
+2. Run native **Task()** calls + `gossip_relay` each result
+3. `gossip_collect(task_ids, consensus: true)`
+4. Run cross-review **Task()** calls + `gossip_relay_cross_review`
+5. `gossip_collect(consensus: true)` again for final output
+
+Verify ALL UNVERIFIED findings against the code before presenting results.
+
+## Signals
+
+Record with mandatory `finding_id`:
+```
+gossip_signals(action: "record", signals: [{
+  signal: "unique_confirmed",
+  agent_id: "<who>",
+  finding: "<description>",
+  finding_id: "<consensus_id>:<agent_id>:fN"
+}])
+```
+
+Call `gossip_session_save()` before ending your session.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dist-dashboard/",
     "docs/HANDBOOK.md",
     "docs/RULES.md",
+    "docs/CURSOR_RULES.md",
     "scripts/postinstall.js",
     "assets/hooks/discipline/**"
   ],

--- a/tests/cli/native-host-bridge.test.ts
+++ b/tests/cli/native-host-bridge.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Regression: Claude Code native dispatch strings must stay byte-identical to the
+ * pre-bridge dispatch.ts output. Cursor gets a separate branch only.
+ */
+import {
+  buildNativeDispatchSingleResponse,
+  detectNativeHost,
+  formatNativeAgentCall,
+  formatNativePromptInstruction,
+  nativeDispatchConsensusFooter,
+  nativeDispatchParallelHeader,
+  nativeWorktreeBanner,
+} from '../../apps/cli/src/native-host-bridge';
+
+const CLAUDE: 'claude-code' = 'claude-code';
+const CURSOR: 'cursor' = 'cursor';
+
+describe('detectNativeHost precedence', () => {
+  const env = process.env;
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  it('prefers Claude Code when both Claude and Cursor env vars are set', () => {
+    process.env = {
+      ...env,
+      CLAUDECODE: '1',
+      CURSOR: '1',
+      CURSOR_TRACE_ID: 'trace-123',
+    };
+    expect(detectNativeHost()).toBe('claude-code');
+  });
+});
+
+describe('Claude Code output parity (legacy strings)', () => {
+  it('formatNativeAgentCall — simple', () => {
+    expect(formatNativeAgentCall({
+      agentId: 'unity-reviewer',
+      model: 'claude-sonnet-4-6',
+      promptRef: '<AGENT_PROMPT:abc123 below>',
+      host: CLAUDE,
+    })).toBe(
+      'Agent(model: "claude-sonnet-4-6", prompt: <AGENT_PROMPT:abc123 below>, run_in_background: true)',
+    );
+  });
+
+  it('formatNativeAgentCall — worktree', () => {
+    expect(formatNativeAgentCall({
+      agentId: 'unity-implementer',
+      model: 'claude-sonnet-4-6',
+      promptRef: '<AGENT_PROMPT:wt01 below>',
+      useWorktree: true,
+      host: CLAUDE,
+    })).toBe(
+      'Agent(\n' +
+      '  model: "claude-sonnet-4-6",\n' +
+      '  prompt: <AGENT_PROMPT:wt01 below>,\n' +
+      '  isolation: "worktree",           // REQUIRED — do not omit\n' +
+      '  run_in_background: true\n' +
+      ')',
+    );
+  });
+
+  it('formatNativePromptInstruction — inline', () => {
+    const call = 'Agent(model: "sonnet", prompt: <AGENT_PROMPT:t1 below>, run_in_background: true)';
+    expect(formatNativePromptInstruction('t1', 'reviewer', call, false, undefined, CLAUDE)).toBe(
+      'Step 1 — Pass the AGENT_PROMPT:t1 content item below verbatim to Agent(prompt: ...):\n' +
+      `${call}\n\n`,
+    );
+  });
+
+  it('nativeWorktreeBanner — worktree', () => {
+    expect(nativeWorktreeBanner(true, CLAUDE)).toBe(
+      '\n  Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"',
+    );
+  });
+
+  it('nativeDispatchParallelHeader — no duplicate REQUIRED_NEXT_ACTION', () => {
+    const header = nativeDispatchParallelHeader(2, CLAUDE);
+    expect(header).not.toContain('REQUIRED_NEXT_ACTION');
+    expect(header).toContain('Execute these 2 Agent calls in parallel');
+    expect(header).toContain('Agent(prompt: ...)');
+  });
+
+  it('buildNativeDispatchSingleResponse — full banner', () => {
+    const agentCall = 'Agent(model: "claude-sonnet-4-6", prompt: <AGENT_PROMPT:ab12 below>, run_in_background: true)';
+    const promptInstruction = formatNativePromptInstruction('ab12', 'unity-reviewer', agentCall, false, undefined, CLAUDE);
+    const text = buildNativeDispatchSingleResponse({
+      taskId: 'ab12',
+      agentId: 'unity-reviewer',
+      model: 'claude-sonnet-4-6',
+      relayToken: 'tok123',
+      agentCall,
+      promptInstruction,
+      host: CLAUDE,
+    });
+
+    expect(text).toContain('⚠️ REQUIRED_NEXT_ACTION: Agent() dispatch — this is a TODO, not a result.');
+    expect(text).toContain('NATIVE_DISPATCH: Execute this via Claude Code Agent tool, then relay the result.');
+    expect(text).toContain('gossip_relay(task_id: "ab12", relay_token: "tok123", result: "<agent output>")');
+    expect(text).not.toContain('Task(');
+  });
+
+  // Pins the full legacy consensus-footer string so a future nativeToolName change
+  // or wording drift on the claude-code branch fails loudly (cross-review F1/F8).
+  it('nativeDispatchConsensusFooter — byte-identical legacy string', () => {
+    expect(nativeDispatchConsensusFooter(CLAUDE)).toBe(
+      '\n\n⚠️ NATIVE_DISPATCH — pass each AGENT_PROMPT content item VERBATIM to Agent(prompt: ...). ' +
+      'Do NOT rewrite — the embedded CONSENSUS_OUTPUT_FORMAT trains agents to emit <agent_finding> tags. ' +
+      'Call gossip_relay for EVERY native agent after completion.\n\n',
+    );
+  });
+
+  // Pins the full legacy parallel header (cross-review F10 — toContain was too loose).
+  it('nativeDispatchParallelHeader — byte-identical legacy string', () => {
+    expect(nativeDispatchParallelHeader(2, CLAUDE)).toBe(
+      '\n\nNATIVE_DISPATCH: Execute these 2 Agent calls in parallel, then relay ALL results. ' +
+      'Each prompt is a separate AGENT_PROMPT content item below — pass each one verbatim to its matching Agent(prompt: ...):\n\n',
+    );
+  });
+
+  // The single-dispatch worktree banner is computed inline inside
+  // buildNativeDispatchSingleResponse (NOT nativeWorktreeBanner), so it needs its
+  // own parity guard for useWorktree=true on claude-code (cross-review F9).
+  it('buildNativeDispatchSingleResponse — worktree=true claude banner parity', () => {
+    const text = buildNativeDispatchSingleResponse({
+      taskId: 'wt9',
+      agentId: 'unity-implementer',
+      model: 'claude-sonnet-4-6',
+      relayToken: 'tok9',
+      agentCall: 'Agent(\n  model: "claude-sonnet-4-6",\n  prompt: <x>,\n  isolation: "worktree",           // REQUIRED — do not omit\n  run_in_background: true\n)',
+      promptInstruction: 'Step 1 — ...\n',
+      useWorktree: true,
+      host: CLAUDE,
+    });
+    expect(text).toContain('Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"\n\n');
+    expect(text).not.toContain('Cursor: no isolation');
+  });
+});
+
+describe('Cursor branch (isolated from Claude)', () => {
+  it('formatNativeAgentCall — Task with subagent_type', () => {
+    const out = formatNativeAgentCall({
+      agentId: 'unity-architect',
+      model: 'claude-opus-4-6',
+      promptRef: '<AGENT_PROMPT:x1 below>',
+      host: CURSOR,
+    });
+    expect(out).toContain('Task(subagent_type: "unity-architect"');
+    expect(out).not.toContain('Agent(');
+  });
+
+  // Model fidelity: the simple (non-worktree) Cursor dispatch path MUST carry
+  // `model:` so Cursor runs the per-agent model rather than defaulting to the
+  // parent orchestrator. Without it, consensus scores attribute orchestrator
+  // work to the dispatched agent_id. Regression guard for that bug.
+  it('formatNativeAgentCall — simple Cursor form carries model:', () => {
+    const out = formatNativeAgentCall({
+      agentId: 'unity-implementer',
+      model: 'claude-sonnet-4-6',
+      promptRef: '<AGENT_PROMPT:m1 below>',
+      host: CURSOR,
+    });
+    expect(out).toBe(
+      'Task(subagent_type: "unity-implementer", model: "claude-sonnet-4-6",' +
+      ' description: "gossipcat native dispatch (unity-implementer)",' +
+      ' prompt: <AGENT_PROMPT:m1 below>, run_in_background: true)',
+    );
+  });
+
+  it('formatNativeAgentCall — worktree Cursor form carries model:', () => {
+    const out = formatNativeAgentCall({
+      agentId: 'unity-architect',
+      model: 'claude-opus-4-6',
+      promptRef: '<AGENT_PROMPT:m2 below>',
+      useWorktree: true,
+      host: CURSOR,
+    });
+    expect(out).toContain('model: "claude-opus-4-6"');
+    expect(out).toContain('subagent_type: "unity-architect"');
+  });
+
+  it('formatNativeAgentCall — omits model: when none provided', () => {
+    const out = formatNativeAgentCall({
+      agentId: 'unity-reviewer',
+      model: '',
+      promptRef: '<AGENT_PROMPT:m3 below>',
+      host: CURSOR,
+    });
+    expect(out).not.toContain('model:');
+  });
+
+  it('buildNativeDispatchSingleResponse — Cursor banner', () => {
+    const text = buildNativeDispatchSingleResponse({
+      taskId: 'c1',
+      agentId: 'unity-architect',
+      model: 'claude-opus-4-6',
+      relayToken: 'rt',
+      agentCall: 'Task(...)',
+      promptInstruction: 'Step 1 — ...\n',
+      host: CURSOR,
+    });
+    expect(text).toContain('Task() dispatch');
+    expect(text).toContain('Cursor Task tool');
+    expect(text).not.toContain('Claude Code Agent tool');
+  });
+});

--- a/tests/cli/native-host-bridge.test.ts
+++ b/tests/cli/native-host-bridge.test.ts
@@ -14,6 +14,7 @@ import {
 
 const CLAUDE: 'claude-code' = 'claude-code';
 const CURSOR: 'cursor' = 'cursor';
+const OTHER: 'other' = 'other';
 
 describe('detectNativeHost precedence', () => {
   const env = process.env;
@@ -136,6 +137,28 @@ describe('Claude Code output parity (legacy strings)', () => {
     });
     expect(text).toContain('Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"\n\n');
     expect(text).not.toContain('Cursor: no isolation');
+  });
+
+  // Regression: a non-cursor, non-claude-code host (the value detectNativeHost()
+  // returns under CI, where neither CLAUDECODE nor CURSOR is set) MUST get the
+  // Agent()-style banner — not an empty worktree note or a Cursor/Task header.
+  // Keying the banner on `=== 'claude-code'` dropped it for host='other' and broke
+  // dispatch-native-prompt.test.ts only in CI. The discriminator is cursor-vs-not.
+  it("buildNativeDispatchSingleResponse — host='other' falls back to Agent-style banner", () => {
+    const text = buildNativeDispatchSingleResponse({
+      taskId: 'o1',
+      agentId: 'unity-implementer',
+      model: 'claude-sonnet-4-6',
+      relayToken: 'tokO',
+      agentCall: 'Agent(model: "claude-sonnet-4-6", prompt: <x>, run_in_background: true)',
+      promptInstruction: 'Step 1 — ...\n',
+      useWorktree: true,
+      host: OTHER,
+    });
+    expect(text).toContain('⚠️ REQUIRED_NEXT_ACTION: Agent() dispatch — this is a TODO, not a result.');
+    expect(text).toContain('Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"\n\n');
+    expect(text).not.toContain('Task() dispatch');
+    expect(text).not.toContain('Cursor Task tool');
   });
 });
 


### PR DESCRIPTION
## What

Upstreams **Cursor native-agent dispatch** into the canonical tree. The feature was built in a vendored fork (`schedule-2/vendor/gossipcat-ai`, the ForbiddenBrew Unity project) but never merged back — on `master`, Cursor still falls back to relay-only agents (`supportsNativeAgents: false`). This makes Cursor a first-class native host alongside Claude Code.

Along the way it fixes a **model-fidelity bug** in the forked code.

## Changes

- **New `apps/cli/src/native-host-bridge.ts`** — host-aware dispatch-string construction. Claude Code emits `Agent(...)`; Cursor emits `Task(subagent_type, model, ...)`. `dispatch.ts` rewired to call it across all six native-dispatch sites (single + parallel + consensus).
- **`mcp-server-sdk.ts`** — cursor host → `supportsNativeAgents: true` (`nativeAgentDir: '.claude/agents'`); null-LLM classification + the zero-config "✅ native orchestration enabled" message now fire for cursor too.
- **`rules-content.ts`** — host-aware rules path: prefers `docs/CURSOR_RULES.md`, falls back to `docs/RULES.md` with `Agent()`→`Task()` / `Claude Code`→`Cursor` substitution. New `docs/CURSOR_RULES.md` added to the published `files` allowlist.

## The model-fidelity fix

The simple (non-worktree) Cursor `Task()` form **omitted `model:`** — so Cursor ran the parent orchestrator's model while consensus scores attributed the work to the dispatched `agent_id` (loop closes, attribution misleads). The inline form now carries `model:`, matching the worktree form. Locked by regression tests that fail if the fix is reverted.

## Safety

- **Claude Code output parity is byte-identical** — verified across all six native-dispatch paths; no sentinel/banner/regex drift.
- typecheck clean, `build:mcp` green, full CLI suite **1258 passed / 0 failed** (+ 3 new parity tests, 15 bridge tests total).

## Pre-merge consensus

sonnet-reviewer (parity) + deepseek-challenger (adversarial), cross-reviewed: **12 confirmed, 0 disputed, 0 unverified**. fable-reviewer excluded (Fable 5 provider down).

Applied confirmed findings: cursor null-LLM success message (f2), full-string parity tests for consensus footer / parallel header / worktree banner (f8/f9/f10), `CURSOR_RULES.md` `model:` docs (f4), comment cleanup (f14). **Deferred** (need Cursor-runtime verification — the schedule-2 integration works empirically with these IDs, so churning blindly risks breaking it): `nativeAgentDir` readability (f3), `cursorSubagentType` preset mapping being largely dead code for kebab-case agent ids (f5/n1).

consensus-id: bad003ec-22574b6f

🤖 Generated with [Claude Code](https://claude.com/claude-code)