### PR TITLE
chore(resolver): flip consensus.resolverLineAnchored default to true (#622, #502)

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -66,8 +66,10 @@ export interface GossipConfig {
      * Enable the line-anchored staleness heuristic in the findings resolver.
      * When true, a finding whose cited identifier is still present in the file
      * but NOT at the cited line (present_elsewhere) is auto-resolved as
-     * `stale_anchor`. Default false (opt-in) per the rollout plan — do NOT
-     * flip to true until the false-resolve safety brake is implemented.
+     * `stale_anchor`. Default true since the false-resolve safety brake shipped
+     * (#580, 2026-06-13) and the rollout audit window closed clean — zero
+     * `unresolve` reverts on `stale_anchor` resolutions (#622/#502). Set to
+     * false to opt out.
      */
     resolverLineAnchored?: boolean;
   };

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -1133,7 +1133,7 @@ export async function handleCollect(
       const autoResolveEnabled = cfgPathAr?.consensus?.autoResolveOnRoundClose !== false;
       if (autoResolveEnabled) {
         const { resolveFindings: rf } = await import('@gossip/orchestrator');
-        const resolveResult = await rf(process.cwd(), { lineAnchored: cfgPathAr?.consensus?.resolverLineAnchored ?? false });
+        const resolveResult = await rf(process.cwd(), { lineAnchored: cfgPathAr?.consensus?.resolverLineAnchored ?? true });
         if (resolveResult.ok) {
           if (resolveResult.resolved > 0) {
             process.stderr.write(

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -4196,7 +4196,7 @@ export function createMcpServer(): McpServer {
       try {
         const { resolveFindings } = await import('@gossip/orchestrator');
         const cfg = (() => { try { const { findConfigPath, loadConfig } = require('./config'); const p = findConfigPath(process.cwd()); return p ? loadConfig(p) : null; } catch { return null; } })();
-        const result = await resolveFindings(process.cwd(), { full, sinceSha, lineAnchored: cfg?.consensus?.resolverLineAnchored ?? false });
+        const result = await resolveFindings(process.cwd(), { full, sinceSha, lineAnchored: cfg?.consensus?.resolverLineAnchored ?? true });
         if (!result.ok) {
           return { content: [{ type: 'text' as const, text: `Resolver skipped: ${result.reason} (another resolver run in progress; try again in a moment).` }] };
         }

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -4219,7 +4219,7 @@ export function createMcpServer(): McpServer {
         if (nonZeroSkips.length > 0) {
           lines.push(`  skipped: ${nonZeroSkips.map(([k, n]) => `${k}=${n}`).join(', ')}`);
           if ((result.skipReasons?.lineAnchoredOff ?? 0) > 0) {
-            lines.push(`  (lineAnchoredOff: enable consensus.resolverLineAnchored to resolve present-elsewhere findings as stale_anchor)`);
+            lines.push(`  (lineAnchoredOff: consensus.resolverLineAnchored is explicitly false in your config; set it to true or remove it — it now defaults on — to resolve present-elsewhere findings as stale_anchor)`);
           }
         }
         return { content: [{ type: 'text' as const, text: lines.join('\n') }] };


### PR DESCRIPTION
consensus-id: 8480b1ed-35ed4318

## What

Flips the `consensus.resolverLineAnchored` default from `false` → `true`, completing the staged rollout tracked in #622 (7-day gate) and #502 (30-day gate). The line-anchored staleness heuristic now resolves present-elsewhere findings as `stale_anchor` by default.

- `apps/cli/src/config.ts` — doc comment updated (default true; opt out via `false`)
- `apps/cli/src/mcp-server-sdk.ts`, `apps/cli/src/handlers/collect.ts` — the two default sites: `?? false` → `?? true`
- `apps/cli/src/mcp-server-sdk.ts` — `lineAnchoredOff` hint reworded (it now fires only when a user explicitly set `false`)

## Why it's safe to flip now

- **Safety brake shipped + active** (#580, 2026-06-13): `finding-resolver.ts:313-322` computes the 5% false-resolve brake inside `if (opts.lineAnchored)`; when engaged, `stale_anchor` candidates divert to `flag_for_review` instead of auto-resolving (`:628-659`).
- **Audit window clean**: `grep "resolved_by":"stale_anchor" .gossip/finding-resolutions.jsonl` = 2 resolutions, **0 `unresolve` reverts** → 0% < the spec's 5% rollback gate.
- **Brake is a progressive floor**: `MIN_BRAKE_SAMPLE=20` (`finding-resolver.ts:98`) means it engages only once ≥20 stale_anchor resolutions accrue — early default-on runs lean on the conservative present-elsewhere heuristic (identifier must still exist in the file), and every resolution is reversible via `unresolve`.

## Consensus (`8480b1ed-35ed4318`, sonnet-reviewer + deepseek-challenger)

Verified safe: exactly two source default sites (both flipped), brake real/active/gated, no test depends on the implicit false default. Two deepseek findings were **refuted**: (f1) "zero stale_anchor entries in production" — `grep` shows 2; (f3) "stale dist-mcp ships `?? false`" — `dist-mcp/` is gitignored and rebuilt at `prepublishOnly`. The one confirmed finding (misleading `lineAnchoredOff` hint, raised by both) is fixed in this PR. One low-pri log-bloat note (resolve-path cross-run dedup) deferred.

**Field-data caveat:** the audit window is thin (2 stale_anchor resolutions, both clean). The gate is met and the brake activates progressively as data accrues; this is the intended staged rollout, not a one-shot risk.

Closes #622, closes #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)