### PR TITLE
fix(dispatch): discover base ref dynamically instead of hardcoding origin/master (#658)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to gossipcat are documented here. The format is loosely base
 
 ## [Unreleased]
 
+### Fixed
+
+- **Ref-allowlist / stale-base detection no longer hardcodes `origin/master`**
+  (issue #658). On repos whose default branch is `main` (or anything else),
+  every dispatch previously ran `git rev-parse origin/master`, which fails
+  with `fatal: ambiguous argument 'origin/master'` and silently disabled both
+  the ref-allowlist pre-dispatch snapshot (`apps/cli/src/handlers/ref-allowlist-detection.ts`)
+  and the `dispatched_stale_base` precondition (`gatherStaleBaseInputs` in
+  `apps/cli/src/handlers/orchestrator-precondition-runner.ts`) — plus printed
+  a misleading "offline or no remote" diagnostic even when the remote was
+  reachable. Both call sites now resolve the base ref through a shared
+  `discoverBaseRef()` helper (`apps/cli/src/handlers/base-ref-discovery.ts`),
+  cached per-process, with precedence: (1) new `GOSSIP_BASE_REF` env var
+  override, (2) `git symbolic-ref refs/remotes/origin/HEAD` (handles an unset
+  `origin/HEAD` quietly), (3) `origin/master` then `origin/main`, whichever
+  resolves first via `rev-parse --verify --quiet` (no `fatal:` log noise). If
+  nothing resolves, the diagnostic now distinguishes "no such base ref
+  (checked origin/master, origin/main)" from a genuine offline/no-remote
+  condition. Set `GOSSIP_BASE_REF=<ref>` (e.g. `origin/trunk`) to force a
+  specific base ref on repos where none of the above heuristics apply.
+
 ## [0.6.13] — 2026-07-19
 
 Hardens the relay image path policy shipped in 0.6.12 (closes #654). Verified via

--- a/apps/cli/src/handlers/base-ref-discovery.ts
+++ b/apps/cli/src/handlers/base-ref-discovery.ts
@@ -41,11 +41,22 @@ export interface BaseRefResult {
   diagnostic?: string;
 }
 
-let cachedResult: BaseRefResult | null = null;
+/**
+ * Positive results only, keyed by cwd. Two deliberate properties:
+ *
+ * - Keyed by cwd: a long-lived MCP server can dispatch against more than one
+ *   root (worktrees), and an unkeyed cache serves the first repo's ref to every
+ *   later one.
+ * - Negatives are NEVER cached: a `null` result means "no base ref right now",
+ *   which self-heals the moment the operator adds a remote or fetches. Caching
+ *   it disabled both the ref-allowlist snapshot and `dispatched_stale_base` for
+ *   the rest of the process, with no way to recover short of a restart.
+ */
+const cachedByCwd = new Map<string, BaseRefResult>();
 
 /** Test-only: clear the per-process cache between test cases. */
 export function resetBaseRefDiscoveryCache(): void {
-  cachedResult = null;
+  cachedByCwd.clear();
 }
 
 function defaultExecFile(cmd: string, args: string[], opts: { cwd: string; encoding: 'utf8' }): string {
@@ -68,22 +79,69 @@ function refResolves(execFile: ExecFileLike, cwd: string, ref: string): boolean 
 }
 
 /**
+ * Reject an override that is not shaped like a ref name before it reaches git.
+ *
+ * A leading `-` would be parsed by git as an OPTION rather than a ref, and
+ * whitespace/newlines mean the operator pasted something that is not a single
+ * ref. Neither is exploitable (execFileSync passes an argv array, no shell),
+ * but both produce a non-SHA `preSha` that silently corrupts the ref-allowlist
+ * verdict, so fail loud instead.
+ */
+function isRefShaped(ref: string): boolean {
+  return ref.length > 0 && !ref.startsWith('-') && !/[\s\x00]/.test(ref);
+}
+
+/**
+ * True when `ref` names a remote-tracking ref. The base ref MUST be
+ * remote-tracking: pointing it at a LOCAL branch makes the direct-push detector
+ * compare against a branch the agent legitimately commits to, so any unrelated
+ * local commit during a task is reported as a REF-ALLOWLIST VIOLATION and emits
+ * a high-severity boundary_escape against an innocent agent. `GOSSIP_BASE_REF=master`
+ * (a missing `origin/` prefix) is the realistic way to hit that.
+ */
+function isRemoteTrackingRef(execFile: ExecFileLike, cwd: string, ref: string): boolean {
+  const full = tryExec(execFile, cwd, ['rev-parse', '--symbolic-full-name', ref]);
+  return full !== null && full.startsWith('refs/remotes/');
+}
+
+/**
  * Discover the base ref to use in place of a hardcoded 'origin/master'.
- * Cached per-process after the first successful (or exhausted) call —
- * pass `forceRefresh: true` to bypass the cache (tests only).
+ *
+ * POSITIVE results are cached per cwd for the process lifetime; negative
+ * results are NOT cached, so adding a remote or fetching mid-session recovers
+ * without an MCP restart. `forceRefresh` bypasses the cache (tests only).
  */
 export function discoverBaseRef(
   cwd: string = process.cwd(),
   execFile: ExecFileLike = defaultExecFile,
   forceRefresh = false,
 ): BaseRefResult {
-  if (cachedResult && !forceRefresh) return cachedResult;
-
-  // 1. Explicit override — always wins, no git calls needed.
+  // 1. Explicit override — always wins. Read BEFORE the cache so an operator
+  // who sets GOSSIP_BASE_REF to recover from a failed discovery is not served a
+  // stale answer, and validated so a malformed value fails loud.
   const override = process.env.GOSSIP_BASE_REF?.trim();
   if (override) {
-    cachedResult = { ref: override };
-    return cachedResult;
+    if (!isRefShaped(override)) {
+      return {
+        ref: null,
+        diagnostic: `GOSSIP_BASE_REF=${JSON.stringify(override)} is not a valid ref name (leading "-" or whitespace) — ignoring`,
+      };
+    }
+    if (!refResolves(execFile, cwd, override)) {
+      return { ref: null, diagnostic: `GOSSIP_BASE_REF=${override} does not resolve in this repository` };
+    }
+    if (!isRemoteTrackingRef(execFile, cwd, override)) {
+      return {
+        ref: null,
+        diagnostic: `GOSSIP_BASE_REF=${override} is not a remote-tracking ref — use e.g. origin/${override}`,
+      };
+    }
+    return { ref: override };
+  }
+
+  if (!forceRefresh) {
+    const hit = cachedByCwd.get(cwd);
+    if (hit) return hit;
   }
 
   // 2. origin/HEAD symbolic-ref — the ref git itself points at.
@@ -92,8 +150,9 @@ export function discoverBaseRef(
     const match = symbolicRef.match(/^refs\/remotes\/(.+)$/);
     const candidate = match?.[1];
     if (candidate && refResolves(execFile, cwd, candidate)) {
-      cachedResult = { ref: candidate };
-      return cachedResult;
+      const result = { ref: candidate };
+      cachedByCwd.set(cwd, result);
+      return result;
     }
     // symbolic-ref pointed somewhere that doesn't resolve (stale ref) — fall
     // through to the fixed-candidate fallback below.
@@ -102,22 +161,23 @@ export function discoverBaseRef(
   // 3. Fixed fallback candidates, in order.
   for (const candidate of ['origin/master', 'origin/main']) {
     if (refResolves(execFile, cwd, candidate)) {
-      cachedResult = { ref: candidate };
-      return cachedResult;
+      const result = { ref: candidate };
+      cachedByCwd.set(cwd, result);
+      return result;
     }
   }
 
-  // 4. Nothing resolved — distinguish "offline / no origin remote" from
-  // "origin is reachable, it just doesn't have a ref we recognize".
+  // 4. Nothing resolved. NOT cached — see cachedByCwd. Every git call above is a
+  // local ref/config lookup, so "offline" is never the true cause; the honest
+  // set is git-unavailable, not-a-repository, or no origin remote configured.
   const remoteList = tryExec(execFile, cwd, ['remote']);
   const hasOriginRemote = remoteList !== null
     && remoteList.split('\n').map(line => line.trim()).includes('origin');
 
-  cachedResult = {
+  return {
     ref: null,
     diagnostic: hasOriginRemote
       ? 'no such base ref (checked origin/master, origin/main; origin/HEAD unset or unresolvable)'
-      : 'offline or no remote named "origin"',
+      : 'no base ref: git unavailable, not a git repository, or no remote named "origin"',
   };
-  return cachedResult;
 }

--- a/apps/cli/src/handlers/base-ref-discovery.ts
+++ b/apps/cli/src/handlers/base-ref-discovery.ts
@@ -1,0 +1,123 @@
+/**
+ * base-ref-discovery.ts
+ *
+ * Resolves the git ref that stands in for "origin's default branch" for the
+ * ref-allowlist pre-dispatch snapshot (ref-allowlist-detection.ts) and the
+ * dispatched_stale_base precondition (orchestrator-precondition-runner.ts).
+ *
+ * Both call sites used to hardcode `origin/master`. On a repo whose default
+ * branch is `main` (or anything else), `git rev-parse origin/master` fails
+ * with `fatal: ambiguous argument 'origin/master'` on every single dispatch,
+ * printing noise and silently disabling both features. Issue #658.
+ *
+ * Precedence:
+ *   1. `GOSSIP_BASE_REF` env var — explicit operator override, always wins.
+ *   2. `git symbolic-ref refs/remotes/origin/HEAD` — the ref git itself
+ *      considers to be origin's default branch (e.g. `refs/remotes/origin/main`
+ *      → `origin/main`). May be unset on some clones (shallow clones, some CI
+ *      checkouts) — handled quietly, falls through to (3).
+ *   3. First of `origin/master`, `origin/main` that resolves via
+ *      `git rev-parse --verify --quiet <ref>` (`--quiet` suppresses the
+ *      `fatal:` line so a missing candidate produces no log noise).
+ *   4. Give up — `ref: null` with a diagnostic that distinguishes "no remote
+ *      reachable" (offline / no `origin` remote) from "remote is fine, we
+ *      just couldn't find a base ref" (checked candidates, none resolved).
+ *
+ * Cached per-process (module-level) so discovery runs once per process, not
+ * once per dispatch. `resetBaseRefDiscoveryCache()` is exported for tests.
+ */
+import { execFileSync } from 'child_process';
+
+export type ExecFileLike = (
+  cmd: string,
+  args: string[],
+  opts: { cwd: string; encoding: 'utf8' },
+) => string;
+
+export interface BaseRefResult {
+  /** The resolved base ref (e.g. 'origin/main'), or null if none resolved. */
+  ref: string | null;
+  /** Human-readable reason discovery failed. Present only when ref is null. */
+  diagnostic?: string;
+}
+
+let cachedResult: BaseRefResult | null = null;
+
+/** Test-only: clear the per-process cache between test cases. */
+export function resetBaseRefDiscoveryCache(): void {
+  cachedResult = null;
+}
+
+function defaultExecFile(cmd: string, args: string[], opts: { cwd: string; encoding: 'utf8' }): string {
+  return execFileSync(cmd, args, opts) as string;
+}
+
+/** Run a git command, returning trimmed stdout or null on any failure. Never throws. */
+function tryExec(execFile: ExecFileLike, cwd: string, args: string[]): string | null {
+  try {
+    const out = execFile('git', args, { cwd, encoding: 'utf8' }).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+/** True when `git rev-parse --verify --quiet <ref>` succeeds (ref exists and resolves). */
+function refResolves(execFile: ExecFileLike, cwd: string, ref: string): boolean {
+  return tryExec(execFile, cwd, ['rev-parse', '--verify', '--quiet', ref]) !== null;
+}
+
+/**
+ * Discover the base ref to use in place of a hardcoded 'origin/master'.
+ * Cached per-process after the first successful (or exhausted) call —
+ * pass `forceRefresh: true` to bypass the cache (tests only).
+ */
+export function discoverBaseRef(
+  cwd: string = process.cwd(),
+  execFile: ExecFileLike = defaultExecFile,
+  forceRefresh = false,
+): BaseRefResult {
+  if (cachedResult && !forceRefresh) return cachedResult;
+
+  // 1. Explicit override — always wins, no git calls needed.
+  const override = process.env.GOSSIP_BASE_REF?.trim();
+  if (override) {
+    cachedResult = { ref: override };
+    return cachedResult;
+  }
+
+  // 2. origin/HEAD symbolic-ref — the ref git itself points at.
+  const symbolicRef = tryExec(execFile, cwd, ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD']);
+  if (symbolicRef) {
+    const match = symbolicRef.match(/^refs\/remotes\/(.+)$/);
+    const candidate = match?.[1];
+    if (candidate && refResolves(execFile, cwd, candidate)) {
+      cachedResult = { ref: candidate };
+      return cachedResult;
+    }
+    // symbolic-ref pointed somewhere that doesn't resolve (stale ref) — fall
+    // through to the fixed-candidate fallback below.
+  }
+
+  // 3. Fixed fallback candidates, in order.
+  for (const candidate of ['origin/master', 'origin/main']) {
+    if (refResolves(execFile, cwd, candidate)) {
+      cachedResult = { ref: candidate };
+      return cachedResult;
+    }
+  }
+
+  // 4. Nothing resolved — distinguish "offline / no origin remote" from
+  // "origin is reachable, it just doesn't have a ref we recognize".
+  const remoteList = tryExec(execFile, cwd, ['remote']);
+  const hasOriginRemote = remoteList !== null
+    && remoteList.split('\n').map(line => line.trim()).includes('origin');
+
+  cachedResult = {
+    ref: null,
+    diagnostic: hasOriginRemote
+      ? 'no such base ref (checked origin/master, origin/main; origin/HEAD unset or unresolvable)'
+      : 'offline or no remote named "origin"',
+  };
+  return cachedResult;
+}

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -769,9 +769,12 @@ export async function handleDispatchSingle(
       emitConsensusSignals(process.cwd(), premiseResult.signals);
     }
 
-    // Ref-allowlist Phase 1: snapshot origin/master before agent runs so the
-    // relay path can detect a direct push to master (no PR-merge entry).
-    // Runs for ALL write-mode dispatches; null on git failure (offline/no remote).
+    // Ref-allowlist Phase 1: snapshot the origin default branch (base ref
+    // resolved via base-ref-discovery.ts — GOSSIP_BASE_REF override, then
+    // origin/HEAD, then origin/master/origin/main fallback; issue #658)
+    // before agent runs so the relay path can detect a direct push (no
+    // PR-merge entry). Runs for ALL write-mode dispatches; null on git
+    // failure (offline/no remote) or when no base ref resolves.
     let preDispatchSha: string | null = null;
     if (write_mode) {
       const { capturePreDispatchSha } = require('./ref-allowlist-detection');

--- a/apps/cli/src/handlers/orchestrator-precondition-runner.ts
+++ b/apps/cli/src/handlers/orchestrator-precondition-runner.ts
@@ -90,6 +90,13 @@ export interface StaleBaseInputs {
   dispatchSha: string;
   originMasterSha: string;
   mergeBaseSha: string | null;
+  /**
+   * The base ref the SHAs above were read from (e.g. 'origin/main'). Carried so
+   * the operator warning and the emitted signal name the ACTUAL ref — on a
+   * main-default repo or with GOSSIP_BASE_REF set, a hardcoded 'origin/master'
+   * label describes a ref that was never consulted.
+   */
+  baseRef: string;
 }
 
 export interface PreconditionGuardAdditionalTask {
@@ -335,8 +342,16 @@ export async function gatherStaleBaseInputs(
   execFile: PreconditionRunnerDeps['execFile'] = defaultExecFile,
 ): Promise<StaleBaseInputs | null> {
   try {
-    const { ref } = discoverBaseRef(projectRoot, execFile);
-    if (!ref) return null;
+    const { ref, diagnostic } = discoverBaseRef(projectRoot, execFile);
+    if (!ref) {
+      // Say so. Silently returning null disabled dispatched_stale_base with no
+      // operator-visible trace, so a misconfigured base ref looked like a
+      // healthy dispatch.
+      process.stderr.write(
+        `[gossipcat] stale-base check skipped — ${diagnostic ?? 'no base ref resolved'}\n`,
+      );
+      return null;
+    }
 
     const dispatchSha = execFile('git', ['rev-parse', 'HEAD'], {
       cwd: projectRoot,
@@ -353,7 +368,7 @@ export async function gatherStaleBaseInputs(
       encoding: 'utf8',
     }).trim();
 
-    return { dispatchSha, originMasterSha, mergeBaseSha };
+    return { dispatchSha, originMasterSha, mergeBaseSha, baseRef: ref };
   } catch {
     return null;
   }
@@ -401,7 +416,7 @@ export async function runDispatchPreconditionGuard(
         const reason = staleResult.reason;
         warnings.push(
           `[dispatch-hygiene] stale base detected (${reason}): ` +
-          `dispatch SHA ${gitInputs.dispatchSha} is behind origin/master ` +
+          `dispatch SHA ${gitInputs.dispatchSha} is behind ${gitInputs.baseRef} ` +
           `${gitInputs.originMasterSha}. Pull and rebase before dispatching.`,
         );
         try {
@@ -413,6 +428,7 @@ export async function runDispatchPreconditionGuard(
             metadata: {
               reason,
               dispatchSha: gitInputs.dispatchSha,
+              baseRef: gitInputs.baseRef,
             },
             timestamp: new Date().toISOString(),
           }]);

--- a/apps/cli/src/handlers/orchestrator-precondition-runner.ts
+++ b/apps/cli/src/handlers/orchestrator-precondition-runner.ts
@@ -27,6 +27,7 @@ import type { PerformanceSignal } from '@gossip/orchestrator';
 // Dynamic import() is NOT bundled in esbuild single-file builds — this was the
 // root cause of the activity-mirror hooks silently no-op'ing (project_activity_mirror_v2_progress).
 import { emitPipelineSignals as staticEmitPipelineSignals } from '@gossip/orchestrator';
+import { discoverBaseRef } from './base-ref-discovery';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -324,7 +325,9 @@ function defaultEmitSignals(projectRoot: string, signals: PerformanceSignal[]): 
 
 /**
  * Run the three git commands needed by detectStaleBase.
- * Returns null if git is unavailable, not in a repo, or origin/master is
+ * Returns null if git is unavailable, not in a repo, or the origin default
+ * branch (resolved via base-ref-discovery.ts — GOSSIP_BASE_REF override, then
+ * origin/HEAD, then origin/master/origin/main fallback; issue #658) is
  * unreachable. NEVER throws.
  */
 export async function gatherStaleBaseInputs(
@@ -332,17 +335,20 @@ export async function gatherStaleBaseInputs(
   execFile: PreconditionRunnerDeps['execFile'] = defaultExecFile,
 ): Promise<StaleBaseInputs | null> {
   try {
+    const { ref } = discoverBaseRef(projectRoot, execFile);
+    if (!ref) return null;
+
     const dispatchSha = execFile('git', ['rev-parse', 'HEAD'], {
       cwd: projectRoot,
       encoding: 'utf8',
     }).trim();
 
-    const originMasterSha = execFile('git', ['rev-parse', 'origin/master'], {
+    const originMasterSha = execFile('git', ['rev-parse', ref], {
       cwd: projectRoot,
       encoding: 'utf8',
     }).trim();
 
-    const mergeBaseSha = execFile('git', ['merge-base', 'HEAD', 'origin/master'], {
+    const mergeBaseSha = execFile('git', ['merge-base', 'HEAD', ref], {
       cwd: projectRoot,
       encoding: 'utf8',
     }).trim();

--- a/apps/cli/src/handlers/ref-allowlist-detection.ts
+++ b/apps/cli/src/handlers/ref-allowlist-detection.ts
@@ -21,10 +21,13 @@ import { discoverBaseRef } from './base-ref-discovery';
 const PROCESS_VIOLATIONS_FILE = '.gossip/process-violations.jsonl';
 
 function execFileForBaseRef(cmd: string, args: string[], opts: { cwd: string; encoding: 'utf8' }): string {
+  // stdio ignores stderr to match every other git call in this file — without
+  // it, git `fatal:` lines leak to the terminal, which is the exact noise class
+  // issue #658 set out to remove.
   // .toString() is a no-op when execFileSync already honored `encoding` and
   // returned a string; it correctly decodes a Buffer when a test double (or a
   // future refactor) returns one despite the encoding option.
-  return execFileSync(cmd, args, opts).toString();
+  return execFileSync(cmd, args, { ...opts, stdio: ['ignore', 'pipe', 'ignore'] }).toString();
 }
 
 /**

--- a/apps/cli/src/handlers/ref-allowlist-detection.ts
+++ b/apps/cli/src/handlers/ref-allowlist-detection.ts
@@ -5,33 +5,52 @@
  *
  * Spec: docs/specs/2026-04-29-ref-allowlist-enforcement.md §"Phase 1 Minimum Viable"
  *
- * Captures origin/master SHA at dispatch time. On relay completion, checks
- * whether origin/master moved without a corresponding PR-merge commit.
- * On violation: appends to .gossip/process-violations.jsonl, records a
- * boundary_escape signal with category process_discipline, and prints a
- * prominent stderr message. No auto-revert — operator must confirm.
+ * Captures the origin default-branch SHA at dispatch time (base ref resolved
+ * via base-ref-discovery.ts — GOSSIP_BASE_REF override, then origin/HEAD,
+ * then origin/master/origin/main fallback; see issue #658). On relay
+ * completion, checks whether that ref moved without a corresponding
+ * PR-merge commit. On violation: appends to .gossip/process-violations.jsonl,
+ * records a boundary_escape signal with category process_discipline, and
+ * prints a prominent stderr message. No auto-revert — operator must confirm.
  */
 import { appendFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { execFileSync } from 'child_process';
+import { discoverBaseRef } from './base-ref-discovery';
 
 const PROCESS_VIOLATIONS_FILE = '.gossip/process-violations.jsonl';
 
+function execFileForBaseRef(cmd: string, args: string[], opts: { cwd: string; encoding: 'utf8' }): string {
+  // .toString() is a no-op when execFileSync already honored `encoding` and
+  // returned a string; it correctly decodes a Buffer when a test double (or a
+  // future refactor) returns one despite the encoding option.
+  return execFileSync(cmd, args, opts).toString();
+}
+
 /**
- * Capture origin/master SHA before dispatching a task.
- * Returns null on git failure (offline, no remote, no repo) — never blocks dispatch.
+ * Capture the origin default-branch SHA before dispatching a task.
+ * Returns null on git failure (offline, no remote, no repo, or no resolvable
+ * base ref) — never blocks dispatch.
  */
 export function capturePreDispatchSha(): string | null {
+  const cwd = process.cwd();
+  const { ref, diagnostic } = discoverBaseRef(cwd, execFileForBaseRef);
+  if (!ref) {
+    process.stderr.write(
+      `[gossipcat] ref-allowlist: could not resolve a base ref (${diagnostic}) — skipping pre-dispatch snapshot\n`,
+    );
+    return null;
+  }
   try {
-    const sha = execFileSync('git', ['rev-parse', 'origin/master'], {
-      cwd: process.cwd(),
+    const sha = execFileSync('git', ['rev-parse', ref], {
+      cwd,
       stdio: ['ignore', 'pipe', 'ignore'],
     })
       .toString()
       .trim();
     return sha || null;
   } catch {
-    process.stderr.write('[gossipcat] ref-allowlist: could not read origin/master SHA (offline or no remote) — skipping pre-dispatch snapshot\n');
+    process.stderr.write(`[gossipcat] ref-allowlist: could not read ${ref} SHA (offline or no remote) — skipping pre-dispatch snapshot\n`);
     return null;
   }
 }
@@ -97,19 +116,24 @@ function appendViolationRecord(record: {
 }
 
 /**
- * Check whether origin/master moved during a task without a PR-merge entry.
- * Emits boundary_escape signal + appends to process-violations.jsonl on violation.
- * Call this at relay-completion time for any task that had a preDispatchSha captured.
+ * Check whether the origin default branch moved during a task without a
+ * PR-merge entry. Emits boundary_escape signal + appends to
+ * process-violations.jsonl on violation. Call this at relay-completion time
+ * for any task that had a preDispatchSha captured.
  */
 export function checkRefAllowlistViolation(
   taskId: string,
   agentId: string,
   preSha: string,
 ): void {
+  const cwd = process.cwd();
+  const { ref } = discoverBaseRef(cwd, execFileForBaseRef);
+  if (!ref) return; // Can't resolve base ref — skip detection, don't false-positive
+
   let postSha: string;
   try {
-    postSha = execFileSync('git', ['rev-parse', 'origin/master'], {
-      cwd: process.cwd(),
+    postSha = execFileSync('git', ['rev-parse', ref], {
+      cwd,
       stdio: ['ignore', 'pipe', 'ignore'],
     })
       .toString()
@@ -125,7 +149,7 @@ export function checkRefAllowlistViolation(
   const mergeCommits = getPrMergeCommits(preSha, postSha);
   if (mergeCommits.length > 0) return; // Legitimate PR merge — no violation
 
-  // Violation: origin/master moved with no PR-merge entry
+  // Violation: the base ref moved with no PR-merge entry
   const allCommits = getCommitRange(preSha, postSha);
   const detectedAt = new Date().toISOString();
 
@@ -143,7 +167,7 @@ export function checkRefAllowlistViolation(
         findingId: `proc:${taskId}:master_push`,
         category: 'process_discipline',
         severity: 'high',
-        evidence: `origin/master moved from ${preSha} to ${postSha} during task ${taskId} without a PR-merge entry — direct push detected. Commits: ${allCommits.slice(0, 5).join('; ')}`,
+        evidence: `${ref} moved from ${preSha} to ${postSha} during task ${taskId} without a PR-merge entry — direct push detected. Commits: ${allCommits.slice(0, 5).join('; ')}`,
         timestamp: detectedAt,
       },
     ]);
@@ -152,7 +176,7 @@ export function checkRefAllowlistViolation(
   }
 
   process.stderr.write(
-    `\nREF-ALLOWLIST VIOLATION: ${taskId} agent=${agentId} origin/master moved ${preSha.slice(0, 8)}→${postSha.slice(0, 8)} with no PR merge.\n` +
+    `\nREF-ALLOWLIST VIOLATION: ${taskId} agent=${agentId} ${ref} moved ${preSha.slice(0, 8)}→${postSha.slice(0, 8)} with no PR merge.\n` +
       `Operator confirmation required for revert or retroactive PR.\n` +
       `Full audit trail at .gossip/process-violations.jsonl\n\n`,
   );

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -97,10 +97,12 @@ export interface NativeTaskInfo {
    */
   memoryQueryCalled?: boolean;
   /**
-   * origin/master SHA captured just before the agent was dispatched.
+   * Origin default-branch SHA captured just before the agent was dispatched
+   * (base ref resolved via base-ref-discovery.ts — GOSSIP_BASE_REF override,
+   * then origin/HEAD, then origin/master/origin/main fallback; issue #658).
    * Used by the ref-allowlist detection layer (Phase 1) to detect direct
-   * pushes to master without a PR-merge entry.
-   * Null when git is unavailable (offline / no remote).
+   * pushes to the origin default branch without a PR-merge entry.
+   * Null when git is unavailable (offline / no remote) or no base ref resolves.
    */
   preDispatchSha?: string | null;
   /**

--- a/tests/cli/base-ref-discovery.test.ts
+++ b/tests/cli/base-ref-discovery.test.ts
@@ -4,15 +4,20 @@
  * dispatched_stale_base precondition. Issue #658.
  *
  * Precedence under test:
- *   1. GOSSIP_BASE_REF env override — wins unconditionally, no git calls.
+ *   1. GOSSIP_BASE_REF env override — wins, but is VALIDATED: it must be
+ *      ref-shaped, must resolve, and must be remote-tracking. An override
+ *      naming a local branch is rejected, because the direct-push detector
+ *      would then flag any unrelated local commit as a violation against an
+ *      innocent agent.
  *   2. git symbolic-ref refs/remotes/origin/HEAD, parsed to 'origin/<branch>'.
  *   3. Fallback candidates origin/master, then origin/main (first that
  *      verifies via `rev-parse --verify --quiet`).
- *   4. Unresolvable → null with a diagnostic distinguishing offline/no-remote
- *      from "checked candidates, none resolved".
+ *   4. Unresolvable → null with a diagnostic. Every git call here is a local
+ *      lookup, so the wording never claims "offline".
  *
- * Also covers per-process caching (discoverBaseRef only calls git once
- * across repeated calls, until resetBaseRefDiscoveryCache()).
+ * Also covers caching semantics: POSITIVE results are cached per cwd; negative
+ * results are NOT cached (so adding a remote mid-session recovers without a
+ * restart), and the env override is read BEFORE the cache.
  */
 
 import {
@@ -37,23 +42,74 @@ afterEach(() => {
 });
 
 describe('discoverBaseRef — GOSSIP_BASE_REF override', () => {
-  it('wins over everything else and makes no git calls', () => {
+  // A validated override DOES call git — it must prove the ref resolves and is
+  // remote-tracking. Accepting it blind is what let GOSSIP_BASE_REF=master fire
+  // a bogus REF-ALLOWLIST VIOLATION against an innocent agent.
+  const remoteTrackingExec = (ref: string) =>
+    jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
+      if (args[0] === 'rev-parse' && args.includes('--verify')) return 'abc123\n';
+      if (args[0] === 'rev-parse' && args.includes('--symbolic-full-name')) return `refs/remotes/${ref}\n`;
+      return throwing(`unexpected git call: ${args.join(' ')}`);
+    });
+
+  it('wins over everything else when it names a resolvable remote-tracking ref', () => {
     process.env.GOSSIP_BASE_REF = 'upstream/develop';
-    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>(
-      () => throwing('should not be called'),
-    );
-    const result = discoverBaseRef(CWD, execFile);
-    expect(result).toEqual({ ref: 'upstream/develop' });
-    expect(execFile).not.toHaveBeenCalled();
+    const execFile = remoteTrackingExec('upstream/develop');
+    expect(discoverBaseRef(CWD, execFile)).toEqual({ ref: 'upstream/develop' });
+    // No symbolic-ref/remote discovery calls — the override short-circuits them.
+    expect(execFile.mock.calls.every(([, args]) => args[0] === 'rev-parse')).toBe(true);
   });
 
   it('trims surrounding whitespace', () => {
     process.env.GOSSIP_BASE_REF = '  origin/release  ';
+    expect(discoverBaseRef(CWD, remoteTrackingExec('origin/release')).ref).toBe('origin/release');
+  });
+
+  it('REJECTS an override naming a local branch (would flag an innocent agent)', () => {
+    process.env.GOSSIP_BASE_REF = 'master';
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
+      if (args[0] === 'rev-parse' && args.includes('--verify')) return 'abc123\n';
+      if (args[0] === 'rev-parse' && args.includes('--symbolic-full-name')) return 'refs/heads/master\n';
+      return throwing(`unexpected git call: ${args.join(' ')}`);
+    });
+    const result = discoverBaseRef(CWD, execFile);
+    expect(result.ref).toBeNull();
+    expect(result.diagnostic).toContain('not a remote-tracking ref');
+    expect(result.diagnostic).toContain('origin/master');
+  });
+
+  it('REJECTS an override that does not resolve', () => {
+    process.env.GOSSIP_BASE_REF = 'origin/mian';
     const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>(
-      () => throwing('should not be called'),
+      () => throwing('unknown revision'),
     );
     const result = discoverBaseRef(CWD, execFile);
-    expect(result.ref).toBe('origin/release');
+    expect(result.ref).toBeNull();
+    expect(result.diagnostic).toContain('does not resolve');
+  });
+
+  it.each(['--all', '-e', 'origin/main extra', 'origin/\tmain'])(
+    'REJECTS a non-ref-shaped override without calling git: %j',
+    (bad) => {
+      process.env.GOSSIP_BASE_REF = bad;
+      const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>(
+        () => throwing('should not be called'),
+      );
+      const result = discoverBaseRef(CWD, execFile);
+      expect(result.ref).toBeNull();
+      expect(result.diagnostic).toContain('not a valid ref name');
+      expect(execFile).not.toHaveBeenCalled();
+    },
+  );
+
+  it('is read BEFORE the cache, so it recovers a cached-negative session', () => {
+    const failing = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>(
+      () => throwing('no refs'),
+    );
+    expect(discoverBaseRef(CWD, failing).ref).toBeNull();
+
+    process.env.GOSSIP_BASE_REF = 'origin/main';
+    expect(discoverBaseRef(CWD, remoteTrackingExec('origin/main')).ref).toBe('origin/main');
   });
 
   it('ignores an empty-string override and falls through to discovery', () => {
@@ -162,7 +218,7 @@ describe('discoverBaseRef — unresolvable diagnostic wording', () => {
     expect(result.diagnostic).toContain('origin/main');
   });
 
-  it('reports "offline or no remote" when there is no origin remote at all', () => {
+  it('names the honest causes when there is no origin remote at all', () => {
     const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
       const key = args.join(' ');
       if (key === 'symbolic-ref --quiet refs/remotes/origin/HEAD') return throwing('unset');
@@ -173,16 +229,48 @@ describe('discoverBaseRef — unresolvable diagnostic wording', () => {
     });
     const result = discoverBaseRef(CWD, execFile);
     expect(result.ref).toBeNull();
-    expect(result.diagnostic).toMatch(/offline or no remote/i);
+    expect(result.diagnostic).toContain('no remote named "origin"');
+    // Every git call in this module is a local ref/config lookup, so "offline"
+    // can never be the true cause and must not be claimed.
+    expect(result.diagnostic).not.toMatch(/offline/i);
   });
 
-  it('reports "offline or no remote" when git itself is unreachable (not a repo)', () => {
+  it('names the honest causes when git itself is unreachable (not a repo)', () => {
     const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>(
       () => throwing('fatal: not a git repository'),
     );
     const result = discoverBaseRef(CWD, execFile);
     expect(result.ref).toBeNull();
-    expect(result.diagnostic).toMatch(/offline or no remote/i);
+    expect(result.diagnostic).toContain('not a git repository');
+    expect(result.diagnostic).not.toMatch(/offline/i);
+  });
+});
+
+describe('discoverBaseRef — cache semantics', () => {
+  const resolvingExec = (which: string) =>
+    jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
+      const key = args.join(' ');
+      if (key === 'symbolic-ref --quiet refs/remotes/origin/HEAD') return throwing('unset');
+      if (key === `rev-parse --verify --quiet ${which}`) return 'abc123\n';
+      if (key.startsWith('rev-parse --verify --quiet')) return throwing('fatal: ambiguous argument');
+      return throwing(`unexpected: ${key}`);
+    });
+
+  it('does NOT cache a negative result — adding a remote mid-session recovers', () => {
+    const failing = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>(
+      () => throwing('no refs yet'),
+    );
+    expect(discoverBaseRef(CWD, failing).ref).toBeNull();
+
+    // Operator runs `git remote add origin ... && git fetch`. No restart.
+    expect(discoverBaseRef(CWD, resolvingExec('origin/main')).ref).toBe('origin/main');
+  });
+
+  it('keys the cache by cwd — a second root does not inherit the first ref', () => {
+    expect(discoverBaseRef('/repoA', resolvingExec('origin/main')).ref).toBe('origin/main');
+    expect(discoverBaseRef('/repoB', resolvingExec('origin/master')).ref).toBe('origin/master');
+    // /repoA still served from its own cache entry, not overwritten by /repoB.
+    expect(discoverBaseRef('/repoA', resolvingExec('origin/main')).ref).toBe('origin/main');
   });
 });
 

--- a/tests/cli/base-ref-discovery.test.ts
+++ b/tests/cli/base-ref-discovery.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for base-ref-discovery.ts — resolves the git ref used in place of a
+ * hardcoded 'origin/master' for ref-allowlist snapshotting and the
+ * dispatched_stale_base precondition. Issue #658.
+ *
+ * Precedence under test:
+ *   1. GOSSIP_BASE_REF env override — wins unconditionally, no git calls.
+ *   2. git symbolic-ref refs/remotes/origin/HEAD, parsed to 'origin/<branch>'.
+ *   3. Fallback candidates origin/master, then origin/main (first that
+ *      verifies via `rev-parse --verify --quiet`).
+ *   4. Unresolvable → null with a diagnostic distinguishing offline/no-remote
+ *      from "checked candidates, none resolved".
+ *
+ * Also covers per-process caching (discoverBaseRef only calls git once
+ * across repeated calls, until resetBaseRefDiscoveryCache()).
+ */
+
+import {
+  discoverBaseRef,
+  resetBaseRefDiscoveryCache,
+  type ExecFileLike,
+} from '../../apps/cli/src/handlers/base-ref-discovery';
+
+const CWD = '/repo';
+
+function throwing(message: string): never {
+  throw new Error(message);
+}
+
+beforeEach(() => {
+  resetBaseRefDiscoveryCache();
+  delete process.env.GOSSIP_BASE_REF;
+});
+
+afterEach(() => {
+  delete process.env.GOSSIP_BASE_REF;
+});
+
+describe('discoverBaseRef — GOSSIP_BASE_REF override', () => {
+  it('wins over everything else and makes no git calls', () => {
+    process.env.GOSSIP_BASE_REF = 'upstream/develop';
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>(
+      () => throwing('should not be called'),
+    );
+    const result = discoverBaseRef(CWD, execFile);
+    expect(result).toEqual({ ref: 'upstream/develop' });
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it('trims surrounding whitespace', () => {
+    process.env.GOSSIP_BASE_REF = '  origin/release  ';
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>(
+      () => throwing('should not be called'),
+    );
+    const result = discoverBaseRef(CWD, execFile);
+    expect(result.ref).toBe('origin/release');
+  });
+
+  it('ignores an empty-string override and falls through to discovery', () => {
+    process.env.GOSSIP_BASE_REF = '   ';
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
+      const key = args.join(' ');
+      if (key === 'rev-parse --verify --quiet origin/master') return 'ok';
+      return throwing(`unexpected: ${key}`);
+    });
+    const result = discoverBaseRef(CWD, execFile);
+    expect(result.ref).toBe('origin/master');
+  });
+});
+
+describe('discoverBaseRef — origin/HEAD symbolic-ref', () => {
+  it('parses refs/remotes/origin/main to origin/main and verifies it', () => {
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
+      const key = args.join(' ');
+      if (key === 'symbolic-ref --quiet refs/remotes/origin/HEAD') return 'refs/remotes/origin/main\n';
+      if (key === 'rev-parse --verify --quiet origin/main') return 'sha123';
+      return throwing(`unexpected: ${key}`);
+    });
+    const result = discoverBaseRef(CWD, execFile);
+    expect(result).toEqual({ ref: 'origin/main' });
+  });
+
+  it('falls through to candidates when symbolic-ref points at a ref that does not verify', () => {
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
+      const key = args.join(' ');
+      if (key === 'symbolic-ref --quiet refs/remotes/origin/HEAD') return 'refs/remotes/origin/stale-branch\n';
+      if (key === 'rev-parse --verify --quiet origin/stale-branch') return throwing('fatal: ambiguous argument');
+      if (key === 'rev-parse --verify --quiet origin/master') return 'ok';
+      return throwing(`unexpected: ${key}`);
+    });
+    const result = discoverBaseRef(CWD, execFile);
+    expect(result).toEqual({ ref: 'origin/master' });
+  });
+
+  it('handles unset origin/HEAD quietly (symbolic-ref throws) and falls through', () => {
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
+      const key = args.join(' ');
+      if (key === 'symbolic-ref --quiet refs/remotes/origin/HEAD') {
+        return throwing('fatal: ref refs/remotes/origin/HEAD is not a symbolic ref');
+      }
+      if (key === 'rev-parse --verify --quiet origin/master') return 'ok';
+      return throwing(`unexpected: ${key}`);
+    });
+    const result = discoverBaseRef(CWD, execFile);
+    expect(result).toEqual({ ref: 'origin/master' });
+    // No diagnostic noise — result is a clean success, no thrown error escaped.
+  });
+});
+
+describe('discoverBaseRef — fallback candidate order', () => {
+  it('prefers origin/master when it resolves', () => {
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
+      const key = args.join(' ');
+      if (key === 'symbolic-ref --quiet refs/remotes/origin/HEAD') return throwing('unset');
+      if (key === 'rev-parse --verify --quiet origin/master') return 'ok';
+      if (key === 'rev-parse --verify --quiet origin/main') return 'ok';
+      return throwing(`unexpected: ${key}`);
+    });
+    const result = discoverBaseRef(CWD, execFile);
+    expect(result.ref).toBe('origin/master');
+  });
+
+  it('falls back to origin/main when origin/master does not exist (main-default repo, issue #658)', () => {
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
+      const key = args.join(' ');
+      if (key === 'symbolic-ref --quiet refs/remotes/origin/HEAD') return throwing('unset');
+      if (key === 'rev-parse --verify --quiet origin/master') return throwing('fatal: ambiguous argument \'origin/master\'');
+      if (key === 'rev-parse --verify --quiet origin/main') return 'ok';
+      return throwing(`unexpected: ${key}`);
+    });
+    const result = discoverBaseRef(CWD, execFile);
+    expect(result.ref).toBe('origin/main');
+  });
+
+  it('never lets a candidate-verify failure surface a "fatal:" style throw to the caller', () => {
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
+      const key = args.join(' ');
+      if (key === 'symbolic-ref --quiet refs/remotes/origin/HEAD') return throwing('unset');
+      if (key === 'rev-parse --verify --quiet origin/master') return throwing('fatal: ambiguous argument');
+      if (key === 'rev-parse --verify --quiet origin/main') return throwing('fatal: ambiguous argument');
+      if (key === 'remote') return 'origin\n';
+      return throwing(`unexpected: ${key}`);
+    });
+    expect(() => discoverBaseRef(CWD, execFile)).not.toThrow();
+  });
+});
+
+describe('discoverBaseRef — unresolvable diagnostic wording', () => {
+  it('reports "no such base ref" when origin is reachable but no candidate resolves', () => {
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
+      const key = args.join(' ');
+      if (key === 'symbolic-ref --quiet refs/remotes/origin/HEAD') return throwing('unset');
+      if (key === 'rev-parse --verify --quiet origin/master') return throwing('fatal: ambiguous argument');
+      if (key === 'rev-parse --verify --quiet origin/main') return throwing('fatal: ambiguous argument');
+      if (key === 'remote') return 'origin\n';
+      return throwing(`unexpected: ${key}`);
+    });
+    const result = discoverBaseRef(CWD, execFile);
+    expect(result.ref).toBeNull();
+    expect(result.diagnostic).toMatch(/no such base ref/i);
+    expect(result.diagnostic).toContain('origin/master');
+    expect(result.diagnostic).toContain('origin/main');
+  });
+
+  it('reports "offline or no remote" when there is no origin remote at all', () => {
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
+      const key = args.join(' ');
+      if (key === 'symbolic-ref --quiet refs/remotes/origin/HEAD') return throwing('unset');
+      if (key === 'rev-parse --verify --quiet origin/master') return throwing('fatal: ambiguous argument');
+      if (key === 'rev-parse --verify --quiet origin/main') return throwing('fatal: ambiguous argument');
+      if (key === 'remote') return ''; // no remotes configured
+      return throwing(`unexpected: ${key}`);
+    });
+    const result = discoverBaseRef(CWD, execFile);
+    expect(result.ref).toBeNull();
+    expect(result.diagnostic).toMatch(/offline or no remote/i);
+  });
+
+  it('reports "offline or no remote" when git itself is unreachable (not a repo)', () => {
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>(
+      () => throwing('fatal: not a git repository'),
+    );
+    const result = discoverBaseRef(CWD, execFile);
+    expect(result.ref).toBeNull();
+    expect(result.diagnostic).toMatch(/offline or no remote/i);
+  });
+});
+
+describe('discoverBaseRef — per-process caching', () => {
+  it('only calls git once across repeated calls until reset', () => {
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
+      const key = args.join(' ');
+      if (key === 'symbolic-ref --quiet refs/remotes/origin/HEAD') return throwing('unset');
+      if (key === 'rev-parse --verify --quiet origin/master') return 'ok';
+      return throwing(`unexpected: ${key}`);
+    });
+
+    const first = discoverBaseRef(CWD, execFile);
+    const callCountAfterFirst = execFile.mock.calls.length;
+    const second = discoverBaseRef(CWD, execFile);
+
+    expect(first).toEqual(second);
+    expect(execFile.mock.calls.length).toBe(callCountAfterFirst); // no new calls — cache hit
+
+    resetBaseRefDiscoveryCache();
+    discoverBaseRef(CWD, execFile);
+    expect(execFile.mock.calls.length).toBeGreaterThan(callCountAfterFirst); // cache reset → re-discovers
+  });
+
+  it('forceRefresh bypasses the cache without an explicit reset', () => {
+    const execFile = jest.fn<ReturnType<ExecFileLike>, Parameters<ExecFileLike>>((_cmd, args) => {
+      const key = args.join(' ');
+      if (key === 'symbolic-ref --quiet refs/remotes/origin/HEAD') return throwing('unset');
+      if (key === 'rev-parse --verify --quiet origin/master') return 'ok';
+      return throwing(`unexpected: ${key}`);
+    });
+
+    discoverBaseRef(CWD, execFile);
+    const callCountAfterFirst = execFile.mock.calls.length;
+    discoverBaseRef(CWD, execFile, true);
+    expect(execFile.mock.calls.length).toBeGreaterThan(callCountAfterFirst);
+  });
+});

--- a/tests/cli/orchestrator-precondition-runner.test.ts
+++ b/tests/cli/orchestrator-precondition-runner.test.ts
@@ -9,6 +9,7 @@ import {
   runDispatchPreconditionGuard,
   type PreconditionRunnerDeps,
 } from '../../apps/cli/src/handlers/orchestrator-precondition-runner';
+import { resetBaseRefDiscoveryCache } from '../../apps/cli/src/handlers/base-ref-discovery';
 import type { PerformanceSignal } from '@gossip/orchestrator';
 
 // ---------------------------------------------------------------------------
@@ -31,6 +32,75 @@ function makeDeps(overrides: Partial<PreconditionRunnerDeps> = {}): Precondition
 /** Default guard input fields for the new task-text check (no referenced paths). */
 const NO_TASK_TEXT = { taskText: '', writeMode: undefined as string | undefined };
 
+type ExecFileArg = string | Error | undefined;
+
+/**
+ * Args-matching execFile stub covering both base-ref discovery calls
+ * (symbolic-ref, rev-parse --verify --quiet) and the three stale-base git
+ * calls (rev-parse HEAD, rev-parse <ref>, merge-base HEAD <ref>).
+ *
+ * By default `origin/HEAD` is unset (symbolic-ref throws, the realistic CI
+ * shallow-clone case) and `origin/master` resolves — matching this repo's
+ * actual default branch — so existing "fresh" / "behind_origin" /
+ * "branched_pre_merge" test intent carries over unchanged. Override any leg
+ * to test a different discovery path (e.g. verifyMaster: undefined,
+ * verifyMain: 'ok' to exercise the origin/main fallback).
+ */
+function makeExecFile(overrides: {
+  head?: ExecFileArg;
+  origin?: ExecFileArg;
+  mergeBase?: ExecFileArg;
+  symbolicRef?: ExecFileArg;
+  verifyMaster?: ExecFileArg;
+  verifyMain?: ExecFileArg;
+  ref?: string; // the ref name used in the 'rev-parse <ref>' / 'merge-base HEAD <ref>' calls
+} = {}): jest.Mock {
+  const ref = overrides.ref ?? 'origin/master';
+  const verifyMaster = 'verifyMaster' in overrides ? overrides.verifyMaster : 'origin/master-exists';
+  return jest.fn().mockImplementation((_cmd: string, args: string[]) => {
+    const key = args.join(' ');
+
+    const resolve = (v: ExecFileArg, unexpectedLabel: string): string => {
+      if (v instanceof Error) throw v;
+      if (v === undefined) throw new Error(`unexpected git call: ${unexpectedLabel}`);
+      return v;
+    };
+
+    if (key === 'symbolic-ref --quiet refs/remotes/origin/HEAD') {
+      if (overrides.symbolicRef instanceof Error) throw overrides.symbolicRef;
+      if (overrides.symbolicRef === undefined) {
+        throw new Error('fatal: ref refs/remotes/origin/HEAD is not a symbolic ref');
+      }
+      return overrides.symbolicRef;
+    }
+    if (key === 'rev-parse --verify --quiet origin/master') {
+      if (verifyMaster instanceof Error) throw verifyMaster;
+      if (verifyMaster === undefined) throw new Error('fatal: ambiguous argument \'origin/master\'');
+      return verifyMaster;
+    }
+    if (key === 'rev-parse --verify --quiet origin/main') {
+      if (overrides.verifyMain instanceof Error) throw overrides.verifyMain;
+      if (overrides.verifyMain === undefined) throw new Error('fatal: ambiguous argument \'origin/main\'');
+      return overrides.verifyMain;
+    }
+    if (key === 'remote') return 'origin\n';
+    if (key === 'rev-parse HEAD') return resolve(overrides.head, 'rev-parse HEAD');
+    if (key === `rev-parse ${ref}`) return resolve(overrides.origin, `rev-parse ${ref}`);
+    if (key === `merge-base HEAD ${ref}`) return resolve(overrides.mergeBase, `merge-base HEAD ${ref}`);
+
+    throw new Error(`unexpected git call: ${key}`);
+  });
+}
+
+/** execFile stub that satisfies stale-base (fresh) so only the task-text path runs. */
+function freshStaleExecFile(): jest.Mock {
+  return makeExecFile({ head: 'sha\n', origin: 'sha\n', mergeBase: 'sha\n' });
+}
+
+beforeEach(() => {
+  resetBaseRefDiscoveryCache();
+});
+
 // ---------------------------------------------------------------------------
 // gatherStaleBaseInputs
 // ---------------------------------------------------------------------------
@@ -42,11 +112,8 @@ describe('gatherStaleBaseInputs', () => {
     expect(result).toBeNull();
   });
 
-  it('returns null when origin/master is not reachable', async () => {
-    // first call (HEAD) succeeds, second (origin/master) throws
-    const execFile = jest.fn()
-      .mockReturnValueOnce('abc123\n')         // git rev-parse HEAD
-      .mockImplementationOnce(() => { throw new Error('fatal: ambiguous argument'); });
+  it('returns null when no base ref resolves (origin/master, origin/main both unreachable)', async () => {
+    const execFile = makeExecFile({ verifyMaster: undefined, verifyMain: undefined });
     const result = await gatherStaleBaseInputs('/some/project', execFile);
     expect(result).toBeNull();
   });
@@ -60,10 +127,11 @@ describe('gatherStaleBaseInputs', () => {
   });
 
   it('returns trimmed SHAs on success', async () => {
-    const execFile = jest.fn()
-      .mockReturnValueOnce('  abc111  \n')    // HEAD
-      .mockReturnValueOnce('  def222  \n')    // origin/master
-      .mockReturnValueOnce('  abc111  \n');   // merge-base
+    const execFile = makeExecFile({
+      head: '  abc111  \n',
+      origin: '  def222  \n',
+      mergeBase: '  abc111  \n',
+    });
     const result = await gatherStaleBaseInputs('/root', execFile);
     expect(result).toEqual({
       dispatchSha: 'abc111',
@@ -73,26 +141,71 @@ describe('gatherStaleBaseInputs', () => {
   });
 
   it('returns null mergeBaseSha when merge-base call fails but HEAD/origin succeed', async () => {
-    const execFile = jest.fn()
-      .mockReturnValueOnce('aaa\n')           // HEAD
-      .mockReturnValueOnce('bbb\n')           // origin/master
-      .mockImplementationOnce(() => { throw new Error('fatal: no merge base'); });
+    const execFile = makeExecFile({
+      head: 'aaa\n',
+      origin: 'bbb\n',
+      mergeBase: new Error('fatal: no merge base'),
+    });
     const result = await gatherStaleBaseInputs('/root', execFile);
     // merge-base failure should produce null result (whole function returns null)
     expect(result).toBeNull();
   });
 
   it('passes cwd to execFile calls', async () => {
-    const execFile = jest.fn()
-      .mockReturnValueOnce('sha1\n')
-      .mockReturnValueOnce('sha2\n')
-      .mockReturnValueOnce('sha1\n');
+    const execFile = makeExecFile({ head: 'sha1\n', origin: 'sha2\n', mergeBase: 'sha1\n' });
     await gatherStaleBaseInputs('/my/project', execFile);
     expect(execFile).toHaveBeenCalledWith(
       'git',
       ['rev-parse', 'HEAD'],
       expect.objectContaining({ cwd: '/my/project' }),
     );
+  });
+
+  it('resolves via origin/main fallback when origin/master does not exist', async () => {
+    const execFile = makeExecFile({
+      ref: 'origin/main',
+      verifyMaster: undefined,
+      verifyMain: 'origin/main-exists',
+      head: 'h1\n',
+      origin: 'o1\n',
+      mergeBase: 'h1\n',
+    });
+    const result = await gatherStaleBaseInputs('/root', execFile);
+    expect(result).toEqual({
+      dispatchSha: 'h1',
+      originMasterSha: 'o1',
+      mergeBaseSha: 'h1',
+    });
+    expect(execFile).toHaveBeenCalledWith(
+      'git',
+      ['rev-parse', 'origin/main'],
+      expect.objectContaining({ cwd: '/root' }),
+    );
+  });
+
+  it('honors GOSSIP_BASE_REF override end to end', async () => {
+    const prev = process.env.GOSSIP_BASE_REF;
+    process.env.GOSSIP_BASE_REF = 'upstream/develop';
+    try {
+      const execFile = jest.fn().mockImplementation((_cmd: string, args: string[]) => {
+        const key = args.join(' ');
+        if (key === 'rev-parse HEAD') return 'h9\n';
+        if (key === 'rev-parse upstream/develop') return 'o9\n';
+        if (key === 'merge-base HEAD upstream/develop') return 'h9\n';
+        throw new Error(`unexpected git call: ${key}`);
+      });
+      const result = await gatherStaleBaseInputs('/root', execFile);
+      expect(result).toEqual({
+        dispatchSha: 'h9',
+        originMasterSha: 'o9',
+        mergeBaseSha: 'h9',
+      });
+      // Override skips discovery entirely — no symbolic-ref / verify calls.
+      expect(execFile).not.toHaveBeenCalledWith('git', expect.arrayContaining(['symbolic-ref']), expect.anything());
+    } finally {
+      if (prev === undefined) delete process.env.GOSSIP_BASE_REF;
+      else process.env.GOSSIP_BASE_REF = prev;
+    }
   });
 });
 
@@ -103,10 +216,7 @@ describe('gatherStaleBaseInputs', () => {
 describe('runDispatchPreconditionGuard — stale base', () => {
   it('emits no signal and no warning when base is fresh', async () => {
     const deps = makeDeps({
-      execFile: jest.fn()
-        .mockReturnValueOnce('samesha\n')
-        .mockReturnValueOnce('samesha\n')
-        .mockReturnValueOnce('samesha\n'),
+      execFile: makeExecFile({ head: 'samesha\n', origin: 'samesha\n', mergeBase: 'samesha\n' }),
     });
     const result = await runDispatchPreconditionGuard(
       { projectRoot: '/project', taskId: 't1', resolutionRoots: [], ...NO_TASK_TEXT },
@@ -118,10 +228,11 @@ describe('runDispatchPreconditionGuard — stale base', () => {
 
   it('emits dispatched_stale_base and warning when behind_origin', async () => {
     const deps = makeDeps({
-      execFile: jest.fn()
-        .mockReturnValueOnce('old111\n')      // HEAD
-        .mockReturnValueOnce('new999\n')      // origin/master
-        .mockReturnValueOnce('old111\n'),     // merge-base === HEAD → behind_origin
+      execFile: makeExecFile({
+        head: 'old111\n',       // HEAD
+        origin: 'new999\n',     // origin/master
+        mergeBase: 'old111\n',  // merge-base === HEAD → behind_origin
+      }),
     });
     const result = await runDispatchPreconditionGuard(
       { projectRoot: '/project', taskId: 'task-abc', resolutionRoots: [], ...NO_TASK_TEXT },
@@ -139,10 +250,11 @@ describe('runDispatchPreconditionGuard — stale base', () => {
 
   it('emits dispatched_stale_base with branched_pre_merge reason', async () => {
     const deps = makeDeps({
-      execFile: jest.fn()
-        .mockReturnValueOnce('branchsha\n')
-        .mockReturnValueOnce('mastersha\n')
-        .mockReturnValueOnce('commonancestor\n'),  // different from HEAD → branched_pre_merge
+      execFile: makeExecFile({
+        head: 'branchsha\n',
+        origin: 'mastersha\n',
+        mergeBase: 'commonancestor\n', // different from HEAD → branched_pre_merge
+      }),
     });
     const result = await runDispatchPreconditionGuard(
       { projectRoot: '/project', taskId: 'task-xyz', resolutionRoots: [], ...NO_TASK_TEXT },
@@ -175,10 +287,11 @@ describe('runDispatchPreconditionGuard — stale base', () => {
 
   it('emits NO dispatched_stale_base signal when branch is strictly ahead of origin (ahead_of_origin)', async () => {
     const deps = makeDeps({
-      execFile: jest.fn()
-        .mockReturnValueOnce('feature-tip\n')   // HEAD
-        .mockReturnValueOnce('origin-head\n')   // origin/master
-        .mockReturnValueOnce('origin-head\n'),  // merge-base === origin → strictly ahead
+      execFile: makeExecFile({
+        head: 'feature-tip\n',    // HEAD
+        origin: 'origin-head\n',  // origin/master
+        mergeBase: 'origin-head\n', // merge-base === origin → strictly ahead
+      }),
     });
     const result = await runDispatchPreconditionGuard(
       { projectRoot: '/project', taskId: 'task-fwd', resolutionRoots: [], ...NO_TASK_TEXT },
@@ -194,10 +307,7 @@ describe('runDispatchPreconditionGuard — stale base', () => {
 
   it('never throws even if emitSignals throws', async () => {
     const deps = makeDeps({
-      execFile: jest.fn()
-        .mockReturnValueOnce('old\n')
-        .mockReturnValueOnce('new\n')
-        .mockReturnValueOnce('old\n'),
+      execFile: makeExecFile({ head: 'old\n', origin: 'new\n', mergeBase: 'old\n' }),
       emitSignals: jest.fn().mockImplementation(() => { throw new Error('emit failed'); }),
     });
     await expect(
@@ -213,10 +323,7 @@ describe('runDispatchPreconditionGuard — stale base', () => {
 describe('runDispatchPreconditionGuard — referenced_unreadable_path', () => {
   it('emits no signal when all resolutionRoots are readable', async () => {
     const deps = makeDeps({
-      execFile: jest.fn()
-        .mockReturnValueOnce('sha\n')
-        .mockReturnValueOnce('sha\n')
-        .mockReturnValueOnce('sha\n'),
+      execFile: freshStaleExecFile(),
       canRead: jest.fn().mockReturnValue(true),
     });
     const result = await runDispatchPreconditionGuard(
@@ -232,10 +339,7 @@ describe('runDispatchPreconditionGuard — referenced_unreadable_path', () => {
 
   it('emits signal and warning when some resolutionRoots are unreadable', async () => {
     const deps = makeDeps({
-      execFile: jest.fn()
-        .mockReturnValueOnce('sha\n')
-        .mockReturnValueOnce('sha\n')
-        .mockReturnValueOnce('sha\n'),
+      execFile: freshStaleExecFile(),
       canRead: jest.fn().mockImplementation((p: string) => p !== '/missing/path'),
     });
     const result = await runDispatchPreconditionGuard(
@@ -261,10 +365,7 @@ describe('runDispatchPreconditionGuard — referenced_unreadable_path', () => {
 
   it('emits no signal when resolutionRoots is empty', async () => {
     const deps = makeDeps({
-      execFile: jest.fn()
-        .mockReturnValueOnce('sha\n')
-        .mockReturnValueOnce('sha\n')
-        .mockReturnValueOnce('sha\n'),
+      execFile: freshStaleExecFile(),
       canRead: jest.fn().mockReturnValue(false), // would fail if called
     });
     const result = await runDispatchPreconditionGuard(
@@ -282,10 +383,7 @@ describe('runDispatchPreconditionGuard — referenced_unreadable_path', () => {
 
   it('handles undefined resolutionRoots (same as empty)', async () => {
     const deps = makeDeps({
-      execFile: jest.fn()
-        .mockReturnValueOnce('sha\n')
-        .mockReturnValueOnce('sha\n')
-        .mockReturnValueOnce('sha\n'),
+      execFile: freshStaleExecFile(),
       canRead: jest.fn().mockReturnValue(false),
     });
     const result = await runDispatchPreconditionGuard(
@@ -298,10 +396,7 @@ describe('runDispatchPreconditionGuard — referenced_unreadable_path', () => {
 
   it('never throws even when canRead throws', async () => {
     const deps = makeDeps({
-      execFile: jest.fn()
-        .mockReturnValueOnce('sha\n')
-        .mockReturnValueOnce('sha\n')
-        .mockReturnValueOnce('sha\n'),
+      execFile: freshStaleExecFile(),
       canRead: jest.fn().mockImplementation(() => { throw new Error('fs error'); }),
     });
     await expect(
@@ -320,10 +415,7 @@ describe('runDispatchPreconditionGuard — referenced_unreadable_path', () => {
 describe('runDispatchPreconditionGuard — combined signals', () => {
   it('can emit both stale base AND unreadable paths signals in one call', async () => {
     const deps = makeDeps({
-      execFile: jest.fn()
-        .mockReturnValueOnce('old\n')
-        .mockReturnValueOnce('new\n')
-        .mockReturnValueOnce('old\n'),     // behind_origin
+      execFile: makeExecFile({ head: 'old\n', origin: 'new\n', mergeBase: 'old\n' }), // behind_origin
       canRead: jest.fn().mockReturnValue(false),
     });
     const result = await runDispatchPreconditionGuard(
@@ -347,14 +439,6 @@ describe('runDispatchPreconditionGuard — combined signals', () => {
 // ---------------------------------------------------------------------------
 // runDispatchPreconditionGuard — referenced_unreadable_path (TASK-TEXT, Bug A)
 // ---------------------------------------------------------------------------
-
-/** execFile stub that satisfies stale-base (fresh) so only the task-text path runs. */
-function freshStaleExecFile(): jest.Mock {
-  return jest.fn()
-    .mockReturnValueOnce('sha\n')   // HEAD
-    .mockReturnValueOnce('sha\n')   // origin/master
-    .mockReturnValueOnce('sha\n');  // merge-base === HEAD → fresh
-}
 
 type RefSignal = PerformanceSignal & {
   agentId: string;

--- a/tests/cli/orchestrator-precondition-runner.test.ts
+++ b/tests/cli/orchestrator-precondition-runner.test.ts
@@ -137,6 +137,7 @@ describe('gatherStaleBaseInputs', () => {
       dispatchSha: 'abc111',
       originMasterSha: 'def222',
       mergeBaseSha: 'abc111',
+      baseRef: 'origin/master',
     });
   });
 
@@ -175,6 +176,7 @@ describe('gatherStaleBaseInputs', () => {
       dispatchSha: 'h1',
       originMasterSha: 'o1',
       mergeBaseSha: 'h1',
+      baseRef: 'origin/main',
     });
     expect(execFile).toHaveBeenCalledWith(
       'git',
@@ -192,6 +194,11 @@ describe('gatherStaleBaseInputs', () => {
         if (key === 'rev-parse HEAD') return 'h9\n';
         if (key === 'rev-parse upstream/develop') return 'o9\n';
         if (key === 'merge-base HEAD upstream/develop') return 'h9\n';
+        // The override is validated before use: it must resolve and be
+        // remote-tracking (a local branch would make the direct-push detector
+        // flag an innocent agent).
+        if (key === 'rev-parse --verify --quiet upstream/develop') return 'o9\n';
+        if (key === 'rev-parse --symbolic-full-name upstream/develop') return 'refs/remotes/upstream/develop\n';
         throw new Error(`unexpected git call: ${key}`);
       });
       const result = await gatherStaleBaseInputs('/root', execFile);
@@ -199,8 +206,9 @@ describe('gatherStaleBaseInputs', () => {
         dispatchSha: 'h9',
         originMasterSha: 'o9',
         mergeBaseSha: 'h9',
+        baseRef: 'upstream/develop',
       });
-      // Override skips discovery entirely — no symbolic-ref / verify calls.
+      // Override skips symbolic-ref discovery — it only validates itself.
       expect(execFile).not.toHaveBeenCalledWith('git', expect.arrayContaining(['symbolic-ref']), expect.anything());
     } finally {
       if (prev === undefined) delete process.env.GOSSIP_BASE_REF;

--- a/tests/cli/ref-allowlist-detection.test.ts
+++ b/tests/cli/ref-allowlist-detection.test.ts
@@ -168,16 +168,33 @@ describe('checkRefAllowlistViolation', () => {
     expect(mockAppendFileSync).not.toHaveBeenCalled();
   });
 
-  it('(e) preDispatchSha null → no detection, no false positive', () => {
-    // Should not be called if null — guard is in caller (dispatch/relay).
-    // But also verify that passing a null-like value short-circuits cleanly.
-    // The real guard lives in handleNativeRelay: `if (taskInfo.preDispatchSha)`.
-    // This test verifies checkRefAllowlistViolation handles a post-SHA read
-    // failure gracefully (no throw, no signal).
+  it('(e) every git call fails → base ref never resolves, detection skipped cleanly', () => {
+    // Every git invocation throws, so base-ref discovery itself fails and
+    // checkRefAllowlistViolation takes the `if (!ref) return` early exit. This
+    // is the "no base ref" path, NOT the postSha-read-failure path — see (e2),
+    // which isolates that separately.
     mockExecFileSync.mockImplementation(() => { throw new Error('git: command not found'); });
 
-    // Should not throw
     expect(() => checkRefAllowlistViolation('task-null', 'sonnet-implementer', PRE_SHA)).not.toThrow();
+
+    expect(mockEmitSignals).not.toHaveBeenCalled();
+    expect(mockAppendFileSync).not.toHaveBeenCalled();
+  });
+
+  it('(e2) base ref resolves but the postSha read fails → no throw, no false positive', () => {
+    // Isolates the postSha try/catch: discovery succeeds, then the `rev-parse
+    // <ref>` that reads the CURRENT sha fails. Without this, (e) masked the
+    // branch because it broke discovery before postSha was ever attempted.
+    mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+      const key = (args as string[]).join(' ');
+      if (key === 'symbolic-ref --quiet refs/remotes/origin/HEAD') return 'refs/remotes/origin/master\n';
+      if (key === 'rev-parse --verify --quiet origin/master') return `${PRE_SHA}\n`;
+      // The post-dispatch SHA read is the one that fails.
+      if (key === 'rev-parse origin/master') throw new Error('fatal: bad object');
+      throw new Error(`unexpected git call: ${key}`);
+    });
+
+    expect(() => checkRefAllowlistViolation('task-postsha', 'sonnet-implementer', PRE_SHA)).not.toThrow();
 
     expect(mockEmitSignals).not.toHaveBeenCalled();
     expect(mockAppendFileSync).not.toHaveBeenCalled();

--- a/tests/cli/ref-allowlist-detection.test.ts
+++ b/tests/cli/ref-allowlist-detection.test.ts
@@ -37,6 +37,7 @@ jest.mock('fs', () => ({
 // ── imports after mocks ──────────────────────────────────────────────────────
 
 import { capturePreDispatchSha, checkRefAllowlistViolation } from '../../apps/cli/src/handlers/ref-allowlist-detection';
+import { resetBaseRefDiscoveryCache } from '../../apps/cli/src/handlers/base-ref-discovery';
 import { emitConsensusSignals } from '@gossip/orchestrator';
 
 const mockExecFileSync = childProcess.execFileSync as jest.Mock;
@@ -53,6 +54,7 @@ const POST_SHA = 'ffff6666gggg7777hhhh8888iiii9999jjjj0000';
 describe('capturePreDispatchSha', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetBaseRefDiscoveryCache();
   });
 
   it('returns the trimmed SHA on success', () => {
@@ -71,6 +73,7 @@ describe('capturePreDispatchSha', () => {
 describe('checkRefAllowlistViolation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetBaseRefDiscoveryCache();
   });
 
   it('(a) SHA unchanged → no signal, no JSONL append', () => {


### PR DESCRIPTION
## Summary

Fixes #658 — the ref-allowlist pre-dispatch snapshot and the `dispatched_stale_base` precondition hardcoded `origin/master`, so on `main`-default repos git printed a `fatal:` line on every dispatch and both features were silently disabled.

New `apps/cli/src/handlers/base-ref-discovery.ts` resolves the base ref with precedence **`GOSSIP_BASE_REF` → `git symbolic-ref refs/remotes/origin/HEAD` → first of `origin/master`/`origin/main` that verifies** (`rev-parse --verify --quiet`, so missing candidates produce no log noise). All three hardcoded call sites route through it; `detectStaleBase` semantics are untouched.

## Pre-merge consensus round

`ref-allowlist-detection.ts` is `@gossip:impact-adjacent`, so this went through a two-reviewer round. Both reviewers found real defects, all fixed in `a9335965`:

**Override validation (medium).** `GOSSIP_BASE_REF` was the only tier that never verified its value. fable-reviewer reproduced the consequence end-to-end: setting it to `master` — a missing `origin/` prefix, a realistic slip — makes the direct-push detector compare against a **local** branch, so any unrelated commit landing during a task is reported as a `REF-ALLOWLIST VIOLATION` and emits a **high-severity `boundary_escape` against an innocent agent**. The override now must be ref-shaped, must resolve, and must be remote-tracking, each with a distinct diagnostic.

**Negative results no longer cached (medium).** `{ref: null}` was cached like a success, so a server started before `origin` existed kept both features dead for the whole process. Worse, the cache was read *before* the env override, so the documented `GOSSIP_BASE_REF` remedy couldn't take effect without a restart. Override is now read first; only positives are cached.

**Cache keyed by cwd (low).** An unkeyed cache served the first repo's ref to every later root. Latent today — both consumers use `process.cwd()` and `process.chdir` appears nowhere in the source — but a two-line trap removal.

**Observability (low).** `StaleBaseInputs` now carries `baseRef`, so the operator warning and the signal metadata name the ref actually consulted rather than a hardcoded `origin/master` — wrong on exactly the `main`-default repos this issue is about, and previously leaving signals un-attributable to a ref. `gatherStaleBaseInputs` no longer returns null silently. `execFileForBaseRef` now passes `stdio:['ignore','pipe','ignore']` like every other git call in the file; without it git `fatal:` lines leaked — the exact noise #658 set out to remove.

**Refuted and deliberately not changed:** argument injection via `GOSSIP_BASE_REF` (15 payloads × 3 argv shapes run as real `git` processes — no execution, no file write, no hang; `execFileSync` passes an argv array, so no shell is involved), and pre/post SHAs diverging between the two consumers (unreachable: the cache guarantees ref identity, and `preDispatchSha` never leaves the in-memory `nativeTaskMap`).

## Verification

- Target suites: 62/62. New coverage for override rejection (local branch, non-resolving, `--all`/`-e`/whitespace), cache-negative recovery, per-cwd keying, env-before-cache recovery, honest diagnostic wording, and an `(e2)` case isolating the `postSha`-read-failure branch that the old `(e)` masked by breaking discovery first.
- Full jest: **354/354 suites, 4852 passed**. `tsc` clean. `build` + `build:mcp` clean.

## Note for reviewers (worktree gotcha)

The implementing agent's in-worktree verification hit dist-mcp binary-suite failures that looked pre-existing. Root cause, confirmed: the dual-zod geometry (`packages/tools/node_modules/zod`, PR #648) is unreachable from inside a git worktree, so any dist-mcp bundle built there collapses to one zod and crashes at import (`Class2 is not a constructor`). All verification here was done from the repo root.

consensus-id: cbb2f4a7-9bf7a7b8

🤖 Generated with [Claude Code](https://claude.com/claude-code)