### PR TITLE
fix(log): include date in MCP log timestamps to disambiguate midnight crossings

### DIFF
--- a/packages/orchestrator/src/log.ts
+++ b/packages/orchestrator/src/log.ts
@@ -2,11 +2,16 @@
 
 function ts(): string {
   const d = new Date();
+  const yyyy = d.getUTCFullYear();
+  const mo = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
   const hh = String(d.getUTCHours()).padStart(2, '0');
   const mm = String(d.getUTCMinutes()).padStart(2, '0');
   const ss = String(d.getUTCSeconds()).padStart(2, '0');
   const ms = String(d.getUTCMilliseconds()).padStart(3, '0');
-  return `${hh}:${mm}:${ss}.${ms}`;
+  // Include the date so midnight crossings aren't ambiguous in long-running
+  // MCP server logs (UTC; trailing 'Z' marks the zone).
+  return `${yyyy}-${mo}-${dd} ${hh}:${mm}:${ss}.${ms}Z`;
 }
 
 /** Tag → emoji prefix for visual scanning in mcp.log. Null-prototype to avoid __proto__ traversal. */


### PR DESCRIPTION
## What

`packages/orchestrator/src/log.ts` `ts()` emitted `HH:MM:SS.mmm` (UTC) with **no date**, so in long-running MCP server logs, entries on either side of a UTC midnight were ambiguous. Now prefixes `YYYY-MM-DD ` and marks the zone with a trailing `Z` → `2026-06-22 18:30:00.000Z`.

## Why

Surfaced during a stale-findings triage sweep (`232d33ff-143b4968:f7`, observability). Kept the compact space-separated form (rather than full `toISOString()` with the `T`) so existing log scanning stays readable.

## Verification

Log-string only, no behavior change. No test pins the timestamp format (grep clean). `npx tsc --noEmit -p packages/orchestrator/tsconfig.json` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)