### PR TITLE
fix(orchestrator): surface undici error.cause + bounded transport retry (#657)

### DIFF
--- a/packages/orchestrator/src/error-format.ts
+++ b/packages/orchestrator/src/error-format.ts
@@ -8,11 +8,46 @@
  * why issue #657 ("fetch failed" with no further detail) was undiagnosable.
  *
  * Also classifies which of those failures are worth a bounded transport-level
- * retry (see `isRetryableTransportError`) — see llm-client.ts's fetchWithRetry503.
+ * retry (see `isRetryableTransportError` / `classifyTransportError`) — see
+ * llm-client.ts's fetchWithRetry503.
  */
 
 /** Depth cap on cause-chain walking — prevents a cyclic/deep chain from looping forever. */
 const MAX_CAUSE_DEPTH = 3;
+
+/**
+ * Per-segment and total-output length caps. `describeOne` interpolates
+ * `err.message` verbatim, and message strings are attacker/upstream-controlled
+ * (e.g. `llm-client.ts`'s `LLM returned no choices: ${JSON.stringify(data)}`
+ * embeds an entire provider response with no cap). Without a cap here, a
+ * multi-megabyte message reaches the log line and the dashboard ERROR payload
+ * verbatim. Mirrors the existing 200-char provider-body truncation convention
+ * used at the HTTP-response boundary (llm-client.ts's `res.text()).slice(0, 200)`
+ * call sites) but sized a little more generously since this formatter carries
+ * a full cause chain, not a single response body.
+ */
+const MAX_SEGMENT_CHARS = 500;
+const MAX_TOTAL_CHARS = 4000;
+
+function truncate(str: string, maxChars: number): string {
+  if (str.length <= maxChars) return str;
+  const removed = str.length - maxChars;
+  return `${str.slice(0, maxChars)}… [truncated ${removed} chars]`;
+}
+
+/**
+ * Read a property that MIGHT be a throwing getter without letting the read
+ * itself escape. `formatErrorWithCause`'s docstring promises it never throws
+ * — a hostile/buggy `Error` subclass with a throwing `message`/`cause`/`name`
+ * getter must not be able to violate that from a plain property read.
+ */
+function safeRead<T>(fn: () => T, fallback: T): T {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}
 
 /**
  * Diagnostic fields worth surfacing from a Node system error (or a nested
@@ -26,7 +61,7 @@ function safeFieldsOf(err: unknown): string {
   if (typeof err !== 'object' || err === null) return '';
   const parts: string[] = [];
   for (const key of SAFE_DIAGNOSTIC_FIELDS) {
-    const val = (err as Record<string, unknown>)[key];
+    const val = safeRead(() => (err as Record<string, unknown>)[key], undefined);
     if ((typeof val === 'string' || typeof val === 'number') && val !== '') {
       parts.push(`${key}=${val}`);
     }
@@ -34,22 +69,33 @@ function safeFieldsOf(err: unknown): string {
   return parts.length > 0 ? ` (${parts.join(', ')})` : '';
 }
 
-/** Describe a single level of the chain — never serializes an arbitrary object shape. */
+/**
+ * Describe a single level of the chain — never serializes an arbitrary object
+ * shape, never throws (every property read that could be a user-defined
+ * getter is wrapped via `safeRead`), and never returns an unbounded string
+ * (capped at `MAX_SEGMENT_CHARS`).
+ */
 function describeOne(err: unknown): string {
+  let result: string;
   if (err instanceof Error) {
-    return `${err.name}: ${err.message}${safeFieldsOf(err)}`;
+    const name = safeRead(() => err.name, 'Error');
+    const rawMessage = safeRead(() => err.message, '[unreadable message]');
+    const message = typeof rawMessage === 'string' ? rawMessage : safeRead(() => String(rawMessage), '[unreadable message]');
+    result = `${name}: ${message}${safeFieldsOf(err)}`;
+  } else if (typeof err === 'string') {
+    result = err;
+  } else if (typeof err === 'number' || typeof err === 'boolean') {
+    result = String(err);
+  } else if (err === null || err === undefined) {
+    result = String(err);
+  } else {
+    // Non-Error object thrown (or a cause that isn't itself an Error) — note
+    // the type only. Do NOT serialize its keys: an unknown shape could carry
+    // request context (headers/body) that must never reach a log or the
+    // dashboard.
+    result = safeRead(() => `[non-Error value: ${Object.prototype.toString.call(err)}]`, '[non-Error value]');
   }
-  if (typeof err === 'string') return err;
-  if (typeof err === 'number' || typeof err === 'boolean') return String(err);
-  if (err === null || err === undefined) return String(err);
-  // Non-Error object thrown (or a cause that isn't itself an Error) — note the
-  // type only. Do NOT serialize its keys: an unknown shape could carry request
-  // context (headers/body) that must never reach a log or the dashboard.
-  try {
-    return `[non-Error value: ${Object.prototype.toString.call(err)}]`;
-  } catch {
-    return '[non-Error value]';
-  }
+  return truncate(result, MAX_SEGMENT_CHARS);
 }
 
 /**
@@ -57,6 +103,14 @@ function describeOne(err: unknown): string {
  * levels, joining each level with " <- caused by: ". Handles non-Error throws
  * (string, object, null/undefined) without itself throwing. Safe to call on
  * any unknown value — this is meant to sit directly in a `catch (err)` block.
+ *
+ * Throw-safety: every property read on the (untrusted) error object — `.cause`,
+ * `.errors` (AggregateError), `.message`/`.name` (in `describeOne`) — goes
+ * through `safeRead` so a throwing getter degrades to a placeholder instead of
+ * escaping this function. This function sits in the OUTERMOST catch of
+ * worker-agent.ts's `executeTask` — if it throws, the task's ERROR event never
+ * fires and the failure becomes an unhandled rejection instead of a reported
+ * one, which is strictly worse than the pre-formatter behavior.
  */
 export function formatErrorWithCause(err: unknown, maxDepth: number = MAX_CAUSE_DEPTH): string {
   // A direct null/undefined throw has no cause chain to walk — describe it
@@ -80,63 +134,117 @@ export function formatErrorWithCause(err: unknown, maxDepth: number = MAX_CAUSE_
     // undici can throw an AggregateError when multiple connection attempts
     // fail (e.g. dual-stack). Fold in a couple of the aggregated sub-errors so
     // the real failure isn't hidden behind the bare "AggregateError" name.
-    if (typeof AggregateError !== 'undefined' && current instanceof AggregateError && Array.isArray(current.errors) && current.errors.length > 0) {
-      const subErrors = current.errors.slice(0, 2).map(describeOne);
-      const more = current.errors.length > 2 ? ` (+${current.errors.length - 2} more)` : '';
-      segments.push(`[${current.errors.length} aggregated error(s)]: ${subErrors.join('; ')}${more}`);
+    if (typeof AggregateError !== 'undefined' && current instanceof AggregateError) {
+      const aggErr = current;
+      const errorsList = safeRead(() => aggErr.errors, undefined);
+      if (Array.isArray(errorsList) && errorsList.length > 0) {
+        const subErrors = errorsList.slice(0, 2).map(describeOne);
+        const more = errorsList.length > 2 ? ` (+${errorsList.length - 2} more)` : '';
+        segments.push(truncate(`[${errorsList.length} aggregated error(s)]: ${subErrors.join('; ')}${more}`, MAX_SEGMENT_CHARS));
+      }
     }
 
-    current = current instanceof Error ? current.cause : undefined;
+    const currentErr = current instanceof Error ? current : undefined;
+    current = currentErr ? safeRead(() => currentErr.cause, undefined) : undefined;
     depth++;
   }
 
-  return segments.join(' <- caused by: ');
+  return truncate(segments.join(' <- caused by: '), MAX_TOTAL_CHARS);
 }
 
 // ─── Transport-failure retry predicate ─────────────────────────────────────
+//
+// The retryable transport-error set is split by PHASE, not just "was this a
+// socket/DNS/TLS-level failure" — because that alone doesn't say whether the
+// request ever reached the server. A blind retry on an error that occurred
+// AFTER the origin received (and possibly billed/executed) the request risks
+// silently re-issuing an already-completed call. See issue #657 follow-up.
 
 /**
- * Node system-error / undici error codes that identify a socket/DNS/TLS-level
- * failure — as opposed to an HTTP response the server actually returned (which
- * must fail fast, never retried here) or a deliberate abort/cancellation.
+ * Connect/DNS-phase error codes: these prove the TCP connection was never
+ * established (DNS never resolved, the OS refused/couldn't route the
+ * connection, or undici's own connect-phase timeout fired). The request body
+ * was never sent, so a retry can never double-execute anything — unconditionally
+ * safe to retry regardless of whether an idempotency key was sent.
  */
-const TRANSPORT_ERROR_CODES = new Set([
-  'ECONNRESET', 'ECONNREFUSED', 'ECONNABORTED', 'ETIMEDOUT', 'ENETUNREACH',
-  'ENETDOWN', 'EHOSTUNREACH', 'EPIPE', 'EAI_AGAIN', 'ENOTFOUND',
-  'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_SOCKET', 'UND_ERR_HEADERS_TIMEOUT',
-  'UND_ERR_BODY_TIMEOUT', 'UND_ERR_DESTROYED', 'UND_ERR_CLOSED',
+export const PRE_SEND_TRANSPORT_ERROR_CODES = new Set([
+  'UND_ERR_CONNECT_TIMEOUT', 'ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN',
+  'ENETUNREACH', 'EHOSTUNREACH',
 ]);
 
-function hasTransportCode(err: unknown): boolean {
-  if (!err || typeof err !== 'object') return false;
-  const code = (err as { code?: unknown }).code;
-  return typeof code === 'string' && TRANSPORT_ERROR_CODES.has(code);
+/**
+ * Ambiguous-phase error codes: the failure surfaced AFTER a connection existed
+ * (or in a state where whether the server received/processed the request
+ * cannot be determined from the code alone) — e.g. a reset/timeout while
+ * headers or body were in flight. A slow-but-successful origin call can look
+ * exactly like this. Retrying blind risks double-billing/double-executing a
+ * request the server already completed, so these are retryable ONLY when the
+ * caller attached an idempotency key the origin can use to dedupe (see
+ * `classifyTransportError` / llm-client.ts's `fetchWithRetry503`).
+ *
+ * Any transport-shaped code NOT in `PRE_SEND_TRANSPORT_ERROR_CODES` defaults
+ * here (deny-by-default): ECONNABORTED / ENETDOWN / EPIPE / UND_ERR_BODY_TIMEOUT
+ * / UND_ERR_DESTROYED / UND_ERR_CLOSED are not proven pre-send by their code
+ * alone, so they're treated as ambiguous rather than assumed safe.
+ */
+export const AMBIGUOUS_TRANSPORT_ERROR_CODES = new Set([
+  'ECONNRESET', 'ETIMEDOUT', 'UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_SOCKET',
+  'ECONNABORTED', 'ENETDOWN', 'EPIPE', 'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_DESTROYED', 'UND_ERR_CLOSED',
+]);
+
+export type TransportErrorClass = 'pre-send' | 'ambiguous' | 'not-transport';
+
+function classifyCode(code: unknown): TransportErrorClass | undefined {
+  if (typeof code !== 'string') return undefined;
+  if (PRE_SEND_TRANSPORT_ERROR_CODES.has(code)) return 'pre-send';
+  if (AMBIGUOUS_TRANSPORT_ERROR_CODES.has(code)) return 'ambiguous';
+  return undefined;
+}
+
+function codeOf(err: unknown): unknown {
+  return err && typeof err === 'object' ? (err as { code?: unknown }).code : undefined;
 }
 
 /**
- * True when `err` represents a socket/DNS/TLS-level transport failure that is
- * safe to retry — undici's generic "fetch failed" wrapper, or a recognized
- * system-error code, at the top level or one `cause` level down. False for:
- * anything that isn't an Error, a deliberate abort/timeout-cancellation
- * (`AbortError` / `TimeoutError`), and any error that doesn't match — in
- * particular a `new Error('OpenAI API error (4xx/5xx): ...')` or
- * `QuotaExhaustedException`, neither of which carries a transport code or the
- * bare "fetch failed" message, so an HTTP response the server actually
- * returned is never retried here.
+ * Classify `err` for the bounded transport retry in llm-client.ts's
+ * `fetchWithRetry503`:
+ *  - `'pre-send'`  — proven to have never reached the server; always safe to retry.
+ *  - `'ambiguous'` — transport-shaped, but whether the server processed the
+ *    request is unknown; safe to retry ONLY when an idempotency key was sent.
+ *  - `'not-transport'` — an HTTP response the server actually returned
+ *    (4xx/5xx), a deliberate abort/timeout-cancellation, or anything else —
+ *    never retried here.
+ *
+ * Looks at the top-level error code, then one `cause` level down (undici
+ * commonly wraps the real OS error in `.cause`), then falls back to a bare
+ * "fetch failed" message (STRICT equality — not a substring test, so
+ * `'OpenAI API error (500): upstream fetch failed'` correctly classifies as
+ * `'not-transport'`) — that bare wrapper carries no code at all, so it can't
+ * be phase-classified and is treated as `'ambiguous'`.
  */
-export function isRetryableTransportError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  if (err.name === 'AbortError' || err.name === 'TimeoutError') return false;
+export function classifyTransportError(err: unknown): TransportErrorClass {
+  if (!(err instanceof Error)) return 'not-transport';
+  if (err.name === 'AbortError' || err.name === 'TimeoutError') return 'not-transport';
 
-  // undici's generic fetch-level wrapper — the real cause (if any) is nested
-  // in err.cause, but even a bare "fetch failed" with no cause at all is a
-  // transport-level failure by definition (it never got an HTTP response).
-  if (err.message === 'fetch failed') return true;
-
-  if (hasTransportCode(err)) return true;
+  const topClass = classifyCode(codeOf(err));
+  if (topClass) return topClass;
 
   const cause = (err as Error & { cause?: unknown }).cause;
-  if (cause instanceof Error && hasTransportCode(cause)) return true;
+  const causeClass = classifyCode(codeOf(cause));
+  if (causeClass) return causeClass;
 
-  return false;
+  if (err.message === 'fetch failed') return 'ambiguous';
+
+  return 'not-transport';
+}
+
+/**
+ * True when `err` represents a socket/DNS/TLS-level transport failure worth a
+ * bounded retry (either phase — pre-send or ambiguous). Kept for existing
+ * callers/tests; prefer `classifyTransportError` where the pre-send/ambiguous
+ * distinction matters (idempotency-gated retry).
+ */
+export function isRetryableTransportError(err: unknown): boolean {
+  return classifyTransportError(err) !== 'not-transport';
 }

--- a/packages/orchestrator/src/error-format.ts
+++ b/packages/orchestrator/src/error-format.ts
@@ -1,0 +1,142 @@
+/**
+ * Format an unknown thrown value into a diagnostic string that includes the
+ * `cause` chain — undici (Node's global `fetch`) wraps the real OS/TLS/DNS
+ * error in `error.cause` and leaves only the generic string "fetch failed" in
+ * `error.message`. Left unhandled, that discards the ONLY information that
+ * identifies the failure class (ECONNRESET, ETIMEDOUT, ENETUNREACH,
+ * UND_ERR_CONNECT_TIMEOUT, EAI_AGAIN, CERT_HAS_EXPIRED, ...), which is exactly
+ * why issue #657 ("fetch failed" with no further detail) was undiagnosable.
+ *
+ * Also classifies which of those failures are worth a bounded transport-level
+ * retry (see `isRetryableTransportError`) — see llm-client.ts's fetchWithRetry503.
+ */
+
+/** Depth cap on cause-chain walking — prevents a cyclic/deep chain from looping forever. */
+const MAX_CAUSE_DEPTH = 3;
+
+/**
+ * Diagnostic fields worth surfacing from a Node system error (or a nested
+ * cause). Deliberately a small allow-list: request body, headers, and any
+ * Authorization/api-key value must NEVER appear here. If a field isn't on
+ * this list it is not read at all, string or not.
+ */
+const SAFE_DIAGNOSTIC_FIELDS = ['code', 'errno', 'syscall', 'hostname', 'address', 'port'] as const;
+
+function safeFieldsOf(err: unknown): string {
+  if (typeof err !== 'object' || err === null) return '';
+  const parts: string[] = [];
+  for (const key of SAFE_DIAGNOSTIC_FIELDS) {
+    const val = (err as Record<string, unknown>)[key];
+    if ((typeof val === 'string' || typeof val === 'number') && val !== '') {
+      parts.push(`${key}=${val}`);
+    }
+  }
+  return parts.length > 0 ? ` (${parts.join(', ')})` : '';
+}
+
+/** Describe a single level of the chain — never serializes an arbitrary object shape. */
+function describeOne(err: unknown): string {
+  if (err instanceof Error) {
+    return `${err.name}: ${err.message}${safeFieldsOf(err)}`;
+  }
+  if (typeof err === 'string') return err;
+  if (typeof err === 'number' || typeof err === 'boolean') return String(err);
+  if (err === null || err === undefined) return String(err);
+  // Non-Error object thrown (or a cause that isn't itself an Error) — note the
+  // type only. Do NOT serialize its keys: an unknown shape could carry request
+  // context (headers/body) that must never reach a log or the dashboard.
+  try {
+    return `[non-Error value: ${Object.prototype.toString.call(err)}]`;
+  } catch {
+    return '[non-Error value]';
+  }
+}
+
+/**
+ * Recursively walk `err.cause` (and `AggregateError.errors`) up to `maxDepth`
+ * levels, joining each level with " <- caused by: ". Handles non-Error throws
+ * (string, object, null/undefined) without itself throwing. Safe to call on
+ * any unknown value — this is meant to sit directly in a `catch (err)` block.
+ */
+export function formatErrorWithCause(err: unknown, maxDepth: number = MAX_CAUSE_DEPTH): string {
+  // A direct null/undefined throw has no cause chain to walk — describe it
+  // directly rather than falling into the loop (which only walks non-nullish
+  // `current` and would otherwise silently produce an empty string).
+  if (err === null || err === undefined) return String(err);
+
+  const segments: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = err;
+  let depth = 0;
+
+  while (current !== undefined && current !== null && depth <= maxDepth) {
+    if (seen.has(current)) {
+      segments.push('[circular cause — truncated]');
+      break;
+    }
+    seen.add(current);
+    segments.push(describeOne(current));
+
+    // undici can throw an AggregateError when multiple connection attempts
+    // fail (e.g. dual-stack). Fold in a couple of the aggregated sub-errors so
+    // the real failure isn't hidden behind the bare "AggregateError" name.
+    if (typeof AggregateError !== 'undefined' && current instanceof AggregateError && Array.isArray(current.errors) && current.errors.length > 0) {
+      const subErrors = current.errors.slice(0, 2).map(describeOne);
+      const more = current.errors.length > 2 ? ` (+${current.errors.length - 2} more)` : '';
+      segments.push(`[${current.errors.length} aggregated error(s)]: ${subErrors.join('; ')}${more}`);
+    }
+
+    current = current instanceof Error ? current.cause : undefined;
+    depth++;
+  }
+
+  return segments.join(' <- caused by: ');
+}
+
+// ─── Transport-failure retry predicate ─────────────────────────────────────
+
+/**
+ * Node system-error / undici error codes that identify a socket/DNS/TLS-level
+ * failure — as opposed to an HTTP response the server actually returned (which
+ * must fail fast, never retried here) or a deliberate abort/cancellation.
+ */
+const TRANSPORT_ERROR_CODES = new Set([
+  'ECONNRESET', 'ECONNREFUSED', 'ECONNABORTED', 'ETIMEDOUT', 'ENETUNREACH',
+  'ENETDOWN', 'EHOSTUNREACH', 'EPIPE', 'EAI_AGAIN', 'ENOTFOUND',
+  'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_SOCKET', 'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT', 'UND_ERR_DESTROYED', 'UND_ERR_CLOSED',
+]);
+
+function hasTransportCode(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'string' && TRANSPORT_ERROR_CODES.has(code);
+}
+
+/**
+ * True when `err` represents a socket/DNS/TLS-level transport failure that is
+ * safe to retry — undici's generic "fetch failed" wrapper, or a recognized
+ * system-error code, at the top level or one `cause` level down. False for:
+ * anything that isn't an Error, a deliberate abort/timeout-cancellation
+ * (`AbortError` / `TimeoutError`), and any error that doesn't match — in
+ * particular a `new Error('OpenAI API error (4xx/5xx): ...')` or
+ * `QuotaExhaustedException`, neither of which carries a transport code or the
+ * bare "fetch failed" message, so an HTTP response the server actually
+ * returned is never retried here.
+ */
+export function isRetryableTransportError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === 'AbortError' || err.name === 'TimeoutError') return false;
+
+  // undici's generic fetch-level wrapper — the real cause (if any) is nested
+  // in err.cause, but even a bare "fetch failed" with no cause at all is a
+  // transport-level failure by definition (it never got an HTTP response).
+  if (err.message === 'fetch failed') return true;
+
+  if (hasTransportCode(err)) return true;
+
+  const cause = (err as Error & { cause?: unknown }).cause;
+  if (cause instanceof Error && hasTransportCode(cause)) return true;
+
+  return false;
+}

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -280,3 +280,4 @@ export { ChatbotAgent } from './chatbot-agent';
 export type { ChatbotTool, ChatbotAgentConfig, ChatStreamEvent } from './chatbot-agent';
 export { detectStaleBase, findUnreadablePaths, detectMidFlightCommits, extractReferencedPaths, extractReferencedPathsWithMeta, findUnreadableReferencedPaths, findUnreadableReferencedPathsWithMeta } from './orchestrator-preconditions';
 export type { StaleBaseResult, MidFlightResult, UnreadableReason, UnreadableReferencedPath, FindUnreadableReferencedPathsOpts, FindUnreadableReferencedPathsResult, ExtractReferencedPathsResult } from './orchestrator-preconditions';
+export { formatErrorWithCause, isRetryableTransportError } from './error-format';

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -280,4 +280,11 @@ export { ChatbotAgent } from './chatbot-agent';
 export type { ChatbotTool, ChatbotAgentConfig, ChatStreamEvent } from './chatbot-agent';
 export { detectStaleBase, findUnreadablePaths, detectMidFlightCommits, extractReferencedPaths, extractReferencedPathsWithMeta, findUnreadableReferencedPaths, findUnreadableReferencedPathsWithMeta } from './orchestrator-preconditions';
 export type { StaleBaseResult, MidFlightResult, UnreadableReason, UnreadableReferencedPath, FindUnreadableReferencedPathsOpts, FindUnreadableReferencedPathsResult, ExtractReferencedPathsResult } from './orchestrator-preconditions';
-export { formatErrorWithCause, isRetryableTransportError } from './error-format';
+export {
+  formatErrorWithCause,
+  isRetryableTransportError,
+  classifyTransportError,
+  PRE_SEND_TRANSPORT_ERROR_CODES,
+  AMBIGUOUS_TRANSPORT_ERROR_CODES,
+} from './error-format';
+export type { TransportErrorClass } from './error-format';

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -16,7 +16,7 @@ import { ToolDefinition, LLMMessage } from '@gossip/types';
 import { LLMResponse } from './types';
 import { log as _log } from './log';
 import { recordAuthFailure, clearAuthFailure } from './auth-state';
-import { formatErrorWithCause, isRetryableTransportError } from './error-format';
+import { formatErrorWithCause, classifyTransportError } from './error-format';
 
 // ─── Optional IPv4-preference DNS toggle (issue #657) ──────────────────────
 //
@@ -56,6 +56,34 @@ if (process.env.GOSSIP_LLM_PREFER_IPV4 === '1') {
 const TRANSPORT_RETRY_MAX_ATTEMPTS = 2; // additional attempts beyond the first (3 total)
 const TRANSPORT_RETRY_BACKOFF_MS = [1_000, 3_000];
 
+/**
+ * Abort-aware sleep: resolves after `ms`, or rejects immediately (with the
+ * signal's abort reason) if/when `signal` aborts first. Always clears its
+ * timer and removes its listener on either path — no dangling handle is left
+ * behind. Used for both the 503 retry sleep and the transport-retry backoff
+ * so a caller's `AbortSignal.timeout(...)` firing mid-backoff returns
+ * promptly instead of sleeping out the full window before the next attempt
+ * (or lack thereof) notices.
+ */
+function sleepAbortable(ms: number, signal?: AbortSignal | null): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason instanceof Error ? signal.reason : new Error('Sleep aborted'));
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      reject(signal?.reason instanceof Error ? signal.reason : new Error('Sleep aborted'));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort);
+  });
+}
+
 // ─── 503 + Transport Retry Helper ──────────────────────────────────────────
 
 /**
@@ -71,6 +99,9 @@ const TRANSPORT_RETRY_BACKOFF_MS = [1_000, 3_000];
  * - Honours Retry-After if present (capped at 30s to avoid oversleeping).
  * - Reuses the caller's RequestInit including AbortSignal — the original
  *   timeout budget still applies across both attempts combined.
+ * - The inter-attempt sleep is abort-aware (`sleepAbortable`) so a caller
+ *   timeout firing mid-sleep rejects promptly rather than waiting out the
+ *   full up-to-30s window before the second attempt fires anyway.
  */
 async function fetchOnceWithServiceUnavailableRetry(
   url: string,
@@ -89,7 +120,7 @@ async function fetchOnceWithServiceUnavailableRetry(
   const retryMs = Number.isFinite(seconds) && seconds > 0 ? Math.min(seconds * 1000, 30_000) : 5_000;
 
   _log(providerName, `503 service unavailable — retrying once after ${Math.round(retryMs / 1000)}s`);
-  await new Promise(r => setTimeout(r, retryMs));
+  await sleepAbortable(retryMs, init.signal);
 
   // Second attempt. If it also returns 503, the caller's existing handle503
   // path takes over and sets the cooldown.
@@ -111,12 +142,27 @@ async function fetchOnceWithServiceUnavailableRetry(
  * response the server actually returned (this function never sees those —
  * they resolve normally, 4xx/5xx included), QuotaExhaustedException (thrown
  * by the 429/503 handlers *after* a response was received — not a transport
- * failure), or abort/cancellation (isRetryableTransportError excludes both).
+ * failure), or abort/cancellation (`classifyTransportError` excludes both).
+ *
+ * Idempotency-safety: `classifyTransportError` splits the retryable set by
+ * phase. `'pre-send'` failures (never reached the server) are always retried.
+ * `'ambiguous'` failures (the server may already have received/processed the
+ * request — e.g. a reset/timeout after the connection was established) are
+ * retried ONLY when `opts.hasIdempotencyKey` is true, i.e. the caller attached
+ * an `Idempotency-Key` header the origin can use to dedupe a resend. Without
+ * that, resending an ambiguous failure risks silently re-billing/re-executing
+ * a request the origin already completed — see issue #657 follow-up.
+ *
+ * The single `init` object (and its `signal`) is reused across every attempt,
+ * so the caller's original timeout budget bounds cumulative wall-clock across
+ * ALL attempts combined, not per-attempt — worst case is the original budget
+ * plus the backoff schedule's ~4s.
  */
 async function fetchWithRetry503(
   url: string,
   init: RequestInit,
   providerName: string,
+  opts: { hasIdempotencyKey?: boolean } = {},
 ): Promise<Response> {
   let lastErr: unknown;
   for (let attempt = 0; attempt <= TRANSPORT_RETRY_MAX_ATTEMPTS; attempt++) {
@@ -128,10 +174,12 @@ async function fetchWithRetry503(
       return res;
     } catch (err) {
       lastErr = err;
-      if (!isRetryableTransportError(err) || attempt === TRANSPORT_RETRY_MAX_ATTEMPTS) throw err;
+      const cls = classifyTransportError(err);
+      const retryable = cls === 'pre-send' || (cls === 'ambiguous' && opts.hasIdempotencyKey === true);
+      if (!retryable || attempt === TRANSPORT_RETRY_MAX_ATTEMPTS) throw err;
       const backoffMs = TRANSPORT_RETRY_BACKOFF_MS[attempt] ?? TRANSPORT_RETRY_BACKOFF_MS[TRANSPORT_RETRY_BACKOFF_MS.length - 1];
-      _log(providerName, `transport failure (attempt ${attempt + 1}/${TRANSPORT_RETRY_MAX_ATTEMPTS + 1}): ${formatErrorWithCause(err)} — retrying in ${backoffMs}ms`);
-      await new Promise(r => setTimeout(r, backoffMs));
+      _log(providerName, `transport failure (attempt ${attempt + 1}/${TRANSPORT_RETRY_MAX_ATTEMPTS + 1}, ${cls}): ${formatErrorWithCause(err)} — retrying in ${backoffMs}ms`);
+      await sleepAbortable(backoffMs, init.signal);
     }
   }
   // Unreachable (loop above always returns or throws) — satisfies control-flow analysis.
@@ -383,16 +431,22 @@ export class AnthropicProvider implements ILLMProvider {
     if (anthropicTools.length > 0) body.tools = anthropicTools;
 
     this.quota.checkBeforeRequest();
+    // One idempotency key per logical generate() call — reused across every
+    // transport-retry attempt of THIS request (never regenerated per attempt),
+    // so Anthropic can dedupe a resend that the caller can't prove was never
+    // received (see fetchWithRetry503's 'ambiguous' classification).
+    const idempotencyKey = randomUUID();
     const res = await fetchWithRetry503('https://api.anthropic.com/v1/messages', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'x-api-key': this.apiKey,
         'anthropic-version': '2023-06-01',
+        'Idempotency-Key': idempotencyKey,
       },
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(120_000),
-    }, 'anthropic');
+    }, 'anthropic', { hasIdempotencyKey: true });
 
     if (!res.ok) {
       const body = (await res.text()).slice(0, 200);
@@ -589,12 +643,21 @@ export class OpenAIProvider implements ILLMProvider {
     this.quota.checkBeforeRequest();
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (this.apiKey) headers['Authorization'] = `Bearer ${this.apiKey}`;
+    // Idempotency-Key: documented/honored on the canonical api.openai.com
+    // endpoint. DeepSeek/Grok/OpenClaw reuse this class over a different
+    // base_url and their support for the header is unconfirmed — do not
+    // invent it for them; those requests stay in the pre-#657-fix retry
+    // posture (ambiguous transport failures are not retried without a key).
+    // One key per logical generate() call, reused across every transport-retry
+    // attempt (never regenerated per attempt).
+    const hasIdempotencyKey = this.isCanonicalOpenAI;
+    if (hasIdempotencyKey) headers['Idempotency-Key'] = randomUUID();
     const res = await fetchWithRetry503(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers,
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(this.timeoutMs),
-    }, 'openai');
+    }, 'openai', { hasIdempotencyKey });
 
     if (!res.ok) {
       // Read the FULL body once: the truncated 200-char slice feeds the thrown
@@ -665,12 +728,18 @@ export class OpenAIProvider implements ILLMProvider {
     this.quota.checkBeforeRequest();
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (this.apiKey) headers['Authorization'] = `Bearer ${this.apiKey}`;
+    // Same Idempotency-Key posture as the chat path: only on the canonical
+    // api.openai.com endpoint (this path can also be reached via the chat
+    // path's self-heal fallback for a non-canonical base_url, so re-check
+    // rather than assume).
+    const hasIdempotencyKey = this.isCanonicalOpenAI;
+    if (hasIdempotencyKey) headers['Idempotency-Key'] = randomUUID();
     const res = await fetchWithRetry503(`${this.baseUrl}/responses`, {
       method: 'POST',
       headers,
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(this.timeoutMs),
-    }, 'openai');
+    }, 'openai', { hasIdempotencyKey });
 
     if (!res.ok) {
       const errBody = (await res.text()).slice(0, 200);
@@ -878,6 +947,12 @@ export class GeminiProvider implements ILLMProvider {
     // loops where a single big-context turn (refactor + multi-test plan) can
     // exceed 120s wall-clock. Matches the 600s budget given to openclaw and
     // the 300_000 default for gossip_dispatch write tasks.
+    //
+    // No Idempotency-Key: Gemini's generateContent API does not document
+    // support for one. Rather than invent an unsupported header, this
+    // endpoint stays on the pre-#657-fix retry posture — an 'ambiguous'
+    // transport failure (see classifyTransportError) is NOT retried here,
+    // only a proven 'pre-send' failure is.
     const res = await fetchWithRetry503(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -11,20 +11,60 @@
 import { randomUUID } from 'crypto';
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
+import * as dns from 'dns';
 import { ToolDefinition, LLMMessage } from '@gossip/types';
 import { LLMResponse } from './types';
 import { log as _log } from './log';
 import { recordAuthFailure, clearAuthFailure } from './auth-state';
+import { formatErrorWithCause, isRetryableTransportError } from './error-format';
 
-// ─── 503 Retry Helper ───────────────────────────────────────────────────────
+// ─── Optional IPv4-preference DNS toggle (issue #657) ──────────────────────
+//
+// HYPOTHESIS considered for #657 ("curl works, undici's fetch doesn't, from
+// the same host in the same minute"): curl performs classic Happy Eyeballs
+// (RFC 8305) — it races A/AAAA and uses whichever connects first — while
+// Node's global `fetch` resolves via `dns.lookup()`'s default result order and
+// does not itself race both families per attempt. If `dns.lookup` hands back
+// an AAAA (IPv6) record on a path where IPv6 is dark (blackholed rather than
+// simply absent), the connect attempt can hang for the OS-level TCP timeout
+// before undici ever surfaces a failure — which lines up with the reported
+// 89–168s latency far better than a fast DNS or connection-refused error would.
+//
+// CONCLUSION: plausible contributing factor, but UNCONFIRMED for this specific
+// incident — no packet capture / DNS trace was collected. This repo's
+// `engines.node` floor is >=22, which does not force IPv4 by default, and this
+// change does not either: silently forcing IPv4 process-wide to fix one
+// unconfirmed report would be a behavior change for every provider and every
+// environment, including ones where IPv6 is the working path. Instead this is
+// opt-in only: set GOSSIP_LLM_PREFER_IPV4=1 to flip Node's global DNS result
+// order so `dns.lookup` (which undici's fetch uses to resolve hosts) returns A
+// records before AAAA. Leave it unset and behavior is unchanged.
+if (process.env.GOSSIP_LLM_PREFER_IPV4 === '1') {
+  try {
+    dns.setDefaultResultOrder('ipv4first');
+    _log('llm-client', 'GOSSIP_LLM_PREFER_IPV4=1 — dns.setDefaultResultOrder("ipv4first")');
+  } catch { /* Node build without this API — no-op, opt-in has no effect */ }
+}
+
+// ─── Transport-retry constants ──────────────────────────────────────────────
+//
+// Bounded retry for socket/DNS/TLS-level failures ONLY (see
+// isRetryableTransportError) — never for an HTTP response the server actually
+// returned (4xx/5xx fail fast, exactly as before) and never for quota/429
+// (QuotaTracker owns that cooldown machinery; transport retries don't touch it)
+// or abort/cancellation.
+const TRANSPORT_RETRY_MAX_ATTEMPTS = 2; // additional attempts beyond the first (3 total)
+const TRANSPORT_RETRY_BACKOFF_MS = [1_000, 3_000];
+
+// ─── 503 + Transport Retry Helper ──────────────────────────────────────────
 
 /**
- * Wraps fetch with one-shot retry on 503 (service unavailable / overloaded).
- * Many 503s clear within seconds — a single short retry recovers the request
- * before triggering the cooldown dance in QuotaTracker.handle503. If the retry
- * also returns 503, returns that response and lets the caller's handle503()
- * set the cooldown as before. The caller does NOT need to know whether a
- * retry happened.
+ * One-shot retry on 503 (service unavailable / overloaded). Many 503s clear
+ * within seconds — a single short retry recovers the request before
+ * triggering the cooldown dance in QuotaTracker.handle503. If the retry also
+ * returns 503, returns that response and lets the caller's handle503() set
+ * the cooldown as before. The caller does NOT need to know whether a retry
+ * happened.
  *
  * Notes:
  * - Drains the first response body before retrying so the connection releases.
@@ -32,7 +72,7 @@ import { recordAuthFailure, clearAuthFailure } from './auth-state';
  * - Reuses the caller's RequestInit including AbortSignal — the original
  *   timeout budget still applies across both attempts combined.
  */
-async function fetchWithRetry503(
+async function fetchOnceWithServiceUnavailableRetry(
   url: string,
   init: RequestInit,
   providerName: string,
@@ -54,6 +94,48 @@ async function fetchWithRetry503(
   // Second attempt. If it also returns 503, the caller's existing handle503
   // path takes over and sets the cooldown.
   return fetch(url, init);
+}
+
+/**
+ * Wraps {@link fetchOnceWithServiceUnavailableRetry} with a bounded retry for
+ * transport-level failures — undici throwing "fetch failed" (or a recognized
+ * socket/DNS/TLS error code) BEFORE any HTTP response was ever received. See
+ * issue #657: undici discards the OS-level cause behind the generic
+ * "fetch failed" message, so this class of failure was previously both
+ * undiagnosable (fixed by {@link formatErrorWithCause}, used in the log line
+ * below and by worker-agent.ts's fatal-error path) and un-retried — a single
+ * transient ECONNRESET/timeout took down the whole dispatch.
+ *
+ * Retries up to TRANSPORT_RETRY_MAX_ATTEMPTS additional times with the
+ * TRANSPORT_RETRY_BACKOFF_MS backoff schedule. Does NOT retry: any HTTP
+ * response the server actually returned (this function never sees those —
+ * they resolve normally, 4xx/5xx included), QuotaExhaustedException (thrown
+ * by the 429/503 handlers *after* a response was received — not a transport
+ * failure), or abort/cancellation (isRetryableTransportError excludes both).
+ */
+async function fetchWithRetry503(
+  url: string,
+  init: RequestInit,
+  providerName: string,
+): Promise<Response> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= TRANSPORT_RETRY_MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetchOnceWithServiceUnavailableRetry(url, init, providerName);
+      if (attempt > 0) {
+        _log(providerName, `transport retry succeeded on attempt ${attempt + 1}/${TRANSPORT_RETRY_MAX_ATTEMPTS + 1}`);
+      }
+      return res;
+    } catch (err) {
+      lastErr = err;
+      if (!isRetryableTransportError(err) || attempt === TRANSPORT_RETRY_MAX_ATTEMPTS) throw err;
+      const backoffMs = TRANSPORT_RETRY_BACKOFF_MS[attempt] ?? TRANSPORT_RETRY_BACKOFF_MS[TRANSPORT_RETRY_BACKOFF_MS.length - 1];
+      _log(providerName, `transport failure (attempt ${attempt + 1}/${TRANSPORT_RETRY_MAX_ATTEMPTS + 1}): ${formatErrorWithCause(err)} — retrying in ${backoffMs}ms`);
+      await new Promise(r => setTimeout(r, backoffMs));
+    }
+  }
+  // Unreachable (loop above always returns or throws) — satisfies control-flow analysis.
+  throw lastErr;
 }
 
 // ─── Provider Placeholder Detection ─────────────────────────────────────────

--- a/packages/orchestrator/src/worker-agent.ts
+++ b/packages/orchestrator/src/worker-agent.ts
@@ -11,6 +11,7 @@ import { GossipAgent } from '@gossip/client';
 import { MessageType, MessageEnvelope, Message, ToolDefinition, LLMMessage } from '@gossip/types';
 import { encode as msgpackEncode } from '@msgpack/msgpack';
 import { ILLMProvider, PROVIDER_PLACEHOLDER_RE } from './llm-client';
+import { formatErrorWithCause } from './error-format';
 import { resolveTaskImages, buildUserContent } from './task-images';
 import {
   TaskStreamEvent,
@@ -460,7 +461,10 @@ export class WorkerAgent {
         yield { type: TaskStreamEventType.FINAL_RESULT, payload: { result: 'Task incomplete — agent exhausted its turn budget.', inputTokens: totalInputTokens, outputTokens: totalOutputTokens, memoryQueryCalled: this.memoryQueryCalled }, timestamp: Date.now() };
       }
     } catch (err) {
-      const errorMessage = `FATAL ERROR in executeTask: ${(err as Error).message}`;
+      // formatErrorWithCause surfaces the OS-level cause undici hides behind a
+      // generic "fetch failed" (code/errno/syscall/hostname/...) — see #657.
+      // Never includes request body/headers/Authorization values.
+      const errorMessage = `FATAL ERROR in executeTask: ${formatErrorWithCause(err)}`;
       yield logAndYield(errorMessage);
       this.onTaskComplete?.({ agentId: this.agentId, taskId: taskId ?? '', toolCalls: toolCallCount, durationMs: Date.now() - startTime, memoryQueryCalled: this.memoryQueryCalled });
       yield { type: TaskStreamEventType.ERROR, payload: { error: errorMessage }, timestamp: Date.now() };

--- a/tests/orchestrator/error-format.test.ts
+++ b/tests/orchestrator/error-format.test.ts
@@ -11,7 +11,13 @@
  *    or a non-Error throw.
  */
 
-import { formatErrorWithCause, isRetryableTransportError } from '@gossip/orchestrator';
+import {
+  formatErrorWithCause,
+  isRetryableTransportError,
+  classifyTransportError,
+  PRE_SEND_TRANSPORT_ERROR_CODES,
+  AMBIGUOUS_TRANSPORT_ERROR_CODES,
+} from '@gossip/orchestrator';
 
 describe('formatErrorWithCause', () => {
   it('formats a plain Error with no cause', () => {
@@ -183,5 +189,158 @@ describe('isRetryableTransportError', () => {
     const err = new Error('openai quota exhausted (429 #1): rate limited');
     err.name = 'QuotaExhaustedException';
     expect(isRetryableTransportError(err)).toBe(false);
+  });
+});
+
+describe('classifyTransportError (issue #657 idempotency follow-up)', () => {
+  it('classifies every code in PRE_SEND_TRANSPORT_ERROR_CODES as pre-send', () => {
+    for (const code of PRE_SEND_TRANSPORT_ERROR_CODES) {
+      const err = Object.assign(new Error('fetch failed'), { code });
+      expect(classifyTransportError(err)).toBe('pre-send');
+    }
+  });
+
+  it('classifies every code in AMBIGUOUS_TRANSPORT_ERROR_CODES as ambiguous', () => {
+    for (const code of AMBIGUOUS_TRANSPORT_ERROR_CODES) {
+      const err = Object.assign(new Error('fetch failed'), { code });
+      expect(classifyTransportError(err)).toBe('ambiguous');
+    }
+  });
+
+  it('classifies a bare "fetch failed" with no code as ambiguous (phase unknown)', () => {
+    expect(classifyTransportError(new Error('fetch failed'))).toBe('ambiguous');
+  });
+
+  it('classifies a code nested one cause level down (pre-send)', () => {
+    const cause = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    const err = new Error('fetch failed', { cause });
+    expect(classifyTransportError(err)).toBe('pre-send');
+  });
+
+  it('classifies a code nested one cause level down (ambiguous)', () => {
+    const cause = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    const err = new Error('fetch failed', { cause });
+    expect(classifyTransportError(err)).toBe('ambiguous');
+  });
+
+  it('classifies an HTTP-error-shaped Error as not-transport (never phase-classified)', () => {
+    expect(classifyTransportError(new Error('OpenAI API error (401): Incorrect API key provided'))).toBe('not-transport');
+  });
+
+  it('preserves STRICT equality on "fetch failed" — a substring match must NOT classify as transport', () => {
+    expect(classifyTransportError(new Error('OpenAI API error (500): upstream fetch failed'))).toBe('not-transport');
+  });
+
+  it('classifies abort/timeout-cancellation as not-transport regardless of any code', () => {
+    const abortErr = Object.assign(new Error('This operation was aborted'), { name: 'AbortError', code: 'ECONNRESET' });
+    expect(classifyTransportError(abortErr)).toBe('not-transport');
+    const timeoutErr = new Error('The operation was aborted due to timeout');
+    timeoutErr.name = 'TimeoutError';
+    expect(classifyTransportError(timeoutErr)).toBe('not-transport');
+  });
+
+  it('classifies a non-Error throw as not-transport', () => {
+    expect(classifyTransportError('fetch failed')).toBe('not-transport');
+    expect(classifyTransportError(null)).toBe('not-transport');
+    expect(classifyTransportError(undefined)).toBe('not-transport');
+  });
+
+  it('isRetryableTransportError is true for both pre-send and ambiguous classes', () => {
+    const preSend = Object.assign(new Error('fetch failed'), { code: 'ECONNREFUSED' });
+    const ambiguous = Object.assign(new Error('fetch failed'), { code: 'ECONNRESET' });
+    expect(classifyTransportError(preSend)).toBe('pre-send');
+    expect(classifyTransportError(ambiguous)).toBe('ambiguous');
+    expect(isRetryableTransportError(preSend)).toBe(true);
+    expect(isRetryableTransportError(ambiguous)).toBe(true);
+  });
+});
+
+describe('formatErrorWithCause — throw-safety on hostile getters (finding: not throw-safe)', () => {
+  it('returns a string rather than throwing when `.message` is a throwing getter', () => {
+    const err = new Error('placeholder');
+    Object.defineProperty(err, 'message', {
+      get() { throw new Error('boom from message getter'); },
+      configurable: true,
+    });
+    let formatted = '';
+    expect(() => { formatted = formatErrorWithCause(err); }).not.toThrow();
+    expect(typeof formatted).toBe('string');
+    expect(formatted.length).toBeGreaterThan(0);
+  });
+
+  it('returns a string rather than throwing when `.cause` is a throwing getter', () => {
+    const err = new Error('top level');
+    Object.defineProperty(err, 'cause', {
+      get() { throw new Error('boom from cause getter'); },
+      configurable: true,
+    });
+    let formatted = '';
+    expect(() => { formatted = formatErrorWithCause(err); }).not.toThrow();
+    expect(formatted).toContain('top level');
+  });
+
+  it('returns a string rather than throwing when a diagnostic field (e.g. `.code`) is a throwing getter', () => {
+    const err = new Error('bad code getter');
+    Object.defineProperty(err, 'code', {
+      get() { throw new Error('boom from code getter'); },
+      configurable: true,
+    });
+    let formatted = '';
+    expect(() => { formatted = formatErrorWithCause(err); }).not.toThrow();
+    expect(formatted).toContain('bad code getter');
+  });
+
+  it('returns a string rather than throwing when `.name` is a throwing getter', () => {
+    const err = new Error('bad name getter');
+    Object.defineProperty(err, 'name', {
+      get() { throw new Error('boom from name getter'); },
+      configurable: true,
+    });
+    expect(() => formatErrorWithCause(err)).not.toThrow();
+  });
+});
+
+describe('formatErrorWithCause — length caps (finding: no length cap anywhere)', () => {
+  it('truncates a giant message with an explicit marker instead of emitting it verbatim', () => {
+    const giant = 'x'.repeat(5_000_000);
+    const err = new Error(giant);
+    const formatted = formatErrorWithCause(err);
+    expect(formatted.length).toBeLessThan(5_000_000);
+    expect(formatted).toMatch(/truncated \d+ chars/);
+  });
+
+  it('caps total output even across a multi-level cause chain of large messages', () => {
+    const big = 'y'.repeat(10_000);
+    const inner = new Error(big);
+    const outer = new Error(big, { cause: inner });
+    const formatted = formatErrorWithCause(outer);
+    expect(formatted.length).toBeLessThan(6_000);
+    expect(formatted).toMatch(/truncated \d+ chars/);
+  });
+});
+
+describe('formatErrorWithCause — message-content redaction (KNOWN GAP, not fixed by this change)', () => {
+  it('KNOWN GAP: a URL-embedded secret in a nested cause .message IS surfaced verbatim', () => {
+    // `SAFE_DIAGNOSTIC_FIELDS` allow-lists only code/errno/syscall/hostname/
+    // address/port for a cause object — `.message` itself is never filtered at
+    // ANY level of the chain, so a secret embedded in a message (e.g. a
+    // webhook/callback URL carrying an API key as a query param, which a
+    // library might legitimately put in an Error message) reaches the
+    // formatted output verbatim.
+    //
+    // This is a CHARACTERIZATION test of current behavior, not a guarantee of
+    // safety: it documents the gap honestly rather than asserting a stronger
+    // property that doesn't hold. If message-level redaction is implemented,
+    // THIS TEST SHOULD START FAILING and must be updated then, not silenced.
+    // See the task report for a proposed redaction follow-up — out of scope
+    // for this change (which addressed cause-chain throw-safety + length caps,
+    // not message-content sanitization).
+    const secret = 'sk-live-EMBEDDED_URL_SECRET_1234567890';
+    const cause = new Error(`upload failed: https://hooks.example.com/callback?api_key=${secret}`);
+    const err = new Error('fetch failed', { cause });
+
+    const formatted = formatErrorWithCause(err);
+
+    expect(formatted).toContain(secret);
   });
 });

--- a/tests/orchestrator/error-format.test.ts
+++ b/tests/orchestrator/error-format.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for packages/orchestrator/src/error-format.ts — issue #657.
+ *
+ * Covers:
+ *  - formatErrorWithCause: nested cause chain, AggregateError, non-Error
+ *    throw (string/object/null/undefined), a cause carrying code+syscall+
+ *    hostname, depth cap on a deep/cyclic chain, and — critically — that an
+ *    api-key-like string is NEVER present in the output.
+ *  - isRetryableTransportError: retries on ECONNRESET / UND_ERR_CONNECT_TIMEOUT
+ *    / bare "fetch failed", does NOT retry on a 401/400-style Error, an abort,
+ *    or a non-Error throw.
+ */
+
+import { formatErrorWithCause, isRetryableTransportError } from '@gossip/orchestrator';
+
+describe('formatErrorWithCause', () => {
+  it('formats a plain Error with no cause', () => {
+    const err = new Error('fetch failed');
+    expect(formatErrorWithCause(err)).toBe('Error: fetch failed');
+  });
+
+  it('walks a nested cause chain and includes code/errno/syscall/hostname', () => {
+    const dnsErr = Object.assign(new Error('getaddrinfo EAI_AGAIN api.openai.com'), {
+      code: 'EAI_AGAIN',
+      errno: -3001,
+      syscall: 'getaddrinfo',
+      hostname: 'api.openai.com',
+    });
+    const connectErr = Object.assign(new Error('connect ECONNREFUSED'), {
+      code: 'ECONNREFUSED',
+      cause: dnsErr,
+    });
+    const fetchErr = new Error('fetch failed', { cause: connectErr });
+
+    const formatted = formatErrorWithCause(fetchErr);
+
+    expect(formatted).toContain('Error: fetch failed');
+    expect(formatted).toContain('caused by');
+    expect(formatted).toContain('code=ECONNREFUSED');
+    expect(formatted).toContain('code=EAI_AGAIN');
+    expect(formatted).toContain('errno=-3001');
+    expect(formatted).toContain('syscall=getaddrinfo');
+    expect(formatted).toContain('hostname=api.openai.com');
+  });
+
+  it('includes address and port when present', () => {
+    const err = Object.assign(new Error('connect ETIMEDOUT'), {
+      code: 'ETIMEDOUT',
+      address: '104.18.7.192',
+      port: 443,
+    });
+    const formatted = formatErrorWithCause(err);
+    expect(formatted).toContain('address=104.18.7.192');
+    expect(formatted).toContain('port=443');
+  });
+
+  it('folds AggregateError.errors into the output', () => {
+    const suberr1 = Object.assign(new Error('connect ECONNREFUSED ::1:443'), { code: 'ECONNREFUSED' });
+    const suberr2 = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:443'), { code: 'ECONNREFUSED' });
+    const agg = new AggregateError([suberr1, suberr2], 'All attempts failed');
+
+    const formatted = formatErrorWithCause(agg);
+
+    expect(formatted).toContain('AggregateError');
+    expect(formatted).toContain('2 aggregated error(s)');
+    expect(formatted).toContain('::1:443');
+    expect(formatted).toContain('127.0.0.1:443');
+  });
+
+  it('handles a non-Error throw: string', () => {
+    expect(formatErrorWithCause('boom')).toBe('boom');
+  });
+
+  it('handles a non-Error throw: plain object', () => {
+    const formatted = formatErrorWithCause({ some: 'shape' });
+    expect(formatted).toContain('non-Error value');
+    // Must not serialize arbitrary object keys/values (could carry secrets).
+    expect(formatted).not.toContain('some');
+    expect(formatted).not.toContain('shape');
+  });
+
+  it('handles a non-Error throw: null and undefined without throwing', () => {
+    expect(() => formatErrorWithCause(null)).not.toThrow();
+    expect(() => formatErrorWithCause(undefined)).not.toThrow();
+    expect(formatErrorWithCause(null)).toBe('null');
+    expect(formatErrorWithCause(undefined)).toBe('undefined');
+  });
+
+  it('caps recursion depth on a very deep cause chain (no infinite loop)', () => {
+    let top: Error = new Error('level 0');
+    for (let i = 1; i <= 50; i++) {
+      top = new Error(`level ${i}`, { cause: top });
+    }
+    let formatted = '';
+    expect(() => { formatted = formatErrorWithCause(top); }).not.toThrow();
+    // Depth-capped: far fewer than 51 "level N" segments should appear.
+    const levelMatches = formatted.match(/level \d+/g) ?? [];
+    expect(levelMatches.length).toBeLessThan(10);
+  });
+
+  it('does not loop forever on a cyclic cause chain', () => {
+    const a: Error & { cause?: unknown } = new Error('a');
+    const b: Error & { cause?: unknown } = new Error('b');
+    a.cause = b;
+    b.cause = a; // cycle
+    let formatted = '';
+    expect(() => { formatted = formatErrorWithCause(a); }).not.toThrow();
+    expect(formatted).toContain('circular cause');
+  });
+
+  it('NEVER includes an api-key-like value in the output', () => {
+    const secret = 'sk-proj-THIS_LOOKS_LIKE_AN_OPENAI_KEY_1234567890';
+    // Simulate a thrown object that happens to carry a header/auth-shaped
+    // field — the formatter must not pick it up since it isn't on the
+    // allow-list of safe diagnostic fields.
+    const err = Object.assign(new Error('fetch failed'), {
+      code: 'ECONNRESET',
+      // Not on the safe allow-list — must never be read/emitted.
+      headers: { Authorization: `Bearer ${secret}` },
+      apiKey: secret,
+      requestBody: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] }),
+    });
+    const formatted = formatErrorWithCause(err);
+    expect(formatted).not.toContain(secret);
+    expect(formatted).not.toContain('Authorization');
+    expect(formatted).toContain('code=ECONNRESET');
+  });
+});
+
+describe('isRetryableTransportError', () => {
+  it('retries on a bare "fetch failed" (undici generic wrapper, no cause)', () => {
+    expect(isRetryableTransportError(new Error('fetch failed'))).toBe(true);
+  });
+
+  it('retries on ECONNRESET', () => {
+    const err = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    expect(isRetryableTransportError(err)).toBe(true);
+  });
+
+  it('retries on UND_ERR_CONNECT_TIMEOUT', () => {
+    const err = Object.assign(new Error('Connect Timeout Error'), { code: 'UND_ERR_CONNECT_TIMEOUT' });
+    expect(isRetryableTransportError(err)).toBe(true);
+  });
+
+  it('retries on a transport code nested one level in cause', () => {
+    const cause = Object.assign(new Error('connect ETIMEDOUT'), { code: 'ETIMEDOUT' });
+    const err = new Error('fetch failed', { cause });
+    // Even though message !== 'fetch failed' exactly is false here (it is),
+    // this also validates the nested-cause code path independent of message.
+    expect(isRetryableTransportError(err)).toBe(true);
+  });
+
+  it('does NOT retry on an HTTP 401 error (server actually responded)', () => {
+    const err = new Error('OpenAI API error (401): Incorrect API key provided');
+    expect(isRetryableTransportError(err)).toBe(false);
+  });
+
+  it('does NOT retry on an HTTP 400 invalid-model error (server actually responded)', () => {
+    const err = new Error('OpenAI API error (400): invalid model id');
+    expect(isRetryableTransportError(err)).toBe(false);
+  });
+
+  it('does NOT retry on abort (AbortError)', () => {
+    const err = new Error('This operation was aborted');
+    err.name = 'AbortError';
+    expect(isRetryableTransportError(err)).toBe(false);
+  });
+
+  it('does NOT retry on timeout-cancellation (TimeoutError)', () => {
+    const err = new Error('The operation was aborted due to timeout');
+    err.name = 'TimeoutError';
+    expect(isRetryableTransportError(err)).toBe(false);
+  });
+
+  it('does NOT retry on a non-Error throw', () => {
+    expect(isRetryableTransportError('fetch failed')).toBe(false);
+    expect(isRetryableTransportError(null)).toBe(false);
+    expect(isRetryableTransportError(undefined)).toBe(false);
+    expect(isRetryableTransportError({ code: 'ECONNRESET' })).toBe(false);
+  });
+
+  it('does NOT retry on QuotaExhaustedException-shaped errors', () => {
+    const err = new Error('openai quota exhausted (429 #1): rate limited');
+    err.name = 'QuotaExhaustedException';
+    expect(isRetryableTransportError(err)).toBe(false);
+  });
+});

--- a/tests/orchestrator/llm-client-idempotency-retry.test.ts
+++ b/tests/orchestrator/llm-client-idempotency-retry.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for the two medium-severity findings fixed on top of the #657
+ * transport-retry loop:
+ *
+ *  1. Retry is idempotency-safe — the retryable transport-error set is split
+ *     by phase ('pre-send' vs 'ambiguous', see error-format.ts's
+ *     classifyTransportError). Pre-send failures (never reached the server)
+ *     retry unconditionally. Ambiguous failures (may have already reached/been
+ *     processed by the server) retry ONLY when an Idempotency-Key was sent —
+ *     Anthropic and the canonical OpenAI endpoint send one; Gemini does not
+ *     (undocumented support), so ambiguous failures stay non-retried there.
+ *  2. The backoff sleep (both the new transport-retry backoff and the
+ *     pre-existing 503 one-shot-retry sleep) is abort-aware: a caller
+ *     AbortSignal firing mid-backoff returns promptly instead of sleeping out
+ *     the full window.
+ *
+ * Also re-confirms the pre-existing "503 is not amplified by the outer
+ * transport-retry loop" property still holds after these changes.
+ */
+
+import { OpenAIProvider, GeminiProvider } from '@gossip/orchestrator';
+
+function transportError(code: string, message = 'fetch failed'): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+function geminiOkResponse(text: string) {
+  return {
+    ok: true,
+    json: async () => ({ candidates: [{ content: { parts: [{ text }] } }] }),
+  };
+}
+
+function openaiOkResponse(text: string) {
+  return {
+    ok: true,
+    json: async () => ({ choices: [{ message: { content: text, tool_calls: null } }] }),
+  };
+}
+
+describe('idempotency-safe transport retry (issue #657 follow-up, finding 1)', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  it('a pre-send error (UND_ERR_CONNECT_TIMEOUT) retries WITHOUT an idempotency key (Gemini sends none)', async () => {
+    let callCount = 0;
+    global.fetch = jest.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.reject(transportError('UND_ERR_CONNECT_TIMEOUT'));
+      return Promise.resolve(geminiOkResponse('recovered'));
+    }) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider('test-key', 'gemini-pro');
+    const generatePromise = provider.generate([{ role: 'user', content: 'hi' }]);
+
+    await jest.advanceTimersByTimeAsync(1_000);
+
+    const response = await generatePromise;
+    expect(response.text).toBe('recovered');
+    expect(callCount).toBe(2);
+
+    // Confirm Gemini never sent an Idempotency-Key (unsupported/undocumented).
+    for (const call of (global.fetch as jest.Mock).mock.calls) {
+      const headers = call[1]?.headers as Record<string, string>;
+      expect(headers['Idempotency-Key']).toBeUndefined();
+    }
+  });
+
+  it('an ambiguous error (ECONNRESET) does NOT retry when no idempotency key was sent (Gemini) — fetch called exactly once', async () => {
+    global.fetch = jest.fn().mockImplementation(() => {
+      return Promise.reject(transportError('ECONNRESET'));
+    }) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider('test-key', 'gemini-pro');
+    const generatePromise = provider.generate([{ role: 'user', content: 'hi' }]);
+    generatePromise.catch(() => {});
+
+    await expect(generatePromise).rejects.toThrow('fetch failed');
+    expect((global.fetch as jest.Mock).mock.calls.length).toBe(1);
+  });
+
+  it('an ambiguous error (ECONNRESET) DOES retry when an idempotency key was sent (canonical OpenAI)', async () => {
+    let callCount = 0;
+    global.fetch = jest.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.reject(transportError('ECONNRESET'));
+      return Promise.resolve(openaiOkResponse('recovered'));
+    }) as unknown as typeof fetch;
+
+    // Default base_url resolves to the canonical api.openai.com endpoint.
+    const provider = new OpenAIProvider('test-key', 'gpt-4');
+    const generatePromise = provider.generate([{ role: 'user', content: 'hi' }]);
+
+    await jest.advanceTimersByTimeAsync(1_000);
+
+    const response = await generatePromise;
+    expect(response.text).toBe('recovered');
+    expect(callCount).toBe(2);
+
+    const calls = (global.fetch as jest.Mock).mock.calls;
+    expect((calls[0][1].headers as Record<string, string>)['Idempotency-Key']).toEqual(expect.any(String));
+  });
+
+  it('reuses the SAME idempotency key across every retry attempt of one logical generate() call', async () => {
+    global.fetch = jest.fn().mockImplementation(() => Promise.reject(transportError('ECONNRESET'))) as unknown as typeof fetch;
+
+    const provider = new OpenAIProvider('test-key', 'gpt-4');
+    const generatePromise = provider.generate([{ role: 'user', content: 'hi' }]);
+    generatePromise.catch(() => {});
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    await jest.advanceTimersByTimeAsync(3_000);
+
+    await expect(generatePromise).rejects.toThrow('fetch failed');
+
+    const calls = (global.fetch as jest.Mock).mock.calls;
+    expect(calls.length).toBe(3); // 1 initial + 2 retries
+    const keys = calls.map(c => (c[1].headers as Record<string, string>)['Idempotency-Key']);
+    expect(keys[0]).toEqual(expect.any(String));
+    expect(keys[1]).toBe(keys[0]);
+    expect(keys[2]).toBe(keys[0]);
+  });
+
+  it('two SEPARATE generate() calls get two DIFFERENT idempotency keys', async () => {
+    global.fetch = jest.fn().mockImplementation(() => Promise.resolve(openaiOkResponse('ok'))) as unknown as typeof fetch;
+
+    const provider = new OpenAIProvider('test-key', 'gpt-4');
+    await provider.generate([{ role: 'user', content: 'first' }]);
+    await provider.generate([{ role: 'user', content: 'second' }]);
+
+    const calls = (global.fetch as jest.Mock).mock.calls;
+    expect(calls.length).toBe(2);
+    const key1 = (calls[0][1].headers as Record<string, string>)['Idempotency-Key'];
+    const key2 = (calls[1][1].headers as Record<string, string>)['Idempotency-Key'];
+    expect(key1).toEqual(expect.any(String));
+    expect(key2).toEqual(expect.any(String));
+    expect(key1).not.toBe(key2);
+  });
+
+  it('does NOT send an Idempotency-Key for a non-canonical OpenAI-compatible base_url (unconfirmed support)', async () => {
+    global.fetch = jest.fn().mockImplementation(() => Promise.resolve(openaiOkResponse('ok'))) as unknown as typeof fetch;
+
+    const provider = new OpenAIProvider('test-key', 'deepseek-chat', undefined, 'https://api.deepseek.com/v1');
+    await provider.generate([{ role: 'user', content: 'hi' }]);
+
+    const headers = (global.fetch as jest.Mock).mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['Idempotency-Key']).toBeUndefined();
+  });
+});
+
+describe('abort-aware backoff (issue #657 follow-up, finding 2)', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns promptly when the caller AbortSignal fires during the transport-retry backoff, instead of sleeping the full window', async () => {
+    global.fetch = jest.fn().mockImplementation(() => Promise.reject(transportError('UND_ERR_CONNECT_TIMEOUT'))) as unknown as typeof fetch;
+
+    // Small timeoutMs so the provider's own AbortSignal.timeout(...) fires well
+    // inside the 1s first-backoff window. Real timers — AbortSignal.timeout is
+    // not driven by jest's fake timer patches.
+    const provider = new OpenAIProvider('test-key', 'gpt-4', undefined, undefined, undefined, 50);
+
+    const start = Date.now();
+    await expect(provider.generate([{ role: 'user', content: 'hi' }])).rejects.toThrow();
+    const elapsed = Date.now() - start;
+
+    // Backoff schedule is 1000ms/3000ms. If the sleep were not abort-aware,
+    // this would take at least 1000ms. An abort-aware sleep returns as soon as
+    // the ~50ms timeout fires.
+    expect(elapsed).toBeLessThan(800);
+  }, 10_000);
+
+  it('returns promptly when the caller AbortSignal fires during the pre-existing 503 one-shot-retry sleep', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      headers: { get: () => null },
+      text: async () => 'service unavailable',
+    }) as unknown as typeof fetch;
+
+    // 503's default sleep is 5s (no Retry-After header) — a 50ms timeout fires
+    // well inside that window.
+    const provider = new OpenAIProvider('test-key', 'gpt-4', undefined, undefined, undefined, 50);
+
+    const start = Date.now();
+    await expect(provider.generate([{ role: 'user', content: 'hi' }])).rejects.toThrow();
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(2_000);
+  }, 10_000);
+});
+
+describe('503 is still NOT amplified by the outer transport-retry loop (regression, unchanged property)', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  it('a persistent 503 response resolves (never throws out of fetchWithRetry503) and is handled by handle503 after exactly 2 fetch calls', async () => {
+    let callCount = 0;
+    global.fetch = jest.fn().mockImplementation(() => {
+      callCount++;
+      return Promise.resolve({
+        ok: false,
+        status: 503,
+        headers: { get: () => null },
+        text: async () => 'service unavailable',
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAIProvider('test-key', 'gpt-4');
+    const generatePromise = provider.generate([{ role: 'user', content: 'hi' }]);
+    generatePromise.catch(() => {});
+
+    // Default 503 sleep with no Retry-After header is 5s.
+    await jest.advanceTimersByTimeAsync(5_000);
+
+    await expect(generatePromise).rejects.toThrow(/service unavailable/);
+    // Exactly 2 fetch calls: the one-shot 503 retry inside
+    // fetchOnceWithServiceUnavailableRetry — the outer transport-retry loop in
+    // fetchWithRetry503 never sees an exception (503 is a resolved Response,
+    // not a thrown transport error) so it never adds additional attempts.
+    expect(callCount).toBe(2);
+  });
+});

--- a/tests/orchestrator/llm-client-transport-retry.test.ts
+++ b/tests/orchestrator/llm-client-transport-retry.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the bounded transport-retry added to llm-client.ts's shared
+ * fetchWithRetry503 helper (issue #657) — exercised through OpenAIProvider
+ * since that's the provider from the reported incident.
+ *
+ * Covers:
+ *  - a transient ECONNRESET/UND_ERR_CONNECT_TIMEOUT is retried and a
+ *    subsequent success is returned (retry-then-succeed)
+ *  - persistent transport failures exhaust the bounded retry budget (3 total
+ *    attempts) and rethrow
+ *  - an HTTP response the server actually returned (401, 400) is NEVER
+ *    retried — fetch is called exactly once
+ *  - an abort is never retried
+ */
+
+import { OpenAIProvider } from '@gossip/orchestrator';
+
+function transportError(code: string, message = 'fetch failed'): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+describe('llm-client transport-level retry (issue #657)', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  it('retries once on ECONNRESET then succeeds (retry-then-succeed stays visible)', async () => {
+    let callCount = 0;
+    global.fetch = jest.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.reject(transportError('ECONNRESET', 'fetch failed'));
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: 'recovered', tool_calls: null } }] }),
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAIProvider('test-key', 'gpt-4');
+    const generatePromise = provider.generate([{ role: 'user', content: 'hi' }]);
+
+    // Let the first attempt reject, then advance past the 1s backoff.
+    await jest.advanceTimersByTimeAsync(1_000);
+
+    const response = await generatePromise;
+    expect(response.text).toBe('recovered');
+    expect(callCount).toBe(2);
+  });
+
+  it('retries UND_ERR_CONNECT_TIMEOUT with the named backoff schedule (~1s then ~3s)', async () => {
+    let callCount = 0;
+    global.fetch = jest.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount <= 2) return Promise.reject(transportError('UND_ERR_CONNECT_TIMEOUT', 'fetch failed'));
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: 'ok after 2 retries', tool_calls: null } }] }),
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAIProvider('test-key', 'gpt-4');
+    const generatePromise = provider.generate([{ role: 'user', content: 'hi' }]);
+
+    await jest.advanceTimersByTimeAsync(1_000); // after attempt 1
+    await jest.advanceTimersByTimeAsync(3_000); // after attempt 2
+
+    const response = await generatePromise;
+    expect(response.text).toBe('ok after 2 retries');
+    expect(callCount).toBe(3);
+  });
+
+  it('exhausts the bounded retry budget (3 total attempts) and rethrows on persistent transport failure', async () => {
+    let callCount = 0;
+    global.fetch = jest.fn().mockImplementation(() => {
+      callCount++;
+      return Promise.reject(transportError('ECONNRESET', 'fetch failed'));
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAIProvider('test-key', 'gpt-4');
+    const generatePromise = provider.generate([{ role: 'user', content: 'hi' }]);
+    // Suppress unhandled-rejection noise until we await below.
+    generatePromise.catch(() => {});
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    await jest.advanceTimersByTimeAsync(3_000);
+
+    await expect(generatePromise).rejects.toThrow('fetch failed');
+    expect(callCount).toBe(3); // 1 initial + 2 retries, per TRANSPORT_RETRY_MAX_ATTEMPTS
+  });
+
+  it('does NOT retry a 401 the server actually returned — fetch called exactly once', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'Incorrect API key provided',
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAIProvider('bad-key', 'gpt-4');
+    await expect(provider.generate([{ role: 'user', content: 'hi' }])).rejects.toThrow(/authentication failed/);
+    expect((global.fetch as jest.Mock).mock.calls.length).toBe(1);
+  });
+
+  it('does NOT retry a 400 invalid-model error the server actually returned — fetch called exactly once', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => 'invalid model id',
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAIProvider('test-key', 'not-a-real-model');
+    await expect(provider.generate([{ role: 'user', content: 'hi' }])).rejects.toThrow(/OpenAI API error \(400\)/);
+    expect((global.fetch as jest.Mock).mock.calls.length).toBe(1);
+  });
+
+  it('does NOT retry on abort — fetch called exactly once', async () => {
+    global.fetch = jest.fn().mockImplementation(() => {
+      const err = new Error('This operation was aborted');
+      err.name = 'AbortError';
+      return Promise.reject(err);
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAIProvider('test-key', 'gpt-4');
+    await expect(provider.generate([{ role: 'user', content: 'hi' }])).rejects.toThrow('This operation was aborted');
+    expect((global.fetch as jest.Mock).mock.calls.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #657 — an openai-provider relay worker failed every dispatch with `FATAL ERROR in executeTask: fetch failed` after 89–168s, while `curl` reached the same endpoint in 0.5s.

Undiagnosable for a specific reason: undici puts the real OS/TLS/DNS error in `error.cause` and leaves only `"fetch failed"` in `error.message`. `worker-agent.ts` read `.message`, discarding the only information that identifies the failure class.

**Surface the cause chain** — new `error-format.ts`: `formatErrorWithCause` walks `err.cause` (depth-capped, cycle-guarded), folds in `AggregateError.errors`, and appends fields from a strict allow-list (`code`, `errno`, `syscall`, `hostname`, `address`, `port`). Non-Error objects in the chain are reported *by type only* — keys are never serialized.

**Bounded transport retry** in `llm-client.ts` — 2 additional attempts, backoff `[1s, 3s]`, gated on a phase-aware predicate. Composes with the existing `QuotaTracker` cooldown rather than duplicating it.

**IPv6 hypothesis** documented, not forced: `GOSSIP_LLM_PREFER_IPV4=1` opts into `dns.setDefaultResultOrder('ipv4first')`.

## Pre-merge consensus round (`worker-agent.ts` is `@gossip:impact-adjacent`)

Two reviewers found **four** real defects in the first cut. All fixed in `551519e8`.

**Retry was not idempotency-safe → double-billing path (medium).** The loop resent the identical POST with no idempotency protection. `UND_ERR_HEADERS_TIMEOUT` / `ECONNRESET` can surface *after* the origin completed and billed the generation — and the reported failures took 89–168s, which is emphatically not connection-refused, so the ambiguous case is the likely one. Fix, both halves:
- **Phase split.** `PRE_SEND_TRANSPORT_ERROR_CODES` (`UND_ERR_CONNECT_TIMEOUT`, `ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN`, `ENETUNREACH`, `EHOSTUNREACH`) prove the request never reached the server and are always safe to retry. `AMBIGUOUS_TRANSPORT_ERROR_CODES` are retried **only** when an idempotency key was sent. Unlisted codes deny-by-default into ambiguous.
- **`Idempotency-Key` only where evidenced.** Anthropic always; OpenAI **only when `isCanonicalOpenAI`** — DeepSeek/Grok/OpenClaw reuse `OpenAIProvider` over a different `base_url` with no evidence they honor the header, so they stay unkeyed and their ambiguous errors stay non-retried. Gemini sends none. One `randomUUID()` per logical `generate()`, reused across every attempt of that call.

**Backoff ignored `AbortSignal` (medium).** New `sleepAbortable(ms, signal)` rejects promptly on abort and always clears the timer/listener. Also applied to the *pre-existing* 503 sleep, which had the same gap.

**`formatErrorWithCause` was not throw-safe (medium).** Its docstring promised it never throws, but `err.message` / `current.cause` were unguarded property reads — a throwing getter escaped. It's called inside `executeTask`'s **outermost** catch, so a throw there rejected the async generator, the `ERROR` event never fired, and `onTaskComplete` was skipped: the diagnostic path converted a clean error into an unhandled rejection. Fixed with a `safeRead` helper on every property read.

**No length cap (medium).** A 5MB message produced 5MB of output into both the log and the dashboard, reachable via `llm-client.ts:811`'s unbounded `JSON.stringify(data)`. Added `MAX_SEGMENT_CHARS=500` / `MAX_TOTAL_CHARS=4000` with an explicit `… [truncated N chars]` marker — matching the 200-char convention already used at five provider-error sites.

**Refuted with executed evidence, deliberately unchanged:**
- *Retry amplification.* The per-request `AbortSignal` is created once and the same `init` is passed on every attempt, so the 120s/300s deadline caps **cumulative** wall-clock. Worst case is the original budget + ~4s of backoff, not 3× of 168s. A sustained 503 is still retried exactly once — a 503 *resolves* rather than throws, so the outer loop never sees it and the quota handlers fire once per `generate()`.
- *Predicate false positives.* `err.message === 'fetch failed'` is strict equality, so `'OpenAI API error (500): upstream fetch failed'` correctly returns false.
- *Secret leak.* Verified three independent ways (synthetic cause, reading undici's `errors.js`, and a live `fetch` to a Gemini-shaped URL carrying `?key=`): undici's transport cause carries syscall/hostname, never the URL.

## Known gap, disclosed not hidden

`.message` is **not** redacted at any chain level, so a secret embedded in a nested cause's message *would* surface. The implementer wrote this as a **characterization test** asserting current (leaky) behavior, documented to start failing — and be updated, not silenced — if redaction lands. It did not weaken the test into a false "safe" assertion. Redaction is recommended as a scoped follow-up.

## Verification

Independently probed against the built output: throwing `message`/`cause`/`code` getters all return a string rather than throwing; 5MB message caps to 527 chars with the marker; all six pre-send codes and four ambiguous codes classify correctly; 401/400/500-containing-"fetch failed"/`AbortError` all classify `not-transport`. Idempotency key confirmed generated once per call and reused across attempts, and grepped every `_log(` site to confirm it is never logged.

Full jest: **356 suites, 4916 passed**. `tsc` clean, `build` + `build:mcp` clean.

consensus-id: d7c93a1e-da09462b

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)