### PR TITLE
docs: retire the "keychain service" misnomer repo-wide (#667 follow-up)

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -473,7 +473,7 @@ export function configToAgentConfigs(config: GossipConfig): AgentConfig[] {
     // #522: carry base_url through so DeepSeek / OpenAI-compatible agents reach
     // their configured endpoint instead of defaulting to api.openai.com.
     base_url: agent.base_url,
-    // #522: carry the keychain service name through so the resolver reads the
+    // #522: carry the key name through so the resolver reads the
     // per-agent key (key_ref ?? provider) at both resolution sites.
     key_ref: agent.key_ref,
     maxToolTurns: agent.maxToolTurns,

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -905,16 +905,16 @@ async function doBoot() {
     mainKey = await ctx.keychain.getKey(config.main_agent.provider);
     if (!mainKey) {
       for (const ac of agentConfigs) {
-        // #522: resolve from the per-agent keychain SERVICE (key_ref ?? provider)
+        // #522: resolve from the per-agent key name (key_ref ?? provider)
         // so an agent whose key is stored under a custom key_ref is visible to
         // the orchestrator-LLM fallback, not just provider-named ones.
-        const keyService = (ac as any).key_ref ?? ac.provider;
-        const key = await ctx.keychain.getKey(keyService);
+        const keyName = (ac as any).key_ref ?? ac.provider;
+        const key = await ctx.keychain.getKey(keyName);
         if (key) {
           mainProvider = ac.provider;
           mainModel = ac.model;
           mainKey = key;
-          process.stderr.write(`[gossipcat] ⚠️  Main agent key unavailable, using ${ac.provider}/${ac.model} (keychain "${keyService}") for orchestration\n`);
+          process.stderr.write(`[gossipcat] ⚠️  Main agent key unavailable, using ${ac.provider}/${ac.model} (key "${keyName}") for orchestration\n`);
           break;
         }
       }
@@ -1596,7 +1596,7 @@ export function createMcpServer(): McpServer {
         } else {
           // Fallback: use the first agent that has a working key
           for (const ac of agentConfigs) {
-            // #522: honor the per-agent keychain service (key_ref ?? provider).
+            // #522: honor the per-agent key name (key_ref ?? provider).
             const key = await ctx.keychain.getKey((ac as any).key_ref ?? ac.provider);
             if (key) {
               llm = createProvider(ac.provider, ac.model, key, undefined, (ac as any).base_url);

--- a/apps/cli/src/utility-provider.ts
+++ b/apps/cli/src/utility-provider.ts
@@ -77,7 +77,7 @@ export async function selectUtilityFallbackProvider(
   // (a) main
   consider(main.provider, main.model, main.key);
 
-  // (b) each non-native agent — key via the per-agent keychain service (key_ref ?? provider).
+  // (b) each non-native agent — key via the per-agent key name (key_ref ?? provider).
   // Carry the agent's base_url so a custom-endpoint openai-compatible agent yields a
   // correct fallback (pointing at ITS endpoint, not api.openai.com) rather than a
   // broken entry that first-seen-wins would then shadow the curated default with.

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -1194,10 +1194,10 @@ export function createProviderForAgent(
  */
 export async function resolveAgentProvider(
   ac: { id: string; provider: string; model: string; base_url?: string; key_ref?: string },
-  getKey: (service: string) => Promise<string | null>,
+  getKey: (keyName: string) => Promise<string | null>,
 ): Promise<ILLMProvider> {
-  const keyService = ac.key_ref ?? ac.provider;
-  const key = await getKey(keyService);
+  const keyName = ac.key_ref ?? ac.provider;
+  const key = await getKey(keyName);
   return createProviderForAgent(ac.id, ac.provider, ac.model, key ?? undefined, ac.base_url, undefined, ac.key_ref);
 }
 

--- a/packages/orchestrator/src/main-agent.ts
+++ b/packages/orchestrator/src/main-agent.ts
@@ -80,7 +80,7 @@ export interface MainAgentConfig {
   relayUrl: string;
   relayApiKey?: string;  // shared secret for relay auth — passed to all workers
   agents: AgentConfig[];
-  apiKeys?: Record<string, string>;  // keychain service name (key_ref ?? provider) → key
+  apiKeys?: Record<string, string>;  // key name (key_ref ?? provider) → key
   projectRoot?: string;  // defaults to process.cwd()
   llm?: ILLMProvider;  // override for testing
   bootstrapPrompt?: string;  // NEW — injected by BootstrapGenerator
@@ -197,10 +197,10 @@ export class MainAgent {
       // base_url and the DegradedProvider pre-flight — mirroring syncWorkers.
       // Previously it used raw createProvider(config.provider, ...), which
       // dropped base_url and bypassed the pre-flight (a latent #523 gap here).
-      const keyService = config.key_ref ?? config.provider;
-      let apiKey: string | undefined = this.apiKeys[keyService];
+      const keyName = config.key_ref ?? config.provider;
+      let apiKey: string | undefined = this.apiKeys[keyName];
       if (!apiKey && this.keyProviderFn) {
-        apiKey = (await this.keyProviderFn(keyService)) ?? undefined;
+        apiKey = (await this.keyProviderFn(keyName)) ?? undefined;
       }
       const llm = createProviderForAgent(
         config.id, config.provider, config.model, apiKey, config.base_url, undefined, config.key_ref,


### PR DESCRIPTION
Follow-up sweep from #667 / PR #683, catching every remaining site that calls the per-agent key name (`key_ref ?? provider`) a "keychain service".

The sweep list from #683 named 5 sites; grep found 2 more (`mcp-server-sdk.ts:911-917` — including a log line printing `keychain "<name>"` for keys that may live in the encrypted file — and `main-agent.ts:200-203`). All 7 fixed:

- `apps/cli/src/utility-provider.ts` — comment
- `apps/cli/src/config.ts` — comment
- `apps/cli/src/mcp-server-sdk.ts` — two comments + `keyService`→`keyName` rename + orchestration-fallback log line now says `key "<name>"`
- `packages/orchestrator/src/main-agent.ts` — `apiKeys` doc comment + `keyService`→`keyName` rename
- `packages/orchestrator/src/llm-client.ts` — `keyService`→`keyName` rename + `getKey` param name

The two remaining "keychain service" mentions in source (`keychain.ts:18`, `llm-client.ts:1167-1168`) are intentionally kept — they document the distinction itself.

No behavior change: comments, local identifiers, and one stderr log string. `npm run build` green; `llm-client` / `main-agent-start-keyref` / `key-command` suites 88/88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)