### PR TITLE
chore: harden launch warnings + unscored-round banner (#589, #554)

### DIFF
--- a/apps/cli/src/code-launch.ts
+++ b/apps/cli/src/code-launch.ts
@@ -67,29 +67,33 @@ function isGossipMcpEntry(entry: { command?: string; args?: unknown[] }): boolea
 /**
  * Detect the MCP server name for gossipcat by reading .mcp.json and/or ~/.claude.json.
  * Returns [serverName, usingFallback].
+ *
+ * Observability: when the chosen name came from <cwd>/.mcp.json (an untrusted,
+ * cwd-local config), a warning is emitted to stderr so users running `gossipcat code`
+ * inside a cloned repo are aware of the source. A mismatch warning is also emitted
+ * when both config files contain a gossipcat entry with different names.
  */
-function detectServerName(cwd: string): [string, boolean] {
+export function detectServerName(cwd: string): [string, boolean] {
+  const cwdPath = join(cwd, '.mcp.json');
+  const homePath = join(homedir(), '.claude.json');
+
   const candidates: [string, unknown][] = [
-    [join(cwd, '.mcp.json'), safeReadJson(join(cwd, '.mcp.json'))],
-    [join(homedir(), '.claude.json'), safeReadJson(join(homedir(), '.claude.json'))],
+    [cwdPath, safeReadJson(cwdPath)],
+    [homePath, safeReadJson(homePath)],
   ];
 
-  for (const [filePath, data] of candidates) {
-    if (!data || typeof data !== 'object') continue;
+  /** Extract the first safe gossipcat server name from a parsed JSON file. */
+  function extractName(data: unknown, filePath: string): string | null {
+    if (!data || typeof data !== 'object') return null;
     const root = data as Record<string, unknown>;
-
-    // .mcp.json top-level { mcpServers: { <name>: {...} } }
-    // ~/.claude.json nested: { mcpServers: { <name>: {...} } }
     const mcpServers = root['mcpServers'];
-    if (!mcpServers || typeof mcpServers !== 'object') continue;
-
+    if (!mcpServers || typeof mcpServers !== 'object') return null;
     const servers = mcpServers as McpServersMap;
     for (const [name, entry] of Object.entries(servers)) {
       if (!entry || typeof entry !== 'object') continue;
       if (isGossipMcpEntry(entry)) {
-        // Validate the name before returning it (it will be passed to spawn args)
         if (SAFE_SERVER_NAME_RE.test(name)) {
-          return [name, false];
+          return name;
         }
         // Name is present but unsafe — log and fall through
         process.stderr.write(
@@ -98,6 +102,28 @@ function detectServerName(cwd: string): [string, boolean] {
         );
       }
     }
+    return null;
+  }
+
+  const cwdName = extractName(candidates[0][1], cwdPath);
+  const homeName = extractName(candidates[1][1], homePath);
+
+  if (cwdName !== null) {
+    // Emit cwd-source observability warning (trust boundary)
+    process.stderr.write(
+      `[gossipcat code] Using channel server "${cwdName}" from ${cwdPath} (cwd-local config — only run this in repos you trust).\n`
+    );
+    // Emit mismatch warning when home also has a different name
+    if (homeName !== null && homeName !== cwdName) {
+      process.stderr.write(
+        `[gossipcat code] Warning: gossipcat server name differs between ${cwdPath} ("${cwdName}") and ${homePath} ("${homeName}"); using "${cwdName}" (cwd takes precedence).\n`
+      );
+    }
+    return [cwdName, false];
+  }
+
+  if (homeName !== null) {
+    return [homeName, false];
   }
 
   return ['gossipcat', true];

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -158,6 +158,7 @@ const __argvShimHandled = (() => {
       '  gossipcat key set <provider>   Store an API key in the OS keychain (service: gossip-mesh)\n' +
       '  gossipcat key list             Show which providers have a stored key\n' +
       '  gossipcat code [args...]       Launch Claude Code with the gossipcat channel active\n' +
+      '                                 Note: <cwd>/.mcp.json is treated as trusted config (server name is read from it).\n' +
       '  gossipcat help           Show this help\n' +
       '\n' +
       'The published binary is the MCP server bundle. The full CLI\n' +

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -1093,7 +1093,9 @@ Return only valid JSON.${skillsBlock}`;
           }
           _log('consensus',
             `⚠ agent "${r.agentId}" emitted ZERO tags — falling back to bullet parsing. ` +
-            `Check if skill Output Format conflicts with FINDING TAG SCHEMA.`
+            `Common causes: the dispatch/cross-review prompt instructed plain prose (no <agent_finding> tags), ` +
+            `a design/research task where the agent emitted none, or a skill Output Format conflicting with the FINDING TAG SCHEMA. ` +
+            `Verify the dispatch prompt keeps the schema in force.`
           );
         } else {
           const offending = Object.entries(parseResult.droppedUnknownType)
@@ -3098,6 +3100,21 @@ Return only valid JSON.${skillsBlock}`;
       // travel in the warning message. Fires after synthesize()'s drain, so
       // write to both round + report.
       this.appendReportWarning(report, 'coverage_degraded', evidence);
+    }
+
+    // Surface zero-tag agents: agents that emitted no <agent_finding> tags were
+    // bullet-parsed, so CONFIRMED/DISPUTED scoring was NOT computed for them.
+    // Mirrors the coverage_degraded pattern: banner in summary + warnings entry.
+    if (report.zeroTagAgents && report.zeroTagAgents.length > 0) {
+      const n = report.zeroTagAgents.length;
+      const overflow = report.zeroTagOverflow ?? 0;
+      const list = report.zeroTagAgents.join(', ');
+      const evidence =
+        `UNSCORED ROUND — ${n}${overflow > 0 ? '+' + overflow : ''} agent(s) emitted zero <agent_finding> tags; ` +
+        `their output was bullet-parsed and CONFIRMED/DISPUTED scoring was NOT computed for them ` +
+        `(agents: ${list})`;
+      report.summary += `\n⚠️  ${evidence}\n`;
+      this.appendReportWarning(report, 'zero_tags', evidence);
     }
 
     // Surface dropped relay agents so the orchestrator can see who silently

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -256,6 +256,28 @@ export class ConsensusEngine {
     report.warnings.push(entry);
   }
 
+  /**
+   * Idempotent helper: appends the UNSCORED ROUND banner to report.summary and
+   * records a zero_tags warning when any agents emitted zero <agent_finding> tags.
+   * Safe to call multiple times — skips if the banner is already present or if
+   * zeroTagAgents is empty/absent.
+   * Called at each finalization point: run(), runSelectedCrossReview(), and
+   * synthesizeWithCrossReview() — so ALL synthesize paths surface the banner.
+   */
+  private surfaceZeroTagBanner(report: ConsensusReport): void {
+    if (!report.zeroTagAgents?.length) return;
+    if (report.summary.includes('UNSCORED ROUND')) return;
+    const n = report.zeroTagAgents.length;
+    const overflow = report.zeroTagOverflow ?? 0;
+    const list = report.zeroTagAgents.join(', ');
+    const evidence =
+      `UNSCORED ROUND — ${n}${overflow > 0 ? '+' + overflow : ''} agent(s) emitted zero <agent_finding> tags; ` +
+      `their output was bullet-parsed and CONFIRMED/DISPUTED scoring was NOT computed for them ` +
+      `(agents: ${list})`;
+    report.summary += `\n⚠️  ${evidence}\n`;
+    this.appendReportWarning(report, 'zero_tags', evidence);
+  }
+
   /** True when a PerformanceReader is available for orchestrator-selected cross-review (Step 3). */
   get hasPerformanceReader(): boolean {
     return this.config.performanceReader !== undefined;
@@ -562,6 +584,10 @@ export class ConsensusEngine {
 
     // Always regenerate report with timing data
     report.summary = this.formatReport(report.confirmed, report.disputed, report.unverified, report.unique, report.newFindings, successful.length, report.rounds, timing, report.insights);
+
+    // Append UNSCORED ROUND banner AFTER formatReport so it is not clobbered
+    // by the summary regeneration that includes timing data.
+    this.surfaceZeroTagBanner(report);
 
     return report;
   }
@@ -2927,7 +2953,9 @@ Return only valid JSON.${skillsBlock}`;
     if (findingSeq === 0) {
       // No structured findings — fall back to synthesize with no cross-review entries
       _log('consensus', 'runSelectedCrossReview: no structured findings extracted; synthesizing without cross-review');
-      return this.synthesize(results, [], consensusId);
+      const report = await this.synthesize(results, [], consensusId);
+      this.surfaceZeroTagBanner(report);
+      return report;
     }
 
     // Build agent candidates from successful results
@@ -2942,6 +2970,7 @@ Return only valid JSON.${skillsBlock}`;
       // Spec §4 — the warnings channel SUBSUMES the legacy report.partialReview
       // field (deleted in PR-C). Fires after synthesize()'s drain.
       this.appendReportWarning(report, 'partial_review', 'no cross-reviewers selected — every finding is under-reviewed (0 of target K)');
+      this.surfaceZeroTagBanner(report);
       return report;
     }
 
@@ -3021,6 +3050,7 @@ Return only valid JSON.${skillsBlock}`;
       targetK: findingKMap.get(f.id) ?? 2,
     }));
 
+    this.surfaceZeroTagBanner(report);
     return report;
   }
 
@@ -3102,20 +3132,10 @@ Return only valid JSON.${skillsBlock}`;
       this.appendReportWarning(report, 'coverage_degraded', evidence);
     }
 
-    // Surface zero-tag agents: agents that emitted no <agent_finding> tags were
-    // bullet-parsed, so CONFIRMED/DISPUTED scoring was NOT computed for them.
-    // Mirrors the coverage_degraded pattern: banner in summary + warnings entry.
-    if (report.zeroTagAgents && report.zeroTagAgents.length > 0) {
-      const n = report.zeroTagAgents.length;
-      const overflow = report.zeroTagOverflow ?? 0;
-      const list = report.zeroTagAgents.join(', ');
-      const evidence =
-        `UNSCORED ROUND — ${n}${overflow > 0 ? '+' + overflow : ''} agent(s) emitted zero <agent_finding> tags; ` +
-        `their output was bullet-parsed and CONFIRMED/DISPUTED scoring was NOT computed for them ` +
-        `(agents: ${list})`;
-      report.summary += `\n⚠️  ${evidence}\n`;
-      this.appendReportWarning(report, 'zero_tags', evidence);
-    }
+    // Surface zero-tag agents via the shared idempotent helper (deduplicated from
+    // the inline block that previously lived here). Mirrors the coverage_degraded
+    // pattern: banner in summary + zero_tags warnings entry.
+    this.surfaceZeroTagBanner(report);
 
     // Surface dropped relay agents so the orchestrator can see who silently
     // failed instead of pretending the round was complete.

--- a/tests/cli/code-launch-detect-server-name.test.ts
+++ b/tests/cli/code-launch-detect-server-name.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for `detectServerName` exported from apps/cli/src/code-launch.ts.
+ *
+ * Tests:
+ *  (a) cwd .mcp.json with gossipcat entry + safe name → returns [name, false] AND
+ *      cwd-source stderr line is emitted.
+ *  (b) cwd + home both have gossipcat entries with DIFFERENT safe names → returns cwd
+ *      name AND mismatch warning emitted.
+ *  (c) only ~/.claude.json has gossipcat entry → returns home name, NO cwd-source warning.
+ *  (d) cwd .mcp.json has a gossipcat entry with an UNSAFE name → fallback ["gossipcat", true].
+ *  (b2) cwd + home have SAME name → cwd wins, cwd-source warning, NO mismatch.
+ *
+ * Strategy: detectServerName(cwd) reads <cwd>/.mcp.json and homedir()/.claude.json.
+ * We control cwd by passing a temp directory. For home, we mock 'os' module via jest.mock.
+ */
+
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Mock 'os' module so homedir() returns a controllable path per test.
+// homedirMock is captured by ref so individual tests can mutate its return value.
+let homedirTarget = '';
+jest.mock('os', () => {
+  const actual = jest.requireActual<typeof import('os')>('os');
+  return {
+    ...actual,
+    homedir: jest.fn(() => homedirTarget),
+  };
+});
+
+// Import after mock registration (jest.mock is hoisted, so this is fine)
+import { detectServerName } from '../../apps/cli/src/code-launch';
+
+/** A minimal .mcp.json with a gossipcat node mcp-server.js entry */
+function mcpJsonContent(serverName: string): string {
+  return JSON.stringify({
+    mcpServers: {
+      [serverName]: {
+        command: 'node',
+        args: ['dist-mcp/mcp-server.js'],
+      },
+    },
+  });
+}
+
+/** A minimal ~/.claude.json with a gossipcat entry (npx form) */
+function claudeJsonContent(serverName: string): string {
+  return JSON.stringify({
+    mcpServers: {
+      [serverName]: {
+        command: 'npx',
+        args: ['gossipcat', 'mcp-serve'],
+      },
+    },
+  });
+}
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'gctest-'));
+}
+
+describe('detectServerName — trust-boundary observability', () => {
+  let stderrLines: string[];
+  let stderrSpy: jest.SpyInstance;
+  let tmpDirs: string[];
+
+  beforeEach(() => {
+    stderrLines = [];
+    tmpDirs = [];
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((msg: string | Uint8Array) => {
+      stderrLines.push(typeof msg === 'string' ? msg : msg.toString());
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    for (const d of tmpDirs) {
+      try { rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+    tmpDirs = [];
+  });
+
+  function tmpDir(): string {
+    const d = makeTmpDir();
+    tmpDirs.push(d);
+    return d;
+  }
+
+  it('(a) cwd .mcp.json gossipcat entry → returns [name, false] and cwd-source warning', () => {
+    const cwdDir = tmpDir();
+    const homeDir = tmpDir();
+    writeFileSync(join(cwdDir, '.mcp.json'), mcpJsonContent('my-gossipcat'));
+    homedirTarget = homeDir; // empty home — no .claude.json
+
+    const result = detectServerName(cwdDir);
+
+    expect(result).toEqual(['my-gossipcat', false]);
+
+    const cwdWarn = stderrLines.find(l =>
+      l.includes('cwd-local config') && l.includes('my-gossipcat')
+    );
+    expect(cwdWarn).toBeDefined();
+    // Should NOT contain mismatch warning (home has no entry)
+    const mismatch = stderrLines.find(l => l.includes('differs between'));
+    expect(mismatch).toBeUndefined();
+  });
+
+  it('(b) cwd + home both have gossipcat entries with DIFFERENT names → cwd wins + mismatch warning', () => {
+    const cwdDir = tmpDir();
+    const homeDir = tmpDir();
+    writeFileSync(join(cwdDir, '.mcp.json'), mcpJsonContent('repo-gossipcat'));
+    writeFileSync(join(homeDir, '.claude.json'), claudeJsonContent('global-gossipcat'));
+    homedirTarget = homeDir;
+
+    const result = detectServerName(cwdDir);
+
+    expect(result).toEqual(['repo-gossipcat', false]);
+
+    // cwd-source warning must be present
+    const cwdWarn = stderrLines.find(l =>
+      l.includes('cwd-local config') && l.includes('repo-gossipcat')
+    );
+    expect(cwdWarn).toBeDefined();
+
+    // mismatch warning must be present with both names
+    const mismatch = stderrLines.find(l =>
+      l.includes('differs between') &&
+      l.includes('repo-gossipcat') &&
+      l.includes('global-gossipcat')
+    );
+    expect(mismatch).toBeDefined();
+  });
+
+  it('(c) only ~/.claude.json has gossipcat entry → returns home name, NO cwd-source warning', () => {
+    const cwdDir = tmpDir();
+    const homeDir = tmpDir();
+    // No .mcp.json in cwdDir — only home has the entry
+    writeFileSync(join(homeDir, '.claude.json'), claudeJsonContent('home-only'));
+    homedirTarget = homeDir;
+
+    const result = detectServerName(cwdDir);
+
+    expect(result).toEqual(['home-only', false]);
+
+    // Must NOT emit cwd-source warning
+    const cwdWarn = stderrLines.find(l => l.includes('cwd-local config'));
+    expect(cwdWarn).toBeUndefined();
+    // Must NOT emit mismatch warning
+    const mismatch = stderrLines.find(l => l.includes('differs between'));
+    expect(mismatch).toBeUndefined();
+  });
+
+  it('(d) cwd .mcp.json has unsafe server name → fallback ["gossipcat", true]', () => {
+    const cwdDir = tmpDir();
+    const homeDir = tmpDir();
+    // Write .mcp.json with an unsafe server name (contains spaces + special chars)
+    const unsafe = JSON.stringify({
+      mcpServers: {
+        'bad name; rm -rf /': {
+          command: 'node',
+          args: ['dist-mcp/mcp-server.js'],
+        },
+      },
+    });
+    writeFileSync(join(cwdDir, '.mcp.json'), unsafe);
+    homedirTarget = homeDir;
+
+    const result = detectServerName(cwdDir);
+
+    expect(result).toEqual(['gossipcat', true]);
+
+    // Should NOT emit cwd-source warning (name was rejected)
+    const cwdWarn = stderrLines.find(l => l.includes('cwd-local config'));
+    expect(cwdWarn).toBeUndefined();
+    // Should emit unsafe-name warning
+    const unsafeWarn = stderrLines.find(l => l.includes('unsafe characters'));
+    expect(unsafeWarn).toBeDefined();
+  });
+
+  it('(b2) cwd + home have SAME name → cwd wins, cwd-source warning, NO mismatch', () => {
+    const cwdDir = tmpDir();
+    const homeDir = tmpDir();
+    writeFileSync(join(cwdDir, '.mcp.json'), mcpJsonContent('shared-name'));
+    writeFileSync(join(homeDir, '.claude.json'), claudeJsonContent('shared-name'));
+    homedirTarget = homeDir;
+
+    const result = detectServerName(cwdDir);
+
+    expect(result).toEqual(['shared-name', false]);
+
+    // cwd-source warning present
+    const cwdWarn = stderrLines.find(l => l.includes('cwd-local config'));
+    expect(cwdWarn).toBeDefined();
+    // No mismatch warning (same name)
+    const mismatch = stderrLines.find(l => l.includes('differs between'));
+    expect(mismatch).toBeUndefined();
+  });
+});

--- a/tests/orchestrator/zero-tag-agents.test.ts
+++ b/tests/orchestrator/zero-tag-agents.test.ts
@@ -1,6 +1,7 @@
 import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
 import { testRound } from '../../packages/orchestrator/src/round-context';
 import { TaskEntry } from '../../packages/orchestrator/src/types';
+import { CrossReviewEntry } from '../../packages/orchestrator/src/consensus-types';
 
 // Minimal engine config so formatReport's registryGet call doesn't throw.
 const makeEngine = () => new ConsensusEngine({
@@ -134,5 +135,81 @@ describe('ConsensusEngine — zeroTagAgents accumulator', () => {
     // agent-b's "approval" type should land in droppedFindingsByType, not zeroTagAgents
     expect(report.droppedFindingsByType?.['approval']).toBeGreaterThanOrEqual(1);
     expect(report.zeroTagOverflow).toBeUndefined();
+  });
+});
+
+describe('ConsensusEngine — unscored-round banner + zero_tags warning (#554)', () => {
+  const makeEngine = () => new ConsensusEngine({
+    llm: { generate: jest.fn() } as any,
+    registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: `preset-${id}`, skills: [] }),
+    round: testRound(),
+  } as any);
+
+  const makeTask = (agentId: string, result: string): TaskEntry => ({
+    id: `task-${agentId}`,
+    agentId,
+    task: 'review',
+    status: 'completed',
+    result,
+    startedAt: Date.now(),
+    completedAt: Date.now(),
+    inputTokens: 0,
+    outputTokens: 0,
+  });
+
+  const zeroTagResult = (note: string) => `## Summary\n- Bullet ${note} without any agent_finding tag\n`;
+  const taggedResult = `<agent_finding type="finding" severity="high">Tagged finding at file.ts:10 for the keeper</agent_finding>`;
+  const consensusId = 'test-consensus-1';
+
+  it('≥1 zero-tag agent → summary contains "UNSCORED ROUND" AND warnings has zero_tags entry', async () => {
+    const engine = makeEngine();
+    const tasks: TaskEntry[] = [
+      makeTask('zero-agent', zeroTagResult('a')),
+      makeTask('keeper', taggedResult),
+    ];
+    const crossReview: CrossReviewEntry[] = [];
+
+    const report = await engine.synthesizeWithCrossReview(tasks, crossReview, consensusId, []);
+
+    expect(report.summary).toContain('UNSCORED ROUND');
+    expect(report.warnings).toBeDefined();
+    const zeroTagWarning = report.warnings?.find(w => w.code === 'zero_tags');
+    expect(zeroTagWarning).toBeDefined();
+    expect(zeroTagWarning?.message).toContain('zero-agent');
+    expect(zeroTagWarning?.message).toContain('UNSCORED ROUND');
+  });
+
+  it('no zero-tag agents → summary does NOT contain "UNSCORED ROUND" and no zero_tags warning', async () => {
+    const engine = makeEngine();
+    const tasks: TaskEntry[] = [
+      makeTask('agent-a', taggedResult),
+      makeTask('agent-b', `<agent_finding type="finding" severity="low">Another finding at b.ts:2 something</agent_finding>`),
+    ];
+    const crossReview: CrossReviewEntry[] = [];
+
+    const report = await engine.synthesizeWithCrossReview(tasks, crossReview, consensusId, []);
+
+    expect(report.summary).not.toContain('UNSCORED ROUND');
+    const zeroTagWarning = report.warnings?.find(w => w.code === 'zero_tags');
+    expect(zeroTagWarning).toBeUndefined();
+  });
+
+  it('multiple zero-tag agents → warning message lists all agents', async () => {
+    const engine = makeEngine();
+    const tasks: TaskEntry[] = [
+      makeTask('zero-1', zeroTagResult('1')),
+      makeTask('zero-2', zeroTagResult('2')),
+      makeTask('keeper', taggedResult),
+    ];
+    const crossReview: CrossReviewEntry[] = [];
+
+    const report = await engine.synthesizeWithCrossReview(tasks, crossReview, consensusId, []);
+
+    const zeroTagWarning = report.warnings?.find(w => w.code === 'zero_tags');
+    expect(zeroTagWarning).toBeDefined();
+    expect(zeroTagWarning?.message).toContain('2');
+    expect(zeroTagWarning?.message).toContain('zero-1');
+    expect(zeroTagWarning?.message).toContain('zero-2');
+    expect(report.summary).toContain('UNSCORED ROUND');
   });
 });


### PR DESCRIPTION
## Summary

Two related hardening changes, both surfacing previously-silent conditions to the operator.

### #589 — cwd-local channel server source warning
Warn when the channel/MCP server is resolved from a cwd-local `.mcp.json`, which is attacker-controllable when running `gossipcat code` in an untrusted repo.

### #554 — unscored-round banner, fully wired
When agents emit zero `<agent_finding>` tags the engine falls back to bullet-parsing, producing a `0 CONFIRMED / 0 DISPUTED` report that *looks* like a valid scored round. This surfaces a prominent **`⚠️ UNSCORED ROUND`** banner + a `zero_tags` warning so a bullet-fallback round can't be mistaken for a real scored one.

The second commit completes the wiring that was left half-done:
- Deduplicated the inline zero-tag block (in `synthesizeWithCrossReview`) into the idempotent `surfaceZeroTagBanner()` helper.
- Wired the helper into **all** orchestrator-facing report paths: `run()`, all three `runSelectedCrossReview()` return paths (previously surfaced **no** banner), and `synthesizeWithCrossReview()`.
- Fixed a wording bug in the WIP helper (`UNSCORED AGENTS` → `UNSCORED ROUND`) so it matches the tested banner string byte-for-byte.
- `synthesize()` left pure — it has 60+ direct test callers and the accumulator tests assert only the `zeroTagAgents` fields, so the banner stays confined to top-level entry points.

## Verification
- `npx tsc --noEmit -p packages/orchestrator` — clean
- `tests/orchestrator` zero-tag + consensus-engine + tier2 — **104/104 pass**

## Notes
- MCP bundle (`dist-mcp/`) not rebuilt in this PR — run `npm run build:mcp` after merge if a fresh bundle is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)