### PR TITLE
fix(orchestrator): run pre-dispatch precondition guard for parallel + consensus dispatches

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -1337,6 +1337,21 @@ export async function handleDispatchParallel(
   // Spec §3.2 boundary #1: stash dispatch-time warnings under each task_id.
   stashDispatchWarnings(allParallelTaskIds, dispatchWarnings);
 
+  // Unit 2 orchestrator signal pipeline: pre-dispatch precondition guard.
+  // Best-effort — never blocks/fails a dispatch. Mirrors the single-dispatch
+  // call shape at dispatch.ts:717-725. One call per dispatch (not per task).
+  if (allParallelTaskIds.length > 0) {
+    runDispatchPreconditionGuard({
+      projectRoot: process.cwd(),
+      taskId: allParallelTaskIds[0],
+      resolutionRoots: effectiveResolutionRoots,
+    }).then(({ warnings: precondWarnings }) => {
+      for (const w of precondWarnings) {
+        process.stderr.write(`[gossipcat] ⚠️ precondition: ${w}\n`);
+      }
+    }).catch(() => { /* best-effort */ });
+  }
+
   const parallelHost = detectNativeHost();
   let msg = '';
   if (nativeInstructions.length > 0) {
@@ -1656,6 +1671,21 @@ export async function handleDispatchConsensus(
   }
   // Spec §3.2 boundary #1: stash dispatch-time warnings under each task_id.
   stashDispatchWarnings(allTaskIds, dispatchRoundWarnings);
+
+  // Unit 2 orchestrator signal pipeline: pre-dispatch precondition guard.
+  // Best-effort — never blocks/fails a dispatch. Mirrors the single-dispatch
+  // call shape at dispatch.ts:717-725. One call per dispatch (not per task).
+  if (allTaskIds.length > 0) {
+    runDispatchPreconditionGuard({
+      projectRoot: process.cwd(),
+      taskId: allTaskIds[0],
+      resolutionRoots: dispatchResolutionRoots,
+    }).then(({ warnings: precondWarnings }) => {
+      for (const w of precondWarnings) {
+        process.stderr.write(`[gossipcat] ⚠️ precondition: ${w}\n`);
+      }
+    }).catch(() => { /* best-effort */ });
+  }
 
   const consensusHost = detectNativeHost();
   const nativeTool = nativeToolName(consensusHost);

--- a/tests/cli/dispatch-precondition-guard-multimode.test.ts
+++ b/tests/cli/dispatch-precondition-guard-multimode.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests that runDispatchPreconditionGuard is invoked for parallel and consensus
+ * dispatch paths (Unit 2 orchestrator signal pipeline, multi-mode wiring).
+ *
+ * The guard must fire once per dispatch call (not per task), fire after task IDs
+ * are minted, and never block or fail the dispatch. The spy verifies the call
+ * shape mirrors the single-dispatch call at dispatch.ts:717-725.
+ */
+
+import { ctx } from '../../apps/cli/src/mcp-context';
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Mock the precondition runner so we can spy without real git I/O.
+jest.mock('../../apps/cli/src/handlers/orchestrator-precondition-runner', () => {
+  const actual = jest.requireActual('../../apps/cli/src/handlers/orchestrator-precondition-runner');
+  return {
+    ...actual,
+    runDispatchPreconditionGuard: jest.fn().mockResolvedValue({ warnings: [] }),
+  };
+});
+
+import { runDispatchPreconditionGuard } from '../../apps/cli/src/handlers/orchestrator-precondition-runner';
+const mockedGuard = runDispatchPreconditionGuard as unknown as jest.Mock;
+
+import { handleDispatchParallel, handleDispatchConsensus } from '../../apps/cli/src/handlers/dispatch';
+
+// ---------------------------------------------------------------------------
+// ctx helpers (mirrors dispatch-parallel-autodiscover-worktrees.test.ts)
+// ---------------------------------------------------------------------------
+
+function makeMainAgent(overrides: Record<string, any> = {}): any {
+  return {
+    dispatch: jest.fn().mockReturnValue({ taskId: 'default-task-id' }),
+    collect: jest.fn().mockResolvedValue({ results: [] }),
+    getAgentConfig: jest.fn().mockReturnValue(null),
+    getLlm: jest.fn().mockReturnValue(null),
+    getLLM: jest.fn().mockReturnValue(null),
+    getAgentList: jest.fn().mockReturnValue([]),
+    getSkillGapSuggestions: jest.fn().mockReturnValue([]),
+    getSkillIndex: jest.fn().mockReturnValue(null),
+    getSessionGossip: jest.fn().mockReturnValue([]),
+    getSessionConsensusHistory: jest.fn().mockReturnValue([]),
+    recordNativeTask: jest.fn(),
+    recordNativeTaskCompleted: jest.fn(),
+    recordPlanStepResult: jest.fn(),
+    publishNativeGossip: jest.fn().mockResolvedValue(undefined),
+    getChainContext: jest.fn().mockReturnValue(''),
+    generateLensesForAgents: jest.fn().mockResolvedValue(new Map()),
+    dispatchParallel: jest.fn().mockResolvedValue({ taskIds: ['p-1'], errors: [] }),
+    dispatchParallelWithLenses: jest.fn().mockResolvedValue({ taskIds: ['p-1'], errors: [] }),
+    getTask: jest.fn().mockReturnValue({ agentId: 'gemini-tester' }),
+    scopeTracker: {
+      hasOverlap: jest.fn().mockReturnValue({ overlaps: false }),
+      register: jest.fn(),
+      release: jest.fn(),
+    },
+    pipeline: null,
+    projectRoot: '/tmp/gossip-test-project',
+    ...overrides,
+  };
+}
+
+const originalCtx = {
+  mainAgent: ctx.mainAgent,
+  relay: ctx.relay,
+  workers: ctx.workers,
+  keychain: ctx.keychain,
+  skillEngine: ctx.skillEngine,
+  nativeTaskMap: ctx.nativeTaskMap,
+  nativeResultMap: ctx.nativeResultMap,
+  nativeAgentConfigs: ctx.nativeAgentConfigs,
+  pendingConsensusRounds: ctx.pendingConsensusRounds,
+  pendingDispatchResolutionRoots: ctx.pendingDispatchResolutionRoots,
+  booted: ctx.booted,
+  boot: ctx.boot,
+  syncWorkersViaKeychain: ctx.syncWorkersViaKeychain,
+};
+
+function resetCtx() {
+  ctx.mainAgent = makeMainAgent();
+  ctx.nativeTaskMap = new Map();
+  ctx.nativeResultMap = new Map();
+  ctx.nativeAgentConfigs = new Map();
+  ctx.pendingConsensusRounds = new Map();
+  ctx.pendingDispatchResolutionRoots = new Map();
+  ctx.booted = true;
+  ctx.boot = jest.fn().mockResolvedValue(undefined) as any;
+  ctx.syncWorkersViaKeychain = jest.fn().mockResolvedValue(undefined) as any;
+  (ctx as any).skillEngine = null;
+}
+
+function restoreCtx() {
+  Object.assign(ctx, originalCtx);
+}
+
+function writeMinimalConfig(dir: string): void {
+  mkdirSync(join(dir, '.gossip', 'skills'), { recursive: true });
+  writeFileSync(
+    join(dir, '.gossip', 'config.json'),
+    JSON.stringify({ main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' } }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// handleDispatchParallel
+// ---------------------------------------------------------------------------
+
+describe('handleDispatchParallel — precondition guard invocation', () => {
+  let projectDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    projectDir = realpathSync(mkdtempSync(join(tmpdir(), 'gossip-precond-parallel-')));
+    writeMinimalConfig(projectDir);
+    process.chdir(projectDir);
+    resetCtx();
+    mockedGuard.mockReset();
+    mockedGuard.mockResolvedValue({ warnings: [] });
+  });
+
+  afterEach(() => {
+    restoreCtx();
+    process.chdir(prevCwd);
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('calls runDispatchPreconditionGuard once for a relay parallel dispatch', async () => {
+    await handleDispatchParallel(
+      [{ agent_id: 'gemini-tester', task: 'Review X' }],
+      /* consensus */ false,
+    );
+
+    // Allow the fire-and-forget .then() microtask to settle.
+    await new Promise(r => setImmediate(r));
+
+    expect(mockedGuard).toHaveBeenCalledTimes(1);
+    const [args] = mockedGuard.mock.calls[0];
+    expect(args).toMatchObject({
+      projectRoot: projectDir,
+      taskId: expect.any(String),
+    });
+  });
+
+  it('calls guard with first minted task id and passes resolutionRoots through', async () => {
+    const roots = ['/some/worktree'];
+    // consensus:false → handleDispatchParallel skips worktree auto-discovery, so
+    // effectiveResolutionRoots === the caller-supplied roots verbatim. This makes
+    // the passthrough deterministic and lets us assert the exact value reached the
+    // guard (a regression that dropped roots to [] or undefined would now fail).
+    await handleDispatchParallel(
+      [{ agent_id: 'gemini-tester', task: 'Review Y' }],
+      /* consensus */ false,
+      roots,
+    );
+
+    await new Promise(r => setImmediate(r));
+
+    expect(mockedGuard).toHaveBeenCalledTimes(1);
+    const [args] = mockedGuard.mock.calls[0];
+    expect(args.resolutionRoots).toEqual(roots);
+  });
+
+  it('guard is called only once even for multiple tasks', async () => {
+    ctx.mainAgent.dispatchParallel = jest.fn().mockResolvedValue({
+      taskIds: ['p-1', 'p-2'],
+      errors: [],
+    });
+    ctx.mainAgent.getTask = jest.fn().mockReturnValue({ agentId: 'gemini-tester' });
+
+    await handleDispatchParallel(
+      [
+        { agent_id: 'gemini-tester', task: 'Task 1' },
+        { agent_id: 'gemini-reviewer', task: 'Task 2' },
+      ],
+      /* consensus */ false,
+    );
+
+    await new Promise(r => setImmediate(r));
+
+    expect(mockedGuard).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatch succeeds even when runDispatchPreconditionGuard rejects', async () => {
+    mockedGuard.mockRejectedValue(new Error('guard exploded'));
+
+    const result: any = await handleDispatchParallel(
+      [{ agent_id: 'gemini-tester', task: 'Safe task' }],
+      /* consensus */ false,
+    );
+
+    // Allow the .catch to settle — no unhandled rejection
+    await new Promise(r => setImmediate(r));
+
+    expect(result.content[0].text).toContain('Dispatched');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleDispatchConsensus
+// ---------------------------------------------------------------------------
+
+describe('handleDispatchConsensus — precondition guard invocation', () => {
+  let projectDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    projectDir = realpathSync(mkdtempSync(join(tmpdir(), 'gossip-precond-consensus-')));
+    writeMinimalConfig(projectDir);
+    process.chdir(projectDir);
+    resetCtx();
+    mockedGuard.mockReset();
+    mockedGuard.mockResolvedValue({ warnings: [] });
+  });
+
+  afterEach(() => {
+    restoreCtx();
+    process.chdir(prevCwd);
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('calls runDispatchPreconditionGuard once for a relay consensus dispatch', async () => {
+    await handleDispatchConsensus(
+      [
+        { agent_id: 'gemini-tester', task: 'Review X security' },
+        { agent_id: 'gemini-reviewer', task: 'Review X architecture' },
+      ],
+    );
+
+    await new Promise(r => setImmediate(r));
+
+    expect(mockedGuard).toHaveBeenCalledTimes(1);
+    const [args] = mockedGuard.mock.calls[0];
+    expect(args).toMatchObject({
+      projectRoot: projectDir,
+      taskId: expect.any(String),
+    });
+  });
+
+  it('passes resolutionRoots through to the guard', async () => {
+    const roots = ['/repo/worktrees/agent-abc'];
+    await handleDispatchConsensus(
+      [{ agent_id: 'gemini-tester', task: 'Review Z' }],
+      /* _utility_task_id */ undefined,
+      roots,
+    );
+
+    await new Promise(r => setImmediate(r));
+
+    expect(mockedGuard).toHaveBeenCalledTimes(1);
+    const [args] = mockedGuard.mock.calls[0];
+    // handleDispatchConsensus ALWAYS runs resolveDispatchResolutionRoots (a
+    // module-internal fn), so the guard receives the post-auto-discovery roots,
+    // not the raw input — exact passthrough is environment-dependent and is
+    // covered deterministically by the parallel consensus:false test above. Here
+    // we only assert the guard received a defined array (catches a drop-to-
+    // undefined regression).
+    expect(Array.isArray(args.resolutionRoots)).toBe(true);
+  });
+
+  it('guard is called only once for a multi-task consensus batch', async () => {
+    ctx.mainAgent.dispatchParallel = jest.fn().mockResolvedValue({
+      taskIds: ['c-1', 'c-2', 'c-3'],
+      errors: [],
+    });
+    ctx.mainAgent.getTask = jest.fn().mockReturnValue({ agentId: 'gemini-tester' });
+
+    await handleDispatchConsensus([
+      { agent_id: 'gemini-tester', task: 'T1' },
+      { agent_id: 'gemini-reviewer', task: 'T2' },
+      { agent_id: 'sonnet-reviewer', task: 'T3' },
+    ]);
+
+    await new Promise(r => setImmediate(r));
+
+    expect(mockedGuard).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatch succeeds even when runDispatchPreconditionGuard rejects', async () => {
+    mockedGuard.mockRejectedValue(new Error('guard exploded'));
+
+    const result: any = await handleDispatchConsensus(
+      [{ agent_id: 'gemini-tester', task: 'Safe consensus task' }],
+    );
+
+    await new Promise(r => setImmediate(r));
+
+    // Handler must not throw — result envelope is present
+    expect(result.content[0].text).toContain('Dispatched');
+  });
+});


### PR DESCRIPTION
## What

`runDispatchPreconditionGuard` — the Unit-2 orchestrator pre-dispatch guard that
emits `dispatched_stale_base` / `referenced_unreadable_path` operational signals
against `agentId:'orchestrator'` — had a **single call site** in
`handleDispatchSingle` (dispatch.ts:717). `handleDispatchParallel` and
`handleDispatchConsensus` never invoked it.

**Consequence:** there was **no pre-dispatch stale-base check before a consensus
round** — exactly the case where dispatching from a stale base wastes the most
agent quota (a core motivation for the signal).

This wires the guard into both multi-task handlers, once per dispatch (anchored to
the first minted task id, with the in-scope resolutionRoots), mirroring the
single-dispatch fire-and-forget + `.catch` best-effort shape. The guard can never
block or throw into the dispatch happy path.

## How it was found

Live-verification of #629 on a freshly-built relay (the runtime had never been
exercised post-merge). Two integration bugs surfaced; this PR fixes the
higher-impact one (Bug B). The other (`referenced_unreadable_path` is wired to the
wrong input — checks `resolutionRoots` instead of task-text-referenced paths) is
tracked separately for a spec-first fix.

## Tests

New `tests/cli/dispatch-precondition-guard-multimode.test.ts` (8 tests): guard
called exactly once per parallel + consensus dispatch, anchored to the first task
id, roots forwarded (deterministic `toEqual` passthrough via the consensus:false
path), and dispatch never throws when the guard rejects.

Local: `apps/cli` typecheck clean; 8/8 new + 92/92 dispatch suite + 43/43
precondition suite pass.

## Review

Pre-merge consensus on this diff.
consensus-id: b8a2dcdf-91ab43cd
(8 confirmed, 0 disputed, 0 production bugs; the 2 medium findings were
test-rigor gaps, both addressed in the amended test. Note: deepseek-challenger
emitted an unparseable tool-call dump and did not contribute findings — effectively
single-reviewer; gemini was quota-suspect, fable down this session.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>