### PR TITLE
feat: orchestrator signal pipeline + ask_back() — self-instrumentation

### DIFF
--- a/apps/cli/src/handlers/ask-back.ts
+++ b/apps/cli/src/handlers/ask-back.ts
@@ -1,0 +1,168 @@
+/**
+ * gossip_ask_back — agent fabrication introspection loop.
+ *
+ * After a hallucination_caught signal is recorded, the orchestrator calls
+ * gossip_ask_back(action:'ask') to re-engage the offending agent for a
+ * first-person root-cause explanation. The answer is logged to
+ * .gossip/fabrication-introspections.jsonl, turning a bare signal count into
+ * rich first-person failure substrate for skill development.
+ *
+ * Unit 4 of the orchestrator signal pipeline feature.
+ */
+
+import { mkdirSync as realMkdirSync, appendFileSync as realAppendFileSync, readFileSync as realReadFileSync } from 'fs';
+import { join } from 'path';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface IntrospectionRecord {
+  agentId: string;
+  findingId?: string;
+  claim: string;
+  groundTruth: string;
+  answer?: string;
+  status: 'asked' | 'answered';
+  askedAt: string;
+  answeredAt?: string;
+}
+
+// Injected fs seam for tests
+export interface FsDepsAppend {
+  mkdirSync(path: string, opts?: unknown): void;
+  appendFileSync(path: string, data: string): void;
+}
+
+export interface FsDepsRead {
+  readFileSync(path: string): string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const LEDGER_REL = join('.gossip', 'fabrication-introspections.jsonl');
+
+function ledgerPath(projectRoot: string): string {
+  return join(projectRoot, LEDGER_REL);
+}
+
+// ---------------------------------------------------------------------------
+// buildIntrospectionPrompt
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a tight, non-accusatory introspection prompt.
+ *
+ * Asks the agent to name the SPECIFIC process failure (e.g. "pattern-matched
+ * the task framing", "cited from memory without opening the file") — a
+ * mechanism, not an apology.
+ */
+export function buildIntrospectionPrompt(claim: string, groundTruth: string): string {
+  return [
+    'You are being asked to help improve the reliability of this review pipeline.',
+    '',
+    'A prior response from you was identified as a fabrication:',
+    `  Claim made:    ${claim}`,
+    `  Ground truth:  ${groundTruth}`,
+    '',
+    'Please reflect on the specific process failure that led to this.',
+    'Do not apologize — instead, name the exact mechanism: for example,',
+    '"I pattern-matched the task framing and assumed the identifier existed"',
+    'or "I cited from memory without opening the file to verify".',
+    '',
+    'Your answer should be one to three sentences describing the HOW and WHY',
+    'of the specific reasoning step that went wrong.',
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// appendIntrospection
+// ---------------------------------------------------------------------------
+
+/**
+ * Append one IntrospectionRecord as a JSONL line to the ledger.
+ *
+ * Best-effort: never throws. Undefined optional fields are omitted from the
+ * serialized output (not serialized as null).
+ */
+export function appendIntrospection(
+  projectRoot: string,
+  record: IntrospectionRecord,
+  deps?: FsDepsAppend,
+): void {
+  // Required-field guard
+  if (
+    typeof record.agentId !== 'string' || !record.agentId ||
+    typeof record.claim !== 'string' ||
+    typeof record.groundTruth !== 'string' ||
+    typeof record.status !== 'string' ||
+    typeof record.askedAt !== 'string'
+  ) {
+    return;
+  }
+
+  // Build clean object without undefined keys
+  const clean: Record<string, unknown> = {
+    agentId: record.agentId,
+    claim: record.claim,
+    groundTruth: record.groundTruth,
+    status: record.status,
+    askedAt: record.askedAt,
+  };
+  if (record.findingId !== undefined) clean['findingId'] = record.findingId;
+  if (record.answer !== undefined) clean['answer'] = record.answer;
+  if (record.answeredAt !== undefined) clean['answeredAt'] = record.answeredAt;
+
+  const line = JSON.stringify(clean) + '\n';
+  const path = ledgerPath(projectRoot);
+
+  try {
+    const fsMkdir = deps?.mkdirSync ?? realMkdirSync;
+    const fsAppend = deps?.appendFileSync ?? realAppendFileSync;
+    fsMkdir(join(projectRoot, '.gossip'), { recursive: true });
+    fsAppend(path, line);
+  } catch {
+    // Best-effort: swallow all errors
+  }
+}
+
+// ---------------------------------------------------------------------------
+// readIntrospections
+// ---------------------------------------------------------------------------
+
+/**
+ * Read and parse the introspection ledger.
+ *
+ * Lenient: skips torn/invalid JSON lines. Returns [] if the file is missing.
+ * Optional agentId filter: when provided, only records for that agent are returned.
+ */
+export function readIntrospections(
+  projectRoot: string,
+  agentId?: string,
+  deps?: FsDepsRead,
+): IntrospectionRecord[] {
+  const path = ledgerPath(projectRoot);
+  let raw: string;
+  try {
+    const fsRead = deps?.readFileSync ?? realReadFileSync;
+    raw = fsRead(path) as string;
+  } catch {
+    return [];
+  }
+
+  const records: IntrospectionRecord[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed) as IntrospectionRecord;
+      if (agentId !== undefined && parsed.agentId !== agentId) continue;
+      records.push(parsed);
+    } catch {
+      // Skip torn lines
+    }
+  }
+  return records;
+}

--- a/apps/cli/src/handlers/ask-back.ts
+++ b/apps/cli/src/handlers/ask-back.ts
@@ -10,7 +10,7 @@
  * Unit 4 of the orchestrator signal pipeline feature.
  */
 
-import { mkdirSync as realMkdirSync, appendFileSync as realAppendFileSync, readFileSync as realReadFileSync } from 'fs';
+import { mkdirSync as realMkdirSync, appendFileSync as realAppendFileSync, readFileSync as realReadFileSync, statSync as realStatSync, renameSync as realRenameSync } from 'fs';
 import { join } from 'path';
 
 // ---------------------------------------------------------------------------
@@ -24,7 +24,8 @@ export interface IntrospectionRecord {
   groundTruth: string;
   answer?: string;
   status: 'asked' | 'answered';
-  askedAt: string;
+  /** Present on 'asked' records; omitted on 'answered'-only records (FIX 4). */
+  askedAt?: string;
   answeredAt?: string;
 }
 
@@ -32,6 +33,10 @@ export interface IntrospectionRecord {
 export interface FsDepsAppend {
   mkdirSync(path: string, opts?: unknown): void;
   appendFileSync(path: string, data: string): void;
+  /** Optional: injected for rotation. Defaults to real statSync. */
+  statSync?: (path: string) => { size: number };
+  /** Optional: injected for rotation. Defaults to real renameSync. */
+  renameSync?: (src: string, dest: string) => void;
 }
 
 export interface FsDepsRead {
@@ -43,6 +48,9 @@ export interface FsDepsRead {
 // ---------------------------------------------------------------------------
 
 const LEDGER_REL = join('.gossip', 'fabrication-introspections.jsonl');
+
+/** Single-slot rotation threshold — mirrors performance-writer.ts MAX_TELEMETRY_BYTES (5MB). */
+export const MAX_INTROSPECTION_BYTES = 5 * 1024 * 1024; // 5MB
 
 function ledgerPath(projectRoot: string): string {
   return join(projectRoot, LEDGER_REL);
@@ -92,15 +100,24 @@ export function appendIntrospection(
   record: IntrospectionRecord,
   deps?: FsDepsAppend,
 ): void {
-  // Required-field guard
+  // Required-field guard (FIX 3 + FIX 4):
+  // - agentId and status are always required and must be non-empty strings.
+  // - claim and groundTruth must be non-empty (trimmed) ONLY when status==='asked'.
+  //   An 'answered' record legitimately omits them (caller passes '' from mcp-server-sdk).
+  // - askedAt is required only for 'asked' records; 'answered' records may omit it.
   if (
     typeof record.agentId !== 'string' || !record.agentId ||
-    typeof record.claim !== 'string' ||
-    typeof record.groundTruth !== 'string' ||
-    typeof record.status !== 'string' ||
-    typeof record.askedAt !== 'string'
+    typeof record.status !== 'string' || !record.status
   ) {
     return;
+  }
+  if (record.status === 'asked') {
+    if (
+      typeof record.claim !== 'string' || !record.claim.trim() ||
+      typeof record.groundTruth !== 'string' || !record.groundTruth.trim()
+    ) {
+      return;
+    }
   }
 
   // Build clean object without undefined keys
@@ -109,8 +126,8 @@ export function appendIntrospection(
     claim: record.claim,
     groundTruth: record.groundTruth,
     status: record.status,
-    askedAt: record.askedAt,
   };
+  if (record.askedAt !== undefined) clean['askedAt'] = record.askedAt;
   if (record.findingId !== undefined) clean['findingId'] = record.findingId;
   if (record.answer !== undefined) clean['answer'] = record.answer;
   if (record.answeredAt !== undefined) clean['answeredAt'] = record.answeredAt;
@@ -121,7 +138,17 @@ export function appendIntrospection(
   try {
     const fsMkdir = deps?.mkdirSync ?? realMkdirSync;
     const fsAppend = deps?.appendFileSync ?? realAppendFileSync;
+    const fsStat = deps?.statSync ?? realStatSync;
+    const fsRename = deps?.renameSync ?? realRenameSync;
     fsMkdir(join(projectRoot, '.gossip'), { recursive: true });
+    // FIX 5: single-slot rotation — mirrors performance-writer.ts rotateJsonlIfNeeded.
+    // Best-effort: if stat/rename fails (file missing, unwritable), just continue to append.
+    try {
+      const st = fsStat(path);
+      if (st.size >= MAX_INTROSPECTION_BYTES) {
+        fsRename(path, path + '.1');
+      }
+    } catch { /* file missing or stat/rename failed — next append re-creates */ }
     fsAppend(path, line);
   } catch {
     // Best-effort: swallow all errors
@@ -144,13 +171,16 @@ export function readIntrospections(
   deps?: FsDepsRead,
 ): IntrospectionRecord[] {
   const path = ledgerPath(projectRoot);
-  let raw: string;
-  try {
-    const fsRead = deps?.readFileSync ?? realReadFileSync;
-    raw = fsRead(path) as string;
-  } catch {
-    return [];
-  }
+  const fsRead = deps?.readFileSync ?? realReadFileSync;
+
+  // FIX 5: read rotated .1 file first (older), then the live file.
+  // Lenient: missing/unreadable files are treated as empty.
+  const rawParts: string[] = [];
+  try { rawParts.push(fsRead(path + '.1') as string); } catch { /* missing */ }
+  try { rawParts.push(fsRead(path) as string); } catch { /* missing */ }
+
+  if (rawParts.length === 0) return [];
+  const raw = rawParts.join('');
 
   const records: IntrospectionRecord[] = [];
   for (const line of raw.split('\n')) {

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -15,6 +15,7 @@ import { makeRoundContext } from '@gossip/orchestrator';
 import type { RelayWarningEntry, RoundContext } from '@gossip/orchestrator';
 import { mkdirSync, appendFileSync } from 'node:fs';
 import { join as joinPath } from 'node:path';
+import { captureHeadSha, runMidFlightCheck } from './orchestrator-precondition-runner';
 
 /**
  * Schedule the per-skill checkEffectiveness runner as a detached, tracked
@@ -878,6 +879,9 @@ export async function handleCollect(
           // populated in parallel for old-reader back-compat. PR-C: this is
           // always a concrete RoundContext (the engine now requires one).
           roundContext: effectiveRound,
+          // UNIT 3: capture HEAD SHA at Phase 2 start for mid_flight_fixup detection.
+          // Best-effort — undefined when git is unavailable (never blocks the round).
+          roundStartSha: captureHeadSha(process.cwd()),
         });
 
         // Seed the relay-lint fallback membership map — keeps round-membership
@@ -1309,6 +1313,28 @@ export async function handleCollect(
           // the shortfall path) and not stale survivors (on the happy path,
           // where pre-Fix-1 the entry would leak in long-lived processes).
           resetRoundCounter(process.cwd(), authId);
+        }
+      }
+    } catch { /* best-effort */ }
+  }
+
+  // UNIT 3: mid_flight_fixup detection.
+  // Check whether commits landed between round-registration (Phase 2 start) and
+  // collect-end synthesis. Warns when reviewers may have seen post-fix code.
+  // Best-effort: never blocks or fails collect.
+  if (consensusReport) {
+    try {
+      const authId = consensusReport?.signals?.[0]?.consensusId
+        ?? consensusReport?.findings?.[0]?.id?.split(':')?.[0];
+      if (authId) {
+        const roundStartSha = ctx.pendingConsensusRounds.get(authId)?.roundStartSha;
+        const midFlightResult = await runMidFlightCheck({
+          projectRoot: process.cwd(),
+          consensusId: authId,
+          roundStartSha,
+        });
+        for (const warn of midFlightResult.warnings) {
+          process.stderr.write(`[gossipcat] ${warn}\n`);
         }
       }
     } catch { /* best-effort */ }

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -15,7 +15,7 @@ import { makeRoundContext } from '@gossip/orchestrator';
 import type { RelayWarningEntry, RoundContext } from '@gossip/orchestrator';
 import { mkdirSync, appendFileSync } from 'node:fs';
 import { join as joinPath } from 'node:path';
-import { captureHeadSha, runMidFlightCheck } from './orchestrator-precondition-runner';
+import { captureHeadSha } from './orchestrator-precondition-runner';
 
 /**
  * Schedule the per-skill checkEffectiveness runner as a detached, tracked
@@ -855,6 +855,9 @@ export async function handleCollect(
       } else {
         // Store pending round for native agents to complete.
         // nativePrompts is persisted so /mcp reconnect can re-issue the EXECUTE NOW block.
+        // FIX 2: hoist captureHeadSha so the execFileSync call is NOT inside
+        // pendingConsensusRounds.set(...) — blocking the MCP handler inline.
+        const roundStartSha = captureHeadSha(process.cwd());
         ctx.pendingConsensusRounds.set(consensusId, {
           consensusId,
           allResults: allResults.filter((r: any) => r.status === 'completed'),
@@ -881,7 +884,9 @@ export async function handleCollect(
           roundContext: effectiveRound,
           // UNIT 3: capture HEAD SHA at Phase 2 start for mid_flight_fixup detection.
           // Best-effort — undefined when git is unavailable (never blocks the round).
-          roundStartSha: captureHeadSha(process.cwd()),
+          // FIX 2: hoisted out of the set() literal so execFileSync does not block
+          // the MCP handler inline inside the Map mutation.
+          roundStartSha,
         });
 
         // Seed the relay-lint fallback membership map — keeps round-membership
@@ -1313,28 +1318,6 @@ export async function handleCollect(
           // the shortfall path) and not stale survivors (on the happy path,
           // where pre-Fix-1 the entry would leak in long-lived processes).
           resetRoundCounter(process.cwd(), authId);
-        }
-      }
-    } catch { /* best-effort */ }
-  }
-
-  // UNIT 3: mid_flight_fixup detection.
-  // Check whether commits landed between round-registration (Phase 2 start) and
-  // collect-end synthesis. Warns when reviewers may have seen post-fix code.
-  // Best-effort: never blocks or fails collect.
-  if (consensusReport) {
-    try {
-      const authId = consensusReport?.signals?.[0]?.consensusId
-        ?? consensusReport?.findings?.[0]?.id?.split(':')?.[0];
-      if (authId) {
-        const roundStartSha = ctx.pendingConsensusRounds.get(authId)?.roundStartSha;
-        const midFlightResult = await runMidFlightCheck({
-          projectRoot: process.cwd(),
-          consensusId: authId,
-          roundStartSha,
-        });
-        for (const warn of midFlightResult.warnings) {
-          process.stderr.write(`[gossipcat] ${warn}\n`);
         }
       }
     } catch { /* best-effort */ }

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -31,6 +31,7 @@ import {
   nativeWorktreeBanner,
 } from '../native-host-bridge';
 import { ctx, NATIVE_TASK_TTL_MS, MAX_PENDING_DISPATCH_WARNINGS } from '../mcp-context';
+import { runDispatchPreconditionGuard } from './orchestrator-precondition-runner';
 
 /**
  * Stash dispatch-time fail-loud warnings (spec §3.2 boundary #1) under every
@@ -708,6 +709,20 @@ export async function handleDispatchSingle(
     const timeoutMs = timeout_ms ?? NATIVE_TASK_TTL_MS;
     // Spec §3.2 boundary #1: stash dispatch-time warnings under this task_id.
     stashDispatchWarnings([taskId], dispatchWarnings);
+
+    // Unit 2 orchestrator signal pipeline: pre-dispatch precondition guard.
+    // Best-effort — never blocks/fails a dispatch. Emits operational pipeline
+    // signals (dispatched_stale_base, referenced_unreadable_path) against
+    // agentId:'orchestrator' and surfaces human-readable warnings to stderr.
+    runDispatchPreconditionGuard({
+      projectRoot: process.cwd(),
+      taskId,
+      resolutionRoots,
+    }).then(({ warnings: precondWarnings }) => {
+      for (const w of precondWarnings) {
+        process.stderr.write(`[gossipcat] ⚠️ precondition: ${w}\n`);
+      }
+    }).catch(() => { /* best-effort */ });
 
     // Stage 2 premise-verification — parse + verify any ```premise-claims
     // block in the task. Runs BEFORE assemblePrompt so the PREMISE-MISMATCH

--- a/apps/cli/src/handlers/orchestrator-precondition-runner.ts
+++ b/apps/cli/src/handlers/orchestrator-precondition-runner.ts
@@ -20,6 +20,10 @@ import {
   detectMidFlightCommits,
 } from '@gossip/orchestrator/orchestrator-preconditions';
 import type { PerformanceSignal } from '@gossip/orchestrator';
+// FIX 6: static import to ensure esbuild bundles emitPipelineSignals.
+// Dynamic import() is NOT bundled in esbuild single-file builds — this was the
+// root cause of the activity-mirror hooks silently no-op'ing (project_activity_mirror_v2_progress).
+import { emitPipelineSignals as staticEmitPipelineSignals } from '@gossip/orchestrator';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -230,13 +234,11 @@ function defaultCanRead(p: string): boolean {
 }
 
 function defaultEmitSignals(projectRoot: string, signals: PerformanceSignal[]): void {
-  // Dynamic import keeps the orchestrator coupling lazy and mirrors the
-  // pattern from dispatch-prompt-cache.ts:emitCacheEvictedSignal.
-  import('@gossip/orchestrator').then(({ emitPipelineSignals }) => {
-    try {
-      emitPipelineSignals(projectRoot, signals);
-    } catch { /* best-effort */ }
-  }).catch(() => { /* best-effort */ });
+  // FIX 6: use static import (bundled by esbuild). Dynamic import() is NOT
+  // bundled in esbuild single-file builds — it silently no-ops at runtime.
+  try {
+    staticEmitPipelineSignals(projectRoot, signals);
+  } catch { /* best-effort */ }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/handlers/orchestrator-precondition-runner.ts
+++ b/apps/cli/src/handlers/orchestrator-precondition-runner.ts
@@ -17,6 +17,7 @@ import { execFileSync } from 'child_process';
 import {
   detectStaleBase,
   findUnreadablePaths,
+  detectMidFlightCommits,
 } from '@gossip/orchestrator/orchestrator-preconditions';
 import type { PerformanceSignal } from '@gossip/orchestrator';
 
@@ -41,6 +42,31 @@ export interface PreconditionRunnerDeps {
   emitSignals: (projectRoot: string, signals: PerformanceSignal[]) => void;
 }
 
+/** Injected collaborators for the mid-flight fixup detector (UNIT 3). */
+export interface MidFlightCheckDeps {
+  /**
+   * Synchronous git invocation — same signature as PreconditionRunnerDeps.execFile.
+   * Only needs to support `git log <sha>..HEAD --format=%H`.
+   */
+  execFile: (cmd: string, args: string[], opts: { cwd: string; encoding: 'utf8' }) => string;
+  /**
+   * Best-effort pipeline signal emitter.
+   * Signature mirrors emitPipelineSignals(projectRoot, signals).
+   */
+  emitSignals: (projectRoot: string, signals: PerformanceSignal[]) => void;
+}
+
+export interface MidFlightCheckInput {
+  projectRoot: string;
+  consensusId: string;
+  /** HEAD SHA captured at round-registration time; falsy → no-op. */
+  roundStartSha: string | undefined;
+}
+
+export interface MidFlightCheckResult {
+  warnings: string[];
+}
+
 export interface StaleBaseInputs {
   dispatchSha: string;
   originMasterSha: string;
@@ -55,6 +81,131 @@ export interface PreconditionGuardInput {
 
 export interface PreconditionGuardResult {
   warnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// captureHeadSha — best-effort HEAD capture for round registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Synchronously capture the current HEAD SHA for use as `roundStartSha`.
+ * Returns undefined on any error (git unavailable, not a repo, etc.).
+ * NEVER throws.
+ *
+ * @param projectRoot  - Directory to run `git rev-parse HEAD` in.
+ *                       Falls back to process.cwd() when falsy.
+ * @param execFile     - Injected git executor; defaults to execFileSync.
+ */
+export function captureHeadSha(
+  projectRoot: string | undefined,
+  execFile: (cmd: string, args: string[], opts: { cwd: string; encoding: 'utf8' }) => string = defaultExecFile,
+): string | undefined {
+  try {
+    const cwd = projectRoot || process.cwd();
+    const sha = execFile('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf8' }).trim();
+    return sha || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getCommitsSince — commits between a base SHA and HEAD
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the list of commit SHAs that landed after `sinceSha` up to HEAD.
+ * Uses `git log <sinceSha>..HEAD --format=%H`.
+ * Returns [] on any error (never throws).
+ *
+ * @param sinceSha     - The base SHA (exclusive lower bound).
+ * @param projectRoot  - Working directory for git.
+ * @param execFile     - Injected git executor; defaults to execFileSync.
+ */
+export function getCommitsSince(
+  sinceSha: string,
+  projectRoot: string,
+  execFile: (cmd: string, args: string[], opts: { cwd: string; encoding: 'utf8' }) => string = defaultExecFile,
+): string[] {
+  try {
+    const output = execFile('git', ['log', `${sinceSha}..HEAD`, '--format=%H'], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+    });
+    return output
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// runMidFlightCheck — UNIT 3 mid-flight fixup detector
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect commits that landed during Phase 2 cross-review (between round
+ * registration and collect-end synthesis). When detected, appends a human-
+ * readable warning and emits ONE `mid_flight_fixup` pipeline signal against
+ * agentId:'orchestrator'.
+ *
+ * Design rules:
+ *   - Falsy `roundStartSha` → immediate no-op {warnings:[]}.
+ *   - Best-effort throughout; NEVER throws into the consensus collect path.
+ *   - Injects all collaborators via `deps` for unit-testability.
+ *
+ * @param input  - Consensus round context (projectRoot, consensusId, roundStartSha).
+ * @param deps   - Optional injected collaborators.
+ */
+export async function runMidFlightCheck(
+  input: MidFlightCheckInput,
+  deps: Partial<MidFlightCheckDeps> = {},
+): Promise<MidFlightCheckResult> {
+  const warnings: string[] = [];
+
+  if (!input.roundStartSha) {
+    return { warnings };
+  }
+
+  const execFile = deps.execFile ?? defaultExecFile;
+  const emitSignals = deps.emitSignals ?? defaultEmitSignals;
+
+  try {
+    const { projectRoot, consensusId, roundStartSha } = input;
+
+    const commits = getCommitsSince(roundStartSha, projectRoot, execFile);
+    const { detected, count } = detectMidFlightCommits(commits);
+
+    if (!detected) {
+      return { warnings };
+    }
+
+    warnings.push(
+      `[mid-flight-fixup] ${count} commit(s) landed during Phase 2 cross-review ` +
+      `(since ${roundStartSha.slice(0, 8)}). Reviewers may have seen post-fix code ` +
+      `and marked legitimate Phase 1 findings DISAGREE. Consensus round: ${consensusId}.`,
+    );
+
+    try {
+      emitSignals(projectRoot, [{
+        type: 'pipeline' as const,
+        signal: 'mid_flight_fixup',
+        agentId: 'orchestrator',
+        taskId: consensusId,
+        consensusId,
+        metadata: {
+          count,
+          roundStartSha,
+          commits,
+        },
+        timestamp: new Date().toISOString(),
+      }]);
+    } catch { /* best-effort */ }
+  } catch { /* outer best-effort guard — must never propagate */ }
+
+  return { warnings };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/handlers/orchestrator-precondition-runner.ts
+++ b/apps/cli/src/handlers/orchestrator-precondition-runner.ts
@@ -1,0 +1,219 @@
+/**
+ * orchestrator-precondition-runner.ts
+ *
+ * UNIT 2: Wiring layer for the orchestrator signal pipeline pre-dispatch guard.
+ * Runs git-based stale-base detection and path-readability checks, then emits
+ * operational pipeline signals against agentId:'orchestrator'.
+ *
+ * Design rules:
+ *   - NEVER throw into callers — every I/O boundary is wrapped in try/catch.
+ *   - All git/fs/emit collaborators are injected via `deps` for testability.
+ *   - Signal names used here are already registered in consensus-types.ts;
+ *     do NOT re-add them.
+ */
+
+import * as fs from 'fs';
+import { execFileSync } from 'child_process';
+import {
+  detectStaleBase,
+  findUnreadablePaths,
+} from '@gossip/orchestrator/orchestrator-preconditions';
+import type { PerformanceSignal } from '@gossip/orchestrator';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Injected collaborators — all optional, defaulting to real I/O impls. */
+export interface PreconditionRunnerDeps {
+  /**
+   * Synchronous git invocation (signature matches execFileSync).
+   * Receives (cmd, args, options) — options includes { cwd, encoding }.
+   * Must return the stdout string or throw on failure.
+   */
+  execFile: (cmd: string, args: string[], opts: { cwd: string; encoding: 'utf8' }) => string;
+  /** Returns true when the given path is readable by the current process. */
+  canRead: (p: string) => boolean;
+  /**
+   * Best-effort pipeline signal emitter.
+   * Signature mirrors emitPipelineSignals(projectRoot, signals).
+   */
+  emitSignals: (projectRoot: string, signals: PerformanceSignal[]) => void;
+}
+
+export interface StaleBaseInputs {
+  dispatchSha: string;
+  originMasterSha: string;
+  mergeBaseSha: string | null;
+}
+
+export interface PreconditionGuardInput {
+  projectRoot: string;
+  taskId: string;
+  resolutionRoots: readonly string[] | undefined;
+}
+
+export interface PreconditionGuardResult {
+  warnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Default collaborator factories (real I/O)
+// ---------------------------------------------------------------------------
+
+function defaultExecFile(
+  cmd: string,
+  args: string[],
+  opts: { cwd: string; encoding: 'utf8' },
+): string {
+  return execFileSync(cmd, args, opts) as string;
+}
+
+function defaultCanRead(p: string): boolean {
+  try {
+    fs.accessSync(p, fs.constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultEmitSignals(projectRoot: string, signals: PerformanceSignal[]): void {
+  // Dynamic import keeps the orchestrator coupling lazy and mirrors the
+  // pattern from dispatch-prompt-cache.ts:emitCacheEvictedSignal.
+  import('@gossip/orchestrator').then(({ emitPipelineSignals }) => {
+    try {
+      emitPipelineSignals(projectRoot, signals);
+    } catch { /* best-effort */ }
+  }).catch(() => { /* best-effort */ });
+}
+
+// ---------------------------------------------------------------------------
+// gatherStaleBaseInputs
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the three git commands needed by detectStaleBase.
+ * Returns null if git is unavailable, not in a repo, or origin/master is
+ * unreachable. NEVER throws.
+ */
+export async function gatherStaleBaseInputs(
+  projectRoot: string,
+  execFile: PreconditionRunnerDeps['execFile'] = defaultExecFile,
+): Promise<StaleBaseInputs | null> {
+  try {
+    const dispatchSha = execFile('git', ['rev-parse', 'HEAD'], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+    }).trim();
+
+    const originMasterSha = execFile('git', ['rev-parse', 'origin/master'], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+    }).trim();
+
+    const mergeBaseSha = execFile('git', ['merge-base', 'HEAD', 'origin/master'], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+    }).trim();
+
+    return { dispatchSha, originMasterSha, mergeBaseSha };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// runDispatchPreconditionGuard
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the UNIT 2 pre-dispatch guard for signals 1 (dispatched_stale_base) and
+ * 2 (referenced_unreadable_path). For each triggered precondition:
+ *   (a) Appends a human-readable warning to the returned array.
+ *   (b) Emits a pipeline signal against agentId:'orchestrator'.
+ *
+ * Is additive and best-effort: a failure inside the guard NEVER propagates to
+ * the caller.
+ */
+export async function runDispatchPreconditionGuard(
+  input: PreconditionGuardInput,
+  deps: Partial<PreconditionRunnerDeps> = {},
+): Promise<PreconditionGuardResult> {
+  const warnings: string[] = [];
+
+  const execFile = deps.execFile ?? defaultExecFile;
+  const canRead = deps.canRead ?? defaultCanRead;
+  const emitSignals = deps.emitSignals ?? defaultEmitSignals;
+
+  const { projectRoot, taskId, resolutionRoots } = input;
+
+  try {
+    // -----------------------------------------------------------------------
+    // Signal 1: dispatched_stale_base
+    // -----------------------------------------------------------------------
+    const gitInputs = await gatherStaleBaseInputs(projectRoot, execFile);
+    if (gitInputs !== null) {
+      const staleResult = detectStaleBase(
+        gitInputs.dispatchSha,
+        gitInputs.originMasterSha,
+        gitInputs.mergeBaseSha,
+      );
+      if (staleResult.stale && staleResult.reason !== null) {
+        const reason = staleResult.reason;
+        warnings.push(
+          `[dispatch-hygiene] stale base detected (${reason}): ` +
+          `dispatch SHA ${gitInputs.dispatchSha} is behind origin/master ` +
+          `${gitInputs.originMasterSha}. Pull and rebase before dispatching.`,
+        );
+        try {
+          emitSignals(projectRoot, [{
+            type: 'pipeline' as const,
+            signal: 'dispatched_stale_base',
+            agentId: 'orchestrator',
+            taskId,
+            metadata: {
+              reason,
+              dispatchSha: gitInputs.dispatchSha,
+            },
+            timestamp: new Date().toISOString(),
+          }]);
+        } catch { /* best-effort */ }
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Signal 2: referenced_unreadable_path
+    // -----------------------------------------------------------------------
+    const roots = resolutionRoots ?? [];
+    if (roots.length > 0) {
+      let unreadable: string[];
+      try {
+        unreadable = findUnreadablePaths(roots, canRead);
+      } catch {
+        // canRead itself threw — treat as empty (safe degradation)
+        unreadable = [];
+      }
+      if (unreadable.length > 0) {
+        warnings.push(
+          `[dispatch-hygiene] ${unreadable.length} resolutionRoot(s) are unreadable: ` +
+          `${unreadable.join(', ')}. Cross-reviewers will fall back to project root.`,
+        );
+        try {
+          emitSignals(projectRoot, [{
+            type: 'pipeline' as const,
+            signal: 'referenced_unreadable_path',
+            agentId: 'orchestrator',
+            taskId,
+            metadata: {
+              unreadable,
+            },
+            timestamp: new Date().toISOString(),
+          }]);
+        } catch { /* best-effort */ }
+      }
+    }
+  } catch { /* outer best-effort guard — must never propagate */ }
+
+  return { warnings };
+}

--- a/apps/cli/src/handlers/orchestrator-precondition-runner.ts
+++ b/apps/cli/src/handlers/orchestrator-precondition-runner.ts
@@ -18,7 +18,7 @@ import {
   detectStaleBase,
   findUnreadablePaths,
   detectMidFlightCommits,
-} from '@gossip/orchestrator/orchestrator-preconditions';
+} from '@gossip/orchestrator';
 import type { PerformanceSignal } from '@gossip/orchestrator';
 // FIX 6: static import to ensure esbuild bundles emitPipelineSignals.
 // Dynamic import() is NOT bundled in esbuild single-file builds — this was the

--- a/apps/cli/src/handlers/relay-cross-review.ts
+++ b/apps/cli/src/handlers/relay-cross-review.ts
@@ -604,6 +604,8 @@ export function restorePendingConsensus(projectRoot: string): void {
         resolutionRoots: Array.isArray(data.resolutionRoots) && data.resolutionRoots.length > 0
           ? data.resolutionRoots
           : undefined,
+        // UNIT 3: restore roundStartSha from persisted data (back-compat: undefined for old rounds).
+        roundStartSha: typeof data.roundStartSha === 'string' ? data.roundStartSha : undefined,
         // Spec §3.2 disk back-compat: prefer the embedded roundContext; fall
         // back per-field to the old flat shape (mirrors the
         // participatingNativeAgents back-compat pattern above). Old pre-PR-A

--- a/apps/cli/src/handlers/relay-cross-review.ts
+++ b/apps/cli/src/handlers/relay-cross-review.ts
@@ -4,6 +4,7 @@
  */
 import { ctx, RECENT_CONSENSUS_TASK_TTL_MS } from '../mcp-context';
 import { seedRecentConsensusAgentIds } from './native-tasks';
+import { runMidFlightCheck } from './orchestrator-precondition-runner';
 import type {
   ConsensusEngine as ConsensusEngineType,
   ConsensusReport,
@@ -121,6 +122,8 @@ export function startConsensusTimeout(consensusId: string): void {
     }
 
     const missingAgents = [...current.pendingNativeAgents];
+    // FIX 1: read roundStartSha BEFORE delete so mid-flight check has it.
+    const roundStartShaForMidFlight = current.roundStartSha;
     // Delete round BEFORE async work to prevent double-synthesis race with concurrent relay
     const snapshot = { allResults: current.allResults, relayCrossReviewEntries: current.relayCrossReviewEntries, relayCrossReviewSkipped: current.relayCrossReviewSkipped, nativeCrossReviewEntries: [...current.nativeCrossReviewEntries], resolutionRoots: current.resolutionRoots, roundContext: current.roundContext };
     // PR #270 v3 review (HIGH): seed the agent-id fallback BEFORE delete from
@@ -163,6 +166,19 @@ export function startConsensusTimeout(consensusId: string): void {
       }
       const { report } = await synthesizeTimeoutRound(snapshot, consensusId, missingAgents, timeoutLlm);
       process.stderr.write(`[gossipcat] 🔮 Timeout synthesis complete: ${report.confirmed.length} confirmed, ${report.disputed.length} disputed\n`);
+
+      // FIX 1: mid_flight_fixup check at timeout-synthesis site.
+      // roundStartSha read BEFORE pendingConsensusRounds.delete above.
+      try {
+        const midFlightResult = await runMidFlightCheck({
+          projectRoot: process.cwd(),
+          consensusId,
+          roundStartSha: roundStartShaForMidFlight,
+        });
+        for (const warn of midFlightResult.warnings) {
+          process.stderr.write(`[gossipcat] ${warn}\n`);
+        }
+      } catch { /* best-effort */ }
     } catch (err) {
       process.stderr.write(`[gossipcat] ❌ Timeout synthesis failed: ${(err as Error).message}\n`);
     }
@@ -309,6 +325,8 @@ export async function handleRelayCrossReview(
 
   // All agents responded — synthesize
   // Snapshot and delete BEFORE async synthesis to prevent double-synthesis race with timeout
+  // FIX 1: read roundStartSha BEFORE delete so mid-flight check has it.
+  const completionRoundStartSha = round.roundStartSha;
   const synthSnapshot = {
     allResults: round.allResults,
     relayCrossReviewEntries: round.relayCrossReviewEntries,
@@ -395,6 +413,19 @@ export async function handleRelayCrossReview(
       const { emitConsensusSignals } = await import('@gossip/orchestrator');
       if (report.signals.length > 0) {
         emitConsensusSignals(process.cwd(), report.signals);
+      }
+    } catch { /* best-effort */ }
+
+    // FIX 1: mid_flight_fixup check at completion-synthesis site.
+    // completionRoundStartSha read BEFORE pendingConsensusRounds.delete above.
+    try {
+      const midFlightResult = await runMidFlightCheck({
+        projectRoot: process.cwd(),
+        consensusId: synthSnapshot.consensusId,
+        roundStartSha: completionRoundStartSha,
+      });
+      for (const warn of midFlightResult.warnings) {
+        process.stderr.write(`[gossipcat] ${warn}\n`);
       }
     } catch { /* best-effort */ }
 

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -44,6 +44,14 @@ export interface PendingConsensusRound {
   /** Cross-review prompts for still-pending native agents. Persisted so /mcp reconnect can re-issue EXECUTE NOW. */
   nativePrompts?: NativeCrossReviewPrompt[];
   /**
+   * HEAD SHA captured at the moment this consensus round was registered
+   * (Phase 2 start). Used by the mid_flight_fixup detector in collect.ts
+   * to check whether commits landed on the branch between Phase 2 start
+   * and collect-end synthesis. Undefined when git was unavailable at
+   * round-registration time (best-effort; never blocks the round).
+   */
+  roundStartSha?: string;
+  /**
    * Post-validation, post-realpath citation resolution roots. Carried from
    * dispatch-time or collect-time (collect-time REPLACES dispatch-time —
    * see #126 spec). Used to seed ConsensusEngineConfig.resolutionRoots at

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -2121,6 +2121,11 @@ export function createMcpServer(): McpServer {
         };
       }
 
+      // FIX 4: 'answered' records write status + answeredAt only.
+      // Omit askedAt (we don't know when the 'ask' happened from here — writing
+      // now would corrupt latency measurements). Also omit empty claim/groundTruth
+      // (FIX 3: the guard rejects empty claim/groundTruth on 'asked' status only;
+      // 'answered' records legitimately don't carry them from the orchestrator).
       appendIntrospection(projectRoot, {
         agentId: agent_id,
         findingId: finding_id,
@@ -2128,7 +2133,6 @@ export function createMcpServer(): McpServer {
         groundTruth: ground_truth ?? '',
         answer,
         status: 'answered',
-        askedAt: now,
         answeredAt: now,
       });
 

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -314,6 +314,7 @@ try {
 } catch { /* never break boot */ }
 import { restoreNativeTaskMap, handleNativeRelay, spawnTimeoutWatcher, scheduleNativeTaskEviction, UTILITY_RESULT_TTL_MS } from './handlers/native-tasks';
 import { handleDispatchSingle, handleDispatchParallel, handleDispatchConsensus, detectLostDispatchWarnings } from './handlers/dispatch';
+import { buildIntrospectionPrompt, appendIntrospection } from './handlers/ask-back';
 import {
   invalidateAgent as invalidateDispatchPromptCacheForAgent,
   invalidateAll as invalidateAllDispatchPromptCache,
@@ -2053,6 +2054,90 @@ export function createMcpServer(): McpServer {
       }
       return {
         content: [{ type: 'text' as const, text: `Asked the dashboard (qid=${qid}); the user's answer will arrive as a channel turn prefixed "[answer qid=${qid}]". Do not wait for it here.` }],
+      };
+    },
+  );
+
+  // ── gossip_ask_back — agent fabrication introspection loop ───────────────
+  server.tool(
+    'gossip_ask_back',
+    'Re-engage an agent after a fabrication (hallucination_caught) for first-person root-cause analysis. action:"ask" dispatches an introspection prompt to the agent and logs the event; action:"record" stores the agent\'s answer. Builds a rich failure ledger (.gossip/fabrication-introspections.jsonl) that feeds skill development.',
+    {
+      action: z.enum(['ask', 'record']).default('ask').describe('"ask" (default): dispatch an introspection prompt to the agent. "record": store the agent\'s answer.'),
+      agent_id: z.string().describe('The agent that produced the fabrication.'),
+      claim: z.string().optional().describe('Required for action:"ask". The fabricated claim the agent made.'),
+      ground_truth: z.string().optional().describe('Required for action:"ask". What the code/evidence actually shows.'),
+      finding_id: z.string().optional().describe('Optional consensus finding_id (format: <consensus_id>:<agent:fN>) to link the introspection to a specific finding.'),
+      answer: z.string().optional().describe('Required for action:"record". The agent\'s root-cause explanation.'),
+    },
+    async ({ action, agent_id, claim, ground_truth, finding_id, answer }) => {
+      const projectRoot = process.cwd();
+      const now = new Date().toISOString();
+
+      if (action === 'ask') {
+        if (!claim || !ground_truth) {
+          return {
+            content: [{ type: 'text' as const, text: 'gossip_ask_back error: action:"ask" requires both claim and ground_truth.' }],
+            isError: true,
+          };
+        }
+
+        // Log the introspection request
+        appendIntrospection(projectRoot, {
+          agentId: agent_id,
+          findingId: finding_id,
+          claim,
+          groundTruth: ground_truth,
+          status: 'asked',
+          askedAt: now,
+        });
+
+        // Build the introspection prompt and dispatch it via handleDispatchSingle
+        const prompt = buildIntrospectionPrompt(claim, ground_truth);
+        const dispatchResult = await handleDispatchSingle(agent_id, prompt);
+
+        // Prepend instruction to record the answer
+        const instruction =
+          `After the agent answers, call gossip_ask_back(action:'record', agent_id:'${agent_id}'` +
+          (finding_id ? `, finding_id:'${finding_id}'` : '') +
+          `, answer:<agent response>) to log the introspection.\n\n`;
+
+        const dispatchText =
+          dispatchResult.content
+            .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+            .map(c => c.text)
+            .join('\n');
+
+        return {
+          content: [{ type: 'text' as const, text: instruction + dispatchText }],
+        };
+      }
+
+      // action === 'record'
+      if (!answer) {
+        return {
+          content: [{ type: 'text' as const, text: 'gossip_ask_back error: action:"record" requires answer.' }],
+          isError: true,
+        };
+      }
+
+      appendIntrospection(projectRoot, {
+        agentId: agent_id,
+        findingId: finding_id,
+        claim: claim ?? '',
+        groundTruth: ground_truth ?? '',
+        answer,
+        status: 'answered',
+        askedAt: now,
+        answeredAt: now,
+      });
+
+      const ledgerPath = `${projectRoot}/.gossip/fabrication-introspections.jsonl`;
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `Introspection recorded for ${agent_id}${finding_id ? ` (finding: ${finding_id})` : ''}.\nLedger: ${ledgerPath}`,
+        }],
       };
     },
   );
@@ -5465,6 +5550,7 @@ export function createMcpServer(): McpServer {
         { name: 'gossip_reload', desc: 'Terminate MCP server so Claude Code respawns with fresh bundle. Use after npm run build:mcp.' },
         { name: 'gossip_format', desc: 'Return the CONSENSUS_OUTPUT_FORMAT block to paste into ad-hoc Agent() prompts so native subagents emit parseable <agent_finding> tags.' },
         { name: 'gossip_bug_feedback', desc: 'File a GitHub issue on the gossipcat repo from an in-session bug report. Dedupes against open issues.' },
+        { name: 'gossip_ask_back', desc: 'Re-engage an agent after a fabrication for first-person root-cause analysis. action:"ask" dispatches the introspection prompt; action:"record" logs the answer.' },
       ];
       const list = tools.map(t => `- ${t.name}: ${t.desc}`).join('\n');
       return { content: [{ type: 'text' as const, text: `Gossipcat Tools (${tools.length}):\n\n${list}` }] };

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -335,7 +335,25 @@ export interface PipelineSignal {
      * invalidation, or concurrent-dispatch overwrite-race. metadata.reason
      * ∈ {'lru' | 'invalidation' | 'overwrite_race'}. Observability-only.
      */
-    | 'dispatch_cache_evicted';
+    | 'dispatch_cache_evicted'
+    /**
+     * UNIT 1 orchestrator signal pipeline — dispatch-hygiene precondition
+     * signals. Operational-only: tallied for observability, never scored into
+     * agent accuracy. Emitted by the orchestrator (not individual agents) when
+     * a precondition failure is detected via orchestrator-preconditions.ts.
+     *
+     * dispatched_stale_base      — dispatch SHA was behind origin/master at
+     *                              dispatch time (behind_origin or branched_pre_merge).
+     * referenced_unreadable_path — dispatch task referenced a spec or context
+     *                              file that the implementer agent cannot read.
+     * mid_flight_fixup           — commits landed on the consensus branch
+     *                              between Phase 1 dispatch and Phase 2
+     *                              cross-review, risking reviewer disagreement
+     *                              on already-fixed items.
+     */
+    | 'dispatched_stale_base'
+    | 'referenced_unreadable_path'
+    | 'mid_flight_fixup';
   /** Real agentId for agent-scoped events; '_system' for system-scoped events. */
   agentId: string;
   taskId: string;
@@ -403,6 +421,13 @@ export const OPERATIONAL_SIGNAL_NAMES: ReadonlySet<string> = new Set([
   'worktree_isolation_failed',
   'auto_verify_attempted',
   'auto_verify_skipped_misconfigured',
+  /**
+   * Orchestrator dispatch-hygiene signals (UNIT 1 — orchestrator signal pipeline).
+   * Tallied as operational; never affect agent accuracy scoring.
+   */
+  'dispatched_stale_base',
+  'referenced_unreadable_path',
+  'mid_flight_fixup',
 ]);
 
 /**

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -267,3 +267,5 @@ export { RUNTIME_FLAG_REGISTRY } from './runtime-config-schema';
 export type { RuntimeFlagKey, RuntimeFlagSpec } from './runtime-config-schema';
 export { ChatbotAgent } from './chatbot-agent';
 export type { ChatbotTool, ChatbotAgentConfig, ChatStreamEvent } from './chatbot-agent';
+export { detectStaleBase, findUnreadablePaths, detectMidFlightCommits } from './orchestrator-preconditions';
+export type { StaleBaseResult, MidFlightResult } from './orchestrator-preconditions';

--- a/packages/orchestrator/src/orchestrator-preconditions.ts
+++ b/packages/orchestrator/src/orchestrator-preconditions.ts
@@ -1,0 +1,107 @@
+/**
+ * orchestrator-preconditions.ts
+ *
+ * Pure, side-effect-free functions for detecting orchestrator dispatch-hygiene
+ * failures. All collaborators (git SHA values, path-readability predicates,
+ * commit lists) are injected as arguments so every function is unit-testable
+ * without touching the filesystem or spawning child processes.
+ *
+ * These are the foundations for UNIT 1 of the orchestrator signal pipeline.
+ * No wiring into dispatch.ts / collect.ts / mcp-server-sdk is done here.
+ */
+
+// ---------------------------------------------------------------------------
+// detectStaleBase
+// ---------------------------------------------------------------------------
+
+export interface StaleBaseResult {
+  stale: boolean;
+  reason: 'behind_origin' | 'branched_pre_merge' | null;
+}
+
+/**
+ * Detect whether a dispatch was started from a stale branch base.
+ *
+ * @param dispatchSha    - The git SHA at the time of dispatch (HEAD of the
+ *                         working branch when the task was dispatched).
+ * @param originMasterSha - The current HEAD of origin/master (or main).
+ * @param mergeBaseSha   - Output of `git merge-base dispatchSha originMasterSha`,
+ *                         or null if it could not be determined.
+ *
+ * Classification:
+ *   - Fresh:             dispatchSha === originMasterSha
+ *   - behind_origin:     dispatchSha !== originMasterSha AND
+ *                        mergeBaseSha === dispatchSha
+ *                        (dispatch SHA is an ancestor of origin master — the
+ *                        branch just hasn't been pulled up yet)
+ *   - branched_pre_merge: dispatchSha !== originMasterSha AND
+ *                         mergeBaseSha !== dispatchSha (or null)
+ *                         (branch diverged from a common ancestor that is not
+ *                         the dispatch SHA itself — PRs have landed on origin
+ *                         that this branch has never seen)
+ */
+export function detectStaleBase(
+  dispatchSha: string,
+  originMasterSha: string,
+  mergeBaseSha: string | null,
+): StaleBaseResult {
+  if (dispatchSha === originMasterSha) {
+    return { stale: false, reason: null };
+  }
+
+  // SHAs differ → stale. Distinguish sub-reason via mergeBase.
+  const reason: 'behind_origin' | 'branched_pre_merge' =
+    mergeBaseSha === dispatchSha ? 'behind_origin' : 'branched_pre_merge';
+
+  return { stale: true, reason };
+}
+
+// ---------------------------------------------------------------------------
+// findUnreadablePaths
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the subset of `paths` for which `canRead(p)` is false.
+ *
+ * The `canRead` predicate is injected so tests can exercise the function
+ * without touching the real filesystem. Production callers pass a wrapper
+ * around `fs.accessSync` or a similar check.
+ *
+ * @param paths    - Ordered list of file paths to check.
+ * @param canRead  - Injected predicate; returns true when the path is readable.
+ * @returns        Paths (in original order) for which canRead returned false.
+ */
+export function findUnreadablePaths(
+  paths: readonly string[],
+  canRead: (p: string) => boolean,
+): string[] {
+  return paths.filter(p => !canRead(p));
+}
+
+// ---------------------------------------------------------------------------
+// detectMidFlightCommits
+// ---------------------------------------------------------------------------
+
+export interface MidFlightResult {
+  detected: boolean;
+  count: number;
+}
+
+/**
+ * Detect commits that landed on the target branch AFTER dispatch was started
+ * (i.e. between the dispatch SHA and the current HEAD).
+ *
+ * The commit list is injected (e.g. from `git log --format=%H dispatch..HEAD`)
+ * so this function remains pure and testable without spawning a subprocess.
+ *
+ * @param commitsBetween - Ordered list of commit SHAs that landed mid-flight.
+ *                         An empty array means no intervening commits.
+ * @returns `{ detected: true, count: N }` when N > 0 commits are present;
+ *          `{ detected: false, count: 0 }` for an empty list.
+ */
+export function detectMidFlightCommits(
+  commitsBetween: readonly string[],
+): MidFlightResult {
+  const count = commitsBetween.length;
+  return { detected: count > 0, count };
+}

--- a/packages/orchestrator/src/performance-writer.ts
+++ b/packages/orchestrator/src/performance-writer.ts
@@ -103,6 +103,13 @@ export const VALID_PIPELINE_SIGNALS = new Set([
   // Phase A self-telemetry: collect-end reconciliation detected fewer signals
   // written than findings in the consensus report. Observability-only.
   'signal_loss_suspected',
+  // UNIT 1 orchestrator signal pipeline: dispatch-hygiene precondition signals.
+  // Operational-only (tallied, never scored). Emitted by orchestrator-preconditions.ts
+  // when a dispatch-hygiene failure is detected (stale base, unreadable reference
+  // paths, mid-flight commits during a consensus round).
+  'dispatched_stale_base',
+  'referenced_unreadable_path',
+  'mid_flight_fixup',
 ]);
 
 /**

--- a/tests/cli/ask-back.test.ts
+++ b/tests/cli/ask-back.test.ts
@@ -19,6 +19,7 @@ import {
   buildIntrospectionPrompt,
   appendIntrospection,
   readIntrospections,
+  MAX_INTROSPECTION_BYTES,
   type IntrospectionRecord,
 } from '../../apps/cli/src/handlers/ask-back';
 
@@ -195,8 +196,12 @@ describe('readIntrospections', () => {
     const r1: IntrospectionRecord = { agentId: 'a1', claim: 'c1', groundTruth: 'g1', status: 'asked', askedAt: '2026-01-01T00:00:00.000Z' };
     const r2: IntrospectionRecord = { agentId: 'a2', claim: 'c2', groundTruth: 'g2', status: 'answered', askedAt: '2026-01-02T00:00:00.000Z', answeredAt: '2026-01-02T01:00:00.000Z', answer: 'pattern matched' };
     const jsonl = JSON.stringify(r1) + '\n' + JSON.stringify(r2) + '\n';
+    // Path-aware: .1 not present; only live file has content
     const fsDep = {
-      readFileSync: (_path: string): string => jsonl,
+      readFileSync: (path: string): string => {
+        if (path.endsWith('.1')) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        return jsonl;
+      },
     } as Parameters<typeof readIntrospections>[2];
     const result = readIntrospections('/fake/root', undefined, fsDep);
     expect(result).toHaveLength(2);
@@ -209,7 +214,10 @@ describe('readIntrospections', () => {
     const r1: IntrospectionRecord = { agentId: 'good', claim: 'c', groundTruth: 'g', status: 'asked', askedAt: '2026-01-01T00:00:00.000Z' };
     const jsonl = JSON.stringify(r1) + '\n' + 'TORN_LINE{{{invalid\n' + JSON.stringify(r1) + '\n';
     const fsDep = {
-      readFileSync: (_path: string): string => jsonl,
+      readFileSync: (path: string): string => {
+        if (path.endsWith('.1')) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        return jsonl;
+      },
     } as Parameters<typeof readIntrospections>[2];
     const result = readIntrospections('/fake/root', undefined, fsDep);
     expect(result).toHaveLength(2);
@@ -221,7 +229,10 @@ describe('readIntrospections', () => {
     const r3: IntrospectionRecord = { agentId: 'target', claim: 'c3', groundTruth: 'g3', status: 'answered', askedAt: '2026-01-01T00:00:00.000Z', answer: 'x' };
     const jsonl = [r1, r2, r3].map(r => JSON.stringify(r)).join('\n') + '\n';
     const fsDep = {
-      readFileSync: (_path: string): string => jsonl,
+      readFileSync: (path: string): string => {
+        if (path.endsWith('.1')) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        return jsonl;
+      },
     } as Parameters<typeof readIntrospections>[2];
     const result = readIntrospections('/fake/root', 'target', fsDep);
     expect(result).toHaveLength(2);
@@ -235,7 +246,10 @@ describe('readIntrospections', () => {
     ];
     const jsonl = records.map(r => JSON.stringify(r)).join('\n') + '\n';
     const fsDep = {
-      readFileSync: (_path: string): string => jsonl,
+      readFileSync: (path: string): string => {
+        if (path.endsWith('.1')) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        return jsonl;
+      },
     } as Parameters<typeof readIntrospections>[2];
     const result = readIntrospections('/fake/root', undefined, fsDep);
     expect(result).toHaveLength(2);
@@ -245,9 +259,240 @@ describe('readIntrospections', () => {
     const r: IntrospectionRecord = { agentId: 'a', claim: 'c', groundTruth: 'g', status: 'asked', askedAt: '2026-01-01T00:00:00.000Z' };
     const jsonl = '\n' + JSON.stringify(r) + '\n\n';
     const fsDep = {
-      readFileSync: (_path: string): string => jsonl,
+      readFileSync: (path: string): string => {
+        if (path.endsWith('.1')) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        return jsonl;
+      },
     } as Parameters<typeof readIntrospections>[2];
     const result = readIntrospections('/fake/root', undefined, fsDep);
     expect(result).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FIX 3: Guard — empty claim/groundTruth on 'asked' rejected; 'answered' allowed
+// ---------------------------------------------------------------------------
+
+describe('appendIntrospection — FIX 3 guard (empty claim/groundTruth)', () => {
+  it('does not write when claim is empty string and status is asked', () => {
+    const { written, fsDep } = makeFsSpyCapturing();
+    const record = {
+      agentId: 'agent',
+      claim: '',
+      groundTruth: 'valid truth',
+      status: 'asked' as const,
+    } as IntrospectionRecord;
+    appendIntrospection('/fake/root', record, fsDep);
+    expect(written).toHaveLength(0);
+  });
+
+  it('does not write when claim is whitespace-only and status is asked', () => {
+    const { written, fsDep } = makeFsSpyCapturing();
+    const record = {
+      agentId: 'agent',
+      claim: '   ',
+      groundTruth: 'valid truth',
+      status: 'asked' as const,
+    } as IntrospectionRecord;
+    appendIntrospection('/fake/root', record, fsDep);
+    expect(written).toHaveLength(0);
+  });
+
+  it('does not write when groundTruth is empty string and status is asked', () => {
+    const { written, fsDep } = makeFsSpyCapturing();
+    const record = {
+      agentId: 'agent',
+      claim: 'valid claim',
+      groundTruth: '',
+      status: 'asked' as const,
+    } as IntrospectionRecord;
+    appendIntrospection('/fake/root', record, fsDep);
+    expect(written).toHaveLength(0);
+  });
+
+  it('writes when status is answered and claim/groundTruth are empty (from mcp record action)', () => {
+    const { written, fsDep } = makeFsSpyCapturing();
+    // This mirrors what mcp-server-sdk.ts action:'record' sends:
+    // claim: claim ?? '', groundTruth: ground_truth ?? '' (may be empty)
+    const record = {
+      agentId: 'agent',
+      claim: '',
+      groundTruth: '',
+      answer: 'I pattern-matched the task framing',
+      status: 'answered' as const,
+      answeredAt: '2026-06-22T10:00:00.000Z',
+    } as IntrospectionRecord;
+    appendIntrospection('/fake/root', record, fsDep);
+    expect(written).toHaveLength(1);
+    const parsed = JSON.parse(written[0].data.trim());
+    expect(parsed.status).toBe('answered');
+    expect(parsed.answer).toBe('I pattern-matched the task framing');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FIX 4: 'answered' records omit askedAt
+// ---------------------------------------------------------------------------
+
+describe('appendIntrospection — FIX 4 askedAt optional on answered', () => {
+  it('writes answered record without askedAt when omitted', () => {
+    const { written, fsDep } = makeFsSpyCapturing();
+    const record: IntrospectionRecord = {
+      agentId: 'agent',
+      claim: 'claimed X',
+      groundTruth: 'actually Y',
+      answer: 'I assumed without checking',
+      status: 'answered',
+      answeredAt: '2026-06-22T10:00:00.000Z',
+      // askedAt intentionally absent
+    };
+    appendIntrospection('/fake/root', record, fsDep);
+    expect(written).toHaveLength(1);
+    const parsed = JSON.parse(written[0].data.trim());
+    expect('askedAt' in parsed).toBe(false);
+    expect(parsed.answeredAt).toBe('2026-06-22T10:00:00.000Z');
+  });
+
+  it('includes askedAt when explicitly provided on answered record', () => {
+    const { written, fsDep } = makeFsSpyCapturing();
+    const record: IntrospectionRecord = {
+      agentId: 'agent',
+      claim: 'c',
+      groundTruth: 'g',
+      answer: 'a',
+      status: 'answered',
+      askedAt: '2026-06-22T09:00:00.000Z',
+      answeredAt: '2026-06-22T10:00:00.000Z',
+    };
+    appendIntrospection('/fake/root', record, fsDep);
+    const parsed = JSON.parse(written[0].data.trim());
+    expect(parsed.askedAt).toBe('2026-06-22T09:00:00.000Z');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FIX 5: Rotation — renames at threshold; readIntrospections reads rotated + live
+// ---------------------------------------------------------------------------
+
+function makeRotationFsDep(fileSize: number): {
+  renamed: { src: string; dest: string }[];
+  written: { path: string; data: string }[];
+  fsDep: Parameters<typeof appendIntrospection>[2];
+} {
+  const renamed: { src: string; dest: string }[] = [];
+  const written: { path: string; data: string }[] = [];
+  const fsDep: Parameters<typeof appendIntrospection>[2] = {
+    mkdirSync: () => { /* no-op */ },
+    appendFileSync: (path: string, data: string) => { written.push({ path, data }); },
+    statSync: (_path: string) => ({ size: fileSize }),
+    renameSync: (src: string, dest: string) => { renamed.push({ src, dest }); },
+  };
+  return { renamed, written, fsDep };
+}
+
+describe('appendIntrospection — FIX 5 rotation', () => {
+  it('renames ledger to .1 when size >= MAX_INTROSPECTION_BYTES', () => {
+    const { renamed, written, fsDep } = makeRotationFsDep(MAX_INTROSPECTION_BYTES);
+    const record: IntrospectionRecord = {
+      agentId: 'agent',
+      claim: 'c',
+      groundTruth: 'g',
+      status: 'asked',
+      askedAt: '2026-01-01T00:00:00.000Z',
+    };
+    appendIntrospection('/fake/root', record, fsDep);
+    expect(renamed).toHaveLength(1);
+    expect(renamed[0].dest.endsWith('.1')).toBe(true);
+    // append still happens after rename
+    expect(written).toHaveLength(1);
+  });
+
+  it('does NOT rename when size < MAX_INTROSPECTION_BYTES', () => {
+    const { renamed, written, fsDep } = makeRotationFsDep(MAX_INTROSPECTION_BYTES - 1);
+    const record: IntrospectionRecord = {
+      agentId: 'agent',
+      claim: 'c',
+      groundTruth: 'g',
+      status: 'asked',
+      askedAt: '2026-01-01T00:00:00.000Z',
+    };
+    appendIntrospection('/fake/root', record, fsDep);
+    expect(renamed).toHaveLength(0);
+    expect(written).toHaveLength(1);
+  });
+
+  it('is best-effort: continues to append when statSync throws (file missing)', () => {
+    const written: { path: string; data: string }[] = [];
+    const fsDep: Parameters<typeof appendIntrospection>[2] = {
+      mkdirSync: () => { /* no-op */ },
+      appendFileSync: (path: string, data: string) => { written.push({ path, data }); },
+      statSync: () => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); },
+      renameSync: () => { /* no-op */ },
+    };
+    const record: IntrospectionRecord = {
+      agentId: 'agent',
+      claim: 'c',
+      groundTruth: 'g',
+      status: 'asked',
+      askedAt: '2026-01-01T00:00:00.000Z',
+    };
+    expect(() => appendIntrospection('/fake/root', record, fsDep)).not.toThrow();
+    // Append still happens after stat failure
+    expect(written).toHaveLength(1);
+  });
+});
+
+describe('readIntrospections — FIX 5 reads rotated .1 + live', () => {
+  it('returns records from both .1 and live file', () => {
+    const r1: IntrospectionRecord = { agentId: 'a1', claim: 'c1', groundTruth: 'g1', status: 'asked', askedAt: '2026-01-01T00:00:00.000Z' };
+    const r2: IntrospectionRecord = { agentId: 'a2', claim: 'c2', groundTruth: 'g2', status: 'asked', askedAt: '2026-01-02T00:00:00.000Z' };
+    const rotatedContent = JSON.stringify(r1) + '\n'; // older records in .1
+    const liveContent = JSON.stringify(r2) + '\n';    // newer records in live
+
+    const fsDep: Parameters<typeof readIntrospections>[2] = {
+      readFileSync: (path: string): string => {
+        if (path.endsWith('.1')) return rotatedContent;
+        return liveContent;
+      },
+    };
+    const result = readIntrospections('/fake/root', undefined, fsDep);
+    expect(result).toHaveLength(2);
+    // .1 is read first (older), then live
+    expect(result[0].agentId).toBe('a1');
+    expect(result[1].agentId).toBe('a2');
+  });
+
+  it('returns records from live file when .1 is missing', () => {
+    const r: IntrospectionRecord = { agentId: 'live-only', claim: 'c', groundTruth: 'g', status: 'asked', askedAt: '2026-01-01T00:00:00.000Z' };
+    const fsDep: Parameters<typeof readIntrospections>[2] = {
+      readFileSync: (path: string): string => {
+        if (path.endsWith('.1')) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        return JSON.stringify(r) + '\n';
+      },
+    };
+    const result = readIntrospections('/fake/root', undefined, fsDep);
+    expect(result).toHaveLength(1);
+    expect(result[0].agentId).toBe('live-only');
+  });
+
+  it('returns records from .1 file when live is missing', () => {
+    const r: IntrospectionRecord = { agentId: 'rotated-only', claim: 'c', groundTruth: 'g', status: 'asked', askedAt: '2026-01-01T00:00:00.000Z' };
+    const fsDep: Parameters<typeof readIntrospections>[2] = {
+      readFileSync: (path: string): string => {
+        if (path.endsWith('.1')) return JSON.stringify(r) + '\n';
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      },
+    };
+    const result = readIntrospections('/fake/root', undefined, fsDep);
+    expect(result).toHaveLength(1);
+    expect(result[0].agentId).toBe('rotated-only');
+  });
+
+  it('returns [] when both .1 and live are missing', () => {
+    const fsDep: Parameters<typeof readIntrospections>[2] = {
+      readFileSync: (_path: string): string => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); },
+    };
+    const result = readIntrospections('/fake/root', undefined, fsDep);
+    expect(result).toEqual([]);
   });
 });

--- a/tests/cli/ask-back.test.ts
+++ b/tests/cli/ask-back.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Unit tests for the gossip_ask_back introspection ledger.
+ * Spec: orchestrator signal pipeline Unit 4.
+ *
+ * Covers:
+ *  - buildIntrospectionPrompt: contains claim, groundTruth, mechanism ask
+ *  - appendIntrospection: round-trip JSONL via fs spy, trailing newline, best-effort on throw
+ *  - readIntrospections: multi-line parse, skips torn line, filters by agentId, [] on missing file
+ *  - required-field guard on appendIntrospection
+ *
+ * All tests use an injected fs dependency — real .gossip is never touched.
+ */
+
+import { mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import {
+  buildIntrospectionPrompt,
+  appendIntrospection,
+  readIntrospections,
+  type IntrospectionRecord,
+} from '../../apps/cli/src/handlers/ask-back';
+
+// ---------------------------------------------------------------------------
+// buildIntrospectionPrompt
+// ---------------------------------------------------------------------------
+
+describe('buildIntrospectionPrompt', () => {
+  it('contains the claim verbatim', () => {
+    const prompt = buildIntrospectionPrompt('Agent cited line 42 but it does not exist', 'grep shows no such line');
+    expect(prompt).toContain('Agent cited line 42 but it does not exist');
+  });
+
+  it('contains the ground truth verbatim', () => {
+    const prompt = buildIntrospectionPrompt('some claim', 'grep shows no such line in auth.ts');
+    expect(prompt).toContain('grep shows no such line in auth.ts');
+  });
+
+  it('asks for a specific failure mechanism (not an apology)', () => {
+    const prompt = buildIntrospectionPrompt('claim', 'truth');
+    // Must request a mechanism explanation
+    const lower = prompt.toLowerCase();
+    expect(
+      lower.includes('mechanism') ||
+      lower.includes('process') ||
+      lower.includes('how') ||
+      lower.includes('why') ||
+      lower.includes('specific')
+    ).toBe(true);
+  });
+
+  it('is non-empty and reasonably sized', () => {
+    const prompt = buildIntrospectionPrompt('a', 'b');
+    expect(prompt.length).toBeGreaterThan(40);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appendIntrospection helpers
+// ---------------------------------------------------------------------------
+
+function makeRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'gossip-ask-back-test-'));
+}
+
+function makeFsSpyCapturing(): { written: { path: string; data: string }[]; fsDep: Parameters<typeof appendIntrospection>[2] } {
+  const written: { path: string; data: string }[] = [];
+  const fsDep = {
+    mkdirSync: (_path: string, _opts?: unknown) => { /* no-op */ },
+    appendFileSync: (path: string, data: string) => {
+      written.push({ path, data });
+    },
+  } as Parameters<typeof appendIntrospection>[2];
+  return { written, fsDep };
+}
+
+// ---------------------------------------------------------------------------
+// appendIntrospection
+// ---------------------------------------------------------------------------
+
+describe('appendIntrospection', () => {
+  it('writes a JSONL line with trailing newline', () => {
+    const { written, fsDep } = makeFsSpyCapturing();
+    const record: IntrospectionRecord = {
+      agentId: 'sonnet-reviewer',
+      claim: 'claimed line 42',
+      groundTruth: 'no such line',
+      status: 'asked',
+      askedAt: new Date().toISOString(),
+    };
+    appendIntrospection('/fake/root', record, fsDep);
+    expect(written).toHaveLength(1);
+    expect(written[0].data.endsWith('\n')).toBe(true);
+  });
+
+  it('written line round-trips back to the original record fields', () => {
+    const { written, fsDep } = makeFsSpyCapturing();
+    const record: IntrospectionRecord = {
+      agentId: 'haiku-researcher',
+      findingId: 'abc123:haiku-researcher:f2',
+      claim: 'claimed X',
+      groundTruth: 'actually Y',
+      status: 'asked',
+      askedAt: '2026-06-22T10:00:00.000Z',
+    };
+    appendIntrospection('/fake/root', record, fsDep);
+    const line = written[0].data.trim();
+    const parsed = JSON.parse(line) as IntrospectionRecord;
+    expect(parsed.agentId).toBe('haiku-researcher');
+    expect(parsed.findingId).toBe('abc123:haiku-researcher:f2');
+    expect(parsed.claim).toBe('claimed X');
+    expect(parsed.groundTruth).toBe('actually Y');
+    expect(parsed.status).toBe('asked');
+    expect(parsed.askedAt).toBe('2026-06-22T10:00:00.000Z');
+  });
+
+  it('does not serialize undefined fields (omits optional absent keys)', () => {
+    const { written, fsDep } = makeFsSpyCapturing();
+    const record: IntrospectionRecord = {
+      agentId: 'gemini-reviewer',
+      claim: 'c',
+      groundTruth: 'g',
+      status: 'asked',
+      askedAt: '2026-06-22T10:00:00.000Z',
+    };
+    appendIntrospection('/fake/root', record, fsDep);
+    const parsed = JSON.parse(written[0].data.trim());
+    expect('answer' in parsed).toBe(false);
+    expect('findingId' in parsed).toBe(false);
+    expect('answeredAt' in parsed).toBe(false);
+  });
+
+  it('is best-effort: does not throw when fs.appendFileSync throws', () => {
+    const throwingFs = {
+      mkdirSync: () => { /* no-op */ },
+      appendFileSync: () => { throw new Error('disk full'); },
+    } as Parameters<typeof appendIntrospection>[2];
+    const record: IntrospectionRecord = {
+      agentId: 'agent',
+      claim: 'c',
+      groundTruth: 'g',
+      status: 'asked',
+      askedAt: new Date().toISOString(),
+    };
+    expect(() => appendIntrospection('/fake/root', record, throwingFs)).not.toThrow();
+  });
+
+  it('is best-effort: does not throw when mkdirSync throws', () => {
+    const throwingFs = {
+      mkdirSync: () => { throw new Error('permission denied'); },
+      appendFileSync: () => { /* no-op */ },
+    } as Parameters<typeof appendIntrospection>[2];
+    const record: IntrospectionRecord = {
+      agentId: 'agent',
+      claim: 'c',
+      groundTruth: 'g',
+      status: 'asked',
+      askedAt: new Date().toISOString(),
+    };
+    expect(() => appendIntrospection('/fake/root', record, throwingFs)).not.toThrow();
+  });
+
+  it('does not write when required fields are missing', () => {
+    const { written, fsDep } = makeFsSpyCapturing();
+    // Missing agentId — cast to bypass TS for the runtime guard test
+    const badRecord = { claim: 'c', groundTruth: 'g', status: 'asked', askedAt: 'now' } as unknown as IntrospectionRecord;
+    appendIntrospection('/fake/root', badRecord, fsDep);
+    expect(written).toHaveLength(0);
+  });
+
+  it('does not write when status is missing', () => {
+    const { written, fsDep } = makeFsSpyCapturing();
+    const badRecord = { agentId: 'x', claim: 'c', groundTruth: 'g', askedAt: 'now' } as unknown as IntrospectionRecord;
+    appendIntrospection('/fake/root', badRecord, fsDep);
+    expect(written).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readIntrospections
+// ---------------------------------------------------------------------------
+
+describe('readIntrospections', () => {
+  it('returns [] when file does not exist', () => {
+    const root = makeRoot(); // empty temp dir
+    const fsDep = {
+      readFileSync: (_path: string): string => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); },
+    } as Parameters<typeof readIntrospections>[2];
+    const result = readIntrospections(root, undefined, fsDep);
+    expect(result).toEqual([]);
+  });
+
+  it('parses multiple JSONL lines', () => {
+    const r1: IntrospectionRecord = { agentId: 'a1', claim: 'c1', groundTruth: 'g1', status: 'asked', askedAt: '2026-01-01T00:00:00.000Z' };
+    const r2: IntrospectionRecord = { agentId: 'a2', claim: 'c2', groundTruth: 'g2', status: 'answered', askedAt: '2026-01-02T00:00:00.000Z', answeredAt: '2026-01-02T01:00:00.000Z', answer: 'pattern matched' };
+    const jsonl = JSON.stringify(r1) + '\n' + JSON.stringify(r2) + '\n';
+    const fsDep = {
+      readFileSync: (_path: string): string => jsonl,
+    } as Parameters<typeof readIntrospections>[2];
+    const result = readIntrospections('/fake/root', undefined, fsDep);
+    expect(result).toHaveLength(2);
+    expect(result[0].agentId).toBe('a1');
+    expect(result[1].agentId).toBe('a2');
+    expect(result[1].answer).toBe('pattern matched');
+  });
+
+  it('skips torn (invalid JSON) lines leniently', () => {
+    const r1: IntrospectionRecord = { agentId: 'good', claim: 'c', groundTruth: 'g', status: 'asked', askedAt: '2026-01-01T00:00:00.000Z' };
+    const jsonl = JSON.stringify(r1) + '\n' + 'TORN_LINE{{{invalid\n' + JSON.stringify(r1) + '\n';
+    const fsDep = {
+      readFileSync: (_path: string): string => jsonl,
+    } as Parameters<typeof readIntrospections>[2];
+    const result = readIntrospections('/fake/root', undefined, fsDep);
+    expect(result).toHaveLength(2);
+  });
+
+  it('filters by agentId when provided', () => {
+    const r1: IntrospectionRecord = { agentId: 'target', claim: 'c1', groundTruth: 'g1', status: 'asked', askedAt: '2026-01-01T00:00:00.000Z' };
+    const r2: IntrospectionRecord = { agentId: 'other', claim: 'c2', groundTruth: 'g2', status: 'asked', askedAt: '2026-01-01T00:00:00.000Z' };
+    const r3: IntrospectionRecord = { agentId: 'target', claim: 'c3', groundTruth: 'g3', status: 'answered', askedAt: '2026-01-01T00:00:00.000Z', answer: 'x' };
+    const jsonl = [r1, r2, r3].map(r => JSON.stringify(r)).join('\n') + '\n';
+    const fsDep = {
+      readFileSync: (_path: string): string => jsonl,
+    } as Parameters<typeof readIntrospections>[2];
+    const result = readIntrospections('/fake/root', 'target', fsDep);
+    expect(result).toHaveLength(2);
+    expect(result.every(r => r.agentId === 'target')).toBe(true);
+  });
+
+  it('returns all records when agentId filter is undefined', () => {
+    const records: IntrospectionRecord[] = [
+      { agentId: 'a', claim: 'c', groundTruth: 'g', status: 'asked', askedAt: '2026-01-01T00:00:00.000Z' },
+      { agentId: 'b', claim: 'c', groundTruth: 'g', status: 'asked', askedAt: '2026-01-01T00:00:00.000Z' },
+    ];
+    const jsonl = records.map(r => JSON.stringify(r)).join('\n') + '\n';
+    const fsDep = {
+      readFileSync: (_path: string): string => jsonl,
+    } as Parameters<typeof readIntrospections>[2];
+    const result = readIntrospections('/fake/root', undefined, fsDep);
+    expect(result).toHaveLength(2);
+  });
+
+  it('ignores blank lines', () => {
+    const r: IntrospectionRecord = { agentId: 'a', claim: 'c', groundTruth: 'g', status: 'asked', askedAt: '2026-01-01T00:00:00.000Z' };
+    const jsonl = '\n' + JSON.stringify(r) + '\n\n';
+    const fsDep = {
+      readFileSync: (_path: string): string => jsonl,
+    } as Parameters<typeof readIntrospections>[2];
+    const result = readIntrospections('/fake/root', undefined, fsDep);
+    expect(result).toHaveLength(1);
+  });
+});

--- a/tests/cli/orchestrator-midflight.test.ts
+++ b/tests/cli/orchestrator-midflight.test.ts
@@ -1,0 +1,231 @@
+// tests/cli/orchestrator-midflight.test.ts
+//
+// Unit tests for UNIT 3 orchestrator mid-flight commit detection.
+// All I/O (git, emitPipelineSignals) is injected via stubs — no real
+// filesystem or shell access.
+
+import {
+  captureHeadSha,
+  getCommitsSince,
+  runMidFlightCheck,
+  type MidFlightCheckDeps,
+} from '../../apps/cli/src/handlers/orchestrator-precondition-runner';
+import type { PerformanceSignal } from '@gossip/orchestrator';
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function makeMidFlightDeps(overrides: Partial<MidFlightCheckDeps> = {}): MidFlightCheckDeps {
+  return {
+    execFile: jest.fn(),
+    emitSignals: jest.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// captureHeadSha
+// ---------------------------------------------------------------------------
+
+describe('captureHeadSha', () => {
+  it('returns the trimmed HEAD SHA on success', () => {
+    const execFile = jest.fn().mockReturnValue('  abc123  \n');
+    const result = captureHeadSha('/project', execFile);
+    expect(result).toBe('abc123');
+    expect(execFile).toHaveBeenCalledWith(
+      'git',
+      ['rev-parse', 'HEAD'],
+      expect.objectContaining({ cwd: '/project', encoding: 'utf8' }),
+    );
+  });
+
+  it('returns undefined when execFile throws', () => {
+    const execFile = jest.fn().mockImplementation(() => { throw new Error('git not found'); });
+    const result = captureHeadSha('/project', execFile);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when execFile returns empty string', () => {
+    const execFile = jest.fn().mockReturnValue('   \n');
+    const result = captureHeadSha('/project', execFile);
+    expect(result).toBeUndefined();
+  });
+
+  it('uses process.cwd() when no projectRoot given and git succeeds', () => {
+    const execFile = jest.fn().mockReturnValue('deadbeef\n');
+    const result = captureHeadSha(undefined, execFile);
+    expect(result).toBe('deadbeef');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCommitsSince
+// ---------------------------------------------------------------------------
+
+describe('getCommitsSince', () => {
+  it('parses multiple commit SHAs from git log output', () => {
+    const execFile = jest.fn().mockReturnValue('sha1\nsha2\nsha3\n');
+    const result = getCommitsSince('abc000', '/project', execFile);
+    expect(result).toEqual(['sha1', 'sha2', 'sha3']);
+    expect(execFile).toHaveBeenCalledWith(
+      'git',
+      ['log', 'abc000..HEAD', '--format=%H'],
+      expect.objectContaining({ cwd: '/project', encoding: 'utf8' }),
+    );
+  });
+
+  it('returns empty array when git log output is empty', () => {
+    const execFile = jest.fn().mockReturnValue('\n\n   \n');
+    const result = getCommitsSince('abc000', '/project', execFile);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when execFile throws (git error)', () => {
+    const execFile = jest.fn().mockImplementation(() => { throw new Error('git error'); });
+    const result = getCommitsSince('abc000', '/project', execFile);
+    expect(result).toEqual([]);
+  });
+
+  it('filters out empty lines from git log output', () => {
+    const execFile = jest.fn().mockReturnValue('sha1\n\nsha2\n\n');
+    const result = getCommitsSince('abc000', '/project', execFile);
+    expect(result).toEqual(['sha1', 'sha2']);
+  });
+
+  it('trims whitespace from each SHA line', () => {
+    const execFile = jest.fn().mockReturnValue('  sha1  \n  sha2  \n');
+    const result = getCommitsSince('abc000', '/project', execFile);
+    expect(result).toEqual(['sha1', 'sha2']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runMidFlightCheck
+// ---------------------------------------------------------------------------
+
+describe('runMidFlightCheck — no roundStartSha', () => {
+  it('returns no warnings and emits no signals when roundStartSha is undefined', async () => {
+    const deps = makeMidFlightDeps();
+    const result = await runMidFlightCheck(
+      { projectRoot: '/project', consensusId: 'cid-001', roundStartSha: undefined },
+      deps,
+    );
+    expect(result.warnings).toHaveLength(0);
+    expect(deps.emitSignals).not.toHaveBeenCalled();
+    expect(deps.execFile).not.toHaveBeenCalled();
+  });
+
+  it('returns no warnings and emits no signals when roundStartSha is null', async () => {
+    const deps = makeMidFlightDeps();
+    const result = await runMidFlightCheck(
+      { projectRoot: '/project', consensusId: 'cid-001', roundStartSha: null as any },
+      deps,
+    );
+    expect(result.warnings).toHaveLength(0);
+    expect(deps.emitSignals).not.toHaveBeenCalled();
+  });
+
+  it('returns no warnings and emits no signals when roundStartSha is empty string', async () => {
+    const deps = makeMidFlightDeps();
+    const result = await runMidFlightCheck(
+      { projectRoot: '/project', consensusId: 'cid-001', roundStartSha: '' },
+      deps,
+    );
+    expect(result.warnings).toHaveLength(0);
+    expect(deps.emitSignals).not.toHaveBeenCalled();
+  });
+});
+
+describe('runMidFlightCheck — commits detected', () => {
+  it('emits mid_flight_fixup signal with agentId orchestrator when commits landed', async () => {
+    const deps = makeMidFlightDeps({
+      execFile: jest.fn().mockReturnValue('commit1\ncommit2\n'),
+    });
+    const result = await runMidFlightCheck(
+      {
+        projectRoot: '/project',
+        consensusId: 'cid-abc',
+        roundStartSha: 'startsha',
+      },
+      deps,
+    );
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(deps.emitSignals).toHaveBeenCalledTimes(1);
+    const [projectRoot, signals]: [string, PerformanceSignal[]] = (deps.emitSignals as jest.Mock).mock.calls[0];
+    expect(projectRoot).toBe('/project');
+    expect(signals).toHaveLength(1);
+    const signal = signals[0] as any;
+    expect(signal.signal).toBe('mid_flight_fixup');
+    expect(signal.agentId).toBe('orchestrator');
+    expect(signal.taskId).toBe('cid-abc');
+    expect(signal.consensusId).toBe('cid-abc');
+    expect(signal.metadata.count).toBe(2);
+    expect(signal.metadata.roundStartSha).toBe('startsha');
+    expect(signal.metadata.commits).toEqual(['commit1', 'commit2']);
+  });
+
+  it('includes a warning message describing the mid-flight fixup', async () => {
+    const deps = makeMidFlightDeps({
+      execFile: jest.fn().mockReturnValue('deadbeef\n'),
+    });
+    const result = await runMidFlightCheck(
+      { projectRoot: '/project', consensusId: 'cid-xyz', roundStartSha: 'base' },
+      deps,
+    );
+    expect(result.warnings[0]).toMatch(/mid.flight/i);
+  });
+});
+
+describe('runMidFlightCheck — zero commits', () => {
+  it('emits no signal and no warning when no commits landed since round start', async () => {
+    const deps = makeMidFlightDeps({
+      execFile: jest.fn().mockReturnValue('\n'),
+    });
+    const result = await runMidFlightCheck(
+      { projectRoot: '/project', consensusId: 'cid-clean', roundStartSha: 'startsha' },
+      deps,
+    );
+    expect(result.warnings).toHaveLength(0);
+    expect(deps.emitSignals).not.toHaveBeenCalled();
+  });
+});
+
+describe('runMidFlightCheck — git error resilience', () => {
+  it('does not throw when execFile throws', async () => {
+    const deps = makeMidFlightDeps({
+      execFile: jest.fn().mockImplementation(() => { throw new Error('git exploded'); }),
+    });
+    await expect(
+      runMidFlightCheck(
+        { projectRoot: '/project', consensusId: 'cid-err', roundStartSha: 'sha' },
+        deps,
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it('returns no signal when execFile throws (git unavailable path)', async () => {
+    const deps = makeMidFlightDeps({
+      execFile: jest.fn().mockImplementation(() => { throw new Error('git unavailable'); }),
+    });
+    const result = await runMidFlightCheck(
+      { projectRoot: '/project', consensusId: 'cid-err', roundStartSha: 'sha' },
+      deps,
+    );
+    expect(deps.emitSignals).not.toHaveBeenCalled();
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('does not throw when emitSignals throws', async () => {
+    const deps = makeMidFlightDeps({
+      execFile: jest.fn().mockReturnValue('commit1\n'),
+      emitSignals: jest.fn().mockImplementation(() => { throw new Error('emit failed'); }),
+    });
+    await expect(
+      runMidFlightCheck(
+        { projectRoot: '/project', consensusId: 'cid-emiterr', roundStartSha: 'sha' },
+        deps,
+      ),
+    ).resolves.toBeDefined();
+  });
+});

--- a/tests/cli/orchestrator-precondition-runner.test.ts
+++ b/tests/cli/orchestrator-precondition-runner.test.ts
@@ -1,0 +1,318 @@
+// tests/cli/orchestrator-precondition-runner.test.ts
+//
+// Unit tests for the UNIT 2 orchestrator precondition runner (wiring layer).
+// All I/O (git, fs, emitPipelineSignals) is injected via stubs — no real
+// filesystem or shell access.
+
+import {
+  gatherStaleBaseInputs,
+  runDispatchPreconditionGuard,
+  type PreconditionRunnerDeps,
+} from '../../apps/cli/src/handlers/orchestrator-precondition-runner';
+import type { PerformanceSignal } from '@gossip/orchestrator';
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal deps object — callers override only what they need. */
+function makeDeps(overrides: Partial<PreconditionRunnerDeps> = {}): PreconditionRunnerDeps {
+  return {
+    execFile: jest.fn(),
+    canRead: jest.fn().mockReturnValue(true),
+    emitSignals: jest.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// gatherStaleBaseInputs
+// ---------------------------------------------------------------------------
+
+describe('gatherStaleBaseInputs', () => {
+  it('returns null when execFile throws (git unavailable)', async () => {
+    const execFile = jest.fn().mockImplementation(() => { throw new Error('git not found'); });
+    const result = await gatherStaleBaseInputs('/some/project', execFile);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when origin/master is not reachable', async () => {
+    // first call (HEAD) succeeds, second (origin/master) throws
+    const execFile = jest.fn()
+      .mockReturnValueOnce('abc123\n')         // git rev-parse HEAD
+      .mockImplementationOnce(() => { throw new Error('fatal: ambiguous argument'); });
+    const result = await gatherStaleBaseInputs('/some/project', execFile);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when not in a git repo', async () => {
+    const execFile = jest.fn().mockImplementation(() => {
+      throw new Error('fatal: not a git repository');
+    });
+    const result = await gatherStaleBaseInputs('/some/project', execFile);
+    expect(result).toBeNull();
+  });
+
+  it('returns trimmed SHAs on success', async () => {
+    const execFile = jest.fn()
+      .mockReturnValueOnce('  abc111  \n')    // HEAD
+      .mockReturnValueOnce('  def222  \n')    // origin/master
+      .mockReturnValueOnce('  abc111  \n');   // merge-base
+    const result = await gatherStaleBaseInputs('/root', execFile);
+    expect(result).toEqual({
+      dispatchSha: 'abc111',
+      originMasterSha: 'def222',
+      mergeBaseSha: 'abc111',
+    });
+  });
+
+  it('returns null mergeBaseSha when merge-base call fails but HEAD/origin succeed', async () => {
+    const execFile = jest.fn()
+      .mockReturnValueOnce('aaa\n')           // HEAD
+      .mockReturnValueOnce('bbb\n')           // origin/master
+      .mockImplementationOnce(() => { throw new Error('fatal: no merge base'); });
+    const result = await gatherStaleBaseInputs('/root', execFile);
+    // merge-base failure should produce null result (whole function returns null)
+    expect(result).toBeNull();
+  });
+
+  it('passes cwd to execFile calls', async () => {
+    const execFile = jest.fn()
+      .mockReturnValueOnce('sha1\n')
+      .mockReturnValueOnce('sha2\n')
+      .mockReturnValueOnce('sha1\n');
+    await gatherStaleBaseInputs('/my/project', execFile);
+    expect(execFile).toHaveBeenCalledWith(
+      'git',
+      ['rev-parse', 'HEAD'],
+      expect.objectContaining({ cwd: '/my/project' }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runDispatchPreconditionGuard — stale base scenarios
+// ---------------------------------------------------------------------------
+
+describe('runDispatchPreconditionGuard — stale base', () => {
+  it('emits no signal and no warning when base is fresh', async () => {
+    const deps = makeDeps({
+      execFile: jest.fn()
+        .mockReturnValueOnce('samesha\n')
+        .mockReturnValueOnce('samesha\n')
+        .mockReturnValueOnce('samesha\n'),
+    });
+    const result = await runDispatchPreconditionGuard(
+      { projectRoot: '/project', taskId: 't1', resolutionRoots: [] },
+      deps,
+    );
+    expect(result.warnings).toHaveLength(0);
+    expect(deps.emitSignals).not.toHaveBeenCalled();
+  });
+
+  it('emits dispatched_stale_base and warning when behind_origin', async () => {
+    const deps = makeDeps({
+      execFile: jest.fn()
+        .mockReturnValueOnce('old111\n')      // HEAD
+        .mockReturnValueOnce('new999\n')      // origin/master
+        .mockReturnValueOnce('old111\n'),     // merge-base === HEAD → behind_origin
+    });
+    const result = await runDispatchPreconditionGuard(
+      { projectRoot: '/project', taskId: 'task-abc', resolutionRoots: [] },
+      deps,
+    );
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toMatch(/stale/i);
+    expect(deps.emitSignals).toHaveBeenCalledTimes(1);
+    const [, signals] = (deps.emitSignals as jest.Mock).mock.calls[0];
+    expect(signals[0].signal).toBe('dispatched_stale_base');
+    expect(signals[0].agentId).toBe('orchestrator');
+    expect(signals[0].taskId).toBe('task-abc');
+    expect(signals[0].metadata.reason).toBe('behind_origin');
+  });
+
+  it('emits dispatched_stale_base with branched_pre_merge reason', async () => {
+    const deps = makeDeps({
+      execFile: jest.fn()
+        .mockReturnValueOnce('branchsha\n')
+        .mockReturnValueOnce('mastersha\n')
+        .mockReturnValueOnce('commonancestor\n'),  // different from HEAD → branched_pre_merge
+    });
+    const result = await runDispatchPreconditionGuard(
+      { projectRoot: '/project', taskId: 'task-xyz', resolutionRoots: [] },
+      deps,
+    );
+    expect(result.warnings.length).toBeGreaterThan(0);
+    const [, signals] = (deps.emitSignals as jest.Mock).mock.calls[0];
+    expect(signals[0].signal).toBe('dispatched_stale_base');
+    expect(signals[0].metadata.reason).toBe('branched_pre_merge');
+    expect(signals[0].metadata.dispatchSha).toBe('branchsha');
+  });
+
+  it('emits no stale signal when git is unavailable (null gatherStaleBaseInputs)', async () => {
+    const deps = makeDeps({
+      execFile: jest.fn().mockImplementation(() => {
+        throw new Error('git not found');
+      }),
+    });
+    const result = await runDispatchPreconditionGuard(
+      { projectRoot: '/project', taskId: 'tX', resolutionRoots: [] },
+      deps,
+    );
+    expect(result.warnings).toHaveLength(0);
+    // stale signal not emitted; only check no dispatched_stale_base
+    const staleSignal = (deps.emitSignals as jest.Mock).mock.calls
+      .flatMap(([, sigs]: [unknown, Array<{ signal: string }>]) => sigs)
+      .find((s: { signal: string }) => s.signal === 'dispatched_stale_base');
+    expect(staleSignal).toBeUndefined();
+  });
+
+  it('never throws even if emitSignals throws', async () => {
+    const deps = makeDeps({
+      execFile: jest.fn()
+        .mockReturnValueOnce('old\n')
+        .mockReturnValueOnce('new\n')
+        .mockReturnValueOnce('old\n'),
+      emitSignals: jest.fn().mockImplementation(() => { throw new Error('emit failed'); }),
+    });
+    await expect(
+      runDispatchPreconditionGuard({ projectRoot: '/p', taskId: 't', resolutionRoots: [] }, deps),
+    ).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runDispatchPreconditionGuard — unreadable paths
+// ---------------------------------------------------------------------------
+
+describe('runDispatchPreconditionGuard — referenced_unreadable_path', () => {
+  it('emits no signal when all resolutionRoots are readable', async () => {
+    const deps = makeDeps({
+      execFile: jest.fn()
+        .mockReturnValueOnce('sha\n')
+        .mockReturnValueOnce('sha\n')
+        .mockReturnValueOnce('sha\n'),
+      canRead: jest.fn().mockReturnValue(true),
+    });
+    const result = await runDispatchPreconditionGuard(
+      { projectRoot: '/p', taskId: 't1', resolutionRoots: ['/p/worktree1', '/p/worktree2'] },
+      deps,
+    );
+    expect(result.warnings).toHaveLength(0);
+    const unreadableSignal = (deps.emitSignals as jest.Mock).mock.calls
+      .flatMap(([, sigs]: [unknown, Array<{ signal: string }>]) => sigs)
+      .find((s: { signal: string }) => s.signal === 'referenced_unreadable_path');
+    expect(unreadableSignal).toBeUndefined();
+  });
+
+  it('emits signal and warning when some resolutionRoots are unreadable', async () => {
+    const deps = makeDeps({
+      execFile: jest.fn()
+        .mockReturnValueOnce('sha\n')
+        .mockReturnValueOnce('sha\n')
+        .mockReturnValueOnce('sha\n'),
+      canRead: jest.fn().mockImplementation((p: string) => p !== '/missing/path'),
+    });
+    const result = await runDispatchPreconditionGuard(
+      {
+        projectRoot: '/p',
+        taskId: 'task-123',
+        resolutionRoots: ['/readable/path', '/missing/path'],
+      },
+      deps,
+    );
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings.join(' ')).toMatch(/unreadable/i);
+    expect(deps.emitSignals).toHaveBeenCalled();
+    const allSignals2 = (deps.emitSignals as jest.Mock).mock.calls
+      .flatMap(([, sigs]: [unknown, PerformanceSignal[]]) => sigs);
+    const unreadableSignal = allSignals2.find(s => s.signal === 'referenced_unreadable_path') as PerformanceSignal & { agentId: string; taskId: string; metadata: { unreadable: string[] } } | undefined;
+    expect(unreadableSignal).toBeDefined();
+    expect(unreadableSignal!.agentId).toBe('orchestrator');
+    expect(unreadableSignal!.taskId).toBe('task-123');
+    expect(unreadableSignal!.metadata.unreadable).toEqual(['/missing/path']);
+  });
+
+  it('emits no signal when resolutionRoots is empty', async () => {
+    const deps = makeDeps({
+      execFile: jest.fn()
+        .mockReturnValueOnce('sha\n')
+        .mockReturnValueOnce('sha\n')
+        .mockReturnValueOnce('sha\n'),
+      canRead: jest.fn().mockReturnValue(false), // would fail if called
+    });
+    const result = await runDispatchPreconditionGuard(
+      { projectRoot: '/p', taskId: 't', resolutionRoots: [] },
+      deps,
+    );
+    // canRead should not have been called (no paths to check)
+    expect(deps.canRead).not.toHaveBeenCalled();
+    const unreadableSignal = (deps.emitSignals as jest.Mock).mock.calls
+      .flatMap(([, sigs]: [unknown, Array<{ signal: string }>]) => sigs)
+      .find((s: { signal: string }) => s.signal === 'referenced_unreadable_path');
+    expect(unreadableSignal).toBeUndefined();
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('handles undefined resolutionRoots (same as empty)', async () => {
+    const deps = makeDeps({
+      execFile: jest.fn()
+        .mockReturnValueOnce('sha\n')
+        .mockReturnValueOnce('sha\n')
+        .mockReturnValueOnce('sha\n'),
+      canRead: jest.fn().mockReturnValue(false),
+    });
+    const result = await runDispatchPreconditionGuard(
+      { projectRoot: '/p', taskId: 't', resolutionRoots: undefined },
+      deps,
+    );
+    expect(deps.canRead).not.toHaveBeenCalled();
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('never throws even when canRead throws', async () => {
+    const deps = makeDeps({
+      execFile: jest.fn()
+        .mockReturnValueOnce('sha\n')
+        .mockReturnValueOnce('sha\n')
+        .mockReturnValueOnce('sha\n'),
+      canRead: jest.fn().mockImplementation(() => { throw new Error('fs error'); }),
+    });
+    await expect(
+      runDispatchPreconditionGuard(
+        { projectRoot: '/p', taskId: 't', resolutionRoots: ['/some/path'] },
+        deps,
+      ),
+    ).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runDispatchPreconditionGuard — combined signals
+// ---------------------------------------------------------------------------
+
+describe('runDispatchPreconditionGuard — combined signals', () => {
+  it('can emit both stale base AND unreadable paths signals in one call', async () => {
+    const deps = makeDeps({
+      execFile: jest.fn()
+        .mockReturnValueOnce('old\n')
+        .mockReturnValueOnce('new\n')
+        .mockReturnValueOnce('old\n'),     // behind_origin
+      canRead: jest.fn().mockReturnValue(false),
+    });
+    const result = await runDispatchPreconditionGuard(
+      {
+        projectRoot: '/p',
+        taskId: 'combined',
+        resolutionRoots: ['/missing/root'],
+      },
+      deps,
+    );
+    expect(result.warnings.length).toBeGreaterThanOrEqual(2);
+    const allEmittedSignals = (deps.emitSignals as jest.Mock).mock.calls
+      .flatMap(([, sigs]: [unknown, Array<{ signal: string }>]) => sigs)
+      .map((s: { signal: string }) => s.signal);
+    expect(allEmittedSignals).toContain('dispatched_stale_base');
+    expect(allEmittedSignals).toContain('referenced_unreadable_path');
+  });
+});

--- a/tests/cli/relay-cross-review-midflight.test.ts
+++ b/tests/cli/relay-cross-review-midflight.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Integration tests for FIX 1 (UNIT 6):
+ * runMidFlightCheck is invoked at the relay-cross-review synthesis site with
+ * a live roundStartSha — NOT in collect.ts (where the round is already deleted).
+ *
+ * Tests:
+ *  1. mid_flight_fixup IS emitted when commits exist AND roundStartSha is present
+ *     (completion-synthesis path).
+ *  2. mid_flight_fixup is NOT emitted when roundStartSha is absent/undefined
+ *     (both paths — shows the no-op guard works).
+ *
+ * All external I/O is stubbed:
+ *  - fs writes (persistPendingConsensus, consensus-reports) are mocked.
+ *  - @gossip/orchestrator is partially mocked (ConsensusEngine stub + runMidFlightCheck spy).
+ *  - orchestrator-precondition-runner.runMidFlightCheck is spied on so we can
+ *    assert it was called with the correct roundStartSha BEFORE the round was deleted.
+ */
+
+import { ctx } from '../../apps/cli/src/mcp-context';
+import type { MainAgent } from '@gossip/orchestrator';
+import type { MidFlightCheckInput } from '../../apps/cli/src/handlers/orchestrator-precondition-runner';
+
+// ── fs mock — suppress all real disk writes ──────────────────────────────────
+jest.mock('fs', () => ({
+  writeFileSync: jest.fn(),
+  readFileSync: jest.fn(),
+  existsSync: jest.fn(() => false),
+  unlinkSync: jest.fn(),
+  mkdirSync: jest.fn(),
+}));
+
+// ── orchestrator-precondition-runner mock — spy on runMidFlightCheck ─────────
+jest.mock(
+  '../../apps/cli/src/handlers/orchestrator-precondition-runner',
+  () => ({
+    runMidFlightCheck: jest.fn(),
+    captureHeadSha: jest.fn(() => undefined),
+  }),
+);
+
+// ── @gossip/orchestrator partial mock ────────────────────────────────────────
+// ConsensusEngine.parseCrossReviewResponse + synthesizeWithCrossReview are
+// needed by the handler. We stub just enough to avoid real LLM calls.
+jest.mock('@gossip/orchestrator', () => {
+  class FakeEngine {
+    parseCrossReviewResponse(_agentId: string, _result: string, _limit: number) {
+      return [];
+    }
+    async synthesizeWithCrossReview(
+      _allResults: any[],
+      _entries: any[],
+      consensusId: string,
+    ) {
+      return {
+        confirmed: [],
+        disputed: [],
+        unverified: [],
+        unique: [],
+        insights: [],
+        newFindings: [],
+        signals: [],
+        agentCount: 1,
+        rounds: 1,
+        summary: `Consensus complete: 0 confirmed (stub) for ${consensusId}`,
+      };
+    }
+    async generateCrossReviewPrompts() {
+      return { prompts: [] };
+    }
+  }
+
+  function makeRoundContext(opts?: { resolutionRoots?: string[] }) {
+    return { resolutionRoots: opts?.resolutionRoots ?? [], warnings: [] };
+  }
+
+  return {
+    ConsensusEngine: FakeEngine,
+    makeRoundContext,
+    emitConsensusSignals: jest.fn(),
+    emitPipelineSignals: jest.fn(),
+    MainAgent: jest.fn(),
+  };
+});
+
+// ── import after mocks ────────────────────────────────────────────────────────
+import { handleRelayCrossReview } from '../../apps/cli/src/handlers/relay-cross-review';
+import * as preconditionRunner from '../../apps/cli/src/handlers/orchestrator-precondition-runner';
+
+const CONSENSUS_ID = 'unit6-test-cafecafe';
+const AGENT_A = 'agent-alpha';
+const AGENT_B = 'agent-beta';
+
+function seedRound(opts: { roundStartSha?: string } = {}) {
+  ctx.pendingConsensusRounds.set(CONSENSUS_ID, {
+    consensusId: CONSENSUS_ID,
+    allResults: [
+      { agentId: AGENT_A, status: 'completed', result: '- finding A', task: 'task' },
+      { agentId: AGENT_B, status: 'completed', result: '- finding B', task: 'task' },
+    ],
+    relayCrossReviewEntries: [],
+    relayCrossReviewSkipped: undefined,
+    // Only ONE pending agent so that when AGENT_A submits, synthesis triggers.
+    pendingNativeAgents: new Set([AGENT_A]),
+    participatingNativeAgents: new Set([AGENT_A, AGENT_B]),
+    nativeCrossReviewEntries: [],
+    deadline: Date.now() + 60_000,
+    createdAt: Date.now(),
+    nativePrompts: [],
+    roundStartSha: opts.roundStartSha,
+  });
+}
+
+describe('relay-cross-review mid-flight check (FIX 1)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    ctx.pendingConsensusRounds.clear();
+    ctx.mainAgent = {
+      projectRoot: '/fake/project',
+      getLlm: () => ({
+        generate: async () => ({ text: '', usage: { inputTokens: 0, outputTokens: 0 } }),
+      }),
+      getAgentConfig: () => undefined,
+    } as unknown as MainAgent;
+  });
+
+  it('calls runMidFlightCheck with roundStartSha when synthesis completes (completion path)', async () => {
+    const SHA = 'deadbeef12345678';
+    // runMidFlightCheck must return {warnings:[]} to not throw.
+    (preconditionRunner.runMidFlightCheck as jest.Mock).mockResolvedValue({ warnings: [] });
+
+    seedRound({ roundStartSha: SHA });
+
+    // Submit cross-review from the only pending agent → triggers completion synthesis.
+    await handleRelayCrossReview(CONSENSUS_ID, AGENT_A, '[]');
+
+    expect(preconditionRunner.runMidFlightCheck).toHaveBeenCalledTimes(1);
+    const call = (preconditionRunner.runMidFlightCheck as jest.Mock).mock.calls[0][0] as MidFlightCheckInput;
+    expect(call.roundStartSha).toBe(SHA);
+    expect(call.consensusId).toBe(CONSENSUS_ID);
+    expect(typeof call.projectRoot).toBe('string');
+  });
+
+  it('calls runMidFlightCheck with undefined roundStartSha when not set (no signal emitted)', async () => {
+    (preconditionRunner.runMidFlightCheck as jest.Mock).mockResolvedValue({ warnings: [] });
+
+    // Seed with no roundStartSha.
+    seedRound({ roundStartSha: undefined });
+
+    await handleRelayCrossReview(CONSENSUS_ID, AGENT_A, '[]');
+
+    expect(preconditionRunner.runMidFlightCheck).toHaveBeenCalledTimes(1);
+    const call = (preconditionRunner.runMidFlightCheck as jest.Mock).mock.calls[0][0] as MidFlightCheckInput;
+    expect(call.roundStartSha).toBeUndefined();
+  });
+
+  it('mid_flight_fixup warning surfaces when runMidFlightCheck returns warnings', async () => {
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    (preconditionRunner.runMidFlightCheck as jest.Mock).mockResolvedValue({
+      warnings: ['[mid-flight-fixup] 2 commit(s) landed during Phase 2 cross-review'],
+    });
+
+    seedRound({ roundStartSha: 'abc00001' });
+    await handleRelayCrossReview(CONSENSUS_ID, AGENT_A, '[]');
+
+    const stderrCalls = stderrSpy.mock.calls.map(c => c[0] as string);
+    expect(stderrCalls.some(s => s.includes('mid-flight-fixup'))).toBe(true);
+    stderrSpy.mockRestore();
+  });
+
+  it('does NOT call runMidFlightCheck when round still has pending agents (no synthesis)', async () => {
+    (preconditionRunner.runMidFlightCheck as jest.Mock).mockResolvedValue({ warnings: [] });
+
+    // Two pending agents — submitting one does NOT trigger synthesis.
+    ctx.pendingConsensusRounds.set(CONSENSUS_ID, {
+      consensusId: CONSENSUS_ID,
+      allResults: [
+        { agentId: AGENT_A, status: 'completed', result: '- A', task: 'task' },
+        { agentId: AGENT_B, status: 'completed', result: '- B', task: 'task' },
+      ],
+      relayCrossReviewEntries: [],
+      relayCrossReviewSkipped: undefined,
+      pendingNativeAgents: new Set([AGENT_A, AGENT_B]),
+      participatingNativeAgents: new Set([AGENT_A, AGENT_B]),
+      nativeCrossReviewEntries: [],
+      deadline: Date.now() + 60_000,
+      createdAt: Date.now(),
+      nativePrompts: [],
+      roundStartSha: 'sha-that-should-not-be-read',
+    });
+
+    await handleRelayCrossReview(CONSENSUS_ID, AGENT_A, '[]');
+
+    // Still waiting for AGENT_B — no synthesis, no mid-flight check.
+    expect(preconditionRunner.runMidFlightCheck).not.toHaveBeenCalled();
+  });
+});

--- a/tests/orchestrator/orchestrator-preconditions.test.ts
+++ b/tests/orchestrator/orchestrator-preconditions.test.ts
@@ -1,0 +1,165 @@
+// tests/orchestrator/orchestrator-preconditions.test.ts
+//
+// Unit tests for the pure orchestrator-preconditions module (UNIT 1).
+// All functions are dependency-injected and have zero filesystem/shell access.
+// TDD: these tests are written before the implementation.
+
+import {
+  detectStaleBase,
+  findUnreadablePaths,
+  detectMidFlightCommits,
+} from '../../packages/orchestrator/src/orchestrator-preconditions';
+
+// ---------------------------------------------------------------------------
+// detectStaleBase
+// ---------------------------------------------------------------------------
+
+describe('detectStaleBase', () => {
+  const ORIGIN = 'abc123';
+
+  describe('fresh (dispatchSha === originMasterSha)', () => {
+    it('returns { stale: false, reason: null } when SHAs match', () => {
+      const result = detectStaleBase(ORIGIN, ORIGIN, null);
+      expect(result).toEqual({ stale: false, reason: null });
+    });
+
+    it('returns { stale: false, reason: null } when SHAs match and mergeBase is provided', () => {
+      const result = detectStaleBase(ORIGIN, ORIGIN, 'somemergebase');
+      expect(result).toEqual({ stale: false, reason: null });
+    });
+  });
+
+  describe('stale — behind_origin (mergeBaseSha === dispatchSha)', () => {
+    it('returns behind_origin when dispatch is an ancestor of origin master', () => {
+      const dispatchSha = 'old111';
+      const originSha = 'new999';
+      const mergeBaseSha = 'old111'; // mergeBase === dispatch → branch is behind origin
+      const result = detectStaleBase(dispatchSha, originSha, mergeBaseSha);
+      expect(result).toEqual({ stale: true, reason: 'behind_origin' });
+    });
+
+    it('returns behind_origin when mergeBase equals dispatch exactly', () => {
+      const dispatchSha = 'deadbeef';
+      const result = detectStaleBase(dispatchSha, 'headhash', dispatchSha);
+      expect(result).toEqual({ stale: true, reason: 'behind_origin' });
+    });
+  });
+
+  describe('stale — branched_pre_merge (dispatchSha !== originSha, mergeBase !== dispatch)', () => {
+    it('returns branched_pre_merge when dispatch diverged before a merge landed', () => {
+      const dispatchSha = 'branch111';
+      const originSha = 'master999';
+      const mergeBaseSha = 'commonancestor'; // differs from dispatchSha
+      const result = detectStaleBase(dispatchSha, originSha, mergeBaseSha);
+      expect(result).toEqual({ stale: true, reason: 'branched_pre_merge' });
+    });
+
+    it('returns branched_pre_merge when mergeBase is null but SHAs differ', () => {
+      const dispatchSha = 'branch111';
+      const originSha = 'master999';
+      const result = detectStaleBase(dispatchSha, originSha, null);
+      expect(result).toEqual({ stale: true, reason: 'branched_pre_merge' });
+    });
+
+    it('returns branched_pre_merge when all three values are distinct', () => {
+      const result = detectStaleBase('sha-a', 'sha-b', 'sha-c');
+      expect(result).toEqual({ stale: true, reason: 'branched_pre_merge' });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('treats empty string dispatch SHA as different from non-empty origin (stale)', () => {
+      const result = detectStaleBase('', 'origin123', null);
+      expect(result.stale).toBe(true);
+    });
+
+    it('treats both SHAs as equal empty strings → fresh', () => {
+      // Degenerate but should not crash
+      const result = detectStaleBase('', '', null);
+      expect(result).toEqual({ stale: false, reason: null });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findUnreadablePaths
+// ---------------------------------------------------------------------------
+
+describe('findUnreadablePaths', () => {
+  const alwaysTrue = (_p: string): boolean => true;
+  const alwaysFalse = (_p: string): boolean => false;
+  const isEven = (_p: string, i: number): boolean => i % 2 === 0;
+
+  it('returns empty array when all paths are readable', () => {
+    const paths = ['a.ts', 'b.ts', 'c.ts'];
+    expect(findUnreadablePaths(paths, alwaysTrue)).toEqual([]);
+  });
+
+  it('returns all paths when none are readable', () => {
+    const paths = ['x.ts', 'y.ts'];
+    expect(findUnreadablePaths(paths, alwaysFalse)).toEqual(['x.ts', 'y.ts']);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(findUnreadablePaths([], alwaysFalse)).toEqual([]);
+  });
+
+  it('returns subset of unreadable paths', () => {
+    const paths = ['readable.ts', 'missing.ts', 'also-readable.ts'];
+    const canRead = (p: string): boolean => !p.startsWith('missing');
+    expect(findUnreadablePaths(paths, canRead)).toEqual(['missing.ts']);
+  });
+
+  it('returns paths in original order', () => {
+    const paths = ['a', 'b', 'c', 'd', 'e'];
+    const canRead = (p: string): boolean => p === 'b' || p === 'd';
+    expect(findUnreadablePaths(paths, canRead)).toEqual(['a', 'c', 'e']);
+  });
+
+  it('handles a single unreadable path', () => {
+    expect(findUnreadablePaths(['/some/file.ts'], alwaysFalse)).toEqual(['/some/file.ts']);
+  });
+
+  it('handles a single readable path', () => {
+    expect(findUnreadablePaths(['/some/file.ts'], alwaysTrue)).toEqual([]);
+  });
+
+  it('passes the full path string to canRead unchanged', () => {
+    const seen: string[] = [];
+    const canRead = (p: string): boolean => { seen.push(p); return true; };
+    findUnreadablePaths(['/a/b/c.ts', 'relative/path'], canRead);
+    expect(seen).toEqual(['/a/b/c.ts', 'relative/path']);
+  });
+
+  // isEven is only used for coverage of the _p param annotation — unused in suite
+  void isEven;
+});
+
+// ---------------------------------------------------------------------------
+// detectMidFlightCommits
+// ---------------------------------------------------------------------------
+
+describe('detectMidFlightCommits', () => {
+  it('returns { detected: false, count: 0 } for empty array', () => {
+    expect(detectMidFlightCommits([])).toEqual({ detected: false, count: 0 });
+  });
+
+  it('returns { detected: true, count: 1 } for one commit', () => {
+    expect(detectMidFlightCommits(['abc123'])).toEqual({ detected: true, count: 1 });
+  });
+
+  it('returns { detected: true, count: N } for N commits', () => {
+    const commits = ['sha1', 'sha2', 'sha3'];
+    expect(detectMidFlightCommits(commits)).toEqual({ detected: true, count: 3 });
+  });
+
+  it('is not affected by commit content — only length matters', () => {
+    expect(detectMidFlightCommits(['', '', ''])).toEqual({ detected: true, count: 3 });
+  });
+
+  it('handles a large array without issues', () => {
+    const many = Array.from({ length: 100 }, (_, i) => `commit${i}`);
+    const result = detectMidFlightCommits(many);
+    expect(result).toEqual({ detected: true, count: 100 });
+  });
+});

--- a/tests/orchestrator/signal-class.test.ts
+++ b/tests/orchestrator/signal-class.test.ts
@@ -77,6 +77,13 @@ describe('signal_class discriminator (PR 5)', () => {
       expect(classifySignal('unverified')).toBe('operational');
     });
 
+    it('maps orchestrator precondition signal names as operational', () => {
+      // UNIT 1 orchestrator signal pipeline — tallied only, never scored.
+      expect(classifySignal('dispatched_stale_base')).toBe('operational');
+      expect(classifySignal('referenced_unreadable_path')).toBe('operational');
+      expect(classifySignal('mid_flight_fixup')).toBe('operational');
+    });
+
     it('classifies category_confirmed / consensus_verified as performance', () => {
       // These are evidence-of-correctness signals — they affect agent accuracy
       // and belong in the performance bucket alongside agreement / hallucination_caught.

--- a/tests/orchestrator/signal-type-snapshot.test.ts
+++ b/tests/orchestrator/signal-type-snapshot.test.ts
@@ -55,6 +55,13 @@ const DOCUMENTED_PATH_SPECIFIC = new Map<string, string>([
   ['relay_findings_dropped',    'collect.ts / relay-tasks.ts (relay-lint Path A)'],
   // Phase A self-telemetry: collect-end reconciliation shortfall
   ['signal_loss_suspected',     'collect.ts (round-reconcile assertion, Phase A self-telemetry)'],
+  // UNIT 1 orchestrator signal pipeline: dispatch-hygiene precondition signals.
+  // Emitted by the orchestrator via orchestrator-preconditions.ts detectors.
+  ['dispatched_stale_base',     'orchestrator-preconditions.ts / dispatch (detectStaleBase)'],
+  ['referenced_unreadable_path', 'orchestrator-preconditions.ts / dispatch (findUnreadablePaths)'],
+  ['mid_flight_fixup',          'orchestrator-preconditions.ts / collect (detectMidFlightCommits)'],
+  // Phase 2 dispatch-prompt warm cache (PR post-signal_loss_suspected)
+  ['dispatch_cache_evicted',    'apps/cli/src/handlers/dispatch-prompt-cache.ts (LRU/invalidation/overwrite_race)'],
 ]);
 
 // ── Exhaustive union of all known signal names ─────────────────────────────
@@ -77,6 +84,12 @@ const ALL_KNOWN_SIGNAL_NAMES: string[] = [
   'citation_fabricated', 'relay_findings_dropped',
   // Phase A self-telemetry
   'signal_loss_suspected',
+  // Phase 2 dispatch-prompt warm cache
+  'dispatch_cache_evicted',
+  // UNIT 1 orchestrator signal pipeline
+  'dispatched_stale_base',
+  'referenced_unreadable_path',
+  'mid_flight_fixup',
   // signal_retracted appears in both ConsensusSignal and PipelineSignal
 ];
 


### PR DESCRIPTION
## What

Gives the **orchestrator** its own signal-driven instrumentation, mirroring how agents are already scored. Two halves of one idea — *close the failure-feedback loops*:

1. **Orchestrator precondition signals** — objectively-checkable dispatch-hygiene failures the orchestrator controls and agents cannot. Operational-only (tallied, never scored into agent accuracy), recorded against a distinct `orchestrator` pseudo-agent id.
2. **`ask_back()`** — the agent-side mirror: after a fabrication is caught, re-engage the offending agent for a first-person root-cause and log it as skill substrate.

Design rule (endorsed independently by two reviewer agents): **score preconditions, not decisions.** Judgment calls (agent selection, consensus gating, when to stop) are explicitly excluded — no ground truth.

## Commits

| Unit | What |
|---|---|
| 1 | Pure precondition detectors (`detectStaleBase`/`findUnreadablePaths`/`detectMidFlightCommits`) + 3 operational signal names |
| 2 | Pre-dispatch guard: `dispatched_stale_base` + `referenced_unreadable_path` warn **before** a round is wasted |
| 3 | `mid_flight_fixup` — commits landing during Phase 2 cross-review |
| 4 | `gossip_ask_back` MCP tool + `.gossip/fabrication-introspections.jsonl` ledger |
| 6 | Consensus-driven fixes (see below) |

## Consensus review

Round `52bd17eb-88b84c50` (2× sonnet-reviewer + deepseek-challenger) — every finding orchestrator-verified against source:

- **HIGH (fixed):** `mid_flight_fixup` never fired in production — `roundStartSha` was read at collect-end *after* the round entry is deleted in `relay-cross-review.ts`, and the `authId` fallback referenced a non-existent `ConsensusReport.findings` field. Moved the check into `relay-cross-review.ts` (read-before-delete at both synthesis sites). The gap was **untested integration** — now locked by `relay-cross-review-midflight.test.ts`.
- **MEDIUM (fixed):** `captureHeadSha` hoisted out of the hot-path literal; `ask_back` empty-string guard; answered-row timestamp no longer corrupts latency; introspection ledger now rotates at 5MB.
- **LOW (fixed):** dynamic `import()` → static (esbuild single-file bundle doesn't include dynamic imports).

## Identity / safety

`orchestrator` (no underscore) passes the reserved-id gate without weakening it, and pipeline signals are filtered out of `readSignals()` before scoring — so it can never pollute agent accuracy (structural, type-level protection).

## Tests

Full `tests/cli` + `tests/orchestrator`: 3850 pass, 0 new failures (`mcp-server-code-dispatch.test.ts` fails pre-existing on master, verified by stash + checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)