### PR TITLE
fix(consensus): resolve absolute citation paths inside configured roots (#660)

### DIFF
--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -1983,6 +1983,38 @@ Return only valid JSON.${skillsBlock}`;
    * Fix: additionally verify the path is NOT inside any currentWorktreeRoot
    * via isInsideAnyRoot, which applies realpath-safe containment checks.
    */
+  /**
+   * Realpath-normalize a path, tolerating non-existence: if the path itself
+   * doesn't exist, walk up to the nearest ancestor that does, realpath THAT,
+   * then re-append the missing tail. Falls back to resolve() when nothing in
+   * the chain exists. Never throws.
+   *
+   * This is the single normalization used for BOTH sides of every containment
+   * and root-prefix comparison. Symmetry is what makes the comparison agree
+   * with the kernel: on macOS /tmp is a symlink to /private/tmp, so a
+   * resolve()-only comparison reports a legitimate path as out-of-root (or a
+   * legitimate root as a non-prefix) purely because one side was realpath'd.
+   */
+  private realpathOrNearest(path: string): string {
+    const resolved = resolve(path);
+    try {
+      return realpathSync(resolved);
+    } catch { /* doesn't exist yet — walk up to the nearest existing ancestor */ }
+
+    let cur = resolved;
+    const tail: string[] = [];
+    while (true) {
+      const parent = dirname(cur);
+      if (parent === cur) return resolved; // reached fs root: nothing existed
+      tail.unshift(cur.slice(parent.length + (parent.endsWith(sep) ? 0 : 1)));
+      try {
+        return join(realpathSync(parent), ...tail);
+      } catch {
+        cur = parent;
+      }
+    }
+  }
+
   private isResolvedFromProjectRootOnly(filePath: string): boolean {
     if (this.currentWorktreeRoots.size === 0) return false;
     if (!this.config.projectRoot) return false;
@@ -2012,34 +2044,7 @@ Return only valid JSON.${skillsBlock}`;
    * (HIGH). Load-bearing for PR-B (#126 auto-discovery).
    */
   private isInsideAnyRoot(candidate: string, roots: string[]): boolean {
-    // Realpath-normalize the candidate. If it doesn't exist, walk up to the
-    // nearest ancestor that does, realpath that, then re-append the missing
-    // tail. This lets us catch symlinked ancestors even for not-yet-created
-    // files without bailing to unsafe prefix-only matching.
-    const resolvedCandidate = resolve(candidate);
-    let normalized = resolvedCandidate;
-    try {
-      normalized = realpathSync(resolvedCandidate);
-    } catch {
-      // Walk ancestors until one exists
-      let cur = resolvedCandidate;
-      const tail: string[] = [];
-      while (true) {
-        const parent = dirname(cur);
-        if (parent === cur) break; // reached root
-        const leaf = cur.slice(parent.length + (parent.endsWith(sep) ? 0 : 1));
-        tail.unshift(leaf);
-        try {
-          const realParent = realpathSync(parent);
-          normalized = tail.length ? join(realParent, ...tail) : realParent;
-          break;
-        } catch {
-          cur = parent;
-          // continue up
-        }
-      }
-      // If nothing in the chain exists, fall through with resolve()'d form.
-    }
+    const normalized = this.realpathOrNearest(candidate);
 
     // Resolve each root symmetrically. Prefer the precomputed realpath cache
     // (populated by updateWorktreeRoots) to avoid repeated syscalls; fall
@@ -2078,7 +2083,11 @@ Return only valid JSON.${skillsBlock}`;
   private async acceptCandidate(candidate: string, allRoots: string[]): Promise<string | null> {
     try {
       if (!this.isInsideAnyRoot(candidate, allRoots)) return null;
-      await stat(candidate);
+      // Directories pass stat() but can never satisfy a `file:line` citation.
+      // Without this gate a cite of `<root>/packages/orchestrator:12`
+      // "resolved", then cachedRead hit EISDIR and returned null — dropping the
+      // anchor silently instead of reporting an unresolvable citation.
+      if (!(await stat(candidate)).isFile()) return null;
       // Fail CLOSED when realpath is unavailable. isInsideAnyRoot normalizes
       // textually (resolve()), but stat/readFile let the kernel resolve `..`
       // AFTER following symlinks — so realpath is the only check that sees
@@ -2100,20 +2109,37 @@ Return only valid JSON.${skillsBlock}`;
    * via shell), and the failure silently depressed their accuracy scores.
    *
    * Two strategies, in order:
-   *  1. Take the path as-is — but ONLY if it is contained in a configured root.
-   *     Containment goes through isInsideAnyRoot (realpath + `relative()`
-   *     boundary), NOT a naive startsWith, so `/abs/root-evil/x` does not pass
-   *     for root `/abs/root`. This preserves the worktree sandbox: an absolute
-   *     path outside every configured root is never resolved.
-   *  2. Strip a matching configured-root prefix and re-join the remainder
-   *     against each root in priority order. This repairs worktree-root
-   *     mismatches (resolutionRoots, issue #126) for free: a cite of
-   *     `<projectRoot>/packages/foo.ts` for a file that only exists in the
-   *     worktree resolves against the worktree root. The prefix must itself be
-   *     a configured root, so this cannot widen the sandbox either.
+   *  1. Strip a matching configured-root prefix and re-join the remainder
+   *     against each root in PRIORITY order. This repairs worktree-root
+   *     mismatches (resolutionRoots, issue #126): a cite of
+   *     `<projectRoot>/packages/foo.ts` for a file that also (or only) exists in
+   *     the worktree resolves against the worktree root. The prefix must itself
+   *     be a configured root, so this cannot widen the sandbox.
+   *  2. Fallback — take the path as-is, but ONLY if it is contained in a
+   *     configured root. Containment goes through isInsideAnyRoot (realpath +
+   *     `relative()` boundary), NOT a naive startsWith, so `/abs/root-evil/x`
+   *     does not pass for root `/abs/root`. This preserves the worktree
+   *     sandbox: an absolute path outside every configured root is never
+   *     resolved.
    *
-   * Longest matching prefix wins in step 2 — worktrees are commonly nested
+   * Priority order is authoritative — step 1 runs FIRST for exactly that
+   * reason. When as-is acceptance came first, an absolute citation of a file
+   * present in BOTH projectRoot and a worktree root always returned the
+   * projectRoot (master HEAD) copy, because as-is only asked "is this inside
+   * ANY root?". That inverted the documented cachedResolveForAnchor contract —
+   * cross-reviewers verified findings against master instead of the branch
+   * under review, turning valid findings into refutations. It is also the
+   * common case: every PR review here runs with a worktree resolutionRoot and
+   * most cited files exist in both trees. Absolute cites now agree with
+   * bare-relative cites, which have always honoured priority order.
+   *
+   * Longest matching prefix wins in step 1 — worktrees are commonly nested
    * under projectRoot, and the longer root yields the correct suffix.
+   *
+   * Prefix comparison is realpath-symmetric (realpathOrNearest on both sides).
+   * With resolve() only, a root reached through a symlink (the everyday macOS
+   * /tmp -> /private/tmp) never matched as a prefix, so strip-and-rejoin
+   * silently degraded to nothing.
    */
   private async resolveAbsoluteFileRef(
     fileRef: string,
@@ -2124,13 +2150,13 @@ Return only valid JSON.${skillsBlock}`;
     // un-normalized `<root>/<symlinked-dir>/../secret.ts` passes the textual
     // containment check while the kernel resolves it outside every root.
     const abs = resolve(fileRef);
+    const absReal = this.realpathOrNearest(abs);
 
-    const asIs = await this.acceptCandidate(abs, allRoots);
-    if (asIs) return asIs;
-
-    const prefixRoots = [...allRoots].sort((a, b) => resolve(b).length - resolve(a).length);
+    const prefixRoots = [...allRoots].sort(
+      (a, b) => this.realpathOrNearest(b).length - this.realpathOrNearest(a).length,
+    );
     for (const prefixRoot of prefixRoots) {
-      const rel = relative(resolve(prefixRoot), abs);
+      const rel = relative(this.realpathOrNearest(prefixRoot), absReal);
       // Not under this root (or identical to it) — nothing to strip.
       if (rel === '' || rel === '..' || rel.startsWith('..' + sep) || isAbsolute(rel)) continue;
       for (const root of priorityRoots) {
@@ -2138,7 +2164,10 @@ Return only valid JSON.${skillsBlock}`;
         if (hit) return hit;
       }
     }
-    return null;
+
+    // No priority root yielded a hit: fall back to the cited location itself.
+    // Reachable when the containing root is absent from priorityRoots.
+    return this.acceptCandidate(abs, allRoots);
   }
 
   private async resolveFilePath(
@@ -2175,11 +2204,12 @@ Return only valid JSON.${skillsBlock}`;
       try {
         const candidate = join(root, fileRef);
         if (this.isInsideAnyRoot(candidate, allRoots)) {
-          await stat(candidate);
+          // isFile(): a directory can never satisfy a `file:line` citation.
+          const isFile = (await stat(candidate)).isFile();
           // For non-bare refs, require matchesRelativePath against this root
           // so a monorepo sibling "packages/other/foo.ts" doesn't satisfy a
           // cite of "packages/target/foo.ts" by basename collision.
-          if (isBare || this.matchesRelativePath(rootAbs, resolve(candidate), fileRef)) {
+          if (isFile && (isBare || this.matchesRelativePath(rootAbs, resolve(candidate), fileRef))) {
             // Realpath & re-verify containment to close any symlink escape
             // introduced by the root itself.
             let real = candidate;
@@ -2193,8 +2223,7 @@ Return only valid JSON.${skillsBlock}`;
       if (fileName !== fileRef) {
         try {
           const candidate = join(root, fileName);
-          if (this.isInsideAnyRoot(candidate, allRoots)) {
-            await stat(candidate);
+          if (this.isInsideAnyRoot(candidate, allRoots) && (await stat(candidate)).isFile()) {
             let real = candidate;
             try { real = realpathSync(candidate); } catch { /* keep */ }
             if (this.isInsideAnyRoot(real, allRoots)) return real;

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -2069,6 +2069,70 @@ Return only valid JSON.${skillsBlock}`;
     });
   }
 
+  /**
+   * Accept a candidate path iff it exists AND stays inside a valid root, with
+   * symlink-safe containment checked both before and after realpath. Shared by
+   * absolute-citation resolution and (conceptually) the relative loop below.
+   * Returns the realpath'd absolute path, or null if unusable.
+   */
+  private async acceptCandidate(candidate: string, allRoots: string[]): Promise<string | null> {
+    try {
+      if (!this.isInsideAnyRoot(candidate, allRoots)) return null;
+      await stat(candidate);
+      let real = candidate;
+      try { real = realpathSync(candidate); } catch { /* keep pre-realpath form */ }
+      if (this.isInsideAnyRoot(real, allRoots)) return real;
+    } catch { /* candidate does not exist at this location */ }
+    return null;
+  }
+
+  /**
+   * Resolve an ABSOLUTE citation path (issue #660).
+   *
+   * `join(root, '/abs/root/src/f.ts')` yields '/abs/root/abs/root/src/f.ts',
+   * which never exists — so before this path existed, every absolute citation
+   * failed anchor resolution even when the cited file was inside a configured
+   * root. Agents emit absolute paths routinely (they echo paths they just read
+   * via shell), and the failure silently depressed their accuracy scores.
+   *
+   * Two strategies, in order:
+   *  1. Take the path as-is — but ONLY if it is contained in a configured root.
+   *     Containment goes through isInsideAnyRoot (realpath + `relative()`
+   *     boundary), NOT a naive startsWith, so `/abs/root-evil/x` does not pass
+   *     for root `/abs/root`. This preserves the worktree sandbox: an absolute
+   *     path outside every configured root is never resolved.
+   *  2. Strip a matching configured-root prefix and re-join the remainder
+   *     against each root in priority order. This repairs worktree-root
+   *     mismatches (resolutionRoots, issue #126) for free: a cite of
+   *     `<projectRoot>/packages/foo.ts` for a file that only exists in the
+   *     worktree resolves against the worktree root. The prefix must itself be
+   *     a configured root, so this cannot widen the sandbox either.
+   *
+   * Longest matching prefix wins in step 2 — worktrees are commonly nested
+   * under projectRoot, and the longer root yields the correct suffix.
+   */
+  private async resolveAbsoluteFileRef(
+    fileRef: string,
+    priorityRoots: string[],
+    allRoots: string[],
+  ): Promise<string | null> {
+    const asIs = await this.acceptCandidate(fileRef, allRoots);
+    if (asIs) return asIs;
+
+    const abs = resolve(fileRef);
+    const prefixRoots = [...allRoots].sort((a, b) => resolve(b).length - resolve(a).length);
+    for (const prefixRoot of prefixRoots) {
+      const rel = relative(resolve(prefixRoot), abs);
+      // Not under this root (or identical to it) — nothing to strip.
+      if (rel === '' || rel === '..' || rel.startsWith('..' + sep) || isAbsolute(rel)) continue;
+      for (const root of priorityRoots) {
+        const hit = await this.acceptCandidate(join(root, rel), allRoots);
+        if (hit) return hit;
+      }
+    }
+    return null;
+  }
+
   private async resolveFilePath(
     fileRef: string,
     opts: { priorityRoots?: string[] } = {},
@@ -2083,6 +2147,13 @@ Return only valid JSON.${skillsBlock}`;
     const fileName = fileRef.split('/').pop()!;
     const isBare = !fileRef.includes('/');
     const projectRoot = this.config.projectRoot ? resolve(this.config.projectRoot) : null;
+
+    // Absolute citations cannot be join()'d onto a root (issue #660) — handle
+    // them separately, then fall through to the relative loop on failure.
+    if (isAbsolute(fileRef)) {
+      const hit = await this.resolveAbsoluteFileRef(fileRef, roots, allRoots);
+      if (hit) return hit;
+    }
 
     // Try every root in order: projectRoot first (most files), then any
     // active worktree paths (for files only present on a feature branch).

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -2079,10 +2079,14 @@ Return only valid JSON.${skillsBlock}`;
     try {
       if (!this.isInsideAnyRoot(candidate, allRoots)) return null;
       await stat(candidate);
-      let real = candidate;
-      try { real = realpathSync(candidate); } catch { /* keep pre-realpath form */ }
+      // Fail CLOSED when realpath is unavailable. isInsideAnyRoot normalizes
+      // textually (resolve()), but stat/readFile let the kernel resolve `..`
+      // AFTER following symlinks — so realpath is the only check that sees
+      // where the path actually lands. Keeping the pre-realpath form here made
+      // the containment re-check below a no-op repeat of the pre-stat check.
+      const real = realpathSync(candidate);
       if (this.isInsideAnyRoot(real, allRoots)) return real;
-    } catch { /* candidate does not exist at this location */ }
+    } catch { /* candidate does not exist here, or realpath is unavailable */ }
     return null;
   }
 
@@ -2116,10 +2120,14 @@ Return only valid JSON.${skillsBlock}`;
     priorityRoots: string[],
     allRoots: string[],
   ): Promise<string | null> {
-    const asIs = await this.acceptCandidate(fileRef, allRoots);
+    // resolve() FIRST — never hand a raw citation to acceptCandidate. An
+    // un-normalized `<root>/<symlinked-dir>/../secret.ts` passes the textual
+    // containment check while the kernel resolves it outside every root.
+    const abs = resolve(fileRef);
+
+    const asIs = await this.acceptCandidate(abs, allRoots);
     if (asIs) return asIs;
 
-    const abs = resolve(fileRef);
     const prefixRoots = [...allRoots].sort((a, b) => resolve(b).length - resolve(a).length);
     for (const prefixRoot of prefixRoots) {
       const rel = relative(resolve(prefixRoot), abs);

--- a/tests/orchestrator/consensus-engine-absolute-citation.test.ts
+++ b/tests/orchestrator/consensus-engine-absolute-citation.test.ts
@@ -103,14 +103,54 @@ describe('ConsensusEngine — absolute citation paths (#660)', () => {
     const wtCopy = writeFileAt(join(wt, 'packages', 'a', 'both.ts'), 'branch\n');
     const engine = makeEngine(repo, [wt]);
 
-    // Cited with the worktree-mismatched (projectRoot) prefix — the file exists
-    // at both locations, so step 1 (as-is) wins and returns the cited copy.
-    const cited = await engine.resolveFilePath(join(repo, 'packages', 'a', 'both.ts'));
-    expect(cited).toBe(join(repo, 'packages', 'a', 'both.ts'));
+    // Cited with the worktree-mismatched (projectRoot) prefix. priorityRoots is
+    // authoritative: strip-and-rejoin runs before as-is acceptance, so the
+    // WORKTREE copy wins — an absolute cite must not pin the reviewer to master
+    // HEAD just because the file also exists there.
+    const cited = await engine.cachedResolveForAnchor(join(repo, 'packages', 'a', 'both.ts'));
+    expect(cited).toBe(wtCopy);
 
-    // A bare-relative citation still honours worktree-priority ordering.
+    // A bare-relative citation honours the same ordering.
     const anchored = await engine.cachedResolveForAnchor('packages/a/both.ts');
     expect(anchored).toBe(wtCopy);
+
+    // Non-anchor resolution (projectRoot-first priority) still returns master.
+    expect(await engine.resolveFilePath(join(repo, 'packages', 'a', 'both.ts')))
+      .toBe(join(repo, 'packages', 'a', 'both.ts'));
+  });
+
+  // Fix (3): the prefix comparison must be realpath-symmetric. With resolve()
+  // only, a root configured through a symlink never matches as a prefix, so
+  // strip-and-rejoin silently degrades to nothing. Note this suite's other
+  // tests sidestep the bug by realpath'ing tmp in setup — this one builds the
+  // asymmetry explicitly (root via symlink, citation via realpath).
+  it('strips a symlinked root prefix when re-joining (realpath-symmetric)', async () => {
+    const realRepo = join(root, 'realrepo');
+    const linkRepo = join(root, 'linkrepo');
+    mkdirSync(realRepo, { recursive: true });
+    symlinkSync(realRepo, linkRepo);
+    const wt = join(linkRepo, '.claude', 'worktrees', 'wt-1');
+    mkdirSync(wt, { recursive: true });
+    const target = writeFileAt(join(wt, 'packages', 'a', 'branch-only.ts'));
+    const engine = makeEngine(linkRepo, [wt]);
+
+    // Roots are configured through the symlink; the agent cited the realpath.
+    const citedAs = join(realRepo, 'packages', 'a', 'branch-only.ts');
+
+    expect(await engine.resolveFilePath(citedAs)).toBe(realpathSync(target));
+  });
+
+  // Fix (2): stat() succeeds for directories, so a directory citation used to
+  // "resolve"; cachedRead then hit EISDIR and the anchor was dropped silently
+  // instead of being counted as an unresolvable citation.
+  it('does NOT resolve a citation that points at a directory', async () => {
+    mkdirSync(join(repo, 'packages', 'orchestrator'), { recursive: true });
+    const engine = makeEngine(repo);
+
+    // Absolute form (acceptCandidate gate).
+    expect(await engine.resolveFilePath(join(repo, 'packages', 'orchestrator'))).toBeNull();
+    // Relative form (relative-loop gate).
+    expect(await engine.resolveFilePath('packages/orchestrator')).toBeNull();
   });
 
   it('leaves relative citation resolution unchanged', async () => {

--- a/tests/orchestrator/consensus-engine-absolute-citation.test.ts
+++ b/tests/orchestrator/consensus-engine-absolute-citation.test.ts
@@ -8,7 +8,7 @@
  */
 import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
 import { testRound } from '../../packages/orchestrator/src/round-context';
-import { mkdtempSync, mkdirSync, writeFileSync, realpathSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync, rmSync, symlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -132,5 +132,39 @@ describe('ConsensusEngine — absolute citation paths (#660)', () => {
     const resolved = await engine.resolveFilePath(join(repo, 'packages', 'a', 'zz-ghost-only.ts'));
 
     expect(resolved).toBeNull();
+  });
+
+  // Regression: the first cut of this fix passed the RAW fileRef to
+  // acceptCandidate, which let `<root>/<symlinked-dir>/../secret.ts` escape
+  // every configured root. isInsideAnyRoot collapses `..` textually (so the
+  // path looks contained), but stat/readFile let the kernel resolve `..` AFTER
+  // following the symlink — landing outside. realpathSync pre-resolves
+  // textually, so it ENOENT'd and the old fail-OPEN catch kept the raw path,
+  // making the post-realpath containment check a no-op. Caught by
+  // fable-reviewer; out-of-root file contents reached the <anchor> block.
+  //
+  // NOTE: the attack path MUST be built by string concat — join()/resolve()
+  // collapse `..` textually and silently defuse the exploit.
+  it('does NOT resolve an absolute path that escapes via a symlinked dir plus ..', async () => {
+    const victimDir = join(root, 'victim');
+    mkdirSync(join(victimDir, 'nested'), { recursive: true });
+    writeFileSync(join(victimDir, 'creds.ts'), 'const SECRET = "sk-EXFILTRATED";\n');
+    symlinkSync(join(victimDir, 'nested'), join(repo, 'link'));
+    const engine = makeEngine(repo);
+
+    const escape = repo + '/link/../creds.ts';
+
+    expect(await engine.resolveFilePath(escape)).toBeNull();
+    expect(await engine.cachedResolveForAnchor(escape)).toBeNull();
+  });
+
+  it('does NOT resolve an absolute path through a symlinked dir that leaves the root', async () => {
+    const victimDir = join(root, 'victim2');
+    mkdirSync(victimDir, { recursive: true });
+    writeFileSync(join(victimDir, 'leak.ts'), 'const SECRET = "leaked";\n');
+    symlinkSync(victimDir, join(repo, 'out'));
+    const engine = makeEngine(repo);
+
+    expect(await engine.resolveFilePath(join(repo, 'out', 'leak.ts'))).toBeNull();
   });
 });

--- a/tests/orchestrator/consensus-engine-absolute-citation.test.ts
+++ b/tests/orchestrator/consensus-engine-absolute-citation.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Absolute-path citation resolution (issue #660).
+ *
+ * `join(root, '/abs/root/src/f.ts')` produces '/abs/root/abs/root/src/f.ts',
+ * so before the fix every absolute citation failed anchor resolution even when
+ * the file existed inside a configured root. These tests pin the fix AND the
+ * sandbox guarantee it must not weaken.
+ */
+import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
+import { testRound } from '../../packages/orchestrator/src/round-context';
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const makeLlm = (): any => ({
+  generate: jest.fn(async () => ({ text: '[]', usage: { inputTokens: 0, outputTokens: 0 } })),
+});
+
+const makeEngine = (projectRoot: string, resolutionRoots: string[] = []): any =>
+  new ConsensusEngine({
+    llm: makeLlm(),
+    registryGet: () => undefined,
+    projectRoot,
+    round: testRound({ resolutionRoots }),
+  });
+
+const writeFileAt = (path: string, contents = 'export const x = 1;\n'): string => {
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, contents);
+  return path;
+};
+
+describe('ConsensusEngine — absolute citation paths (#660)', () => {
+  let tmp: string;
+  let root: string;
+  let repo: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'cea-'));
+    root = realpathSync(tmp);
+    repo = join(root, 'repo');
+    mkdirSync(repo, { recursive: true });
+  });
+
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it('resolves an absolute path that lies inside projectRoot', async () => {
+    const target = writeFileAt(join(repo, 'packages', 'orchestrator', 'src', 'thing.ts'));
+    const engine = makeEngine(repo);
+
+    const resolved = await engine.resolveFilePath(target);
+
+    expect(resolved).toBe(target);
+  });
+
+  it('resolves an absolute path inside a worktree resolutionRoot', async () => {
+    const wt = join(repo, '.claude', 'worktrees', 'wt-1');
+    mkdirSync(wt, { recursive: true });
+    const target = writeFileAt(join(wt, 'packages', 'a', 'only-here.ts'));
+    const engine = makeEngine(repo, [wt]);
+
+    const resolved = await engine.resolveFilePath(target);
+
+    expect(resolved).toBe(target);
+  });
+
+  it('does NOT resolve an absolute path outside every configured root (sandbox preserved)', async () => {
+    const outside = writeFileAt(join(root, 'outside', 'src', 'zz-secret-only.ts'));
+    const engine = makeEngine(repo);
+
+    const resolved = await engine.resolveFilePath(outside);
+
+    expect(resolved).toBeNull();
+  });
+
+  it('does NOT resolve a sibling-prefix path (no naive startsWith containment)', async () => {
+    // `<root>/repo-evil` shares a textual prefix with root `<root>/repo`.
+    const evil = writeFileAt(join(root, 'repo-evil', 'src', 'zz-evil-only.ts'));
+    const engine = makeEngine(repo);
+
+    const resolved = await engine.resolveFilePath(evil);
+
+    expect(resolved).toBeNull();
+  });
+
+  it('repairs a worktree-root mismatch by stripping the root prefix and re-joining', async () => {
+    // File exists ONLY in the worktree; the agent cited it under projectRoot.
+    const wt = join(repo, '.claude', 'worktrees', 'wt-1');
+    mkdirSync(wt, { recursive: true });
+    const target = writeFileAt(join(wt, 'packages', 'a', 'branch-only.ts'));
+    const citedAs = join(repo, 'packages', 'a', 'branch-only.ts');
+    const engine = makeEngine(repo, [wt]);
+
+    const resolved = await engine.resolveFilePath(citedAs);
+
+    expect(resolved).toBe(target);
+  });
+
+  it('prefers the worktree copy for anchor resolution when both roots have the file', async () => {
+    const wt = join(repo, '.claude', 'worktrees', 'wt-1');
+    mkdirSync(wt, { recursive: true });
+    writeFileAt(join(repo, 'packages', 'a', 'both.ts'), 'master\n');
+    const wtCopy = writeFileAt(join(wt, 'packages', 'a', 'both.ts'), 'branch\n');
+    const engine = makeEngine(repo, [wt]);
+
+    // Cited with the worktree-mismatched (projectRoot) prefix — the file exists
+    // at both locations, so step 1 (as-is) wins and returns the cited copy.
+    const cited = await engine.resolveFilePath(join(repo, 'packages', 'a', 'both.ts'));
+    expect(cited).toBe(join(repo, 'packages', 'a', 'both.ts'));
+
+    // A bare-relative citation still honours worktree-priority ordering.
+    const anchored = await engine.cachedResolveForAnchor('packages/a/both.ts');
+    expect(anchored).toBe(wtCopy);
+  });
+
+  it('leaves relative citation resolution unchanged', async () => {
+    const target = writeFileAt(join(repo, 'packages', 'orchestrator', 'src', 'rel-thing.ts'));
+    const engine = makeEngine(repo);
+
+    expect(await engine.resolveFilePath('packages/orchestrator/src/rel-thing.ts')).toBe(target);
+    // Trailing-segment match still works.
+    expect(await engine.resolveFilePath('src/rel-thing.ts')).toBe(target);
+    // Basename collision against a different directory is still rejected.
+    expect(await engine.resolveFilePath('packages/other/rel-thing.ts')).toBeNull();
+    // Non-existent relative path still resolves to null.
+    expect(await engine.resolveFilePath('packages/orchestrator/src/zz-nope.ts')).toBeNull();
+  });
+
+  it('returns null for an absolute path inside a root that does not exist on disk', async () => {
+    const engine = makeEngine(repo);
+
+    const resolved = await engine.resolveFilePath(join(repo, 'packages', 'a', 'zz-ghost-only.ts'));
+
+    expect(resolved).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #660. The anchor resolver built every candidate as `path.join(root, citedPath)`, which for an already-absolute citation yields a doubled path (`/root` + `/root/src/f.ts` → `/root/root/src/f.ts`) that never exists. Every absolute-path citation failed anchor resolution even when the cited file sat inside a configured root — pushing correctly-cited findings toward UNVERIFIED and unfairly depressing the citing agent's accuracy score.

Two commits, deliberately kept separate:

**`105641f8` — the fix** (opus-implementer). New `acceptCandidate` (containment → stat → realpath → containment re-check) and `resolveAbsoluteFileRef` with two strategies: accept-as-is when contained in a configured root, else strip the longest matching root prefix and re-join against each root in priority order (which also repairs the worktree-root mismatch from #126). Hooked into `resolveFilePath` ahead of the relative loop, falling through on miss. A second, independent reason the old code could never work: `matchesRelativePath` splits on `/`, so an absolute cite always has more segments than the relative candidate and is rejected.

**`8b8b1644` — closing an escape the fix introduced.** Adversarial review broke the first cut, and I reproduced it end-to-end against the real engine: a citation of the form `<configured-root>/<symlinked-dir>/../secret.ts` **resolved, and the out-of-root file contents were emitted inside an `<anchor>` block.**

The mechanism is a three-way disagreement about when `..` is resolved:
- `isInsideAnyRoot` collapses `..` **textually** via `resolve()` → the path looks contained.
- `stat()` / `readFile()` let the **kernel** resolve `..` *after* following the symlink → lands outside every root.
- `realpathSync` pre-resolves **textually**, so it `ENOENT`s on the collapsed path → the old fail-**open** `catch` kept the raw candidate → the post-realpath containment check degenerated into a repeat of the pre-stat check.

Fix: `resolve(fileRef)` before `acceptCandidate` (no un-normalized path reaches the containment/stat sequence), and fail **closed** when `realpathSync` throws — realpath is the only check that sees where a path actually lands. Matches the fail-closed precedent in `bd0d712b`.

## Verification

- Escape reproduced against the built engine pre-fix (out-of-root secret leaked), returns `null` post-fix; legitimate in-root absolute citations still resolve.
- Two regression tests added, with a comment warning that the attack path **must** be built by string concat — `join()`/`resolve()` collapse `..` and would make the test vacuously pass.
- `#660` suite 10/10; `tests/orchestrator` 180 suites / 2665 passed; full jest **354/354 suites, 4836 passed**; `tsc --noEmit` clean; `build` + `build:mcp` clean.

## Known follow-ups (filed separately, not in this PR)

1. **Strategy 1 ignores `priorityRoots`** — an absolute cite of a file present in both master and the worktree resolves to the **master** copy, contradicting `cachedResolveForAnchor`'s worktree-priority contract. Labeled (not silent) via the existing `anchor_master_fallback` warning, but it inverts anchor priority for the common PR-review case. The existing test at line 99 pins this behavior under a title claiming the opposite.
2. `acceptCandidate` has no `isFile()` gate, so a directory cite "resolves" and is then silently dropped downstream instead of reported unresolvable (pre-existing in the relative loop too).
3. Strategy 2's prefix comparison uses `resolve`, not realpath, so a root reached through a symlink never matches as a prefix and strip-and-rejoin silently degrades.

consensus-id: 51e0f1a2-8e658464

🤖 Generated with [Claude Code](https://claude.com/claude-code)