### PR TITLE
chore(cli): simplify cursorSubagentType — drop vestigial preset map

### DIFF
--- a/apps/cli/src/native-host-bridge.ts
+++ b/apps/cli/src/native-host-bridge.ts
@@ -35,18 +35,34 @@ export function nativeHostLabel(host: NativeHost = detectNativeHost()): string {
   return 'host native subagent tool';
 }
 
-/** Cursor Task subagent_type: prefer agent id when it matches Cursor naming rules. */
+/**
+ * Cursor `Task` subagent_type for a NATIVE agent id.
+ *
+ * Cursor registers its `subagent_type` enum from `.claude/agents/<id>.md`
+ * filenames, so a native agent's id IS its registered Cursor type — pass it
+ * through verbatim. This function only runs for native agents (gated upstream by
+ * `ctx.nativeAgentConfigs` in handlers/dispatch.ts before formatNativeAgentCall),
+ * and a native agent maps 1:1 to a backing `.claude/agents/<id>.md` definition, so
+ * the kebab id is exactly the type Cursor knows. Verified against Cursor runtime:
+ * `Task(subagent_type: "unity-playtester")` resolved to a real sub-agent because
+ * `.claude/agents/unity-playtester.md` registered that type.
+ *
+ * Reserved/utility ids (`_utility`, `_project`, …) and any non-kebab id have no
+ * backing `.claude/agents/*.md` file and thus no registered Cursor type; fall back
+ * to the always-available `generalPurpose` built-in. (The former preset map —
+ * `sonnet-reviewer`→`code-reviewer` etc. — was dead code: every real native id is
+ * kebab-case and hits the pass-through, and a gossipcat-native project registers
+ * `sonnet-reviewer` itself as the type, so remapping it would have been wrong.)
+ *
+ * NOTE: relay-only ids (`gemini-reviewer`, `deepseek-challenger`) are kebab-case and
+ * would pass through here, but they never reach this function — the upstream
+ * nativeAgentConfigs gate routes them to the relay worker, not native Task dispatch.
+ */
 export function cursorSubagentType(agentId: string): string {
   if (/^[a-z][a-z0-9-]*$/.test(agentId) && agentId.includes('-')) {
     return agentId;
   }
-  const presetMap: Record<string, string> = {
-    'sonnet-reviewer': 'code-reviewer',
-    'haiku-researcher': 'explore',
-    'opus-implementer': 'generalPurpose',
-    'opus-architect': 'code-architect',
-  };
-  return presetMap[agentId] ?? 'generalPurpose';
+  return 'generalPurpose';
 }
 
 export interface FormatNativeCallOptions {

--- a/tests/cli/native-host-bridge.test.ts
+++ b/tests/cli/native-host-bridge.test.ts
@@ -4,6 +4,7 @@
  */
 import {
   buildNativeDispatchSingleResponse,
+  cursorSubagentType,
   detectNativeHost,
   formatNativeAgentCall,
   formatNativePromptInstruction,
@@ -159,6 +160,29 @@ describe('Claude Code output parity (legacy strings)', () => {
     expect(text).toContain('Worktree isolation: REQUIRED — Agent() MUST be invoked with isolation: "worktree"\n\n');
     expect(text).not.toContain('Task() dispatch');
     expect(text).not.toContain('Cursor Task tool');
+  });
+});
+
+describe('cursorSubagentType', () => {
+  // Native agent ids are kebab-case and equal their .claude/agents/<id>.md
+  // filename = the type Cursor registered. Pass through verbatim.
+  it('passes a kebab-case native id through verbatim', () => {
+    expect(cursorSubagentType('unity-playtester')).toBe('unity-playtester');
+    expect(cursorSubagentType('sonnet-reviewer')).toBe('sonnet-reviewer');
+    expect(cursorSubagentType('opus-implementer')).toBe('opus-implementer');
+  });
+
+  // Reserved/utility ids start with '_', have no backing .claude/agents file →
+  // no registered Cursor type → fall back to the generalPurpose built-in.
+  it('falls back to generalPurpose for reserved/utility ids', () => {
+    expect(cursorSubagentType('_utility')).toBe('generalPurpose');
+    expect(cursorSubagentType('_project')).toBe('generalPurpose');
+  });
+
+  // A non-kebab id (no dash) has no backing file either → generalPurpose.
+  it('falls back to generalPurpose for non-kebab ids', () => {
+    expect(cursorSubagentType('claude')).toBe('generalPurpose');
+    expect(cursorSubagentType('Reviewer')).toBe('generalPurpose');
   });
 });
 


### PR DESCRIPTION
## What

Small follow-up cleanup to #617, informed by **Cursor-runtime verification** of consensus findings f5/n1.

`cursorSubagentType()` decided what `subagent_type` to emit in a Cursor `Task(...)` call. Confirmed from Cursor runtime + schedule-2 session artifacts: **Cursor registers its `subagent_type` enum from `.claude/agents/<id>.md` filenames**, so a native agent's id *is* its registered Cursor type — `Task(subagent_type: "unity-playtester")` resolved to a real sub-agent (157s relay, tagged findings) precisely because `.claude/agents/unity-playtester.md` registered that type.

## Changes

- **Removed the preset map** (`sonnet-reviewer`→`code-reviewer`, etc.) — it was **dead code**: every real native id is kebab-case and hits the pass-through branch first. Worse, a gossipcat-native project registers `sonnet-reviewer` *itself* as the type, so the remap would have been **wrong** if it ever executed.
- Non-kebab and reserved ids (`_utility`, `_project`) still fall back to the always-available `generalPurpose` built-in.
- **Documented** why relay-only ids (`gemini-reviewer`, `deepseek-challenger`) can't reach this function: they're gated out upstream by `ctx.nativeAgentConfigs` in `handlers/dispatch.ts:693` and route to the relay worker, never native `Task` dispatch. (This is why the Cursor agent's "relay-id passthrough" concern isn't triggerable in normal flow.)
- Added `cursorSubagentType` unit tests: kebab pass-through, reserved-id fallback, non-kebab fallback.

## Net

Pure simplification — deletes a dead branch, tightens the fallback, adds test coverage. No behavior change for any real dispatch (native kebab ids pass through identically; reserved ids still → `generalPurpose`).

## Verification

typecheck clean; `build:mcp` green; bridge suite 19 tests + dispatch/rules suites pass in a **CI-like env** (`env -u CLAUDECODE -u CURSOR …`), the bare environment that caught the #617 host-coupling regression.

Follow-up to #617 (consensus `bad003ec`); resolves deferred findings f5/n1 as working-as-intended + removes the vestigial code they flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)