### PR TITLE
fix(skill-parser): stop dropping+warning on skills missing description/status (v0.6.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ## [Unreleased]
 
+## [0.6.11] — 2026-07-11
+
+Stops the `[skill-parser] missing required field(s)` warnings that reached
+installed users after PR #647's loud parse-failure warnings. Verified via
+consensus (`consensus-id: 41d9d4d9-16fb45b9`).
+
+### Fixed
+
+- **Bundled default skill `memory-retrieval.md` was missing `status`**, so the
+  strict parser dropped its metadata and warned on every dispatch that loaded
+  default skills. Added `status: active` (matching its sibling permanent
+  defaults) and a regression test that asserts every frontmatter-bearing bundled
+  default skill parses cleanly.
+- **A missing one-line `description` no longer drops a functional skill.**
+  `parseSkillFrontmatter` now hard-requires only `name` (identity); `description`
+  is backfilled from a humanized `name` and `status` defaults to `active`, with a
+  single `backfilled missing field(s): …` notice (the loud-visibility intent of
+  PR #647 is kept, but a usable contextual skill is no longer discarded and
+  double-warned). Generated agent-local skills that omitted `description` — the
+  develop prompt never listed it as required — were the main casualty.
+- **The skill generator now always emits `description`.** The develop prompt
+  lists it as required, and `injectSnapshotFields` guarantees a (colon-safe,
+  JSON-quoted) `description:` line at write time, derived from the skill name.
+- **Edge hardening:** a quoted-whitespace name (`name: "   "`) is now trimmed
+  after quote-stripping so it is correctly rejected instead of surviving as a
+  blank normalized name; the write-time derived description is JSON-quoted so a
+  name containing a colon can't produce malformed YAML.
+
 ## [0.6.10] — 2026-07-11
 
 Two provider/routing fixes so utility summarization survives a broken main

--- a/README.md
+++ b/README.md
@@ -194,10 +194,10 @@ Add to `~/.claude/mcp_settings.json` (Claude Code) or project-local `.mcp.json`:
 
 ```bash
 # Pin to a version
-npm install -g gossipcat@0.6.10
+npm install -g gossipcat@0.6.11
 
 # Pin to a GitHub release tarball (bypasses the npm registry)
-npm install -g https://github.com/gossipcat-ai/gossipcat-ai/releases/download/v0.6.10/gossipcat-0.6.10.tgz
+npm install -g https://github.com/gossipcat-ai/gossipcat-ai/releases/download/v0.6.11/gossipcat-0.6.11.tgz
 
 # Project-local (postinstall writes .mcp.json — open the IDE there, no `mcp add` needed)
 cd your-project && npm install --save-dev gossipcat

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossipcat",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
   "mcpName": "io.github.ataberk-xyz/gossipcat",
   "repository": {

--- a/packages/orchestrator/src/default-skills/memory-retrieval.md
+++ b/packages/orchestrator/src/default-skills/memory-retrieval.md
@@ -1,6 +1,7 @@
 ---
 name: memory-retrieval
 mode: permanent
+status: active
 description: Call gossip_remember BEFORE reviewing — recall prior findings on the same code so you don't re-discover or contradict yourself
 ---
 

--- a/packages/orchestrator/src/skill-engine.ts
+++ b/packages/orchestrator/src/skill-engine.ts
@@ -516,7 +516,7 @@ Peer scores: ${peerScores.length > 0 ? peerScores.join(', ') : 'no peer data'}
 
 Output a skill markdown file with this exact structure:
 
-1. YAML frontmatter with fields: name, category (${category}), agent (${agentId}), generated, effectiveness (0.0), baseline_rate (${baselineRate.toFixed(3)}), baseline_dispatches (${totalDispatches}), version (1), mode (contextual), keywords ([${(CATEGORY_KEYWORDS[category] || [category]).join(', ')}])
+1. YAML frontmatter with fields: name, description (one concise line describing what the skill improves), category (${category}), agent (${agentId}), generated, effectiveness (0.0), baseline_rate (${baselineRate.toFixed(3)}), baseline_dispatches (${totalDispatches}), version (1), mode (contextual), keywords ([${(CATEGORY_KEYWORDS[category] || [category]).join(', ')}])
 2. ## Iron Law — one absolute rule (MUST/NEVER language)
 3. ## When This Skill Activates — task patterns that trigger it
 4. ## Methodology — 5-8 step checklist, actionable not vague
@@ -617,6 +617,26 @@ Requirements:
     // Ensure effectiveness is present as a number
     if (!fm.match(/^effectiveness:/m)) {
       fm = fm.trimEnd() + '\neffectiveness: 0.0';
+    }
+
+    // Guarantee a `description` line so generated skills are spec-compliant
+    // regardless of LLM output. The develop prompt asks for one, but the LLM
+    // omits it non-deterministically; without it the loader's skill-parser
+    // would have to backfill a stand-in (and warn) on every dispatch. Derive
+    // a one-liner from the skill name (falling back to category) here so the
+    // authored file is complete at write time.
+    if (!fm.match(/^description:/m)) {
+      const nameMatch = fm.match(/^name:\s*(.+)$/m);
+      // Fall back to a literal AFTER the transform so a quoted-whitespace or
+      // all-separator name (which humanizes to '') doesn't write an empty
+      // `description:` that re-triggers the loader's backfill+warn every load.
+      const derived = ((nameMatch?.[1]?.trim() ?? '')
+        .replace(/^['"]|['"]$/g, '')
+        .replace(/[-_]/g, ' ')
+        .trim()) || 'generated skill';
+      // JSON.stringify quotes + escapes so a name with an unescaped colon
+      // (e.g. `circuit: breaker`) can't write malformed YAML (consensus 41d9d4d9).
+      fm = fm.trimEnd() + `\ndescription: ${JSON.stringify(derived)}`;
     }
 
     // Append snapshot fields

--- a/packages/orchestrator/src/skill-parser.ts
+++ b/packages/orchestrator/src/skill-parser.ts
@@ -96,10 +96,11 @@ export interface SkillFrontmatter {
 const BLOCK_SEQUENCE_KEYS = new Set(['keywords', 'scope']);
 
 /** Writes a loud, prefixed diagnostic to stderr for parse failures. Warnings
- * fire ONLY when a `---` frontmatter block IS present but is missing a
- * REQUIRED field (name, description, status) — a genuine authoring error.
- * The silent-coercion philosophy for OPTIONAL axes (task_type, scope
- * unknown-token dropping, mode) is unchanged below.
+ * fire when a `---` frontmatter block IS present but either (a) is missing the
+ * hard-required `name` field — a genuine authoring error that drops the skill —
+ * or (b) had `description`/`status` backfilled with safe defaults (one warning,
+ * skill preserved). The silent-coercion philosophy for OPTIONAL axes (task_type,
+ * scope unknown-token dropping, mode) is unchanged below.
  *
  * Deliberately silent when no frontmatter block is found at all: plain
  * `# Title` markdown with no `---` block is a supported, common skill
@@ -162,7 +163,10 @@ export function parseSkillFrontmatter(content: string, sourceLabel?: string): Sk
     if (value.length >= 2 &&
         ((value.startsWith('"') && value.endsWith('"')) ||
          (value.startsWith("'") && value.endsWith("'")))) {
-      value = value.slice(1, -1);
+      // `.trim()` AFTER the strip too: a quoted-whitespace value like
+      // `name: "   "` is otherwise 3 truthy spaces that slip the `!name`
+      // guard below and normalize to '' downstream (consensus 41d9d4d9).
+      value = value.slice(1, -1).trim();
     }
     fields[key] = value;
 
@@ -171,10 +175,32 @@ export function parseSkillFrontmatter(content: string, sourceLabel?: string): Sk
     }
   }
 
