### PR TITLE
feat(relay): image attachments for custom-provider (OpenAI/Gemini) dispatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,3 +513,40 @@ Gossipcat is open source and early-stage — bug reports, ideas, and PRs welcome
 ## License
 
 [MIT](LICENSE)
+
+**Image attachments (vision-capable relay agents):**
+
+Relay agents on vision-capable providers (OpenAI, Google Gemini, Anthropic, Grok, local Ollama)
+can receive images. Pass an `images` array of **local absolute PNG/JPEG paths** — the relay
+worker reads each file, base64-encodes it, and attaches it as a native image content part
+(OpenAI `image_url` data URI, Gemini `inlineData`, Anthropic `image` block):
+
+```
+gossip_dispatch(
+  mode: "single",
+  agent_id: "gpt56-critic",
+  task: "Critique the HUD layout in this screenshot",
+  images: ["/abs/path/Logs/hud.png"]
+)
+
+// Per-task in parallel / consensus:
+gossip_dispatch(mode: "consensus", tasks: [
+  { agent_id: "gpt56-critic",    task: "...", images: ["/abs/path/a.png"] },
+  { agent_id: "gemini31-critic", task: "...", images: ["/abs/path/a.png"] }
+])
+```
+
+Auto-detect: if you omit `images`, any absolute PNG/JPEG paths already present in the task
+text are auto-attached (up to 4) — existing text workflows that cite screenshot paths start
+sending pixels with no change.
+
+Limits & behavior:
+- **Max 4 images** per task; overflow is rejected with a clear error (not silently truncated).
+- **≤ 4 MB each**; larger files are rejected per-image.
+- **PNG / JPEG only** — validated by extension **and** magic-byte sniff (a renamed non-image is rejected).
+- A **non-existent / unreadable path** produces a clear per-image error surfaced in the task
+  context, never a silent drop.
+- **Text-only providers** (e.g. DeepSeek) and the **native (Agent-tool) path** ignore the
+  field with a logged notice — native subagents receive images via their own multimodal flow,
+  not this relay path.
+

--- a/README.md
+++ b/README.md
@@ -542,11 +542,27 @@ sending pixels with no change.
 
 Limits & behavior:
 - **Max 4 images** per task; overflow is rejected with a clear error (not silently truncated).
-- **≤ 4 MB each**; larger files are rejected per-image.
+- **≤ 4 MB each**; larger files are rejected per-image. Reads are capped and go through a
+  single file descriptor (open → fstat → read the *same* fd), so a file swapped or grown
+  between the size check and the read cannot smuggle a larger/different file (TOCTOU-resistant).
 - **PNG / JPEG only** — validated by extension **and** magic-byte sniff (a renamed non-image is rejected).
+- **Path policy (allowed-root confinement).** Every image path is `realpath`'d (symlinks
+  followed) and must resolve **within the dispatching project root**. A path that escapes the
+  root — via `..`, an absolute path elsewhere, or a symlink pointing outside — is rejected with
+  a per-image "path policy" error and is never opened. Image paths are untrusted input (they
+  come from the caller or from task prose), so they are confined the same way citation
+  resolution roots are (`realpath` both sides + prefix check).
 - A **non-existent / unreadable path** produces a clear per-image error surfaced in the task
   context, never a silent drop.
-- **Text-only providers** (e.g. DeepSeek) and the **native (Agent-tool) path** ignore the
-  field with a logged notice — native subagents receive images via their own multimodal flow,
-  not this relay path.
+- **Explicit vs auto-detect error surfacing.** Errors from an **explicit `images` field** are
+  appended to the agent's prompt (the caller asked for those attachments). Errors from
+  **auto-detected** prose paths are **log-only** — a path-shaped token in prose that fails to
+  resolve must not mutate the prompt, keeping pure-prose tasks byte-identical to pre-feature
+  behavior.
+- **Text-only providers** (e.g. DeepSeek) ignore the field with a logged notice.
+- **The native (Agent-tool) path does NOT deliver images.** gossipcat has no native multimodal
+  wiring; native subagents run through the host `Agent()` tool, which the dispatch handler
+  cannot feed pixels. Passing `images` to a native agent produces an explicit
+  *"images are relay-only; native agent X did not receive N image(s)"* notice in the dispatch
+  response rather than a silent drop.
 

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -624,6 +624,17 @@ function reroutableAgent(agentId: string): string {
   return agentId;
 }
 
