### PR TITLE
chore(resolver): flip resolverLineAnchored default to true (post-#580 soak)

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -1133,7 +1133,7 @@ export async function handleCollect(
       const autoResolveEnabled = cfgPathAr?.consensus?.autoResolveOnRoundClose !== false;
       if (autoResolveEnabled) {
         const { resolveFindings: rf } = await import('@gossip/orchestrator');
-        const resolveResult = await rf(process.cwd(), { lineAnchored: cfgPathAr?.consensus?.resolverLineAnchored ?? false });
+        const resolveResult = await rf(process.cwd(), { lineAnchored: cfgPathAr?.consensus?.resolverLineAnchored ?? true });
         if (resolveResult.ok) {
           if (resolveResult.resolved > 0) {
             process.stderr.write(

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -4196,7 +4196,7 @@ export function createMcpServer(): McpServer {
       try {
         const { resolveFindings } = await import('@gossip/orchestrator');
         const cfg = (() => { try { const { findConfigPath, loadConfig } = require('./config'); const p = findConfigPath(process.cwd()); return p ? loadConfig(p) : null; } catch { return null; } })();
-        const result = await resolveFindings(process.cwd(), { full, sinceSha, lineAnchored: cfg?.consensus?.resolverLineAnchored ?? false });
+        const result = await resolveFindings(process.cwd(), { full, sinceSha, lineAnchored: cfg?.consensus?.resolverLineAnchored ?? true });
         if (!result.ok) {
           return { content: [{ type: 'text' as const, text: `Resolver skipped: ${result.reason} (another resolver run in progress; try again in a moment).` }] };
         }


### PR DESCRIPTION
## Summary

Flips the `resolverLineAnchored` runtime default from `false` → `true` now that the 7-day post-#580 soak window has elapsed (brake merged 2026-06-13; flip date 2026-06-20).

### What changed

Two `?? false` fallback literals → `?? true`:

| File | Line | Context |
|------|------|---------|
| `apps/cli/src/mcp-server-sdk.ts` | 4199 | `gossip_resolve` MCP handler |
| `apps/cli/src/handlers/collect.ts` | 1136 | Auto-resolver on round-close |

No other logic is touched. The 5% false-resolve safety brake (#580), brake thresholds, `skipReasons` observability, and the `commit:<sha>` fastpath are **entirely unchanged**. Operators who need the old behaviour can pin `consensus.resolverLineAnchored: false` in `.gossip/config.json`.

Refs: #578 (lineAnchored implementation), #580 (stale_anchor safety brake), this PR (default flip).

---

## ⚠️ Human operator checklist — MUST complete BEFORE marking ready + merging

> **This PR was prepared by an automated cloud session that cannot access `.gossip/finding-resolutions.jsonl` (gitignored). The soak-window safety check MUST be performed locally.**

- [ ] **Verify the 7-day soak locally:** Open `.gossip/finding-resolutions.jsonl` on your local machine. Confirm the trailing-30d `stale_anchor` unresolve rate is **BELOW the 5% brake threshold** — i.e., no findings resolved as `stale_anchor` subsequently had `flag_for_review` pivots indicating false-resolves. This file is gitignored and cannot be checked in the cloud.
- [ ] **Run gossipcat consensus on this diff** per `CLAUDE.md` (resolver/signal pipeline is impact-adjacent). Add the resulting `consensus-id: <id>` token to this PR body so the impact-adjacency CI gate passes.
- [ ] **Only if both checks above are clean:** mark ready for review and merge. If ANY false-resolve regression appears in the soak data, **CLOSE this PR** (do not flip), and extend the soak window.

---

## Test results (cloud checkout — pre-existing baseline)

```
Test Suites: 2 failed, 167 passed, 169 total
Tests:       8 failed, 2 skipped, 2493 passed, 2503 total
Time:        ~48s
```

The 8 failures are **pre-existing on master** (verified by running the suite before and after the change — identical counts both times). They are in `tests/orchestrator/claim-verifier.test.ts` and `tests/orchestrator/runtime-config.test.ts`, in the `verifyClaims` count-relation and 16-claim-cap paths — unrelated to the resolver. TypeScript workspace packages (`@gossip/types`, `@gossip/tools`, `@gossip/client`) are not resolvable in the ephemeral cloud checkout due to missing workspace builds; this is a cloud-environment limitation, not a regression introduced by this PR.

**Do not merge on the basis of these test results alone** — run locally with workspace dependencies built to get a clean baseline.

---

consensus-id: <!-- ADD AFTER RUNNING GOSSIPCAT CONSENSUS -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrZ37FFaQVJidxJt3DinWi)_