### PR TITLE
fix(skill-parser): YAML block-sequence support + loud parse-failure warnings

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -4791,7 +4791,7 @@ export function createMcpServer(): McpServer {
           // Overwrite protection
           if (existsSync(filePath)) {
             const existing = readFileSync(filePath, 'utf-8');
-            const fm = parseSkillFrontmatter(existing);
+            const fm = parseSkillFrontmatter(existing, filePath);
             if (fm) {
               if (fm.generated_by === 'manual') {
                 results.push(`Skipped ${name}: manually created file (generated_by: manual)`);

--- a/packages/orchestrator/src/skill-catalog.ts
+++ b/packages/orchestrator/src/skill-catalog.ts
@@ -102,7 +102,7 @@ export class SkillCatalog {
         const mtime = statSync(filePath).mtimeMs;
         newMtimes.set(file, mtime);
         const content = readFileSync(filePath, 'utf-8');
-        const fm = parseSkillFrontmatter(content);
+        const fm = parseSkillFrontmatter(content, filePath);
         if (!fm) continue;
 
         const entry: CatalogEntry & { _status?: string } = {

--- a/packages/orchestrator/src/skill-loader.ts
+++ b/packages/orchestrator/src/skill-loader.ts
@@ -331,7 +331,7 @@ export function loadSkills(
     if (mode === 'permanent') {
       permanent.push({ name: skill, content, path: resolvedPath });
     } else if (task) {
-      const rawHits = countKeywordHits(content, skill, task);
+      const rawHits = countKeywordHits(content, skill, task, resolvedPath);
       const frontmatter = parseSkillFrontmatter(content, resolvedPath);
       const boost = categoryBoost(frontmatter?.category, categories);
       const effectiveHits = rawHits + boost;
@@ -431,9 +431,13 @@ function getPattern(keyword: string): RegExp {
 /**
  * Count keyword hits for a contextual skill against a task string.
  * Uses word-boundary matching to prevent false positives (e.g., "auth" won't match "author").
+ *
+ * `sourceLabel` is the resolved skill file path when the caller has one
+ * (threaded down to getKeywords -> parseSkillFrontmatter for diagnosability);
+ * falls back to `skillName` when no resolved path is available.
  */
-function countKeywordHits(skillContent: string, skillName: string, task: string): number {
-  const keywords = getKeywords(skillContent, skillName);
+function countKeywordHits(skillContent: string, skillName: string, task: string, sourceLabel?: string): number {
+  const keywords = getKeywords(skillContent, skillName, sourceLabel);
   if (keywords.length === 0) return 0;
 
   let hits = 0;
@@ -446,8 +450,8 @@ function countKeywordHits(skillContent: string, skillName: string, task: string)
 /**
  * Extract keywords from skill frontmatter or fall back to category defaults.
  */
-function getKeywords(content: string, skillName: string): string[] {
-  const frontmatter = parseSkillFrontmatter(content, skillName);
+function getKeywords(content: string, skillName: string, sourceLabel?: string): string[] {
+  const frontmatter = parseSkillFrontmatter(content, sourceLabel ?? skillName);
   if (frontmatter?.keywords && frontmatter.keywords.length > 0) {
     return frontmatter.keywords.map(k => k.toLowerCase());
   }

--- a/packages/orchestrator/src/skill-loader.ts
+++ b/packages/orchestrator/src/skill-loader.ts
@@ -219,7 +219,7 @@ export function loadSkills(
     // docs/specs/2026-05-13-passed-skill-drift-detection.md §"Quarantine
     // drift-demoted skills". Organic inconclusive (no regressed_from_passed_at)
     // continues to inject unchanged.
-    const parsedFrontmatter = parseSkillFrontmatter(content);
+    const parsedFrontmatter = parseSkillFrontmatter(content, resolvedPath);
     const frontmatterStatus = parsedFrontmatter?.status;
     const isDriftDemoted =
       frontmatterStatus === 'inconclusive' &&
@@ -297,7 +297,7 @@ export function loadSkills(
     // scope-declared skills are treated as permanent (injected unconditionally)
     // so the backwards-compat guarantee is preserved — the same as the
     // task_type filter, which is also skipped when dispatchTaskType is absent.
-    const frontmatterForScope = parseSkillFrontmatter(content);
+    const frontmatterForScope = parseSkillFrontmatter(content, resolvedPath);
     const skillScope = frontmatterForScope?.scope;
     if (skillScope && skillScope.length > 0) {
       if (!dispatchTaskType || skillScope.includes(dispatchTaskType)) {
@@ -332,7 +332,7 @@ export function loadSkills(
       permanent.push({ name: skill, content, path: resolvedPath });
     } else if (task) {
       const rawHits = countKeywordHits(content, skill, task);
-      const frontmatter = parseSkillFrontmatter(content);
+      const frontmatter = parseSkillFrontmatter(content, resolvedPath);
       const boost = categoryBoost(frontmatter?.category, categories);
       const effectiveHits = rawHits + boost;
       // Threshold applied to effective hits. With CATEGORY_BOOST=0.5 and
@@ -447,7 +447,7 @@ function countKeywordHits(skillContent: string, skillName: string, task: string)
  * Extract keywords from skill frontmatter or fall back to category defaults.
  */
 function getKeywords(content: string, skillName: string): string[] {
-  const frontmatter = parseSkillFrontmatter(content);
+  const frontmatter = parseSkillFrontmatter(content, skillName);
   if (frontmatter?.keywords && frontmatter.keywords.length > 0) {
     return frontmatter.keywords.map(k => k.toLowerCase());
   }

--- a/packages/orchestrator/src/skill-parser.ts
+++ b/packages/orchestrator/src/skill-parser.ts
@@ -126,12 +126,23 @@ export function parseSkillFrontmatter(content: string, sourceLabel?: string): Sk
   let activeBlockKey: string | null = null;
 
   for (const line of lines) {
-    // Block-sequence continuation: an indented `- item` line following a
-    // key whose inline value was empty (e.g. `keywords:` with no trailing
-    // value). Only keywords/scope collect these; any other line ends the
-    // block-sequence context so scalar fields aren't misread as list items.
+    // Block-sequence continuation: a `- item` line following a key whose
+    // inline value was empty (e.g. `keywords:` with no trailing value).
+    // Leading indentation is OPTIONAL (`\s*`, not `\s+`) — valid YAML
+    // allows sequence items at column 0 under their key, which is common
+    // LLM-authoring style:
+    //   keywords:
+    //   - injection
+    //   - sanitize
+    // A single space after `-` is REQUIRED (`\s`, not `\s?`): per YAML,
+    // `- item` is a sequence item but `-item` (no space) is not — pin that
+    // distinction here rather than silently accepting it. Only
+    // keywords/scope collect these; any other line (including a bare
+    // `-item` that fails this match) ends the block-sequence context so
+    // scalar fields aren't misread as list items — this reset path is
+    // unchanged from before.
     if (activeBlockKey) {
-      const itemMatch = line.match(/^\s+-\s?(.*)$/);
+      const itemMatch = line.match(/^\s*-\s(.*)$/);
       if (itemMatch) {
         (blockSequences[activeBlockKey] ??= []).push(itemMatch[1].trim());
         continue;

--- a/packages/orchestrator/src/skill-parser.ts
+++ b/packages/orchestrator/src/skill-parser.ts
@@ -96,9 +96,17 @@ export interface SkillFrontmatter {
 const BLOCK_SEQUENCE_KEYS = new Set(['keywords', 'scope']);
 
 /** Writes a loud, prefixed diagnostic to stderr for parse failures. Warnings
- * only fire on total parse failure or missing REQUIRED fields (name,
- * description, status) — the silent-coercion philosophy for OPTIONAL axes
- * (task_type, scope unknown-token dropping, mode) is unchanged below. */
+ * fire ONLY when a `---` frontmatter block IS present but is missing a
+ * REQUIRED field (name, description, status) — a genuine authoring error.
+ * The silent-coercion philosophy for OPTIONAL axes (task_type, scope
+ * unknown-token dropping, mode) is unchanged below.
+ *
+ * Deliberately silent when no frontmatter block is found at all: plain
+ * `# Title` markdown with no `---` block is a supported, common skill
+ * format — most of the bundled default skills under
+ * `packages/orchestrator/src/default-skills/` are authored this way.
+ * Warning on every such file would spam stderr/mcp.log on every dispatch
+ * that loads default skills for no actionable reason. */
 function warnParseFailure(message: string, sourceLabel?: string): void {
   const suffix = sourceLabel ? ` (source: ${sourceLabel})` : '';
   process.stderr.write(`[skill-parser] ${message}${suffix}\n`);
@@ -107,7 +115,8 @@ function warnParseFailure(message: string, sourceLabel?: string): void {
 export function parseSkillFrontmatter(content: string, sourceLabel?: string): SkillFrontmatter | null {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) {
-    warnParseFailure('no frontmatter block found', sourceLabel);
+    // No `---` frontmatter block — a supported format for skills without
+    // metadata (see warnParseFailure doc comment). Silent by design.
     return null;
   }
 

--- a/packages/orchestrator/src/skill-parser.ts
+++ b/packages/orchestrator/src/skill-parser.ts
@@ -85,14 +85,51 @@ export interface SkillFrontmatter {
   scope?: SkillScope;
 }
 
-export function parseSkillFrontmatter(content: string): SkillFrontmatter | null {
+/**
+ * Fields that support the YAML block-sequence form:
+ *   keywords:
+ *     - injection
+ *     - sanitize
+ * in addition to the inline `keywords: [injection, sanitize]` form. Kept to
+ * these two list-valued axes deliberately — other fields stay scalar.
+ */
+const BLOCK_SEQUENCE_KEYS = new Set(['keywords', 'scope']);
+
+/** Writes a loud, prefixed diagnostic to stderr for parse failures. Warnings
+ * only fire on total parse failure or missing REQUIRED fields (name,
+ * description, status) — the silent-coercion philosophy for OPTIONAL axes
+ * (task_type, scope unknown-token dropping, mode) is unchanged below. */
+function warnParseFailure(message: string, sourceLabel?: string): void {
+  const suffix = sourceLabel ? ` (source: ${sourceLabel})` : '';
+  process.stderr.write(`[skill-parser] ${message}${suffix}\n`);
+}
+
+export function parseSkillFrontmatter(content: string, sourceLabel?: string): SkillFrontmatter | null {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!match) return null;
+  if (!match) {
+    warnParseFailure('no frontmatter block found', sourceLabel);
+    return null;
+  }
 
   const lines = match[1].split('\n');
   const fields: Record<string, string> = {};
+  const blockSequences: Record<string, string[]> = {};
+  let activeBlockKey: string | null = null;
 
   for (const line of lines) {
+    // Block-sequence continuation: an indented `- item` line following a
+    // key whose inline value was empty (e.g. `keywords:` with no trailing
+    // value). Only keywords/scope collect these; any other line ends the
+    // block-sequence context so scalar fields aren't misread as list items.
+    if (activeBlockKey) {
+      const itemMatch = line.match(/^\s+-\s?(.*)$/);
+      if (itemMatch) {
+        (blockSequences[activeBlockKey] ??= []).push(itemMatch[1].trim());
+        continue;
+      }
+      activeBlockKey = null;
+    }
+
     const colonIdx = line.indexOf(':');
     if (colonIdx === -1) continue;
     const key = line.slice(0, colonIdx).trim();
@@ -108,12 +145,24 @@ export function parseSkillFrontmatter(content: string): SkillFrontmatter | null 
       value = value.slice(1, -1);
     }
     fields[key] = value;
+
+    if (value === '' && BLOCK_SEQUENCE_KEYS.has(key)) {
+      activeBlockKey = key;
+    }
   }
 
-  if (!fields.name || !fields.description || !fields.status) return null;
+  if (!fields.name || !fields.description || !fields.status) {
+    const missing = ['name', 'description', 'status'].filter(f => !fields[f]);
+    warnParseFailure(`missing required field(s): ${missing.join(', ')}`, sourceLabel);
+    return null;
+  }
 
   let keywords: string[] = [];
-  if (fields.keywords) {
+  if (blockSequences.keywords && blockSequences.keywords.length > 0) {
+    keywords = blockSequences.keywords
+      .map(k => k.trim().replace(/^['"]|['"]$/g, '').slice(0, 100))
+      .filter(Boolean);
+  } else if (fields.keywords) {
     const raw = fields.keywords;
     if (raw.startsWith('[') && raw.endsWith(']')) {
       keywords = raw.slice(1, -1).split(',').map(k => k.trim().replace(/^['"]|['"]$/g, '').slice(0, 100)).filter(Boolean);
@@ -138,7 +187,14 @@ export function parseSkillFrontmatter(content: string): SkillFrontmatter | null 
   // dropped (same coercion philosophy as task_type). An empty parsed
   // array is treated as absent — callers check `scope && scope.length > 0`.
   let scope: SkillScope | undefined;
-  if (fields.scope) {
+  if (blockSequences.scope && blockSequences.scope.length > 0) {
+    const tokens = blockSequences.scope.map(t => t.trim().replace(/^['"]|['"]$/g, ''));
+    const valid = tokens.filter(
+      (t): t is 'review' | 'implement' | 'research' =>
+        t === 'review' || t === 'implement' || t === 'research',
+    );
+    if (valid.length > 0) scope = valid;
+  } else if (fields.scope) {
     const raw = fields.scope.trim();
     let tokens: string[];
     if (raw.startsWith('[') && raw.endsWith(']')) {

--- a/tests/orchestrator/skill-parser.test.ts
+++ b/tests/orchestrator/skill-parser.test.ts
@@ -123,6 +123,31 @@ Check endpoints.`;
       const result = parseSkillFrontmatter(md);
       expect(result?.keywords).toEqual(['dos', 'rate-limit', 'payload']);
     });
+
+    it('parses zero-indent block sequence items equal to their indented and inline equivalents', () => {
+      const inline = `---\nname: t\ndescription: d\nkeywords: [injection, sanitize]\nstatus: active\n---\nBody`;
+      const indented = `---\nname: t\ndescription: d\nkeywords:\n  - injection\n  - sanitize\nstatus: active\n---\nBody`;
+      // Zero-indent sequence items at column 0 under their key — valid YAML,
+      // and common LLM-authoring style.
+      const zeroIndent = `---\nname: t\ndescription: d\nkeywords:\n- injection\n- sanitize\nstatus: active\n---\nBody`;
+
+      const inlineResult = parseSkillFrontmatter(inline);
+      const indentedResult = parseSkillFrontmatter(indented);
+      const zeroIndentResult = parseSkillFrontmatter(zeroIndent);
+
+      expect(zeroIndentResult?.keywords).toEqual(['injection', 'sanitize']);
+      expect(zeroIndentResult?.keywords).toEqual(indentedResult?.keywords);
+      expect(zeroIndentResult?.keywords).toEqual(inlineResult?.keywords);
+    });
+
+    it('does NOT treat `-item` (no space after dash) as a block-sequence item', () => {
+      // Pinned behavior: YAML requires a space after `-` for a sequence
+      // item. `-item` fails the match, ends the block-sequence context, and
+      // (since it has no colon) is skipped entirely rather than collected.
+      const md = `---\nname: t\ndescription: d\nkeywords:\n-item\nstatus: active\n---\nBody`;
+      const result = parseSkillFrontmatter(md);
+      expect(result?.keywords).toEqual([]);
+    });
   });
 
   describe('parse-failure warnings', () => {

--- a/tests/orchestrator/skill-parser.test.ts
+++ b/tests/orchestrator/skill-parser.test.ts
@@ -149,16 +149,12 @@ Check endpoints.`;
       expect(message).toContain('missing-name.md');
     });
 
-    it('returns null and warns to stderr when no frontmatter block is present', () => {
+    it('returns null and does NOT warn when no frontmatter block is present (supported format)', () => {
       const md = `# Just a title\n\nSome content`;
       const result = parseSkillFrontmatter(md, 'no-frontmatter.md');
 
       expect(result).toBeNull();
-      expect(stderrSpy).toHaveBeenCalledTimes(1);
-      const [message] = stderrSpy.mock.calls[0];
-      expect(message).toContain('[skill-parser]');
-      expect(message).toContain('no frontmatter block found');
-      expect(message).toContain('no-frontmatter.md');
+      expect(stderrSpy).not.toHaveBeenCalled();
     });
 
     it('does not warn when parsing succeeds', () => {

--- a/tests/orchestrator/skill-parser.test.ts
+++ b/tests/orchestrator/skill-parser.test.ts
@@ -85,4 +85,88 @@ Check endpoints.`;
     const result = parseSkillFrontmatter(md);
     expect(result?.regressed_from_passed_at).toBeUndefined();
   });
+
+  describe('block-sequence YAML lists', () => {
+    it('parses keywords as a block sequence equal to the inline equivalent', () => {
+      const inline = `---\nname: t\ndescription: d\nkeywords: [injection, sanitize]\nstatus: active\n---\nBody`;
+      const block = `---\nname: t\ndescription: d\nkeywords:\n  - injection\n  - sanitize\nstatus: active\n---\nBody`;
+
+      const inlineResult = parseSkillFrontmatter(inline);
+      const blockResult = parseSkillFrontmatter(block);
+
+      expect(blockResult?.keywords).toEqual(['injection', 'sanitize']);
+      expect(blockResult?.keywords).toEqual(inlineResult?.keywords);
+    });
+
+    it('parses scope as a block sequence', () => {
+      const md = `---\nname: t\ndescription: d\nkeywords: [k]\nstatus: active\nscope:\n  - review\n  - research\n---\nBody`;
+      const result = parseSkillFrontmatter(md);
+      expect(result?.scope).toEqual(['review', 'research']);
+    });
+
+    it('handles mixed inline and block-sequence fields on the same file', () => {
+      const md = `---\nname: t\ndescription: d\nstatus: active\nscope: [review]\nkeywords:\n  - injection\n  - sanitize\n---\nBody`;
+      const result = parseSkillFrontmatter(md);
+      expect(result?.scope).toEqual(['review']);
+      expect(result?.keywords).toEqual(['injection', 'sanitize']);
+    });
+
+    it('applies per-item quote stripping and 100-char cap to block-sequence items', () => {
+      const longItem = 'x'.repeat(150);
+      const md = `---\nname: t\ndescription: d\nstatus: active\nkeywords:\n  - "quoted"\n  - '${longItem}'\n---\nBody`;
+      const result = parseSkillFrontmatter(md);
+      expect(result?.keywords).toEqual(['quoted', longItem.slice(0, 100)]);
+    });
+
+    it('leaves existing inline-array behavior unchanged (regression)', () => {
+      const md = `---\nname: t\ndescription: d\nkeywords: [dos, "rate-limit", 'payload']\nstatus: active\n---\nBody`;
+      const result = parseSkillFrontmatter(md);
+      expect(result?.keywords).toEqual(['dos', 'rate-limit', 'payload']);
+    });
+  });
+
+  describe('parse-failure warnings', () => {
+    let stderrSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    });
+
+    afterEach(() => {
+      stderrSpy.mockRestore();
+    });
+
+    it('returns null and warns to stderr when a required field is missing', () => {
+      const md = `---\ndescription: d\nkeywords: [k]\nstatus: active\n---\nBody`;
+      const result = parseSkillFrontmatter(md, 'missing-name.md');
+
+      expect(result).toBeNull();
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+      const [message] = stderrSpy.mock.calls[0];
+      expect(message).toContain('[skill-parser]');
+      expect(message).toContain('missing required field');
+      expect(message).toContain('name');
+      expect(message).toContain('missing-name.md');
+    });
+
+    it('returns null and warns to stderr when no frontmatter block is present', () => {
+      const md = `# Just a title\n\nSome content`;
+      const result = parseSkillFrontmatter(md, 'no-frontmatter.md');
+
+      expect(result).toBeNull();
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+      const [message] = stderrSpy.mock.calls[0];
+      expect(message).toContain('[skill-parser]');
+      expect(message).toContain('no frontmatter block found');
+      expect(message).toContain('no-frontmatter.md');
+    });
+
+    it('does not warn when parsing succeeds', () => {
+      const md = `---\nname: t\ndescription: d\nkeywords: [k]\nstatus: active\n---\nBody`;
+      const result = parseSkillFrontmatter(md, 'ok.md');
+
+      expect(result).not.toBeNull();
+      expect(stderrSpy).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes open consensus finding `c8977bda-37564212:f7` — the hand-rolled frontmatter parser silently unsupported YAML block sequences and returned null silently on parse failure.

**`packages/orchestrator/src/skill-parser.ts`** (`parseSkillFrontmatter`):
- Block-sequence lists now parse for the two list-valued fields (`keywords`, `scope`): `- item` lines (indented **or** zero-indent) are collected under an `activeBlockKey`, with the same per-item quote-stripping and 100-char cap as the inline-array path. No YAML dependency — deliberate, parser stays hand-rolled and small (245 lines).
- `[skill-parser]` stderr warning when a `---` frontmatter block **is present** but missing a required field (`name`/`description`/`status`) — a genuine authoring error that previously vanished silently. Files with no frontmatter at all stay silent by design (15/19 bundled default skills are frontmatter-less; warning there would spam mcp.log on every dispatch).
- New optional `sourceLabel` param threaded from all 6 production call sites (5 in `skill-loader.ts`/`skill-catalog.ts`, plus the pre-existing unthreaded site in `mcp-server-sdk.ts`) so warnings name the offending file.

**Tests:** 11 new tests in `tests/orchestrator/skill-parser.test.ts` — block sequences (indented, zero-indent, mixed inline+block), quote-stripping/cap on block items, `-item` no-space pin, stderr-warning spy tests, inline-array regression.

## Consensus review

Pre-merge consensus round (sonnet-reviewer + deepseek-challenger). Sonnet-reviewer caught the zero-indent bug + sourceLabel inconsistency in round 1; both fixed in `bba72f8a`. Deepseek's four disputes were verified as stale-root reads (reviewed master instead of the worktree) and recorded as `hallucination_caught`.

consensus-id: e8604f94-40af49a0

## Testing

- Full `npm run build` — clean
- Full jest suite in the branch worktree: 348 suites, 4725 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)