### PR TITLE
fix(consensus): direct verification-scoped memory recall in cross-review (#659)

### DIFF
--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -62,6 +62,29 @@ const VALID_ACTIONS = new Set(['agree', 'disagree', 'unverified', 'new']);
 const ANCHOR_PATTERN = /(?:[a-zA-Z]:\/)?[\w./-]+\.(ts|js|tsx|jsx|py|go|rs|java|rb|md|json|yaml|yml|toml|sh):\d+/;
 const MAX_VERIFIER_TURNS = 7;
 
+/**
+ * Verification-scoped memory directive for the Phase-2 cross-review system
+ * prompt (issue #659).
+ *
+ * The memory-recall tool is already REACHABLE during cross-review — `memory_query`
+ * is in VERIFIER_TOOLS for engine-driven reviewers, and native reviewers hold
+ * `mcp__gossipcat__gossip_remember` from their agent definition — but nothing in
+ * the cross-review prompt directs its use, so recall happens ad hoc with no
+ * discipline. This block narrows recall to PROCESS memory (prior adjudications,
+ * peer miscite patterns) and hard-forbids substituting a recalled verdict for
+ * fresh verification, reinforcing the "a false confirmation poisons the system"
+ * rule immediately above it.
+ *
+ * Runtime-agnostic on purpose: `buildCrossReviewPrompt` is shared by native and
+ * relay reviewers (the isNative split happens in the caller), so the tool name
+ * is stated conditionally the same way `default-skills/memory-retrieval.md`
+ * does — never naming a tool the reader's runtime lacks.
+ */
+export const CROSS_REVIEW_MEMORY_DIRECTIVE = `MEMORY (optional, verification-scoped) — recall tool: \`memory_query(query)\` if your Identity block says \`runtime: relay\`, \`gossip_remember(agent_id, query)\` if \`runtime: native\`.
+- ALLOWED: process memory only — whether this exact finding was already adjudicated in an earlier round, and known miscite patterns for the peer you are reviewing.
+- FORBIDDEN: substituting a recalled verdict for fresh verification against the code. A recalled verdict is NOT evidence — "I confirmed this last cycle" must NEVER produce an AGREE. Re-verify every round.
+- If memory informed your verdict, make it traceable: cite \`per gossip_remember finding <id>\` inline.`;
+
 const VERIFIER_TOOLS: ToolDefinition[] = [
   { name: 'file_read', description: 'Read file contents', parameters: { type: 'object', properties: { path: { type: 'string', description: 'Absolute or project-relative file path' }, startLine: { type: 'number', description: 'First line to read (1-based)' }, endLine: { type: 'number', description: 'Last line to read (inclusive)' } }, required: ['path'] } },
   { name: 'file_grep', description: 'Search file contents by regex', parameters: { type: 'object', properties: { pattern: { type: 'string', description: 'Regex pattern to search for' }, path: { type: 'string', description: 'Directory or file to search in' }, maxResults: { type: 'number', description: 'Maximum number of results to return' } }, required: ['pattern'] } },
@@ -860,6 +883,8 @@ VERIFICATION RULES:
 - ⚠ warnings mean the agent's citation is unresolvable (file not found, line out of range, or blank line). Use file_read/file_grep to attempt verification before falling back to UNVERIFIED.
 - Do NOT agree with a finding just because it sounds plausible — verify it
 - Agreeing without verification is WORSE than disagreeing — a false confirmation poisons the system
+
+${CROSS_REVIEW_MEMORY_DIRECTIVE}
 
 Return only valid JSON.${skillsBlock}`;
 

--- a/tests/orchestrator/consensus-memory-directive.test.ts
+++ b/tests/orchestrator/consensus-memory-directive.test.ts
@@ -1,0 +1,144 @@
+// tests/orchestrator/consensus-memory-directive.test.ts
+//
+// Issue #659: the Phase-2 cross-review system prompt never directed memory
+// recall, even though the tool is reachable (`memory_query` in VERIFIER_TOOLS
+// for engine-driven reviewers, `mcp__gossipcat__gossip_remember` for native
+// ones). These tests pin the verification-scoped directive AND its
+// anti-anchoring guardrail — the guardrail is the load-bearing half, so it is
+// asserted independently of the permission clause.
+import {
+  ConsensusEngine,
+  ConsensusEngineConfig,
+  CROSS_REVIEW_MEMORY_DIRECTIVE,
+} from '../../packages/orchestrator/src/consensus-engine';
+import { testRound } from '../../packages/orchestrator/src/round-context';
+import { AgentConfig, TaskEntry } from '../../packages/orchestrator/src/types';
+import { ILLMProvider } from '../../packages/orchestrator/src/llm-client';
+
+const mockLlm: jest.Mocked<ILLMProvider> = { generate: jest.fn() };
+
+const mockRegistryGet = jest.fn((agentId: string): AgentConfig | undefined => ({
+  id: agentId,
+  provider: 'local',
+  model: 'test-model',
+  preset: `preset-for-${agentId}`,
+  skills: [],
+}));
+
+const baseConfig: ConsensusEngineConfig = {
+  llm: mockLlm,
+  registryGet: mockRegistryGet,
+  round: testRound(),
+};
+
+const createTaskEntry = (agentId: string, result: string): TaskEntry => ({
+  id: `task-${agentId}`,
+  agentId,
+  task: 'review the code',
+  status: 'completed',
+  result,
+  startedAt: Date.now(),
+  completedAt: Date.now(),
+  inputTokens: 100,
+  outputTokens: 200,
+});
+
+const twoAgents = (): TaskEntry[] => [
+  createTaskEntry('agent-a', '## Consensus Summary\n- Finding A at file.ts:10\n- Finding A2 at file.ts:11'),
+  createTaskEntry('agent-b', '## Consensus Summary\n- Finding B at other.ts:20\n- Finding B2 at other.ts:21'),
+];
+
+async function systemPrompts(config: ConsensusEngineConfig = baseConfig): Promise<string[]> {
+  const engine = new ConsensusEngine({ ...config, round: testRound() });
+  const { prompts } = await engine.generateCrossReviewPrompts(twoAgents());
+  expect(prompts.length).toBeGreaterThan(0);
+  return prompts.map(p => p.system);
+}
+
+describe('cross-review memory directive (#659)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('injects the verification-scoped memory directive into every cross-review system prompt', async () => {
+    for (const system of await systemPrompts()) {
+      expect(system).toContain(CROSS_REVIEW_MEMORY_DIRECTIVE);
+      expect(system).toContain('MEMORY (optional, verification-scoped)');
+      expect(system).toContain('ALLOWED: process memory only');
+    }
+  });
+
+  it('injects the directive even when no skills block is available', async () => {
+    // The four production ConsensusEngine construction sites outside
+    // consensus-coordinator.ts do NOT pass getAgentSkillsContent, so the
+    // skills block is empty there. The directive must not depend on it.
+    for (const system of await systemPrompts()) {
+      expect(system).not.toContain('--- SKILLS ---');
+      expect(system).toContain(CROSS_REVIEW_MEMORY_DIRECTIVE);
+    }
+  });
+
+  it('states the FORBIDDEN anti-anchoring clause, not just the recall permission', async () => {
+    for (const system of await systemPrompts()) {
+      expect(system).toContain('FORBIDDEN: substituting a recalled verdict for fresh verification');
+      expect(system).toContain('A recalled verdict is NOT evidence');
+      expect(system).toContain('must NEVER produce an AGREE');
+      expect(system).toContain('Re-verify every round.');
+    }
+  });
+
+  it('places the guardrail after the "false confirmation poisons the system" rule it reinforces', async () => {
+    for (const system of await systemPrompts()) {
+      const poisonIdx = system.indexOf('a false confirmation poisons the system');
+      const forbiddenIdx = system.indexOf('FORBIDDEN: substituting a recalled verdict');
+      expect(poisonIdx).toBeGreaterThan(-1);
+      expect(forbiddenIdx).toBeGreaterThan(poisonIdx);
+    }
+  });
+
+  it('requires traceable memory-informed verdicts using the existing citation convention', async () => {
+    for (const system of await systemPrompts()) {
+      expect(system).toContain('per gossip_remember finding <id>');
+    }
+  });
+
+  it('names the recall tool conditionally so a relay reviewer is never told to call a native-only tool', async () => {
+    for (const system of await systemPrompts()) {
+      // Both tool names appear, each gated on the reader's runtime — mirroring
+      // default-skills/memory-retrieval.md. Neither is stated unconditionally.
+      expect(system).toContain('`memory_query(query)` if your Identity block says `runtime: relay`');
+      expect(system).toContain('`gossip_remember(agent_id, query)` if `runtime: native`');
+    }
+  });
+
+  it('is tight enough to pay for on every cross-review call', () => {
+    // Budget guard: this block ships on every agent's Phase-2 prompt in every
+    // round. A regression that grows it into an essay should fail loudly.
+    expect(CROSS_REVIEW_MEMORY_DIRECTIVE.length).toBeLessThan(1000);
+  });
+
+  it('leaves the pre-existing verification rules intact', async () => {
+    for (const system of await systemPrompts()) {
+      expect(system).toContain('VERIFICATION RULES:');
+      expect(system).toContain('AGREE only if you can confirm the claim is factually correct — cite your evidence');
+      expect(system).toContain('DISAGREE only if you have concrete evidence the finding is WRONG — the code contradicts the claim');
+      expect(system).toContain('UNVERIFIED only as a last resort after attempting tool-based verification');
+      expect(system).toContain('Do NOT agree with a finding just because it sounds plausible — verify it');
+      expect(system).toContain('Agreeing without verification is WORSE than disagreeing');
+      expect(system).toContain('If a finding has an <anchor> block, use the code shown to verify the claim');
+      expect(system).toContain('SOURCE FILES: Always cite original source files');
+      expect(system).toContain('Return only valid JSON.');
+    }
+  });
+
+  it('keeps "Return only valid JSON." as the final instruction before any skills block', async () => {
+    const [system] = await systemPrompts({
+      ...baseConfig,
+      getAgentSkillsContent: () => 'SKILL BODY',
+    });
+    expect(system).toContain('--- SKILLS ---');
+    // Directive sits above the JSON contract; the skills block stays last.
+    expect(system.indexOf(CROSS_REVIEW_MEMORY_DIRECTIVE))
+      .toBeLessThan(system.indexOf('Return only valid JSON.'));
+    expect(system.indexOf('Return only valid JSON.'))
+      .toBeLessThan(system.indexOf('--- SKILLS ---'));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #659. Phase-2 cross-reviewers had `gossip_remember` / `memory_query` reachable but were never told when or whether to use it, so recall happened ad hoc with no discipline — the worst of both worlds.

## What the investigation actually found (two corrections)

**I was wrong, and the original issue was right.** I told the implementer that a skills block *is* injected into cross-review and only `memory-retrieval` was missing, based on a probe showing `loadSkills` returning 32KB with zero occurrences. That probe was faulty: my ad-hoc compiled `SkillIndex` loaded empty, so `resolveEffectiveSkills` (`skill-loader.ts:135`) fell back to the raw config array `['code_review','security_audit','typescript']` — underscore names that legitimately contain no `memory-retrieval`. Re-run properly, `loadSkills` returns 43,228 chars **with** `memory-retrieval` present. There is no loader bug; fixing that layer would have been fixing a non-bug.

**The real defect is a construction-site wiring gap, broader than the issue described.** `getAgentSkillsContent` is passed to `ConsensusEngine` at exactly **one** of five construction sites (`consensus-coordinator.ts:122`). The other four omit it: `collect.ts:613` — which is the `gossip_collect(consensus: true)` **production path** — and `relay-cross-review.ts:53/:227/:363`. On those paths the callback is `undefined`, `skillsBlock` stays empty, and cross-reviewers get **no skills at all**. So the skills injection at `consensus-engine.ts:837-848` is effectively dead code on the path that actually runs, and the issue's original wording ("no skills block is injected at all for cross-review") was accurate in production.

Verified independently: `grep -c getAgentSkillsContent` returns **0** for both `collect.ts` and `relay-cross-review.ts`.

## Why the fix went in the prompt layer

A block inside `buildCrossReviewPrompt` is **unconditional**, so it reaches all five construction sites including the four that drop the callback. Routing it through `getAgentSkillsContent` would have shipped it only on the one path that already works — the prompt-layer fix is the *broader* one here, inverting my own assumption.

Also: injecting `default-skills/memory-retrieval.md` verbatim into Phase 2 would be **actively harmful**. Its text is Phase-1-framed — *"STEP 0 — DO THIS BEFORE READING ANY CODE"*, *"so you don't re-discover or contradict yourself"* — and "don't contradict yourself" is precisely the anchoring hazard #659 warns about, with no FORBIDDEN clause.

## The directive (783 chars)

- **ALLOWED**: process memory only — whether this finding was already adjudicated in an earlier round, and known miscite patterns for the peer being reviewed.
- **FORBIDDEN**: substituting a recalled verdict for fresh verification. *"A recalled verdict is NOT evidence — 'I confirmed this last cycle' must NEVER produce an AGREE."* This reinforces the existing rule that agreeing without verification is worse than disagreeing.
- **Traceable**: memory-informed verdicts cite `per gossip_remember finding <id>` inline.

Tool naming is **conditional on the Identity block** (`memory_query` for `runtime: relay`, `gossip_remember` for `runtime: native`) because `buildCrossReviewPrompt` is shared by native and relay reviewers and the runtime isn't knowable at build time. Neither name is stated unconditionally, so no reader is told to call a tool it lacks. A test pins this.

## Verification

- 9 new tests: FORBIDDEN clause asserted **independently** of the permission clause; guardrail ordering; presence with an empty skills block; all pre-existing verification rules byte-identical; `Return only valid JSON.` still ahead of `--- SKILLS ---`; and a **<1000-char budget guard** so a future regression that grows this into an essay fails loudly.
- `tests/orchestrator`: 181 suites, 2676 passed. Also ran the CLI suites asserting on cross-review prompt content (`relay-cross-review-midflight`, `timeout-synthesis-seam`, `post-collect-pipeline`): 23/23. `tsc` clean.

## Follow-up filed, deliberately not fixed here

The four-site wiring gap is cited, not fixed — it touches four call sites and has a real cost consequence (43KB of skills × every agent × every round), so it deserves its own change and its own review rather than riding along.

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)