### PR TITLE
chore(release): v0.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ### Added
 
+- **Agent learning loop (lesson cards + per-agent correction injection).** When an
+  agent's output is later marked wrong via a terminal correction signal
+  (`hallucination_caught` / `impl_test_fail` / `impl_peer_rejected`), the
+  orchestrator can attach a `lesson` narrative to `gossip_signals` and gossipcat
+  writes an idempotent lesson card into that agent's memory. On the agent's next
+  dispatch, its own most-relevant prior corrections are injected into the prompt
+  under a `### Your Prior Corrections` section — so the agent sees its past miss in
+  context, not just as a score change. Best-effort (never fails signal recording),
+  sanitized, and count-capped per agent. Closes #642 (requests A + B-delta).
+
 - **First-class Cursor support.** Cursor is now a co-equal native host alongside
   Claude Code. A host-aware dispatch bridge (`native-host-bridge.ts`) emits the
   right call per host — Claude Code `Agent(model, …)` and Cursor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gossipcat",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gossipcat",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossipcat",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
   "mcpName": "io.github.ataberk-xyz/gossipcat",
   "repository": {


### PR DESCRIPTION
Cuts **v0.6.9**.

### Shipped since v0.6.8
- **#643** — Agent learning loop: lesson cards + per-agent correction injection (closes #642, requests A + B-delta).
- **#644** — Fix wall-clock time-bomb in `check-effectiveness` resolveVerdict fixtures (was failing CI repo-wide after 2026-06-30).

### Changes
- `package.json` / `package-lock.json`: 0.6.8 → 0.6.9
- `CHANGELOG.md`: learning-loop entry under Unreleased

Tag `v0.6.9` will be pushed on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)