+/**
+ * Finding #6 (relay-image consensus round): a NATIVE agent dispatch cannot
+ * deliver images — gossipcat has no native multimodal wiring; native subagents
+ * run through the host Agent() tool, which this handler cannot feed pixels.
+ * Callers surface this exact notice in the dispatch response instead of dropping
+ * the `images` field silently, so the operator knows the pixels never landed.
+ */
+function nativeImageDropNotice(agentId: string, count: number): string {
+  return `images are relay-only; native agent ${agentId} did not receive ${count} image(s)`;
+}
+
 export async function handleDispatchSingle(
   agent_id: string, task: string,
   write_mode?: 'sequential' | 'scoped' | 'worktree',
@@ -657,9 +668,13 @@ export async function handleDispatchSingle(
    * vision-capable relay providers. Forwarded to dispatch-pipeline via
    * DispatchOptions.images; the worker reads + base64-encodes + guards them
    * (max 4, ≤4 MB each, magic-byte sniff). When omitted, the worker
-   * auto-detects up to 4 absolute PNG/JPEG paths from the task text. Ignored by
-   * the native dispatch path (native agents receive images via their own Agent
-   * tool multimodal flow, not this relay path).
+   * auto-detects up to 4 absolute PNG/JPEG paths from the task text.
+   *
+   * The NATIVE (Agent-tool) dispatch path does NOT deliver images — there is no
+   * native multimodal wiring in gossipcat; native subagents run through the host
+   * Agent() tool, which this handler cannot feed pixels. Rather than drop the
+   * field silently, the native branches emit an explicit "images are relay-only"
+   * notice in the dispatch response (see nativeImageDropNotice).
    */
   images?: readonly string[],
 ) {
@@ -919,6 +934,11 @@ export async function handleDispatchSingle(
     // Split into two content items so relay_token stays in orchestrator-only text
     // and AGENT_PROMPT is passed verbatim to the host native tool.
     // Tag format matches parallel/consensus: `AGENT_PROMPT:<taskId> (<agentId>)`.
+    // Finding #6: native path can't deliver images — surface an explicit notice
+    // rather than silently dropping the `images` field.
+    const nativeImgNotice = (images && images.length > 0)
+      ? `\n\n⚠️ ${nativeImageDropNotice(agent_id, images.length)}`
+      : '';
     return { content: [
       { type: 'text' as const, text: buildNativeDispatchSingleResponse({
         taskId,
@@ -930,7 +950,7 @@ export async function handleDispatchSingle(
         useWorktree,
         gitDowngradeReason,
         host,
-      }) },
+      }) + nativeImgNotice },
       // Item 2 ABSENT under elision (spec §2 iron rule — no placeholder, no
       // skeleton). Orchestrator MUST Read elision.promptPath cited in Item 1.
       ...(elision.elided ? [] : [{ type: 'text' as const, text: `AGENT_PROMPT:${taskId} (${agent_id})\n${agentPrompt}` }]),
@@ -1103,6 +1123,15 @@ export async function handleDispatchParallel(
       nativeTasks.push(def);
     } else {
       relayTasks.push(def);
+    }
+  }
+
+  // Finding #6: native agents can't receive images (no native multimodal path).
+  // Surface an explicit notice per native task that carried images instead of
+  // dropping the field silently.
+  for (const def of taskDefs) {
+    if (ctx.nativeAgentConfigs.has(def.agent_id) && def.images && def.images.length > 0) {
+      parallelDispatchWarnings.push(nativeImageDropNotice(def.agent_id, def.images.length));
     }
   }
 
@@ -1513,6 +1542,15 @@ export async function handleDispatchConsensus(
       nativeTasks.push(def);
     } else {
       relayTasks.push(def);
+    }
+  }
+
+  // Finding #6: native agents can't receive images (no native multimodal path).
+  // Surface an explicit notice per native task that carried images instead of
+  // dropping the field silently.
+  for (const def of taskDefs) {
+    if (ctx.nativeAgentConfigs.has(def.agent_id) && def.images && def.images.length > 0) {
+      dispatchWarnings.push(nativeImageDropNotice(def.agent_id, def.images.length));
     }
   }
 

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -652,6 +652,16 @@ export async function handleDispatchSingle(
    * stash is best-effort for the collect path.
    */
   dispatchWarnings?: readonly RoundWarning[],
+  /**
+   * Local absolute image file paths (PNG/JPEG) to attach to the dispatch for
+   * vision-capable relay providers. Forwarded to dispatch-pipeline via
+   * DispatchOptions.images; the worker reads + base64-encodes + guards them
+   * (max 4, ≤4 MB each, magic-byte sniff). When omitted, the worker
+   * auto-detects up to 4 absolute PNG/JPEG paths from the task text. Ignored by
+   * the native dispatch path (native agents receive images via their own Agent
+   * tool multimodal flow, not this relay path).
+   */
+  images?: readonly string[],
 ) {
   await ctx.boot();
   await ctx.syncWorkersViaKeychain();
@@ -686,6 +696,12 @@ export async function handleDispatchSingle(
   // dispatch path above (native agents don't go through pipeline.dispatch).
   if (resolutionRoots && resolutionRoots.length > 0) {
     options.resolutionRoots = resolutionRoots;
+  }
+  // Image attachments for vision-capable relay providers. Threaded via
+  // DispatchOptions.images; the relay worker reads + guards them. Ignored by the
+  // native dispatch branch below (native agents don't go through pipeline.dispatch).
+  if (images && images.length > 0) {
+    options.images = [...images];
   }
   const dispatchOptions = Object.keys(options).length > 0 ? options : undefined;
 
@@ -1028,7 +1044,7 @@ async function resolveDispatchResolutionRoots(
 }
 
 export async function handleDispatchParallel(
-  taskDefs: Array<{ agent_id: string; task: string; write_mode?: string; scope?: string }>,
+  taskDefs: Array<{ agent_id: string; task: string; write_mode?: string; scope?: string; images?: string[] }>,
   consensus: boolean,
   /**
    * Spec docs/specs/2026-04-29-relay-worker-resolution-roots.md (Path 1).
@@ -1127,6 +1143,10 @@ export async function handleDispatchParallel(
         }
         if (effectiveResolutionRoots && effectiveResolutionRoots.length > 0) {
           opts.resolutionRoots = effectiveResolutionRoots;
+        }
+        // Per-task image attachments for vision-capable relay providers.
+        if (d.images && d.images.length > 0) {
+          opts.images = [...d.images];
         }
         return {
           agentId: d.agent_id,
@@ -1387,7 +1407,7 @@ export async function handleDispatchParallel(
 }
 
 export async function handleDispatchConsensus(
-  taskDefs: Array<{ agent_id: string; task: string; write_mode?: string }>,
+  taskDefs: Array<{ agent_id: string; task: string; write_mode?: string; images?: string[] }>,
   _utility_task_id?: string,
   /**
    * #126 PR-B: optional dispatch-time resolutionRoots (post-validation,
@@ -1506,17 +1526,23 @@ export async function handleDispatchConsensus(
     // pipeline can pin tool-call cwd via toolServer.assignRoot before
     // worker.executeTask iterates. Without this, gemini-reviewer / gemini-tester
     // run with cwd=projectRoot even when resolutionRoots was supplied.
-    const relayOptions = (dispatchResolutionRoots && dispatchResolutionRoots.length > 0)
-      ? { resolutionRoots: dispatchResolutionRoots }
-      : undefined;
+    // Per-task options merge shared resolutionRoots with the task's own image
+    // attachments (vision-capable relay providers). Returns undefined when
+    // neither is present so the pre-feature call shape is preserved.
+    const relayOptsFor = (d: any): Record<string, unknown> | undefined => {
+      const o: Record<string, unknown> = {};
+      if (dispatchResolutionRoots && dispatchResolutionRoots.length > 0) o.resolutionRoots = dispatchResolutionRoots;
+      if (d.images && d.images.length > 0) o.images = [...d.images];
+      return Object.keys(o).length > 0 ? o : undefined;
+    };
     const { taskIds, errors } = precomputedLenses
       ? await ctx.mainAgent.dispatchParallelWithLenses(
-          relayTasks.map((d: any) => ({ agentId: d.agent_id, task: d.task, options: relayOptions })),
+          relayTasks.map((d: any) => ({ agentId: d.agent_id, task: d.task, options: relayOptsFor(d) })),
           { consensus: true },
           precomputedLenses,
         )
       : await ctx.mainAgent.dispatchParallel(
-          relayTasks.map((d: any) => ({ agentId: d.agent_id, task: d.task, options: relayOptions })),
+          relayTasks.map((d: any) => ({ agentId: d.agent_id, task: d.task, options: relayOptsFor(d) })),
           { consensus: true },
         );
     persistRelayTasks(); // Survive MCP reconnects

--- a/apps/cli/src/handlers/relay-tasks.ts
+++ b/apps/cli/src/handlers/relay-tasks.ts
@@ -28,6 +28,13 @@ export interface RelayTaskRecord {
    * resume capability inherit the field without a schema change.
    */
   resolutionRoots?: string[];
+  /**
+   * Local image file paths attached to this dispatch (DispatchOptions.images).
+   * Persisted for reconnect/audit symmetry with resolutionRoots — relay tasks
+   * do not resume after MCP restart, but the binding stays visible in the
+   * dashboard / re-dispatch hint.
+   */
+  images?: string[];
 }
 
 const RELAY_TASK_FILE = 'relay-tasks.json';
@@ -61,6 +68,9 @@ export function persistRelayTasks(): void {
         // websocket-bound runtime task is marked timed_out.
         ...(task.resolutionRoots && task.resolutionRoots.length > 0
           ? { resolutionRoots: [...task.resolutionRoots] }
+          : {}),
+        ...(task.images && task.images.length > 0
+          ? { images: [...task.images] }
           : {}),
       });
     }

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -853,7 +853,7 @@ async function doBoot() {
     const identityBlock = identity ? m.formatIdentityBlock(identity) + '\n' : '';
     const instructions = (identityBlock + baseInstructions).trim() || undefined;
     const enableWebSearch = ac.preset === 'researcher' || (ac.skills ?? []).includes('research');
-    const worker = new m.WorkerAgent(ac.id, llm, ctx.relay.url, m.ALL_TOOLS, instructions, enableWebSearch, relayApiKey, ac.maxToolTurns);
+    const worker = new m.WorkerAgent(ac.id, llm, ctx.relay.url, m.ALL_TOOLS, instructions, enableWebSearch, relayApiKey, ac.maxToolTurns, ac.provider);
     // ATI profiling signals (task_completed + task_tool_turns + format_compliance +
     // finding_dropped_format) are emitted from the dispatch-pipeline via the shared
     // `emitCompletionSignals` helper on FINAL_RESULT / ERROR. Emitting them here too
@@ -1700,7 +1700,7 @@ export function createMcpServer(): McpServer {
   // ── Low-level: dispatch to specific agent ─────────────────────────────────
   server.tool(
     'gossip_dispatch',
-    'Dispatch tasks to agents. mode:"single" (default) sends to one agent. mode:"parallel" fans out to multiple agents. mode:"consensus" dispatches with cross-review instructions. Returns task IDs for collecting results.',
+    'Dispatch tasks to agents. mode:"single" (default) sends to one agent. mode:"parallel" fans out to multiple agents. mode:"consensus" dispatches with cross-review instructions. Returns task IDs for collecting results. Image attachments: pass `images` (mode:"single") or per-task `images` (parallel/consensus) as local absolute PNG/JPEG paths to send screenshots to vision-capable relay providers (openai/google/anthropic/grok/local) — max 4 images, ≤4 MB each, magic-byte-sniffed. When omitted, absolute PNG/JPEG paths in the task text are auto-attached (up to 4). Text-only providers and native agents ignore the field.',
     {
       mode: z.enum(['single', 'parallel', 'consensus']).default('single').describe('Dispatch mode: "single" (one agent), "parallel" (fan-out), "consensus" (cross-review)'),
       agent_id: z.string().optional().describe('Agent ID — required for mode:"single"'),
@@ -1710,9 +1710,17 @@ export function createMcpServer(): McpServer {
         task: z.string(),
         write_mode: z.enum(['sequential', 'scoped', 'worktree']).optional(),
         scope: z.string().optional(),
+        images: z.array(z.string().min(1).max(4096)).max(4).optional().describe('Local absolute PNG/JPEG paths to attach as images for this task (vision-capable relay providers only). Max 4, ≤4 MB each.'),
       })).optional().describe('Task array — required for mode:"parallel" and mode:"consensus"'),
       write_mode: z.enum(['sequential', 'scoped', 'worktree']).optional().describe('Write mode for single dispatch'),
       scope: z.string().optional().describe('Directory scope for "scoped" write mode'),
+      // Image attachments for vision-capable relay providers (openai / google /
+      // anthropic / grok / local). Read + base64-encoded + guarded by the relay
+      // worker (max 4 images, ≤4 MB each, PNG/JPEG magic-byte sniff). When
+      // omitted, up to 4 absolute PNG/JPEG paths are auto-detected from the task
+      // text so existing text-only workflows keep working unchanged. Ignored by
+      // native (Agent-tool) dispatches and text-only providers.
+      images: z.array(z.string().min(1).max(4096)).max(4).optional().describe('mode:"single" only. Local absolute PNG/JPEG file paths to attach as images for vision-capable relay providers. Max 4, ≤4 MB each. When omitted, absolute PNG/JPEG paths in the task text are auto-attached (up to 4).'),
       timeout_ms: z.number().optional().describe('Write task timeout in ms. Default 300000.'),
       plan_id: z.string().optional().describe('Plan ID from gossip_plan. Enables chain context from prior steps.'),
       step: z.number().optional().describe('Step number in the plan (1-indexed).'),
@@ -1733,7 +1741,7 @@ export function createMcpServer(): McpServer {
       // orchestrator MUST Read the cited file and forward verbatim to Agent().
       prompt_format: z.enum(['inline', 'elided']).default('inline').describe('Prompt delivery mode for native dispatches: "inline" (default, AGENT_PROMPT content item) or "elided" (write to .gossip/dispatch-prompts/<taskId>.txt; orchestrator Reads + forwards).'),
     },
-    async ({ mode, agent_id, task, tasks, write_mode, scope, timeout_ms, plan_id, step, _utility_task_id, resolutionRoots, prompt_format }) => {
+    async ({ mode, agent_id, task, tasks, write_mode, scope, timeout_ms, plan_id, step, _utility_task_id, resolutionRoots, prompt_format, images }) => {
       // Track plan execution depth for re-entrant guard
       planExecutionDepth++;
       // #126 PR-B: validate resolutionRoots at the MCP boundary. Fatal (NUL /
@@ -1804,6 +1812,7 @@ export function createMcpServer(): McpServer {
             validatedDispatchRoots.length > 0 ? validatedDispatchRoots : undefined,
             prompt_format,
             dispatchWarnings.length > 0 ? dispatchWarnings : undefined,
+            images && images.length > 0 ? images : undefined,
           ), dispatchWarnings);
         }
         if (mode === 'parallel') {

--- a/packages/orchestrator/src/dispatch-pipeline.ts
+++ b/packages/orchestrator/src/dispatch-pipeline.ts
@@ -75,6 +75,13 @@ type TrackedTask = TaskEntry & {
      * collect-time staleness sweep). Spec invariant #4.
      */
     resolutionRootAssigned?: boolean;
+    /**
+     * Local image file paths attached to this dispatch (DispatchOptions.images).
+     * Forwarded to worker.executeTask and persisted (audit symmetry with
+     * resolutionRoots) so the dashboard / reconnect audit can show a task ran
+     * with image attachments. Relay tasks do not resume after reconnect.
+     */
+    images?: string[];
 };
 
 /**
@@ -413,6 +420,7 @@ export class DispatchPipeline {
     };
     entry.writeMode = options?.writeMode;
     entry.scope = options?.scope;
+    if (options?.images && options.images.length > 0) entry.images = [...options.images];
     entry.planId = options?.planId;
     entry.planStep = options?.step;
     if (options?.resolutionRoots && options.resolutionRoots.length > 0) {
@@ -517,7 +525,7 @@ export class DispatchPipeline {
           log(`→ resolutionRoots: assignRoot(${agentId}, ${rrCandidate}) [taskId=${taskId}]`);
         }
       }
-      const stream = worker.executeTask(task, options?.lens, promptContent, taskId);
+      const stream = worker.executeTask(task, options?.lens, promptContent, taskId, options?.images);
       entry.stream = stream;
       for await (const event of stream) {
         entry.lastEventAt = Date.now();
@@ -636,12 +644,13 @@ export class DispatchPipeline {
   }
 
   /** Get metadata for all running tasks — used by relay task persistence */
-  getRunningTaskRecords(): Array<{ id: string; agentId: string; task: string; startedAt: number; timeoutMs: number; resolutionRoots?: readonly string[] }> {
+  getRunningTaskRecords(): Array<{ id: string; agentId: string; task: string; startedAt: number; timeoutMs: number; resolutionRoots?: readonly string[]; images?: string[] }> {
     return Array.from(this.tasks.entries())
       .filter(([, t]) => t.status === 'running')
       .map(([id, t]) => ({
         id, agentId: t.agentId, task: t.task, startedAt: t.startedAt, timeoutMs: 300_000,
         ...(t.resolutionRoots && t.resolutionRoots.length > 0 ? { resolutionRoots: t.resolutionRoots } : {}),
+        ...(t.images && t.images.length > 0 ? { images: [...t.images] } : {}),
       }));
   }
 

--- a/packages/orchestrator/src/dispatch-pipeline.ts
+++ b/packages/orchestrator/src/dispatch-pipeline.ts
@@ -525,7 +525,7 @@ export class DispatchPipeline {
           log(`→ resolutionRoots: assignRoot(${agentId}, ${rrCandidate}) [taskId=${taskId}]`);
         }
       }
-      const stream = worker.executeTask(task, options?.lens, promptContent, taskId, options?.images);
+      const stream = worker.executeTask(task, options?.lens, promptContent, taskId, options?.images, this.projectRoot);
       entry.stream = stream;
       for await (const event of stream) {
         entry.lastEventAt = Date.now();

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -8,6 +8,16 @@ export { SkillCounterTracker } from './skill-counters';
 export type { MainAgentConfig } from './main-agent';
 export { WorkerAgent } from './worker-agent';
 export type { TaskCompleteCallback } from './worker-agent';
+export {
+  resolveTaskImages,
+  buildUserContent,
+  detectImagePathsInText,
+  providerSupportsVision,
+  IMAGE_PATH_RE,
+  MAX_IMAGES,
+  MAX_IMAGE_BYTES,
+} from './task-images';
+export type { ResolvedTaskImages } from './task-images';
 export { AgentRegistry } from './agent-registry';
 export type { FindBestMatchOptions } from './agent-registry';
 export { TaskDispatcher } from './task-dispatcher';

--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -213,7 +213,7 @@ export class MainAgent {
 
       // Enable web search for researcher agents (they need to look things up)
       const enableWebSearch = config.preset === 'researcher' || config.skills.includes('research');
-      const worker = new WorkerAgent(config.id, llm, this.relayUrl, ALL_TOOLS, instructions, enableWebSearch, this.relayApiKey, config.maxToolTurns);
+      const worker = new WorkerAgent(config.id, llm, this.relayUrl, ALL_TOOLS, instructions, enableWebSearch, this.relayApiKey, config.maxToolTurns, config.provider);
       await worker.start();
       // Record the key snapshot so the first syncWorkers call can short-circuit
       // when the keychain hasn't changed — otherwise every dispatch tears down
@@ -400,7 +400,7 @@ export class MainAgent {
         ? readFileSync(instructionsPath, 'utf-8') : undefined;
 
       const enableWebSearch = ac.preset === 'researcher' || ac.skills.includes('research');
-      const worker = new WorkerAgent(ac.id, llm, this.relayUrl, ALL_TOOLS, instructions, enableWebSearch, this.relayApiKey, ac.maxToolTurns);
+      const worker = new WorkerAgent(ac.id, llm, this.relayUrl, ALL_TOOLS, instructions, enableWebSearch, this.relayApiKey, ac.maxToolTurns, ac.provider);
       await worker.start();
       this.workers.set(ac.id, worker);
       this.lastKeyByAgent.set(ac.id, key);

--- a/packages/orchestrator/src/task-images.ts
+++ b/packages/orchestrator/src/task-images.ts
@@ -1,0 +1,192 @@
+/**
+ * task-images — resolve local image files into multimodal message content for
+ * relay (custom-provider) dispatches.
+ *
+ * Background: a relay dispatch delivers its task to the worker's LLM as a single
+ * `{ role: 'user', content: <task string> }` message. Even when the task text
+ * cites local PNG/JPEG paths, the model receives TEXT ONLY — no pixels. This
+ * module turns explicit `images: string[]` (or paths auto-detected in the task
+ * text) into base64 `ImageContent` blocks that the provider clients already know
+ * how to render onto each API's wire format:
+ *   - OpenAI (chat/completions): content array `{ type: 'image_url', image_url: { url: 'data:...' } }`
+ *   - Gemini:                    parts `{ inlineData: { mimeType, data } }`
+ *   - Anthropic:                 content `{ type: 'image', source: { type: 'base64', ... } }`
+ *   - Ollama:                    message `images: [base64]`
+ * (see llm-client.ts toOpenAIMessage / toGeminiMessage / toAnthropicMessage).
+ *
+ * Guardrails: at most {@link MAX_IMAGES} images, each at most
+ * {@link MAX_IMAGE_BYTES}, PNG/JPEG only (extension + magic-byte sniff),
+ * non-existent / unreadable paths surface a per-image error instead of being
+ * silently dropped. Text-only providers ignore the field with a logged notice.
+ */
+
+import { readFileSync, statSync } from 'fs';
+import { isAbsolute } from 'path';
+import { ContentBlock, ImageContent } from '@gossip/types';
+import { log as _log } from './log';
+
+/** Maximum number of images attached to a single dispatch. */
+export const MAX_IMAGES = 4;
+
+/** Maximum size of a single image (~4 MB). Larger files are rejected. */
+export const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Absolute-path image detector for auto-attach. Matches a non-whitespace run
+ * ending in .png/.jpg/.jpeg (word boundary). Global so `String.match` returns
+ * every hit; callers still filter to absolute paths and apply the MAX_IMAGES
+ * cap. Mirrors the regex spelled out in the images feature spec.
+ */
+export const IMAGE_PATH_RE = /\S+\.(?:png|jpe?g)\b/g;
+
+/** File-extension gate applied to explicit `images` entries. */
+const IMAGE_EXT_RE = /\.(?:png|jpe?g)$/i;
+
+/**
+ * Providers whose API + models accept inline base64 images. Text-only providers
+ * (deepseek-chat, openclaw, none) get the field ignored with a logged notice
+ * rather than a request the provider would reject. The anthropic-native path
+ * does NOT go through this relay module at all.
+ */
+const VISION_CAPABLE_PROVIDERS = new Set(['anthropic', 'openai', 'google', 'grok', 'local']);
+
+/** Whether a provider can accept inline images. Unknown / undefined → false. */
+export function providerSupportsVision(provider?: string): boolean {
+  return provider ? VISION_CAPABLE_PROVIDERS.has(provider) : false;
+}
+
+/**
+ * Sniff PNG/JPEG from magic bytes — the only two formats we attach. Returns the
+ * media type, or null when the content is neither (so a .png that is actually a
+ * renamed PDF is rejected).
+ */
+function sniffImageMediaType(buf: Buffer): 'image/png' | 'image/jpeg' | null {
+  if (buf.length >= 4 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'image/png';
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'image/jpeg';
+  return null;
+}
+
+export interface ResolvedTaskImages {
+  /** Successfully-read images, ready to drop into a multimodal message. */
+  blocks: ImageContent[];
+  /** Per-image rejection reasons (surfaced in the task result, not silently dropped). */
+  errors: string[];
+  /** Informational notices (e.g. provider not vision-capable). */
+  notices: string[];
+  /** True when the candidate paths came from scanning the task text (no explicit field). */
+  autoDetected: boolean;
+}
+
+/**
+ * Extract absolute PNG/JPEG paths from free-form task text, de-duplicated and in
+ * first-seen order. Relative paths are ignored (a relay worker's cwd is not the
+ * orchestrator's, so only absolute paths are portable).
+ */
+export function detectImagePathsInText(task: string): string[] {
+  const found: string[] = [];
+  const seen = new Set<string>();
+  const matches = task.match(IMAGE_PATH_RE) ?? [];
+  for (const raw of matches) {
+    // Trim bracket/quote punctuation that commonly abuts a path in prose — the
+    // \S+ match greedily swallows a leading "(" and trailing ")." etc.
+    const m = raw.replace(/^[([{<'"]+/, '').replace(/[)\]}>.,;:'"]+$/, '');
+    if (!isAbsolute(m)) continue;
+    if (!IMAGE_EXT_RE.test(m)) continue;
+    if (seen.has(m)) continue;
+    seen.add(m);
+    found.push(m);
+  }
+  return found;
+}
+
+/**
+ * Resolve the images for a dispatch: explicit `images` field takes precedence;
+ * otherwise up to {@link MAX_IMAGES} absolute paths are auto-detected from the
+ * task text. Applies all guardrails and returns base64 image blocks plus any
+ * per-image errors / notices.
+ */
+export function resolveTaskImages(opts: {
+  task: string;
+  images?: string[];
+  provider?: string;
+  logLabel?: string;
+}): ResolvedTaskImages {
+  const { task, images, provider } = opts;
+  const label = opts.logLabel ?? 'task-images';
+  const result: ResolvedTaskImages = { blocks: [], errors: [], notices: [], autoDetected: false };
+
+  // 1. Candidate paths — explicit field wins; else auto-detect from task text.
+  let candidates: string[];
+  if (images && images.length > 0) {
+    candidates = images;
+  } else {
+    candidates = detectImagePathsInText(task);
+    result.autoDetected = candidates.length > 0;
+  }
+  if (candidates.length === 0) return result;
+
+  // 2. Vision gate — text-only providers ignore the field with a logged notice.
+  if (!providerSupportsVision(provider)) {
+    const notice = `provider "${provider ?? 'unknown'}" is not vision-capable — ignoring ${candidates.length} image attachment(s)`;
+    result.notices.push(notice);
+    _log(label, notice);
+    return result;
+  }
+
+  // 3. Enforce the count cap — reject the overflow loudly, don't silently truncate.
+  let list = candidates;
+  if (list.length > MAX_IMAGES) {
+    result.errors.push(`too many images: ${list.length} supplied, max ${MAX_IMAGES} — dropping the last ${list.length - MAX_IMAGES}`);
+    list = list.slice(0, MAX_IMAGES);
+  }
+
+  // 4. Read + validate each candidate.
+  for (const p of list) {
+    if (!isAbsolute(p)) { result.errors.push(`${p}: not an absolute path`); continue; }
+    if (!IMAGE_EXT_RE.test(p)) { result.errors.push(`${p}: unsupported extension (png/jpeg only)`); continue; }
+    let size: number;
+    try {
+      const st = statSync(p);
+      if (!st.isFile()) { result.errors.push(`${p}: not a regular file`); continue; }
+      size = st.size;
+    } catch {
+      result.errors.push(`${p}: file not found`);
+      continue;
+    }
+    if (size > MAX_IMAGE_BYTES) {
+      result.errors.push(`${p}: too large (${(size / 1024 / 1024).toFixed(1)} MB, max ${MAX_IMAGE_BYTES / 1024 / 1024} MB)`);
+      continue;
+    }
+    let buf: Buffer;
+    try {
+      buf = readFileSync(p);
+    } catch (e) {
+      result.errors.push(`${p}: read failed (${(e as Error).message})`);
+      continue;
+    }
+    const media = sniffImageMediaType(buf);
+    if (!media) { result.errors.push(`${p}: content is not valid PNG or JPEG`); continue; }
+    result.blocks.push({ type: 'image', data: buf.toString('base64'), mediaType: media });
+  }
+
+  for (const e of result.errors) _log(label, `attachment error — ${e}`);
+  return result;
+}
+
+/**
+ * Build the `content` for the initial user message from the task text and the
+ * resolved images. Returns a plain string when no image blocks resolved
+ * (byte-identical to the pre-feature behavior), otherwise a multimodal
+ * ContentBlock[] with the task text first. Per-image errors are appended to the
+ * text so a rejected attachment is visible in the agent's context / result
+ * rather than silently dropped.
+ */
+export function buildUserContent(task: string, resolved: ResolvedTaskImages): string | ContentBlock[] {
+  const errNote = resolved.errors.length > 0
+    ? `\n\n[image attachment errors]\n- ${resolved.errors.join('\n- ')}`
+    : '';
+  if (resolved.blocks.length === 0) {
+    return errNote ? task + errNote : task;
+  }
+  return [{ type: 'text', text: task + errNote }, ...resolved.blocks];
+}

--- a/packages/orchestrator/src/task-images.ts
+++ b/packages/orchestrator/src/task-images.ts
@@ -18,12 +18,40 @@
  * {@link MAX_IMAGE_BYTES}, PNG/JPEG only (extension + magic-byte sniff),
  * non-existent / unreadable paths surface a per-image error instead of being
  * silently dropped. Text-only providers ignore the field with a logged notice.
+ *
+ * ── Trust model (path policy) ────────────────────────────────────────────────
+ * Image paths are UNTRUSTED input: they arrive from the dispatch caller (the
+ * `images` field) or from free-form task prose (auto-detect). Two defenses apply:
+ *
+ *  1. Allowed-root confinement. When a `projectRoot` is supplied, every candidate
+ *     is `realpathSync`'d (canonicalized, symlinks followed) and MUST resolve
+ *     within that root (`realPath === realRoot || realPath.startsWith(realRoot + sep)`).
+ *     A path that escapes — via `..`, an absolute path elsewhere, or a symlink
+ *     pointing outside — is rejected with a per-image "path policy" error and is
+ *     never read. This mirrors the repo's own citation-root precedent
+ *     (dispatch-pipeline.ts spec-review enrichment + validate-resolution-root.ts):
+ *     realpath BOTH sides, then a `startsWith(root + sep)` prefix test. When
+ *     `projectRoot` is omitted the confinement check is skipped (legacy callers /
+ *     unit fixtures); production dispatch always threads it through from
+ *     `WorkerAgent.executeTask` → `resolveTaskImages`.
+ *
+ *  2. Capped, TOCTOU-resistant reads. A candidate is opened ONCE (`openSync`);
+ *     size, regular-file check, and the byte read all operate on that single file
+ *     descriptor (`fstatSync`/`readSync`), so a swap between stat and read cannot
+ *     smuggle a different or larger file. Reads are hard-capped at
+ *     {@link MAX_IMAGE_BYTES} (+1 sentinel byte) so an under-reporting `fstat`
+ *     can never cause an unbounded slurp — belt and suspenders.
+ *
+ * Log hygiene: `_log` lines hash candidate paths via {@link hashPath} so the MCP
+ * stderr log never records absolute filesystem paths. Full paths DO remain in the
+ * `errors[]` strings (surfaced in the operator-facing task context by design).
  */
 
-import { readFileSync, statSync } from 'fs';
-import { isAbsolute } from 'path';
+import { openSync, fstatSync, readSync, closeSync, realpathSync } from 'fs';
+import { isAbsolute, normalize, sep } from 'path';
 import { ContentBlock, ImageContent } from '@gossip/types';
 import { log as _log } from './log';
+import { hashPath } from './validate-resolution-root';
 
 /** Maximum number of images attached to a single dispatch. */
 export const MAX_IMAGES = 4;
@@ -66,6 +94,11 @@ function sniffImageMediaType(buf: Buffer): 'image/png' | 'image/jpeg' | null {
   return null;
 }
 
+/** True when `child` is `root` itself or lives beneath it (realpath'd, prefix test). */
+function isWithinRoot(child: string, root: string): boolean {
+  return child === root || child.startsWith(root + sep);
+}
+
 export interface ResolvedTaskImages {
   /** Successfully-read images, ready to drop into a multimodal message. */
   blocks: ImageContent[];
@@ -88,8 +121,14 @@ export function detectImagePathsInText(task: string): string[] {
   const matches = task.match(IMAGE_PATH_RE) ?? [];
   for (const raw of matches) {
     // Trim bracket/quote punctuation that commonly abuts a path in prose — the
-    // \S+ match greedily swallows a leading "(" and trailing ")." etc.
-    const m = raw.replace(/^[([{<'"]+/, '').replace(/[)\]}>.,;:'"]+$/, '');
+    // \S+ match greedily swallows a leading "(" etc.
+    //
+    // NOTE: only a LEADING-punctuation trim is needed. IMAGE_PATH_RE ends in
+    // `\b` immediately after the png/jpg/jpeg run, and those are all word chars,
+    // so a raw match ALWAYS ends on the extension — trailing punctuation (")",
+    // ".", ",", …) is outside the match by construction. A trailing-trim would
+    // be dead code; do not add one back.
+    const m = raw.replace(/^[([{<'"]+/, '');
     if (!isAbsolute(m)) continue;
     if (!IMAGE_EXT_RE.test(m)) continue;
     if (seen.has(m)) continue;
@@ -104,16 +143,28 @@ export function detectImagePathsInText(task: string): string[] {
  * otherwise up to {@link MAX_IMAGES} absolute paths are auto-detected from the
  * task text. Applies all guardrails and returns base64 image blocks plus any
  * per-image errors / notices.
+ *
+ * `projectRoot` — when supplied, confines every image to that realpath'd root
+ * (see the module trust-model docstring). Omit only for legacy callers / fixtures.
  */
 export function resolveTaskImages(opts: {
   task: string;
   images?: string[];
   provider?: string;
+  projectRoot?: string;
   logLabel?: string;
 }): ResolvedTaskImages {
-  const { task, images, provider } = opts;
+  const { task, images, provider, projectRoot } = opts;
   const label = opts.logLabel ?? 'task-images';
   const result: ResolvedTaskImages = { blocks: [], errors: [], notices: [], autoDetected: false };
+
+  // Push a per-image error AND emit a path-HASHED log line. Full paths stay in
+  // result.errors (operator-facing task context) but never reach _log.
+  const addError = (userMsg: string, logMsg?: string): void => {
+    result.errors.push(userMsg);
+    _log(label, `attachment error — ${logMsg ?? userMsg}`);
+  };
+  const pathError = (p: string, reason: string): void => addError(`${p}: ${reason}`, `${hashPath(p)}: ${reason}`);
 
   // 1. Candidate paths — explicit field wins; else auto-detect from task text.
   let candidates: string[];
@@ -122,6 +173,21 @@ export function resolveTaskImages(opts: {
   } else {
     candidates = detectImagePathsInText(task);
     result.autoDetected = candidates.length > 0;
+  }
+
+  // 1b. Normalize + de-dup BOTH sources before the count cap so the same file
+  // cited two ways (e.g. /a//b.png vs /a/b.png, or repeated in the explicit
+  // field) counts once and does not burn a MAX_IMAGES slot twice.
+  {
+    const seen = new Set<string>();
+    const deduped: string[] = [];
+    for (const c of candidates) {
+      const n = normalize(c);
+      if (seen.has(n)) continue;
+      seen.add(n);
+      deduped.push(n);
+    }
+    candidates = deduped;
   }
   if (candidates.length === 0) return result;
 
@@ -133,43 +199,85 @@ export function resolveTaskImages(opts: {
     return result;
   }
 
+  // 2b. Resolve the confinement root once (realpath'd). If projectRoot is given
+  // but unresolvable, the policy can't be enforced — note it and proceed without
+  // confinement rather than reject-all on a misconfiguration.
+  let realRoot: string | undefined;
+  if (projectRoot) {
+    try {
+      realRoot = realpathSync(projectRoot);
+    } catch {
+      const notice = `image path policy disabled: project root "${projectRoot}" did not resolve`;
+      result.notices.push(notice);
+      _log(label, `${notice} (${hashPath(projectRoot)})`);
+    }
+  }
+
   // 3. Enforce the count cap — reject the overflow loudly, don't silently truncate.
   let list = candidates;
   if (list.length > MAX_IMAGES) {
-    result.errors.push(`too many images: ${list.length} supplied, max ${MAX_IMAGES} — dropping the last ${list.length - MAX_IMAGES}`);
+    // No single path in this message → nothing to hash; log as-is.
+    addError(`too many images: ${list.length} supplied, max ${MAX_IMAGES} — dropping the last ${list.length - MAX_IMAGES}`);
     list = list.slice(0, MAX_IMAGES);
   }
 
-  // 4. Read + validate each candidate.
+  // 4. Read + validate each candidate through a single file descriptor.
   for (const p of list) {
-    if (!isAbsolute(p)) { result.errors.push(`${p}: not an absolute path`); continue; }
-    if (!IMAGE_EXT_RE.test(p)) { result.errors.push(`${p}: unsupported extension (png/jpeg only)`); continue; }
-    let size: number;
+    if (!isAbsolute(p)) { pathError(p, 'not an absolute path'); continue; }
+    if (!IMAGE_EXT_RE.test(p)) { pathError(p, 'unsupported extension (png/jpeg only)'); continue; }
+
+    // Canonicalize (also proves existence). realpathSync throws on a missing path.
+    let realPath: string;
     try {
-      const st = statSync(p);
-      if (!st.isFile()) { result.errors.push(`${p}: not a regular file`); continue; }
-      size = st.size;
+      realPath = realpathSync(p);
     } catch {
-      result.errors.push(`${p}: file not found`);
+      pathError(p, 'file not found');
       continue;
     }
-    if (size > MAX_IMAGE_BYTES) {
-      result.errors.push(`${p}: too large (${(size / 1024 / 1024).toFixed(1)} MB, max ${MAX_IMAGE_BYTES / 1024 / 1024} MB)`);
+
+    // Allowed-root confinement (path policy). Rejected paths are never opened.
+    if (realRoot && !isWithinRoot(realPath, realRoot)) {
+      pathError(p, `resolves outside the allowed project root — image attachments must stay within ${realRoot} (path policy)`);
       continue;
     }
-    let buf: Buffer;
+
+    // fd-based capped read: open once; stat + read the SAME descriptor so a
+    // stat→read swap can't smuggle a different/larger file (TOCTOU), and the
+    // read is hard-capped so an under-reporting fstat can't cause a huge slurp.
+    let fd: number | undefined;
     try {
-      buf = readFileSync(p);
+      fd = openSync(realPath, 'r');
+      const st = fstatSync(fd);
+      if (!st.isFile()) { pathError(p, 'not a regular file'); continue; }
+      if (st.size > MAX_IMAGE_BYTES) {
+        pathError(p, `too large (${(st.size / 1024 / 1024).toFixed(1)} MB, max ${MAX_IMAGE_BYTES / 1024 / 1024} MB)`);
+        continue;
+      }
+      // Read at most MAX_IMAGE_BYTES + 1 bytes. The +1 sentinel lets us detect a
+      // file that is actually over-cap even if fstat under-reported its size.
+      const buf = Buffer.allocUnsafe(MAX_IMAGE_BYTES + 1);
+      let bytesRead = 0;
+      while (bytesRead <= MAX_IMAGE_BYTES) {
+        const n = readSync(fd, buf, bytesRead, (MAX_IMAGE_BYTES + 1) - bytesRead, null);
+        if (n === 0) break; // EOF
+        bytesRead += n;
+      }
+      if (bytesRead > MAX_IMAGE_BYTES) {
+        pathError(p, `too large (exceeds ${MAX_IMAGE_BYTES / 1024 / 1024} MB read cap)`);
+        continue;
+      }
+      const image = buf.subarray(0, bytesRead);
+      const media = sniffImageMediaType(image);
+      if (!media) { pathError(p, 'content is not valid PNG or JPEG'); continue; }
+      result.blocks.push({ type: 'image', data: image.toString('base64'), mediaType: media });
     } catch (e) {
-      result.errors.push(`${p}: read failed (${(e as Error).message})`);
+      pathError(p, `read failed (${(e as Error).message})`);
       continue;
+    } finally {
+      if (fd !== undefined) closeSync(fd);
     }
-    const media = sniffImageMediaType(buf);
-    if (!media) { result.errors.push(`${p}: content is not valid PNG or JPEG`); continue; }
-    result.blocks.push({ type: 'image', data: buf.toString('base64'), mediaType: media });
   }
 
-  for (const e of result.errors) _log(label, `attachment error — ${e}`);
   return result;
 }
 
@@ -177,12 +285,19 @@ export function resolveTaskImages(opts: {
  * Build the `content` for the initial user message from the task text and the
  * resolved images. Returns a plain string when no image blocks resolved
  * (byte-identical to the pre-feature behavior), otherwise a multimodal
- * ContentBlock[] with the task text first. Per-image errors are appended to the
- * text so a rejected attachment is visible in the agent's context / result
- * rather than silently dropped.
+ * ContentBlock[] with the task text first.
+ *
+ * Error-surfacing rule: per-image errors are appended to the prompt ONLY when the
+ * candidates came from an EXPLICIT `images` field — the caller asked for those
+ * attachments, so a rejection is worth surfacing in-context. AUTO-DETECTED
+ * failures are log-only: a path-shaped token in pure prose that fails to resolve
+ * must NOT mutate the prompt, or a plain text-only task stops being byte-identical
+ * to the pre-feature behavior. (Auto-detect errors still live in `resolved.errors`
+ * and are logged; they just don't splice into the message.)
  */
 export function buildUserContent(task: string, resolved: ResolvedTaskImages): string | ContentBlock[] {
-  const errNote = resolved.errors.length > 0
+  const surfaceErrors = resolved.errors.length > 0 && !resolved.autoDetected;
+  const errNote = surfaceErrors
     ? `\n\n[image attachment errors]\n- ${resolved.errors.join('\n- ')}`
     : '';
   if (resolved.blocks.length === 0) {

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -206,6 +206,15 @@ export interface DispatchOptions {
    * Spec: docs/specs/2026-04-29-relay-worker-resolution-roots.md (Path 1).
    */
   resolutionRoots?: readonly string[];
+  /**
+   * Local absolute image file paths (PNG/JPEG) to attach to the initial user
+   * message for vision-capable relay providers. Read + base64-encoded + guarded
+   * (max 4 images, ≤4 MB each, magic-byte sniff) by the worker via
+   * `resolveTaskImages`. Non-vision providers ignore the field with a notice.
+   * When omitted, the worker auto-detects up to 4 absolute PNG/JPEG paths from
+   * the task text. See task-images.ts.
+   */
+  images?: string[];
 }
 
 /** Result of analyzing skill overlap between co-dispatched agents */

--- a/packages/orchestrator/src/worker-agent.ts
+++ b/packages/orchestrator/src/worker-agent.ts
@@ -11,6 +11,7 @@ import { GossipAgent } from '@gossip/client';
 import { MessageType, MessageEnvelope, Message, ToolDefinition, LLMMessage } from '@gossip/types';
 import { encode as msgpackEncode } from '@msgpack/msgpack';
 import { ILLMProvider, PROVIDER_PLACEHOLDER_RE } from './llm-client';
+import { resolveTaskImages, buildUserContent } from './task-images';
 import {
   TaskStreamEvent,
   TaskStreamEventType,
@@ -149,6 +150,13 @@ export class WorkerAgent {
     webSearch?: boolean,
     apiKey?: string,
     maxToolTurns?: number,
+    /**
+     * Provider slug for THIS worker's LLM (anthropic / openai / google / …).
+     * Used only to decide image-attachment vision capability in executeTask
+     * (see task-images.ts). Optional — when omitted, image attachments are
+     * treated as non-vision-capable and ignored with a notice.
+     */
+    private readonly providerName?: string,
   ) {
     this.webSearchEnabled = webSearch ?? false;
     this.maxToolTurns = maxToolTurns ?? MAX_TOOL_TURNS;
@@ -208,7 +216,7 @@ export class WorkerAgent {
    * Execute a task with the LLM, using multi-turn tool calling.
    * Returns the final text response.
    */
-  async *executeTask(task: string, context?: string, skillsContent?: string, taskId?: string): AsyncGenerator<TaskStreamEvent, void, undefined> {
+  async *executeTask(task: string, context?: string, skillsContent?: string, taskId?: string, images?: string[]): AsyncGenerator<TaskStreamEvent, void, undefined> {
     const logAndYield = (message: string): TaskStreamEvent => {
         log(this.agentId, message);
         return { type: TaskStreamEventType.LOG, payload: message, timestamp: Date.now() };
@@ -216,6 +224,22 @@ export class WorkerAgent {
 
     yield logAndYield(`executeTask started — task: "${task.slice(0, 100)}..." webSearch=${this.webSearchEnabled} tools=${this.tools.length}`);
     this.gossipQueue = []; // clear gossip from previous task
+
+    // Resolve any image attachments (explicit `images` field or auto-detected
+    // absolute PNG/JPEG paths in the task text) into base64 blocks the provider
+    // client renders onto the API's multimodal shape. Non-vision providers get
+    // a notice and the plain-text message. See task-images.ts.
+    const resolvedImages = resolveTaskImages({
+      task,
+      images,
+      provider: this.providerName,
+      logLabel: `worker:${this.agentId}`,
+    });
+    if (resolvedImages.blocks.length > 0) {
+      yield logAndYield(`attached ${resolvedImages.blocks.length} image(s)${resolvedImages.autoDetected ? ' (auto-detected from task text)' : ''}`);
+    }
+    for (const n of resolvedImages.notices) yield logAndYield(n);
+    for (const e of resolvedImages.errors) yield logAndYield(`image attachment error: ${e}`);
     this.toolCallBudget = new Map(); // reset per-tool call budgets per task
     this.memoryQueryCalled = false; // reset memory_query tracking per task
     const startTime = Date.now();
@@ -253,7 +277,7 @@ export class WorkerAgent {
 
 10. **Update your memory.** If the AGENT MEMORY section is present above, save what you learned: tech stack, file structure, patterns, gotchas. Use file_write to your memory directory. This helps you on future tasks.`,
       },
-      { role: 'user', content: task },
+      { role: 'user', content: buildUserContent(task, resolvedImages) },
     ];
 
     try {

--- a/packages/orchestrator/src/worker-agent.ts
+++ b/packages/orchestrator/src/worker-agent.ts
@@ -216,7 +216,7 @@ export class WorkerAgent {
    * Execute a task with the LLM, using multi-turn tool calling.
    * Returns the final text response.
    */
-  async *executeTask(task: string, context?: string, skillsContent?: string, taskId?: string, images?: string[]): AsyncGenerator<TaskStreamEvent, void, undefined> {
+  async *executeTask(task: string, context?: string, skillsContent?: string, taskId?: string, images?: string[], projectRoot?: string): AsyncGenerator<TaskStreamEvent, void, undefined> {
     const logAndYield = (message: string): TaskStreamEvent => {
         log(this.agentId, message);
         return { type: TaskStreamEventType.LOG, payload: message, timestamp: Date.now() };
@@ -233,6 +233,7 @@ export class WorkerAgent {
       task,
       images,
       provider: this.providerName,
+      projectRoot,
       logLabel: `worker:${this.agentId}`,
     });
     if (resolvedImages.blocks.length > 0) {

--- a/tests/cli/dispatch-native-prompt.test.ts
+++ b/tests/cli/dispatch-native-prompt.test.ts
@@ -1014,3 +1014,66 @@ describe('native dispatch — git-downgrade warning text (issue #538 item 2)', (
     expect(banner).not.toContain('isolation: "worktree"');
   });
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// Finding #6 (relay-image consensus round): images passed to a NATIVE agent
+// must produce an explicit "images are relay-only" notice — never a silent drop
+// (gossipcat has no native multimodal path). Covers single / parallel / consensus.
+// ────────────────────────────────────────────────────────────────────────────
+describe('native dispatch — image drop notice (relay-only, no silent drop)', () => {
+  let testDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    testDir = mkdtempSync(join(tmpdir(), 'gossip-native-imgdrop-'));
+    mkdirSync(join(testDir, '.gossip', 'skills'), { recursive: true });
+    process.chdir(testDir);
+    resetCtx({ generateLensesForAgents: jest.fn().mockResolvedValue(new Map()) });
+    ctx.nativeAgentConfigs.set('native-claude', {
+      model: 'claude-sonnet-4-6',
+      instructions: 'You are a reviewer.',
+      description: 'Native reviewer',
+      skills: [],
+    });
+  });
+
+  afterEach(() => {
+    restoreCtx();
+    process.chdir(prevCwd);
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('handleDispatchSingle surfaces the notice when images are passed to a native agent', async () => {
+    const result = await handleDispatchSingle(
+      'native-claude', 'Critique this screenshot',
+      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+      ['/abs/a.png', '/abs/b.png'],
+    );
+    const banner = result.content[0].text;
+    expect(banner).toContain('images are relay-only');
+    expect(banner).toContain('native agent native-claude did not receive 2 image(s)');
+  });
+
+  it('handleDispatchSingle emits NO notice when no images are passed', async () => {
+    const result = await handleDispatchSingle('native-claude', 'Critique the design');
+    expect(result.content[0].text).not.toContain('images are relay-only');
+  });
+
+  it('handleDispatchParallel surfaces the notice per native task carrying images', async () => {
+    const result = await handleDispatchParallel(
+      [{ agent_id: 'native-claude', task: 'Audit A', images: ['/abs/a.png'] }],
+      false,
+    );
+    expect(result.content[0].text).toContain('images are relay-only');
+    expect(result.content[0].text).toContain('did not receive 1 image(s)');
+  });
+
+  it('handleDispatchConsensus surfaces the notice for a native task carrying images', async () => {
+    const result = await handleDispatchConsensus([
+      { agent_id: 'native-claude', task: 'Audit memory', images: ['/abs/a.png', '/abs/b.png', '/abs/c.png'] },
+    ]);
+    expect(result.content[0].text).toContain('images are relay-only');
+    expect(result.content[0].text).toContain('did not receive 3 image(s)');
+  });
+});

--- a/tests/orchestrator/relay-image-attachments.test.ts
+++ b/tests/orchestrator/relay-image-attachments.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import { OpenAIProvider, GeminiProvider, AnthropicProvider } from '../../packages/orchestrator/src/llm-client';
 import { LLMMessage } from '../../packages/types/src/tools';
 
@@ -26,14 +27,14 @@ const imageMessage: LLMMessage = {
 
 function captureBody(responseJson: unknown): { getBody: () => any } {
   let captured: any;
-  global.fetch = jest.fn(async (_url: any, init?: RequestInit) => {
+  global.fetch = vi.fn(async (_url: any, init?: RequestInit) => {
     captured = JSON.parse(init!.body as string);
     return new Response(JSON.stringify(responseJson), { status: 200, headers: { 'Content-Type': 'application/json' } });
   }) as any;
   return { getBody: () => captured };
 }
 
-afterEach(() => { jest.restoreAllMocks(); });
+afterEach(() => { vi.restoreAllMocks(); });
 
 describe('relay image attachments — provider wire-format construction', () => {
   it('OpenAI: image block → { type:"image_url", image_url:{ url:"data:image/png;base64,..." } }', async () => {

--- a/tests/orchestrator/relay-image-attachments.test.ts
+++ b/tests/orchestrator/relay-image-attachments.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import { OpenAIProvider, GeminiProvider, AnthropicProvider } from '../../packages/orchestrator/src/llm-client';
 import { LLMMessage } from '../../packages/types/src/tools';
 
@@ -27,14 +26,14 @@ const imageMessage: LLMMessage = {
 
 function captureBody(responseJson: unknown): { getBody: () => any } {
   let captured: any;
-  global.fetch = vi.fn(async (_url: any, init?: RequestInit) => {
+  global.fetch = jest.fn(async (_url: any, init?: RequestInit) => {
     captured = JSON.parse(init!.body as string);
     return new Response(JSON.stringify(responseJson), { status: 200, headers: { 'Content-Type': 'application/json' } });
   }) as any;
   return { getBody: () => captured };
 }
 
-afterEach(() => { vi.restoreAllMocks(); });
+afterEach(() => { jest.restoreAllMocks(); });
 
 describe('relay image attachments — provider wire-format construction', () => {
   it('OpenAI: image block → { type:"image_url", image_url:{ url:"data:image/png;base64,..." } }', async () => {

--- a/tests/orchestrator/relay-image-attachments.test.ts
+++ b/tests/orchestrator/relay-image-attachments.test.ts
@@ -1,0 +1,75 @@
+import { OpenAIProvider, GeminiProvider, AnthropicProvider } from '../../packages/orchestrator/src/llm-client';
+import { LLMMessage } from '../../packages/types/src/tools';
+
+/**
+ * Verifies that when a multimodal message (text + base64 image block) is passed
+ * to a provider client, the outgoing HTTP request carries the image as a proper,
+ * provider-specific content part:
+ *   - OpenAI chat/completions → content[] with { type:'image_url', image_url:{ url:'data:...' } }
+ *   - Gemini generateContent  → parts[] with { inlineData: { mimeType, data } }
+ *   - Anthropic messages       → content[] with { type:'image', source:{ type:'base64', ... } }
+ *
+ * This is the seam that carries `resolveTaskImages` output (ImageContent blocks)
+ * onto the wire — the piece that was previously never exercised because the
+ * relay only ever sent a plain-string task.
+ */
+
+const B64 = Buffer.from('fake-png-bytes').toString('base64');
+
+const imageMessage: LLMMessage = {
+  role: 'user',
+  content: [
+    { type: 'text', text: 'Describe this screenshot.' },
+    { type: 'image', data: B64, mediaType: 'image/png' },
+  ],
+};
+
+function captureBody(responseJson: unknown): { getBody: () => any } {
+  let captured: any;
+  global.fetch = jest.fn(async (_url: any, init?: RequestInit) => {
+    captured = JSON.parse(init!.body as string);
+    return new Response(JSON.stringify(responseJson), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }) as any;
+  return { getBody: () => captured };
+}
+
+afterEach(() => { jest.restoreAllMocks(); });
+
+describe('relay image attachments — provider wire-format construction', () => {
+  it('OpenAI: image block → { type:"image_url", image_url:{ url:"data:image/png;base64,..." } }', async () => {
+    const cap = captureBody({ choices: [{ message: { content: 'ok' } }], usage: { prompt_tokens: 1, completion_tokens: 1 } });
+    const p = new OpenAIProvider('sk-test', 'gpt-5.2');
+    await p.generate([imageMessage]);
+    const body = cap.getBody();
+    const parts = body.messages[0].content;
+    expect(Array.isArray(parts)).toBe(true);
+    expect(parts[0]).toEqual({ type: 'text', text: 'Describe this screenshot.' });
+    expect(parts[1]).toEqual({ type: 'image_url', image_url: { url: `data:image/png;base64,${B64}` } });
+  });
+
+  it('Gemini: image block → parts[] { inlineData: { mimeType, data } }', async () => {
+    const cap = captureBody({ candidates: [{ content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' }], usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 } });
+    const p = new GeminiProvider('ai-test', 'gemini-3.1-pro');
+    await p.generate([imageMessage]);
+    const body = cap.getBody();
+    const parts = body.contents[0].parts;
+    expect(parts[0]).toEqual({ text: 'Describe this screenshot.' });
+    expect(parts[1]).toEqual({ inlineData: { mimeType: 'image/png', data: B64 } });
+  });
+
+  it('Anthropic: image block → content[] { type:"image", source:{ type:"base64", media_type, data } }', async () => {
+    const cap = captureBody({ content: [{ type: 'text', text: 'ok' }], usage: { input_tokens: 1, output_tokens: 1 } });
+    const p = new AnthropicProvider('sk-ant-test', 'claude-opus-4-6');
+    await p.generate([imageMessage]);
+    const body = cap.getBody();
+    const parts = body.messages[0].content;
+    expect(parts[1]).toEqual({ type: 'image', source: { type: 'base64', media_type: 'image/png', data: B64 } });
+  });
+
+  it('plain-string message is unchanged on the wire (no multimodal regression)', async () => {
+    const cap = captureBody({ choices: [{ message: { content: 'ok' } }] });
+    const p = new OpenAIProvider('sk-test', 'gpt-5.2');
+    await p.generate([{ role: 'user', content: 'just text' }]);
+    expect(cap.getBody().messages[0].content).toBe('just text');
+  });
+});

--- a/tests/orchestrator/task-images.test.ts
+++ b/tests/orchestrator/task-images.test.ts
@@ -1,4 +1,15 @@
-import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+// Mock 'fs' by spreading the real module and wrapping fstatSync in a jest.fn so
+// it becomes configurable (Node's real fs.fstatSync is non-configurable, so
+// jest.spyOn cannot redefine it). Everything else delegates to the real fs, so
+// file I/O in these tests is genuine; only fstatSync is overridable per-call
+// (used to simulate an under-reporting fstat for the read-cap belt test).
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return { ...actual, fstatSync: jest.fn(actual.fstatSync) };
+});
+
+import * as fs from 'fs';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, symlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
@@ -47,8 +58,12 @@ describe('task-images — image attachment resolution for relay dispatch', () =>
       const text = '/a/b.png then again /a/b.png and /c/d.png';
       expect(detectImagePathsInText(text)).toEqual(['/a/b.png', '/c/d.png']);
     });
-    it('strips trailing punctuation abutting a path', () => {
+    it('strips leading bracket/quote punctuation abutting a path (trailing handled by \\b)', () => {
+      // The regex ends in `\b` right after the extension, so the raw match never
+      // includes trailing punctuation — only a leading trim is needed.
       expect(detectImagePathsInText('look at (/a/b.png).')).toEqual(['/a/b.png']);
+      expect(detectImagePathsInText('see "/x/y.jpeg", then')).toEqual(['/x/y.jpeg']);
+      expect(detectImagePathsInText('[/p/q.jpg];')).toEqual(['/p/q.jpg']);
     });
   });
 
@@ -157,7 +172,7 @@ describe('task-images — image attachment resolution for relay dispatch', () =>
       expect((arr[0] as TextContent).text).toContain('describe');
       expect(arr[1].type).toBe('image');
     });
-    it('surfaces per-image errors in the text even when a valid image is present', () => {
+    it('surfaces EXPLICIT per-image errors in the text even when a valid image is present', () => {
       const good = mk('good.png', PNG_MAGIC);
       const content = buildUserContent(
         'task',
@@ -166,11 +181,149 @@ describe('task-images — image attachment resolution for relay dispatch', () =>
       expect((content[0] as TextContent).text).toMatch(/image attachment errors/);
       expect((content[0] as TextContent).text).toMatch(/file not found/);
     });
-    it('surfaces errors as a plain string when NO image resolved (all rejected)', () => {
+    it('surfaces EXPLICIT errors as a plain string when NO image resolved (all rejected)', () => {
       const r = resolveTaskImages({ task: 'task', images: ['/nope/x.png'], provider: 'openai' });
       const content = buildUserContent('task', r);
       expect(typeof content).toBe('string');
       expect(content as string).toMatch(/image attachment errors/);
+    });
+    it('does NOT surface AUTO-DETECTED errors in the prompt — byte-identical prose task', () => {
+      // A path-shaped token in prose that fails to resolve is auto-detect, not an
+      // explicit request. The prompt must stay byte-identical (log-only errors).
+      const task = 'Investigate /nope/ghost.png and report back';
+      const r = resolveTaskImages({ task, provider: 'openai' });
+      expect(r.autoDetected).toBe(true);
+      expect(r.errors.some(e => /file not found/.test(e))).toBe(true);
+      const content = buildUserContent(task, r);
+      expect(typeof content).toBe('string');
+      expect(content).toBe(task); // byte-identical
+      expect(content as string).not.toMatch(/image attachment errors/);
+    });
+    it('does NOT surface AUTO-DETECTED errors even when a valid image is present', () => {
+      const good = mk('good.png', PNG_MAGIC);
+      const task = `Compare ${good} with /nope/missing.png`;
+      const r = resolveTaskImages({ task, provider: 'openai' });
+      expect(r.autoDetected).toBe(true);
+      const content = buildUserContent(task, r) as Array<TextContent | ImageContent>;
+      expect((content[0] as TextContent).text).toBe(task);
+      expect((content[0] as TextContent).text).not.toMatch(/image attachment errors/);
+      expect(content[1].type).toBe('image');
+    });
+  });
+
+  describe('capped / TOCTOU-resistant read', () => {
+    afterEach(() => (fs.fstatSync as jest.Mock).mockClear());
+    it('rejects when bytes read exceed the cap even if fstat under-reports (belt-and-suspenders)', () => {
+      // Real file is > cap, but a lying fstat reports it small so the size gate
+      // passes. The capped read must still detect the over-cap file.
+      const over = Buffer.concat([PNG_MAGIC, Buffer.alloc(MAX_IMAGE_BYTES + 8 - PNG_MAGIC.length, 0)]);
+      const p = mk('lying.png', over);
+      (fs.fstatSync as jest.Mock).mockReturnValueOnce({ isFile: () => true, size: 128 });
+      const r = resolveTaskImages({ task: 't', images: [p], provider: 'openai' });
+      expect(r.blocks).toEqual([]);
+      expect(r.errors[0]).toMatch(/read cap/);
+    });
+    it('accepts a file exactly at the cap boundary', () => {
+      const atCap = Buffer.concat([PNG_MAGIC, Buffer.alloc(MAX_IMAGE_BYTES - PNG_MAGIC.length, 0)]);
+      const p = mk('atcap.png', atCap);
+      const r = resolveTaskImages({ task: 't', images: [p], provider: 'openai' });
+      expect(r.errors).toEqual([]);
+      expect(r.blocks).toHaveLength(1);
+    });
+  });
+
+  describe('allowed-root confinement (path policy)', () => {
+    it('accepts an image that resolves within projectRoot', () => {
+      const good = mk('inroot.png', PNG_MAGIC);
+      const r = resolveTaskImages({ task: 't', images: [good], provider: 'openai', projectRoot: dir });
+      expect(r.errors).toEqual([]);
+      expect(r.blocks).toHaveLength(1);
+    });
+    it('rejects an image that resolves OUTSIDE projectRoot (sibling dir)', () => {
+      const outside = mkdtempSync(join(tmpdir(), 'task-images-outside-'));
+      try {
+        const evil = join(outside, 'evil.png');
+        writeFileSync(evil, PNG_MAGIC);
+        const r = resolveTaskImages({ task: 't', images: [evil], provider: 'openai', projectRoot: dir });
+        expect(r.blocks).toEqual([]);
+        expect(r.errors[0]).toMatch(/path policy/);
+        expect(r.errors[0]).toMatch(/outside the allowed project root/);
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
+    });
+    it('rejects a `..` traversal escape out of projectRoot', () => {
+      const outside = mkdtempSync(join(tmpdir(), 'task-images-outside-'));
+      try {
+        writeFileSync(join(outside, 'escape.png'), PNG_MAGIC);
+        // sub/../../<outside>/escape.png style escape via an explicit relative-ish
+        // absolute path that normalizes out of the root.
+        const sub = join(dir, 'sub');
+        mkdirSync(sub);
+        const escape = join(sub, '..', '..', outside.split('/').pop()!, 'escape.png');
+        const r = resolveTaskImages({ task: 't', images: [escape], provider: 'openai', projectRoot: dir });
+        expect(r.blocks).toEqual([]);
+        expect(r.errors[0]).toMatch(/path policy/);
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
+    });
+    it('rejects a symlink inside the root that points OUTSIDE it', () => {
+      const outside = mkdtempSync(join(tmpdir(), 'task-images-outside-'));
+      try {
+        const target = join(outside, 'real.png');
+        writeFileSync(target, PNG_MAGIC);
+        const link = join(dir, 'link.png');
+        symlinkSync(target, link);
+        const r = resolveTaskImages({ task: 't', images: [link], provider: 'openai', projectRoot: dir });
+        expect(r.blocks).toEqual([]);
+        expect(r.errors[0]).toMatch(/path policy/);
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
+    });
+    it('skips the policy (no rejection) when projectRoot is omitted — legacy callers', () => {
+      const outside = mkdtempSync(join(tmpdir(), 'task-images-outside-'));
+      try {
+        const p = join(outside, 'x.png');
+        writeFileSync(p, PNG_MAGIC);
+        const r = resolveTaskImages({ task: 't', images: [p], provider: 'openai' });
+        expect(r.errors).toEqual([]);
+        expect(r.blocks).toHaveLength(1);
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('dedup — both explicit and auto-detect sources', () => {
+    it('de-dups a repeated explicit path (counts once)', () => {
+      const p = mk('dup.png', PNG_MAGIC);
+      const r = resolveTaskImages({ task: 't', images: [p, p], provider: 'openai' });
+      expect(r.blocks).toHaveLength(1);
+    });
+    it('normalizes before de-dup (/a//b.png === /a/b.png) so cap is not double-charged', () => {
+      const p = mk('norm.png', PNG_MAGIC);
+      const doubled = p.replace('/norm.png', '//norm.png'); // extra slash, same file
+      const r = resolveTaskImages({ task: 't', images: [p, doubled], provider: 'openai' });
+      expect(r.blocks).toHaveLength(1);
+    });
+  });
+
+  describe('log hygiene — hashed paths in _log output', () => {
+    it('never writes a raw absolute path to _log; uses hashPath (sha256:) instead', () => {
+      const spy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      try {
+        const secret = '/nope/super-secret-dir/leak-me.png';
+        resolveTaskImages({ task: 't', images: [secret], provider: 'openai' });
+        const logged = spy.mock.calls.map(c => String(c[0])).join('');
+        expect(logged).toContain('attachment error');
+        expect(logged).toContain('sha256:');       // hashed
+        expect(logged).not.toContain(secret);      // raw path never logged
+        expect(logged).not.toContain('leak-me');   // no path fragment either
+      } finally {
+        spy.mockRestore();
+      }
     });
   });
 });

--- a/tests/orchestrator/task-images.test.ts
+++ b/tests/orchestrator/task-images.test.ts
@@ -1,0 +1,176 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  resolveTaskImages,
+  buildUserContent,
+  detectImagePathsInText,
+  providerSupportsVision,
+  MAX_IMAGES,
+  MAX_IMAGE_BYTES,
+} from '../../packages/orchestrator/src/task-images';
+import { ImageContent, TextContent } from '../../packages/types/src/tools';
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const JPEG_MAGIC = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+
+describe('task-images — image attachment resolution for relay dispatch', () => {
+  let dir: string;
+  const mk = (name: string, body: Buffer): string => {
+    const p = join(dir, name);
+    writeFileSync(p, body);
+    return p;
+  };
+
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'task-images-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  describe('providerSupportsVision', () => {
+    it.each(['openai', 'google', 'anthropic', 'grok', 'local'])('is true for vision provider %s', (p) => {
+      expect(providerSupportsVision(p)).toBe(true);
+    });
+    it.each(['deepseek', 'openclaw', 'none', undefined, ''])('is false for text-only / unknown provider %s', (p) => {
+      expect(providerSupportsVision(p as any)).toBe(false);
+    });
+  });
+
+  describe('detectImagePathsInText (auto-detect regex)', () => {
+    it('extracts absolute png/jpg/jpeg paths from prose', () => {
+      const text = 'Compare /a/b/shot.png with /x/y/before.jpeg and /p/q/after.jpg please';
+      expect(detectImagePathsInText(text)).toEqual(['/a/b/shot.png', '/x/y/before.jpeg', '/p/q/after.jpg']);
+    });
+    it('ignores relative paths and non-image extensions', () => {
+      const text = 'see ./local.png and notes.txt and /abs/doc.pdf';
+      expect(detectImagePathsInText(text)).toEqual([]);
+    });
+    it('de-duplicates repeated paths, first-seen order', () => {
+      const text = '/a/b.png then again /a/b.png and /c/d.png';
+      expect(detectImagePathsInText(text)).toEqual(['/a/b.png', '/c/d.png']);
+    });
+    it('strips trailing punctuation abutting a path', () => {
+      expect(detectImagePathsInText('look at (/a/b.png).')).toEqual(['/a/b.png']);
+    });
+  });
+
+  describe('base64 block construction', () => {
+    it('reads a PNG and produces an image/png base64 block', () => {
+      const p = mk('a.png', Buffer.concat([PNG_MAGIC, Buffer.from('rest')]));
+      const r = resolveTaskImages({ task: 't', images: [p], provider: 'openai' });
+      expect(r.errors).toEqual([]);
+      expect(r.blocks).toHaveLength(1);
+      expect(r.blocks[0]).toEqual<ImageContent>({
+        type: 'image',
+        mediaType: 'image/png',
+        data: Buffer.concat([PNG_MAGIC, Buffer.from('rest')]).toString('base64'),
+      });
+    });
+    it('reads a JPEG (.jpg) and produces an image/jpeg base64 block', () => {
+      const p = mk('a.jpg', Buffer.concat([JPEG_MAGIC, Buffer.from('body')]));
+      const r = resolveTaskImages({ task: 't', images: [p], provider: 'google' });
+      expect(r.errors).toEqual([]);
+      expect(r.blocks[0].mediaType).toBe('image/jpeg');
+    });
+  });
+
+  describe('auto-detect from task text when no explicit images field', () => {
+    it('attaches an absolute path found in the task text', () => {
+      const p = mk('shot.png', PNG_MAGIC);
+      const r = resolveTaskImages({ task: `Look at ${p} and describe it`, provider: 'openai' });
+      expect(r.autoDetected).toBe(true);
+      expect(r.blocks).toHaveLength(1);
+    });
+    it('explicit images field wins over text auto-detect', () => {
+      const inText = mk('intext.png', PNG_MAGIC);
+      const explicit = mk('explicit.png', PNG_MAGIC);
+      const r = resolveTaskImages({ task: `mentions ${inText}`, images: [explicit], provider: 'openai' });
+      expect(r.autoDetected).toBe(false);
+      expect(r.blocks).toHaveLength(1);
+      // explicit file content is identical here; assert it did NOT auto-detect a 2nd
+      expect(r.blocks).toHaveLength(1);
+    });
+  });
+
+  describe('guardrails', () => {
+    it('non-existent path → per-image error, not a silent drop', () => {
+      const r = resolveTaskImages({ task: 't', images: ['/nope/missing.png'], provider: 'openai' });
+      expect(r.blocks).toEqual([]);
+      expect(r.errors[0]).toMatch(/missing\.png: file not found/);
+    });
+    it('unsupported extension → per-image error', () => {
+      const p = mk('a.gif', Buffer.from([0x47, 0x49, 0x46, 0x38]));
+      const r = resolveTaskImages({ task: 't', images: [p], provider: 'openai' });
+      expect(r.errors[0]).toMatch(/unsupported extension/);
+    });
+    it('mislabeled content (.png that is not a PNG) → magic-byte rejection', () => {
+      const p = mk('fake.png', Buffer.from('%PDF-1.4 not an image'));
+      const r = resolveTaskImages({ task: 't', images: [p], provider: 'openai' });
+      expect(r.blocks).toEqual([]);
+      expect(r.errors[0]).toMatch(/not valid PNG or JPEG/);
+    });
+    it('oversize image (> MAX_IMAGE_BYTES) → rejected with size error', () => {
+      const big = Buffer.concat([PNG_MAGIC, Buffer.alloc(MAX_IMAGE_BYTES + 1 - PNG_MAGIC.length, 0)]);
+      const p = mk('big.png', big);
+      const r = resolveTaskImages({ task: 't', images: [p], provider: 'openai' });
+      expect(r.blocks).toEqual([]);
+      expect(r.errors[0]).toMatch(/too large/);
+    });
+    it('more than MAX_IMAGES → overflow rejected, first MAX_IMAGES kept', () => {
+      const paths = Array.from({ length: MAX_IMAGES + 2 }, (_, i) => mk(`i${i}.png`, PNG_MAGIC));
+      const r = resolveTaskImages({ task: 't', images: paths, provider: 'openai' });
+      expect(r.blocks).toHaveLength(MAX_IMAGES);
+      expect(r.errors.some(e => /too many images/.test(e))).toBe(true);
+    });
+    it('auto-detect also capped at MAX_IMAGES', () => {
+      const paths = Array.from({ length: MAX_IMAGES + 1 }, (_, i) => mk(`d${i}.png`, PNG_MAGIC));
+      const r = resolveTaskImages({ task: `imgs ${paths.join(' ')}`, provider: 'openai' });
+      expect(r.blocks.length).toBeLessThanOrEqual(MAX_IMAGES);
+    });
+  });
+
+  describe('vision gate', () => {
+    it('text-only provider ignores images with a notice, no blocks', () => {
+      const p = mk('a.png', PNG_MAGIC);
+      const r = resolveTaskImages({ task: 't', images: [p], provider: 'deepseek' });
+      expect(r.blocks).toEqual([]);
+      expect(r.notices[0]).toMatch(/not vision-capable/);
+    });
+    it('undefined provider ignored with a notice', () => {
+      const p = mk('a.png', PNG_MAGIC);
+      const r = resolveTaskImages({ task: 't', images: [p] });
+      expect(r.blocks).toEqual([]);
+      expect(r.notices).toHaveLength(1);
+    });
+  });
+
+  describe('buildUserContent', () => {
+    it('returns the plain task string when no images resolved (backward compatible)', () => {
+      const r = resolveTaskImages({ task: 'plain task', provider: 'openai' });
+      expect(buildUserContent('plain task', r)).toBe('plain task');
+    });
+    it('returns a multimodal ContentBlock[] with text first, then image blocks', () => {
+      const p = mk('a.png', PNG_MAGIC);
+      const r = resolveTaskImages({ task: 'describe', images: [p], provider: 'openai' });
+      const content = buildUserContent('describe', r);
+      expect(Array.isArray(content)).toBe(true);
+      const arr = content as Array<TextContent | ImageContent>;
+      expect(arr[0].type).toBe('text');
+      expect((arr[0] as TextContent).text).toContain('describe');
+      expect(arr[1].type).toBe('image');
+    });
+    it('surfaces per-image errors in the text even when a valid image is present', () => {
+      const good = mk('good.png', PNG_MAGIC);
+      const content = buildUserContent(
+        'task',
+        resolveTaskImages({ task: 'task', images: [good, '/nope/x.png'], provider: 'openai' }),
+      ) as Array<TextContent | ImageContent>;
+      expect((content[0] as TextContent).text).toMatch(/image attachment errors/);
+      expect((content[0] as TextContent).text).toMatch(/file not found/);
+    });
+    it('surfaces errors as a plain string when NO image resolved (all rejected)', () => {
+      const r = resolveTaskImages({ task: 'task', images: ['/nope/x.png'], provider: 'openai' });
+      const content = buildUserContent('task', r);
+      expect(typeof content).toBe('string');
+      expect(content as string).toMatch(/image attachment errors/);
+    });
+  });
+});

--- a/tests/orchestrator/task-images.test.ts
+++ b/tests/orchestrator/task-images.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';

--- a/tests/orchestrator/task-images.test.ts
+++ b/tests/orchestrator/task-images.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';


### PR DESCRIPTION
Custom-provider relay agents received dispatch tasks as text only — image paths never became pixels, though the provider clients already supported multimodal content parts. This adds an `images: string[]` field on `gossip_dispatch` (single + per-task, documented in the tool schema and README), auto-detection of absolute PNG/JPEG paths in task text, and a shared `task-images.ts` helper (single base64 encode; provider-specific wire formats: OpenAI `image_url`, Gemini `inlineData`, Anthropic `image`). Guardrails: max 4 images, ≤4MB each, extension + magic-byte validation, per-image errors, text-only providers ignore with a notice. Verified live: pre-patch, a gpt-5.2 relay critic answered 'I received no image data, only text.'

---

## Pre-merge consensus

This PR touches `packages/orchestrator/src/worker-agent.ts` (`@gossip:impact-adjacent`), so it ran multi-agent consensus. Two rounds, all findings re-verified against the branch by the orchestrator.

consensus-id: 2a2f7f6b-186241dc
consensus-id: 771df75b-5e6647b6

**Round 1 (`2a2f7f6b`)** on the original feature surfaced a HIGH trust-boundary finding: auto-detecting absolute PNG/JPEG paths from untrusted task text and shipping their bytes to a third-party provider was an arbitrary-file read primitive. Plus resource/validation follow-ups (no aggregate cap, regex over-match, "supplied" wording, error masking, test gaps).

**Hardening (`dc61745d`→tip)** addressed those: `projectRoot` confinement — every image path (explicit or auto-detected) is `realpath`-resolved and rejected if it lands outside `process.cwd()` (`isWithinRoot`, separator-boundary check, symlink/`..` escapes closed and unit-tested); fd-based capped read (single fd shared by `fstat`+`read`, `MAX_IMAGE_BYTES+1` sentinel) closing the stat→read TOCTOU and OOM items; dedup/normalize; path-hashed logs; native-dispatch drop notice.

**Round 2 (`771df75b`)** verified the hardening. The HIGH trust-boundary finding is **closed** for the threat model this feature defends against (untrusted task *text*): out-of-repo paths (`~/Desktop/*.png`, browser caches, `~/.ssh`) are now rejected as outside the project root. Two residual hardening items remain, tracked as fast-follows (neither is a regression, neither is reachable by a task-text attacker):

- **[LOW] realpath→open TOCTOU** — the containment check `realpath`s a path string, then `openSync` re-opens by that string; a *local attacker with filesystem write access racing two syscalls* could swap a symlink between them. Out of scope for the task-text threat model (such an attacker already has arbitrary read). Follow-up: open-fd-then-verify (`/proc/self/fd`).
- **[MEDIUM] fail-open on unresolvable `projectRoot`** — if `realpath(projectRoot)` throws (e.g. cwd deleted mid-run), confinement is silently skipped and the notice is dropped by the pipeline's `LOG` handler. Edge-case (not task-text-triggerable), currently a deliberate availability-over-security choice. Follow-up: fail-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
