### PR TITLE
fix(cli): report the resolved key store in key list/set; retire the "keychain service" misnomer (#667)

### DIFF
--- a/apps/cli/src/key-command.ts
+++ b/apps/cli/src/key-command.ts
@@ -11,12 +11,16 @@
  * through the LLM tool layer would be a trust-boundary violation.
  */
 import { KEY_REQUIRING_PROVIDERS } from '@gossip/orchestrator';
+import type { KeyStoreInfo, KeyStoreKind } from './keychain';
 
 const VALID_PROVIDERS = /^[a-zA-Z0-9_-]{1,32}$/;
 
 export interface KeyCommandIO {
-  setKey(provider: string, key: string): Promise<void>;
+  /** Resolves to the store the key ACTUALLY landed in (keychain writes can fall back to file). */
+  setKey(provider: string, key: string): Promise<KeyStoreKind>;
   getKey(provider: string): Promise<string | null>;
+  /** Which store this invocation resolved to — reported to the operator, never guessed. */
+  storeInfo(): KeyStoreInfo;
   readSecret(): Promise<string>;
   out(line: string): void;
   err(line: string): void;
@@ -24,8 +28,16 @@ export interface KeyCommandIO {
 
 const USAGE =
   'Usage:\n' +
-  '  gossipcat key set <provider>   Store an API key in the OS keychain (service: gossip-mesh)\n' +
-  '  gossipcat key list             Show which providers have a stored key';
+  '  gossipcat key set <provider>   Store an API key (OS keychain when available, else encrypted file)\n' +
+  '  gossipcat key list             Show the resolved store and which providers have a stored key';
+
+/**
+ * Human-readable destination for a given store kind. The file case always names
+ * the ABSOLUTE path so a relay-vs-CLI cwd mismatch is visible at a glance.
+ */
+function describeStore(kind: KeyStoreKind, info: KeyStoreInfo): string {
+  return kind === 'keychain' ? `keychain (service ${info.service})` : `file ${info.path}`;
+}
 
 /** args = everything AFTER `key`. Returns exit code (0 ok, 2 usage/error). */
 export async function runKeyCommand(args: string[], io: KeyCommandIO): Promise<number> {
@@ -47,12 +59,20 @@ export async function runKeyCommand(args: string[], io: KeyCommandIO): Promise<n
       io.err('no key provided (stdin was empty)');
       return 2;
     }
-    await io.setKey(provider, key);
-    io.out(`stored key for "${provider}" in the gossip-mesh keychain`);
+    // Report the destination setKey actually used — a failed keychain write
+    // falls back to the encrypted file, and claiming "keychain" there is a lie.
+    const written = await io.setKey(provider, key);
+    io.out(`stored key for "${provider}" in ${describeStore(written, io.storeInfo())}`);
     return 0;
   }
 
   if (sub === 'list') {
+    const info = io.storeInfo();
+    io.out(
+      info.kind === 'keychain'
+        ? `(store: keychain  service ${info.service})`
+        : `(store: file  ${info.path})`,
+    );
     for (const provider of KEY_REQUIRING_PROVIDERS) {
       const value = await io.getKey(provider);
       const present = typeof value === 'string' && value.length > 0;

--- a/apps/cli/src/keychain.ts
+++ b/apps/cli/src/keychain.ts
@@ -9,6 +9,24 @@ const VALID_PROVIDERS = /^[a-zA-Z0-9_-]{1,32}$/;
 const ENCRYPTED_FILE = '.gossip/keys.enc';
 const ALGO = 'aes-256-gcm';
 
+/** Which store a key actually lives in / was actually written to. */
+export type KeyStoreKind = 'keychain' | 'file';
+
+/** Where this Keychain instance resolved its store to. Never contains key values. */
+export interface KeyStoreInfo {
+  kind: KeyStoreKind;
+  /** OS-keychain service name — always the `gossip-mesh` constant, not the provider. */
+  service: string;
+  /**
+   * ABSOLUTE path of the encrypted key file. Always populated: it is the live
+   * store when `kind === 'file'`, and the fallback destination a failed keychain
+   * write drops to when `kind === 'keychain'` (see {@link Keychain.setKey}).
+   * Absolute because it is cwd-derived — relay-vs-CLI cwd mismatches are only
+   * visible if the full path is shown.
+   */
+  path: string;
+}
+
 export class Keychain {
   private inMemoryStore: Map<string, string> = new Map();
   private keychainAvailable: boolean;
@@ -34,18 +52,34 @@ export class Keychain {
     return this.inMemoryStore.get(provider) || null;
   }
 
-  async setKey(provider: string, key: string): Promise<void> {
+  /** Where keys resolve for this instance. Safe to print: no key values. */
+  storeInfo(): KeyStoreInfo {
+    return {
+      kind: this.keychainAvailable ? 'keychain' : 'file',
+      service: this.serviceName,
+      path: join(process.cwd(), ENCRYPTED_FILE),
+    };
+  }
+
+  /**
+   * @returns the store the key ACTUALLY landed in. A failed keychain write
+   * silently falls back to the encrypted file, so callers must report this
+   * value rather than assuming {@link storeInfo}'s `kind`.
+   */
+  async setKey(provider: string, key: string): Promise<KeyStoreKind> {
     this.inMemoryStore.set(provider, key);
     if (this.keychainAvailable) {
       try {
         this.writeToKeychain(provider, key);
+        return 'keychain';
       } catch {
         // Keychain write failed — fall through to encrypted file
         this.saveEncryptedFile();
+        return 'file';
       }
-    } else {
-      this.saveEncryptedFile();
     }
+    this.saveEncryptedFile();
+    return 'file';
   }
 
   private deriveKey(salt: Buffer): Buffer {

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -155,8 +155,8 @@ const __argvShimHandled = (() => {
       '  gossipcat                Start MCP server (for Claude Code / Cursor)\n' +
       '  gossipcat hook --run     Run UserPromptSubmit bootstrap hook (internal)\n' +
       '  gossipcat hook mirror-prompt|mirror-stop|mirror-tool   Activity-mirror hooks (internal; opt-in via gossip_setup mirror_hooks)\n' +
-      '  gossipcat key set <provider>   Store an API key in the OS keychain (service: gossip-mesh)\n' +
-      '  gossipcat key list             Show which providers have a stored key\n' +
+      '  gossipcat key set <provider>   Store an API key (OS keychain when available, else encrypted file)\n' +
+      '  gossipcat key list             Show the resolved store and which providers have a stored key\n' +
       '  gossipcat code [args...]       Launch Claude Code with the gossipcat channel active\n' +
       '                                 Note: <cwd>/.mcp.json is treated as trusted config (server name is read from it).\n' +
       '  gossipcat help           Show this help\n' +
@@ -178,6 +178,7 @@ const __argvShimHandled = (() => {
       const io = {
         setKey: (p: string, k: string) => kc.setKey(p, k),
         getKey: (p: string) => kc.getKey(p),
+        storeInfo: () => kc.storeInfo(),
         readSecret: () => readSecretFromStdin(),
         out: (l: string) => process.stdout.write(l + '\n'),
         err: (l: string) => process.stderr.write(l + '\n'),

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -1163,23 +1163,26 @@ export function createProviderForAgent(
   keyRef?: string,
 ): ILLMProvider {
   if ((KEY_REQUIRING_PROVIDERS as readonly string[]).includes(provider) && !apiKey) {
-    // Name the keychain SERVICE the resolver tried (key_ref ?? provider) so a
-    // missing per-agent key is actionable — the operator knows exactly which
-    // service to store. Service names are safe to log; never the key value. #522
-    const service = keyRef ?? provider;
+    // Name the KEY the resolver tried (key_ref ?? provider) so a missing
+    // per-agent key is actionable. Do NOT call it a "keychain service": the
+    // keychain service is always the `gossip-mesh` constant and this name is
+    // the ACCOUNT under it — and on platforms without an OS keychain the key
+    // lands in the encrypted file instead. Name the command, not the store.
+    // Key names are safe to log; never the key value. #522 / #667
+    const keyName = keyRef ?? provider;
     return new DegradedProvider(
       `no API key configured for agent "${agentId}" (provider ${provider}, ` +
-      `base_url ${baseUrl ?? 'default'}); set the key for keychain service "${service}"`,
+      `base_url ${baseUrl ?? 'default'}); run 'gossipcat key set "${keyName}"'`,
     );
   }
-  // Auth-failure slot = the keychain SERVICE the operator must fix (key_ref ??
-  // provider), so gossip_status names the right `gossipcat key set <service>`.
+  // Auth-failure slot = the KEY NAME the operator must fix (key_ref ??
+  // provider), so gossip_status names the right `gossipcat key set <name>`.
   // Distinct from the quota slot (per-endpoint rate-limit state). #522
   return createProvider(provider, model, apiKey, projectRoot, baseUrl, keyRef ?? provider);
 }
 
 /**
- * Pure async helper: resolves the per-agent keychain service (key_ref ?? provider),
+ * Pure async helper: resolves the per-agent key name (key_ref ?? provider),
  * fetches the key via the injected `getKey` callback, then delegates to
  * {@link createProviderForAgent}. Extracted from the doBoot inline block so the
  * key-resolution + provider-construction path can be unit-tested without a
@@ -1187,7 +1190,7 @@ export function createProviderForAgent(
  *
  * @param ac  Minimal agent config shape — same fields used at every construction site.
  * @param getKey  Injected key lookup (e.g. `(s) => ctx.keychain.getKey(s)`); returns
- *                `null` when the service has no stored key.
+ *                `null` when that key name has nothing stored.
  */
 export async function resolveAgentProvider(
   ac: { id: string; provider: string; model: string; base_url?: string; key_ref?: string },

--- a/tests/cli/key-command.test.ts
+++ b/tests/cli/key-command.test.ts
@@ -8,6 +8,9 @@
  */
 
 import { runKeyCommand, KeyCommandIO } from '../../apps/cli/src/key-command';
+import type { KeyStoreInfo, KeyStoreKind } from '../../apps/cli/src/keychain';
+
+const FILE_PATH = '/abs/project/.gossip/keys.enc';
 
 interface FakeIO extends KeyCommandIO {
   store: Map<string, string>;
@@ -19,17 +22,30 @@ interface FakeIO extends KeyCommandIO {
 function makeIO(opts: {
   secret?: string;
   seed?: Record<string, string>;
+  /** Store the CLI resolved to. Defaults to the OS keychain. */
+  storeKind?: KeyStoreKind;
+  /** Store setKey actually wrote to — models the silent keychain→file fallback. */
+  writeDestination?: KeyStoreKind;
 } = {}): FakeIO {
   const store = new Map<string, string>(Object.entries(opts.seed ?? {}));
   const outLines: string[] = [];
   const errLines: string[] = [];
+  const info: KeyStoreInfo = {
+    kind: opts.storeKind ?? 'keychain',
+    service: 'gossip-mesh',
+    path: FILE_PATH,
+  };
   const io: FakeIO = {
     store,
     outLines,
     errLines,
     readSecretCalls: 0,
-    async setKey(provider, key) { store.set(provider, key); },
+    async setKey(provider, key) {
+      store.set(provider, key);
+      return opts.writeDestination ?? info.kind;
+    },
     async getKey(provider) { return store.get(provider) ?? null; },
+    storeInfo() { return info; },
     async readSecret() { io.readSecretCalls++; return opts.secret ?? ''; },
     out(line) { outLines.push(line); },
     err(line) { errLines.push(line); },
@@ -55,6 +71,36 @@ describe('runKeyCommand', () => {
       expect(io.store.get('deepseek')).toBe(secret);
       expect(io.outLines.join('\n')).toContain('deepseek');
       assertNoLeak(io, secret);
+    });
+
+    it('names the keychain store and its service on a keychain write (issue #667)', async () => {
+      const io = makeIO({ secret: 'sk-abc', storeKind: 'keychain' });
+      const code = await runKeyCommand(['set', 'google'], io);
+
+      expect(code).toBe(0);
+      expect(io.outLines.join('\n')).toBe(
+        'stored key for "google" in keychain (service gossip-mesh)',
+      );
+    });
+
+    it('names the file store and its ABSOLUTE path on a file write (issue #667)', async () => {
+      const io = makeIO({ secret: 'sk-abc', storeKind: 'file' });
+      const code = await runKeyCommand(['set', 'google'], io);
+
+      expect(code).toBe(0);
+      expect(io.outLines.join('\n')).toBe(`stored key for "google" in file ${FILE_PATH}`);
+    });
+
+    it('reports the FALLBACK destination when a keychain write drops to file (issue #667)', async () => {
+      // storeInfo() still says "keychain" (it is available) but the write threw
+      // and fell back — the confirmation must follow the write, not the store.
+      const io = makeIO({ secret: 'sk-abc', storeKind: 'keychain', writeDestination: 'file' });
+      const code = await runKeyCommand(['set', 'google'], io);
+
+      expect(code).toBe(0);
+      const out = io.outLines.join('\n');
+      expect(out).toBe(`stored key for "google" in file ${FILE_PATH}`);
+      expect(out).not.toContain('keychain');
     });
 
     it('returns 2 and does not store when the secret is empty/whitespace', async () => {
@@ -98,6 +144,24 @@ describe('runKeyCommand', () => {
       expect(out).toMatch(/✓\s+deepseek/);
       expect(out).toMatch(/·\s+openai/);
       assertNoLeak(io, secret);
+    });
+
+    it('leads with the keychain store and service (issue #667)', async () => {
+      const io = makeIO({ storeKind: 'keychain' });
+      const code = await runKeyCommand(['list'], io);
+
+      expect(code).toBe(0);
+      expect(io.outLines[0]).toBe('(store: keychain  service gossip-mesh)');
+    });
+
+    it('leads with the file store and its ABSOLUTE path (issue #667)', async () => {
+      const io = makeIO({ storeKind: 'file' });
+      const code = await runKeyCommand(['list'], io);
+
+      expect(code).toBe(0);
+      expect(io.outLines[0]).toBe(`(store: file  ${FILE_PATH})`);
+      // Absolute, so a relay-vs-CLI cwd mismatch is visible.
+      expect(io.outLines[0]).toContain('/');
     });
   });
 

--- a/tests/cli/keychain.test.ts
+++ b/tests/cli/keychain.test.ts
@@ -1,6 +1,6 @@
 import { Keychain } from '../../apps/cli/src/keychain';
 import { existsSync, unlinkSync } from 'fs';
-import { join } from 'path';
+import { isAbsolute, join } from 'path';
 
 const ENCRYPTED_FILE = join(process.cwd(), '.gossip/keys.enc');
 
@@ -83,6 +83,48 @@ describe('Keychain', () => {
     await keychain.setKey('provider-x', 'old-key');
     await keychain.setKey('provider-x', 'new-key');
     expect(await keychain.getKey('provider-x')).toBe('new-key');
+  });
+
+  it('storeInfo reports the service and an ABSOLUTE encrypted-file path (issue #667)', () => {
+    const info = new Keychain(TEST_SERVICE).storeInfo();
+    expect(info.service).toBe(TEST_SERVICE);
+    expect(info.path).toBe(ENCRYPTED_FILE);
+    expect(isAbsolute(info.path)).toBe(true);
+    expect(['keychain', 'file']).toContain(info.kind);
+  });
+
+  it('setKey reports the store the key actually landed in (issue #667)', async () => {
+    const kc = new Keychain(TEST_SERVICE);
+    const dest = await kc.setKey('test-provider', 'test-key-123');
+
+    if (kc.storeInfo().kind === 'file') {
+      expect(dest).toBe('file'); // no OS keychain — the file is the only store
+    } else {
+      expect(['keychain', 'file']).toContain(dest); // a keychain write may fall back
+    }
+    if (dest === 'file') expect(existsSync(ENCRYPTED_FILE)).toBe(true);
+  });
+
+  it('setKey returns "file" when an available keychain write fails and falls back (issue #667)', async () => {
+    const hasKeychainBackend = process.platform === 'darwin' || process.platform === 'linux';
+    if (!hasKeychainBackend) return; // no keychain to fall back FROM
+
+    const cp = require('child_process');
+    const spy = jest.spyOn(cp, 'execFileSync').mockImplementation((...callArgs: unknown[]) => {
+      const argv = (callArgs[1] as string[]) ?? [];
+      // Availability probe (`security help` / `which secret-tool`) succeeds…
+      if (argv[0] === 'help' || argv[0] === 'secret-tool') return Buffer.from('');
+      throw new Error('keychain write refused'); // …but every write is refused.
+    });
+
+    try {
+      const kc = new Keychain(TEST_SERVICE);
+      expect(kc.storeInfo().kind).toBe('keychain');
+      expect(await kc.setKey('test-provider', 'test-key-123')).toBe('file');
+    } finally {
+      spy.mockRestore();
+    }
+    expect(existsSync(ENCRYPTED_FILE)).toBe(true);
   });
 
   it('handles corrupted encrypted file gracefully', async () => {

--- a/tests/orchestrator/llm-client.test.ts
+++ b/tests/orchestrator/llm-client.test.ts
@@ -685,7 +685,10 @@ describe('LLM Client', () => {
       expect(caught!.message).toContain('no API key configured for agent "deepseek-agent"');
       expect(caught!.message).toContain('provider openai');
       expect(caught!.message).toContain('https://api.deepseek.com/v1');
-      expect(caught!.message).toMatch(/keychain/);
+      // Names the actionable command, NOT a "keychain service" that only exists
+      // on some platforms and is never the provider name anyway (issue #667).
+      expect(caught!.message).toMatch(/run 'gossipcat key set "openai"'/);
+      expect(caught!.message).not.toMatch(/keychain/);
       expect(fetchSpy).not.toHaveBeenCalled();
 
       fetchSpy.mockRestore();
@@ -715,21 +718,21 @@ describe('LLM Client', () => {
       return expect(nullp.generate([{ role: 'user', content: 'hi' }])).resolves.toEqual({ text: '' });
     });
 
-    it('DegradedProvider names the keychain SERVICE from key_ref, not the provider (issue #522)', async () => {
-      // key_ref:"my-custom-key" on an openai agent → message names that service.
+    it('DegradedProvider names the key from key_ref, not the provider (issue #522)', async () => {
+      // key_ref:"my-custom-key" on an openai agent → message names that key.
       const provider = createProviderForAgent('cust', 'openai', 'gpt-4', undefined, 'https://api.example.com/v1', undefined, 'my-custom-key');
       let caught: Error | undefined;
       try { await provider.generate([{ role: 'user', content: 'hi' }]); } catch (e) { caught = e as Error; }
       expect(caught).toBeDefined();
       expect(caught!.message).toContain('no API key configured for agent "cust"');
-      expect(caught!.message).toContain('keychain service "my-custom-key"');
+      expect(caught!.message).toContain(`run 'gossipcat key set "my-custom-key"'`);
     });
 
     it('DegradedProvider falls back to provider name when key_ref absent', async () => {
       const provider = createProviderForAgent('a6', 'openai', 'gpt-4', undefined);
       let caught: Error | undefined;
       try { await provider.generate([{ role: 'user', content: 'hi' }]); } catch (e) { caught = e as Error; }
-      expect(caught!.message).toContain('keychain service "openai"');
+      expect(caught!.message).toContain(`run 'gossipcat key set "openai"'`);
     });
   });
 
@@ -780,7 +783,7 @@ describe('LLM Client', () => {
       expect(caught).toBeDefined();
       expect(caught!.message).toContain('no API key configured for agent "ds-agent"');
       expect(caught!.message).toContain('provider deepseek');
-      expect(caught!.message).toContain('keychain service "deepseek"');
+      expect(caught!.message).toContain(`run 'gossipcat key set "deepseek"'`);
       expect(fetchSpy).not.toHaveBeenCalled();
       fetchSpy.mockRestore();
     });
@@ -822,14 +825,14 @@ describe('LLM Client', () => {
       fetchSpy.mockRestore();
     });
 
-    it('key missing, no key_ref → DegradedProvider names the provider as the keychain service', async () => {
+    it('key missing, no key_ref → DegradedProvider names the provider as the key name', async () => {
       const getKey = jest.fn().mockResolvedValue(null);
       const provider = await resolveAgentProvider(
         { id: 'a3', provider: 'anthropic', model: 'claude-3' },
         getKey,
       );
       await expect(provider.generate([{ role: 'user', content: 'hi' }]))
-        .rejects.toThrow(/keychain service "anthropic"/);
+        .rejects.toThrow(/gossipcat key set "anthropic"/);
     });
 
     it('base_url threaded: deepseek with custom base_url builds provider without throwing', async () => {

--- a/tests/orchestrator/main-agent-start-keyref.test.ts
+++ b/tests/orchestrator/main-agent-start-keyref.test.ts
@@ -92,7 +92,7 @@ describe('MainAgent.start() — key_ref + base_url on the MCP-boot path (#522)',
     try { await llm.generate([{ role: 'user', content: 'hi' }]); } catch (e) { caught = e as Error; }
     expect(caught).toBeDefined();
     expect(caught!.message).toContain('no API key configured for agent "ds"');
-    expect(caught!.message).toContain('keychain service "deepseek"');
+    expect(caught!.message).toContain(`run 'gossipcat key set "deepseek"'`);
     // base_url is honored on the boot path (no longer dropped).
     expect(caught!.message).toContain('https://api.deepseek.com/v1');
   });


### PR DESCRIPTION
Closes #667.

## The bug (triage-verified)

1. `key list` / `key set` never reported which store they resolved — keychain vs the cwd-relative `.gossip/keys.enc` — so a relay process and a CLI invocation resolving from different directories could truthfully disagree with no visible cause.
2. Worse than filed: `key set` affirmatively printed "in the gossip-mesh keychain" even when `Keychain.setKey` silently fell back to the encrypted file (the fallback catch returned void, so the caller couldn't know).
3. The DegradedProvider missing-key message called `key_ref ?? provider` a "keychain service" — wrong on every platform (the service is always the `gossip-mesh` constant; that value is the keychain ACCOUNT), and doubly wrong on Windows where `isKeychainAvailable()` has no branch and no keychain is ever used.

## The fix

- `apps/cli/src/keychain.ts` — new `storeInfo(): KeyStoreInfo` (kind, service, absolute file path); `setKey` now returns the destination the write ACTUALLY landed in (`'keychain' | 'file'`), including the silent-fallback case.
- `apps/cli/src/key-command.ts` — `key list` leads with `(store: keychain  service gossip-mesh)` / `(store: file  <absolute path>)`; `key set` reports the returned destination, not the resolved one; USAGE no longer presumes a keychain. No key value ever reaches out/err.
- `packages/orchestrator/src/llm-client.ts` — missing-key message now says `run 'gossipcat key set "<name>"'`; surrounding docs no longer use "keychain service" for the account name.
- `apps/cli/src/mcp-server-sdk.ts` — production IO wiring gains `storeInfo`; duplicated usage string kept identical.

`KeyStoreInfo.path` is deliberately required (not optional): on the fallback path `storeInfo().kind` is `'keychain'` while the key landed in the file, so the path must be available regardless of resolved kind.

## Tests

367 suites / 5095 tests green + typecheck. New coverage: file-store line shows the absolute path; keychain-store line shows the service; fallback truthfulness (probe passes, write refused → output says `file` and asserts `not.toContain('keychain')`); old vocabulary is regression-pinned with `not.toMatch(/keychain/)` in the #522 case.

## Follow-up (not in this PR)

Three more comments + two identifiers still use the "keychain service" vocabulary (`utility-provider.ts:80`, `config.ts:476`, `mcp-server-sdk.ts:1598`, `keyService` in `llm-client.ts`, `main-agent.ts:83` comment) — candidate for a docs-only sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)