### PR TITLE
feat(dashboard): deep-linkable task detail page + connective tissue

### DIFF
--- a/packages/dashboard-v2/src/App.tsx
+++ b/packages/dashboard-v2/src/App.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useMemo, useState } from 'react';
-import { useRoute } from '@/lib/router';
+import { useRoute, matchRoute } from '@/lib/router';
 import { OverviewPage } from '@/pages/OverviewPage';
 import { ConsensusFlowPage } from '@/pages/ConsensusFlowPage';
+import { TaskPage } from '@/pages/TaskPage';
 import { AuthGate } from '@/components/AuthGate';
 import { TopBar } from '@/components/TopBar';
 import { NeuralAvatar } from '@/components/NeuralAvatar';
@@ -12,6 +13,7 @@ import { AgentPage } from '@/components/AgentPage';
 import { LogsPage } from '@/components/LogsPage';
 import { SignalsPage } from '@/components/SignalsPage';
 import { TaskRow } from '@/components/TaskRow';
+import { EmptyState } from '@/components/EmptyState';
 import { OverviewSkeleton, TeamPageSkeleton, TasksPageSkeleton, DebatesPageSkeleton } from '@/components/Skeleton';
 import { useAuth } from '@/hooks/useAuth';
 import { useWebSocket } from '@/hooks/useWebSocket';
