### PR TITLE
fix(security): harden hook-installer — drop cwd resolution + load-before-copy (#570, #500)

### DIFF
--- a/packages/orchestrator/src/hook-installer.ts
+++ b/packages/orchestrator/src/hook-installer.ts
@@ -40,18 +40,20 @@ const HOOK_MATCHER = HOOKED_TOOLS.join('|');
  *   1. <__dirname>/assets/hooks/worktree-sandbox.sh
  *      — published: build:mcp copies ./assets → dist-mcp/assets
  *   2. <__dirname>/../../../assets/hooks/worktree-sandbox.sh
- *      — dev (ts-node): __dirname = packages/orchestrator/src/
+ *      — dev (ts-node): __dirname = packages/orchestrator/src/, so ../../.. = repo root
  *   3. <__dirname>/../assets/hooks/worktree-sandbox.sh
  *      — fallback for compiled-but-not-bundled layouts
- *   4. <cwd>/assets/hooks/worktree-sandbox.sh
- *      — last-resort dev fallback from monorepo root
+ *
+ * Note: a cwd-based candidate was intentionally removed (issue #570). cwd is
+ * attacker-influenceable; a planted ./assets/hooks/worktree-sandbox.sh would be
+ * copied into .claude/hooks/ and executed on every Bash/Edit/Write tool call.
+ * The dev-from-monorepo-root case is covered by candidate #2.
  */
 export function findBundledHook(): string | null {
   const candidates = [
     resolve(__dirname, 'assets', 'hooks', HOOK_FILENAME),
     resolve(__dirname, '..', '..', '..', 'assets', 'hooks', HOOK_FILENAME),
     resolve(__dirname, '..', 'assets', 'hooks', HOOK_FILENAME),
-    resolve(process.cwd(), 'assets', 'hooks', HOOK_FILENAME),
   ];
   for (const p of candidates) {
     if (existsSync(p)) return p;
@@ -145,17 +147,14 @@ export function writeOrchestratorRoleMarker(projectRoot: string): string {
  */
 export function installWorktreeSandboxHook(projectRoot: string): HookInstallResult {
   try {
+    // 1. Locate the bundled hook asset — bail early if not found.
     const bundled = findBundledHook();
     if (!bundled) return { installed: false, reason: 'bundled hook asset not found' };
 
-    // 1. Copy the hook script into the project and mark it executable.
-    const targetDir = join(projectRoot, '.claude', 'hooks');
-    const target = join(targetDir, HOOK_FILENAME);
-    mkdirSync(targetDir, { recursive: true });
-    copyFileSync(bundled, target);
-    chmodSync(target, 0o755);
-
-    // 2. Merge the PreToolUse registration into settings.json.
+    // 2. Load settings.json BEFORE touching the filesystem so a malformed file
+    //    causes an early return without leaving the hook script on disk
+    //    (issue #500 — previously a malformed settings.json threw AFTER copy,
+    //    leaving the script on disk but unregistered → Layer-2 sandbox silently inert).
     const settingsPath = join(projectRoot, '.claude', 'settings.json');
     mkdirSync(dirname(settingsPath), { recursive: true });
 
@@ -170,6 +169,14 @@ export function installWorktreeSandboxHook(projectRoot: string): HookInstallResu
       return { installed: false, reason: (err as Error).message };
     }
 
+    // 3. Settings loaded cleanly — now copy the hook script and mark it executable.
+    const targetDir = join(projectRoot, '.claude', 'hooks');
+    const target = join(targetDir, HOOK_FILENAME);
+    mkdirSync(targetDir, { recursive: true });
+    copyFileSync(bundled, target);
+    chmodSync(target, 0o755);
+
+    // 4. Merge the PreToolUse registration into settings.json.
     const mutated = mergePreToolUseEntry(settings);
     if (mutated) {
       writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
@@ -250,13 +257,15 @@ const DISCIPLINE_HOOKS = [
 /**
  * Resolve a bundled discipline hook asset. Mirrors `findBundledHook` candidate
  * strategy so it works from both the esbuild bundle (dist-mcp/) and dev (ts-node).
+ *
+ * Note: a cwd-based candidate was intentionally removed (issue #570). See
+ * `findBundledHook` doc comment for rationale.
  */
 function findDisciplineHook(filename: string): string | null {
   const candidates = [
     resolve(__dirname, 'assets', 'hooks', DISCIPLINE_HOOK_DIR, filename),
     resolve(__dirname, '..', '..', '..', 'assets', 'hooks', DISCIPLINE_HOOK_DIR, filename),
     resolve(__dirname, '..', 'assets', 'hooks', DISCIPLINE_HOOK_DIR, filename),
-    resolve(process.cwd(), 'assets', 'hooks', DISCIPLINE_HOOK_DIR, filename),
   ];
   for (const p of candidates) {
     if (existsSync(p)) return p;

--- a/packages/orchestrator/src/hook-installer.ts
+++ b/packages/orchestrator/src/hook-installer.ts
@@ -595,23 +595,9 @@ export function installDisciplineHooks(projectRoot: string): DisciplineHookInsta
   const skipped: string[] = [];
 
   try {
-    // 1. Copy hook scripts into .claude/hooks/discipline/ and mark executable.
-    const targetDir = join(projectRoot, '.claude', 'hooks', DISCIPLINE_HOOK_DIR);
-    mkdirSync(targetDir, { recursive: true });
-
-    for (const hook of DISCIPLINE_HOOKS) {
-      const bundled = findDisciplineHook(hook.filename);
-      if (!bundled) {
-        skipped.push(hook.name);
-        continue;
-      }
-      const target = join(targetDir, hook.filename);
-      copyFileSync(bundled, target);
-      chmodSync(target, 0o755);
-    }
-
-    // 2. Load settings.local.json — throw on malformed JSON so we never
-    //    silently clobber user content.
+    // 1. Load settings.local.json FIRST — throw on malformed JSON so we never
+    //    silently clobber user content, and so we never copy hook scripts that
+    //    will be left unregistered (mirrors the installWorktreeSandboxHook fix).
     const settingsPath = join(projectRoot, '.claude', 'settings.local.json');
     mkdirSync(dirname(settingsPath), { recursive: true });
 
@@ -624,6 +610,23 @@ export function installDisciplineHooks(projectRoot: string): DisciplineHookInsta
         `Fix the file or delete it and re-run gossip_setup.\n`,
       );
       return { installed, skipped, reason: (err as Error).message };
+    }
+
+    // 2. Copy hook scripts into .claude/hooks/discipline/ and mark executable.
+    //    Only reached after settings.local.json has been validated — no
+    //    copied-but-unregistered files can accumulate on malformed settings.
+    const targetDir = join(projectRoot, '.claude', 'hooks', DISCIPLINE_HOOK_DIR);
+    mkdirSync(targetDir, { recursive: true });
+
+    for (const hook of DISCIPLINE_HOOKS) {
+      const bundled = findDisciplineHook(hook.filename);
+      if (!bundled) {
+        skipped.push(hook.name);
+        continue;
+      }
+      const target = join(targetDir, hook.filename);
+      copyFileSync(bundled, target);
+      chmodSync(target, 0o755);
     }
 
     // 3. Merge all three hook entries idempotently.

--- a/tests/orchestrator/hook-installer-cwd-security.test.ts
+++ b/tests/orchestrator/hook-installer-cwd-security.test.ts
@@ -2,14 +2,24 @@
  * Security test for findBundledHook — cwd fallback removal (issue #570).
  *
  * A planted ./assets/hooks/worktree-sandbox.sh in the current working directory
- * must NEVER be returned by findBundledHook(), even if it exists. The cwd
+ * must NEVER be probed by findBundledHook(), even if it exists. The cwd
  * candidate is attacker-influenceable and was removed as a security fix.
+ *
+ * This test uses jest.spyOn on the `fs` module object (via require('fs')) to
+ * record every path that findBundledHook() probes, then asserts the cwd-planted
+ * path is never among the probed candidates — i.e. not just "not returned" but
+ * "never checked".
+ *
+ * hook-installer.ts uses `import { existsSync } from 'fs'` — a named CJS
+ * re-export. In Jest's node environment the named export and the module property
+ * are the same reference on the module object, so spyOn(require('fs'),
+ * 'existsSync') intercepts the call. We verify the spy actually intercepted by
+ * asserting probedPaths.length > 0.
  */
 import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { tmpdir } from 'os';
 import { rmSync } from 'fs';
-import { findBundledHook } from '../../packages/orchestrator/src/hook-installer';
 
 function makeTmpDir(): string {
   return mkdtempSync(join(tmpdir(), 'gossip-cwd-security-'));
@@ -28,7 +38,7 @@ describe('findBundledHook — cwd fallback must not be used (security #570)', ()
     }
   });
 
-  it('does NOT return a cwd-planted hook path even when the file exists at <cwd>/assets/hooks/worktree-sandbox.sh', () => {
+  it('does NOT probe the cwd-planted hook path (existsSync never called with it)', () => {
     const tmp = makeTmpDir();
     created.push(tmp);
 
@@ -40,10 +50,34 @@ describe('findBundledHook — cwd fallback must not be used (security #570)', ()
     // Change cwd to the attacker-controlled directory.
     process.chdir(tmp);
 
-    const plantedPath = resolve(tmp, 'assets', 'hooks', 'worktree-sandbox.sh');
-    const result = findBundledHook();
+    // Spy on the fs module object's existsSync. In Jest's node environment,
+    // named CJS imports share the same property on the module object, so this
+    // intercepts calls from hook-installer.ts's `import { existsSync } from 'fs'`.
+    const probedPaths: string[] = [];
+    const fsModule = require('fs') as typeof import('fs');
+    const realExistsSync = fsModule.existsSync.bind(fsModule);
+    const spy = jest.spyOn(fsModule, 'existsSync').mockImplementation((p) => {
+      probedPaths.push(String(p));
+      return realExistsSync(p);
+    });
 
-    // The cwd-planted path must NEVER be returned.
-    expect(result).not.toBe(plantedPath);
+    try {
+      // Dynamically require to ensure it uses the spied-on fs module.
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { findBundledHook } = require('../../packages/orchestrator/src/hook-installer');
+      findBundledHook();
+    } finally {
+      spy.mockRestore();
+    }
+
+    const cwdPlantedPath = resolve(tmp, 'assets', 'hooks', 'worktree-sandbox.sh');
+
+    // Verify the spy actually intercepted calls (must be > 0 probed paths).
+    // If this assertion fails, the spy did not intercept — the test would be
+    // vacuous and we must report BLOCKED.
+    expect(probedPaths.length).toBeGreaterThan(0);
+
+    // The cwd-planted path must NEVER have been probed.
+    expect(probedPaths).not.toContain(cwdPlantedPath);
   });
 });

--- a/tests/orchestrator/hook-installer-cwd-security.test.ts
+++ b/tests/orchestrator/hook-installer-cwd-security.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Security test for findBundledHook — cwd fallback removal (issue #570).
+ *
+ * A planted ./assets/hooks/worktree-sandbox.sh in the current working directory
+ * must NEVER be returned by findBundledHook(), even if it exists. The cwd
+ * candidate is attacker-influenceable and was removed as a security fix.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { tmpdir } from 'os';
+import { rmSync } from 'fs';
+import { findBundledHook } from '../../packages/orchestrator/src/hook-installer';
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'gossip-cwd-security-'));
+}
+
+describe('findBundledHook — cwd fallback must not be used (security #570)', () => {
+  const created: string[] = [];
+  const originalCwd = process.cwd();
+
+  afterEach(() => {
+    // Always restore cwd before cleanup.
+    process.chdir(originalCwd);
+    while (created.length) {
+      const dir = created.pop()!;
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+  });
+
+  it('does NOT return a cwd-planted hook path even when the file exists at <cwd>/assets/hooks/worktree-sandbox.sh', () => {
+    const tmp = makeTmpDir();
+    created.push(tmp);
+
+    // Plant an attacker-controlled hook at <tmp>/assets/hooks/worktree-sandbox.sh.
+    const plantedDir = join(tmp, 'assets', 'hooks');
+    mkdirSync(plantedDir, { recursive: true });
+    writeFileSync(join(plantedDir, 'worktree-sandbox.sh'), '#!/bin/sh\necho "pwned"\n', { mode: 0o755 });
+
+    // Change cwd to the attacker-controlled directory.
+    process.chdir(tmp);
+
+    const plantedPath = resolve(tmp, 'assets', 'hooks', 'worktree-sandbox.sh');
+    const result = findBundledHook();
+
+    // The cwd-planted path must NEVER be returned.
+    expect(result).not.toBe(plantedPath);
+  });
+});

--- a/tests/orchestrator/hook-installer-discipline.test.ts
+++ b/tests/orchestrator/hook-installer-discipline.test.ts
@@ -181,6 +181,45 @@ describe('installDisciplineHooks', () => {
     expect(after).toBe(arrayJson);
   });
 
+  it('does NOT copy discipline hook scripts when settings.local.json is malformed', () => {
+    const root = makeTmpProject();
+    created.push(root);
+
+    // Write a malformed settings.local.json before calling installDisciplineHooks.
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const malformed = '{not valid json';
+    const settingsPath = join(root, '.claude', 'settings.local.json');
+    writeFileSync(settingsPath, malformed);
+
+    let result: ReturnType<typeof installDisciplineHooks>;
+    expect(() => {
+      result = installDisciplineHooks(root);
+    }).not.toThrow();
+
+    // Must return a reason matching /malformed/i from the JSON parse error.
+    expect(result!.reason).toMatch(/malformed|Unexpected token|JSON/i);
+
+    // The discipline hook script files must NOT have been copied to disk —
+    // the load-before-copy ordering fix ensures no files land when settings
+    // validation fails.
+    const disciplineDir = join(root, '.claude', 'hooks', 'discipline');
+    const filenames = [
+      'session-start-bootstrap.sh',
+      'pretool-signals-validate.sh',
+      'posttool-collect-reminder.sh',
+    ];
+    for (const filename of filenames) {
+      expect(existsSync(join(disciplineDir, filename))).toBe(false);
+    }
+
+    // The discipline directory itself must not have been created either.
+    expect(existsSync(disciplineDir)).toBe(false);
+
+    // The malformed file must be byte-identical — zero data loss.
+    const after = readFileSync(settingsPath, 'utf-8');
+    expect(after).toBe(malformed);
+  });
+
   it('referenced discipline script files exist on disk as bundled assets', () => {
     // Sanity check — the hook-finder must locate all 3 scripts from the
     // current working environment (mirrors findBundledHook sanity test).

--- a/tests/orchestrator/hook-installer-malformed-settings.test.ts
+++ b/tests/orchestrator/hook-installer-malformed-settings.test.ts
@@ -5,8 +5,9 @@
  * object, the installer must:
  *   1. Return { installed: false } without throwing to the caller.
  *   2. Leave the file byte-identical to its original content (zero data loss).
+ *   3. NOT copy the hook script to disk (issue #500 — ordering fix).
  */
-import { mkdtempSync, writeFileSync, readFileSync, mkdirSync } from 'fs';
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { rmSync } from 'fs';
@@ -67,6 +68,27 @@ describe('installWorktreeSandboxHook — malformed settings.json guard', () => {
     // File must be byte-identical to the original non-object JSON.
     const after = readFileSync(join(root, '.claude', 'settings.json'), 'utf-8');
     expect(after).toBe(arrayJson);
+  });
+
+  it('does NOT copy the hook script when settings.json is malformed (#500 ordering fix)', () => {
+    const root = makeTmpProject();
+    created.push(root);
+
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    const malformed = '{not valid json';
+    writeFileSync(join(root, '.claude', 'settings.json'), malformed);
+
+    let result: ReturnType<typeof installWorktreeSandboxHook>;
+    expect(() => {
+      result = installWorktreeSandboxHook(root);
+    }).not.toThrow();
+
+    expect(result!.installed).toBe(false);
+
+    // The hook script must NOT be on disk — settings were malformed so we
+    // must bail before any filesystem side-effects on the hook target.
+    const hookPath = join(root, '.claude', 'hooks', 'worktree-sandbox.sh');
+    expect(existsSync(hookPath)).toBe(false);
   });
 
   it('does not throw and skips write when settings.json is a JSON string (not an object)', () => {


### PR DESCRIPTION
consensus-id: 5eb5f4d4-d2fe4616

## What

Two confirmed defects in `packages/orchestrator/src/hook-installer.ts`, plus the same-class bug a reviewer caught in the sibling function.

### #570 (security) — drop the cwd fallback in hook resolution
`findBundledHook()` and `findDisciplineHook()` each had a last-resort `resolve(process.cwd(), 'assets', 'hooks', ...)` candidate. `cwd` is attacker-influenceable (open/clone a repo, run gossipcat from its root): a planted `./assets/hooks/worktree-sandbox.sh` would be copied into `.claude/hooks/` and executed on every Bash/Edit/Write tool call. Removed from both functions. The legitimate dev-from-monorepo-root case is already covered by the `__dirname/../../../assets` candidate, and the published bundle resolves via `__dirname/assets` (`dist-mcp/assets`), so resolution is unaffected.

### #500 (bug) — load settings before copying the hook
`installWorktreeSandboxHook()` copied the hook script **before** `loadSettings()`. A malformed `settings.json` threw after the copy, leaving the script on disk but unregistered → Layer-2 sandbox silently inert. Reordered so the malformed-settings guard runs first; nothing is copied unless settings load cleanly.

### Review follow-up — same fix applied to `installDisciplineHooks()`
Consensus review (`5eb5f4d4-d2fe4616`, sonnet-reviewer + deepseek-challenger) caught that `installDisciplineHooks()` had the identical copy-before-load ordering. Applied the same reorder there.

## Tests
- New `tests/orchestrator/hook-installer-cwd-security.test.ts` — spies on `existsSync` to assert the cwd-planted path is **never probed** by `findBundledHook()` (3 real candidates probed, cwd path absent).
- `hook-installer-malformed-settings.test.ts` — asserts the worktree hook script is not copied on malformed `settings.json`.
- `hook-installer-discipline.test.ts` — asserts discipline scripts are not copied on malformed `settings.local.json`.
- Full `hook-installer` suite: 43/43 pass. tsc clean (orchestrator).

## Consensus notes
Round `5eb5f4d4-d2fe4616`. Two deepseek findings were verified **false** and refuted: (f1) "hook not shipped in npm package" — `npm pack --dry-run` confirms `dist-mcp/assets/hooks/worktree-sandbox.sh` ships via `files:["dist-mcp/"]`; (f2) "stale compiled dist/ runs in prod" — `packages/orchestrator/dist/` is gitignored; production runs the esbuild bundle rebuilt from source. One low-pri enhancement deferred (orphan-hook cleanup on bail).

Closes #570, closes #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)