### PR TITLE
feat(skills): one-command install via `npx skills add gossipcat-ai/gossipcat-ai`

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ The difference: gossipcat verifies findings against actual `file:line` citations
 
 **Requirements:** Node.js 22+ and either host below. Claude Code and Cursor are co-equal first-class hosts — pick the one you use; gossipcat auto-detects it and runs native agents either way.
 
+**Fastest path (skills CLI):** one command installs the server and walks you through setup:
+
+```bash
+npx skills add gossipcat-ai/gossipcat-ai
+```
+
+This drops an installer skill into `.claude/skills/`; your agent runs the install and then hands off to `gossip_status()` for the live rules. Prefer it over the manual steps below if you use the [skills](https://github.com/vercel-labs/skills) CLI. The manual npm install is documented next.
+
 Install the package once:
 ```bash
 npm install -g gossipcat

--- a/skills/gossipcat/SKILL.md
+++ b/skills/gossipcat/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: gossipcat
+description: Use when installing or setting up gossipcat multi-agent orchestration (parallel review, consensus, adaptive dispatch) in Claude Code or Cursor. Installs the gossipcat MCP server and hands off to gossip_status() for all live rules.
+---
+
+# Install gossipcat
+
+gossipcat is an **MCP server** (a running relay + tool server + native-agent dispatch),
+not a set of prompt rules. This skill installs the server. Once it is connected, **all
+operational rules — dispatch, consensus, signals — load live from `gossip_status()` and
+stay in sync with the running server.** This skill does not carry them.
+
+## Steps
+
+1. **Detect the host.** Check the environment:
+   - `echo $CLAUDECODE` prints `1` → **Claude Code**.
+   - `echo $CURSOR` is set, or you are running inside Cursor → **Cursor**.
+   If unclear, ask the user which one they use.
+
+2. **Ask the user: global or project-local install?**
+
+3. **Run the matching commands.**
+
+   **Global** (works for both Claude Code and Cursor):
+   ```bash
+   npm install -g gossipcat
+   claude mcp add gossipcat -s user -- gossipcat
+   ```
+   The `claude mcp add` step is **required** for global installs — the postinstall step
+   cannot write a usable `.mcp.json` for a global install, so you must register the server
+   manually. (Cursor users: add `{ "mcpServers": { "gossipcat": { "command": "gossipcat" } } }`
+   to `~/.cursor/mcp.json` instead of `claude mcp add`.)
+
+   **Project-local** (run inside the target project):
+   ```bash
+   npm install --save-dev gossipcat
+   ```
+   The postinstall step writes `.mcp.json` into the project root automatically — no
+   `claude mcp add` needed. Open the IDE in that project.
+
+4. **Reconnect.** If you added the server mid-session, run `/mcp` (Claude Code) or restart
+   the IDE so the gossipcat tools load.
+
+5. **Verify and hand off.** Call `gossip_status()`. It returns the dashboard URL, the agent
+   roster, and the full live operator playbook. Print the dashboard URL for the user, then
+   tell them: *"Set up a gossipcat team for this project."*
+
+> All dispatch rules, the consensus workflow, and signal discipline are delivered by
+> `gossip_status()` at runtime — they are kept in sync with the installed server version
+> and are intentionally NOT duplicated in this skill.


### PR DESCRIPTION
## What

Adds a thin **installer skill** so gossipcat can be set up with one command:

```
npx skills add gossipcat-ai/gossipcat-ai
```

- **`skills/gossipcat/SKILL.md`** — installer skill (flat layout, discovered by the [vercel-labs/skills](https://github.com/vercel-labs/skills) CLI). Detects host (Claude Code / Cursor), asks global vs project-local, runs the install, reconnects, then calls `gossip_status()`.
- **README Quickstart** — adds the one-liner as the fastest install front door, above the manual npm path.

## Why a thin installer (not the whole playbook)

gossipcat is an **MCP server**, not prompt rules — `npx skills add` only installs markdown, so the skill installs the server and **hands off to `gossip_status()` for all live rules**. It deliberately does **not** embed dispatch/consensus/signal rules: those ship live via `docs/RULES.md` → `gossip_status()`, and a static copy would drift (two canonical sources).

## Verification

- `skills@1.5.12` discovers **exactly one** skill (`gossipcat`) from the repo — `.agents/`, `.claude/skills/` are gitignored, so no collision.
- Local-path install (`npx skills add . --skill gossipcat`) writes valid `SKILL.md` to `.claude/skills/` + `.agents/skills/`, frontmatter intact.
- Install commands match README Quickstart + `scripts/postinstall.js` behavior (global needs manual `claude mcp add`; project-local postinstall writes `.mcp.json`).
- Docs/markdown-only — no `packages/`/`apps/`/server changes.

Design was consensus-reviewed (`2e1cda75-e5864785`): the embedded-playbook variant was rejected for drift risk in favor of this thin-installer design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)