### PR TITLE
fix(cache): split the warm prompt cache on an exact caller-supplied tail (#672)

### DIFF
--- a/apps/cli/src/handlers/dispatch-prompt-cache.ts
+++ b/apps/cli/src/handlers/dispatch-prompt-cache.ts
@@ -204,15 +204,18 @@ function emitCacheEvictedSignal(
 /**
  * Splice helpers — share the boundary contract with dispatch.ts.
  *
- * Splice contract (spec + task description):
- *   - Live `Task:` block = everything from the LAST `\n\nTask:` to end-of-string.
- *   - Cached skills-section = everything BEFORE that boundary.
- *   - Warm-hit body = cachedSkillsSection + extractedLiveTaskBlock.
+ * Splice contract:
+ *   - Live `Task:` block = the caller-supplied `\n\nTask: ${task}` tail.
+ *   - Cached skills-section = the assembled body with exactly that tail removed
+ *     (so it still ends with ASSEMBLER_TASK_SEPARATOR, which composeWarmBody
+ *     relies on to place the RECALLED LESSONS block).
+ *   - Warm-hit body = cachedSkillsSection + liveTaskBlock.
  *
  * The assembler emits exactly one `\n\n---\n\nTask: ${task}` segment at
- * priority 0 (see packages/orchestrator/src/prompt-assembler.ts:280). The
- * structural lint test in tests/orchestrator/dispatch-prompt-cache.test.ts
- * asserts this invariant.
+ * priority 0 (see packages/orchestrator/src/prompt-assembler.ts:332). Priority-0
+ * suffix segments are never dropped and TASK is pushed last, so the assembled
+ * body always ENDS with that segment. The structural lint test in
+ * tests/orchestrator/dispatch-prompt-cache.test.ts asserts this invariant.
  */
 export interface SplitPromptParts {
   skillsSection: string;
@@ -220,19 +223,44 @@ export interface SplitPromptParts {
 }
 
 /**
- * Split an assembled prompt into [skills-section, task-block] at the LAST
- * `\n\nTask:` boundary. If the boundary is missing (assembler invariant
- * violated), returns the whole body as skillsSection and an empty taskBlock
- * — caller MUST treat empty taskBlock as fatal and skip caching.
+ * Separator `assemblePrompt` emits immediately before the TASK segment
+ * (the full segment is `\n\n---\n\nTask: ${task}`). Single owner — dispatch.ts
+ * imports this rather than re-declaring it.
  */
-export function splitAssembledPrompt(body: string): SplitPromptParts {
-  const idx = body.lastIndexOf('\n\nTask:');
-  if (idx < 0) {
+export const ASSEMBLER_TASK_SEPARATOR = '\n\n---';
+
+/**
+ * Split an assembled prompt into [skills-section, task-block].
+ *
+ * `liveTaskTail` is the EXACT tail the caller knows `assemblePrompt` emitted for
+ * this dispatch (`\n\nTask: ${task}`). The boundary is verified by exact suffix
+ * match — `body` must end with `ASSEMBLER_TASK_SEPARATOR + liveTaskTail` — not
+ * recovered by searching the body for a literal that task text may also contain.
+ *
+ * Issue #672: this used to be `body.lastIndexOf('\n\nTask:')`. A task whose own
+ * text contained that sequence (a review brief quoting the brief it reviews, an
+ * inlined spec) moved the cut INSIDE the task, so the persisted skills-section
+ * swallowed part of task 1 and was replayed to every later dispatch on the same
+ * cache key — a cross-task leak through a persisted cache. The search anchor was
+ * also strictly less specific than the separator actually emitted, widening the
+ * collision surface for no benefit.
+ *
+ * Fails CLOSED: if the suffix does not match (assembler invariant violated, or a
+ * caller passed a tail that is not this body's tail), returns the whole body as
+ * skillsSection and an empty taskBlock. Callers MUST treat an empty taskBlock as
+ * fatal and skip caching — `cacheColdPathStore` is the only production caller
+ * and does exactly that.
+ */
+export function splitAssembledPrompt(body: string, liveTaskTail: string): SplitPromptParts {
+  if (!liveTaskTail) return { skillsSection: body, taskBlock: '' };
+  if (!body.endsWith(ASSEMBLER_TASK_SEPARATOR + liveTaskTail)) {
     return { skillsSection: body, taskBlock: '' };
   }
   return {
-    skillsSection: body.slice(0, idx),
-    taskBlock: body.slice(idx),
+    // Keep ASSEMBLER_TASK_SEPARATOR in the cached section — composeWarmBody
+    // splices the lesson block in front of it on a warm hit.
+    skillsSection: body.slice(0, body.length - liveTaskTail.length),
+    taskBlock: liveTaskTail,
   };
 }
 

--- a/apps/cli/src/handlers/dispatch.ts
+++ b/apps/cli/src/handlers/dispatch.ts
@@ -123,6 +123,7 @@ function buildNativeIdentity(agentId: string, model: string): string {
 import { evictStaleNativeTasks, persistNativeTaskMap, spawnTimeoutWatcher } from './native-tasks';
 import { writeDispatchPrompt } from './dispatch-prompt-storage';
 import {
+  ASSEMBLER_TASK_SEPARATOR,
   computeSkillFingerprint,
   getCachedPrompt,
   setCachedPrompt,
@@ -276,13 +277,6 @@ export function tryWarmCacheHit(
 }
 
 /**
- * Separator `assemblePrompt` emits immediately before the TASK segment
- * (`\n\n---\n\nTask: `). `splitAssembledPrompt` cuts at `\n\nTask:`, so the
- * cached skills-section always ends with this string.
- */
-const ASSEMBLER_TASK_SEPARATOR = '\n\n---';
-
-/**
  * Compose a warm-hit body, inserting the RECALLED LESSONS block (issue #669) at
  * the SAME position `assemblePrompt` would place `retrievedLessons` on a cold
  * miss — i.e. as the last suffix segment before the `\n\n---\n\nTask:`
@@ -292,7 +286,9 @@ const ASSEMBLER_TASK_SEPARATOR = '\n\n---';
  * This replaces a post-hoc `lastIndexOf('\n\n---\n\nTask: ')` splice on the
  * finished prompt. That anchor is CONTENT, not structure: a brief that quotes a
  * prior prompt carries the same bytes, and the block landed inside the quoted
- * material. Here the boundary is a string this function itself constructed.
+ * material. Here the boundary is a string this function itself constructed —
+ * `skillsSection` comes from `splitAssembledPrompt`, which cuts by exact
+ * caller-supplied suffix (issue #672), so the `\n\n---` tail is structural.
  *
  * The cap re-check exists because the cached skills-section was sized by
  * `assemblePrompt` against a DIFFERENT task, so its priority-drop pass cannot
@@ -314,18 +310,24 @@ export function composeWarmBody(
 }
 
 /**
- * Phase-2 cache cold-path store. Call after assemblePrompt on a miss. Splits
- * the assembled body at the LAST `\n\nTask:` boundary, persists the prefix to
- * a content-addressed skills-section file, and inserts a cache entry keyed by
- * the supplied PromptCacheKey. No-op if liveTaskBlock could not be extracted
- * (assembler invariant violated — skip caching defensively).
+ * Phase-2 cache cold-path store. Call after assemblePrompt on a miss. Strips the
+ * caller-supplied live `Task:` tail off the assembled body by EXACT suffix match,
+ * persists the remaining prefix to a content-addressed skills-section file, and
+ * inserts a cache entry keyed by the supplied PromptCacheKey.
+ *
+ * `liveTaskTail` must be the same `\n\nTask: ${task}` string the caller hands
+ * `tryWarmCacheHit` — passing it makes the cold/warm splice boundary an
+ * assertion rather than a search (issue #672). No-op if the suffix does not
+ * match (assembler invariant violated, or the tail belongs to another dispatch)
+ * — refusing to cache is always safe, a wrong split is not.
  */
 export function cacheColdPathStore(
   projectRoot: string,
   assembledBody: string,
   cacheKey: PromptCacheKey,
+  liveTaskTail: string,
 ): void {
-  const { skillsSection, taskBlock } = splitAssembledPrompt(assembledBody);
+  const { skillsSection, taskBlock } = splitAssembledPrompt(assembledBody, liveTaskTail);
   if (!taskBlock) return; // boundary missing — refuse to cache.
   try {
     const skillsSectionPath = writeCachedSkillsSection(projectRoot, cacheKey.skillFingerprint, skillsSection);
@@ -930,8 +932,10 @@ export async function handleDispatchSingle(
       skillFingerprint: computeSkillFingerprint(skillResult.paths || []),
       taskKind: 'single' as TaskKind,
     };
-    // splitAssembledPrompt cuts at "\n\nTask:" (the structural anchor), so the
-    // cached skillsSection already ends with the "\n\n---" separator that
+    // This exact string is BOTH the warm-hit splice tail and the suffix
+    // cacheColdPathStore strips off the cold body, so the two paths cannot
+    // disagree about where the boundary is (issue #672). The cached
+    // skillsSection therefore still ends with the "\n\n---" separator that
     // precedes Task: in assemblePrompt's output. liveTaskTail must NOT
     // re-include "\n\n---\n\n" or the warm body grows a duplicate separator
     // per dispatch (caught by dispatch-prompt-cache.test.ts splice integrity).
@@ -963,7 +967,7 @@ export async function handleDispatchSingle(
       // and lessons are task-matched, so caching either risks leaking T1's
       // content into T2 on a warm hit. Cache the plain assembler output.
       if (prompt_format === 'elided') {
-        cacheColdPathStore(process.cwd(), agentPrompt, singleCacheKey);
+        cacheColdPathStore(process.cwd(), agentPrompt, singleCacheKey, singleLiveTaskTail);
       }
       if (singleLessonBlock) {
         agentPrompt = assemblePrompt({ ...singleParts, retrievedLessons: singleLessonBlock });
@@ -1422,7 +1426,7 @@ export async function handleDispatchParallel(
       };
       agentPrompt = assemblePrompt(parallelParts);
       if (prompt_format === 'elided') {
-        cacheColdPathStore(process.cwd(), agentPrompt, parallelCacheKey);
+        cacheColdPathStore(process.cwd(), agentPrompt, parallelCacheKey, parallelLiveTaskTail);
       }
       if (parallelLessonBlock) {
         agentPrompt = assemblePrompt({ ...parallelParts, retrievedLessons: parallelLessonBlock });
@@ -1800,7 +1804,7 @@ export async function handleDispatchConsensus(
       };
       agentPrompt = assemblePrompt(consensusParts);
       if (prompt_format === 'elided') {
-        cacheColdPathStore(process.cwd(), agentPrompt, consensusCacheKey);
+        cacheColdPathStore(process.cwd(), agentPrompt, consensusCacheKey, consensusLiveTaskTail);
       }
       if (consensusLessonBlock) {
         agentPrompt = assemblePrompt({ ...consensusParts, retrievedLessons: consensusLessonBlock });

--- a/tests/cli/dispatch-lesson-injection.test.ts
+++ b/tests/cli/dispatch-lesson-injection.test.ts
@@ -178,7 +178,10 @@ describe('native dispatch lesson injection (issue #669)', () => {
 
     const cold = assemblePrompt({ ...nativeParts(WORKTREE_TASK), retrievedLessons: block });
     // The cache stores the LESSON-FREE assembly, split at `\n\nTask:`.
-    const { skillsSection, taskBlock } = splitAssembledPrompt(assemblePrompt(nativeParts(WORKTREE_TASK)));
+    const { skillsSection, taskBlock } = splitAssembledPrompt(
+      assemblePrompt(nativeParts(WORKTREE_TASK)),
+      `\n\nTask: ${WORKTREE_TASK}`,
+    );
     expect(taskBlock).not.toBe('');
     expect(composeWarmBody(skillsSection, taskBlock, block)).toBe(cold);
     // …and without lessons the warm body is unchanged.

--- a/tests/orchestrator/dispatch-prompt-cache.test.ts
+++ b/tests/orchestrator/dispatch-prompt-cache.test.ts
@@ -16,6 +16,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, utimesSync, w
 import { tmpdir } from 'os';
 import { join } from 'path';
 
+import { assemblePrompt } from '../../packages/orchestrator/src/prompt-assembler';
 import { ctx } from '../../apps/cli/src/mcp-context';
 import {
   handleDispatchSingle,
@@ -156,10 +157,76 @@ describe('dispatch-prompt warm cache (Phase 2)', () => {
       expect(body2).toContain('Task: Task TWO');
       expect(body2).not.toContain('Task: Task ONE');
       // Skills prefix should match the cached skills section from r1.
-      const { skillsSection: s1 } = splitAssembledPrompt(body1);
-      const { skillsSection: s2 } = splitAssembledPrompt(body2);
+      const { skillsSection: s1 } = splitAssembledPrompt(body1, '\n\nTask: Task ONE');
+      const { skillsSection: s2 } = splitAssembledPrompt(body2, '\n\nTask: Task TWO');
       expect(s2).toEqual(s1);
       void r1;
+    });
+  });
+
+  describe('Test 1b: task text containing the split anchor (issue #672)', () => {
+    // A brief that QUOTES a prior brief carries `\n\nTask:` as CONTENT. The old
+    // `lastIndexOf('\n\nTask:')` split cut INSIDE the task, so the persisted
+    // skills-section swallowed task 1 and was replayed to every later dispatch
+    // on the same cache key — a cross-task leak through a persisted cache.
+    const QUOTING_TASK = [
+      'Review the brief we sent last round and say whether it was well-scoped.',
+      '',
+      'It said:',
+      '',
+      'Task: unrelated follow-up work about CSS design tokens in the dashboard',
+      '',
+      'That is the whole brief. Assess it.',
+    ].join('\n');
+
+    it('does not leak task 1 text into the cached skills section', () => {
+      const body = assemblePrompt({
+        identity: '## Identity\nagent_id: native-claude',
+        instructions: 'You are a reviewer.',
+        skills: 'IRON LAW: verify before asserting.\n'.repeat(600), // ~21KB, production scale
+        task: QUOTING_TASK,
+      });
+      const liveTaskTail = `\n\nTask: ${QUOTING_TASK}`;
+      expect(body.length).toBeGreaterThan(20_000);
+
+      const { skillsSection, taskBlock } = splitAssembledPrompt(body, liveTaskTail);
+
+      // No part of the task may survive into the cacheable prefix.
+      expect(skillsSection).not.toContain('Task:');
+      expect(skillsSection).not.toContain('Review the brief we sent last round');
+      expect(skillsSection).not.toContain('CSS design tokens');
+      expect(skillsSection.endsWith('\n\n---')).toBe(true);
+      expect(taskBlock).toBe(liveTaskTail);
+    });
+
+    it('fails closed (no caching) when the body does not end with the given tail', () => {
+      // Assembler invariant violated, or a tail from a different dispatch.
+      expect(splitAssembledPrompt('prefix\n\n---\n\nTask: real', '\n\nTask: OTHER').taskBlock).toBe('');
+      expect(splitAssembledPrompt('no boundary at all', '\n\nTask: x').taskBlock).toBe('');
+      // Separator absent — refuse rather than guess.
+      expect(splitAssembledPrompt('prefix\n\nTask: real', '\n\nTask: real').taskBlock).toBe('');
+      expect(splitAssembledPrompt('prefix\n\n---\n\nTask: real', '').taskBlock).toBe('');
+    });
+
+    it('end-to-end: dispatch 2 never sees dispatch 1 task text', async () => {
+      registerNativeAgent();
+      await handleDispatchSingle(
+        'native-claude', QUOTING_TASK,
+        undefined, undefined, undefined, undefined, undefined,
+        undefined, 'elided',
+      );
+      const files1 = listDispatchFiles(workDir);
+      const r2 = await handleDispatchSingle(
+        'native-claude', 'unrelated second task',
+        undefined, undefined, undefined, undefined, undefined,
+        undefined, 'elided',
+      );
+      expect(r2.content[0].text).toContain('warm-cached (skills) + live task');
+      const body2Path = listDispatchFiles(workDir).find(f => !files1.includes(f))!;
+      const body2 = readFileSync(join(workDir, '.gossip', 'dispatch-prompts', body2Path), 'utf8');
+      expect(body2).toContain('Task: unrelated second task');
+      expect(body2).not.toContain('Review the brief we sent last round');
+      expect(body2).not.toContain('CSS design tokens');
     });
   });
 
@@ -395,7 +462,7 @@ describe('dispatch-prompt warm cache (Phase 2)', () => {
   describe('Test 14: splice integrity — cached skills + live task assembly', () => {
     it('splitAssembledPrompt followed by splice yields a body whose Task: tail is fresh', () => {
       const fakeBody = '<identity>\n\n--- SKILLS ---\nx\n--- END SKILLS ---\n\n---\n\nTask: original';
-      const { skillsSection, taskBlock } = splitAssembledPrompt(fakeBody);
+      const { skillsSection, taskBlock } = splitAssembledPrompt(fakeBody, '\n\nTask: original');
       expect(skillsSection).not.toContain('Task:');
       expect(taskBlock).toEqual('\n\nTask: original');
       // Splice a new task tail


### PR DESCRIPTION
Closes #672.

## The bug

`splitAssembledPrompt` recovered the skills/task boundary with `body.lastIndexOf('\n\nTask:')`. A task whose own text contains that sequence — a review brief quoting the brief it reviews — moves the cut *inside* the task, so the persisted skills section swallows task 1 and replays it to every later dispatch on the same cache key.

Reproduced at 21 KB production scale. With the old logic the "skills section" ends:

```
...--- END FINDING TAG SCHEMA --- ... \n\n---\n\nTask: Review the brief we sent last round...\n\nIt said:
```

The structural boundary *plus* task 1's opening, inside the cacheable prefix.

## The fix: stop recovering a boundary the caller already knows

`cacheColdPathStore` is the **only** production caller, and it already holds the exact task text — it builds `\n\nTask: ${task}` two lines earlier for the warm path, then discarded the split's `taskBlock` and used it only as a truthiness gate.

So the tail is now passed in and verified by exact suffix match, failing closed if the body doesn't end with `ASSEMBLER_TASK_SEPARATOR + tail`. **No search over task-controlled text remains.**

### Two alternatives measured and rejected

**Return the split offset from `assemblePrompt`** — correct, but expensive. I specifically asked whether a returned offset could go stale against the priority-based suffix dropping and truncation; it can't (both complete before the final concatenation at `prompt-assembler.ts:370`, and TASK is priority 0, always last). Rejected because it changes a `string` return shared by **67 call sites** for zero information gain, since the one consumer already holds the value.

**A sentinel delimiter** — loses differently. The assembled body is passed verbatim as the `Agent(prompt:)` value and written to `.gossip/dispatch-prompts/<taskId>.txt`, so a nonce would be **visible to the agent in its own prompt**, and a control character fails **open** if any provider normalizes it away.

Also folds the separator literal, previously spelled out in both files, into one exported `ASSEMBLER_TASK_SEPARATOR`.

## Frequency correction — the issue overstated this

The issue called the trigger routine and said this session's dispatches had hit it. Measured across **1160 untruncated real dispatch task strings** (556 over 500 chars, 142 at production scale, max 12,604):

| anchor | collisions |
|---|---|
| `\n\nTask:` | **0 / 1160** |
| `\n\n---\n\nTask: ` | **0 / 1160** |

The four briefs containing a literal `Task:` carry it as `executeTask:` or as *backslash-escaped* visible text — never real newlines. **The defect is confirmed and reproduced; its historical incidence is zero.** Latent, not active.

(Don't use `.gossip/agents/*/memory/tasks.jsonl` for this measurement — `writeTaskEntry` truncates to 500 chars at `memory-writer.ts:226`, which would understate collisions.)

## No migration needed — and why that could change

The persisted `skills-<fingerprint>.txt` files are **not a standalone cache source**. `tryWarmCacheHit` requires an in-memory Map hit first, and that Map is process-scoped — so every disk read is preceded by a same-process write. A poisoned file cannot be served after a restart, and this ships as a new binary.

This stops being true the moment anyone adds **disk-backed rehydration** — a plausible startup optimization, since the files are already content-addressed. At that point stale entries written by any prior split logic become servable and the fingerprint *would* need a split-version component. Noted in the code.

The 12 existing cache files were re-verified clean (`grep -c 'Task:'` → 0 on all 12) and left untouched.

## The documented contract nobody tested

The old doc claimed "caller MUST treat empty taskBlock as fatal and skip caching." There is exactly one production caller and it *does* enforce it (`if (!taskBlock) return;`) — but no test covered the violation branch. Now covered.

## Verification

- **Full suite: 369 suites / 5097 passed / 0 failed** after `npm run build:mcp`; bundle boots exit 0.
- Three new regression tests: no task text in the cacheable prefix at 21 KB scale; fail-closed on mismatched, absent, and empty tails; end-to-end that dispatch 2's on-disk body never contains dispatch 1's task text.
- **Mutation-tested**: restoring `lastIndexOf('\n\nTask:')` fails all three; restoring the fix passes all three. The 23 pre-existing tests pass under both, so the new tests are the discriminator.

## Follow-up, not in this PR

`ASSEMBLER_TASK_SEPARATOR` now has one owner in `apps/cli`, but the *true* owner is `prompt-assembler.ts:332`, which builds the separator from an inline template with no exported constant — the same single-owner-delimiter shape as #677. Worth exporting `TASK_BLOCK_SEPARATOR` / `TASK_BLOCK_PREFIX` so the shared boundary is structural rather than conventional.

Both halves of this bug class are now closed by the same principle, arrived at independently: #671 replaced a `lastIndexOf` splice with assembly-time placement; this replaces a `lastIndexOf` split with a caller-supplied exact suffix. If you're calling `indexOf`/`lastIndexOf` on a string containing task-supplied text to find a boundary *you emitted*, the boundary should have been passed down instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)