@@ -418,9 +420,16 @@ function TasksPage({ tasks }: { tasks: import('@/lib/types').TasksData }) {
 
       <div className="overflow-hidden rounded-md [border-color:color-mix(in_oklch,var(--border)_40%,transparent)] border" style={{ background: 'color-mix(in oklch, var(--surface-elev) 80%, transparent)' }}>
         {paged.length === 0 ? (
-          <div className="py-12 text-center text-sm" style={{ color: 'var(--ink-3)' }}>
-            {q ? 'No tasks match your search.' : 'No tasks yet.'}
-          </div>
+          q ? (
+            <div className="py-12 text-center text-sm" style={{ color: 'var(--ink-3)' }}>
+              No tasks match your search.
+            </div>
+          ) : (
+            <EmptyState
+              title="No tasks yet"
+              hint="Dispatch with gossip_run to populate this view."
+            />
+          )
         ) : (
           <table className="w-full text-left">
             <thead>
@@ -428,6 +437,7 @@ function TasksPage({ tasks }: { tasks: import('@/lib/types').TasksData }) {
                 <th className="py-2.5 pl-4 pr-2 h-section" style={{ width: 32 }}></th>
                 <th className="py-2.5 pr-3 h-section">ID</th>
                 <th className="py-2.5 pr-3 h-section">Agent</th>
+                <th className="py-2.5 pr-3 h-section">Kind</th>
                 <th className="py-2.5 pr-3 h-section">Description</th>
                 <th className="py-2.5 pr-3 h-section">Duration</th>
                 <th className="py-2.5 pr-4 text-right h-section">When</th>
@@ -556,12 +566,15 @@ function Dashboard({ onUnauthorized }: { onUnauthorized: () => void }) {
   let content;
   const agentMatch = route.match(/^\/agent\/(.+)$/);
   const consensusFlowMatch = route.match(/^\/consensus\/(.+)$/);
+  const taskDetailId = matchRoute('/tasks/:id', route);
   if (agentMatch && agents) {
     const agentId = decodeURIComponent(agentMatch[1]);
     content = <AgentPage agentId={agentId} agents={agents} tasks={tasks} consensus={consensus} />;
   } else if (consensusFlowMatch) {
     const consensusId = decodeURIComponent(consensusFlowMatch[1]);
     content = <ConsensusFlowPage consensusId={consensusId} />;
+  } else if (taskDetailId) {
+    content = <TaskPage taskId={taskDetailId} tasks={tasks} />;
   } else if (route === '/team') {
     content = agents
       ? <TeamPage agents={agents} tasks={tasks} consensusReports={consensusReports} fleetTrend={fleetTrend} />
@@ -615,7 +628,7 @@ function Dashboard({ onUnauthorized }: { onUnauthorized: () => void }) {
   // Overview owns its own outer container (max-w-5xl). For everything else,
   // the historical max-w-7xl + space-y-6 wrapper applies.
   const isOverview = route === '/' || route === '/overview' ||
-    !(/^\/(agent\/|consensus\/|team|tasks|debates|logs|signals|violations|chat)/.test(route));
+    !(/^\/(agent\/|consensus\/|tasks\/|team|tasks|debates|logs|signals|violations|chat)/.test(route));
   const mainClass = isOverview
     ? 'px-6 py-6'
     : 'mx-auto max-w-7xl space-y-6 px-6 py-6';

--- a/packages/dashboard-v2/src/components/TaskRow.tsx
+++ b/packages/dashboard-v2/src/components/TaskRow.tsx
@@ -1,114 +1,12 @@
-import type { JSX } from 'react';
-import type React from 'react';
 import type { TaskItem } from '@/lib/types';
-import { timeAgo, agentColor } from '@/lib/utils';
+import { timeAgo, agentColor, taskKindFromAgentId } from '@/lib/utils';
+import { normaliseStatus, STATUS_META, STATUS_ICON } from '@/lib/task-status';
+import { navigate } from '@/lib/router';
 
 interface TaskRowProps {
   task: TaskItem;
   onClick?: (task: TaskItem) => void;
 }
-
-/**
- * Canonical status buckets the indicator renders. We normalise incoming status
- * strings (including aliases we may receive from older task sources) into one
- * of these five keys so the icon-box treatment stays exhaustive.
- */
-type StatusKey = 'completed' | 'running' | 'failed' | 'cancelled' | 'unknown';
-
-/**
- * Normalise a free-form task status into one of our canonical buckets. The
- * TaskItem type currently narrows to four literals, but collect/relay can
- * surface aliases ("done", "error", "in_progress", etc.) — we fold those in
- * rather than letting them fall through to the gray "unknown" fallback.
- */
-function normaliseStatus(status: string): StatusKey {
-  const s = status.toLowerCase();
-  if (s === 'completed' || s === 'done' || s === 'success' || s === 'succeeded') return 'completed';
-  if (s === 'running' || s === 'active' || s === 'in_progress' || s === 'pending') return 'running';
-  if (s === 'failed' || s === 'error' || s === 'errored' || s === 'timeout' || s === 'timed_out') return 'failed';
-  if (s === 'cancelled' || s === 'canceled' || s === 'queued' || s === 'waiting') return 'cancelled';
-  return 'unknown';
-}
-
-/**
- * Per-status visual treatment: label, icon box tint, text color, and whether
- * the icon box animates. Mirrors the MemoryFolders icon-box pattern (faint
- * tinted background + 1px border ring in the same hue) so the dashboard's
- * semantic palette stays consistent across panels.
- */
-const STATUS_META: Record<StatusKey, {
-  label: string;
-  iconBox: string;   // bg tint + border ring on the 22px square
-  text: string;      // icon stroke + label color
-  textStyle?: React.CSSProperties;
-  pulse: boolean;    // subtle breathing outline for in-flight tasks
-}> = {
-  completed: {
-    label: 'Done',
-    iconBox: 'bg-confirmed/10 border-confirmed/30',
-    text: 'text-confirmed',
-    pulse: false,
-  },
-  running: {
-    label: 'Running',
-    iconBox: 'bg-unverified/10 border-unverified/30',
-    text: 'text-unverified',
-    pulse: true,
-  },
-  failed: {
-    label: 'Failed',
-    iconBox: 'bg-bad/10 border-bad/30',
-    text: 'text-bad',
-    pulse: false,
-  },
-  cancelled: {
-    label: 'Cancelled',
-    iconBox: 'border-muted-foreground/25',
-    text: '',
-    textStyle: { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--text-dim) 10%, transparent)' },
-    pulse: false,
-  },
-  unknown: {
-    label: 'Unknown',
-    iconBox: 'border-muted-foreground/25',
-    text: '',
-    textStyle: { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--text-dim) 10%, transparent)' },
-    pulse: false,
-  },
-};
-
-/**
- * Inline SVG glyphs — no icon library, stroke="currentColor" so the parent's
- * text color drives hue, and strokeWidth="1.5" matches MemoryFolders.
- *
- *   completed → check
- *   running   → concentric dot (reads as "in progress" and pulses)
- *   failed    → x
- *   cancelled → horizontal bar (dash)
- *   unknown   → question mark
- */
-const STATUS_ICON: Record<StatusKey, JSX.Element> = {
-  completed: <polyline points="5 12 10 17 19 7" />,
-  running: (
-    <>
-      <circle cx="12" cy="12" r="3" fill="currentColor" stroke="none" />
-      <circle cx="12" cy="12" r="8" opacity="0.45" />
-    </>
-  ),
-  failed: (
-    <>
-      <line x1="6" y1="6" x2="18" y2="18" />
-      <line x1="18" y1="6" x2="6" y2="18" />
-    </>
-  ),
-  cancelled: <line x1="6" y1="12" x2="18" y2="12" />,
-  unknown: (
-    <>
-      <path d="M9.5 9a2.5 2.5 0 1 1 3.5 2.3c-.8.4-1 .9-1 1.7" />
-      <line x1="12" y1="16.5" x2="12" y2="16.5" />
-    </>
-  ),
-};
 
 function formatDurationNice(ms?: number): string {
   if (!ms) return '—';
@@ -127,19 +25,23 @@ function formatDurationNice(ms?: number): string {
 export function TaskRow({ task, onClick }: TaskRowProps) {
   const key = normaliseStatus(task.status);
   const meta = STATUS_META[key];
+  const kind = taskKindFromAgentId(task.agentId);
 
   return (
     <tr
-      className={`border-b border-border hover:bg-accent/10 transition-colors ${onClick ? 'cursor-pointer' : ''}`}
-      onClick={onClick ? (e) => {
+      className={`border-b border-border hover:bg-accent/10 transition-colors cursor-pointer`}
+      onClick={(e) => {
         if ((e.target as HTMLElement).closest('a')) return;
-        onClick(task);
-      } : undefined}
+        // Navigate to the task detail page; also call the legacy setSelected callback
+        // so the modal still works until it's fully deprecated.
+        onClick?.(task);
+        navigate('/tasks/' + task.taskId);
+      }}
     >
       <td className="py-2.5 pl-4 pr-2">
         <span className="inline-flex items-center gap-2" aria-label={`Status: ${meta.label}`}>
           <span
-            className={`flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full border ${meta.iconBox} ${meta.text} ${meta.pulse ? 'animate-pulse' : ''}`}
+            className={`flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full border ${meta.iconBox} ${meta.text} ${meta.pulse ? 'animate-pulse motion-reduce:animate-none' : ''}`}
             style={meta.textStyle}
             aria-hidden
           >
@@ -162,8 +64,14 @@ export function TaskRow({ task, onClick }: TaskRowProps) {
         </span>
       </td>
       <td className="py-2.5 pr-3">
+        {/* Neutral ID badge — not warn-badge amber (semantic misuse fixed) */}
         <span
-          className="warn-badge rounded px-2 py-1 font-mono text-[10px] font-semibold"
+          className="rounded border px-2 py-1 font-mono text-[10px] font-semibold"
+          style={{
+            borderColor: 'color-mix(in oklch, var(--border) 40%, transparent)',
+            color: 'var(--ink-3)',
+            background: 'color-mix(in oklch, var(--surface) 60%, transparent)',
+          }}
           title={task.taskId}
         >
           {task.taskId.slice(0, 8)}
@@ -175,6 +83,17 @@ export function TaskRow({ task, onClick }: TaskRowProps) {
           {task.agentId}
         </a>
       </td>
+      {kind && (
+        <td className="py-2.5 pr-3">
+          <span
+            className={`rounded-sm border border-border/40 px-1 py-0.5 font-mono text-[9px] font-bold uppercase tracking-wider ${kind.cls}`}
+            style={{ background: 'color-mix(in oklch, var(--surface) 40%, transparent)', ...kind.clsStyle }}
+          >
+            {kind.label}
+          </span>
+        </td>
+      )}
+      {!kind && <td className="py-2.5 pr-3" />}
       <td className="py-2.5 pr-3 text-xs leading-snug" style={{ color: 'color-mix(in oklch, var(--text) 80%, transparent)' }}>
         {(() => { const line = task.task.replace(/\n.*/s, ''); return line.length > 100 ? line.slice(0, 100) + '…' : line; })()}
       </td>

--- a/packages/dashboard-v2/src/components/TasksSection.tsx
+++ b/packages/dashboard-v2/src/components/TasksSection.tsx
@@ -1,7 +1,6 @@
-import type { JSX } from 'react';
-import type React from 'react';
 import type { TasksData } from '@/lib/types';
-import { timeAgo } from '@/lib/utils';
+import { timeAgo, taskKindFromAgentId } from '@/lib/utils';
+import { normaliseStatus, STATUS_META, STATUS_ICON } from '@/lib/task-status';
 import { EmptyState } from './EmptyState';
 
 const DEFAULT_PAGE_SIZE = 8;
@@ -11,78 +10,9 @@ interface TasksSectionProps {
   limit?: number;
 }
 
-/**
- * Canonical status buckets — kept in sync with TaskRow.tsx. If you tweak one,
- * tweak the other: these two components are the dashboard's two surface areas
- * for task status and should read as the same visual language.
- */
-type StatusKey = 'completed' | 'running' | 'failed' | 'cancelled' | 'unknown';
-
-function normaliseStatus(status: string): StatusKey {
-  const s = status.toLowerCase();
-  if (s === 'completed' || s === 'done' || s === 'success' || s === 'succeeded') return 'completed';
-  if (s === 'running' || s === 'active' || s === 'in_progress' || s === 'pending') return 'running';
-  if (s === 'failed' || s === 'error' || s === 'errored' || s === 'timeout' || s === 'timed_out') return 'failed';
-  if (s === 'cancelled' || s === 'canceled' || s === 'queued' || s === 'waiting') return 'cancelled';
-  return 'unknown';
-}
-
-/**
- * Compact variant of the TaskRow icon-box treatment: 18px square so the inline
- * task list stays dense. Same palette + glyph language to keep both surfaces
- * reading as one system.
- */
-const STATUS_META: Record<StatusKey, {
-  label: string;
-  iconBox: string;
-  text: string;
-  textStyle?: React.CSSProperties;
-  pulse: boolean;
-}> = {
-  completed: { label: 'Done', iconBox: 'bg-confirmed/10 border-confirmed/30', text: 'text-confirmed', pulse: false },
-  running: { label: 'Running', iconBox: 'bg-unverified/10 border-unverified/30', text: 'text-unverified', pulse: true },
-  failed: { label: 'Failed', iconBox: 'bg-destructive/10 border-destructive/30', text: 'text-destructive', pulse: false },
-  cancelled: { label: 'Cancelled', iconBox: 'border-muted-foreground/25', text: '', textStyle: { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--text-dim) 10%, transparent)' }, pulse: false },
-  unknown: { label: 'Unknown', iconBox: 'border-muted-foreground/25', text: '', textStyle: { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--text-dim) 10%, transparent)' }, pulse: false },
-};
-
-const STATUS_ICON: Record<StatusKey, JSX.Element> = {
-  completed: <polyline points="5 12 10 17 19 7" />,
-  running: (
-    <>
-      <circle cx="12" cy="12" r="3" fill="currentColor" stroke="none" />
-      <circle cx="12" cy="12" r="8" opacity="0.45" />
-    </>
-  ),
-  failed: (
-    <>
-      <line x1="6" y1="6" x2="18" y2="18" />
-      <line x1="18" y1="6" x2="6" y2="18" />
-    </>
-  ),
-  cancelled: <line x1="6" y1="12" x2="18" y2="12" />,
-  unknown: (
-    <>
-      <path d="M9.5 9a2.5 2.5 0 1 1 3.5 2.3c-.8.4-1 .9-1 1.7" />
-      <line x1="12" y1="16.5" x2="12" y2="16.5" />
-    </>
-  ),
-};
-
 // Short-form task ID: first 8 chars of a UUID (or whatever ID is present).
 function shortTaskId(id: string): string {
   return id.length > 8 ? id.slice(0, 8) : id;
-}
-
-// Derive a visual kind chip from the agentId suffix.
-// Returns null for unrecognized suffixes so the chip is omitted entirely.
-function taskKindFromAgentId(agentId: string): { label: string; cls: string; clsStyle?: React.CSSProperties } | null {
-  if (agentId.endsWith('-implementer')) return { label: 'IMPL', cls: 'text-unique' };
-  if (agentId.endsWith('-reviewer'))    return { label: 'REVIEW', cls: 'text-chart' };
-  if (agentId.endsWith('-tester'))      return { label: 'TEST', cls: 'text-unique' };
-  if (agentId.endsWith('-researcher'))  return { label: 'RESEARCH', cls: '', clsStyle: { color: 'var(--text-dim)' } };
-  if (agentId.endsWith('-designer'))    return { label: 'DESIGN', cls: 'text-chart' };
-  return null;
 }
 
 export function TasksSection({ tasks, limit = DEFAULT_PAGE_SIZE }: TasksSectionProps) {
@@ -118,7 +48,7 @@ export function TasksSection({ tasks, limit = DEFAULT_PAGE_SIZE }: TasksSectionP
                 className={`flex items-start gap-3 px-3.5 py-2.5 hover:bg-accent/20 transition-colors ${i > 0 ? 'border-t border-border/20' : ''}`}
               >
                 <span
-                  className={`mt-0.5 flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border ${meta.iconBox} ${meta.text} ${meta.pulse ? 'animate-pulse' : ''}`}
+                  className={`mt-0.5 flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border ${meta.iconBox} ${meta.text} ${meta.pulse ? 'animate-pulse motion-reduce:animate-none' : ''}`}
                   style={meta.textStyle}
                   aria-label={`Status: ${meta.label}`}
                   data-tooltip={meta.label}

--- a/packages/dashboard-v2/src/lib/router.ts
+++ b/packages/dashboard-v2/src/lib/router.ts
@@ -44,6 +44,30 @@ if (typeof document !== 'undefined' && !(window as any).__dashboardRouterInstall
   });
 }
 
+/**
+ * Match a parametric route pattern against the current route string.
+ * Supports a single `:param` segment (e.g. "/tasks/:id").
+ *
+ * Returns the captured param value (URL-decoded) or null if no match.
+ *
+ * Examples:
+ *   matchRoute('/tasks/:id', '/tasks/abc123')  → 'abc123'
+ *   matchRoute('/tasks/:id', '/tasks')          → null
+ *   matchRoute('/agent/:id', '/tasks/abc123')   → null
+ */
+export function matchRoute(pattern: string, route: string): string | null {
+  // Build a regex from the pattern by replacing `:param` with a capture group.
+  // We first escape regex special chars, then replace the (now-escaped) `:param`
+  // placeholder with a capture group.  The `:` char is not a regex special char so
+  // it survives the first pass intact; `\w` is safe to replace afterward.
+  const escaped = pattern
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/:\w+/g, '([^/]+)');
+  const re = new RegExp(`^${escaped}$`);
+  const m = route.match(re);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
 export function useRoute(): string {
   const [route, setRoute] = useState(currentRoute());
 

--- a/packages/dashboard-v2/src/lib/task-status.tsx
+++ b/packages/dashboard-v2/src/lib/task-status.tsx
@@ -1,0 +1,105 @@
+/**
+ * Canonical task status constants shared between TaskRow.tsx and TasksSection.tsx.
+ * Extract here to avoid duplicating normaliseStatus / STATUS_META / STATUS_ICON
+ * across two components that must render the same visual language.
+ */
+import type { JSX } from 'react';
+import type React from 'react';
+
+/** The five canonical status buckets the indicator renders. */
+export type StatusKey = 'completed' | 'running' | 'failed' | 'cancelled' | 'unknown';
+
+/**
+ * Normalise a free-form task status into one of our canonical buckets. The
+ * TaskItem type currently narrows to four literals, but collect/relay can
+ * surface aliases ("done", "error", "in_progress", etc.) — we fold those in
+ * rather than letting them fall through to the gray "unknown" fallback.
+ */
+export function normaliseStatus(status: string): StatusKey {
+  const s = status.toLowerCase();
+  if (s === 'completed' || s === 'done' || s === 'success' || s === 'succeeded') return 'completed';
+  if (s === 'running' || s === 'active' || s === 'in_progress' || s === 'pending') return 'running';
+  if (s === 'failed' || s === 'error' || s === 'errored' || s === 'timeout' || s === 'timed_out') return 'failed';
+  if (s === 'cancelled' || s === 'canceled' || s === 'queued' || s === 'waiting') return 'cancelled';
+  return 'unknown';
+}
+
+/**
+ * Per-status visual treatment: label, icon box tint, text color, and whether
+ * the icon box animates. Mirrors the MemoryFolders icon-box pattern (faint
+ * tinted background + 1px border ring in the same hue) so the dashboard's
+ * semantic palette stays consistent across panels.
+ */
+export const STATUS_META: Record<StatusKey, {
+  label: string;
+  iconBox: string;   // bg tint + border ring on the status icon square
+  text: string;      // icon stroke + label color
+  textStyle?: React.CSSProperties;
+  pulse: boolean;    // subtle breathing outline for in-flight tasks
+}> = {
+  completed: {
+    label: 'Done',
+    iconBox: 'bg-confirmed/10 border-confirmed/30',
+    text: 'text-confirmed',
+    pulse: false,
+  },
+  running: {
+    label: 'Running',
+    iconBox: 'bg-unverified/10 border-unverified/30',
+    text: 'text-unverified',
+    pulse: true,
+  },
+  failed: {
+    label: 'Failed',
+    iconBox: 'bg-bad/10 border-bad/30',
+    text: 'text-bad',
+    pulse: false,
+  },
+  cancelled: {
+    label: 'Cancelled',
+    iconBox: 'border-muted-foreground/25',
+    text: '',
+    textStyle: { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--text-dim) 10%, transparent)' },
+    pulse: false,
+  },
+  unknown: {
+    label: 'Unknown',
+    iconBox: 'border-muted-foreground/25',
+    text: '',
+    textStyle: { color: 'var(--text-dim)', background: 'color-mix(in oklch, var(--text-dim) 10%, transparent)' },
+    pulse: false,
+  },
+};
+
+/**
+ * Inline SVG glyphs — no icon library, stroke="currentColor" so the parent's
+ * text color drives hue, and strokeWidth="1.5" matches MemoryFolders.
+ *
+ *   completed → check
+ *   running   → concentric dot (reads as "in progress" and pulses)
+ *   failed    → x
+ *   cancelled → horizontal bar (dash)
+ *   unknown   → question mark
+ */
+export const STATUS_ICON: Record<StatusKey, JSX.Element> = {
+  completed: <polyline points="5 12 10 17 19 7" />,
+  running: (
+    <>
+      <circle cx="12" cy="12" r="3" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="12" r="8" opacity="0.45" />
+    </>
+  ),
+  failed: (
+    <>
+      <line x1="6" y1="6" x2="18" y2="18" />
+      <line x1="18" y1="6" x2="6" y2="18" />
+    </>
+  ),
+  cancelled: <line x1="6" y1="12" x2="18" y2="12" />,
+  unknown: (
+    <>
+      <path d="M9.5 9a2.5 2.5 0 1 1 3.5 2.3c-.8.4-1 .9-1 1.7" />
+      <line x1="12" y1="16.5" x2="12" y2="16.5" />
+    </>
+  ),
+};

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -119,7 +119,12 @@ export interface TaskItem {
   result?: string;
   status: 'completed' | 'failed' | 'cancelled' | 'running';
   duration?: number;
+  /** ISO timestamp of completion/failure/cancellation event (or dispatch time if running).
+   *  Used as the "Completed" node in LifecycleTimeline. */
   timestamp: string;
+  /** ISO timestamp of task.created event — always the dispatch time.
+   *  Used as the "Dispatched" node in LifecycleTimeline. */
+  createdAt?: string;
   inputTokens?: number;
   outputTokens?: number;
 }
@@ -137,9 +142,11 @@ export interface TaskDetail extends TaskItem {
   consensusId?: string;
   /** Other taskIds sharing the same consensusId (capped at 25). */
   siblingTaskIds?: string[];
+  /** True if sibling list was truncated at the SIBLING_CAP limit. */
+  siblingsTruncated?: boolean;
   /** Count of agent-performance signal rows for this task. */
   signalCount?: number;
-  /** Count of implementation-findings rows for this task. */
+  /** Count of implementation-findings rows whose taskId starts with `${consensusId}:`. */
   findingCount?: number;
 }
 

--- a/packages/dashboard-v2/src/lib/types.ts
+++ b/packages/dashboard-v2/src/lib/types.ts
@@ -131,6 +131,18 @@ export interface TasksData {
   limit: number;
 }
 
+/** Enriched single-task response from /dashboard/api/tasks/:id */
+export interface TaskDetail extends TaskItem {
+  /** First consensusId from agent-performance rows matching this task. */
+  consensusId?: string;
+  /** Other taskIds sharing the same consensusId (capped at 25). */
+  siblingTaskIds?: string[];
+  /** Count of agent-performance signal rows for this task. */
+  signalCount?: number;
+  /** Count of implementation-findings rows for this task. */
+  findingCount?: number;
+}
+
 export interface ConsensusRun {
   taskId: string;
   timestamp: string;

--- a/packages/dashboard-v2/src/lib/utils.ts
+++ b/packages/dashboard-v2/src/lib/utils.ts
@@ -314,3 +314,23 @@ export function agentColor(id: string): string {
   for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
   return AGENT_COLORS[h % AGENT_COLORS.length];
 }
+
+/**
+ * Derive a visual kind label from the agentId suffix.
+ * Returns null for unrecognized suffixes so the chip is omitted entirely.
+ * Shared between TaskRow.tsx, TasksSection.tsx, and TaskPage.tsx.
+ */
+export interface TaskKind {
+  label: string;
+  cls: string;
+  clsStyle?: import('react').CSSProperties;
+}
+
+export function taskKindFromAgentId(agentId: string): TaskKind | null {
+  if (agentId.endsWith('-implementer')) return { label: 'IMPL', cls: 'text-unique' };
+  if (agentId.endsWith('-reviewer'))    return { label: 'REVIEW', cls: 'text-chart' };
+  if (agentId.endsWith('-tester'))      return { label: 'TEST', cls: 'text-unique' };
+  if (agentId.endsWith('-researcher'))  return { label: 'RESEARCH', cls: '', clsStyle: { color: 'var(--text-dim)' } };
+  if (agentId.endsWith('-designer'))    return { label: 'DESIGN', cls: 'text-chart' };
+  return null;
+}

--- a/packages/dashboard-v2/src/pages/TaskPage.tsx
+++ b/packages/dashboard-v2/src/pages/TaskPage.tsx
@@ -74,14 +74,17 @@ interface TimelineProps {
 
 function LifecycleTimeline({ task }: TimelineProps) {
   const key = normaliseStatus(task.status);
-  const dispatched = new Date(task.timestamp);
-  const completedMs = task.duration != null ? new Date(dispatched.getTime() + task.duration).getTime() : null;
+  // Dispatched node always uses createdAt (dispatch time); fall back to timestamp
+  // only for tasks loaded from older data that lack createdAt.
+  const dispatched = new Date(task.createdAt ?? task.timestamp);
+  // For terminal tasks timestamp IS the completion time; for running tasks there is no end.
+  const isRunning = key === 'running';
+  const completedMs = !isRunning ? new Date(task.timestamp).getTime() : null;
 
   const formatTime = (d: Date) =>
     d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' });
 
   const isFailed = key === 'failed';
-  const isRunning = key === 'running';
 
   // Terminal node label + color
   const endLabel = isFailed ? 'Failed' : isRunning ? 'Running…' : 'Completed';
@@ -168,7 +171,7 @@ function KVRow({ label, children, dimmed = false }: { label: string; children: R
 }
 
 // ──────────────────────────────────────────────
-// Not-found frame (cold deep-link)
+// Not-found frame (task absent from task-graph.jsonl)
 // ──────────────────────────────────────────────
 function TaskNotFound({ taskId }: { taskId: string }) {
   return (
@@ -179,7 +182,7 @@ function TaskNotFound({ taskId }: { taskId: string }) {
         style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
       >
         <div className="font-mono text-sm font-semibold" style={{ color: 'var(--ink-2)' }}>
-          Task not in the loaded list
+          Task not found
         </div>
         <div className="mt-2 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
           <code
@@ -190,15 +193,51 @@ function TaskNotFound({ taskId }: { taskId: string }) {
           </code>
         </div>
         <div className="mt-4 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
-          Open it from the{' '}
+          No task with this ID exists in task-graph.jsonl.{' '}
           <button
             onClick={() => navigate('/tasks')}
             className="underline transition hover:opacity-80"
             style={{ color: 'var(--info)' }}
           >
-            Tasks list
-          </button>{' '}
-          first to load the session — direct task fetch arrives in a later update.
+            Back to Tasks list
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Error frame — non-404 fetch failure
+// ──────────────────────────────────────────────
+function TaskLoadError({ taskId }: { taskId: string }) {
+  return (
+    <div>
+      <Breadcrumb taskId={taskId} />
+      <div
+        className="rounded-lg border p-8 text-center"
+        style={{ borderColor: 'var(--bad)', background: 'color-mix(in oklch, var(--bad) 6%, var(--surface))' }}
+      >
+        <div className="font-mono text-sm font-semibold" style={{ color: 'var(--bad)' }}>
+          Failed to load task
+        </div>
+        <div className="mt-2 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
+          <code
+            className="rounded px-1"
+            style={{ fontFamily: 'JetBrains Mono, monospace', background: 'color-mix(in oklch, var(--surface-sunk) 40%, transparent)' }}
+          >
+            {taskId}
+          </code>
+        </div>
+        <div className="mt-4 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
+          The server returned an error or the response was malformed.{' '}
+          <button
+            onClick={() => navigate('/tasks')}
+            className="underline transition hover:opacity-80"
+            style={{ color: 'var(--info)' }}
+          >
+            Back to Tasks list
+          </button>
         </div>
       </div>
     </div>
@@ -225,7 +264,7 @@ function ContextSection({ detail, loading }: ContextSectionProps) {
   if (loading) {
     return (
       <div className="space-y-0">
-        {(['consensus round', 'sibling tasks', 'findings', 'signals'] as const).map((label) => (
+        {(['consensus round', 'sibling tasks', 'round findings', 'signals'] as const).map((label) => (
           <KVRow key={label} label={label} dimmed>
             <span
               className="inline-block h-3 w-24 rounded animate-pulse"
@@ -240,6 +279,7 @@ function ContextSection({ detail, loading }: ContextSectionProps) {
 
   const consensusId = detail?.consensusId;
   const siblings = detail?.siblingTaskIds ?? [];
+  const siblingsTruncated = detail?.siblingsTruncated ?? false;
   const signalCount = detail?.signalCount ?? 0;
   const findingCount = detail?.findingCount ?? 0;
 
@@ -264,7 +304,7 @@ function ContextSection({ detail, loading }: ContextSectionProps) {
       <KVRow label="sibling tasks">
         {siblings.length > 0 ? (
           <span className="flex flex-wrap gap-x-3 gap-y-0.5">
-            <span style={{ color: 'var(--ink-2)' }}>{siblings.length}</span>
+            <span style={{ color: 'var(--ink-2)' }}>{siblings.length}{siblingsTruncated ? '+' : ''}</span>
             {siblings.slice(0, 5).map((sid) => (
               <a
                 key={sid}
@@ -284,8 +324,8 @@ function ContextSection({ detail, loading }: ContextSectionProps) {
         )}
       </KVRow>
 
-      {/* Findings */}
-      <KVRow label="findings">
+      {/* Round findings (count of implementation-findings rows for this consensus round) */}
+      <KVRow label="round findings">
         {findingCount > 0 ? (
           <span style={{ color: 'var(--ink-2)' }}>{findingCount}</span>
         ) : (
@@ -324,11 +364,14 @@ export function TaskPage({ taskId, tasks }: TaskPageProps) {
   const [detail, setDetail] = useState<TaskDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(true);
   const [detailNotFound, setDetailNotFound] = useState(false);
+  // detailError is set on non-404 failures (500, malformed JSON, network error).
+  const [detailError, setDetailError] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     setDetailLoading(true);
     setDetailNotFound(false);
+    setDetailError(false);
     setDetail(null);
 
     fetch(`/dashboard/api/tasks/${encodeURIComponent(taskId)}`)
@@ -337,11 +380,26 @@ export function TaskPage({ taskId, tasks }: TaskPageProps) {
           if (!cancelled) setDetailNotFound(true);
           return;
         }
-        if (!res.ok) return; // best-effort; fall back to prop
+        if (!res.ok) {
+          // Non-404 server error — flag as error so we don't show an infinite skeleton.
+          if (!cancelled) setDetailError(true);
+          return;
+        }
         const body = await res.json().catch(() => null);
-        if (!cancelled && body) setDetail(body as TaskDetail);
+        if (!cancelled) {
+          // Runtime shape guard before casting.
+          if (body && typeof body === 'object' && 'taskId' in body) {
+            setDetail(body as TaskDetail);
+          } else {
+            // Malformed JSON or unexpected shape.
+            setDetailError(true);
+          }
+        }
       })
-      .catch(() => { /* network failure — fall back to prop */ })
+      .catch(() => {
+        // Network failure — flag error so the skeleton resolves.
+        if (!cancelled) setDetailError(true);
+      })
       .finally(() => { if (!cancelled) setDetailLoading(false); });
 
     return () => { cancelled = true; };
@@ -349,15 +407,26 @@ export function TaskPage({ taskId, tasks }: TaskPageProps) {
 
   // Resolve which task record to render from.
   // Prefer the fetched detail; fall back to the prop task while loading.
-  const task: TaskItem | undefined = detail ?? propTask;
+  const taskOrUndefined: TaskItem | undefined = detail ?? propTask;
 
-  // Not found: neither the API nor the prop list knows this taskId.
-  if (!detailLoading && detailNotFound && !task) {
+  // Not found: API returned 404 and no prop task to fall back to.
+  if (!detailLoading && detailNotFound && !taskOrUndefined) {
     return <TaskNotFound taskId={taskId} />;
   }
 
-  // Still loading AND no prop task to show yet.
-  if (!task) {
+  // Non-404 error (500 / malformed JSON / network) with no prop task fallback — show error frame.
+  if (!detailLoading && detailError && !taskOrUndefined) {
+    return <TaskLoadError taskId={taskId} />;
+  }
+
+  // Loading has finished but we still have no task record — shouldn't normally happen,
+  // but guard it to prevent an infinite skeleton.
+  if (!detailLoading && !taskOrUndefined) {
+    return <TaskNotFound taskId={taskId} />;
+  }
+
+  // Fetch is in-flight and we have no prop task to show yet — show skeleton.
+  if (detailLoading && !taskOrUndefined) {
     return (
       <div>
         <Breadcrumb taskId={taskId} />
@@ -374,6 +443,8 @@ export function TaskPage({ taskId, tasks }: TaskPageProps) {
     );
   }
 
+  // At this point all early-return guards have passed — task is guaranteed to exist.
+  const task: TaskItem = taskOrUndefined!;
   const key = normaliseStatus(task.status);
   const kind = taskKindFromAgentId(task.agentId);
   const totalTokens = (task.inputTokens ?? 0) + (task.outputTokens ?? 0);
@@ -415,7 +486,7 @@ export function TaskPage({ taskId, tasks }: TaskPageProps) {
         {/* Row 2: agent identity dot + name → /agent/:id */}
         <div className="mt-3 flex flex-wrap items-center gap-4">
           <a
-            href={`/dashboard/agent/${encodeURIComponent(task.agentId)}`}
+            href={href(`/agent/${encodeURIComponent(task.agentId)}`)}
             className="inline-flex items-center gap-2 font-mono text-xs transition hover:opacity-80"
             style={{ color: 'var(--ink-2)' }}
           >

--- a/packages/dashboard-v2/src/pages/TaskPage.tsx
+++ b/packages/dashboard-v2/src/pages/TaskPage.tsx
@@ -1,16 +1,14 @@
 /**
  * TaskPage — deep-linkable full-page task detail view.
  *
- * Reads the task from the same tasks data TasksPage uses (passed as a prop).
- * Does NOT make any API call — that is Tranche 2.
- *
- * If the task ID is not in the loaded set (cold deep-link), renders a graceful
- * "not found" frame rather than crashing.
+ * Fetches enriched task detail from /dashboard/api/tasks/:id on mount so that
+ * deep-linked URLs work without prior navigation to the Tasks list. Falls back
+ * to the prop task if the fetch is in-flight or unavailable.
  */
 import { renderMarkdown, renderFindingMarkdown, agentColor, taskKindFromAgentId, formatDuration, timeAgo } from '@/lib/utils';
 import { normaliseStatus, STATUS_META, STATUS_ICON } from '@/lib/task-status';
-import type { TaskItem, TasksData } from '@/lib/types';
-import { navigate } from '@/lib/router';
+import type { TaskItem, TasksData, TaskDetail } from '@/lib/types';
+import { navigate, href } from '@/lib/router';
 
 interface TaskPageProps {
   taskId: string;
@@ -208,16 +206,172 @@ function TaskNotFound({ taskId }: { taskId: string }) {
 }
 
 // ──────────────────────────────────────────────
+// Context section — wired to backend enrichment
+// ──────────────────────────────────────────────
+
+/** Dimmed "○ none" placeholder for genuinely absent data. */
+function AbsentValue() {
+  return (
+    <span style={{ color: 'color-mix(in oklch, var(--ink-3) 50%, transparent)' }}>○ none</span>
+  );
+}
+
+interface ContextSectionProps {
+  detail: TaskDetail | null;
+  loading: boolean;
+}
+
+function ContextSection({ detail, loading }: ContextSectionProps) {
+  if (loading) {
+    return (
+      <div className="space-y-0">
+        {(['consensus round', 'sibling tasks', 'findings', 'signals'] as const).map((label) => (
+          <KVRow key={label} label={label} dimmed>
+            <span
+              className="inline-block h-3 w-24 rounded animate-pulse"
+              style={{ background: 'color-mix(in oklch, var(--border) 60%, transparent)' }}
+              aria-label="loading"
+            />
+          </KVRow>
+        ))}
+      </div>
+    );
+  }
+
+  const consensusId = detail?.consensusId;
+  const siblings = detail?.siblingTaskIds ?? [];
+  const signalCount = detail?.signalCount ?? 0;
+  const findingCount = detail?.findingCount ?? 0;
+
+  return (
+    <div className="space-y-0">
+      {/* Consensus round */}
+      <KVRow label="consensus round">
+        {consensusId ? (
+          <a
+            href={href(`/consensus/${encodeURIComponent(consensusId)}`)}
+            className="transition hover:underline"
+            style={{ color: 'var(--info)', fontFamily: 'JetBrains Mono, monospace' }}
+          >
+            {consensusId}
+          </a>
+        ) : (
+          <AbsentValue />
+        )}
+      </KVRow>
+
+      {/* Sibling tasks */}
+      <KVRow label="sibling tasks">
+        {siblings.length > 0 ? (
+          <span className="flex flex-wrap gap-x-3 gap-y-0.5">
+            <span style={{ color: 'var(--ink-2)' }}>{siblings.length}</span>
+            {siblings.slice(0, 5).map((sid) => (
+              <a
+                key={sid}
+                href={href(`/tasks/${encodeURIComponent(sid)}`)}
+                className="transition hover:underline"
+                style={{ color: 'var(--info)', fontFamily: 'JetBrains Mono, monospace' }}
+              >
+                {sid.slice(0, 8)}
+              </a>
+            ))}
+            {siblings.length > 5 && (
+              <span style={{ color: 'var(--ink-3)' }}>+{siblings.length - 5} more</span>
+            )}
+          </span>
+        ) : (
+          <AbsentValue />
+        )}
+      </KVRow>
+
+      {/* Findings */}
+      <KVRow label="findings">
+        {findingCount > 0 ? (
+          <span style={{ color: 'var(--ink-2)' }}>{findingCount}</span>
+        ) : (
+          <AbsentValue />
+        )}
+      </KVRow>
+
+      {/* Signals */}
+      <KVRow label="signals">
+        {signalCount > 0 ? (
+          <a
+            href={href('/signals')}
+            className="transition hover:underline"
+            style={{ color: 'var(--info)' }}
+          >
+            {signalCount}
+          </a>
+        ) : (
+          <AbsentValue />
+        )}
+      </KVRow>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────
 // Main page
 // ──────────────────────────────────────────────
-import type React from 'react';
+import { useState, useEffect } from 'react';
 
 export function TaskPage({ taskId, tasks }: TaskPageProps) {
-  // Find the task in the loaded set
-  const task: TaskItem | undefined = tasks?.items.find((t) => t.taskId === taskId);
+  // Prop task used as fast initial render (if already loaded in the session).
+  const propTask: TaskItem | undefined = tasks?.items.find((t) => t.taskId === taskId);
 
-  if (!task) {
+  // Fetch enriched detail from the backend.
+  const [detail, setDetail] = useState<TaskDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(true);
+  const [detailNotFound, setDetailNotFound] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setDetailLoading(true);
+    setDetailNotFound(false);
+    setDetail(null);
+
+    fetch(`/dashboard/api/tasks/${encodeURIComponent(taskId)}`)
+      .then(async (res) => {
+        if (res.status === 404) {
+          if (!cancelled) setDetailNotFound(true);
+          return;
+        }
+        if (!res.ok) return; // best-effort; fall back to prop
+        const body = await res.json().catch(() => null);
+        if (!cancelled && body) setDetail(body as TaskDetail);
+      })
+      .catch(() => { /* network failure — fall back to prop */ })
+      .finally(() => { if (!cancelled) setDetailLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [taskId]);
+
+  // Resolve which task record to render from.
+  // Prefer the fetched detail; fall back to the prop task while loading.
+  const task: TaskItem | undefined = detail ?? propTask;
+
+  // Not found: neither the API nor the prop list knows this taskId.
+  if (!detailLoading && detailNotFound && !task) {
     return <TaskNotFound taskId={taskId} />;
+  }
+
+  // Still loading AND no prop task to show yet.
+  if (!task) {
+    return (
+      <div>
+        <Breadcrumb taskId={taskId} />
+        <div
+          className="rounded-lg border p-8 text-center font-mono text-[11px]"
+          style={{ borderColor: 'var(--border)', background: 'var(--surface)', color: 'var(--ink-3)' }}
+        >
+          <span
+            className="inline-block h-3 w-32 rounded animate-pulse"
+            style={{ background: 'color-mix(in oklch, var(--border) 60%, transparent)' }}
+          />
+        </div>
+      </div>
+    );
   }
 
   const key = normaliseStatus(task.status);
@@ -301,31 +455,13 @@ export function TaskPage({ taskId, tasks }: TaskPageProps) {
         </div>
       </div>
 
-      {/* ── Context section (Tranche 2 placeholders) ── */}
+      {/* ── Context section ── */}
       <div
         className="rounded-lg border p-5"
         style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
       >
         <SectionHeader>context</SectionHeader>
-        <div className="space-y-0">
-          {/* Tranche 2: these will be wired to backend data */}
-          <KVRow label="consensus round" dimmed>
-            <span style={{ color: 'color-mix(in oklch, var(--ink-3) 50%, transparent)' }}>○ none</span>
-            {/* TODO Tranche 2: wire to consensus round ID */}
-          </KVRow>
-          <KVRow label="sibling tasks" dimmed>
-            <span style={{ color: 'color-mix(in oklch, var(--ink-3) 50%, transparent)' }}>○ none</span>
-            {/* TODO Tranche 2: wire to parallel task siblings */}
-          </KVRow>
-          <KVRow label="findings" dimmed>
-            <span style={{ color: 'color-mix(in oklch, var(--ink-3) 50%, transparent)' }}>○ none</span>
-            {/* TODO Tranche 2: wire to implementation-findings.jsonl filtered by taskId */}
-          </KVRow>
-          <KVRow label="signals" dimmed>
-            <span style={{ color: 'color-mix(in oklch, var(--ink-3) 50%, transparent)' }}>○ none</span>
-            {/* TODO Tranche 2: wire to agent-performance.jsonl filtered by taskId */}
-          </KVRow>
-        </div>
+        <ContextSection detail={detail} loading={detailLoading} />
       </div>
 
       {/* ── Task prompt ── */}

--- a/packages/dashboard-v2/src/pages/TaskPage.tsx
+++ b/packages/dashboard-v2/src/pages/TaskPage.tsx
@@ -1,0 +1,382 @@
+/**
+ * TaskPage — deep-linkable full-page task detail view.
+ *
+ * Reads the task from the same tasks data TasksPage uses (passed as a prop).
+ * Does NOT make any API call — that is Tranche 2.
+ *
+ * If the task ID is not in the loaded set (cold deep-link), renders a graceful
+ * "not found" frame rather than crashing.
+ */
+import { renderMarkdown, renderFindingMarkdown, agentColor, taskKindFromAgentId, formatDuration, timeAgo } from '@/lib/utils';
+import { normaliseStatus, STATUS_META, STATUS_ICON } from '@/lib/task-status';
+import type { TaskItem, TasksData } from '@/lib/types';
+import { navigate } from '@/lib/router';
+
+interface TaskPageProps {
+  taskId: string;
+  tasks: TasksData | null;
+}
+
+// ──────────────────────────────────────────────
+// Status chip — semantic per DESIGN.md
+// ──────────────────────────────────────────────
+function StatusChip({ status }: { status: string }) {
+  const key = normaliseStatus(status);
+  const meta = STATUS_META[key];
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[11px] font-semibold ${meta.iconBox} ${meta.text}`}
+      style={meta.textStyle}
+    >
+      <svg
+        width="10"
+        height="10"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+        className={meta.pulse ? 'animate-pulse motion-reduce:animate-none' : ''}
+      >
+        {STATUS_ICON[key]}
+      </svg>
+      {meta.label}
+    </span>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Breadcrumb
+// ──────────────────────────────────────────────
+function Breadcrumb({ taskId }: { taskId: string }) {
+  return (
+    <nav className="mb-4 flex items-center gap-1.5 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }} aria-label="Breadcrumb">
+      <button
+        onClick={() => navigate('/tasks')}
+        className="transition hover:underline"
+        style={{ color: 'var(--ink-2)' }}
+      >
+        Tasks
+      </button>
+      <span aria-hidden>›</span>
+      <span style={{ color: 'var(--ink-3)' }}>{taskId.slice(0, 8)}</span>
+    </nav>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Lifecycle timeline — 2-node hairline CSS
+// dispatched → completed (or failed)
+// ──────────────────────────────────────────────
+interface TimelineProps {
+  task: TaskItem;
+}
+
+function LifecycleTimeline({ task }: TimelineProps) {
+  const key = normaliseStatus(task.status);
+  const dispatched = new Date(task.timestamp);
+  const completedMs = task.duration != null ? new Date(dispatched.getTime() + task.duration).getTime() : null;
+
+  const formatTime = (d: Date) =>
+    d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+
+  const isFailed = key === 'failed';
+  const isRunning = key === 'running';
+
+  // Terminal node label + color
+  const endLabel = isFailed ? 'Failed' : isRunning ? 'Running…' : 'Completed';
+  const endColor = isFailed ? 'var(--bad)' : isRunning ? 'var(--info)' : 'var(--ok)';
+  const endBorder = isFailed ? 'var(--bad)' : isRunning ? 'var(--info)' : 'var(--ok)';
+
+  return (
+    <div className="flex items-start gap-0" aria-label="Task lifecycle timeline">
+      {/* Dispatched node */}
+      <div className="flex flex-col items-center" style={{ minWidth: 120 }}>
+        <div
+          className="h-3 w-3 rounded-full border-2"
+          style={{ borderColor: 'var(--ink-3)', background: 'var(--surface)' }}
+        />
+        <div className="mt-1 font-mono text-[10px] font-semibold" style={{ color: 'var(--ink-2)' }}>
+          Dispatched
+        </div>
+        <div className="font-mono text-[10px]" style={{ color: 'var(--ink-3)' }}>
+          {formatTime(dispatched)}
+        </div>
+      </div>
+
+      {/* Connecting line */}
+      <div
+        className="mt-1.5 flex-1"
+        style={{ height: 2, background: isFailed ? 'color-mix(in oklch, var(--bad) 30%, transparent)' : 'var(--border)', minWidth: 40 }}
+        aria-hidden
+      />
+
+      {/* Terminal node */}
+      <div className="flex flex-col items-center" style={{ minWidth: 120 }}>
+        <div
+          className="h-3 w-3 rounded-full border-2"
+          style={{
+            borderColor: endBorder,
+            background: isFailed ? 'color-mix(in oklch, var(--bad) 15%, transparent)' : 'var(--surface)',
+          }}
+        />
+        <div className="mt-1 font-mono text-[10px] font-semibold" style={{ color: endColor }}>
+          {endLabel}
+        </div>
+        <div className="font-mono text-[10px]" style={{ color: 'var(--ink-3)' }}>
+          {completedMs ? formatTime(new Date(completedMs)) : '—'}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Section header — small-caps Geist per DESIGN.md
+// ──────────────────────────────────────────────
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h3
+      className="mb-3 h-section pb-2"
+      style={{ borderBottom: '1px solid var(--border)' }}
+    >
+      {children}
+    </h3>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Key-value row
+// ──────────────────────────────────────────────
+function KVRow({ label, children, dimmed = false }: { label: string; children: React.ReactNode; dimmed?: boolean }) {
+  return (
+    <div className="flex items-start gap-4 py-1.5 border-b border-border/20 last:border-0">
+      <span
+        className="w-32 shrink-0 font-mono text-[11px]"
+        style={{ color: 'var(--ink-3)' }}
+      >
+        {label}
+      </span>
+      <span
+        className="flex-1 font-mono text-[11px]"
+        style={{ color: dimmed ? 'color-mix(in oklch, var(--ink-3) 60%, transparent)' : 'var(--ink-2)' }}
+      >
+        {children}
+      </span>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Not-found frame (cold deep-link)
+// ──────────────────────────────────────────────
+function TaskNotFound({ taskId }: { taskId: string }) {
+  return (
+    <div>
+      <Breadcrumb taskId={taskId} />
+      <div
+        className="rounded-lg border p-8 text-center"
+        style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+      >
+        <div className="font-mono text-sm font-semibold" style={{ color: 'var(--ink-2)' }}>
+          Task not in the loaded list
+        </div>
+        <div className="mt-2 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
+          <code
+            className="rounded px-1"
+            style={{ fontFamily: 'JetBrains Mono, monospace', background: 'color-mix(in oklch, var(--surface-sunk) 40%, transparent)' }}
+          >
+            {taskId}
+          </code>
+        </div>
+        <div className="mt-4 font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
+          Open it from the{' '}
+          <button
+            onClick={() => navigate('/tasks')}
+            className="underline transition hover:opacity-80"
+            style={{ color: 'var(--info)' }}
+          >
+            Tasks list
+          </button>{' '}
+          first to load the session — direct task fetch arrives in a later update.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Main page
+// ──────────────────────────────────────────────
+import type React from 'react';
+
+export function TaskPage({ taskId, tasks }: TaskPageProps) {
+  // Find the task in the loaded set
+  const task: TaskItem | undefined = tasks?.items.find((t) => t.taskId === taskId);
+
+  if (!task) {
+    return <TaskNotFound taskId={taskId} />;
+  }
+
+  const key = normaliseStatus(task.status);
+  const kind = taskKindFromAgentId(task.agentId);
+  const totalTokens = (task.inputTokens ?? 0) + (task.outputTokens ?? 0);
+
+  return (
+    <div className="space-y-6">
+      {/* Breadcrumb */}
+      <Breadcrumb taskId={taskId} />
+
+      {/* ── Header card ── */}
+      <div
+        className="rounded-lg border p-5"
+        style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+      >
+        {/* Row 1: status + kind + full ID */}
+        <div className="flex flex-wrap items-center gap-3">
+          <StatusChip status={task.status} />
+          {kind && (
+            <span
+              className={`rounded-sm border border-border/40 px-1.5 py-0.5 font-mono text-[10px] font-bold uppercase tracking-wider ${kind.cls}`}
+              style={{ background: 'color-mix(in oklch, var(--surface) 40%, transparent)', ...kind.clsStyle }}
+            >
+              {kind.label}
+            </span>
+          )}
+          {/* Full UUID in JetBrains Mono */}
+          <code
+            className="rounded px-2 py-0.5 text-[11px]"
+            style={{
+              fontFamily: 'JetBrains Mono, monospace',
+              color: 'var(--ink-2)',
+              background: 'color-mix(in oklch, var(--surface-sunk) 40%, transparent)',
+            }}
+          >
+            {task.taskId}
+          </code>
+        </div>
+
+        {/* Row 2: agent identity dot + name → /agent/:id */}
+        <div className="mt-3 flex flex-wrap items-center gap-4">
+          <a
+            href={`/dashboard/agent/${encodeURIComponent(task.agentId)}`}
+            className="inline-flex items-center gap-2 font-mono text-xs transition hover:opacity-80"
+            style={{ color: 'var(--ink-2)' }}
+          >
+            <span
+              className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+              style={{ backgroundColor: agentColor(task.agentId) }}
+            />
+            {task.agentId}
+          </a>
+
+          {/* Token split */}
+          {totalTokens > 0 && (
+            <span className="font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
+              <span style={{ color: 'var(--ink-2)' }}>{(task.inputTokens ?? 0).toLocaleString()}</span>
+              {' '}in /{' '}
+              <span style={{ color: 'var(--ink-2)' }}>{(task.outputTokens ?? 0).toLocaleString()}</span>
+              {' '}out tokens
+            </span>
+          )}
+
+          {/* Duration */}
+          {task.duration != null && (
+            <span className="font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
+              {formatDuration(task.duration)}
+            </span>
+          )}
+
+          {/* Timestamp */}
+          <span className="font-mono text-[11px]" style={{ color: 'var(--ink-3)' }}>
+            {timeAgo(task.timestamp)}
+          </span>
+        </div>
+
+        {/* Row 3: lifecycle timeline */}
+        <div className="mt-5">
+          <LifecycleTimeline task={task} />
+        </div>
+      </div>
+
+      {/* ── Context section (Tranche 2 placeholders) ── */}
+      <div
+        className="rounded-lg border p-5"
+        style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+      >
+        <SectionHeader>context</SectionHeader>
+        <div className="space-y-0">
+          {/* Tranche 2: these will be wired to backend data */}
+          <KVRow label="consensus round" dimmed>
+            <span style={{ color: 'color-mix(in oklch, var(--ink-3) 50%, transparent)' }}>○ none</span>
+            {/* TODO Tranche 2: wire to consensus round ID */}
+          </KVRow>
+          <KVRow label="sibling tasks" dimmed>
+            <span style={{ color: 'color-mix(in oklch, var(--ink-3) 50%, transparent)' }}>○ none</span>
+            {/* TODO Tranche 2: wire to parallel task siblings */}
+          </KVRow>
+          <KVRow label="findings" dimmed>
+            <span style={{ color: 'color-mix(in oklch, var(--ink-3) 50%, transparent)' }}>○ none</span>
+            {/* TODO Tranche 2: wire to implementation-findings.jsonl filtered by taskId */}
+          </KVRow>
+          <KVRow label="signals" dimmed>
+            <span style={{ color: 'color-mix(in oklch, var(--ink-3) 50%, transparent)' }}>○ none</span>
+            {/* TODO Tranche 2: wire to agent-performance.jsonl filtered by taskId */}
+          </KVRow>
+        </div>
+      </div>
+
+      {/* ── Task prompt ── */}
+      <div
+        className="rounded-lg border p-5"
+        style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+      >
+        <SectionHeader>task</SectionHeader>
+        <div
+          className="task-md rounded-md border border-border/40 p-3 text-xs leading-relaxed overflow-x-auto"
+          style={{
+            background: 'color-mix(in oklch, var(--surface) 40%, transparent)',
+            color: 'color-mix(in oklch, var(--ink) 90%, transparent)',
+          }}
+          dangerouslySetInnerHTML={{ __html: renderMarkdown(task.task) }}
+        />
+      </div>
+
+      {/* ── Result ── */}
+      <div
+        className="rounded-lg border p-5"
+        style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+      >
+        <SectionHeader>result</SectionHeader>
+        {task.result ? (
+          <div
+            className="finding-md rounded-md border border-border/40 p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap [&_.cite-file]:rounded [&_.cite-file]:bg-[color-mix(in_oklch,var(--cite-file)_10%,transparent)] [&_.cite-file]:px-1 [&_.cite-file]:text-[var(--cite-file)] [&_.cite-fn]:rounded [&_.cite-fn]:bg-[color-mix(in_oklch,var(--cite-fn)_10%,transparent)] [&_.cite-fn]:px-1 [&_.cite-fn]:text-[var(--cite-fn)] [&_.inline-code]:rounded [&_.inline-code]:bg-[color-mix(in_oklch,var(--surface-sunk)_40%,transparent)] [&_.inline-code]:px-1 [&_.inline-code-block]:my-2 [&_.inline-code-block]:block [&_.inline-code-block]:rounded [&_.inline-code-block]:bg-[color-mix(in_oklch,var(--surface-sunk)_30%,transparent)] [&_.inline-code-block]:p-2"
+            style={{
+              background: 'color-mix(in oklch, var(--surface) 40%, transparent)',
+              color: 'color-mix(in oklch, var(--ink) 90%, transparent)',
+            }}
+            dangerouslySetInnerHTML={{ __html: renderFindingMarkdown(task.result) }}
+          />
+        ) : (
+          <div
+            className="rounded-md border border-border/40 p-5 text-center font-mono text-xs"
+            style={{
+              background: 'color-mix(in oklch, var(--surface) 40%, transparent)',
+              color: 'var(--ink-3)',
+            }}
+          >
+            {key === 'running' ? (
+              <span style={{ color: 'var(--info)' }}>Task is still running…</span>
+            ) : key === 'failed' ? (
+              <span style={{ color: 'var(--bad)' }}>Task failed — no result recorded.</span>
+            ) : (
+              <span>No result recorded.</span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/relay/src/dashboard/api-task-detail.ts
+++ b/packages/relay/src/dashboard/api-task-detail.ts
@@ -1,29 +1,15 @@
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
-import { tasksHandler } from './api-tasks';
 
-/** Reads agent-performance.jsonl + its .1 rotation. */
-function readPerfLines(perfPath: string): string[] {
+/** Reads a jsonl file + its .1 rotation into an array of raw lines. */
+function readJsonlLines(filePath: string): string[] {
   const out: string[] = [];
-  const archive = perfPath + '.1';
+  const archive = filePath + '.1';
   if (existsSync(archive)) {
     out.push(...readFileSync(archive, 'utf-8').split('\n').filter(Boolean));
   }
-  if (existsSync(perfPath)) {
-    out.push(...readFileSync(perfPath, 'utf-8').split('\n').filter(Boolean));
-  }
-  return out;
-}
-
-/** Reads implementation-findings.jsonl + its .1 rotation. */
-function readFindingsLines(findingsPath: string): string[] {
-  const out: string[] = [];
-  const archive = findingsPath + '.1';
-  if (existsSync(archive)) {
-    out.push(...readFileSync(archive, 'utf-8').split('\n').filter(Boolean));
-  }
-  if (existsSync(findingsPath)) {
-    out.push(...readFileSync(findingsPath, 'utf-8').split('\n').filter(Boolean));
+  if (existsSync(filePath)) {
+    out.push(...readFileSync(filePath, 'utf-8').split('\n').filter(Boolean));
   }
   return out;
 }
@@ -34,21 +20,24 @@ export interface TaskDetailResponse {
   task: string;
   result?: string;
   status: 'completed' | 'failed' | 'cancelled' | 'running';
-  /** Duration in milliseconds. Sourced from durationMs field in task-graph.jsonl.
-   *  Note: the raw event field is "durationMs" on disk; api-tasks.ts reads it
-   *  as "entry.duration" which is undefined — this handler reads the correct
-   *  "entry.durationMs" field and maps it to "duration" in the response. */
+  /** Duration in milliseconds sourced from durationMs (preferred) or duration field
+   *  in task-graph.jsonl. */
   duration?: number;
+  /** ISO timestamp of completion/failure/cancellation event (or dispatch time if running). */
   timestamp: string;
+  /** ISO timestamp of task.created event — always the dispatch time. */
+  createdAt: string;
   inputTokens?: number;
   outputTokens?: number;
   /** First non-empty consensusId from agent-performance.jsonl rows matching this taskId. */
   consensusId?: string;
-  /** Other taskIds that share the same consensusId, capped at 25. */
+  /** Other taskIds that share the same consensusId, capped at SIBLING_CAP. */
   siblingTaskIds?: string[];
+  /** True when the sibling list was truncated at SIBLING_CAP. */
+  siblingsTruncated?: boolean;
   /** Count of agent-performance.jsonl rows matching this taskId. */
   signalCount?: number;
-  /** Count of implementation-findings.jsonl rows where taskId field matches this taskId. */
+  /** Count of implementation-findings.jsonl rows whose taskId starts with `${consensusId}:`. */
   findingCount?: number;
 }
 
@@ -59,86 +48,140 @@ export async function taskDetailHandler(
   projectRoot: string,
   taskId: string,
 ): Promise<TaskDetailResponse | null> {
-  // Fetch base task from tasksHandler (reuses task-graph parsing logic).
-  // Use a large limit to ensure we can find the task even if it's old.
-  const all = await tasksHandler(projectRoot, new URLSearchParams({ limit: '2000', offset: '0' }));
-  const base = all.items.find((t) => t.taskId === taskId);
-  if (!base) return null;
+  // ── FIX 3: query task-graph.jsonl directly (no 2000-row cap, includes utility-agent tasks) ──
+  const graphPath = join(projectRoot, '.gossip', 'task-graph.jsonl');
+  if (!existsSync(graphPath) && !existsSync(graphPath + '.1')) {
+    return null;
+  }
 
-  // Enrich with agent-performance.jsonl
-  let consensusId: string | undefined;
-  let signalCount = 0;
-  const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+  const created = new Map<string, { agentId: string; task: string; timestamp: string }>();
+  const completed = new Map<string, {
+    duration?: number;
+    timestamp: string;
+    failed: boolean;
+    cancelled?: boolean;
+    inputTokens?: number;
+    outputTokens?: number;
+    result?: string;
+  }>();
+
   try {
-    const lines = readPerfLines(perfPath);
+    const lines = readJsonlLines(graphPath);
     for (const line of lines) {
       try {
         const entry = JSON.parse(line);
-        if (entry.taskId !== taskId) continue;
-        signalCount++;
-        if (!consensusId && typeof entry.consensusId === 'string' && entry.consensusId) {
-          consensusId = entry.consensusId;
+        if (entry.type === 'task.created') {
+          created.set(entry.taskId, {
+            agentId: entry.agentId || '?',
+            task: entry.task || '',
+            timestamp: entry.timestamp,
+          });
+        } else if (entry.type === 'task.completed') {
+          completed.set(entry.taskId, {
+            duration: entry.durationMs ?? entry.duration,
+            timestamp: entry.timestamp,
+            failed: false,
+            inputTokens: entry.inputTokens,
+            outputTokens: entry.outputTokens,
+            result: typeof entry.result === 'string' ? entry.result : undefined,
+          });
+        } else if (entry.type === 'task.failed') {
+          completed.set(entry.taskId, { timestamp: entry.timestamp, failed: true });
+        } else if (entry.type === 'task.cancelled') {
+          completed.set(entry.taskId, { timestamp: entry.timestamp, failed: false, cancelled: true });
         }
       } catch { /* skip malformed */ }
     }
+  } catch { return null; }
+
+  const info = created.get(taskId);
+  if (!info) return null;
+
+  const result = completed.get(taskId);
+  const base = {
+    taskId,
+    agentId: info.agentId,
+    task: info.task,
+    result: result?.result,
+    status: (result
+      ? (result.cancelled ? 'cancelled' : result.failed ? 'failed' : 'completed')
+      : 'running') as TaskDetailResponse['status'],
+    duration: result?.duration,
+    timestamp: result?.timestamp || info.timestamp,
+    createdAt: info.timestamp,
+    inputTokens: result?.inputTokens,
+    outputTokens: result?.outputTokens,
+  };
+
+  // ── FIX 4: single pass over agent-performance.jsonl for signalCount + consensusId + siblings ──
+  let consensusId: string | undefined;
+  let signalCount = 0;
+  const siblingSet = new Set<string>();
+
+  const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+  try {
+    const lines = readJsonlLines(perfPath);
+    // First pass: collect signalCount + consensusId for this taskId.
+    // We need consensusId before we can filter siblings, so do two logical passes
+    // but only one file read.
+    const allEntries: { taskId: string; consensusId?: string }[] = [];
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line);
+        if (typeof entry.taskId !== 'string') continue;
+        allEntries.push(entry);
+        if (entry.taskId === taskId) {
+          signalCount++;
+          if (!consensusId && typeof entry.consensusId === 'string' && entry.consensusId) {
+            consensusId = entry.consensusId;
+          }
+        }
+      } catch { /* skip malformed */ }
+    }
+    // Second logical pass (same in-memory array) for siblings.
+    if (consensusId) {
+      for (const entry of allEntries) {
+        if (siblingSet.size >= SIBLING_CAP) break;
+        if (
+          entry.consensusId === consensusId &&
+          typeof entry.taskId === 'string' &&
+          entry.taskId &&
+          entry.taskId !== taskId
+        ) {
+          siblingSet.add(entry.taskId);
+        }
+      }
+    }
   } catch { /* file unreadable — best effort */ }
 
-  // Collect sibling taskIds (other tasks sharing the same consensusId)
-  let siblingTaskIds: string[] | undefined;
+  // ── FIX 5: count implementation-findings by consensusId prefix ──
+  // implementation-findings.jsonl rows use `taskId` = `${consensusId}:fN` (finding-level IDs).
+  // Count rows that START WITH `${consensusId}:` to get round-level finding count.
+  let findingCount = 0;
   if (consensusId) {
-    const siblingSet = new Set<string>();
-    const perfPath2 = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+    const prefix = `${consensusId}:`;
+    const findingsPath = join(projectRoot, '.gossip', 'implementation-findings.jsonl');
     try {
-      const lines = readPerfLines(perfPath2);
+      const lines = readJsonlLines(findingsPath);
       for (const line of lines) {
-        if (siblingSet.size >= SIBLING_CAP) break;
         try {
           const entry = JSON.parse(line);
-          if (
-            entry.consensusId === consensusId &&
-            typeof entry.taskId === 'string' &&
-            entry.taskId &&
-            entry.taskId !== taskId
-          ) {
-            siblingSet.add(entry.taskId);
+          if (typeof entry.taskId === 'string' && entry.taskId.startsWith(prefix)) {
+            findingCount++;
           }
         } catch { /* skip malformed */ }
       }
     } catch { /* best effort */ }
-    if (siblingSet.size > 0) {
-      siblingTaskIds = [...siblingSet];
-    }
   }
 
-  // Count implementation-findings rows for this taskId.
-  // Note: the "taskId" field in implementation-findings.jsonl currently stores
-  // finding-level IDs (e.g. "consensusId:fN") rather than dispatch task IDs,
-  // so this count will typically be 0 until that data schema is unified.
-  // We still perform the lookup faithfully per spec.
-  let findingCount = 0;
-  const findingsPath = join(projectRoot, '.gossip', 'implementation-findings.jsonl');
-  try {
-    const lines = readFindingsLines(findingsPath);
-    for (const line of lines) {
-      try {
-        const entry = JSON.parse(line);
-        if (entry.taskId === taskId) findingCount++;
-      } catch { /* skip malformed */ }
-    }
-  } catch { /* best effort */ }
+  const siblingTaskIds = siblingSet.size > 0 ? [...siblingSet] : undefined;
+  const siblingsTruncated = siblingSet.size >= SIBLING_CAP;
 
   return {
-    taskId: base.taskId,
-    agentId: base.agentId,
-    task: base.task,
-    result: base.result,
-    status: base.status,
-    duration: base.duration,
-    timestamp: base.timestamp,
-    inputTokens: base.inputTokens,
-    outputTokens: base.outputTokens,
+    ...base,
     ...(consensusId !== undefined && { consensusId }),
     ...(siblingTaskIds !== undefined && { siblingTaskIds }),
+    ...(siblingsTruncated && { siblingsTruncated }),
     signalCount,
     findingCount,
   };

--- a/packages/relay/src/dashboard/api-task-detail.ts
+++ b/packages/relay/src/dashboard/api-task-detail.ts
@@ -1,0 +1,145 @@
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tasksHandler } from './api-tasks';
+
+/** Reads agent-performance.jsonl + its .1 rotation. */
+function readPerfLines(perfPath: string): string[] {
+  const out: string[] = [];
+  const archive = perfPath + '.1';
+  if (existsSync(archive)) {
+    out.push(...readFileSync(archive, 'utf-8').split('\n').filter(Boolean));
+  }
+  if (existsSync(perfPath)) {
+    out.push(...readFileSync(perfPath, 'utf-8').split('\n').filter(Boolean));
+  }
+  return out;
+}
+
+/** Reads implementation-findings.jsonl + its .1 rotation. */
+function readFindingsLines(findingsPath: string): string[] {
+  const out: string[] = [];
+  const archive = findingsPath + '.1';
+  if (existsSync(archive)) {
+    out.push(...readFileSync(archive, 'utf-8').split('\n').filter(Boolean));
+  }
+  if (existsSync(findingsPath)) {
+    out.push(...readFileSync(findingsPath, 'utf-8').split('\n').filter(Boolean));
+  }
+  return out;
+}
+
+export interface TaskDetailResponse {
+  taskId: string;
+  agentId: string;
+  task: string;
+  result?: string;
+  status: 'completed' | 'failed' | 'cancelled' | 'running';
+  /** Duration in milliseconds. Sourced from durationMs field in task-graph.jsonl.
+   *  Note: the raw event field is "durationMs" on disk; api-tasks.ts reads it
+   *  as "entry.duration" which is undefined — this handler reads the correct
+   *  "entry.durationMs" field and maps it to "duration" in the response. */
+  duration?: number;
+  timestamp: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  /** First non-empty consensusId from agent-performance.jsonl rows matching this taskId. */
+  consensusId?: string;
+  /** Other taskIds that share the same consensusId, capped at 25. */
+  siblingTaskIds?: string[];
+  /** Count of agent-performance.jsonl rows matching this taskId. */
+  signalCount?: number;
+  /** Count of implementation-findings.jsonl rows where taskId field matches this taskId. */
+  findingCount?: number;
+}
+
+/** Cap for sibling task IDs to avoid unbounded response size. */
+const SIBLING_CAP = 25;
+
+export async function taskDetailHandler(
+  projectRoot: string,
+  taskId: string,
+): Promise<TaskDetailResponse | null> {
+  // Fetch base task from tasksHandler (reuses task-graph parsing logic).
+  // Use a large limit to ensure we can find the task even if it's old.
+  const all = await tasksHandler(projectRoot, new URLSearchParams({ limit: '2000', offset: '0' }));
+  const base = all.items.find((t) => t.taskId === taskId);
+  if (!base) return null;
+
+  // Enrich with agent-performance.jsonl
+  let consensusId: string | undefined;
+  let signalCount = 0;
+  const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+  try {
+    const lines = readPerfLines(perfPath);
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line);
+        if (entry.taskId !== taskId) continue;
+        signalCount++;
+        if (!consensusId && typeof entry.consensusId === 'string' && entry.consensusId) {
+          consensusId = entry.consensusId;
+        }
+      } catch { /* skip malformed */ }
+    }
+  } catch { /* file unreadable — best effort */ }
+
+  // Collect sibling taskIds (other tasks sharing the same consensusId)
+  let siblingTaskIds: string[] | undefined;
+  if (consensusId) {
+    const siblingSet = new Set<string>();
+    const perfPath2 = join(projectRoot, '.gossip', 'agent-performance.jsonl');
+    try {
+      const lines = readPerfLines(perfPath2);
+      for (const line of lines) {
+        if (siblingSet.size >= SIBLING_CAP) break;
+        try {
+          const entry = JSON.parse(line);
+          if (
+            entry.consensusId === consensusId &&
+            typeof entry.taskId === 'string' &&
+            entry.taskId &&
+            entry.taskId !== taskId
+          ) {
+            siblingSet.add(entry.taskId);
+          }
+        } catch { /* skip malformed */ }
+      }
+    } catch { /* best effort */ }
+    if (siblingSet.size > 0) {
+      siblingTaskIds = [...siblingSet];
+    }
+  }
+
+  // Count implementation-findings rows for this taskId.
+  // Note: the "taskId" field in implementation-findings.jsonl currently stores
+  // finding-level IDs (e.g. "consensusId:fN") rather than dispatch task IDs,
+  // so this count will typically be 0 until that data schema is unified.
+  // We still perform the lookup faithfully per spec.
+  let findingCount = 0;
+  const findingsPath = join(projectRoot, '.gossip', 'implementation-findings.jsonl');
+  try {
+    const lines = readFindingsLines(findingsPath);
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line);
+        if (entry.taskId === taskId) findingCount++;
+      } catch { /* skip malformed */ }
+    }
+  } catch { /* best effort */ }
+
+  return {
+    taskId: base.taskId,
+    agentId: base.agentId,
+    task: base.task,
+    result: base.result,
+    status: base.status,
+    duration: base.duration,
+    timestamp: base.timestamp,
+    inputTokens: base.inputTokens,
+    outputTokens: base.outputTokens,
+    ...(consensusId !== undefined && { consensusId }),
+    ...(siblingTaskIds !== undefined && { siblingTaskIds }),
+    signalCount,
+    findingCount,
+  };
+}

--- a/packages/relay/src/dashboard/api-tasks.ts
+++ b/packages/relay/src/dashboard/api-tasks.ts
@@ -26,7 +26,12 @@ interface TaskEntry {
   result?: string;
   status: 'completed' | 'failed' | 'cancelled' | 'running';
   duration?: number;
+  /** ISO timestamp of task.completed/failed/cancelled event (or task.created if still running).
+   *  Used as the "Completed" / "Failed" node in the LifecycleTimeline. */
   timestamp: string;
+  /** ISO timestamp of task.created event — always the dispatch time.
+   *  Used as the "Dispatched" node in the LifecycleTimeline. */
+  createdAt: string;
   inputTokens?: number;
   outputTokens?: number;
 }
@@ -101,7 +106,11 @@ export async function tasksHandler(projectRoot: string, query?: URLSearchParams)
       result: result?.result,
       status: result ? (result.cancelled ? 'cancelled' : result.failed ? 'failed' : 'completed') : 'running',
       duration: result?.duration,
+      // timestamp = completion time for terminal tasks (used as "Completed" node in timeline).
+      // For running tasks, falls back to createdAt.
       timestamp: result?.timestamp || info.timestamp,
+      // createdAt = always the dispatch time (task.created event timestamp).
+      createdAt: info.timestamp,
       inputTokens: result?.inputTokens,
       outputTokens: result?.outputTokens,
     });

--- a/packages/relay/src/dashboard/api-tasks.ts
+++ b/packages/relay/src/dashboard/api-tasks.ts
@@ -65,7 +65,9 @@ export async function tasksHandler(projectRoot: string, query?: URLSearchParams)
           });
         } else if (entry.type === 'task.completed') {
           completed.set(entry.taskId, {
-            duration: entry.duration,
+            // On-disk field is "durationMs"; "entry.duration" was previously
+            // undefined, silently dropping all task durations from the response.
+            duration: entry.durationMs ?? entry.duration,
             timestamp: entry.timestamp,
             failed: false,
             inputTokens: entry.inputTokens,

--- a/packages/relay/src/dashboard/routes.ts
+++ b/packages/relay/src/dashboard/routes.ts
@@ -16,6 +16,7 @@ import { findingHandler } from './api-finding';
 import { openFindingsHandler } from './api-open-findings';
 import { learningsHandler } from './api-learnings';
 import { tasksHandler } from './api-tasks';
+import { taskDetailHandler } from './api-task-detail';
 import { activeTasksHandler } from './api-active-tasks';
 import { sessionHandler } from './api-session';
 import { logsHandler } from './api-logs';
@@ -583,6 +584,22 @@ export class DashboardRouter {
         const data = await tasksHandler(this.projectRoot, query ?? undefined);
         this.json(res, 200, data);
         return true;
+      }
+
+      {
+        // /dashboard/api/tasks/:id — placed AFTER the literal /tasks route so
+        // that the exact path still matches first.
+        const m = url.match(/^\/dashboard\/api\/tasks\/([^/]+)$/);
+        if (m && req.method === 'GET') {
+          const taskId = decodeURIComponent(m[1]);
+          const data = await taskDetailHandler(this.projectRoot, taskId);
+          if (data === null) {
+            this.json(res, 404, { error: `Task not found: ${taskId}` });
+          } else {
+            this.json(res, 200, data);
+          }
+          return true;
+        }
       }
 
       if (url === '/dashboard/api/active-tasks' && req.method === 'GET') {

--- a/tests/dashboard/api-task-detail.test.ts
+++ b/tests/dashboard/api-task-detail.test.ts
@@ -62,7 +62,50 @@ describe('taskDetailHandler', () => {
     expect(result!.result).toBe('done');
   });
 
-  it('enriches with signalCount and consensusId from agent-performance.jsonl', async () => {
+  it('returns createdAt as the dispatch (task.created) timestamp', async () => {
+    const graphPath = join(gossipDir, 'task-graph.jsonl');
+    writeLines(graphPath, [
+      { type: 'task.created', taskId: 'task-b2', agentId: 'haiku-researcher', task: 'Research B2', timestamp: '2026-06-01T00:00:00.000Z' },
+      { type: 'task.completed', taskId: 'task-b2', durationMs: 12000, result: 'done', timestamp: '2026-06-01T00:00:12.000Z' },
+    ]);
+    const result = await taskDetailHandler(dir, 'task-b2');
+    expect(result).not.toBeNull();
+    // createdAt = task.created timestamp
+    expect(result!.createdAt).toBe('2026-06-01T00:00:00.000Z');
+    // timestamp = task.completed timestamp (completion time, not dispatch time)
+    expect(result!.timestamp).toBe('2026-06-01T00:00:12.000Z');
+  });
+
+  it('resolves task beyond 2000 rows by reading task-graph directly', async () => {
+    const graphPath = join(gossipDir, 'task-graph.jsonl');
+    // Write 2001 tasks; the target task is last
+    const lines: object[] = [];
+    for (let i = 0; i < 2000; i++) {
+      lines.push({ type: 'task.created', taskId: `filler-${i}`, agentId: 'sonnet-implementer', task: `Task ${i}`, timestamp: '2026-06-01T00:00:00.000Z' });
+      lines.push({ type: 'task.completed', taskId: `filler-${i}`, durationMs: 1000, timestamp: '2026-06-01T00:00:01.000Z' });
+    }
+    lines.push({ type: 'task.created', taskId: 'task-deep', agentId: 'gemini-reviewer', task: 'Deep task', timestamp: '2026-05-01T00:00:00.000Z' });
+    lines.push({ type: 'task.completed', taskId: 'task-deep', durationMs: 5000, timestamp: '2026-05-01T00:00:05.000Z' });
+    writeLines(graphPath, lines);
+    const result = await taskDetailHandler(dir, 'task-deep');
+    expect(result).not.toBeNull();
+    expect(result!.taskId).toBe('task-deep');
+    expect(result!.agentId).toBe('gemini-reviewer');
+  });
+
+  it('resolves utility-agent tasks (not filtered out)', async () => {
+    const graphPath = join(gossipDir, 'task-graph.jsonl');
+    writeLines(graphPath, [
+      { type: 'task.created', taskId: 'util-task-1', agentId: '_utility', task: 'Utility work', timestamp: '2026-06-01T00:00:00.000Z' },
+      { type: 'task.completed', taskId: 'util-task-1', durationMs: 100, timestamp: '2026-06-01T00:00:00.100Z' },
+    ]);
+    const result = await taskDetailHandler(dir, 'util-task-1');
+    expect(result).not.toBeNull();
+    expect(result!.taskId).toBe('util-task-1');
+    expect(result!.agentId).toBe('_utility');
+  });
+
+  it('enriches with signalCount and consensusId from agent-performance.jsonl (single pass)', async () => {
     const graphPath = join(gossipDir, 'task-graph.jsonl');
     writeLines(graphPath, [
       { type: 'task.created', taskId: 'task-c', agentId: 'sonnet-reviewer', task: 'Review C', timestamp: '2026-06-02T00:00:00.000Z' },
@@ -110,7 +153,60 @@ describe('taskDetailHandler', () => {
     expect(result!.siblingTaskIds).not.toContain('task-other');
   });
 
-  it('returns findingCount=0 for a task with no matching implementation-findings rows', async () => {
+  it('sets siblingsTruncated=true when sibling cap is hit', async () => {
+    const graphPath = join(gossipDir, 'task-graph.jsonl');
+    writeLines(graphPath, [
+      { type: 'task.created', taskId: 'task-cap', agentId: 'sonnet-reviewer', task: 'Cap test', timestamp: '2026-06-03T00:00:00.000Z' },
+      { type: 'task.completed', taskId: 'task-cap', durationMs: 1000, timestamp: '2026-06-03T00:00:01.000Z' },
+    ]);
+
+    const perfPath = join(gossipDir, 'agent-performance.jsonl');
+    // Write 26 sibling entries (cap is 25) + 1 for the main task
+    const lines: object[] = [
+      { type: 'consensus', signal: 'agreement', taskId: 'task-cap', agentId: 'sonnet-reviewer', consensusId: 'cap-round-id', timestamp: '2026-06-03T00:00:02.000Z' },
+    ];
+    for (let i = 0; i < 26; i++) {
+      lines.push({ type: 'consensus', signal: 'agreement', taskId: `sib-${i}`, agentId: 'sonnet-reviewer', consensusId: 'cap-round-id', timestamp: '2026-06-03T00:00:02.000Z' });
+    }
+    writeLines(perfPath, lines);
+
+    const result = await taskDetailHandler(dir, 'task-cap');
+    expect(result).not.toBeNull();
+    expect(result!.siblingTaskIds).toHaveLength(25);
+    expect(result!.siblingsTruncated).toBe(true);
+  });
+
+  it('counts findingCount by consensusId prefix (not exact match)', async () => {
+    const graphPath = join(gossipDir, 'task-graph.jsonl');
+    writeLines(graphPath, [
+      { type: 'task.created', taskId: 'task-findings', agentId: 'gemini-reviewer', task: 'Review', timestamp: '2026-06-04T00:00:00.000Z' },
+      { type: 'task.completed', taskId: 'task-findings', durationMs: 3000, timestamp: '2026-06-04T00:00:03.000Z' },
+    ]);
+
+    const perfPath = join(gossipDir, 'agent-performance.jsonl');
+    writeLines(perfPath, [
+      { type: 'consensus', signal: 'agreement', taskId: 'task-findings', agentId: 'gemini-reviewer', consensusId: 'round-abc123', timestamp: '2026-06-04T00:00:04.000Z' },
+    ]);
+
+    const findingsPath = join(gossipDir, 'implementation-findings.jsonl');
+    writeLines(findingsPath, [
+      // These match the consensusId prefix
+      { taskId: 'round-abc123:f1', originalAgentId: 'gemini-reviewer', finding: 'bug A', tag: 'confirmed' },
+      { taskId: 'round-abc123:f2', originalAgentId: 'sonnet-reviewer', finding: 'bug B', tag: 'unique' },
+      // Different consensus round — should NOT be counted
+      { taskId: 'round-other:f1', originalAgentId: 'haiku-researcher', finding: 'bug C', tag: 'confirmed' },
+      // Exact task dispatch ID — also should NOT be counted (not the prefix format)
+      { taskId: 'task-findings', originalAgentId: 'gemini-reviewer', finding: 'bug D', tag: 'confirmed' },
+    ]);
+
+    const result = await taskDetailHandler(dir, 'task-findings');
+    expect(result).not.toBeNull();
+    expect(result!.consensusId).toBe('round-abc123');
+    // Only the two rows starting with "round-abc123:" should be counted
+    expect(result!.findingCount).toBe(2);
+  });
+
+  it('returns findingCount=0 when no consensusId (no findings lookup)', async () => {
     const graphPath = join(gossipDir, 'task-graph.jsonl');
     writeLines(graphPath, [
       { type: 'task.created', taskId: 'task-e', agentId: 'sonnet-implementer', task: 'Implement E', timestamp: '2026-06-04T00:00:00.000Z' },
@@ -124,8 +220,9 @@ describe('taskDetailHandler', () => {
 
     const result = await taskDetailHandler(dir, 'task-e');
     expect(result).not.toBeNull();
-    // implementation-findings taskId field uses consensusId:fN format, not dispatch taskIds
+    // No consensusId → findingCount stays 0, no prefix lookup
     expect(result!.findingCount).toBe(0);
+    expect(result!.consensusId).toBeUndefined();
   });
 
   it('gracefully handles missing agent-performance.jsonl (no enrichment fields)', async () => {
@@ -141,5 +238,6 @@ describe('taskDetailHandler', () => {
     expect(result!.signalCount).toBe(0);
     expect(result!.consensusId).toBeUndefined();
     expect(result!.siblingTaskIds).toBeUndefined();
+    expect(result!.siblingsTruncated).toBeUndefined();
   });
 });

--- a/tests/dashboard/api-task-detail.test.ts
+++ b/tests/dashboard/api-task-detail.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for taskDetailHandler (packages/relay/src/dashboard/api-task-detail.ts).
+ *
+ * Uses a tmp fixture directory with synthetic task-graph.jsonl,
+ * agent-performance.jsonl, and implementation-findings.jsonl files.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { taskDetailHandler } from '../../packages/relay/src/dashboard/api-task-detail';
+
+// ─── fixture helpers ────────────────────────────────────────────────────────
+
+function writeLines(path: string, lines: object[]) {
+  writeFileSync(path, lines.map((l) => JSON.stringify(l)).join('\n') + '\n', 'utf-8');
+}
+
+// ─── suite ──────────────────────────────────────────────────────────────────
+
+describe('taskDetailHandler', () => {
+  let dir: string;
+  let gossipDir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'gossip-task-detail-test-'));
+    gossipDir = join(dir, '.gossip');
+    mkdirSync(gossipDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns null when task-graph.jsonl does not exist', async () => {
+    const result = await taskDetailHandler(dir, 'nonexistent-id');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when taskId is not in task-graph.jsonl', async () => {
+    const graphPath = join(gossipDir, 'task-graph.jsonl');
+    writeLines(graphPath, [
+      { type: 'task.created', taskId: 'task-a', agentId: 'sonnet-implementer', task: 'Do A', timestamp: '2026-06-01T00:00:00.000Z' },
+      { type: 'task.completed', taskId: 'task-a', durationMs: 5000, timestamp: '2026-06-01T00:00:05.000Z' },
+    ]);
+    const result = await taskDetailHandler(dir, 'task-does-not-exist');
+    expect(result).toBeNull();
+  });
+
+  it('returns basic task data for a completed task', async () => {
+    const graphPath = join(gossipDir, 'task-graph.jsonl');
+    writeLines(graphPath, [
+      { type: 'task.created', taskId: 'task-b', agentId: 'haiku-researcher', task: 'Research B', timestamp: '2026-06-01T00:00:00.000Z' },
+      { type: 'task.completed', taskId: 'task-b', durationMs: 12000, result: 'done', timestamp: '2026-06-01T00:00:12.000Z' },
+    ]);
+    const result = await taskDetailHandler(dir, 'task-b');
+    expect(result).not.toBeNull();
+    expect(result!.taskId).toBe('task-b');
+    expect(result!.agentId).toBe('haiku-researcher');
+    expect(result!.status).toBe('completed');
+    expect(result!.duration).toBe(12000);
+    expect(result!.result).toBe('done');
+  });
+
+  it('enriches with signalCount and consensusId from agent-performance.jsonl', async () => {
+    const graphPath = join(gossipDir, 'task-graph.jsonl');
+    writeLines(graphPath, [
+      { type: 'task.created', taskId: 'task-c', agentId: 'sonnet-reviewer', task: 'Review C', timestamp: '2026-06-02T00:00:00.000Z' },
+      { type: 'task.completed', taskId: 'task-c', durationMs: 3000, timestamp: '2026-06-02T00:00:03.000Z' },
+    ]);
+
+    const perfPath = join(gossipDir, 'agent-performance.jsonl');
+    writeLines(perfPath, [
+      { type: 'consensus', signal: 'agreement', taskId: 'task-c', agentId: 'sonnet-reviewer', consensusId: 'aaaa0000-bbbb1111', timestamp: '2026-06-02T00:00:04.000Z' },
+      { type: 'consensus', signal: 'unique_confirmed', taskId: 'task-c', agentId: 'sonnet-reviewer', consensusId: 'aaaa0000-bbbb1111', timestamp: '2026-06-02T00:00:05.000Z' },
+      // Different task — should not be counted
+      { type: 'consensus', signal: 'agreement', taskId: 'other-task', agentId: 'sonnet-reviewer', consensusId: 'aaaa0000-bbbb1111', timestamp: '2026-06-02T00:00:06.000Z' },
+    ]);
+
+    const result = await taskDetailHandler(dir, 'task-c');
+    expect(result).not.toBeNull();
+    expect(result!.signalCount).toBe(2);
+    expect(result!.consensusId).toBe('aaaa0000-bbbb1111');
+  });
+
+  it('collects siblingTaskIds from other tasks sharing the same consensusId', async () => {
+    const graphPath = join(gossipDir, 'task-graph.jsonl');
+    writeLines(graphPath, [
+      { type: 'task.created', taskId: 'task-d', agentId: 'gemini-reviewer', task: 'Review D', timestamp: '2026-06-03T00:00:00.000Z' },
+      { type: 'task.completed', taskId: 'task-d', durationMs: 2000, timestamp: '2026-06-03T00:00:02.000Z' },
+    ]);
+
+    const perfPath = join(gossipDir, 'agent-performance.jsonl');
+    writeLines(perfPath, [
+      { type: 'consensus', signal: 'agreement', taskId: 'task-d', agentId: 'gemini-reviewer', consensusId: 'cccc2222-dddd3333', timestamp: '2026-06-03T00:00:03.000Z' },
+      // Sibling tasks in same consensus round
+      { type: 'consensus', signal: 'agreement', taskId: 'task-sib1', agentId: 'sonnet-reviewer', consensusId: 'cccc2222-dddd3333', timestamp: '2026-06-03T00:00:03.000Z' },
+      { type: 'consensus', signal: 'agreement', taskId: 'task-sib2', agentId: 'haiku-researcher', consensusId: 'cccc2222-dddd3333', timestamp: '2026-06-03T00:00:04.000Z' },
+      // Different consensus round — should NOT be a sibling
+      { type: 'consensus', signal: 'agreement', taskId: 'task-other', agentId: 'haiku-researcher', consensusId: 'eeee4444-ffff5555', timestamp: '2026-06-03T00:00:05.000Z' },
+    ]);
+
+    const result = await taskDetailHandler(dir, 'task-d');
+    expect(result).not.toBeNull();
+    expect(result!.siblingTaskIds).toBeDefined();
+    expect(result!.siblingTaskIds).toHaveLength(2);
+    expect(result!.siblingTaskIds).toContain('task-sib1');
+    expect(result!.siblingTaskIds).toContain('task-sib2');
+    expect(result!.siblingTaskIds).not.toContain('task-d');
+    expect(result!.siblingTaskIds).not.toContain('task-other');
+  });
+
+  it('returns findingCount=0 for a task with no matching implementation-findings rows', async () => {
+    const graphPath = join(gossipDir, 'task-graph.jsonl');
+    writeLines(graphPath, [
+      { type: 'task.created', taskId: 'task-e', agentId: 'sonnet-implementer', task: 'Implement E', timestamp: '2026-06-04T00:00:00.000Z' },
+      { type: 'task.completed', taskId: 'task-e', durationMs: 8000, timestamp: '2026-06-04T00:00:08.000Z' },
+    ]);
+
+    const findingsPath = join(gossipDir, 'implementation-findings.jsonl');
+    writeLines(findingsPath, [
+      { taskId: 'some-consensus-id:f1', originalAgentId: 'gemini-reviewer', finding: 'bug', tag: 'confirmed' },
+    ]);
+
+    const result = await taskDetailHandler(dir, 'task-e');
+    expect(result).not.toBeNull();
+    // implementation-findings taskId field uses consensusId:fN format, not dispatch taskIds
+    expect(result!.findingCount).toBe(0);
+  });
+
+  it('gracefully handles missing agent-performance.jsonl (no enrichment fields)', async () => {
+    const graphPath = join(gossipDir, 'task-graph.jsonl');
+    writeLines(graphPath, [
+      { type: 'task.created', taskId: 'task-f', agentId: 'deepseek-challenger', task: 'Challenge F', timestamp: '2026-06-05T00:00:00.000Z' },
+      { type: 'task.completed', taskId: 'task-f', durationMs: 1000, timestamp: '2026-06-05T00:00:01.000Z' },
+    ]);
+
+    // No agent-performance.jsonl written
+    const result = await taskDetailHandler(dir, 'task-f');
+    expect(result).not.toBeNull();
+    expect(result!.signalCount).toBe(0);
+    expect(result!.consensusId).toBeUndefined();
+    expect(result!.siblingTaskIds).toBeUndefined();
+  });
+});

--- a/tests/dashboard/router-param.test.ts
+++ b/tests/dashboard/router-param.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for the matchRoute param-extraction helper added to lib/router.ts.
+ */
+
+import { matchRoute } from '../../packages/dashboard-v2/src/lib/router';
+
+describe('matchRoute', () => {
+  describe('/tasks/:id pattern', () => {
+    it('extracts the task id from a matching route', () => {
+      expect(matchRoute('/tasks/:id', '/tasks/abc12345-def6-7890-ghij-klmnopqrstuv')).toBe(
+        'abc12345-def6-7890-ghij-klmnopqrstuv'
+      );
+    });
+
+    it('extracts a short id', () => {
+      expect(matchRoute('/tasks/:id', '/tasks/abc12345')).toBe('abc12345');
+    });
+
+    it('returns null for /tasks (no id segment)', () => {
+      expect(matchRoute('/tasks/:id', '/tasks')).toBeNull();
+    });
+
+    it('returns null for a completely different route', () => {
+      expect(matchRoute('/tasks/:id', '/agent/sonnet-reviewer')).toBeNull();
+    });
+
+    it('returns null for a route with extra segments', () => {
+      expect(matchRoute('/tasks/:id', '/tasks/abc12345/detail')).toBeNull();
+    });
+
+    it('returns null for empty route', () => {
+      expect(matchRoute('/tasks/:id', '/')).toBeNull();
+    });
+  });
+
+  describe('/agent/:id pattern', () => {
+    it('extracts the agent id', () => {
+      expect(matchRoute('/agent/:id', '/agent/sonnet-reviewer')).toBe('sonnet-reviewer');
+    });
+
+    it('returns null for a mismatched route', () => {
+      expect(matchRoute('/agent/:id', '/tasks/abc123')).toBeNull();
+    });
+  });
+
+  describe('URL decoding', () => {
+    it('decodes percent-encoded characters', () => {
+      expect(matchRoute('/agent/:id', '/agent/my%20agent')).toBe('my agent');
+    });
+
+    it('handles hyphens and underscores', () => {
+      expect(matchRoute('/tasks/:id', '/tasks/my-task_id')).toBe('my-task_id');
+    });
+  });
+
+  describe('TaskPage not-found state', () => {
+    it('matchRoute returns null when the task segment is missing — the not-found frame renders', () => {
+      // The TaskPage renders a graceful not-found frame when tasks.find returns undefined.
+      // We test the routing layer: when there is no :id segment, matchRoute is null
+      // so App.tsx never renders TaskPage at all (falls through to overview).
+      expect(matchRoute('/tasks/:id', '/tasks/')).toBeNull();
+      expect(matchRoute('/tasks/:id', '/tasks')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Supersedes #630 — this is the complete, consensus-reviewed task-representation feature (both tranches + fixes) in one PR.

## What

Fixes the dashboard's "task representation is too weak — hard to reach, weak content." Promotes individual tasks from an ephemeral, modal-only view to a **deep-linkable `/tasks/:id` detail page** with real connective tissue.

## Commits

| | |
|---|---|
| `dca329f5` | **Tranche 1** — `/tasks/:id` page (full UUID, semantic status chip, agent link, lifecycle timeline, prompt + result), `matchRoute` parametric routing, 3 DESIGN.md fixes (amber→neutral ID, EmptyState, dedup status logic) |
| `e87bee36` | **Tranche 2** — `GET /api/tasks/:id` (cold deep-link survives refresh) + context section wired to consensus round / siblings / round-findings / signals, all derived from existing ledgers |
| `50a15364` | **Consensus fixes** — see below |

## Consensus review (round `4bc68342-1b324334`)

Reviewed **both tranches** (2× sonnet-reviewer, split frontend / relay-API / adversarial). Every finding orchestrator-verified against source before fixing.

- 🔴 **HIGH** — cold deep-link + non-404 error (500 / malformed JSON / network) hung on an infinite skeleton with no recovery. Fixed: `detailError` state, skeleton gated on `detailLoading`, distinct `TaskNotFound` / `TaskLoadError` frames.
- 🔴 **HIGH** — lifecycle timeline showed the *completion* time as "Dispatched" for terminal tasks. Fixed: expose `createdAt` (task.created event time); dispatched node uses it, completed node uses the real completion timestamp.
- 🟡 **MEDIUM** — `/api/tasks/:id` now reads `task-graph.jsonl` directly (the paginated lookup 404'd tasks beyond position 2000 and utility-agent tasks); single-pass ledger read; `findingCount` joins by `consensusId:` prefix (the on-disk `taskId` is finding-level, so the old UUID join was always 0).
- ✅ **Confirmed safe** — route ordering, decode, trailing-slash, **no path injection** (taskId only string-compared).

## Bonus bug fix

`api-tasks.ts` read `entry.duration` but the on-disk `task.completed` field is `durationMs` — **every task duration was silently dropped** from `/api/tasks` and `TaskItem.duration`. Now `entry.durationMs ?? entry.duration`.

## Verification

Dashboard + relay typecheck clean; dashboard build green; **191 tests pass** (incl. 12 api-task-detail + 11 router-param). Design-reviewed by sonnet-designer (Tranche 1). **Not yet visually verified in-browser** — recommend a quick visual pass of the page states before merge.

## Known / deferred

- `findingCount` shows *round* findings (per-task finding attribution needs a schema change).
- `StatusChip` uses `font-mono` for status labels (dashboard-wide convention; deferred).
- No `TaskPage` component-test harness exists (handler + router are tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)