### PR TITLE
chore(release): v0.6.12 — relay image attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ## [Unreleased]
 
+## [0.6.12] — 2026-07-19
+
+Adds image attachments to custom-provider (relay) dispatches so OpenAI/Gemini/
+Anthropic/Ollama review agents can receive screenshots and diagrams, not just
+text. Verified via two consensus rounds (`consensus-id: 2a2f7f6b-186241dc`,
+`consensus-id: 771df75b-5e6647b6`).
+
+### Added
+
+- **`images: string[]` on `gossip_dispatch`** (single + per-task) — attaches
+  local PNG/JPEG files to a relay dispatch as provider-native multimodal content
+  (OpenAI `image_url`, Gemini `inlineData`, Anthropic `image`, Ollama `images`).
+  Guardrails: max 4 images, ≤4 MB each, extension + magic-byte validation,
+  per-image errors surfaced in task context, text-only providers ignore the
+  field with a notice.
+- **Opt-in path auto-detection** — absolute PNG/JPEG paths cited in task text are
+  attached automatically, but only when they resolve **inside the project root**.
+  Every image path (explicit or auto-detected) is `realpath`-resolved and
+  rejected if it lands outside `process.cwd()`, so untrusted task text cannot
+  cause reads of arbitrary on-disk files.
+
+### Security
+
+- Image resolution is confined to the project root via a `realpath` +
+  separator-boundary containment check (symlink/`..` escapes closed and
+  unit-tested), and files are read through a single capped file descriptor
+  (`fstat`+`read` on one fd, `MAX_IMAGE_BYTES+1` sentinel) to close stat→read
+  TOCTOU and oversize-slurp vectors. Known follow-ups tracked for a fast patch: a
+  low-severity realpath→open TOCTOU (only reachable by a local filesystem-write
+  attacker, out of scope for the untrusted-task-text threat model) and a
+  fail-open on an unresolvable project root (edge case; should fail closed).
+
 ## [0.6.11] — 2026-07-11
 
 Stops the `[skill-parser] missing required field(s)` warnings that reached

--- a/README.md
+++ b/README.md
@@ -194,10 +194,10 @@ Add to `~/.claude/mcp_settings.json` (Claude Code) or project-local `.mcp.json`:
 
 ```bash
 # Pin to a version
-npm install -g gossipcat@0.6.11
+npm install -g gossipcat@0.6.12
 
 # Pin to a GitHub release tarball (bypasses the npm registry)
-npm install -g https://github.com/gossipcat-ai/gossipcat-ai/releases/download/v0.6.11/gossipcat-0.6.11.tgz
+npm install -g https://github.com/gossipcat-ai/gossipcat-ai/releases/download/v0.6.12/gossipcat-0.6.12.tgz
 
 # Project-local (postinstall writes .mcp.json — open the IDE there, no `mcp add` needed)
 cd your-project && npm install --save-dev gossipcat

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gossipcat",
-  "version": "0.6.9",
+  "version": "0.6.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gossipcat",
-      "version": "0.6.9",
+      "version": "0.6.12",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossipcat",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
   "mcpName": "io.github.ataberk-xyz/gossipcat",
   "repository": {


### PR DESCRIPTION
Release **v0.6.12** off master (which now includes #652).

- Bumps `gossipcat` 0.6.11 → 0.6.12 (package.json + package-lock; corrects the lockfile root version which had drifted to 0.6.9).
- README install pins → 0.6.12.
- CHANGELOG `[0.6.12]` entry for the relay image-attachment feature (#652), including the security notes (project-root confinement, capped fd reads) and the two tracked follow-ups (realpath→open TOCTOU, fail-open on unresolvable root).

No code changes beyond the version bump — the feature itself already merged in #652 and passed two consensus rounds (`2a2f7f6b-186241dc`, `771df75b-5e6647b6`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)