### PR TITLE
feat(dashboard): deep-linkable task detail page (Tranche 1)

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useMemo, useState } from 'react';
-import { useRoute } from '@/lib/router';
+import { useRoute, matchRoute } from '@/lib/router';
 import { OverviewPage } from '@/pages/OverviewPage';
 import { ConsensusFlowPage } from '@/pages/ConsensusFlowPage';
+import { TaskPage } from '@/pages/TaskPage';
 import { AuthGate } from '@/components/AuthGate';
 import { TopBar } from '@/components/TopBar';
 import { NeuralAvatar } from '@/components/NeuralAvatar';
@@ -12,6 +13,7 @@ import { AgentPage } from '@/components/AgentPage';
 import { LogsPage } from '@/components/LogsPage';
 import { SignalsPage } from '@/components/SignalsPage';
 import { TaskRow } from '@/components/TaskRow';
+import { EmptyState } from '@/components/EmptyState';
 import { OverviewSkeleton, TeamPageSkeleton, TasksPageSkeleton, DebatesPageSkeleton } from '@/components/Skeleton';
 import { useAuth } from '@/hooks/useAuth';
 import { useWebSocket } from '@/hooks/useWebSocket';
@@ -418,9 +420,16 @@ function TasksPage({ tasks }: { tasks: import('@/lib/types').TasksData }) {
 
       <div className="overflow-hidden rounded-md [border-color:color-mix(in_oklch,var(--border)_40%,transparent)] border" style={{ background: 'color-mix(in oklch, var(--surface-elev) 80%, transparent)' }}>
         {paged.length === 0 ? (
-          <div className="py-12 text-center text-sm" style={{ color: 'var(--ink-3)' }}>
-            {q ? 'No tasks match your search.' : 'No tasks yet.'}
-          </div>
+          q ? (
+            <div className="py-12 text-center text-sm" style={{ color: 'var(--ink-3)' }}>
+              No tasks match your search.
+            </div>
+          ) : (
+            <EmptyState
+              title="No tasks yet"
+              hint="Dispatch with gossip_run to populate this view."
+            />
+          )
         ) : (
           <table className="w-full text-left">
             <thead>
@@ -428,6 +437,7 @@ function TasksPage({ tasks }: { tasks: import('@/lib/types').TasksData }) {
                 <th className="py-2.5 pl-4 pr-2 h-section" style={{ width: 32 }}></th>
                 <th className="py-2.5 pr-3 h-section">ID</th>
                 <th className="py-2.5 pr-3 h-section">Agent</th>
+                <th className="py-2.5 pr-3 h-section">Kind</th>
                 <th className="py-2.5 pr-3 h-section">Description</th>
                 <th className="py-2.5 pr-3 h-section">Duration</th>
                 <th className="py-2.5 pr-4 text-right h-section">When</th>
@@ -556,12 +566,15 @@ function Dashboard({ onUnauthorized }: { onUnauthorized: () => void }) {
   let content;
   const agentMatch = route.match(/^\/agent\/(.+)$/);
   const consensusFlowMatch = route.match(/^\/consensus\/(.+)$/);
+  const taskDetailId = matchRoute('/tasks/:id', route);
   if (agentMatch && agents) {
     const agentId = decodeURIComponent(agentMatch[1]);
     content = <AgentPage agentId={agentId} agents={agents} tasks={tasks} consensus={consensus} />;
   } else if (consensusFlowMatch) {
     const consensusId = decodeURIComponent(consensusFlowMatch[1]);
     content = <ConsensusFlowPage consensusId={consensusId} />;
+  } else if (taskDetailId) {
+    content = <TaskPage taskId={taskDetailId} tasks={tasks} />;
   } else if (route === '/team') {
     content = agents
       ? <TeamPage agents={agents} tasks={tasks} consensusReports={consensusReports} fleetTrend={fleetTrend} />
@@ -615,7 +628,7 @@ function Dashboard({ onUnauthorized }: { onUnauthorized: () => void }) {
   // Overview owns its own outer container (max-w-5xl). For everything else,
   // the historical max-w-7xl + space-y-6 wrapper applies.
   const isOverview = route === '/' || route === '/overview' ||
-    !(/^\/(agent\/|consensus\/|team|tasks|debates|logs|signals|violations|chat)/.test(route));
+    !(/^\/(agent\/|consensus\/|tasks\/|team|tasks|debates|logs|signals|violations|chat)/.test(route));
   const mainClass = isOverview
     ? 'px-6 py-6'
     : 'mx-auto max-w-7xl space-y-6 px-6 py-6';

--- a/packages/dashboard-v2/src/components/TaskRow.tsx
+++ b/packages/dashboard-v2/src/components/TaskRow.tsx
@@ -1,114 +1,12 @@
-import type { JSX } from 'react';
-import type React from 'react';
 import type { TaskItem } from '@/lib/types';
-import { timeAgo, agentColor } from '@/lib/utils';
+import { timeAgo, agentColor, taskKindFromAgentId } from '@/lib/utils';
+import { normaliseStatus, STATUS_META, STATUS_ICON } from '@/lib/task-status';
+import { navigate } from '@/lib/router';
 
 interface TaskRowProps {
   task: TaskItem;
   onClick?: (task: TaskItem) => void;
 }
-
-/**
- * Canonical status buckets the indicator renders. We normalise incoming status
- * strings (including aliases we may receive from older task sources) into one
- * of these five keys so the icon-box treatment stays exhaustive.
- */
-type StatusKey = 'completed' | 'running' | 'failed' | 'cancelled' | 'unknown';
-
-/**
- * Normalise a free-form task status into one of our canonical buckets. The
- * TaskItem type currently narrows to four literals, but collect/relay can
- * surface aliases ("done", "error", "in_progress", etc.) — we fold those in
- * rather than letting them fall through to the gray "unknown" fallback.
- */
-function normaliseStatus(status: string): StatusKey {
-  const s = status.toLowerCase();
-  if (s === 'completed' || s === 'done' || s === 'success' || s === 'succeeded') return 'completed';
-  if (s === 'running' || s === 'active' || s === 'in_progress' || s === 'pending') return 'running';
-  if (s === 'failed' || s === 'error' || s === 'errored' || s === 'timeout' || s === 'timed_out') return 'failed';
-  if (s === 'cancelled' || s === 'canceled' || s === 'queued' || s === 'waiting') return 'cancelled';
-  return 'unknown';
-}
-
-/**
- * Per-status visual treatment: label, icon box tint, text color, and whether
- * the icon box animates. Mirrors the MemoryFolders icon-box pattern (faint
- * tinted background + 1px border ring in the same hue) so the dashboard's
- * semantic palette stays consistent across panels.
- */
-const STATUS_META: Record<StatusKey, {
-  label: string;
-  iconBox: string;   // bg tint + border ring on the 22px square
-  text: string;      // icon stroke + label color
-  textStyle?: React.CSSProperties;
-  pulse: boolean;    // subtle breathing outline for in-flight tasks
-}> = {
-  completed: {
-    label: 'Done',
-    iconBox: 'bg-confirmed/10 border-confirmed/30',
-    text: 'text-confirmed',
-    pulse: false,
-  },
-  running: {
-    label: 'Running',
-    iconBox: 'bg-unverified/10 border-unverified/30',
-    text: 'text-unverified',
-    pulse: true,
-  },
-  failed: {
-    label: 'Failed',
-    iconBox: 'bg-bad/10 border-bad/30',
-    text: 'text-bad',
-    pulse: false,
-  },
-  cancelled: {
-    label: 'Cancelled',
-    iconBox: 'border-muted-foreground/25',
-    text: '',
-    textStyle: { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--text-dim) 10%, transparent)' },
-    pulse: false,
-  },
-  unknown: {
-    label: 'Unknown',
-    iconBox: 'border-muted-foreground/25',
-    text: '',
-    textStyle: { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--text-dim) 10%, transparent)' },
-    pulse: false,
-  },
-};
-
-/**
- * Inline SVG glyphs — no icon library, stroke="currentColor" so the parent's
- * text color drives hue, and strokeWidth="1.5" matches MemoryFolders.
- *
- *   completed → check
- *   running   → concentric dot (reads as "in progress" and pulses)
- *   failed    → x
- *   cancelled → horizontal bar (dash)
- *   unknown   → question mark
- */
-const STATUS_ICON: Record<StatusKey, JSX.Element> = {
-  completed: <polyline points="5 12 10 17 19 7" />,
-  running: (
-    <>
-      <circle cx="12" cy="12" r="3" fill="currentColor" stroke="none" />
-      <circle cx="12" cy="12" r="8" opacity="0.45" />
-    </>
-  ),
-  failed: (
-    <>
-      <line x1="6" y1="6" x2="18" y2="18" />
-      <line x1="18" y1="6" x2="6" y2="18" />
-    </>
-  ),
-  cancelled: <line x1="6" y1="12" x2="18" y2="12" />,
-  unknown: (
-    <>
-      <path d="M9.5 9a2.5 2.5 0 1 1 3.5 2.3c-.8.4-1 .9-1 1.7" />
-      <line x1="12" y1="16.5" x2="12" y2="16.5" />
-    </>
-  ),
-};
 
 function formatDurationNice(ms?: number): string {
   if (!ms) return '—';
@@ -127,19 +25,23 @@ function formatDurationNice(ms?: number): string {
 export function TaskRow({ task, onClick }: TaskRowProps) {
   const key = normaliseStatus(task.status);
   const meta = STATUS_META[key];
+  const kind = taskKindFromAgentId(task.agentId);
 
   return (
     <tr
-      className={`border-b border-border hover:bg-accent/10 transition-colors ${onClick ? 'cursor-pointer' : ''}`}
-      onClick={onClick ? (e) => {
+      className={`border-b border-border hover:bg-accent/10 transition-colors cursor-pointer`}
+      onClick={(e) => {
         if ((e.target as HTMLElement).closest('a')) return;
-        onClick(task);
-      } : undefined}
+        // Navigate to the task detail page; also call the legacy setSelected callback
+        // so the modal still works until it's fully deprecated.
+        onClick?.(task);
+        navigate('/tasks/' + task.taskId);
+      }}
     >
       <td className="py-2.5 pl-4 pr-2">
         <span className="inline-flex items-center gap-2" aria-label={`Status: ${meta.label}`}>
           <span
-            className={`flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full border ${meta.iconBox} ${meta.text} ${meta.pulse ? 'animate-pulse' : ''}`}
+            className={`flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full border ${meta.iconBox} ${meta.text} ${meta.pulse ? 'animate-pulse motion-reduce:animate-none' : ''}`}
             style={meta.textStyle}
             aria-hidden
           >
@@ -162,8 +64,14 @@ export function TaskRow({ task, onClick }: TaskRowProps) {
         </span>
       </td>
       <td className="py-2.5 pr-3">
+        {/* Neutral ID badge — not warn-badge amber (semantic misuse fixed) */}
         <span
-          className="warn-badge rounded px-2 py-1 font-mono text-[10px] font-semibold"
+          className="rounded border px-2 py-1 font-mono text-[10px] font-semibold"
+          style={{
+            borderColor: 'color-mix(in oklch, var(--border) 40%, transparent)',
+            color: 'var(--ink-3)',
+            background: 'color-mix(in oklch, var(--surface) 60%, transparent)',
+          }}
           title={task.taskId}
         >
           {task.taskId.slice(0, 8)}
@@ -175,6 +83,17 @@ export function TaskRow({ task, onClick }: TaskRowProps) {
           {task.agentId}
         </a>
       </td>
+      {kind && (
+        <td className="py-2.5 pr-3">
+          <span
+            className={`rounded-sm border border-border/40 px-1 py-0.5 font-mono text-[9px] font-bold uppercase tracking-wider ${kind.cls}`}
+            style={{ background: 'color-mix(in oklch, var(--surface) 40%, transparent)', ...kind.clsStyle }}
+          >
+            {kind.label}
+          </span>
+        </td>
+      )}
+      {!kind && <td className="py-2.5 pr-3" />}
       <td className="py-2.5 pr-3 text-xs leading-snug" style={{ color: 'color-mix(in oklch, var(--text) 80%, transparent)' }}>
         {(() => { const line = task.task.replace(/\n.*/s, ''); return line.length > 100 ? line.slice(0, 100) + '…' : line; })()}
       </td>

--- a/packages/dashboard-v2/src/components/TasksSection.tsx
+++ b/packages/dashboard-v2/src/components/TasksSection.tsx
@@ -1,7 +1,6 @@
-import type { JSX } from 'react';
-import type React from 'react';
 import type { TasksData } from '@/lib/types';
-import { timeAgo } from '@/lib/utils';
+import { timeAgo, taskKindFromAgentId } from '@/lib/utils';
+import { normaliseStatus, STATUS_META, STATUS_ICON } from '@/lib/task-status';
 import { EmptyState } from './EmptyState';
 
 const DEFAULT_PAGE_SIZE = 8;
@@ -11,78 +10,9 @@ interface TasksSectionProps {
   limit?: number;
 }
 
-/**
- * Canonical status buckets — kept in sync with TaskRow.tsx. If you tweak one,
- * tweak the other: these two components are the dashboard's two surface areas
- * for task status and should read as the same visual language.
- */
-type StatusKey = 'completed' | 'running' | 'failed' | 'cancelled' | 'unknown';
-
-function normaliseStatus(status: string): StatusKey {
-  const s = status.toLowerCase();
-  if (s === 'completed' || s === 'done' || s === 'success' || s === 'succeeded') return 'completed';
-  if (s === 'running' || s === 'active' || s === 'in_progress' || s === 'pending') return 'running';
-  if (s === 'failed' || s === 'error' || s === 'errored' || s === 'timeout' || s === 'timed_out') return 'failed';
-  if (s === 'cancelled' || s === 'canceled' || s === 'queued' || s === 'waiting') return 'cancelled';
-  return 'unknown';
-}
-
-/**
- * Compact variant of the TaskRow icon-box treatment: 18px square so the inline
- * task list stays dense. Same palette + glyph language to keep both surfaces
- * reading as one system.
- */
-const STATUS_META: Record<StatusKey, {
-  label: string;
-  iconBox: string;
-  text: string;
-  textStyle?: React.CSSProperties;
-  pulse: boolean;
-}> = {
-  completed: { label: 'Done', iconBox: 'bg-confirmed/10 border-confirmed/30', text: 'text-confirmed', pulse: false },
-  running: { label: 'Running', iconBox: 'bg-unverified/10 border-unverified/30', text: 'text-unverified', pulse: true },
-  failed: { label: 'Failed', iconBox: 'bg-destructive/10 border-destructive/30', text: 'text-destructive', pulse: false },
-  cancelled: { label: 'Cancelled', iconBox: 'border-muted-foreground/25', text: '', textStyle: { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--text-dim) 10%, transparent)' }, pulse: false },
-  unknown: { label: 'Unknown', iconBox: 'border-muted-foreground/25', text: '', textStyle: { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--text-dim) 10%, transparent)' }, pulse: false },
-};
-
-const STATUS_ICON: Record<StatusKey, JSX.Element> = {
-  completed: <polyline points="5 12 10 17 19 7" />,
-  running: (
-    <>
-      <circle cx="12" cy="12" r="3" fill="currentColor" stroke="none" />
-      <circle cx="12" cy="12" r="8" opacity="0.45" />
-    </>
-  ),
-  failed: (
-    <>
-      <line x1="6" y1="6" x2="18" y2="18" />
-      <line x1="18" y1="6" x2="6" y2="18" />
-    </>
-  ),
-  cancelled: <line x1="6" y1="12" x2="18" y2="12" />,
-  unknown: (
-    <>
-      <path d="M9.5 9a2.5 2.5 0 1 1 3.5 2.3c-.8.4-1 .9-1 1.7" />
-      <line x1="12" y1="16.5" x2="12" y2="16.5" />
-    </>
-  ),
-};
-
 // Short-form task ID: first 8 chars of a UUID (or whatever ID is present).
 function shortTaskId(id: string): string {
   return id.length > 8 ? id.slice(0, 8) : id;
-}
-
-// Derive a visual kind chip from the agentId suffix.
-// Returns null for unrecognized suffixes so the chip is omitted entirely.
-function taskKindFromAgentId(agentId: string): { label: string; cls: string; clsStyle?: React.CSSProperties } | null {
-  if (agentId.endsWith('-implementer')) return { label: 'IMPL', cls: 'text-unique' };
-  if (agentId.endsWith('-reviewer'))    return { label: 'REVIEW', cls: 'text-chart' };
-  if (agentId.endsWith('-tester'))      return { label: 'TEST', cls: 'text-unique' };
-  if (agentId.endsWith('-researcher'))  return { label: 'RESEARCH', cls: '', clsStyle: { color: 'var(--text-dim)' } };
-  if (agentId.endsWith('-designer'))    return { label: 'DESIGN', cls: 'text-chart' };
-  return null;
 }
 
 export function TasksSection({ tasks, limit = DEFAULT_PAGE_SIZE }: TasksSectionProps) {
@@ -118,7 +48,7 @@ export function TasksSection({ tasks, limit = DEFAULT_PAGE_SIZE }: TasksSectionP
                 className={`flex items-start gap-3 px-3.5 py-2.5 hover:bg-accent/20 transition-colors ${i > 0 ? 'border-t border-border/20' : ''}`}
               >
                 <span
-                  className={`mt-0.5 flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border ${meta.iconBox} ${meta.text} ${meta.pulse ? 'animate-pulse' : ''}`}
+                  className={`mt-0.5 flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border ${meta.iconBox} ${meta.text} ${meta.pulse ? 'animate-pulse motion-reduce:animate-none' : ''}`}
                   style={meta.textStyle}
                   aria-label={`Status: ${meta.label}`}
                   data-tooltip={meta.label}

--- a/packages/dashboard-v2/src/lib/router.ts
+++ b/packages/dashboard-v2/src/lib/router.ts
@@ -44,6 +44,30 @@ if (typeof document !== 'undefined' && !(window as any).__dashboardRouterInstall
   });
 }
 
+/**
+ * Match a parametric route pattern against the current route string.
+ * Supports a single `:param` segment (e.g. "/tasks/:id").
+ *
+ * Returns the captured param value (URL-decoded) or null if no match.
+ *
+ * Examples:
+ *   matchRoute('/tasks/:id', '/tasks/abc123')  → 'abc123'
+ *   matchRoute('/tasks/:id', '/tasks')          → null
+ *   matchRoute('/agent/:id', '/tasks/abc123')   → null
+ */
+export function matchRoute(pattern: string, route: string): string | null {
+  // Build a regex from the pattern by replacing `:param` with a capture group.
+  // We first escape regex special chars, then replace the (now-escaped) `:param`
+  // placeholder with a capture group.  The `:` char is not a regex special char so
+  // it survives the first pass intact; `\w` is safe to replace afterward.
+  const escaped = pattern
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/:\w+/g, '([^/]+)');
+  const re = new RegExp(`^${escaped}$`);
+  const m = route.match(re);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
 export function useRoute(): string {
   const [route, setRoute] = useState(currentRoute());
 

--- a/packages/dashboard-v2/src/lib/task-status.tsx
+++ b/packages/dashboard-v2/src/lib/task-status.tsx
@@ -1,0 +1,105 @@
+/**
+ * Canonical task status constants shared between TaskRow.tsx and TasksSection.tsx.
+ * Extract here to avoid duplicating normaliseStatus / STATUS_META / STATUS_ICON
+ * across two components that must render the same visual language.
+ */
+import type { JSX } from 'react';
+import type React from 'react';
+
+/** The five canonical status buckets the indicator renders. */
+export type StatusKey = 'completed' | 'running' | 'failed' | 'cancelled' | 'unknown';
+
+/**
+ * Normalise a free-form task status into one of our canonical buckets. The
+ * TaskItem type currently narrows to four literals, but collect/relay can
+ * surface aliases ("done", "error", "in_progress", etc.) — we fold those in
+ * rather than letting them fall through to the gray "unknown" fallback.
+ */
+export function normaliseStatus(status: string): StatusKey {
+  const s = status.toLowerCase();
+  if (s === 'completed' || s === 'done' || s === 'success' || s === 'succeeded') return 'completed';
+  if (s === 'running' || s === 'active' || s === 'in_progress' || s === 'pending') return 'running';
+  if (s === 'failed' || s === 'error' || s === 'errored' || s === 'timeout' || s === 'timed_out') return 'failed';
+  if (s === 'cancelled' || s === 'canceled' || s === 'queued' || s === 'waiting') return 'cancelled';
+  return 'unknown';
+}
+
+/**
+ * Per-status visual treatment: label, icon box tint, text color, and whether
+ * the icon box animates. Mirrors the MemoryFolders icon-box pattern (faint
+ * tinted background + 1px border ring in the same hue) so the dashboard's
+ * semantic palette stays consistent across panels.
+ */
+export const STATUS_META: Record<StatusKey, {
+  label: string;
+  iconBox: string;   // bg tint + border ring on the status icon square
+  text: string;      // icon stroke + label color
+  textStyle?: React.CSSProperties;
+  pulse: boolean;    // subtle breathing outline for in-flight tasks
+}> = {
+  completed: {
+    label: 'Done',
+    iconBox: 'bg-confirmed/10 border-confirmed/30',
+    text: 'text-confirmed',
+    pulse: false,
+  },
+  running: {
+    label: 'Running',
+    iconBox: 'bg-unverified/10 border-unverified/30',
+    text: 'text-unverified',
+    pulse: true,
+  },
+  failed: {
+    label: 'Failed',
+    iconBox: 'bg-bad/10 border-bad/30',
+    text: 'text-bad',
+    pulse: false,
+  },
+  cancelled: {
+    label: 'Cancelled',
+    iconBox: 'border-muted-foreground/25',
+    text: '',
+    textStyle: { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--text-dim) 10%, transparent)' },
+    pulse: false,
+  },
+  unknown: {
+    label: 'Unknown',
+    iconBox: 'border-muted-foreground/25',
+    text: '',
+    textStyle: { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--text-dim) 10%, transparent)' },
+    pulse: false,
+  },
+};
+
+/**
+ * Inline SVG glyphs — no icon library, stroke="currentColor" so the parent's
+ * text color drives hue, and strokeWidth="1.5" matches MemoryFolders.
+ *
+ *   completed → check
+ *   running   → concentric dot (reads as "in progress" and pulses)
+ *   failed    → x
+ *   cancelled → horizontal bar (dash)
+ *   unknown   → question mark
+ */
+export const STATUS_ICON: Record<StatusKey, JSX.Element> = {
+  completed: <polyline points="5 12 10 17 19 7" />,
+  running: (
+    <>
+      <circle cx="12" cy="12" r="3" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="12" r="8" opacity="0.45" />
+    </>
+  ),
+  failed: (
+    <>
+      <line x1="6" y1="6" x2="18" y2="18" />
+      <line x1="18" y1="6" x2="6" y2="18" />
+    </>
+  ),
+  cancelled: <line x1="6" y1="12" x2="18" y2="12" />,
+  unknown: (
+    <>
+      <path d="M9.5 9a2.5 2.5 0 1 1 3.5 2.3c-.8.4-1 .9-1 1.7" />
+      <line x1="12" y1="16.5" x2="12" y2="16.5" />
+    </>
+  ),
+};

--- a/packages/dashboard-v2/src/lib/utils.ts
+++ b/packages/dashboard-v2/src/lib/utils.ts
@@ -314,3 +314,23 @@ export function agentColor(id: string): string {
   for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
   return AGENT_COLORS[h % AGENT_COLORS.length];
 }
+
+/**
+ * Derive a visual kind label from the agentId suffix.
+ * Returns null for unrecognized suffixes so the chip is omitted entirely.
+ * Shared between TaskRow.tsx, TasksSection.tsx, and TaskPage.tsx.
+ */
+export interface TaskKind {
+  label: string;
+  cls: string;
+  clsStyle?: import('react').CSSProperties;
+}
+
+export function taskKindFromAgentId(agentId: string): TaskKind | null {
+  if (agentId.endsWith('-implementer')) return { label: 'IMPL', cls: 'text-unique' };
+  if (agentId.endsWith('-reviewer'))    return { label: 'REVIEW', cls: 'text-chart' };
+  if (agentId.endsWith('-tester'))      return { label: 'TEST', cls: 'text-unique' };
+  if (agentId.endsWith('-researcher'))  return { label: 'RESEARCH', cls: '', clsStyle: { color: 'var(--text-dim)' } };
+  if (agentId.endsWith('-designer'))    return { label: 'DESIGN', cls: 'text-chart' };
+  return null;
+}

--- a/packages/dashboard-v2/src/pages/TaskPage.tsx
+++ b/packages/dashboard-v2/src/pages/TaskPage.tsx
@@ -1,0 +1,382 @@
+/**
+ * TaskPage — deep-linkable full-page task detail view.
+ *
+ * Reads the task from the same tasks data TasksPage uses (passed as a prop).
+ * Does NOT make any API call — that is Tranche 2.
+ *
+ * If the task ID is not in the loaded set (cold deep-link), renders a graceful
+ * "not found" frame rather than crashing.
+ */
+import { renderMarkdown, renderFindingMarkdown, agentColor, taskKindFromAgentId, formatDuration, timeAgo } from '@/lib/utils';
+import { normaliseStatus, STATUS_META, STATUS_ICON } from '@/lib/task-status';
+import type { TaskItem, TasksData } from '@/lib/types';
+import { navigate } from '@/lib/router';
+
+interface TaskPageProps {
+  taskId: string;
+  tasks: TasksData | null;
+}
+
+// ──────────────────────────────────────────────
+// Status chip — semantic per DESIGN.md
+// ──────────────────────────────────────────────
+function StatusChip({ status }: { status: string }) {
+  const key = normaliseStatus(status);
+  const meta = STATUS_META[key];
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[11px] font-semibold ${meta.iconBox} ${meta.text}`}
+      style={meta.textStyle}
+    >
+      <svg
+        width="10"
+        height="10"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+        className={meta.pulse ? 'animate-pulse motion-reduce:animate-none' : ''}
+      >
+        {STATUS_ICON[key]}
+      </svg>
+      {meta.label}
+    </span>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Breadcrumb
+// ──────────────────────────────────────────────
+function Breadcrumb({ taskId }: { taskId: string }) {
+  return (
+    <nav className="mb-4 flex items-center gap-1.5 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }} aria-label="Breadcrumb">
+      <button
+        onClick={() => navigate('/tasks')}
+        className="transition hover:underline"
+        style={{ color: 'var(--ink-2)' }}
+      >
+        Tasks
+      </button>
+      <span aria-hidden>›</span>
+      <span style={{ color: 'var(--ink-3)' }}>{taskId.slice(0, 8)}</span>
+    </nav>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Lifecycle timeline — 2-node hairline CSS
+// dispatched → completed (or failed)
+// ──────────────────────────────────────────────
+interface TimelineProps {
+  task: TaskItem;
+}
+
+function LifecycleTimeline({ task }: TimelineProps) {
+  const key = normaliseStatus(task.status);
+  const dispatched = new Date(task.timestamp);
+  const completedMs = task.duration != null ? new Date(dispatched.getTime() + task.duration).getTime() : null;
+
+  const formatTime = (d: Date) =>
+    d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+
+  const isFailed = key === 'failed';
+  const isRunning = key === 'running';
+
+  // Terminal node label + color
+  const endLabel = isFailed ? 'Failed' : isRunning ? 'Running…' : 'Completed';
+  const endColor = isFailed ? 'var(--bad)' : isRunning ? 'var(--info)' : 'var(--ok)';
+  const endBorder = isFailed ? 'var(--bad)' : isRunning ? 'var(--info)' : 'var(--ok)';
+
+  return (
+    <div className="flex items-start gap-0" aria-label="Task lifecycle timeline">
+      {/* Dispatched node */}
+      <div className="flex flex-col items-center" style={{ minWidth: 120 }}>
+        <div
+          className="h-3 w-3 rounded-full border-2"
+          style={{ borderColor: 'var(--ink-3)', background: 'var(--surface)' }}
+        />
+        <div className="mt-1 font-mono text-[10px] font-semibold" style={{ color: 'var(--ink-2)' }}>
+          Dispatched
+        </div>
+        <div className="font-mono text-[10px]" style={{ color: 'var(--ink-3)' }}>
+          {formatTime(dispatched)}
+        </div>
+      </div>
+
+      {/* Connecting line */}
+      <div
+        className="mt-1.5 flex-1"
+        style={{ height: 2, background: isFailed ? 'color-mix(in oklch, var(--bad) 30%, transparent)' : 'var(--border)', minWidth: 40 }}
+        aria-hidden
+      />
+
+      {/* Terminal node */}
+      <div className="flex flex-col items-center" style={{ minWidth: 120 }}>
+        <div
+          className="h-3 w-3 rounded-full border-2"
+          style={{
+            borderColor: endBorder,
+            background: isFailed ? 'color-mix(in oklch, var(--bad) 15%, transparent)' : 'var(--surface)',
+          }}
+        />
+        <div className="mt-1 font-mono text-[10px] font-semibold" style={{ color: endColor }}>
+          {endLabel}
+        </div>
+        <div className="font-mono text-[10px]" style={{ color: 'var(--ink-3)' }}>
+          {completedMs ? formatTime(new Date(completedMs)) : '—'}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Section header — small-caps Geist per DESIGN.md
+// ──────────────────────────────────────────────
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h3
+      className="mb-3 h-section pb-2"
+      style={{ borderBottom: '1px solid var(--border)' }}
+    >
+      {children}
+    </h3>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Key-value row
+// ──────────────────────────────────────────────
+function KVRow({ label, children, dimmed = false }: { label: string; children: React.ReactNode; dimmed?: boolean }) {
+  return (
+    <div className="flex items-start gap-4 py-1.5 border-b border-border/20 last:border-0">
+      <span
+        className="w-32 shrink-0 font-mono text-[11px]"
+        style={{ color: 'var(--ink-3)' }}
+      >
+        {label}
+      </span>
+      <span
+        className="flex-1 font-mono text-[11px]"
+        style={{ color: dimmed ? 'color-mix(in oklch, var(--ink-3) 60%, transparent)' : 'var(--ink-2)' }}
+      >
+        {children}
+      </span>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Not-found frame (cold deep-link)
+// ──────────────────────────────────────────────
+function TaskNotFound({ taskId }: { taskId: string }) {
+  return (
+    <div>
+      <Breadcrumb taskId={taskId} />
+      <div
+        className="rounded-lg border p-8 text-center"
+        style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+      >
+        <div className="font-mono text-sm font-semibold" style={{ color: 'var(--ink-2)' }}>
+          Task not in the loaded list
+        </div>
+        <div className="mt-2 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
+          <code
+            className="rounded px-1"
+            style={{ fontFamily: 'JetBrains Mono, monospace', background: 'color-mix(in oklch, var(--surface-sunk) 40%, transparent)' }}
+          >
+            {taskId}
+          </code>
+        </div>
+        <div className="mt-4 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
+          Open it from the{' '}
+          <button
+            onClick={() => navigate('/tasks')}
+            className="underline transition hover:opacity-80"
+            style={{ color: 'var(--info)' }}
+          >
+            Tasks list
+          </button>{' '}
+          first to load the session — direct task fetch arrives in a later update.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Main page
+// ──────────────────────────────────────────────
+import type React from 'react';
+
+export function TaskPage({ taskId, tasks }: TaskPageProps) {
+  // Find the task in the loaded set
+  const task: TaskItem | undefined = tasks?.items.find((t) => t.taskId === taskId);
+
+  if (!task) {
+    return <TaskNotFound taskId={taskId} />;
+  }
+
+  const key = normaliseStatus(task.status);
+  const kind = taskKindFromAgentId(task.agentId);
+  const totalTokens = (task.inputTokens ?? 0) + (task.outputTokens ?? 0);
+
+  return (
+    <div className="space-y-6">
+      {/* Breadcrumb */}
+      <Breadcrumb taskId={taskId} />
+
+      {/* ── Header card ── */}
+      <div
+        className="rounded-lg border p-5"
+        style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+      >
+        {/* Row 1: status + kind + full ID */}
+        <div className="flex flex-wrap items-center gap-3">
+          <StatusChip status={task.status} />
+          {kind && (
+            <span
+              className={`rounded-sm border border-border/40 px-1.5 py-0.5 font-mono text-[10px] font-bold uppercase tracking-wider ${kind.cls}`}
+              style={{ background: 'color-mix(in oklch, var(--surface) 40%, transparent)', ...kind.clsStyle }}
+            >
+              {kind.label}
+            </span>
+          )}
+          {/* Full UUID in JetBrains Mono */}
+          <code
+            className="rounded px-2 py-0.5 text-[11px]"
+            style={{
+              fontFamily: 'JetBrains Mono, monospace',
+              color: 'var(--ink-2)',
+              background: 'color-mix(in oklch, var(--surface-sunk) 40%, transparent)',
+            }}
+          >
+            {task.taskId}
+          </code>
+        </div>
+
+        {/* Row 2: agent identity dot + name → /agent/:id */}
+        <div className="mt-3 flex flex-wrap items-center gap-4">
+          <a
+            href={`/dashboard/agent/${encodeURIComponent(task.agentId)}`}
+            className="inline-flex items-center gap-2 font-mono text-xs transition hover:opacity-80"
+            style={{ color: 'var(--ink-2)' }}
+          >
+            <span
+              className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+              style={{ backgroundColor: agentColor(task.agentId) }}
+            />
+            {task.agentId}
+          </a>
+
+          {/* Token split */}
+          {totalTokens > 0 && (
+            <span className="font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
+              <span style={{ color: 'var(--ink-2)' }}>{(task.inputTokens ?? 0).toLocaleString()}</span>
+              {' '}in /{' '}
+              <span style={{ color: 'var(--ink-2)' }}>{(task.outputTokens ?? 0).toLocaleString()}</span>
+              {' '}out tokens
+            </span>
+          )}
+
+          {/* Duration */}
+          {task.duration != null && (
+            <span className="font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
+              {formatDuration(task.duration)}
+            </span>
+          )}
+
+          {/* Timestamp */}
+          <span className="font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
+            {timeAgo(task.timestamp)}
+          </span>
+        </div>
+
+        {/* Row 3: lifecycle timeline */}
+        <div className="mt-5">
+          <LifecycleTimeline task={task} />
+        </div>
+      </div>
+
+      {/* ── Context section (Tranche 2 placeholders) ── */}
+      <div
+        className="rounded-lg border p-5"
+        style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+      >
+        <SectionHeader>context</SectionHeader>
+        <div className="space-y-0">
+          {/* Tranche 2: these will be wired to backend data */}
+          <KVRow label="consensus round" dimmed>
+            <span style={{ color: 'color-mix(in oklch, var(--ink-3) 50%, transparent)' }}>○ none</span>
+            {/* TODO Tranche 2: wire to consensus round ID */}
+          </KVRow>
+          <KVRow label="sibling tasks" dimmed>
+            <span style={{ color: 'color-mix(in oklch, var(--ink-3) 50%, transparent)' }}>○ none</span>
+            {/* TODO Tranche 2: wire to parallel task siblings */}
+          </KVRow>
+          <KVRow label="findings" dimmed>
+            <span style={{ color: 'color-mix(in oklch, var(--ink-3) 50%, transparent)' }}>○ none</span>
+            {/* TODO Tranche 2: wire to implementation-findings.jsonl filtered by taskId */}
+          </KVRow>
+          <KVRow label="signals" dimmed>
+            <span style={{ color: 'color-mix(in oklch, var(--ink-3) 50%, transparent)' }}>○ none</span>
+            {/* TODO Tranche 2: wire to agent-performance.jsonl filtered by taskId */}
+          </KVRow>
+        </div>
+      </div>
+
+      {/* ── Task prompt ── */}
+      <div
+        className="rounded-lg border p-5"
+        style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+      >
+        <SectionHeader>task</SectionHeader>
+        <div
+          className="task-md rounded-md border border-border/40 p-3 text-xs leading-relaxed overflow-x-auto"
+          style={{
+            background: 'color-mix(in oklch, var(--surface) 40%, transparent)',
+            color: 'color-mix(in oklch, var(--ink) 90%, transparent)',
+          }}
+          dangerouslySetInnerHTML={{ __html: renderMarkdown(task.task) }}
+        />
+      </div>
+
+      {/* ── Result ── */}
+      <div
+        className="rounded-lg border p-5"
+        style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+      >
+        <SectionHeader>result</SectionHeader>
+        {task.result ? (
+          <div
+            className="finding-md rounded-md border border-border/40 p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap [&_.cite-file]:rounded [&_.cite-file]:bg-[color-mix(in_oklch,var(--cite-file)_10%,transparent)] [&_.cite-file]:px-1 [&_.cite-file]:text-[var(--cite-file)] [&_.cite-fn]:rounded [&_.cite-fn]:bg-[color-mix(in_oklch,var(--cite-fn)_10%,transparent)] [&_.cite-fn]:px-1 [&_.cite-fn]:text-[var(--cite-fn)] [&_.inline-code]:rounded [&_.inline-code]:bg-[color-mix(in_oklch,var(--surface-sunk)_40%,transparent)] [&_.inline-code]:px-1 [&_.inline-code-block]:my-2 [&_.inline-code-block]:block [&_.inline-code-block]:rounded [&_.inline-code-block]:bg-[color-mix(in_oklch,var(--surface-sunk)_30%,transparent)] [&_.inline-code-block]:p-2"
+            style={{
+              background: 'color-mix(in oklch, var(--surface) 40%, transparent)',
+              color: 'color-mix(in oklch, var(--ink) 90%, transparent)',
+            }}
+            dangerouslySetInnerHTML={{ __html: renderFindingMarkdown(task.result) }}
+          />
+        ) : (
+          <div
+            className="rounded-md border border-border/40 p-5 text-center font-mono text-xs"
+            style={{
+              background: 'color-mix(in oklch, var(--surface) 40%, transparent)',
+              color: 'var(--ink-3)',
+            }}
+          >
+            {key === 'running' ? (
+              <span style={{ color: 'var(--info)' }}>Task is still running…</span>
+            ) : key === 'failed' ? (
+              <span style={{ color: 'var(--bad)' }}>Task failed — no result recorded.</span>
+            ) : (
+              <span>No result recorded.</span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/tests/dashboard/router-param.test.ts
+++ b/tests/dashboard/router-param.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for the matchRoute param-extraction helper added to lib/router.ts.
+ */
+
+import { matchRoute } from '../../packages/dashboard-v2/src/lib/router';
+
+describe('matchRoute', () => {
+  describe('/tasks/:id pattern', () => {
+    it('extracts the task id from a matching route', () => {
+      expect(matchRoute('/tasks/:id', '/tasks/abc12345-def6-7890-ghij-klmnopqrstuv')).toBe(
+        'abc12345-def6-7890-ghij-klmnopqrstuv'
+      );
+    });
+
+    it('extracts a short id', () => {
+      expect(matchRoute('/tasks/:id', '/tasks/abc12345')).toBe('abc12345');
+    });
+
+    it('returns null for /tasks (no id segment)', () => {
+      expect(matchRoute('/tasks/:id', '/tasks')).toBeNull();
+    });
+
+    it('returns null for a completely different route', () => {
+      expect(matchRoute('/tasks/:id', '/agent/sonnet-reviewer')).toBeNull();
+    });
+
+    it('returns null for a route with extra segments', () => {
+      expect(matchRoute('/tasks/:id', '/tasks/abc12345/detail')).toBeNull();
+    });
+
+    it('returns null for empty route', () => {
+      expect(matchRoute('/tasks/:id', '/')).toBeNull();
+    });
+  });
+
+  describe('/agent/:id pattern', () => {
+    it('extracts the agent id', () => {
+      expect(matchRoute('/agent/:id', '/agent/sonnet-reviewer')).toBe('sonnet-reviewer');
+    });
+
+    it('returns null for a mismatched route', () => {
+      expect(matchRoute('/agent/:id', '/tasks/abc123')).toBeNull();
+    });
+  });
+
+  describe('URL decoding', () => {
+    it('decodes percent-encoded characters', () => {
+      expect(matchRoute('/agent/:id', '/agent/my%20agent')).toBe('my agent');
+    });
+
+    it('handles hyphens and underscores', () => {
+      expect(matchRoute('/tasks/:id', '/tasks/my-task_id')).toBe('my-task_id');
+    });
+  });
+
+  describe('TaskPage not-found state', () => {
+    it('matchRoute returns null when the task segment is missing — the not-found frame renders', () => {
+      // The TaskPage renders a graceful not-found frame when tasks.find returns undefined.
+      // We test the routing layer: when there is no :id segment, matchRoute is null
+      // so App.tsx never renders TaskPage at all (falls through to overview).
+      expect(matchRoute('/tasks/:id', '/tasks/')).toBeNull();
+      expect(matchRoute('/tasks/:id', '/tasks')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## What

Fixes two complaints about the dashboard's task representation: **hard to reach** and **weak content**. Promotes individual tasks from an ephemeral, modal-only view to a **deep-linkable `/tasks/:id` detail page**.

This is **Tranche 1 (frontend-only)**. The connective-tissue *content* (consensus round, sibling tasks, findings, signal counts) needs backend fields and lands in **Tranche 2** — surfaced here as honest `○ none` placeholders.

## Changes

- **`router.ts`** — `matchRoute()` parametric `:param` matching (was literal-only).
- **`pages/TaskPage.tsx`** (new) — full UUID (JetBrains Mono), semantic status chip, agent identity dot → `/agent/:id`, in/out token split, a 2-node hairline **lifecycle timeline** (dispatched → completed/failed, client-computed), a **context** section with `○ none` Tranche-2 placeholders, prompt + result rendering, and a graceful **cold-deep-link not-found** frame.
- **`TaskRow`** — row click navigates (no more modal-only); task-ID badge **amber → neutral** (`--warn` was semantic misuse); added a **kind chip** column.
- **De-duplication** — extracted shared `lib/task-status.tsx` (`STATUS_META`/`ICON`/`normaliseStatus`) and `taskKindFromAgentId` → `lib/utils`, removing copy-paste between `TaskRow` and `TasksSection` (drift risk).
- **`TasksPage` empty state** → `EmptyState` (was a naked string, violated the DESIGN.md empty-state contract).
- `TaskDetailModal` kept for now (deprecate after the page is proven).

## Design review

`sonnet-designer` reviewed against DESIGN.md before this PR; applied: `--accent`→`--info` on the recovery link (terracotta is brand/CTA-only), legacy `--text`/`--text-dim` → `--ink`/`--ink-3`, `motion-reduce` guard on `animate-pulse` (mandatory motion rule, 3 sites), failed-state lifecycle line, clearer cold-deep-link copy.

**Deliberately out of scope:** the `pending → running` status mapping (pre-existing on master, dashboard-wide) — flagged separately rather than changed here.

## Verification

Typecheck clean; dashboard build green (128 modules); 179 tests pass incl. 11 new `router-param` tests. **Not yet visually verified in-browser** — recommend a quick visual pass of the new page states before merge.

## Follow-up (Tranche 2)

`/api/tasks/:id` endpoint (deep-link survives refresh) + `consensusId`/`dispatchGroupId` on tasks + `SignalEntry.taskId` join → fills the context section with real connective tissue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)