### PR TITLE
test: fix wall-clock time-bomb in check-effectiveness resolveVerdict fixtures

### DIFF
--- a/tests/orchestrator/check-effectiveness-pure.test.ts
+++ b/tests/orchestrator/check-effectiveness-pure.test.ts
@@ -35,7 +35,7 @@ describe('resolveVerdict', () => {
   const baseSnapshot: SkillSnapshot = {
     baseline_accuracy_correct: 50,
     baseline_accuracy_hallucinated: 50,
-    bound_at: '2026-04-01T00:00:00Z',
+    bound_at: new Date(Date.now() - 86400_000).toISOString(), // 1d ago — recent, deterministic (avoids wall-clock TIMEOUT_DAYS flip)
     status: 'pending',
     migration_count: 0,
   };

--- a/tests/orchestrator/check-effectiveness.test.ts
+++ b/tests/orchestrator/check-effectiveness.test.ts
@@ -18,7 +18,7 @@ import {
 const baseSnapshot: SkillSnapshot = {
   baseline_accuracy_correct: 50,
   baseline_accuracy_hallucinated: 50,
-  bound_at: '2026-04-01T00:00:00Z',
+  bound_at: new Date(Date.now() - 86400_000).toISOString(), // 1d ago — recent, deterministic (avoids wall-clock TIMEOUT_DAYS flip)
   status: 'pending',
   migration_count: 0,
 };
@@ -80,7 +80,7 @@ describe('checkEffectiveness — Test 4: Dampener asymmetry guard', () => {
     const snap: SkillSnapshot = {
       baseline_accuracy_correct: 90,
       baseline_accuracy_hallucinated: 10,
-      bound_at: '2026-04-01T00:00:00Z',
+      bound_at: new Date(Date.now() - 86400_000).toISOString(), // 1d ago — recent, deterministic (avoids wall-clock TIMEOUT_DAYS flip)
       status: 'pending',
       migration_count: 0,
     };
@@ -95,7 +95,7 @@ describe('checkEffectiveness — Test 4: Dampener asymmetry guard', () => {
     const snap: SkillSnapshot = {
       baseline_accuracy_correct: 50,
       baseline_accuracy_hallucinated: 50,
-      bound_at: '2026-04-01T00:00:00Z',
+      bound_at: new Date(Date.now() - 86400_000).toISOString(), // 1d ago — recent, deterministic (avoids wall-clock TIMEOUT_DAYS flip)
       status: 'pending',
       migration_count: 0,
     };
@@ -116,7 +116,7 @@ describe('checkEffectiveness — Test 5: Inconclusive epoch', () => {
   const snap: SkillSnapshot = {
     baseline_accuracy_correct: 50,
     baseline_accuracy_hallucinated: 50,
-    bound_at: '2026-04-01T00:00:00Z',
+    bound_at: new Date(Date.now() - 86400_000).toISOString(), // 1d ago — recent, deterministic (avoids wall-clock TIMEOUT_DAYS flip)
     status: 'pending',
     migration_count: 0,
   };
@@ -186,7 +186,7 @@ describe('checkEffectiveness — Test 6: FDR boundary at baseline', () => {
     const baseline: SkillSnapshot = {
       baseline_accuracy_correct: 75,
       baseline_accuracy_hallucinated: 25,
-      bound_at: '2026-04-01T00:00:00Z',
+      bound_at: new Date(Date.now() - 86400_000).toISOString(), // 1d ago — recent, deterministic (avoids wall-clock TIMEOUT_DAYS flip)
       status: 'pending',
       migration_count: 0,
     };


### PR DESCRIPTION
## Problem

`tests/orchestrator/check-effectiveness*.test.ts` fixtures hardcode `bound_at: '2026-04-01T00:00:00Z'` and pass `Date.now()` as the clock to `resolveVerdict`. That function times out a skill once `now - bound_at >= TIMEOUT_DAYS` (~90d), which flips a below-`MIN_EVIDENCE` delta from `pending` to `insufficient_evidence`.

So two supposedly-deterministic tests silently broke by wall-clock: they were green when CI last ran on 2026-06-22 (~82d elapsed) and go red once real time passes 2026-04-01 + 90d (~2026-06-30). This is why master's last CI was green but the same tree fails today.

Failing:
- `resolveVerdict › returns pending when post-bind delta is below MIN_EVIDENCE`
- `Test 5: Inconclusive epoch › subsequent runs measure delta from inconclusive epoch`

## Fix

Make the default `bound_at` fixtures **relative** (`new Date(Date.now() - 86400_000)`, 1 day ago) so the non-timeout tests never trip the timeout branch by wall-clock. Timeout-path tests already use relative dates (`Date.now() - 91d`) and are unchanged. Test-only; no source change.

Full `tests/orchestrator`: 2546 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)