### PR TITLE
fix(relay): use AgentConfig type in setAgentConfigs + close category test gaps

### DIFF
--- a/packages/relay/src/server.ts
+++ b/packages/relay/src/server.ts
@@ -16,11 +16,11 @@ import { DashboardAuth } from './dashboard/auth';
 import { DashboardRouter } from './dashboard/routes';
 import { DashboardWs } from './dashboard/ws';
 import type { BridgeSink, AskQuestion } from './dashboard/api-bridge';
-import type { ChatbotAgent } from '@gossip/orchestrator';
+import type { ChatbotAgent, AgentConfig } from '@gossip/orchestrator';
 
 export interface DashboardConfig {
   projectRoot: string;
-  agentConfigs: Array<{ id: string; provider: string; model: string; preset?: string; skills: string[]; native?: boolean }>;
+  agentConfigs: AgentConfig[];
 }
 
 export interface RelayServerConfig {
@@ -457,7 +457,7 @@ export class RelayServer {
    * (mcp-server-sdk.ts:365) still wins on initial boot — this method is a
    * post-setup override, not a replacement.
    */
-  setAgentConfigs(configs: Array<{ id: string; provider: string; model: string; preset?: string; skills: string[]; native?: boolean }>): void {
+  setAgentConfigs(configs: AgentConfig[]): void {
     this.dashboardRouter?.updateContext({ agentConfigs: configs });
   }
 

--- a/tests/orchestrator/category-extractor.test.ts
+++ b/tests/orchestrator/category-extractor.test.ts
@@ -1,4 +1,4 @@
-import { extractCategories, PerformanceWriter } from '@gossip/orchestrator';
+import { extractCategories, isValidCategory, PerformanceWriter } from '@gossip/orchestrator';
 import { mkdirSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -85,6 +85,26 @@ describe('extractCategories', () => {
   test('testing \\btest\\b avoids contest/protest/latest', () => {
     expect(extractCategories('the latest consensus round')).not.toContain('testing');
     expect(extractCategories('protest against unbounded growth')).not.toContain('testing');
+  });
+});
+
+describe('isValidCategory', () => {
+  test('accepts canonical lowercase category names', () => {
+    expect(isValidCategory('concurrency')).toBe(true);
+    expect(isValidCategory('injection_vectors')).toBe(true);
+  });
+
+  test('is case-sensitive — rejects valid names with wrong casing', () => {
+    // Agent-supplied categories must match the canonical (lowercase) keys
+    // exactly; "Concurrency" would otherwise poison categoryStrengths with a
+    // duplicate bucket (spec 2026-05-20-category-resolution-fix.md PART F).
+    expect(isValidCategory('Concurrency')).toBe(false);
+    expect(isValidCategory('INJECTION_VECTORS')).toBe(false);
+  });
+
+  test('rejects unknown categories and undefined', () => {
+    expect(isValidCategory('not_a_category')).toBe(false);
+    expect(isValidCategory(undefined)).toBe(false);
   });
 });
 

--- a/tests/orchestrator/consensus-engine-category-parse.test.ts
+++ b/tests/orchestrator/consensus-engine-category-parse.test.ts
@@ -80,6 +80,37 @@ SQL injection at db.ts:42
       expect(agreementSignal!.category).toBe('injection_vectors');
     });
 
+    it('ignores category supplied on an agree entry — parent finding category wins', async () => {
+      const engine = makeEngine();
+
+      const resultA = makeTask('agent-a', `<agent_finding type="finding" severity="high" category="injection_vectors">SQL injection at db.ts:42</agent_finding>`);
+      const resultB = makeTask('agent-b', `<agent_finding type="finding" severity="low">Unrelated finding at util.ts:10</agent_finding>`);
+
+      // Agent B agrees but ships its OWN (valid, different) category. The agree
+      // path at consensus-engine.ts resolveSignalCategory(f.category, ...) must
+      // use the parent finding's category and never the entry's.
+      const crossReview: CrossReviewEntry[] = [
+        {
+          action: 'agree',
+          agentId: 'agent-b',
+          peerAgentId: 'agent-a',
+          findingId: 'agent-a:f1',
+          finding: 'SQL injection at db.ts:42',
+          evidence: 'Confirmed — input unsanitised before query',
+          confidence: 5,
+          category: 'type_safety',
+        } as CrossReviewEntry,
+      ];
+
+      const report = await engine.synthesize([resultA, resultB], crossReview);
+
+      const agreementSignal = report.signals.find(
+        s => s.signal === 'agreement' && s.agentId === 'agent-b',
+      );
+      expect(agreementSignal).toBeDefined();
+      expect(agreementSignal!.category).toBe('injection_vectors'); // not 'type_safety'
+    });
+
     it('propagates category onto hallucination_caught signal (disagree path)', async () => {
       const engine = makeEngine();
 


### PR DESCRIPTION
## Summary

Closes two open consensus findings from the ledger:

**`20c17ac3-03bb4f25:f17`** (sonnet-reviewer, confirmed) — `setAgentConfigs` at `packages/relay/src/server.ts` and `DashboardConfig` inlined the agent-config shape instead of importing `AgentConfig` from `@gossip/orchestrator`, reintroducing the type-layer drift the PR #59 series closed. Both callers (`configToAgentConfigs`, `claudeSubagentsToConfigs`) already return `AgentConfig[]`, so this is a pure type tightening — no runtime change.

**`2bba9fb9-682c4710:f8`** (gemini-tester, suggestion) — adds the two missing regression tests:
- an `agree` cross-review entry that ships its own (valid, different) `category` is ignored — the parent finding's category wins on the agreement signal
- `isValidCategory` is case-sensitive: `"Concurrency"` / `"INJECTION_VECTORS"` are rejected

## Testing

- Full `npm run build` (public-interface change) — clean
- Full jest suite: 350 suites, 4729 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)