### PR TITLE
fix(orchestrator): classify strictly-ahead branch as ahead_of_origin, not stale

### DIFF
--- a/packages/orchestrator/src/orchestrator-preconditions.ts
+++ b/packages/orchestrator/src/orchestrator-preconditions.ts
@@ -16,7 +16,7 @@
 
 export interface StaleBaseResult {
   stale: boolean;
-  reason: 'behind_origin' | 'branched_pre_merge' | null;
+  reason: 'behind_origin' | 'branched_pre_merge' | 'ahead_of_origin' | null;
 }
 
 /**
@@ -29,31 +29,46 @@ export interface StaleBaseResult {
  *                         or null if it could not be determined.
  *
  * Classification:
- *   - Fresh:             dispatchSha === originMasterSha
- *   - behind_origin:     dispatchSha !== originMasterSha AND
- *                        mergeBaseSha === dispatchSha
- *                        (dispatch SHA is an ancestor of origin master — the
- *                        branch just hasn't been pulled up yet)
+ *   - Fresh:              dispatchSha === originMasterSha
+ *                         Branch is exactly at origin/master — nothing to flag.
+ *   - behind_origin:      dispatchSha !== originMasterSha AND
+ *                         mergeBaseSha === dispatchSha
+ *                         (dispatch SHA is an ancestor of origin/master — HEAD ⊂ origin;
+ *                         the local branch just hasn't been pulled up yet)
+ *   - ahead_of_origin:    dispatchSha !== originMasterSha AND
+ *                         mergeBaseSha === originMasterSha
+ *                         (origin/master is an ancestor of HEAD — origin ⊂ HEAD;
+ *                         branch is strictly ahead with no divergence; the normal
+ *                         review-on-branch workflow — NOT stale, informational only)
  *   - branched_pre_merge: dispatchSha !== originMasterSha AND
- *                         mergeBaseSha !== dispatchSha (or null)
- *                         (branch diverged from a common ancestor that is not
- *                         the dispatch SHA itself — PRs have landed on origin
- *                         that this branch has never seen)
+ *                         mergeBaseSha !== dispatchSha AND mergeBaseSha !== originMasterSha
+ *                         (or mergeBaseSha is null — true divergence; origin has commits
+ *                         that branched from a common ancestor this branch has never seen;
+ *                         merge-base equals neither SHA)
  */
 export function detectStaleBase(
   dispatchSha: string,
   originMasterSha: string,
   mergeBaseSha: string | null,
 ): StaleBaseResult {
+  // Case 1: exactly on origin/master — fresh, nothing to flag.
   if (dispatchSha === originMasterSha) {
     return { stale: false, reason: null };
   }
 
-  // SHAs differ → stale. Distinguish sub-reason via mergeBase.
-  const reason: 'behind_origin' | 'branched_pre_merge' =
-    mergeBaseSha === dispatchSha ? 'behind_origin' : 'branched_pre_merge';
+  // Case 2: HEAD is an ancestor of origin/master (behind_origin).
+  if (mergeBaseSha === dispatchSha) {
+    return { stale: true, reason: 'behind_origin' };
+  }
 
-  return { stale: true, reason };
+  // Case 3: origin/master is an ancestor of HEAD (strictly ahead — NOT stale).
+  if (mergeBaseSha === originMasterSha) {
+    return { stale: false, reason: 'ahead_of_origin' };
+  }
+
+  // Case 4: true divergence — merge-base is neither dispatch nor origin SHA
+  // (includes mergeBaseSha === null).
+  return { stale: true, reason: 'branched_pre_merge' };
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/cli/orchestrator-precondition-runner.test.ts
+++ b/tests/cli/orchestrator-precondition-runner.test.ts
@@ -173,6 +173,25 @@ describe('runDispatchPreconditionGuard — stale base', () => {
     expect(staleSignal).toBeUndefined();
   });
 
+  it('emits NO dispatched_stale_base signal when branch is strictly ahead of origin (ahead_of_origin)', async () => {
+    const deps = makeDeps({
+      execFile: jest.fn()
+        .mockReturnValueOnce('feature-tip\n')   // HEAD
+        .mockReturnValueOnce('origin-head\n')   // origin/master
+        .mockReturnValueOnce('origin-head\n'),  // merge-base === origin → strictly ahead
+    });
+    const result = await runDispatchPreconditionGuard(
+      { projectRoot: '/project', taskId: 'task-fwd', resolutionRoots: [], ...NO_TASK_TEXT },
+      deps,
+    );
+    // Branch strictly ahead of origin is NOT stale — no signal, no warning
+    expect(result.warnings).toHaveLength(0);
+    const staleSignal = (deps.emitSignals as jest.Mock).mock.calls
+      .flatMap(([, sigs]: [unknown, Array<{ signal: string }>]) => sigs)
+      .find((s: { signal: string }) => s.signal === 'dispatched_stale_base');
+    expect(staleSignal).toBeUndefined();
+  });
+
   it('never throws even if emitSignals throws', async () => {
     const deps = makeDeps({
       execFile: jest.fn()

--- a/tests/orchestrator/orchestrator-preconditions.test.ts
+++ b/tests/orchestrator/orchestrator-preconditions.test.ts
@@ -71,6 +71,19 @@ describe('detectStaleBase', () => {
     });
   });
 
+  describe('strictly ahead of origin (mergeBaseSha === originMasterSha)', () => {
+    it('returns { stale: false, reason: ahead_of_origin } when origin is an ancestor of HEAD', () => {
+      // mergeBase === originSha → origin is an ancestor of HEAD; branch is strictly ahead
+      const result = detectStaleBase('feature-tip', 'origin-head', 'origin-head');
+      expect(result).toEqual({ stale: false, reason: 'ahead_of_origin' });
+    });
+
+    it('returns ahead_of_origin for any feature branch strictly ahead of origin', () => {
+      const result = detectStaleBase('abc999', 'abc111', 'abc111');
+      expect(result).toEqual({ stale: false, reason: 'ahead_of_origin' });
+    });
+  });
+
   describe('edge cases', () => {
     it('treats empty string dispatch SHA as different from non-empty origin (stale)', () => {
       const result = detectStaleBase('', 'origin123', null);


### PR DESCRIPTION
## Problem

`detectStaleBase` (`packages/orchestrator/src/orchestrator-preconditions.ts`) modeled the HEAD-vs-origin git topology as **binary** — it tested only `mergeBaseSha === dispatchSha` (→ `behind_origin`) and dumped *everything else* into `branched_pre_merge` with `stale: true`. That misfired on the **strictly-ahead** case (`mergeBaseSha === originMasterSha` → origin is an ancestor of HEAD → clean feature branch, no divergence) — i.e. the *normal review-on-branch workflow*. Caught live: a consensus review dispatch from a clean branch one commit ahead of `origin/master` emitted `dispatched_stale_base/branched_pre_merge`. **5/5 historical firings were this false positive** (0 legitimate `behind_origin`).

## Fix

Add the missing equivalence class. `detectStaleBase` is now a 4-way partition by ancestry:

| merge-base equals | topology | result |
|---|---|---|
| `dispatchSha` | HEAD ⊂ origin (behind) | `{ stale: true, reason: 'behind_origin' }` |
| `originMasterSha` | origin ⊂ HEAD (**strictly ahead**) | `{ stale: false, reason: 'ahead_of_origin' }` ← NEW |
| neither / null | true divergence | `{ stale: true, reason: 'branched_pre_merge' }` |

`branched_pre_merge` now means **only** true divergence (origin has commits the branch never saw). The runner already gates emission on `stale && reason !== null` (`orchestrator-precondition-runner.ts:394`), so `ahead_of_origin` (`stale:false`) correctly emits **no** signal — no runner change needed.

## Scope / impact

`dispatched_stale_base` is a `type: pipeline` / `signal_class: operational` signal, **excluded from accuracy scoring** (`performance-reader.ts:758-762`). So this is **telemetry-accuracy, not score-correctness** — the orchestrator was never penalized; the dashboard stale-base semantics were just wrong.

## Verification

Investigated via 3-agent fan-out (sonnet-reviewer code-trace + haiku-researcher blast-radius + fable-reviewer policy), implemented TDD, and pre-merge consensus-reviewed.

- 85/85 tests pass (`tests/orchestrator/orchestrator-preconditions.test.ts` + `tests/cli/orchestrator-precondition-runner.test.ts`); typecheck clean for orchestrator/CLI.
- Pre-merge consensus: **9 confirmed / 0 disputed / 0 unverified**. fable's topology proof: `git merge-base(A,B) === B` iff B is an ancestor of A, so `mergeBase === origin` ⟺ strictly-ahead — no divergent counterexample can exist.

consensus-id: 124a9ba4-ca5645e4

## Known minor (non-blocking, per consensus)

- Degenerate `originMasterSha === ''` would hit the new Case 3, but `gatherStaleBaseInputs` never yields an empty origin SHA (`git rev-parse` returns a 40-char SHA or throws → returns null), so it's **unreachable in production**. `detectStaleBase` has no empty-string guard (pre-existing). Severity adjudicated LOW.
- Test gap: no fixture for `originMasterSha=''` into Case 3; no multi-signal non-suppression assertion. Cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)