-  if (!fields.name || !fields.description || !fields.status) {
-    const missing = ['name', 'description', 'status'].filter(f => !fields[f]);
-    warnParseFailure(`missing required field(s): ${missing.join(', ')}`, sourceLabel);
+  // `name` is the only HARD requirement: a skill with no identity is unusable,
+  // so keep PR #647's loud-drop path for it (warn + return null). `description`
+  // and `status` are recall/lifecycle metadata — dropping a functional
+  // contextual skill for a missing one-liner is too harsh (it stranded
+  // generated agent-local skills that omit `description`). Backfill safe
+  // defaults instead and emit ONE observability warning noting what was
+  // filled in.
+  if (!fields.name) {
+    warnParseFailure('missing required field(s): name', sourceLabel);
     return null;
+  }
+  const backfilled: string[] = [];
+  if (!fields.description) {
+    // Humanize the identity into a stand-in one-liner: `resource-exhaustion`
+    // → `resource exhaustion`. Pure recall metadata, so a derived value is
+    // strictly better than dropping the whole skill.
+    // `|| fields.name` guards an all-separator name (e.g. `---`) humanizing to ''.
+    fields.description = fields.name.replace(/[-_]/g, ' ').trim() || fields.name;
+    backfilled.push('description');
+  }
+  if (!fields.status) {
+    fields.status = 'active';
+    backfilled.push('status');
+  }
+  if (backfilled.length > 0) {
+    warnParseFailure(`backfilled missing field(s): ${backfilled.join(', ')}`, sourceLabel);
   }
 
   let keywords: string[] = [];

--- a/tests/orchestrator/skill-engine.test.ts
+++ b/tests/orchestrator/skill-engine.test.ts
@@ -1,4 +1,4 @@
-import { SkillEngine, PerformanceReader, ILLMProvider } from '@gossip/orchestrator';
+import { SkillEngine, PerformanceReader, ILLMProvider, parseSkillFrontmatter } from '@gossip/orchestrator';
 import { mkdirSync, writeFileSync, rmSync, readFileSync, existsSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -157,6 +157,23 @@ describe('SkillEngine', () => {
     expect(body).toContain('# Injection Audit');
     expect(body).toContain('## Iron Law');
     expect(body).toContain('## Quality Gate');
+  });
+
+  test('injects a description into generated frontmatter when the LLM omits one', async () => {
+    // VALID_SKILL has no `description:` line. injectSnapshotFields must
+    // backfill one derived from `name` so the written file is spec-compliant
+    // and the loader's skill-parser never has to backfill+warn on dispatch.
+    const llm = mockLLM(VALID_SKILL);
+    const gen = new SkillEngine(llm, new PerformanceReader(testDir), testDir);
+    const result = await gen.generate('agent-a', 'injection_vectors');
+
+    const written = readFileSync(result.path, 'utf-8');
+    const fmEnd = written.indexOf('\n---', 4);
+    const frontmatter = written.slice(4, fmEnd);
+    // Derived description is written JSON-quoted (colon-safe); the loader's
+    // parser strips the quotes back to the plain value on read.
+    expect(frontmatter).toMatch(/^description:\s*"injection audit"$/m);
+    expect(parseSkillFrontmatter(written)?.description).toBe('injection audit');
   });
 
   test('rejects LLM output missing required sections', async () => {

--- a/tests/orchestrator/skill-parser.test.ts
+++ b/tests/orchestrator/skill-parser.test.ts
@@ -1,4 +1,6 @@
 import { parseSkillFrontmatter } from '@gossip/orchestrator';
+import { readdirSync, readFileSync } from 'fs';
+import { join, resolve } from 'path';
 
 describe('parseSkillFrontmatter', () => {
   it('parses valid frontmatter with all fields', () => {
@@ -174,6 +176,59 @@ Check endpoints.`;
       expect(message).toContain('missing-name.md');
     });
 
+    it('backfills description from name and warns exactly once when only description is missing', () => {
+      // Generated agent-local skills (e.g. .gossip/agents/<id>/skills/
+      // resource-exhaustion.md) routinely omit `description`. Preserve the
+      // skill with a humanized stand-in instead of dropping it.
+      const md = `---\nname: resource-exhaustion\nkeywords: [dos]\nstatus: active\n---\nBody`;
+      const result = parseSkillFrontmatter(md, 'resource-exhaustion.md');
+
+      expect(result).not.toBeNull();
+      expect(result!.description).toBe('resource exhaustion');
+      expect(result!.status).toBe('active');
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+      const [message] = stderrSpy.mock.calls[0];
+      expect(message).toContain('[skill-parser]');
+      expect(message).toContain('backfilled');
+      expect(message).toContain('description');
+      expect(message).toContain('resource-exhaustion.md');
+    });
+
+    it('backfills status to active and warns once when only status is missing', () => {
+      const md = `---\nname: t\ndescription: d\nkeywords: [k]\n---\nBody`;
+      const result = parseSkillFrontmatter(md, 'no-status.md');
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe('active');
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+      const [message] = stderrSpy.mock.calls[0];
+      expect(message).toContain('backfilled');
+      expect(message).toContain('status');
+    });
+
+    it('backfills BOTH description and status in a single joined warning when both are missing', () => {
+      const md = `---\nname: resource-exhaustion\nkeywords: [dos]\n---\nBody`;
+      const result = parseSkillFrontmatter(md, 'both-missing.md');
+
+      expect(result).not.toBeNull();
+      expect(result!.description).toBe('resource exhaustion');
+      expect(result!.status).toBe('active');
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+      const [message] = stderrSpy.mock.calls[0];
+      expect(message).toContain('backfilled missing field(s): description, status');
+    });
+
+    it('rejects a quoted-whitespace name (trims after quote-strip) rather than backfilling from empty', () => {
+      // `name: "   "` must not slip the `!name` guard as three truthy spaces
+      // (consensus 41d9d4d9). The post-strip trim collapses it to '' → dropped.
+      const md = `---\nname: "   "\ndescription: d\nstatus: active\n---\nBody`;
+      const result = parseSkillFrontmatter(md, 'whitespace-name.md');
+
+      expect(result).toBeNull();
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+      expect(stderrSpy.mock.calls[0][0]).toContain('missing required field(s): name');
+    });
+
     it('returns null and does NOT warn when no frontmatter block is present (supported format)', () => {
       const md = `# Just a title\n\nSome content`;
       const result = parseSkillFrontmatter(md, 'no-frontmatter.md');
@@ -188,6 +243,37 @@ Check endpoints.`;
 
       expect(result).not.toBeNull();
       expect(stderrSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // Regression: every SHIPPED default skill that carries a frontmatter block
+  // must satisfy the required-field contract, or the loud warnParseFailure path
+  // spams stderr on every install/dispatch and the skill's metadata is dropped.
+  // A missing `status:` on memory-retrieval.md reached users in v0.6.10 — this
+  // guards the whole default-skills dir so it can't recur.
+  describe('bundled default skills parse cleanly', () => {
+    const defaultSkillsDir = resolve(__dirname, '../../packages/orchestrator/src/default-skills');
+    const frontmatterSkills = readdirSync(defaultSkillsDir)
+      .filter(f => f.endsWith('.md'))
+      .filter(f => readFileSync(join(defaultSkillsDir, f), 'utf8').startsWith('---\n'));
+
+    it('has at least one frontmatter-bearing default skill to check', () => {
+      expect(frontmatterSkills.length).toBeGreaterThan(0);
+    });
+
+    it.each(frontmatterSkills)('%s parses non-null with name/description/status and no warning', (file) => {
+      const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      try {
+        const content = readFileSync(join(defaultSkillsDir, file), 'utf8');
+        const result = parseSkillFrontmatter(content, file);
+        expect(result).not.toBeNull();
+        expect(result!.name).toBeTruthy();
+        expect(result!.description).toBeTruthy();
+        expect(result!.status).toBeTruthy();
+        expect(stderrSpy).not.toHaveBeenCalled();
+      } finally {
+        stderrSpy.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the `[skill-parser] missing required field(s): …` warnings reported by installed users after PR #647's loud parse-failure warnings.

consensus-id: 41d9d4d9-16fb45b9

Two skills reached users with incomplete frontmatter, and the strict parser dropped their metadata + double-warned on every dispatch:
1. **Bundled default `memory-retrieval.md`** lacked `status:` → added `status: active` + a regression test guarding every frontmatter-bearing default.
2. **Generated agent-local skills** lacked `description:` — the develop prompt (`skill-engine.ts`) never listed it as required, so the LLM omitted it non-deterministically.

## Change
- `parseSkillFrontmatter` now hard-requires **only `name`** (identity). `description` is backfilled from a humanized name; `status` defaults to `active`; a single `backfilled missing field(s): …` notice is emitted. PR #647's loud-visibility intent is preserved, but a usable contextual skill is no longer discarded and double-warned.
- The generator now emits `description` (prompt field list) and `injectSnapshotFields` guarantees a JSON-quoted, colon-safe `description:` at write time.
- Edge hardening (consensus-confirmed, medium): quoted-whitespace name (`name: "   "`) is trimmed after quote-strip so it's rejected not blank-normalized; the derived description is JSON-quoted so a name with a colon can't write malformed YAML.

## Review
Consensus `41d9d4d9-16fb45b9` (2 agents, 2 rounds): the softening is correct with no regression — status-filter still drops `failed`/`silent_skill`/drift-demoted; the one intended behavior change is that project skills previously dropped for a missing description now appear in the catalog with backfilled values. Two medium edge cases found + fixed here.

## Tests
Full suite green (351 suites, 4774 tests). New: both-fields-missing backfill, quoted-whitespace-name rejection, bundled-defaults-parse-cleanly, colon-safe generated description round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)