### PR TITLE
chore(release): v0.6.13 — image path policy hardening (#654)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ## [Unreleased]
 
+## [0.6.13] — 2026-07-19
+
+Hardens the relay image path policy shipped in 0.6.12 (closes #654). Verified via
+consensus (`consensus-id: 040da732-35274d72`).
+
+### Security
+
+- **Image confinement now fails closed.** When a `projectRoot` is supplied but
+  cannot be resolved, every image candidate is rejected instead of being read
+  unconfined (previously a silent fail-open).
+- **Closed the realpath→open TOCTOU.** Each image is now opened first
+  (`O_RDONLY|O_NONBLOCK`, pinning the inode) and the project-root confinement
+  check runs against the open file descriptor's real path (`/proc/self/fd` on
+  Linux; a `realpath`+`dev`/`ino`-equality fallback elsewhere), so a symlink swap
+  between path resolution and open can no longer escape the root. Neither issue
+  was reachable by the untrusted-task-text threat model 0.6.12 already defended
+  against; both are defense-in-depth for local-filesystem attackers.
+
 ## [0.6.12] — 2026-07-19
 
 Adds image attachments to custom-provider (relay) dispatches so OpenAI/Gemini/

--- a/README.md
+++ b/README.md
@@ -194,10 +194,10 @@ Add to `~/.claude/mcp_settings.json` (Claude Code) or project-local `.mcp.json`:
 
 ```bash
 # Pin to a version
-npm install -g gossipcat@0.6.12
+npm install -g gossipcat@0.6.13
 
 # Pin to a GitHub release tarball (bypasses the npm registry)
-npm install -g https://github.com/gossipcat-ai/gossipcat-ai/releases/download/v0.6.12/gossipcat-0.6.12.tgz
+npm install -g https://github.com/gossipcat-ai/gossipcat-ai/releases/download/v0.6.13/gossipcat-0.6.13.tgz
 
 # Project-local (postinstall writes .mcp.json — open the IDE there, no `mcp add` needed)
 cd your-project && npm install --save-dev gossipcat

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gossipcat",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gossipcat",
-      "version": "0.6.12",
+      "version": "0.6.13",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossipcat",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Multi-agent orchestration for Claude Code — parallel review, consensus, adaptive dispatch",
   "mcpName": "io.github.ataberk-xyz/gossipcat",
   "repository": {


### PR DESCRIPTION
Release **v0.6.13** off master (which now includes the #654 fix, PR #655).

- Bumps `gossipcat` 0.6.12 → 0.6.13 (package.json + package-lock).
- README install pins → 0.6.13.
- CHANGELOG `[0.6.13]` entry: fail-closed image confinement + realpath→open TOCTOU closure.

No code changes beyond the version bump — the fix merged in #655 and passed a two-round consensus (`040da732-35274d72`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)