### PR TITLE
fix(providers): utility-summary fallback + OpenAI Responses API for GPT-5.x (v0.6.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ## [Unreleased]
 
+## [0.6.10] — 2026-07-11
+
+Two provider/routing fixes so utility summarization survives a broken main
+provider and GPT-5.x reasoning models work with function tools. Verified across
+two consensus rounds (`consensus-id: 26ab9b31-b7aa4f69`, `consensus-id: b8138867-e4564f31`).
+
+### Fixed
+
+- **Automatic utility summarizers no longer pin to a quota-exhausted main
+  provider.** The relay-side summarizers (cognitive memory, session gossip,
+  sibling gossip) run synchronously in a post-dispatch hook with no turn to
+  dispatch a native `Agent()`, so they cannot use the native-utility path and
+  were left bound to the main provider. When `main_agent` is a keyed-but-cooled
+  provider (e.g. a Google 429 cooldown), every automatic summary silently failed.
+  A new `selectUtilityFallbackProvider` keeps a healthy main, else picks the best
+  keyed, non-cooled provider (preference-ordered, openai-first), else a
+  `NullProvider` that degrades summaries to regex extraction. Reads
+  `.gossip/quota-state.json` once to skip cooled providers; threads each agent's
+  `base_url`/`projectRoot` so a custom-endpoint key builds a correct fallback.
+- **OpenAI GPT-5.x / o-series reasoning models now work with function tools.**
+  These models reject function tools on `/v1/chat/completions` and require the
+  Responses API. `OpenAIProvider` now auto-routes tool-bearing reasoning-model
+  requests to `/v1/responses` — but only on the canonical `api.openai.com`
+  endpoint, so the DeepSeek/Grok/OpenClaw/custom-base_url reuses stay on
+  `/chat/completions` (they don't serve `/responses`). `temperature` is omitted
+  on the Responses path (reasoning models reject non-default temperature), image
+  blocks map to `input_image`, and a self-heal retry transparently falls back to
+  `/v1/responses` when any endpoint's error body asks for it.
+
+### Changed
+
+- **Utility summaries may now incur real HTTP spend on a stored-but-unagented
+  key.** On a host where the main provider degrades to `none` but a keyed
+  provider (e.g. an `openai` key) is present in the keychain, automatic summaries
+  now use that key instead of silently degrading to empty output. The chosen
+  provider is disclosed in the startup banner (`utility: native/orchestrator
+  (summary via openai/gpt-4o-mini)`).
+
+### Known limitations (low-severity, tracked for follow-up)
+
+- A custom-`base_url` `openai` fallback persists its cooldown under the
+  `openai:<base_url>` quota slot, which `isCooled('openai')` does not read back.
+- When the main key is missing and an agent is adopted as the main fallback, its
+  `base_url` is not carried, so a custom-endpoint agent can still resolve to
+  `api.openai.com`.
+- Fallback providers do not thread `key_ref` as `authSlot`, so a 401 names the
+  quota slot rather than the keychain service in the operator hint.
+
 ## [0.6.9] — 2026-07-03
 
 Agents now learn from their own past mistakes: corrections are written into

--- a/README.md
+++ b/README.md
@@ -194,10 +194,10 @@ Add to `~/.claude/mcp_settings.json` (Claude Code) or project-local `.mcp.json`:
 
 ```bash
 # Pin to a version
-npm install -g gossipcat@0.6.9
+npm install -g gossipcat@0.6.10
 
 # Pin to a GitHub release tarball (bypasses the npm registry)
-npm install -g https://github.com/gossipcat-ai/gossipcat-ai/releases/download/v0.6.9/gossipcat-0.6.9.tgz
+npm install -g https://github.com/gossipcat-ai/gossipcat-ai/releases/download/v0.6.10/gossipcat-0.6.10.tgz
 
 # Project-local (postinstall writes .mcp.json — open the IDE there, no `mcp add` needed)
 cd your-project && npm install --save-dev gossipcat

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -301,6 +301,7 @@ import { ctx, NATIVE_TASK_TTL_MS } from './mcp-context';
 import { MAX_TOOL_TURNS_CEILING, MCP_MAIN_PROVIDER_ENUM, MCP_CUSTOM_PROVIDER_ENUM } from './config';
 import { getGossipcatVersion } from './version';
 import { captureGitStatus, checkUnexpectedChanges } from './utility-guard';
+import { selectUtilityFallbackProvider } from './utility-provider';
 import { buildUtilityAgentPrompt, getUncategorizedStatusLine, checkDistMcpStaleness, logStalenessToMcpLog, isValidCategory, seedPermanentDefaults, GLOBAL_PERMANENT_DEFAULTS, IMPLEMENTER_PERMANENT_DEFAULTS, RESEARCHER_REVIEWER_PERMANENT_DEFAULTS } from '@gossip/orchestrator';
 
 // Prime the dist-mcp staleness cache from the running bundle path. In the bundled
@@ -1001,14 +1002,52 @@ async function doBoot() {
     let utilityLlm = m.createProvider(mainProvider as any, mainModel, mainKey ?? undefined);
     let utilityModelId = `${mainProvider}/${mainModel}`;
 
+    // A provider is "cooled" while its exhaustedUntil (from a 429/spend-cap
+    // cooldown) is still in the future. Read+parse the quota-state file ONCE here
+    // so the pure selection helper stays fs-free and isCooled doesn't re-read on
+    // every candidate probe. Missing/unparseable file ⇒ {} ⇒ nothing cooled.
+    const quotaState: Record<string, { exhaustedUntil?: number }> = (() => {
+      try {
+        const { readFileSync } = require('fs');
+        const { join: joinP } = require('path');
+        const raw = readFileSync(joinP(process.cwd(), '.gossip', 'quota-state.json'), 'utf-8');
+        // A valid-JSON scalar (e.g. the literal `null`, a number, a string) parses
+        // WITHOUT throwing but is not an indexable record — guard so isCooled never
+        // indexes null and throws, which would be swallowed and disable all of ATI.
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' ? parsed : {};
+      } catch { return {}; }
+    })();
+    const isCooled = (provider: string): boolean =>
+      typeof quotaState[provider]?.exhaustedUntil === 'number' && quotaState[provider].exhaustedUntil! > Date.now();
+    // Pick the best keyed, non-cooled provider for the AUTOMATIC relay-side
+    // summarizers (they call summaryLlm directly with no turn to dispatch a
+    // native Agent(), so the native path can't cover them). Keeps a healthy
+    // main; only diverges when main is quota-exhausted or keyless.
+    const pickUtilityFallback = () => selectUtilityFallbackProvider({
+      main: { provider: mainProvider, model: mainModel, key: mainKey },
+      agents: agentConfigs as Array<{ provider: string; model: string; key_ref?: string; native?: boolean; base_url?: string }>,
+      getKey: (service: string) => ctx.keychain.getKey(service),
+      isCooled,
+      createProvider: m.createProvider,
+      projectRoot: process.cwd(),
+    });
+
     if (autoNative) {
       ctx.nativeUtilityConfig = { model: 'sonnet' };
-      utilityModelId = 'native/orchestrator';
+      // Explicit utility TASKS (session-save, verify-memory) still dispatch a
+      // native Agent(); the automatic summarizers fall back to a real keyed
+      // provider so they don't hit a quota-exhausted main (e.g. google 429).
+      const fb = await pickUtilityFallback();
+      utilityLlm = fb.llm;
+      utilityModelId = `native/orchestrator (summary via ${fb.label})`;
     } else if (config.utility_model?.provider === 'native') {
-      // Native utility: calls go through Agent() dispatch + gossip_relay, not direct LLM
+      // Native utility: explicit-task calls go through Agent() dispatch + gossip_relay.
       ctx.nativeUtilityConfig = { model: config.utility_model.model };
-      utilityModelId = `native/${config.utility_model.model}`;
-      // Don't override utilityLlm — native path branches at call sites, not at provider level
+      // Automatic summarizers still need a direct LLM — route them via the fallback.
+      const fb = await pickUtilityFallback();
+      utilityLlm = fb.llm;
+      utilityModelId = `native/${config.utility_model.model} (summary via ${fb.label})`;
     } else if (config.utility_model) {
       const utilityKey = await ctx.keychain.getKey(config.utility_model.provider);
       if (utilityKey) {
@@ -1016,8 +1055,12 @@ async function doBoot() {
         utilityLlm = m.createProvider(config.utility_model.provider, config.utility_model.model, utilityKey);
         utilityModelId = `${config.utility_model.provider}/${config.utility_model.model}`;
       } else {
-        // If configured but key is missing, just warn. The fallback is already set.
-        process.stderr.write(`[gossipcat] ⚠️  Utility model key for "${config.utility_model.provider}" not found, falling back to main agent model for lens generation.\n`);
+        // Configured but key is missing — don't strand summaries on a possibly
+        // quota-exhausted main; route through the same best-keyed fallback.
+        const fb = await pickUtilityFallback();
+        utilityLlm = fb.llm;
+        utilityModelId = `${config.utility_model.provider}/${config.utility_model.model} → ${fb.label}`;
+        process.stderr.write(`[gossipcat] ⚠️  Utility model key for "${config.utility_model.provider}" not found, using ${fb.label} for lens generation & summaries.\n`);
       }
     }
 

--- a/apps/cli/src/utility-provider.ts
+++ b/apps/cli/src/utility-provider.ts
@@ -1,0 +1,117 @@
+/**
+ * Utility-summarizer provider selection ("best keyed provider" fallback).
+ *
+ * The AUTOMATIC relay-side summarizers — MemoryWriter.generateCognitiveSummary,
+ * SessionContext.summarizeForSession, GossipPublisher.publishGossip — call their
+ * injected summaryLlm.generate() SYNCHRONOUSLY inside a post-dispatch hook. There
+ * is no orchestrator turn there to dispatch a native Agent(), so they cannot use
+ * the native-utility path (which branches at the explicit-task call sites). They
+ * must run on a real keyed HTTP provider. When that provider defaults to the main
+ * agent's and the main agent's key is quota-exhausted (e.g. a google 429 cooldown
+ * recorded in .gossip/quota-state.json), every automatic summary silently fails.
+ *
+ * selectUtilityFallbackProvider picks the least-surprising viable provider:
+ *   1. keep the MAIN provider whenever it is viable — never gratuitously switch a
+ *      healthy main, so today's behavior is preserved when main is fine;
+ *   2. otherwise the best keyed, non-cooled provider by preference order;
+ *   3. otherwise a NullProvider that degrades summaries to '' (all three call
+ *      sites already handle an empty summary gracefully).
+ *
+ * The helper is pure/fs-free: quota state (`isCooled`) and key lookup (`getKey`)
+ * and provider construction (`createProvider`) are all injected so it unit-tests
+ * without a keychain, filesystem, or MCP-boot harness.
+ */
+import type { ILLMProvider } from '@gossip/orchestrator';
+
+/**
+ * Curated default model per provider. Lets a key that is SET but not attached to
+ * any configured agent (e.g. a stored `openai` key on a google-main host) still
+ * become a reachable utility candidate.
+ */
+export const UTILITY_DEFAULT_MODELS: ReadonlyArray<{ provider: string; model: string }> = [
+  { provider: 'openai', model: 'gpt-4o-mini' },
+  { provider: 'anthropic', model: 'claude-haiku-4-5' },
+  { provider: 'deepseek', model: 'deepseek-chat' },
+  { provider: 'google', model: 'gemini-2.5-flash' },
+];
+
+/**
+ * Ranking used only when the main provider is NOT viable. openai first = the
+ * reliable, cheap key on this host; google last (spend-cap / quota prone).
+ */
+export const UTILITY_PREFERENCE_ORDER: readonly string[] = [
+  'openai', 'anthropic', 'deepseek', 'grok', 'openclaw', 'google',
+];
+
+/** Providers that never make a keyed HTTP summary call and can't be a fallback. */
+const NON_HTTP_PROVIDERS = new Set(['native', 'none', 'local']);
+
+interface Candidate { provider: string; model: string; key: string; baseUrl?: string }
+
+export interface SelectUtilityFallbackOpts {
+  main: { provider: string; model: string; key: string | null };
+  agents: Array<{ provider: string; model: string; key_ref?: string; native?: boolean; base_url?: string }>;
+  getKey: (service: string) => Promise<string | null>;
+  isCooled: (provider: string) => boolean;
+  createProvider: typeof import('@gossip/orchestrator').createProvider;
+  /** Threaded into every createProvider call so fallback providers persist their
+   *  own 429/spend-cap cooldowns to .gossip/quota-state.json (same as the main). */
+  projectRoot?: string;
+}
+
+export async function selectUtilityFallbackProvider(
+  opts: SelectUtilityFallbackOpts,
+): Promise<{ llm: ILLMProvider; label: string }> {
+  const { main, agents, getKey, isCooled, createProvider, projectRoot } = opts;
+
+  // provider → {model, key, baseUrl}, FIRST-SEEN WINS. Sources in order: (a) main,
+  // (b) each non-native agent, (c) curated defaults.
+  const candidates = new Map<string, Candidate>();
+  const consider = (provider: string, model: string, key: string | null | undefined, baseUrl?: string): void => {
+    if (!provider || NON_HTTP_PROVIDERS.has(provider)) return;
+    if (!key) return;
+    if (candidates.has(provider)) return; // first-seen wins
+    candidates.set(provider, { provider, model, key, baseUrl });
+  };
+
+  // (a) main
+  consider(main.provider, main.model, main.key);
+
+  // (b) each non-native agent — key via the per-agent keychain service (key_ref ?? provider).
+  // Carry the agent's base_url so a custom-endpoint openai-compatible agent yields a
+  // correct fallback (pointing at ITS endpoint, not api.openai.com) rather than a
+  // broken entry that first-seen-wins would then shadow the curated default with.
+  for (const ac of agents) {
+    if (ac.native) continue;
+    if (NON_HTTP_PROVIDERS.has(ac.provider) || candidates.has(ac.provider)) continue;
+    consider(ac.provider, ac.model, await getKey(ac.key_ref ?? ac.provider), ac.base_url);
+  }
+
+  // (c) curated defaults — reach a set-but-unagented key. No base_url ⇒ hit the
+  // provider default endpoint.
+  for (const d of UTILITY_DEFAULT_MODELS) {
+    if (candidates.has(d.provider)) continue;
+    consider(d.provider, d.model, await getKey(d.provider));
+  }
+
+  const viable = (c: Candidate | undefined): c is Candidate => !!c && !isCooled(c.provider);
+
+  // (1) main viable ⇒ keep it (preserve today's behavior for a healthy main).
+  // `main.key` guards the shared-provider case: if main has no key, a same-provider
+  // agent may own candidates.get(main.provider) — that's an agent fallback, not main.
+  const mainCand = main.key ? candidates.get(main.provider) : undefined;
+  if (viable(mainCand)) {
+    return { llm: createProvider(mainCand.provider, mainCand.model, mainCand.key, projectRoot, mainCand.baseUrl), label: `${mainCand.provider}/${mainCand.model}` };
+  }
+
+  // (2) best viable candidate by preference order.
+  for (const provider of UTILITY_PREFERENCE_ORDER) {
+    const c = candidates.get(provider);
+    if (viable(c)) {
+      return { llm: createProvider(c.provider, c.model, c.key, projectRoot, c.baseUrl), label: `${c.provider}/${c.model}` };
+    }
+  }
+
+  // (3) nothing viable ⇒ NullProvider (summaries degrade to '').
+  return { llm: createProvider('none', 'none'), label: 'degraded/none' };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossipcat",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
   "mcpName": "io.github.ataberk-xyz/gossipcat",
   "repository": {

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -22,6 +22,7 @@ export {
   OllamaProvider,
   QuotaExhaustedException,
   PROVIDER_PLACEHOLDER_RE,
+  isReasoningModel,
 } from './llm-client';
 export type { ILLMProvider, LLMGenerateOptions } from './llm-client';
 export { recordAuthFailure, clearAuthFailure, readRecentAuthFailures } from './auth-state';

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -384,6 +384,47 @@ export class AnthropicProvider implements ILLMProvider {
 
 // ─── OpenAI ─────────────────────────────────────────────────────────────────
 
+/**
+ * OpenAI reasoning models (GPT-5.x family, o-series) that reject function tools
+ * on the legacy `/chat/completions` endpoint and require the Responses API
+ * (`/v1/responses`) instead. Matching `gpt-5*` and `o<digit>*` is conservative:
+ * it only changes routing inside OpenAIProvider, and only when tools are present
+ * (see `generate`). Non-tool calls stay on `/chat/completions` for every model.
+ */
+export function isReasoningModel(model: string): boolean {
+  return /^gpt-5/i.test(model) || /^o[0-9]/i.test(model);
+}
+
+/**
+ * Error-body signature emitted by the OpenAI API when a reasoning model is sent
+ * function tools on `/chat/completions` (e.g. "Function tools with reasoning_effort
+ * are not supported … use /v1/responses"). Used as a transparent self-healing
+ * retry trigger for models `isReasoningModel` doesn't yet recognize.
+ */
+const RESPONSES_REQUIRED_RE = /use\s+\/?v1\/responses|use the Responses API/i;
+
+/**
+ * Build a toolCall entry from a provider-supplied arguments string, reusing the
+ * same JSON-parse-failure fallback for both the `/chat/completions` and
+ * `/v1/responses` parsers: on malformed JSON the tool is NOT executed — the raw
+ * string + parse error are surfaced so the model can self-correct. Shared so the
+ * two OpenAI response shapes never drift on argument handling.
+ */
+function parseToolArgs(id: string, name: string, rawArgs: string): NonNullable<LLMResponse['toolCalls']>[number] {
+  try {
+    return { id, name, arguments: JSON.parse(rawArgs) };
+  } catch (parseErr) {
+    const raw = rawArgs ?? '';
+    return {
+      id,
+      name,
+      arguments: {},
+      argumentsParseError: (parseErr as Error).message,
+      rawArguments: raw.slice(0, 200),
+    };
+  }
+}
+
 export class OpenAIProvider implements ILLMProvider {
   private quota: QuotaTracker;
   private baseUrl: string;
@@ -429,7 +470,27 @@ export class OpenAIProvider implements ILLMProvider {
     this.projectRoot = projectRoot;
   }
 
+  /**
+   * True only for the canonical OpenAI endpoint. The Responses API (/v1/responses)
+   * is served ONLY by api.openai.com — the deepseek/grok/openclaw/custom-base_url
+   * reuses of OpenAIProvider don't serve it, so up-front /responses routing must be
+   * gated on this to avoid a silent 404 on those endpoints. The self-heal retry
+   * stays ungated: it only fires when an endpoint itself asks for /v1/responses.
+   */
+  private get isCanonicalOpenAI(): boolean {
+    return this.baseUrl === 'https://api.openai.com/v1';
+  }
+
   async generate(messages: LLMMessage[], options?: LLMGenerateOptions): Promise<LLMResponse> {
+    // Reasoning models (GPT-5.x, o-series) reject function tools on
+    // /chat/completions and require /v1/responses. Route them there up front
+    // when tools are present — but ONLY on the canonical OpenAI endpoint, since
+    // the OpenAI-compatible reuses (deepseek/grok/openclaw/custom base_url) don't
+    // serve /responses and would silently 404. Every non-tool call stays on chat.
+    if (options?.tools?.length && isReasoningModel(this.model) && this.isCanonicalOpenAI) {
+      return this.generateViaResponses(messages, options);
+    }
+
     const body: Record<string, unknown> = {
       model: this.model,
       messages: messages.map(m => this.toOpenAIMessage(m)),
@@ -454,7 +515,11 @@ export class OpenAIProvider implements ILLMProvider {
     }, 'openai');
 
     if (!res.ok) {
-      const body = (await res.text()).slice(0, 200);
+      // Read the FULL body once: the truncated 200-char slice feeds the thrown
+      // message + quota handlers, but the Responses-retry directive can appear
+      // past char 200 in a verbose error, so the regex must test the full text.
+      const fullBody = await res.text();
+      const body = fullBody.slice(0, 200);
       if (res.status === 429) this.quota.handle429(res, body);
       if (res.status === 503) this.quota.handle503(res, body);
       // 401/403: auth/key failure for THIS endpoint. Surface a clear message
@@ -467,12 +532,170 @@ export class OpenAIProvider implements ILLMProvider {
         recordAuthFailure(this.projectRoot, this.authProvider, res.status);
         throw new Error(authErrorMessage(this.providerLabel, res.status, this.baseUrl, body));
       }
+      // SAFETY NET: a future reasoning model that isReasoningModel() doesn't yet
+      // know about will reject function tools here and tell us to use /v1/responses.
+      // Transparently retry the same request on the Responses API before surfacing
+      // a generic error, so routing self-heals without a code change. Only when
+      // tools were actually sent (the error can't occur otherwise). Fires for ANY
+      // endpoint — it's the endpoint itself asking for /responses, which is safe.
+      if (options?.tools?.length && RESPONSES_REQUIRED_RE.test(fullBody)) {
+        return this.generateViaResponses(messages, options);
+      }
       throw new Error(`OpenAI API error (${res.status}): ${body}`);
     }
     this.quota.onSuccess();
     clearAuthFailure(this.projectRoot, this.authProvider);
     const data = await res.json() as Record<string, unknown>;
     return this.parseOpenAIResponse(data);
+  }
+
+  /**
+   * OpenAI Responses API (`/v1/responses`) path — required for GPT-5.x / o-series
+   * reasoning models when function tools are present. Same auth/quota/503 handling
+   * as the chat path (shared via {@link raiseOpenAIError}); only the request body
+   * shape and response parsing differ. Verified against the openai-node SDK
+   * `ResponseInputItem` / `ResponseFunctionToolCall(Output)` / `FunctionTool` types.
+   */
+  private async generateViaResponses(messages: LLMMessage[], options?: LLMGenerateOptions): Promise<LLMResponse> {
+    const systemMsg = messages.find(m => m.role === 'system');
+    const input: Array<Record<string, unknown>> = [];
+    for (const m of messages) {
+      if (m.role === 'system') continue;
+      input.push(...this.toResponsesInput(m));
+    }
+
+    const body: Record<string, unknown> = { model: this.model, input };
+    // System prompt rides as top-level `instructions`, not an input message.
+    if (systemMsg) body.instructions = typeof systemMsg.content === 'string' ? systemMsg.content : '';
+    if (options?.maxTokens) body.max_output_tokens = options.maxTokens;
+    // temperature is intentionally OMITTED: the /responses path is only ever hit
+    // for reasoning models, which reject any non-default temperature (400 error).
+    if (options?.tools?.length) {
+      // Responses API uses a FLAT function-tool shape (no nested `function: {}`).
+      body.tools = options.tools.map(t => ({
+        type: 'function',
+        name: t.name,
+        description: t.description,
+        parameters: t.parameters,
+      }));
+    }
+
+    this.quota.checkBeforeRequest();
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.apiKey) headers['Authorization'] = `Bearer ${this.apiKey}`;
+    const res = await fetchWithRetry503(`${this.baseUrl}/responses`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(this.timeoutMs),
+    }, 'openai');
+
+    if (!res.ok) {
+      const errBody = (await res.text()).slice(0, 200);
+      this.raiseOpenAIError(res.status, errBody, res);
+    }
+    this.quota.onSuccess();
+    clearAuthFailure(this.projectRoot, this.authProvider);
+    const data = await res.json() as Record<string, unknown>;
+    return this.parseResponsesResponse(data);
+  }
+
+  /**
+   * Shared 4xx/5xx handling for both OpenAI endpoints: 429/503 feed the quota
+   * state machine, 401/403 record an auth failure and surface a keychain-aware
+   * message, everything else throws the generic OpenAI error. Takes a pre-read
+   * body so the caller can inspect it first (the chat path's Responses-retry
+   * safety net). Always throws.
+   */
+  private raiseOpenAIError(status: number, body: string, res: Response): never {
+    if (status === 429) this.quota.handle429(res, body);
+    if (status === 503) this.quota.handle503(res, body);
+    if (status === 401 || status === 403) {
+      recordAuthFailure(this.projectRoot, this.authProvider, status);
+      throw new Error(authErrorMessage(this.providerLabel, status, this.baseUrl, body));
+    }
+    throw new Error(`OpenAI API error (${status}): ${body}`);
+  }
+
+  /**
+   * Map one LLMMessage to zero-or-more Responses API `input` items. System
+   * messages are handled by the caller (top-level `instructions`) and never
+   * reach here. Tool results become `function_call_output`; prior assistant
+   * tool calls become `function_call` items; plain text becomes a `message`
+   * with an `input_text` (user) or `output_text` (assistant) content part.
+   */
+  private toResponsesInput(m: LLMMessage): Array<Record<string, unknown>> {
+    if (m.role === 'tool') {
+      return [{
+        type: 'function_call_output',
+        call_id: m.toolCallId,
+        output: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+      }];
+    }
+
+    const textOf = (content: LLMMessage['content']): string =>
+      typeof content === 'string'
+        ? content
+        : content.map(b => (b.type === 'text' ? b.text : '')).join('');
+
+    if (m.role === 'assistant' && m.toolCalls?.length) {
+      const items: Array<Record<string, unknown>> = [];
+      const text = textOf(m.content);
+      if (text) items.push({ role: 'assistant', content: [{ type: 'output_text', text }] });
+      for (const tc of m.toolCalls) {
+        items.push({
+          type: 'function_call',
+          call_id: tc.id,
+          name: tc.name,
+          arguments: JSON.stringify(tc.arguments),
+        });
+      }
+      return items;
+    }
+
+    // Plain user/assistant message. For a string, keep the single-part shape.
+    // For a ContentBlock[], map each block: text → input_text/output_text, image
+    // → input_image with a data: URL (mirrors toOpenAIMessage + the Anthropic
+    // path). Images only make sense as user input; an assistant image block is
+    // not representable, so assistant content stays text-only via output_text.
+    const partType = m.role === 'assistant' ? 'output_text' : 'input_text';
+    if (typeof m.content === 'string') {
+      return [{ role: m.role, content: [{ type: partType, text: m.content }] }];
+    }
+    const parts = m.content.map(block =>
+      block.type === 'image'
+        ? { type: 'input_image', image_url: `data:${block.mediaType};base64,${block.data}` }
+        : { type: partType, text: block.text }
+    );
+    return [{ role: m.role, content: parts }];
+  }
+
+  /**
+   * Parse a Responses API payload: concatenate `output_text` parts from every
+   * `message` item for the text, collect `function_call` items as toolCalls
+   * (reusing {@link parseToolArgs} so malformed JSON degrades identically to the
+   * chat parser), and map `usage.input_tokens`/`output_tokens`.
+   */
+  private parseResponsesResponse(data: Record<string, unknown>): LLMResponse {
+    const output = (data.output as Array<Record<string, unknown>>) ?? [];
+    let text = '';
+    const toolCalls: LLMResponse['toolCalls'] = [];
+    for (const item of output) {
+      if (item.type === 'message') {
+        const content = (item.content as Array<Record<string, unknown>>) ?? [];
+        for (const part of content) {
+          if (part.type === 'output_text') text += (part.text as string) ?? '';
+        }
+      } else if (item.type === 'function_call') {
+        toolCalls.push(parseToolArgs(item.call_id as string, item.name as string, item.arguments as string));
+      }
+    }
+    const usage = data.usage as Record<string, number> | undefined;
+    return {
+      text,
+      toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+      usage: usage ? { inputTokens: usage.input_tokens, outputTokens: usage.output_tokens } : undefined,
+    };
   }
 
   private toOpenAIMessage(m: LLMMessage): Record<string, unknown> {
@@ -510,20 +733,7 @@ export class OpenAIProvider implements ILLMProvider {
     if (msg.tool_calls) {
       for (const tc of msg.tool_calls as Array<Record<string, unknown>>) {
         const fn = tc.function as Record<string, string>;
-        let parsedArgs: Record<string, unknown>;
-        try {
-          parsedArgs = JSON.parse(fn.arguments);
-          toolCalls.push({ id: tc.id as string, name: fn.name, arguments: parsedArgs });
-        } catch (parseErr) {
-          const raw = fn.arguments ?? '';
-          toolCalls.push({
-            id: tc.id as string,
-            name: fn.name,
-            arguments: {},
-            argumentsParseError: (parseErr as Error).message,
-            rawArguments: raw.slice(0, 200),
-          });
-        }
+        toolCalls.push(parseToolArgs(tc.id as string, fn.name, fn.arguments));
       }
     }
     const usage = data.usage as Record<string, number> | undefined;

--- a/tests/cli/utility-provider.test.ts
+++ b/tests/cli/utility-provider.test.ts
@@ -1,0 +1,135 @@
+import { selectUtilityFallbackProvider } from '../../apps/cli/src/utility-provider';
+import type { ILLMProvider } from '@gossip/orchestrator';
+
+/**
+ * A tagged fake provider so assertions can read back exactly which
+ * provider/model createProvider was invoked with, without any network or
+ * keychain. `label` on the returned selection already encodes provider/model,
+ * but the tag lets us also assert the constructed llm is the SAME candidate.
+ */
+function makeStubCreateProvider() {
+  const calls: Array<{ provider: string; model: string; key?: string; projectRoot?: string; baseUrl?: string }> = [];
+  const createProvider = ((provider: string, model: string, apiKey?: string, projectRoot?: string, baseUrl?: string): ILLMProvider => {
+    calls.push({ provider, model, key: apiKey, projectRoot, baseUrl });
+    return { tag: `${provider}/${model}`, generate: async () => ({ text: '' }) } as unknown as ILLMProvider;
+  }) as unknown as typeof import('@gossip/orchestrator').createProvider;
+  return { createProvider, calls };
+}
+
+describe('selectUtilityFallbackProvider', () => {
+  it('(a) keeps the main provider when it is viable, even if an openai key is also present', async () => {
+    const { createProvider, calls } = makeStubCreateProvider();
+    const res = await selectUtilityFallbackProvider({
+      main: { provider: 'anthropic', model: 'claude-sonnet-4-6', key: 'sk-ant' },
+      agents: [],
+      getKey: async (s) => (s === 'openai' ? 'sk-openai' : null),
+      isCooled: () => false,
+      createProvider,
+    });
+    expect(res.label).toBe('anthropic/claude-sonnet-4-6');
+    expect(calls).toEqual([{ provider: 'anthropic', model: 'claude-sonnet-4-6', key: 'sk-ant' }]);
+  });
+
+  it('(b) main cooled ⇒ picks openai over a keyed deepseek agent (preference order)', async () => {
+    const { createProvider } = makeStubCreateProvider();
+    const res = await selectUtilityFallbackProvider({
+      main: { provider: 'google', model: 'gemini-2.5-pro', key: 'ai-key' },
+      agents: [{ provider: 'deepseek', model: 'deepseek-chat', key_ref: 'deepseek' }],
+      getKey: async (s) => (s === 'openai' ? 'sk-openai' : s === 'deepseek' ? 'sk-deep' : null),
+      isCooled: (p) => p === 'google',
+      createProvider,
+    });
+    // openai (from the curated default list) outranks the keyed deepseek agent.
+    expect(res.label).toBe('openai/gpt-4o-mini');
+  });
+
+  it('(c) main cooled + only deepseek keyed ⇒ picks deepseek', async () => {
+    const { createProvider } = makeStubCreateProvider();
+    const res = await selectUtilityFallbackProvider({
+      main: { provider: 'google', model: 'gemini-2.5-pro', key: 'ai-key' },
+      agents: [{ provider: 'deepseek', model: 'deepseek-chat', key_ref: 'deepseek' }],
+      getKey: async (s) => (s === 'deepseek' ? 'sk-deep' : null),
+      isCooled: (p) => p === 'google',
+      createProvider,
+    });
+    expect(res.label).toBe('deepseek/deepseek-chat');
+  });
+
+  it('(d) nothing viable ⇒ NullProvider labelled degraded/none', async () => {
+    const { createProvider, calls } = makeStubCreateProvider();
+    const res = await selectUtilityFallbackProvider({
+      main: { provider: 'google', model: 'gemini-2.5-pro', key: null },
+      agents: [],
+      getKey: async () => null,
+      isCooled: () => false,
+      createProvider,
+    });
+    expect(res.label).toBe('degraded/none');
+    expect(calls).toEqual([{ provider: 'none', model: 'none', key: undefined }]);
+  });
+
+  it('(e) native / none / local candidates are skipped', async () => {
+    const { createProvider } = makeStubCreateProvider();
+    const res = await selectUtilityFallbackProvider({
+      // main is a keyless "none" host (Claude Code native orchestration).
+      main: { provider: 'none', model: 'none', key: null },
+      agents: [
+        { provider: 'anthropic', model: 'claude-native', native: true },  // native → skip
+        { provider: 'local', model: 'qwen2.5-coder' },                    // local → skip
+        { provider: 'deepseek', model: 'deepseek-chat', key_ref: 'deepseek' }, // real fallback
+      ],
+      getKey: async (s) => (s === 'deepseek' ? 'sk-deep' : null),
+      isCooled: () => false,
+      createProvider,
+    });
+    // The native anthropic agent and the local agent must not be chosen — only
+    // the keyed deepseek agent is a viable HTTP candidate.
+    expect(res.label).toBe('deepseek/deepseek-chat');
+  });
+
+  it('(f) cooled providers are skipped even when keyed', async () => {
+    const { createProvider } = makeStubCreateProvider();
+    const res = await selectUtilityFallbackProvider({
+      main: { provider: 'google', model: 'gemini-2.5-pro', key: 'ai-key' },
+      agents: [],
+      // openai key present but openai is cooled too ⇒ fall through to anthropic.
+      getKey: async (s) => (s === 'openai' || s === 'anthropic' ? `sk-${s}` : null),
+      isCooled: (p) => p === 'google' || p === 'openai',
+      createProvider,
+    });
+    expect(res.label).toBe('anthropic/claude-haiku-4-5');
+  });
+
+  it('(g) an openai agent with a custom base_url yields a candidate that createProvider receives WITH that base_url', async () => {
+    const { createProvider, calls } = makeStubCreateProvider();
+    const res = await selectUtilityFallbackProvider({
+      // main is a keyless native host so the openai agent becomes the fallback.
+      main: { provider: 'none', model: 'none', key: null },
+      agents: [
+        { provider: 'openai', model: 'local-gpt', key_ref: 'openai', base_url: 'https://llm.internal/v1' },
+      ],
+      getKey: async (s) => (s === 'openai' ? 'sk-openai' : null),
+      isCooled: () => false,
+      createProvider,
+      projectRoot: '/proj',
+    });
+    expect(res.label).toBe('openai/local-gpt');
+    // createProvider must receive the agent's custom base_url + projectRoot, so
+    // the fallback points at the agent's endpoint (NOT api.openai.com) and can
+    // persist its own 429s. The curated openai default must not shadow it.
+    const openaiCall = calls.find((c) => c.provider === 'openai');
+    expect(openaiCall).toEqual({ provider: 'openai', model: 'local-gpt', key: 'sk-openai', projectRoot: '/proj', baseUrl: 'https://llm.internal/v1' });
+  });
+
+  it('all viable candidates cooled ⇒ NullProvider', async () => {
+    const { createProvider } = makeStubCreateProvider();
+    const res = await selectUtilityFallbackProvider({
+      main: { provider: 'openai', model: 'gpt-4o', key: 'sk-openai' },
+      agents: [{ provider: 'deepseek', model: 'deepseek-chat', key_ref: 'deepseek' }],
+      getKey: async (s) => `sk-${s}`,
+      isCooled: () => true, // everything cooled
+      createProvider,
+    });
+    expect(res.label).toBe('degraded/none');
+  });
+});

--- a/tests/orchestrator/llm-client.test.ts
+++ b/tests/orchestrator/llm-client.test.ts
@@ -1,4 +1,4 @@
-import { createProvider, createProviderForAgent, resolveAgentProvider, AnthropicProvider, OpenAIProvider, GeminiProvider, OllamaProvider } from '@gossip/orchestrator';
+import { createProvider, createProviderForAgent, resolveAgentProvider, AnthropicProvider, OpenAIProvider, GeminiProvider, OllamaProvider, isReasoningModel } from '@gossip/orchestrator';
 import { mkdtempSync, readFileSync, rmSync, mkdirSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -433,6 +433,237 @@ describe('LLM Client', () => {
       expect(ok.name).toBe('file_read');
       expect(ok.arguments).toEqual({ path: '/src/main.ts' });
       expect(ok.argumentsParseError).toBeUndefined();
+
+      global.fetch = originalFetch;
+    });
+  });
+
+  describe('isReasoningModel — Responses API routing predicate', () => {
+    it.each([
+      ['gpt-5.6-terra', true],
+      ['gpt-5', true],
+      ['GPT-5.6-Terra', true],   // case-insensitive
+      ['o3', true],
+      ['o1-mini', true],
+      ['gpt-4o', false],
+      ['gpt-4o-mini', false],
+      ['gpt-3.5-turbo', false],
+      ['deepseek-chat', false],
+      ['omni-model', false],     // "o" not followed by a digit
+    ])('%s → %s', (model, expected) => {
+      expect(isReasoningModel(model)).toBe(expected);
+    });
+  });
+
+  describe('OpenAIProvider — Responses API (/v1/responses) path', () => {
+    it('reasoning model + tools ⇒ POSTs /responses with FLAT tool shape and an input array', async () => {
+      const originalFetch = global.fetch;
+      const seen: { url?: string; body?: any } = {};
+      global.fetch = jest.fn().mockImplementation((url: string, init: any) => {
+        seen.url = url;
+        seen.body = JSON.parse(init.body);
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            output: [{ type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'ok' }] }],
+            usage: { input_tokens: 3, output_tokens: 1 },
+          }),
+        });
+      }) as unknown as typeof fetch;
+
+      const provider = new OpenAIProvider('test-key', 'gpt-5.6-terra');
+      const response = await provider.generate(
+        [
+          { role: 'system', content: 'you are terse' },
+          { role: 'user', content: 'hi' },
+        ],
+        { tools: [{ name: 'read_file', description: 'Read a file', parameters: { type: 'object', properties: {} } }], maxTokens: 128, temperature: 0.2 },
+      );
+
+      // Hit the Responses endpoint, not chat/completions.
+      expect(seen.url).toBe('https://api.openai.com/v1/responses');
+      // System prompt rides as top-level `instructions`.
+      expect(seen.body.instructions).toBe('you are terse');
+      // FLAT function tool (no nested `function: {}`).
+      expect(seen.body.tools).toEqual([
+        { type: 'function', name: 'read_file', description: 'Read a file', parameters: { type: 'object', properties: {} } },
+      ]);
+      // Non-system messages become input items with input_text content.
+      expect(seen.body.input).toEqual([
+        { role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
+      ]);
+      expect(seen.body.max_output_tokens).toBe(128);
+      // temperature is intentionally OMITTED on /responses — reasoning models
+      // reject any non-default temperature, so the field must be absent even
+      // when the caller passed one.
+      expect('temperature' in seen.body).toBe(false);
+
+      expect(response.text).toBe('ok');
+      expect(response.usage).toEqual({ inputTokens: 3, outputTokens: 1 });
+
+      global.fetch = originalFetch;
+    });
+
+    it('non-reasoning model + tools ⇒ still hits /chat/completions', async () => {
+      const originalFetch = global.fetch;
+      const seen: { url?: string } = {};
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        seen.url = url;
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ choices: [{ message: { content: 'chat', tool_calls: null } }] }),
+        });
+      }) as unknown as typeof fetch;
+
+      const provider = new OpenAIProvider('test-key', 'gpt-4o');
+      await provider.generate(
+        [{ role: 'user', content: 'hi' }],
+        { tools: [{ name: 'read_file', description: 'Read a file', parameters: { type: 'object', properties: {} } }] },
+      );
+      expect(seen.url).toBe('https://api.openai.com/v1/chat/completions');
+
+      global.fetch = originalFetch;
+    });
+
+    it('safety net: /chat/completions 400 saying "use /v1/responses" ⇒ transparent retry on /responses', async () => {
+      const originalFetch = global.fetch;
+      const urls: string[] = [];
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        urls.push(url);
+        if (url.endsWith('/chat/completions')) {
+          return Promise.resolve({
+            ok: false,
+            status: 400,
+            headers: { get: () => null },
+            text: async () => 'Function tools with reasoning_effort are not supported for future-model in /v1/chat/completions. To use function tools, use /v1/responses',
+          });
+        }
+        // /responses retry succeeds.
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            output: [{ type: 'message', content: [{ type: 'output_text', text: 'healed' }] }],
+          }),
+        });
+      }) as unknown as typeof fetch;
+
+      // A model isReasoningModel() does NOT recognize — the self-heal must still fire.
+      const provider = new OpenAIProvider('test-key', 'future-model');
+      const response = await provider.generate(
+        [{ role: 'user', content: 'hi' }],
+        { tools: [{ name: 'read_file', description: 'Read a file', parameters: { type: 'object', properties: {} } }] },
+      );
+      expect(urls).toEqual([
+        'https://api.openai.com/v1/chat/completions',
+        'https://api.openai.com/v1/responses',
+      ]);
+      expect(response.text).toBe('healed');
+
+      global.fetch = originalFetch;
+    });
+
+    it('reasoning model on a NON-canonical base_url + tools ⇒ stays on /chat/completions (no silent /responses 404)', async () => {
+      const originalFetch = global.fetch;
+      const seen: { url?: string } = {};
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        seen.url = url;
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ choices: [{ message: { content: 'chat', tool_calls: null } }] }),
+        });
+      }) as unknown as typeof fetch;
+
+      // deepseek-style custom endpoint + a reasoning-shaped model name. The
+      // up-front /responses route must NOT fire because only api.openai.com
+      // serves /v1/responses.
+      const provider = new OpenAIProvider('test-key', 'gpt-5-x', undefined, 'https://api.deepseek.com/v1');
+      await provider.generate(
+        [{ role: 'user', content: 'hi' }],
+        { tools: [{ name: 'read_file', description: 'Read a file', parameters: { type: 'object', properties: {} } }] },
+      );
+      expect(seen.url).toBe('https://api.deepseek.com/v1/chat/completions');
+
+      global.fetch = originalFetch;
+    });
+
+    it('toResponsesInput maps an image ContentBlock to an input_image item with a data: URL', async () => {
+      const originalFetch = global.fetch;
+      const seen: { body?: any } = {};
+      global.fetch = jest.fn().mockImplementation((_url: string, init: any) => {
+        seen.body = JSON.parse(init.body);
+        return Promise.resolve({ ok: true, json: async () => ({ output: [{ type: 'message', content: [{ type: 'output_text', text: 'ok' }] }] }) });
+      }) as unknown as typeof fetch;
+
+      const provider = new OpenAIProvider('test-key', 'gpt-5.6-terra');
+      await provider.generate(
+        [{ role: 'user', content: [
+          { type: 'text', text: 'what is this?' },
+          { type: 'image', mediaType: 'image/png', data: 'BASE64DATA' },
+        ] }],
+        { tools: [{ name: 'read_file', description: 'Read a file', parameters: { type: 'object', properties: {} } }] },
+      );
+
+      expect(seen.body.input).toEqual([
+        { role: 'user', content: [
+          { type: 'input_text', text: 'what is this?' },
+          { type: 'input_image', image_url: 'data:image/png;base64,BASE64DATA' },
+        ] },
+      ]);
+
+      global.fetch = originalFetch;
+    });
+
+    it('Responses parser extracts concatenated text, tool calls, and usage', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          output: [
+            { type: 'message', content: [{ type: 'output_text', text: 'part-a ' }, { type: 'output_text', text: 'part-b' }] },
+            { type: 'function_call', call_id: 'call_z', name: 'shell_exec', arguments: '{"command":"ls"}' },
+            { type: 'reasoning', summary: [] }, // ignored item type
+          ],
+          usage: { input_tokens: 11, output_tokens: 4 },
+        }),
+      }) as unknown as typeof fetch;
+
+      const provider = new OpenAIProvider('test-key', 'gpt-5.6-terra');
+      const response = await provider.generate(
+        [{ role: 'user', content: 'do it' }],
+        { tools: [{ name: 'shell_exec', description: 'Run a shell command', parameters: { type: 'object', properties: {} } }] },
+      );
+
+      expect(response.text).toBe('part-a part-b');
+      expect(response.toolCalls).toHaveLength(1);
+      expect(response.toolCalls![0]).toEqual({ id: 'call_z', name: 'shell_exec', arguments: { command: 'ls' } });
+      expect(response.usage).toEqual({ inputTokens: 11, outputTokens: 4 });
+
+      global.fetch = originalFetch;
+    });
+
+    it('Responses path maps prior tool calls / results into function_call(+output) input items', async () => {
+      const originalFetch = global.fetch;
+      const seen: { body?: any } = {};
+      global.fetch = jest.fn().mockImplementation((_url: string, init: any) => {
+        seen.body = JSON.parse(init.body);
+        return Promise.resolve({ ok: true, json: async () => ({ output: [{ type: 'message', content: [{ type: 'output_text', text: 'done' }] }] }) });
+      }) as unknown as typeof fetch;
+
+      const provider = new OpenAIProvider('test-key', 'gpt-5.6-terra');
+      await provider.generate(
+        [
+          { role: 'user', content: 'read the file' },
+          { role: 'assistant', content: '', toolCalls: [{ id: 'call_1', name: 'read_file', arguments: { path: '/a.ts' } }] },
+          { role: 'tool', toolCallId: 'call_1', content: 'file contents' },
+        ],
+        { tools: [{ name: 'read_file', description: 'Read a file', parameters: { type: 'object', properties: {} } }] },
+      );
+
+      expect(seen.body.input).toEqual([
+        { role: 'user', content: [{ type: 'input_text', text: 'read the file' }] },
+        { type: 'function_call', call_id: 'call_1', name: 'read_file', arguments: '{"path":"/a.ts"}' },
+        { type: 'function_call_output', call_id: 'call_1', output: 'file contents' },
+      ]);
 
       global.fetch = originalFetch;
     });


### PR DESCRIPTION
## Summary

Two provider/routing fixes the user hit directly, verified across two consensus rounds.

consensus-id: 26ab9b31-b7aa4f69
consensus-id: b8138867-e4564f31

### Bug 1 — utility summarizers pinned to a broken main provider
The relay-side summarizers (cognitive memory, session gossip, sibling gossip) run synchronously in a post-dispatch hook with no turn to dispatch a native `Agent()`, so they can't use the native-utility path and were left bound to the main provider. With a keyed-but-cooled main (e.g. a Google 429 cooldown) every automatic summary silently failed. New `selectUtilityFallbackProvider` keeps a healthy main, else picks the best keyed non-cooled provider (openai-first), else a `NullProvider` that degrades to regex extraction. Threads each agent's `base_url`/`projectRoot`; reads `.gossip/quota-state.json` once to skip cooled slots.

### Bug 2 — GPT-5.x / o-series reasoning models rejected function tools
These models require `/v1/responses` for function tools (`chat/completions` returns "use /v1/responses"). `OpenAIProvider` now auto-routes tool-bearing reasoning-model requests there — but **only on the canonical `api.openai.com` endpoint**, so the deepseek/grok/openclaw/custom-`base_url` reuses stay on `/chat/completions` (they don't serve `/responses`). `temperature` is omitted on the Responses path (reasoning models reject non-default temperature), image blocks map to `input_image`, and a self-heal retry falls back to `/responses` when any endpoint's error body asks for it.

Also hardens the quota-state parse against a valid-JSON scalar (e.g. literal `null`) that would otherwise crash `isCooled` and disable the entire ATI block.

## Review
- **Round 1** (`26ab9b31-b7aa4f69`): 3-agent consensus found the temperature-on-reasoning-models critical, the non-canonical-endpoint routing high, and the base_url-drop medium — all fixed here. One adversarial API-shape claim was verified as a hallucination and rejected.
- **Round 2** (`b8138867-e4564f31`): 3 agents, 2 rounds, 6 confirmed / 0 disputed — all fixes verified correct, no regressions. Remaining findings are low-severity residuals (documented as Known limitations in CHANGELOG).

## Behavior change
Utility summaries may now incur real HTTP spend on a stored-but-unagented key (e.g. an `openai` key on a host whose main degraded to `none`) instead of silently degrading to empty output. The chosen provider is disclosed in the startup banner.

## Tests
Full suite green (351 suites, 4764 tests). New coverage: `tests/cli/utility-provider.test.ts`, `tests/orchestrator/llm-client.test.ts` (Responses API: routing gate, temperature-absent, image mapping, self-heal retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)