### PR TITLE
fix(orchestrator): wire referenced_unreadable_path to task-text paths (Bug A, #629 follow-up)

### DIFF
--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -718,6 +718,8 @@ export async function handleDispatchSingle(
       projectRoot: process.cwd(),
       taskId,
       resolutionRoots,
+      taskText: task,
+      writeMode: write_mode,
     }).then(({ warnings: precondWarnings }) => {
       for (const w of precondWarnings) {
         process.stderr.write(`[gossipcat] ⚠️ precondition: ${w}\n`);
@@ -1345,6 +1347,11 @@ export async function handleDispatchParallel(
       projectRoot: process.cwd(),
       taskId: allParallelTaskIds[0],
       resolutionRoots: effectiveResolutionRoots,
+      taskText: taskDefs[0]?.task ?? '',
+      writeMode: taskDefs[0]?.write_mode,
+      // Bug A follow-up (Fix 1): scan ALL tasks for referenced paths, not just
+      // taskDefs[0]. Stale-base/mid-flight stay one-per-dispatch above.
+      additionalTasks: taskDefs.slice(1).map(d => ({ taskText: d.task ?? '', writeMode: d.write_mode })),
     }).then(({ warnings: precondWarnings }) => {
       for (const w of precondWarnings) {
         process.stderr.write(`[gossipcat] ⚠️ precondition: ${w}\n`);
@@ -1680,6 +1687,11 @@ export async function handleDispatchConsensus(
       projectRoot: process.cwd(),
       taskId: allTaskIds[0],
       resolutionRoots: dispatchResolutionRoots,
+      taskText: taskDefs[0]?.task ?? '',
+      writeMode: taskDefs[0]?.write_mode,
+      // Bug A follow-up (Fix 1): scan ALL tasks for referenced paths, not just
+      // taskDefs[0]. Stale-base/mid-flight stay one-per-dispatch above.
+      additionalTasks: taskDefs.slice(1).map(d => ({ taskText: d.task ?? '', writeMode: d.write_mode })),
     }).then(({ warnings: precondWarnings }) => {
       for (const w of precondWarnings) {
         process.stderr.write(`[gossipcat] ⚠️ precondition: ${w}\n`);

--- a/apps/cli/src/handlers/orchestrator-precondition-runner.ts
+++ b/apps/cli/src/handlers/orchestrator-precondition-runner.ts
@@ -13,12 +13,15 @@
  */
 
 import * as fs from 'fs';
+import * as path from 'path';
 import { execFileSync } from 'child_process';
 import {
   detectStaleBase,
   findUnreadablePaths,
+  findUnreadableReferencedPathsWithMeta,
   detectMidFlightCommits,
 } from '@gossip/orchestrator';
+import type { UnreadableReferencedPath } from '@gossip/orchestrator';
 import type { PerformanceSignal } from '@gossip/orchestrator';
 // FIX 6: static import to ensure esbuild bundles emitPipelineSignals.
 // Dynamic import() is NOT bundled in esbuild single-file builds — this was the
@@ -39,6 +42,17 @@ export interface PreconditionRunnerDeps {
   execFile: (cmd: string, args: string[], opts: { cwd: string; encoding: 'utf8' }) => string;
   /** Returns true when the given path is readable by the current process. */
   canRead: (p: string) => boolean;
+  /**
+   * Returns true when the referenced repo-relative path exists / is readable at
+   * the project root. Injected so the task-text check is unit-testable without
+   * touching the filesystem.
+   */
+  pathExists: (projectRoot: string, p: string) => boolean;
+  /**
+   * Returns true when the repo-relative path is gitignored OR untracked (i.e.
+   * absent from a fresh worktree checkout). Injected for testability.
+   */
+  isGitignoredOrUntracked: (projectRoot: string, p: string, execFile: PreconditionRunnerDeps['execFile']) => boolean;
   /**
    * Best-effort pipeline signal emitter.
    * Signature mirrors emitPipelineSignals(projectRoot, signals).
@@ -77,10 +91,28 @@ export interface StaleBaseInputs {
   mergeBaseSha: string | null;
 }
 
+export interface PreconditionGuardAdditionalTask {
+  /** A non-primary task's body — scanned for referenced repo-relative paths. */
+  taskText: string;
+  /** That task's own effective write mode (gitignored_in_worktree is per-task). */
+  writeMode?: string;
+}
+
 export interface PreconditionGuardInput {
   projectRoot: string;
   taskId: string;
   resolutionRoots: readonly string[] | undefined;
+  /** The primary dispatch task body — scanned for referenced repo-relative paths. */
+  taskText: string;
+  /** Effective write mode of the primary task ('worktree' | 'sequential' | 'scoped' | undefined). */
+  writeMode: string | undefined;
+  /**
+   * Non-primary tasks in a multi-task dispatch. The referenced-path check (Signal
+   * 2b) runs per-task across the primary task + these, so a worktree implementer
+   * at index ≥1 referencing a gitignored spec is still flagged. Stale-base and
+   * mid-flight checks remain one-per-dispatch (repo-global) and ignore this.
+   */
+  additionalTasks?: ReadonlyArray<PreconditionGuardAdditionalTask>;
 }
 
 export interface PreconditionGuardResult {
@@ -233,6 +265,51 @@ function defaultCanRead(p: string): boolean {
   }
 }
 
+/**
+ * Production predicate: does the repo-relative path exist + read at projectRoot?
+ * Best-effort — any error (including a path that escapes the root) → false.
+ */
+function defaultPathExists(projectRoot: string, p: string): boolean {
+  try {
+    const resolved = path.resolve(projectRoot, p);
+    fs.accessSync(resolved, fs.constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Production predicate: is the repo-relative path gitignored OR untracked (so it
+ * is absent from a fresh worktree checkout)?
+ *
+ * `git check-ignore <p>` exits 0 when the path IS ignored. `git ls-files
+ * --error-unmatch <p>` exits 0 when the path IS tracked; non-zero (throw) means
+ * untracked. A path is absent from a fresh checkout iff it is ignored OR
+ * untracked. Best-effort: on any git failure we return false (safe default —
+ * assume present rather than emit a spurious signal).
+ */
+function defaultIsGitignoredOrUntracked(
+  projectRoot: string,
+  p: string,
+  execFile: PreconditionRunnerDeps['execFile'],
+): boolean {
+  // Is it gitignored?
+  try {
+    execFile('git', ['check-ignore', '-q', p], { cwd: projectRoot, encoding: 'utf8' });
+    return true; // exit 0 → ignored
+  } catch {
+    // non-zero exit → not ignored (fall through to tracked check)
+  }
+  // Not ignored — is it tracked? Untracked ⇒ absent from a fresh checkout.
+  try {
+    execFile('git', ['ls-files', '--error-unmatch', p], { cwd: projectRoot, encoding: 'utf8' });
+    return false; // exit 0 → tracked → present in checkout
+  } catch {
+    return true; // non-zero → untracked → absent from checkout
+  }
+}
+
 function defaultEmitSignals(projectRoot: string, signals: PerformanceSignal[]): void {
   // FIX 6: use static import (bundled by esbuild). Dynamic import() is NOT
   // bundled in esbuild single-file builds — it silently no-ops at runtime.
@@ -297,9 +374,11 @@ export async function runDispatchPreconditionGuard(
 
   const execFile = deps.execFile ?? defaultExecFile;
   const canRead = deps.canRead ?? defaultCanRead;
+  const pathExists = deps.pathExists ?? defaultPathExists;
+  const isGitignoredOrUntracked = deps.isGitignoredOrUntracked ?? defaultIsGitignoredOrUntracked;
   const emitSignals = deps.emitSignals ?? defaultEmitSignals;
 
-  const { projectRoot, taskId, resolutionRoots } = input;
+  const { projectRoot, taskId, resolutionRoots, taskText, writeMode, additionalTasks } = input;
 
   try {
     // -----------------------------------------------------------------------
@@ -364,6 +443,113 @@ export async function runDispatchPreconditionGuard(
             timestamp: new Date().toISOString(),
           }]);
         } catch { /* best-effort */ }
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Signal 2b: referenced_unreadable_path — task-text path check (Bug A fix).
+    //
+    // Scans the TASK TEXT for referenced repo-relative paths the executing
+    // agent won't be able to read. This is the signal's DOCUMENTED purpose:
+    // the recurring "worktree agent can't read a gitignored docs/specs/*.md"
+    // failure. The resolutionRoots check above is a distinct, near-dead path
+    // (kept as-is for safety). All fs/git access is wrapped — never throws.
+    //
+    // PER-TASK: scans the primary task PLUS every additionalTask, each under
+    // THAT task's own writeMode (a path is only gitignored_in_worktree for a
+    // worktree task). Unreadable paths are deduped by `path` across all tasks
+    // (gitignored_in_worktree preferred over missing when both occur), so an
+    // index-≥1 worktree implementer referencing a gitignored spec is flagged.
+    // -----------------------------------------------------------------------
+    const scanTasks: PreconditionGuardAdditionalTask[] = [];
+    if (taskText) {
+      scanTasks.push({ taskText, writeMode });
+    }
+    if (additionalTasks) {
+      for (const t of additionalTasks) {
+        if (t && t.taskText) {
+          scanTasks.push({ taskText: t.taskText, writeMode: t.writeMode });
+        }
+      }
+    }
+
+    if (scanTasks.length > 0) {
+      // Dedupe by path; prefer gitignored_in_worktree over missing.
+      const byPath = new Map<string, UnreadableReferencedPath>();
+      let droppedOverCap = 0;
+
+      for (const t of scanTasks) {
+        let result: { unreadable: UnreadableReferencedPath[]; droppedOverCap: number } = {
+          unreadable: [],
+          droppedOverCap: 0,
+        };
+        try {
+          result = findUnreadableReferencedPathsWithMeta(t.taskText, {
+            writeMode: t.writeMode,
+            pathExists: (p: string) => {
+              try {
+                return pathExists(projectRoot, p);
+              } catch {
+                return true; // safe default: assume present → no spurious signal
+              }
+            },
+            isGitignoredOrUntracked: (p: string) => {
+              try {
+                return isGitignoredOrUntracked(projectRoot, p, execFile);
+              } catch {
+                return false; // safe default: assume present in checkout
+              }
+            },
+          });
+        } catch {
+          result = { unreadable: [], droppedOverCap: 0 }; // safe degradation
+        }
+
+        droppedOverCap += result.droppedOverCap;
+
+        for (const entry of result.unreadable) {
+          const existing = byPath.get(entry.path);
+          if (!existing) {
+            byPath.set(entry.path, entry);
+          } else if (
+            existing.reason !== 'gitignored_in_worktree' &&
+            entry.reason === 'gitignored_in_worktree'
+          ) {
+            byPath.set(entry.path, entry); // upgrade missing → gitignored_in_worktree
+          }
+        }
+      }
+
+      const referenced = [...byPath.values()];
+
+      if (referenced.length > 0) {
+        const detail = referenced.map(r => `${r.path} (${r.reason})`).join(', ');
+        warnings.push(
+          `[dispatch-hygiene] ${referenced.length} referenced path(s) the dispatched ` +
+          `agent cannot read: ${detail}. The agent may fail mid-task — inline the ` +
+          `file contents or copy it into the worktree.`,
+        );
+        try {
+          emitSignals(projectRoot, [{
+            type: 'pipeline' as const,
+            signal: 'referenced_unreadable_path',
+            agentId: 'orchestrator',
+            taskId,
+            metadata: {
+              referenced,
+            },
+            timestamp: new Date().toISOString(),
+          }]);
+        } catch { /* best-effort */ }
+      }
+
+      // Fix 3: surface tokens dropped over the 20-path cap (best-effort, never
+      // throws). The existence check never ran for these, so just warn.
+      if (droppedOverCap > 0) {
+        warnings.push(
+          `[dispatch-hygiene] ${droppedOverCap} referenced path(s) beyond the 20-path ` +
+          `cap were not checked.`,
+        );
       }
     }
   } catch { /* outer best-effort guard — must never propagate */ }

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -267,5 +267,5 @@ export { RUNTIME_FLAG_REGISTRY } from './runtime-config-schema';
 export type { RuntimeFlagKey, RuntimeFlagSpec } from './runtime-config-schema';
 export { ChatbotAgent } from './chatbot-agent';
 export type { ChatbotTool, ChatbotAgentConfig, ChatStreamEvent } from './chatbot-agent';
-export { detectStaleBase, findUnreadablePaths, detectMidFlightCommits } from './orchestrator-preconditions';
-export type { StaleBaseResult, MidFlightResult } from './orchestrator-preconditions';
+export { detectStaleBase, findUnreadablePaths, detectMidFlightCommits, extractReferencedPaths, extractReferencedPathsWithMeta, findUnreadableReferencedPaths, findUnreadableReferencedPathsWithMeta } from './orchestrator-preconditions';
+export type { StaleBaseResult, MidFlightResult, UnreadableReason, UnreadableReferencedPath, FindUnreadableReferencedPathsOpts, FindUnreadableReferencedPathsResult, ExtractReferencedPathsResult } from './orchestrator-preconditions';

--- a/packages/orchestrator/src/orchestrator-preconditions.ts
+++ b/packages/orchestrator/src/orchestrator-preconditions.ts
@@ -79,6 +79,202 @@ export function findUnreadablePaths(
 }
 
 // ---------------------------------------------------------------------------
+// extractReferencedPaths
+// ---------------------------------------------------------------------------
+
+/**
+ * Conservative repo-path shape: an optional `./` prefix followed by
+ * word/dot/slash/dash chars, ending in a known source/doc extension. The
+ * extension allowlist keeps the extractor narrow so arbitrary prose tokens
+ * (e.g. "e.g." or version strings) don't get treated as referenced files.
+ */
+const REPO_PATH_SHAPE = /^(?:\.\/)?[\w./-]+\.(?:md|ts|tsx|js|json|txt|ya?ml)$/;
+
+/** Max number of distinct referenced paths checked per dispatch. */
+const MAX_REFERENCED_PATHS = 20;
+
+/**
+ * Result of {@link extractReferencedPathsWithMeta}: the extracted paths plus a
+ * count of how many additional distinct path tokens were dropped because the
+ * {@link MAX_REFERENCED_PATHS} cap was reached.
+ */
+export interface ExtractReferencedPathsResult {
+  /** Up to {@link MAX_REFERENCED_PATHS} distinct paths, first-seen order. */
+  paths: string[];
+  /**
+   * Number of further DISTINCT, shape-valid path tokens that were not included
+   * because the cap was already full. 0 when nothing was dropped over the cap.
+   */
+  droppedOverCap: number;
+}
+
+/**
+ * Extract repo-relative, path-shaped tokens from free-form task text, returning
+ * both the (capped) path list and a count of distinct tokens dropped over the
+ * cap. See {@link extractReferencedPaths} for the matching rules.
+ *
+ * @param taskText - The dispatch task body to scan.
+ * @returns The capped path list plus `droppedOverCap`.
+ */
+export function extractReferencedPathsWithMeta(
+  taskText: string,
+): ExtractReferencedPathsResult {
+  if (!taskText) {
+    return { paths: [], droppedOverCap: 0 };
+  }
+
+  // Split on whitespace AND backticks so `path` and bare path both yield the
+  // raw token. Backticks are treated purely as delimiters here.
+  const rawTokens = taskText.split(/[\s`]+/);
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  let droppedOverCap = 0;
+
+  for (const raw of rawTokens) {
+    // Trim leading/trailing punctuation that commonly abuts a path in prose
+    // (e.g. "see foo.ts," or "(bar.md)") without altering the path itself.
+    const trimmed = raw.replace(/^[([{<"']+/, '').replace(/[)\]}>"',.;:]+$/, '');
+    // Strip a trailing line/col citation suffix (`path:line` or `path:line:col`)
+    // BEFORE the shape test — this codebase cites `path:line` pervasively, and
+    // the digits would otherwise fail REPO_PATH_SHAPE and drop the reference.
+    // Conservative: only a trailing :<digits>[:<digits>], never mid-path.
+    const token = trimmed.replace(/:\d+(?::\d+)?$/, '');
+    if (token.length === 0) {
+      continue;
+    }
+    // Reject absolute paths and traversal outright.
+    if (token.startsWith('/') || token.includes('..')) {
+      continue;
+    }
+    if (!REPO_PATH_SHAPE.test(token)) {
+      continue;
+    }
+    if (seen.has(token)) {
+      continue;
+    }
+    seen.add(token);
+    if (out.length >= MAX_REFERENCED_PATHS) {
+      // Cap full: count this distinct, shape-valid token as dropped but keep
+      // scanning so the dropped count reflects the true overflow.
+      droppedOverCap += 1;
+      continue;
+    }
+    out.push(token);
+  }
+
+  return { paths: out, droppedOverCap };
+}
+
+/**
+ * Extract repo-relative, path-shaped tokens from free-form task text.
+ *
+ * Accepts tokens that are EITHER backtick-quoted OR bare whitespace-delimited,
+ * provided they match {@link REPO_PATH_SHAPE}. Rejects:
+ *   - absolute paths (leading `/`),
+ *   - any token containing `..` (path traversal),
+ * so only conservative repo-relative references survive. A trailing `path:line`
+ * (or `path:line:col`) citation suffix is stripped before the shape test.
+ *
+ * Results are de-duplicated (first-seen order preserved) and CAPPED at
+ * {@link MAX_REFERENCED_PATHS}; tokens beyond the cap are dropped. The function
+ * is pure — it performs no filesystem access. Use
+ * {@link extractReferencedPathsWithMeta} when you also need the over-cap count.
+ *
+ * @param taskText - The dispatch task body to scan.
+ * @returns Up to 20 distinct repo-relative path tokens, in first-seen order.
+ */
+export function extractReferencedPaths(taskText: string): string[] {
+  return extractReferencedPathsWithMeta(taskText).paths;
+}
+
+// ---------------------------------------------------------------------------
+// findUnreadableReferencedPaths
+// ---------------------------------------------------------------------------
+
+export type UnreadableReason = 'missing' | 'gitignored_in_worktree';
+
+export interface UnreadableReferencedPath {
+  path: string;
+  reason: UnreadableReason;
+}
+
+export interface FindUnreadableReferencedPathsResult {
+  /** One entry per unreadable referenced path (readable paths omitted). */
+  unreadable: UnreadableReferencedPath[];
+  /**
+   * Count of distinct, shape-valid path tokens dropped because the 20-path cap
+   * was reached BEFORE any existence check ran. 0 when nothing was dropped.
+   */
+  droppedOverCap: number;
+}
+
+export interface FindUnreadableReferencedPathsOpts {
+  /**
+   * Effective write mode of the dispatch. `'worktree'` means the agent runs in
+   * a fresh checkout (so gitignored/untracked files are absent); any other
+   * value (or undefined) means the agent runs from the repo root.
+   */
+  writeMode?: string;
+  /** True iff the path exists / is readable at the project root. */
+  pathExists(p: string): boolean;
+  /** True iff the path is gitignored OR untracked (absent from a fresh checkout). */
+  isGitignoredOrUntracked(p: string): boolean;
+}
+
+/**
+ * Given task text, determine which referenced repo-relative paths the executing
+ * agent will be UNABLE to read, and why.
+ *
+ * Reasoning (all I/O is injected, so this stays pure + unit-testable):
+ *   - `writeMode === 'worktree'`: the agent runs in a fresh checkout. A path is
+ *     unreadable iff it is absent from that checkout — i.e. gitignored OR
+ *     untracked → reason `'gitignored_in_worktree'`. If the path does not exist
+ *     at the repo root at all → reason `'missing'` (a typo / nonexistent ref).
+ *   - any other writeMode: the agent runs from the repo root. A path is
+ *     unreadable iff it does not exist / is not readable there → `'missing'`.
+ *
+ * @param taskText - The dispatch task body.
+ * @param opts     - Injected write-mode + predicates.
+ * @returns One entry per unreadable referenced path (readable paths omitted).
+ */
+export function findUnreadableReferencedPaths(
+  taskText: string,
+  opts: FindUnreadableReferencedPathsOpts,
+): UnreadableReferencedPath[] {
+  return findUnreadableReferencedPathsWithMeta(taskText, opts).unreadable;
+}
+
+/**
+ * Variant of {@link findUnreadableReferencedPaths} that also reports how many
+ * distinct referenced-path tokens were dropped because the 20-path cap was hit
+ * before any existence check ran. Callers that surface an over-cap warning use
+ * this; everything else can use {@link findUnreadableReferencedPaths}.
+ */
+export function findUnreadableReferencedPathsWithMeta(
+  taskText: string,
+  opts: FindUnreadableReferencedPathsOpts,
+): FindUnreadableReferencedPathsResult {
+  const { paths, droppedOverCap } = extractReferencedPathsWithMeta(taskText);
+  const out: UnreadableReferencedPath[] = [];
+
+  const isWorktree = opts.writeMode === 'worktree';
+
+  for (const path of paths) {
+    const exists = opts.pathExists(path);
+    if (!exists) {
+      out.push({ path, reason: 'missing' });
+      continue;
+    }
+    if (isWorktree && opts.isGitignoredOrUntracked(path)) {
+      out.push({ path, reason: 'gitignored_in_worktree' });
+    }
+  }
+
+  return { unreadable: out, droppedOverCap };
+}
+
+// ---------------------------------------------------------------------------
 // detectMidFlightCommits
 // ---------------------------------------------------------------------------
 

--- a/tests/cli/dispatch-precondition-guard-multimode.test.ts
+++ b/tests/cli/dispatch-precondition-guard-multimode.test.ts
@@ -161,6 +161,9 @@ describe('handleDispatchParallel — precondition guard invocation', () => {
     expect(mockedGuard).toHaveBeenCalledTimes(1);
     const [args] = mockedGuard.mock.calls[0];
     expect(args.resolutionRoots).toEqual(roots);
+    // Bug A wiring: the first task's text + write_mode must reach the guard.
+    expect(args.taskText).toBe('Review Y');
+    expect(args.writeMode).toBeUndefined();
   });
 
   it('guard is called only once even for multiple tasks', async () => {
@@ -181,6 +184,31 @@ describe('handleDispatchParallel — precondition guard invocation', () => {
     await new Promise(r => setImmediate(r));
 
     expect(mockedGuard).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes ALL non-primary tasks through as additionalTasks (Bug A Fix 1)', async () => {
+    ctx.mainAgent.dispatchParallel = jest.fn().mockResolvedValue({
+      taskIds: ['p-1', 'p-2'],
+      errors: [],
+    });
+    ctx.mainAgent.getTask = jest.fn().mockReturnValue({ agentId: 'gemini-tester' });
+
+    await handleDispatchParallel(
+      [
+        { agent_id: 'gemini-tester', task: 'Primary task' },
+        { agent_id: 'gemini-reviewer', task: 'Secondary references docs/specs/x.md', write_mode: 'worktree' },
+      ],
+      /* consensus */ false,
+    );
+
+    await new Promise(r => setImmediate(r));
+
+    expect(mockedGuard).toHaveBeenCalledTimes(1);
+    const [args] = mockedGuard.mock.calls[0];
+    expect(args.taskText).toBe('Primary task');
+    expect(args.additionalTasks).toEqual([
+      { taskText: 'Secondary references docs/specs/x.md', writeMode: 'worktree' },
+    ]);
   });
 
   it('dispatch succeeds even when runDispatchPreconditionGuard rejects', async () => {
@@ -277,6 +305,28 @@ describe('handleDispatchConsensus — precondition guard invocation', () => {
     await new Promise(r => setImmediate(r));
 
     expect(mockedGuard).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes non-primary consensus tasks through as additionalTasks (Bug A Fix 1)', async () => {
+    ctx.mainAgent.dispatchParallel = jest.fn().mockResolvedValue({
+      taskIds: ['c-1', 'c-2'],
+      errors: [],
+    });
+    ctx.mainAgent.getTask = jest.fn().mockReturnValue({ agentId: 'gemini-tester' });
+
+    await handleDispatchConsensus([
+      { agent_id: 'gemini-tester', task: 'Primary review' },
+      { agent_id: 'gemini-reviewer', task: 'Secondary review docs/specs/y.md', write_mode: 'worktree' },
+    ]);
+
+    await new Promise(r => setImmediate(r));
+
+    expect(mockedGuard).toHaveBeenCalledTimes(1);
+    const [args] = mockedGuard.mock.calls[0];
+    expect(args.taskText).toBe('Primary review');
+    expect(args.additionalTasks).toEqual([
+      { taskText: 'Secondary review docs/specs/y.md', writeMode: 'worktree' },
+    ]);
   });
 
   it('dispatch succeeds even when runDispatchPreconditionGuard rejects', async () => {

--- a/tests/cli/orchestrator-precondition-runner.test.ts
+++ b/tests/cli/orchestrator-precondition-runner.test.ts
@@ -20,10 +20,16 @@ function makeDeps(overrides: Partial<PreconditionRunnerDeps> = {}): Precondition
   return {
     execFile: jest.fn(),
     canRead: jest.fn().mockReturnValue(true),
+    // Default: every referenced path exists and is tracked → no task-text signal.
+    pathExists: jest.fn().mockReturnValue(true),
+    isGitignoredOrUntracked: jest.fn().mockReturnValue(false),
     emitSignals: jest.fn(),
     ...overrides,
   };
 }
+
+/** Default guard input fields for the new task-text check (no referenced paths). */
+const NO_TASK_TEXT = { taskText: '', writeMode: undefined as string | undefined };
 
 // ---------------------------------------------------------------------------
 // gatherStaleBaseInputs
@@ -103,7 +109,7 @@ describe('runDispatchPreconditionGuard — stale base', () => {
         .mockReturnValueOnce('samesha\n'),
     });
     const result = await runDispatchPreconditionGuard(
-      { projectRoot: '/project', taskId: 't1', resolutionRoots: [] },
+      { projectRoot: '/project', taskId: 't1', resolutionRoots: [], ...NO_TASK_TEXT },
       deps,
     );
     expect(result.warnings).toHaveLength(0);
@@ -118,7 +124,7 @@ describe('runDispatchPreconditionGuard — stale base', () => {
         .mockReturnValueOnce('old111\n'),     // merge-base === HEAD → behind_origin
     });
     const result = await runDispatchPreconditionGuard(
-      { projectRoot: '/project', taskId: 'task-abc', resolutionRoots: [] },
+      { projectRoot: '/project', taskId: 'task-abc', resolutionRoots: [], ...NO_TASK_TEXT },
       deps,
     );
     expect(result.warnings.length).toBeGreaterThan(0);
@@ -139,7 +145,7 @@ describe('runDispatchPreconditionGuard — stale base', () => {
         .mockReturnValueOnce('commonancestor\n'),  // different from HEAD → branched_pre_merge
     });
     const result = await runDispatchPreconditionGuard(
-      { projectRoot: '/project', taskId: 'task-xyz', resolutionRoots: [] },
+      { projectRoot: '/project', taskId: 'task-xyz', resolutionRoots: [], ...NO_TASK_TEXT },
       deps,
     );
     expect(result.warnings.length).toBeGreaterThan(0);
@@ -156,7 +162,7 @@ describe('runDispatchPreconditionGuard — stale base', () => {
       }),
     });
     const result = await runDispatchPreconditionGuard(
-      { projectRoot: '/project', taskId: 'tX', resolutionRoots: [] },
+      { projectRoot: '/project', taskId: 'tX', resolutionRoots: [], ...NO_TASK_TEXT },
       deps,
     );
     expect(result.warnings).toHaveLength(0);
@@ -176,7 +182,7 @@ describe('runDispatchPreconditionGuard — stale base', () => {
       emitSignals: jest.fn().mockImplementation(() => { throw new Error('emit failed'); }),
     });
     await expect(
-      runDispatchPreconditionGuard({ projectRoot: '/p', taskId: 't', resolutionRoots: [] }, deps),
+      runDispatchPreconditionGuard({ projectRoot: '/p', taskId: 't', resolutionRoots: [], ...NO_TASK_TEXT }, deps),
     ).resolves.toBeDefined();
   });
 });
@@ -195,7 +201,7 @@ describe('runDispatchPreconditionGuard — referenced_unreadable_path', () => {
       canRead: jest.fn().mockReturnValue(true),
     });
     const result = await runDispatchPreconditionGuard(
-      { projectRoot: '/p', taskId: 't1', resolutionRoots: ['/p/worktree1', '/p/worktree2'] },
+      { projectRoot: '/p', taskId: 't1', resolutionRoots: ['/p/worktree1', '/p/worktree2'], ...NO_TASK_TEXT },
       deps,
     );
     expect(result.warnings).toHaveLength(0);
@@ -218,6 +224,7 @@ describe('runDispatchPreconditionGuard — referenced_unreadable_path', () => {
         projectRoot: '/p',
         taskId: 'task-123',
         resolutionRoots: ['/readable/path', '/missing/path'],
+        ...NO_TASK_TEXT,
       },
       deps,
     );
@@ -242,7 +249,7 @@ describe('runDispatchPreconditionGuard — referenced_unreadable_path', () => {
       canRead: jest.fn().mockReturnValue(false), // would fail if called
     });
     const result = await runDispatchPreconditionGuard(
-      { projectRoot: '/p', taskId: 't', resolutionRoots: [] },
+      { projectRoot: '/p', taskId: 't', resolutionRoots: [], ...NO_TASK_TEXT },
       deps,
     );
     // canRead should not have been called (no paths to check)
@@ -263,7 +270,7 @@ describe('runDispatchPreconditionGuard — referenced_unreadable_path', () => {
       canRead: jest.fn().mockReturnValue(false),
     });
     const result = await runDispatchPreconditionGuard(
-      { projectRoot: '/p', taskId: 't', resolutionRoots: undefined },
+      { projectRoot: '/p', taskId: 't', resolutionRoots: undefined, ...NO_TASK_TEXT },
       deps,
     );
     expect(deps.canRead).not.toHaveBeenCalled();
@@ -280,7 +287,7 @@ describe('runDispatchPreconditionGuard — referenced_unreadable_path', () => {
     });
     await expect(
       runDispatchPreconditionGuard(
-        { projectRoot: '/p', taskId: 't', resolutionRoots: ['/some/path'] },
+        { projectRoot: '/p', taskId: 't', resolutionRoots: ['/some/path'], ...NO_TASK_TEXT },
         deps,
       ),
     ).resolves.toBeDefined();
@@ -305,6 +312,7 @@ describe('runDispatchPreconditionGuard — combined signals', () => {
         projectRoot: '/p',
         taskId: 'combined',
         resolutionRoots: ['/missing/root'],
+        ...NO_TASK_TEXT,
       },
       deps,
     );
@@ -314,5 +322,292 @@ describe('runDispatchPreconditionGuard — combined signals', () => {
       .map((s: { signal: string }) => s.signal);
     expect(allEmittedSignals).toContain('dispatched_stale_base');
     expect(allEmittedSignals).toContain('referenced_unreadable_path');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runDispatchPreconditionGuard — referenced_unreadable_path (TASK-TEXT, Bug A)
+// ---------------------------------------------------------------------------
+
+/** execFile stub that satisfies stale-base (fresh) so only the task-text path runs. */
+function freshStaleExecFile(): jest.Mock {
+  return jest.fn()
+    .mockReturnValueOnce('sha\n')   // HEAD
+    .mockReturnValueOnce('sha\n')   // origin/master
+    .mockReturnValueOnce('sha\n');  // merge-base === HEAD → fresh
+}
+
+type RefSignal = PerformanceSignal & {
+  agentId: string;
+  taskId: string;
+  metadata: { referenced: Array<{ path: string; reason: string }> };
+};
+
+function findRefSignal(emit: jest.Mock): RefSignal | undefined {
+  return emit.mock.calls
+    .flatMap(([, sigs]: [unknown, PerformanceSignal[]]) => sigs)
+    .find((s: PerformanceSignal) => s.signal === 'referenced_unreadable_path') as RefSignal | undefined;
+}
+
+describe('runDispatchPreconditionGuard — referenced_unreadable_path (task text)', () => {
+  it('emits signal + warning for a gitignored path under writeMode worktree', async () => {
+    const deps = makeDeps({
+      execFile: freshStaleExecFile(),
+      pathExists: jest.fn().mockReturnValue(true),
+      isGitignoredOrUntracked: jest.fn().mockReturnValue(true),
+    });
+    const result = await runDispatchPreconditionGuard(
+      {
+        projectRoot: '/p',
+        taskId: 'task-wt',
+        resolutionRoots: [],
+        taskText: 'Implement BUG A from spec `docs/specs/2026-06-22-fix.md` now.',
+        writeMode: 'worktree',
+      },
+      deps,
+    );
+    expect(result.warnings.join(' ')).toMatch(/cannot read/i);
+    const sig = findRefSignal(deps.emitSignals as jest.Mock);
+    expect(sig).toBeDefined();
+    expect(sig!.agentId).toBe('orchestrator');
+    expect(sig!.taskId).toBe('task-wt');
+    expect(sig!.metadata.referenced).toEqual([
+      { path: 'docs/specs/2026-06-22-fix.md', reason: 'gitignored_in_worktree' },
+    ]);
+  });
+
+  it('emits missing reason for a nonexistent referenced path (sequential mode)', async () => {
+    const deps = makeDeps({
+      execFile: freshStaleExecFile(),
+      pathExists: jest.fn().mockReturnValue(false),
+      isGitignoredOrUntracked: jest.fn().mockReturnValue(false),
+    });
+    const result = await runDispatchPreconditionGuard(
+      {
+        projectRoot: '/p',
+        taskId: 'task-typo',
+        resolutionRoots: [],
+        taskText: 'Read `docs/typo.md` and proceed.',
+        writeMode: 'sequential',
+      },
+      deps,
+    );
+    expect(result.warnings.length).toBeGreaterThan(0);
+    const sig = findRefSignal(deps.emitSignals as jest.Mock);
+    expect(sig!.metadata.referenced).toEqual([{ path: 'docs/typo.md', reason: 'missing' }]);
+  });
+
+  it('does NOT emit a task-text signal when the referenced path is readable', async () => {
+    const deps = makeDeps({
+      execFile: freshStaleExecFile(),
+      pathExists: jest.fn().mockReturnValue(true),
+      isGitignoredOrUntracked: jest.fn().mockReturnValue(false),
+    });
+    const result = await runDispatchPreconditionGuard(
+      {
+        projectRoot: '/p',
+        taskId: 't-ok',
+        resolutionRoots: [],
+        taskText: 'Edit `src/index.ts` carefully.',
+        writeMode: 'worktree',
+      },
+      deps,
+    );
+    expect(findRefSignal(deps.emitSignals as jest.Mock)).toBeUndefined();
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('does NOT flag a gitignored path under non-worktree mode (readable from root)', async () => {
+    const deps = makeDeps({
+      execFile: freshStaleExecFile(),
+      pathExists: jest.fn().mockReturnValue(true),
+      isGitignoredOrUntracked: jest.fn().mockReturnValue(true),
+    });
+    await runDispatchPreconditionGuard(
+      {
+        projectRoot: '/p',
+        taskId: 't-seq',
+        resolutionRoots: [],
+        taskText: 'Read `docs/specs/x.md`.',
+        writeMode: 'sequential',
+      },
+      deps,
+    );
+    expect(findRefSignal(deps.emitSignals as jest.Mock)).toBeUndefined();
+  });
+
+  it('never throws when pathExists predicate throws (safe default → no signal)', async () => {
+    const deps = makeDeps({
+      execFile: freshStaleExecFile(),
+      pathExists: jest.fn().mockImplementation(() => { throw new Error('fs blew up'); }),
+      isGitignoredOrUntracked: jest.fn().mockReturnValue(true),
+    });
+    const result = await runDispatchPreconditionGuard(
+      {
+        projectRoot: '/p',
+        taskId: 't-throw',
+        resolutionRoots: [],
+        taskText: 'Read `docs/specs/x.md`.',
+        writeMode: 'worktree',
+      },
+      deps,
+    );
+    // pathExists throws → treated as "present" → no missing; gitignored check
+    // still runs (returns true) → flagged gitignored_in_worktree. Key assertion:
+    // the guard resolves and never throws.
+    expect(result).toBeDefined();
+  });
+
+  it('never throws when isGitignoredOrUntracked predicate throws', async () => {
+    const deps = makeDeps({
+      execFile: freshStaleExecFile(),
+      pathExists: jest.fn().mockReturnValue(true),
+      isGitignoredOrUntracked: jest.fn().mockImplementation(() => { throw new Error('git blew up'); }),
+    });
+    await expect(
+      runDispatchPreconditionGuard(
+        {
+          projectRoot: '/p',
+          taskId: 't-throw2',
+          resolutionRoots: [],
+          taskText: 'Read `docs/specs/x.md`.',
+          writeMode: 'worktree',
+        },
+        deps,
+      ),
+    ).resolves.toBeDefined();
+    // git predicate throws → safe default false → not flagged.
+    expect(findRefSignal(deps.emitSignals as jest.Mock)).toBeUndefined();
+  });
+
+  it('emits no task-text signal when taskText is empty', async () => {
+    const deps = makeDeps({
+      execFile: freshStaleExecFile(),
+      pathExists: jest.fn().mockReturnValue(false),
+    });
+    await runDispatchPreconditionGuard(
+      { projectRoot: '/p', taskId: 't', resolutionRoots: [], taskText: '', writeMode: 'worktree' },
+      deps,
+    );
+    expect(deps.pathExists).not.toHaveBeenCalled();
+    expect(findRefSignal(deps.emitSignals as jest.Mock)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runDispatchPreconditionGuard — multi-task referenced-path scan (Fix 1)
+// ---------------------------------------------------------------------------
+
+describe('runDispatchPreconditionGuard — additionalTasks (multi-task)', () => {
+  it('flags a gitignored spec referenced by a worktree task at index >=1', async () => {
+    // Primary task (index 0) references nothing; the SECOND task references a
+    // gitignored spec under writeMode worktree. Without Fix 1 this would never
+    // be flagged — the exact failure the signal exists to catch.
+    const deps = makeDeps({
+      execFile: freshStaleExecFile(),
+      pathExists: jest.fn().mockReturnValue(true),
+      isGitignoredOrUntracked: jest.fn().mockReturnValue(true),
+    });
+    const result = await runDispatchPreconditionGuard(
+      {
+        projectRoot: '/p',
+        taskId: 'task-multi',
+        resolutionRoots: [],
+        taskText: 'Primary task, no path refs here.',
+        writeMode: undefined,
+        additionalTasks: [
+          { taskText: 'Implement from `docs/specs/2026-06-22-fix.md`.', writeMode: 'worktree' },
+        ],
+      },
+      deps,
+    );
+    const sig = findRefSignal(deps.emitSignals as jest.Mock);
+    expect(sig).toBeDefined();
+    expect(sig!.metadata.referenced).toEqual([
+      { path: 'docs/specs/2026-06-22-fix.md', reason: 'gitignored_in_worktree' },
+    ]);
+    expect(result.warnings.join(' ')).toMatch(/cannot read/i);
+  });
+
+  it('dedupes the same unreadable path across tasks, preferring gitignored_in_worktree', async () => {
+    // Both tasks reference docs/specs/x.md. The primary (sequential) would yield
+    // 'missing' if it did not exist, but here it EXISTS; the worktree task makes
+    // it gitignored_in_worktree. Dedup must emit a single entry.
+    const deps = makeDeps({
+      execFile: freshStaleExecFile(),
+      // exists everywhere → sequential task sees it as readable (no entry),
+      // worktree task sees gitignored → gitignored_in_worktree.
+      pathExists: jest.fn().mockReturnValue(true),
+      isGitignoredOrUntracked: jest.fn().mockReturnValue(true),
+    });
+    await runDispatchPreconditionGuard(
+      {
+        projectRoot: '/p',
+        taskId: 'task-dedup',
+        resolutionRoots: [],
+        taskText: 'Read `docs/specs/x.md`.',
+        writeMode: 'sequential',
+        additionalTasks: [
+          { taskText: 'Also read `docs/specs/x.md`.', writeMode: 'worktree' },
+        ],
+      },
+      deps,
+    );
+    const sig = findRefSignal(deps.emitSignals as jest.Mock);
+    expect(sig).toBeDefined();
+    expect(sig!.metadata.referenced).toEqual([
+      { path: 'docs/specs/x.md', reason: 'gitignored_in_worktree' },
+    ]);
+  });
+
+  it('evaluates each task under its OWN writeMode (worktree-only flag does not leak to sequential task)', async () => {
+    // Task A (sequential) references a.md; Task B (worktree) references b.md.
+    // a.md is gitignored but readable from root → NOT flagged (sequential).
+    // b.md is gitignored under worktree → flagged. Asserts per-task writeMode.
+    const deps = makeDeps({
+      execFile: freshStaleExecFile(),
+      pathExists: jest.fn().mockReturnValue(true),
+      isGitignoredOrUntracked: jest.fn().mockReturnValue(true),
+    });
+    const result = await runDispatchPreconditionGuard(
+      {
+        projectRoot: '/p',
+        taskId: 'task-permode',
+        resolutionRoots: [],
+        taskText: 'Read `a.md`.',
+        writeMode: 'sequential',
+        additionalTasks: [
+          { taskText: 'Read `b.md`.', writeMode: 'worktree' },
+        ],
+      },
+      deps,
+    );
+    const sig = findRefSignal(deps.emitSignals as jest.Mock);
+    expect(sig).toBeDefined();
+    expect(sig!.metadata.referenced).toEqual([
+      { path: 'b.md', reason: 'gitignored_in_worktree' },
+    ]);
+    expect(result.warnings.join(' ')).not.toMatch(/a\.md/);
+  });
+
+  it('emits an over-cap warning when more than 20 paths are referenced (Fix 3)', async () => {
+    const tokens = Array.from({ length: 25 }, (_, i) => `file${i}.ts`);
+    const deps = makeDeps({
+      execFile: freshStaleExecFile(),
+      pathExists: jest.fn().mockReturnValue(true),
+      isGitignoredOrUntracked: jest.fn().mockReturnValue(false),
+    });
+    const result = await runDispatchPreconditionGuard(
+      {
+        projectRoot: '/p',
+        taskId: 'task-cap',
+        resolutionRoots: [],
+        taskText: `Touch these: ${tokens.join(' ')}`,
+        writeMode: 'sequential',
+      },
+      deps,
+    );
+    // 5 over the cap of 20.
+    expect(result.warnings.join('\n')).toMatch(/5 referenced path\(s\) beyond the 20-path cap/);
   });
 });

--- a/tests/orchestrator/orchestrator-preconditions.test.ts
+++ b/tests/orchestrator/orchestrator-preconditions.test.ts
@@ -8,6 +8,10 @@ import {
   detectStaleBase,
   findUnreadablePaths,
   detectMidFlightCommits,
+  extractReferencedPaths,
+  extractReferencedPathsWithMeta,
+  findUnreadableReferencedPaths,
+  findUnreadableReferencedPathsWithMeta,
 } from '../../packages/orchestrator/src/orchestrator-preconditions';
 
 // ---------------------------------------------------------------------------
@@ -161,5 +165,266 @@ describe('detectMidFlightCommits', () => {
     const many = Array.from({ length: 100 }, (_, i) => `commit${i}`);
     const result = detectMidFlightCommits(many);
     expect(result).toEqual({ detected: true, count: 100 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractReferencedPaths
+// ---------------------------------------------------------------------------
+
+describe('extractReferencedPaths', () => {
+  it('returns [] for empty text', () => {
+    expect(extractReferencedPaths('')).toEqual([]);
+  });
+
+  it('extracts a backtick-quoted path', () => {
+    const text = 'Implement BUG A from spec `docs/specs/2026-06-22-fix.md` now.';
+    expect(extractReferencedPaths(text)).toEqual(['docs/specs/2026-06-22-fix.md']);
+  });
+
+  it('extracts a bare whitespace-delimited path', () => {
+    const text = 'Edit packages/orchestrator/src/orchestrator-preconditions.ts please.';
+    expect(extractReferencedPaths(text)).toEqual([
+      'packages/orchestrator/src/orchestrator-preconditions.ts',
+    ]);
+  });
+
+  it('extracts mixed backtick and bare tokens', () => {
+    const text = 'Read `a/b.md` then update c/d.ts and e.json';
+    expect(extractReferencedPaths(text)).toEqual(['a/b.md', 'c/d.ts', 'e.json']);
+  });
+
+  it('accepts a leading ./ prefix', () => {
+    expect(extractReferencedPaths('see ./src/index.ts')).toEqual(['./src/index.ts']);
+  });
+
+  it('ignores non-path tokens (prose, version strings, e.g.)', () => {
+    const text = 'Implement this now, e.g. quickly, version 1.2.3 of the thing.';
+    expect(extractReferencedPaths(text)).toEqual([]);
+  });
+
+  it('ignores tokens without a known extension', () => {
+    expect(extractReferencedPaths('go to packages/orchestrator/src and look')).toEqual([]);
+  });
+
+  it('rejects absolute paths', () => {
+    expect(extractReferencedPaths('read /etc/passwd.txt and /tmp/x.md')).toEqual([]);
+  });
+
+  it('rejects traversal tokens containing ..', () => {
+    expect(extractReferencedPaths('read ../secrets/key.json and ../../a.ts')).toEqual([]);
+  });
+
+  it('strips surrounding punctuation/parentheses', () => {
+    expect(extractReferencedPaths('see (foo/bar.md), then baz.ts.')).toEqual([
+      'foo/bar.md',
+      'baz.ts',
+    ]);
+  });
+
+  it('de-duplicates repeated paths (first-seen order)', () => {
+    const text = 'edit a.ts, then b.ts, then a.ts again';
+    expect(extractReferencedPaths(text)).toEqual(['a.ts', 'b.ts']);
+  });
+
+  it('caps the result at 20 distinct paths', () => {
+    const tokens = Array.from({ length: 30 }, (_, i) => `file${i}.ts`);
+    const text = tokens.join(' ');
+    const result = extractReferencedPaths(text);
+    expect(result).toHaveLength(20);
+    expect(result[0]).toBe('file0.ts');
+    expect(result[19]).toBe('file19.ts');
+  });
+
+  it('accepts each allowed extension', () => {
+    const text = 'a.md b.ts c.tsx d.js e.json f.txt g.yaml h.yml';
+    expect(extractReferencedPaths(text)).toEqual([
+      'a.md', 'b.ts', 'c.tsx', 'd.js', 'e.json', 'f.txt', 'g.yaml', 'h.yml',
+    ]);
+  });
+
+  // Fix 2: strip a trailing path:line (and path:line:col) citation suffix
+  // before the shape test, since this codebase cites path:line pervasively.
+  it('strips a trailing :line citation suffix', () => {
+    expect(extractReferencedPaths('see docs/specs/x.md:12 now')).toEqual([
+      'docs/specs/x.md',
+    ]);
+  });
+
+  it('strips a trailing :line:col citation suffix', () => {
+    expect(extractReferencedPaths('at src/index.ts:12:5 there')).toEqual([
+      'src/index.ts',
+    ]);
+  });
+
+  it('strips a :line suffix inside a backtick-quoted citation', () => {
+    expect(extractReferencedPaths('`packages/orchestrator/src/x.ts:99`')).toEqual([
+      'packages/orchestrator/src/x.ts',
+    ]);
+  });
+
+  it('does not strip digits that are part of the filename (no trailing colon)', () => {
+    // 2026-06-22-fix.md has no `:line` suffix — must survive intact.
+    expect(extractReferencedPaths('docs/specs/2026-06-22-fix.md')).toEqual([
+      'docs/specs/2026-06-22-fix.md',
+    ]);
+  });
+
+  it('dedupes path:12 and path (same path) to a single entry', () => {
+    expect(extractReferencedPaths('foo.ts:12 and foo.ts again')).toEqual(['foo.ts']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractReferencedPathsWithMeta — over-cap drop count (Fix 3)
+// ---------------------------------------------------------------------------
+
+describe('extractReferencedPathsWithMeta', () => {
+  it('reports droppedOverCap 0 when under the cap', () => {
+    const result = extractReferencedPathsWithMeta('a.ts b.ts c.ts');
+    expect(result.paths).toEqual(['a.ts', 'b.ts', 'c.ts']);
+    expect(result.droppedOverCap).toBe(0);
+  });
+
+  it('reports the number of distinct tokens dropped over the 20-path cap', () => {
+    const tokens = Array.from({ length: 25 }, (_, i) => `file${i}.ts`);
+    const result = extractReferencedPathsWithMeta(tokens.join(' '));
+    expect(result.paths).toHaveLength(20);
+    expect(result.paths[0]).toBe('file0.ts');
+    expect(result.paths[19]).toBe('file19.ts');
+    // 25 distinct − 20 kept = 5 dropped over cap.
+    expect(result.droppedOverCap).toBe(5);
+  });
+
+  it('does not count duplicate tokens beyond the cap as drops', () => {
+    const distinct = Array.from({ length: 22 }, (_, i) => `f${i}.ts`);
+    // Append 5 repeats of already-seen paths — those must NOT inflate the count.
+    const text = [...distinct, 'f0.ts', 'f1.ts', 'f2.ts', 'f3.ts', 'f4.ts'].join(' ');
+    const result = extractReferencedPathsWithMeta(text);
+    expect(result.paths).toHaveLength(20);
+    expect(result.droppedOverCap).toBe(2);
+  });
+
+  it('returns empty + 0 for empty input', () => {
+    expect(extractReferencedPathsWithMeta('')).toEqual({ paths: [], droppedOverCap: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findUnreadableReferencedPathsWithMeta — propagates the drop count (Fix 3)
+// ---------------------------------------------------------------------------
+
+describe('findUnreadableReferencedPathsWithMeta', () => {
+  it('propagates droppedOverCap from the extractor', () => {
+    const tokens = Array.from({ length: 23 }, (_, i) => `g${i}.ts`);
+    const result = findUnreadableReferencedPathsWithMeta(tokens.join(' '), {
+      writeMode: 'sequential',
+      pathExists: () => true,
+      isGitignoredOrUntracked: () => false,
+    });
+    expect(result.droppedOverCap).toBe(3);
+    expect(result.unreadable).toEqual([]); // all readable
+  });
+
+  it('reports unreadable entries plus a zero drop count under cap', () => {
+    const result = findUnreadableReferencedPathsWithMeta('read `docs/typo.md`', {
+      writeMode: 'worktree',
+      pathExists: () => false,
+      isGitignoredOrUntracked: () => false,
+    });
+    expect(result.unreadable).toEqual([{ path: 'docs/typo.md', reason: 'missing' }]);
+    expect(result.droppedOverCap).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findUnreadableReferencedPaths
+// ---------------------------------------------------------------------------
+
+describe('findUnreadableReferencedPaths', () => {
+  const allExist = (_p: string): boolean => true;
+  const noneExist = (_p: string): boolean => false;
+  const neverIgnored = (_p: string): boolean => false;
+  const alwaysIgnored = (_p: string): boolean => true;
+
+  it('returns [] when there are no referenced paths', () => {
+    const result = findUnreadableReferencedPaths('no paths here at all', {
+      writeMode: 'worktree',
+      pathExists: allExist,
+      isGitignoredOrUntracked: alwaysIgnored,
+    });
+    expect(result).toEqual([]);
+  });
+
+  describe('worktree write mode', () => {
+    it('flags a gitignored existing path as gitignored_in_worktree', () => {
+      const result = findUnreadableReferencedPaths('read `docs/specs/x.md`', {
+        writeMode: 'worktree',
+        pathExists: allExist,
+        isGitignoredOrUntracked: alwaysIgnored,
+      });
+      expect(result).toEqual([
+        { path: 'docs/specs/x.md', reason: 'gitignored_in_worktree' },
+      ]);
+    });
+
+    it('flags a nonexistent path as missing (typo case)', () => {
+      const result = findUnreadableReferencedPaths('read `docs/typo.md`', {
+        writeMode: 'worktree',
+        pathExists: noneExist,
+        isGitignoredOrUntracked: neverIgnored,
+      });
+      expect(result).toEqual([{ path: 'docs/typo.md', reason: 'missing' }]);
+    });
+
+    it('does not flag a tracked, existing path', () => {
+      const result = findUnreadableReferencedPaths('read `src/index.ts`', {
+        writeMode: 'worktree',
+        pathExists: allExist,
+        isGitignoredOrUntracked: neverIgnored,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('reports missing for nonexistent and gitignored_in_worktree for ignored together', () => {
+      const result = findUnreadableReferencedPaths('read present.md and absent.md', {
+        writeMode: 'worktree',
+        pathExists: (p: string) => p === 'present.md',
+        isGitignoredOrUntracked: (p: string) => p === 'present.md',
+      });
+      expect(result).toEqual([
+        { path: 'present.md', reason: 'gitignored_in_worktree' },
+        { path: 'absent.md', reason: 'missing' },
+      ]);
+    });
+  });
+
+  describe('non-worktree (sequential / scoped / undefined) write mode', () => {
+    it('flags a missing path as missing', () => {
+      const result = findUnreadableReferencedPaths('read `docs/typo.md`', {
+        writeMode: 'sequential',
+        pathExists: noneExist,
+        isGitignoredOrUntracked: alwaysIgnored,
+      });
+      expect(result).toEqual([{ path: 'docs/typo.md', reason: 'missing' }]);
+    });
+
+    it('does NOT flag a gitignored-but-existing path (readable from repo root)', () => {
+      const result = findUnreadableReferencedPaths('read `docs/specs/x.md`', {
+        writeMode: 'sequential',
+        pathExists: allExist,
+        isGitignoredOrUntracked: alwaysIgnored, // ignored, but writeMode != worktree
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('returns [] for a readable path', () => {
+      const result = findUnreadableReferencedPaths('read `src/index.ts`', {
+        writeMode: undefined,
+        pathExists: allExist,
+        isGitignoredOrUntracked: neverIgnored,
+      });
+      expect(result).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

The `referenced_unreadable_path` precondition signal shipped in #629 **never fired for its documented purpose**. It scanned `resolutionRoots` (worktree citation dirs, stripped upstream by `validateResolutionRoot`) instead of the paths a dispatch task actually references. This wires it to its real input — repo paths named in the **task text** that the executing agent won't be able to read (the recurring "worktree agent can't read a gitignored `docs/specs/*.md`" failure).

Bug A from `docs/specs/2026-06-22-referenced-unreadable-path-fix.md`; follow-up to #629 (Bug B was #632).

## What changed

**Core** — `packages/orchestrator/src/orchestrator-preconditions.ts`
- `extractReferencedPaths(taskText)` — conservative backtick/bare repo-path extractor (extension allowlist; rejects absolute + `..`; dedupes; 20-path cap). Strips a trailing `:line`/`:line:col` citation suffix so `docs/specs/x.md:12` (the pervasive `path:line` form) is matched, not dropped.
- `findUnreadableReferencedPaths(taskText, opts)` — **worktree-aware via git, not by statting a dir**. At pre-dispatch time the worktree doesn't exist yet, so unreadability is reasoned via git: a worktree dispatch can't read a path that is gitignored OR untracked (absent from a fresh checkout) → `gitignored_in_worktree`; missing at repo root → `missing`. Non-worktree → unreadable iff missing at root.
- `*WithMeta` variants surface a `droppedOverCap` count for cap observability.

**Wiring** — `apps/cli/src/handlers/`
- `orchestrator-precondition-runner.ts`: new Signal 2b emit block scans the primary task **+ all `additionalTasks`**, each under its own `writeMode`, deduping unreadable paths by path (`missing → gitignored_in_worktree` upgrade). Emits `[dispatch-hygiene]` + over-cap warnings. All fs/git access try/catch-wrapped — best-effort, **never throws** into the dispatch path. Production predicates: `defaultPathExists` (R_OK at `resolve(projectRoot,p)`) and `defaultIsGitignoredOrUntracked` (`git check-ignore -q` OR `ls-files --error-unmatch`; safe-default on failure).
- `dispatch.ts`: threads `taskText`/`writeMode` (single) and `additionalTasks` = all `taskDefs` (parallel + consensus) into the guard. The repo-global stale-base / mid-flight checks stay one-call-per-dispatch.

## Review

Consensus-hardened (sonnet-reviewer + fable-reviewer, 2 rounds): **7 confirmed, 0 disputed, 0 hallucinations**. The reviewers caught the multi-task coverage gap (guard originally scanned only `taskDefs[0]` — the exact worktree-implementer scenario this signal targets) plus the `path:line` drop and silent cap drop; all three are addressed in this PR.

consensus-id: 4e1cac73-f33049f0

## Tests

`tests/orchestrator/orchestrator-preconditions.test.ts`, `tests/cli/orchestrator-precondition-runner.test.ts`, `tests/cli/dispatch-precondition-guard-multimode.test.ts` — **92 passed**. `tsc --noEmit` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)