### PR TITLE
feat(consensus): severity-gated cross-review skill injection on gossip_collect (#666)

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -11,6 +11,7 @@ import { FILE_TOOLS, FileTools, GitTools, Sandbox } from '@gossip/tools';
 import { MemorySearcher } from '@gossip/orchestrator';
 import type { PromptFormat } from './dispatch';
 import { discoverVerifier, type VerifierBinding } from './auto-verify-discovery';
+import { buildGatedCrossReviewSkillsResolver } from './cross-review-skill-gate';
 import { makeRoundContext } from '@gossip/orchestrator';
 import type { RelayWarningEntry, RoundContext } from '@gossip/orchestrator';
 import { mkdirSync, appendFileSync } from 'node:fs';
@@ -610,9 +611,22 @@ export async function handleCollect(
         } catch { /* fail-open: never crash synthesis on observability write */ }
       };
 
+      // Issue #666: cross-reviewers get their own skill files ONLY when the
+      // Phase-1 findings under review contain a critical/high severity. The
+      // builder returns undefined when the gate is closed, and the spread below
+      // then omits `getAgentSkillsContent` entirely so the ungated prompt is
+      // byte-identical to the pre-#666 one.
+      const gatedCrossReviewSkills = buildGatedCrossReviewSkillsResolver({
+        results: allResults,
+        registryGet: (id: string) => ctx.mainAgent.getAgentConfig(id),
+        projectRoot: process.cwd(),
+        getSkillIndex: () => ctx.mainAgent.getSkillIndex(),
+      });
+
       const engine = new ConsensusEngine({
         llm: mainLlm,
         registryGet: (id: string) => ctx.mainAgent.getAgentConfig(id),
+        ...(gatedCrossReviewSkills ? { getAgentSkillsContent: gatedCrossReviewSkills } : {}),
         projectRoot: process.cwd(),
         agentLlm: (id: string) => agentLlmCache.get(id),
         performanceReader,

--- a/apps/cli/src/handlers/cross-review-skill-gate.ts
+++ b/apps/cli/src/handlers/cross-review-skill-gate.ts
@@ -1,0 +1,83 @@
+/**
+ * Severity-conditional cross-review skill injection for the `gossip_collect`
+ * consensus path (issue #666).
+ *
+ * `gossip_collect`'s two-phase branch builds its own `ConsensusEngine`, so it
+ * does not inherit the `getAgentSkillsContent` wiring that `DispatchPipeline`
+ * hands to `ConsensusCoordinator`. Injecting skills there unconditionally costs
+ * ~43KB per agent per round, which the operator decision on #666 accepted only
+ * for rounds that actually verify a critical/high-severity finding.
+ *
+ * This module computes that gate from the Phase-1 agent outputs and returns
+ * either the shared resolver (gate open) or `undefined` (gate closed). When it
+ * returns `undefined` the caller must omit `getAgentSkillsContent` entirely, so
+ * the ungated prompt stays byte-identical to today's.
+ */
+
+import {
+  parseAgentFindingsStrict,
+  crossReviewSkillGateSeverity,
+  createAgentSkillsContentResolver,
+  type SkillIndex,
+} from '@gossip/orchestrator';
+
+/** The subset of a collect result row the gate reads. */
+export interface Phase1ResultLike {
+  status?: string;
+  result?: unknown;
+}
+
+export interface GatedCrossReviewSkillsConfig {
+  /** Phase-1 results as merged by handleCollect (relay + native). */
+  results: readonly Phase1ResultLike[];
+  registryGet: (agentId: string) => { skills?: string[] } | null | undefined;
+  projectRoot: string;
+  getSkillIndex?: () => SkillIndex | null | undefined;
+  /** Observability sink. Defaults to stderr, matching the other `[consensus]` lines. */
+  log?: (line: string) => void;
+}
+
+/**
+ * Returns the `getAgentSkillsContent` callback when the Phase-1 findings under
+ * review contain at least one `critical`/`high` severity, else `undefined`.
+ *
+ * Always logs one auditable line naming the verdict and the triggering severity.
+ */
+export function buildGatedCrossReviewSkillsResolver(
+  config: GatedCrossReviewSkillsConfig,
+): ((agentId: string, task: string) => string | undefined) | undefined {
+  const findings = collectPhase1Findings(config.results);
+  const triggeringSeverity = crossReviewSkillGateSeverity(findings);
+  const log = config.log ?? ((line: string) => { process.stderr.write(line); });
+
+  log(
+    `[consensus] cross-review skills_injected: ${triggeringSeverity !== null} ` +
+    `(severity_gate=${triggeringSeverity ?? 'none'}, phase1_findings=${findings.length})\n`,
+  );
+
+  if (triggeringSeverity === null) return undefined;
+
+  return createAgentSkillsContentResolver({
+    registryGet: config.registryGet,
+    projectRoot: config.projectRoot,
+    getSkillIndex: config.getSkillIndex,
+  });
+}
+
+/**
+ * Parse `<agent_finding>` tags out of every completed Phase-1 result. Rows that
+ * are not completed, or whose `result` is not a string, contribute nothing —
+ * result payloads cross an LLM boundary and are never assumed well-shaped.
+ */
+function collectPhase1Findings(
+  results: readonly Phase1ResultLike[] | null | undefined,
+): Array<{ severity?: unknown }> {
+  if (!Array.isArray(results)) return [];
+  const findings: Array<{ severity?: unknown }> = [];
+  for (const row of results) {
+    if (!row || typeof row !== 'object') continue;
+    if (row.status !== 'completed' || typeof row.result !== 'string') continue;
+    findings.push(...parseAgentFindingsStrict(row.result).findings);
+  }
+  return findings;
+}

--- a/packages/orchestrator/src/cross-review-skills.ts
+++ b/packages/orchestrator/src/cross-review-skills.ts
@@ -1,0 +1,93 @@
+/**
+ * Phase-2 cross-review skill injection: the severity gate + the single shared
+ * resolver that turns an agent's configured skills into prompt content.
+ *
+ * Issue #666. Injecting every reviewer's skill files into every cross-review
+ * prompt costs ~43KB/agent/round. That price is worth paying when the round is
+ * verifying a critical/high-severity finding and is not worth paying otherwise,
+ * so `crossReviewSkillGateSeverity` computes a mechanical gate from the Phase-1
+ * findings under review and callers omit `getAgentSkillsContent` entirely when
+ * the gate is closed.
+ *
+ * `createAgentSkillsContentResolver` is deliberately the ONLY adapter from
+ * `loadSkills` to `ConsensusEngineConfig.getAgentSkillsContent` (HANDBOOK
+ * invariant #7 — one filter site). Every construction site that wants skills on
+ * cross-review must go through it so the agent-local → project-wide → bundled
+ * resolution order stays identical everywhere.
+ */
+
+import type { SkillIndex } from './skill-index';
+import { loadSkills } from './skill-loader';
+
+/** Severities that open the cross-review skill gate. */
+export type CrossReviewSkillGateSeverity = 'critical' | 'high';
+
+/**
+ * Minimal shape the gate reads. `ParsedFinding` from `parse-findings` satisfies
+ * it, but the gate never depends on the rest of that record so it stays a pure
+ * `findings[] → verdict` function that is trivial to unit-test.
+ */
+export interface SeverityBearingFinding {
+  severity?: unknown;
+}
+
+/**
+ * Highest gate-opening severity present in `findings`, or `null` when none is.
+ *
+ * Fail-closed by construction: only the canonical lowercase enum emitted by
+ * `parseAgentFindingsStrict` (`critical` / `high`) opens the gate. Anything else
+ * — `undefined`, `'HIGH'`, `'sev:high'`, a number, a null entry, a non-array
+ * argument — is treated as non-triggering rather than coerced.
+ */
+export function crossReviewSkillGateSeverity(
+  findings: readonly SeverityBearingFinding[] | null | undefined,
+): CrossReviewSkillGateSeverity | null {
+  if (!Array.isArray(findings)) return null;
+
+  let sawHigh = false;
+  for (const finding of findings) {
+    if (!finding || typeof finding !== 'object') continue;
+    const severity = (finding as SeverityBearingFinding).severity;
+    if (severity === 'critical') return 'critical';
+    if (severity === 'high') sawHigh = true;
+  }
+  return sawHigh ? 'high' : null;
+}
+
+/** True when at least one finding under review is `critical` or `high`. */
+export function shouldInjectCrossReviewSkills(
+  findings: readonly SeverityBearingFinding[] | null | undefined,
+): boolean {
+  return crossReviewSkillGateSeverity(findings) !== null;
+}
+
+export interface AgentSkillsContentResolverConfig {
+  /** Registry lookup returning the agent's configured skill names. */
+  registryGet: (agentId: string) => { skills?: string[] } | null | undefined;
+  projectRoot: string;
+  /**
+   * Read lazily on every call — the skill index is often installed after the
+   * owning object is constructed, so a snapshot taken at factory time would
+   * permanently resolve to `undefined`.
+   */
+  getSkillIndex?: () => SkillIndex | null | undefined;
+}
+
+/**
+ * Build the `getAgentSkillsContent` callback consumed by `ConsensusEngine`.
+ * Returns `undefined` (no skills block) on any resolution failure — skill
+ * injection is best-effort and must never abort a consensus round.
+ */
+export function createAgentSkillsContentResolver(
+  config: AgentSkillsContentResolverConfig,
+): (agentId: string, task: string) => string | undefined {
+  return (agentId: string, task: string): string | undefined => {
+    try {
+      const agentSkills = config.registryGet(agentId)?.skills || [];
+      const index = config.getSkillIndex?.() ?? undefined;
+      return loadSkills(agentId, agentSkills, config.projectRoot, index, task).content || undefined;
+    } catch {
+      return undefined;
+    }
+  };
+}

--- a/packages/orchestrator/src/dispatch-pipeline.ts
+++ b/packages/orchestrator/src/dispatch-pipeline.ts
@@ -6,6 +6,7 @@ import { WorkerAgent } from './worker-agent';
 import { emitConsensusSignals } from './signal-helpers';
 import { ILLMProvider } from './llm-client';
 import { loadSkills, resolveEffectiveSkills } from './skill-loader';
+import { createAgentSkillsContentResolver } from './cross-review-skills';
 import { assemblePrompt, extractSpecReferences, buildSpecReviewEnrichment, parseSpecFrontMatter } from './prompt-assembler';
 import { AgentMemoryReader } from './agent-memory';
 import { selectLessons, renderLessonBlock, logLessonInjection } from './lesson-injector';
@@ -231,15 +232,11 @@ export class DispatchPipeline {
       registryGet: config.registryGet,
       projectRoot: config.projectRoot,
       keyProvider: config.keyProvider ?? null,
-      getAgentSkillsContent: (agentId, task) => {
-        const agentSkills = this.registryGet(agentId)?.skills || [];
-        try {
-          const res = loadSkills(agentId, agentSkills, this.projectRoot, this.skillIndex ?? undefined, task);
-          return res.content || undefined;
-        } catch {
-          return undefined;
-        }
-      },
+      getAgentSkillsContent: createAgentSkillsContentResolver({
+        registryGet: (agentId) => this.registryGet(agentId),
+        projectRoot: config.projectRoot,
+        getSkillIndex: () => this.skillIndex,
+      }),
     });
 
     try { this.catalog = new SkillCatalog(config.projectRoot); }

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -4,6 +4,8 @@ export type { MemoryHygieneSeedResult } from './memory-hygiene-seed';
 export { detectFormatCompliance, MAX_COMPLIANCE_INPUT } from './dispatch-pipeline';
 export { loadSkills, resolveEffectiveSkills, DEFAULT_KEYWORDS, resolveSkillExists, resolveSkill } from './skill-loader';
 export type { LoadSkillsResult, DroppedSkill } from './skill-loader';
+export { crossReviewSkillGateSeverity, shouldInjectCrossReviewSkills, createAgentSkillsContentResolver } from './cross-review-skills';
+export type { CrossReviewSkillGateSeverity, SeverityBearingFinding, AgentSkillsContentResolverConfig } from './cross-review-skills';
 export { SkillCounterTracker } from './skill-counters';
 export type { MainAgentConfig } from './main-agent';
 export { WorkerAgent } from './worker-agent';

--- a/tests/cli/collect-cross-review-skill-gate.test.ts
+++ b/tests/cli/collect-cross-review-skill-gate.test.ts
@@ -1,0 +1,170 @@
+// tests/cli/collect-cross-review-skill-gate.test.ts
+//
+// Issue #666: severity-conditional cross-review skill injection on the
+// gossip_collect path. handleCollect composes the exact seam exercised here —
+// `buildGatedCrossReviewSkillsResolver(...)` spread into the `ConsensusEngine`
+// config it constructs — so these tests drive the production builder into a
+// real engine and assert on the emitted Phase-2 system prompt.
+//
+// The load-bearing guarantee is the NEGATIVE one: when the gate is closed the
+// prompt must be byte-identical to a round with no skill wiring at all, so the
+// ~43KB/agent/round cost is never paid on a medium/low round.
+import { buildGatedCrossReviewSkillsResolver } from '../../apps/cli/src/handlers/cross-review-skill-gate';
+import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
+import { testRound } from '../../packages/orchestrator/src/round-context';
+import { AgentConfig, TaskEntry } from '../../packages/orchestrator/src/types';
+import { ILLMProvider } from '../../packages/orchestrator/src/llm-client';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const SKILL_MARKER = 'CROSS_REVIEW_SKILL_MARKER_666';
+
+const mockLlm: jest.Mocked<ILLMProvider> = { generate: jest.fn() };
+
+const registryGet = (agentId: string): AgentConfig => ({
+  id: agentId,
+  provider: 'local',
+  model: 'test-model',
+  skills: ['gate-lens'],
+});
+
+const finding = (severity: string, text: string): string =>
+  `<agent_finding type="finding" severity="${severity}">${text}</agent_finding>`;
+
+const taskEntry = (agentId: string, result: string): TaskEntry => ({
+  id: `task-${agentId}`,
+  agentId,
+  task: 'review the collect path',
+  status: 'completed',
+  result,
+  startedAt: Date.now(),
+  completedAt: Date.now(),
+  inputTokens: 10,
+  outputTokens: 20,
+});
+
+describe('gossip_collect cross-review skill gate (#666)', () => {
+  let tmp: string;
+  const logLines: string[] = [];
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'collect-gate-'));
+    for (const agentId of ['agent-a', 'agent-b']) {
+      const dir = join(tmp, '.gossip', 'agents', agentId, 'skills');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'gate-lens.md'), `# Gate Lens\n${SKILL_MARKER}\n`);
+    }
+    logLines.length = 0;
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const build = (results: TaskEntry[]) =>
+    buildGatedCrossReviewSkillsResolver({
+      results,
+      registryGet,
+      projectRoot: tmp,
+      log: (line) => { logLines.push(line); },
+    });
+
+  const systemPrompts = async (
+    results: TaskEntry[],
+    getAgentSkillsContent?: (agentId: string, task: string) => string | undefined,
+  ): Promise<string[]> => {
+    const engine = new ConsensusEngine({
+      llm: mockLlm,
+      registryGet,
+      round: testRound(),
+      ...(getAgentSkillsContent ? { getAgentSkillsContent } : {}),
+    });
+    const { prompts } = await engine.generateCrossReviewPrompts(results);
+    expect(prompts.length).toBeGreaterThan(0);
+    return prompts.map(p => p.system);
+  };
+
+  const criticalRound = (): TaskEntry[] => [
+    taskEntry('agent-a', finding('critical', 'Unvalidated path reaches disk at src/a.ts:10')),
+    taskEntry('agent-b', finding('low', 'Naming nit in the helper at src/b.ts:20')),
+  ];
+
+  const highRound = (): TaskEntry[] => [
+    taskEntry('agent-a', finding('high', 'Missing bounds check at src/a.ts:11')),
+    taskEntry('agent-b', finding('medium', 'Duplicated branch at src/b.ts:21')),
+  ];
+
+  const lowRound = (): TaskEntry[] => [
+    taskEntry('agent-a', finding('medium', 'Duplicated branch at src/a.ts:12')),
+    taskEntry('agent-b', finding('low', 'Naming nit in the helper at src/b.ts:22')),
+  ];
+
+  it('injects each reviewer\'s skills into the Phase-2 prompt on a critical round', async () => {
+    const resolver = build(criticalRound());
+    expect(resolver).toBeDefined();
+    for (const system of await systemPrompts(criticalRound(), resolver)) {
+      expect(system).toContain('--- SKILLS ---');
+      expect(system).toContain(SKILL_MARKER);
+    }
+  });
+
+  it('injects skills on a high round', async () => {
+    const resolver = build(highRound());
+    expect(resolver).toBeDefined();
+    for (const system of await systemPrompts(highRound(), resolver)) {
+      expect(system).toContain(SKILL_MARKER);
+    }
+  });
+
+  it('leaves the ungated (medium/low) prompt byte-identical to the no-skills baseline', async () => {
+    const resolver = build(lowRound());
+    expect(resolver).toBeUndefined();
+
+    const gated = await systemPrompts(lowRound(), resolver);
+    const baseline = await systemPrompts(lowRound());
+    expect(gated).toEqual(baseline);
+    for (const system of gated) {
+      expect(system).not.toContain('--- SKILLS ---');
+      expect(system).not.toContain(SKILL_MARKER);
+    }
+  });
+
+  it('stays closed when no agent emitted a parseable finding', () => {
+    expect(build([
+      taskEntry('agent-a', 'Prose summary with no schema tags at all.'),
+      taskEntry('agent-b', ''),
+    ])).toBeUndefined();
+  });
+
+  it('ignores severities on results that never completed', () => {
+    const running: TaskEntry = {
+      ...taskEntry('agent-a', finding('critical', 'Unvalidated path reaches disk at src/a.ts:10')),
+      status: 'running',
+    };
+    expect(build([running, taskEntry('agent-b', finding('low', 'Naming nit at src/b.ts:20'))])).toBeUndefined();
+  });
+
+  it('ignores a non-string result payload instead of throwing', () => {
+    const malformed = { status: 'completed', result: { severity: 'critical' } };
+    expect(buildGatedCrossReviewSkillsResolver({
+      results: [malformed],
+      registryGet,
+      projectRoot: tmp,
+      log: (line) => { logLines.push(line); },
+    })).toBeUndefined();
+  });
+
+  it('logs one auditable line naming the verdict and the triggering severity', () => {
+    build(criticalRound());
+    expect(logLines).toHaveLength(1);
+    expect(logLines[0]).toContain('cross-review skills_injected: true');
+    expect(logLines[0]).toContain('severity_gate=critical');
+
+    logLines.length = 0;
+    build(lowRound());
+    expect(logLines).toHaveLength(1);
+    expect(logLines[0]).toContain('cross-review skills_injected: false');
+    expect(logLines[0]).toContain('severity_gate=none');
+  });
+});

--- a/tests/orchestrator/consensus-memory-directive.test.ts
+++ b/tests/orchestrator/consensus-memory-directive.test.ts
@@ -67,9 +67,10 @@ describe('cross-review memory directive (#659)', () => {
   });
 
   it('injects the directive even when no skills block is available', async () => {
-    // The four production ConsensusEngine construction sites outside
-    // consensus-coordinator.ts do NOT pass getAgentSkillsContent, so the
-    // skills block is empty there. The directive must not depend on it.
+    // Most production ConsensusEngine construction sites outside
+    // consensus-coordinator.ts pass no getAgentSkillsContent at all (the
+    // gossip_collect site passes one only when the #666 severity gate opens),
+    // so the skills block is empty there. The directive must not depend on it.
     for (const system of await systemPrompts()) {
       expect(system).not.toContain('--- SKILLS ---');
       expect(system).toContain(CROSS_REVIEW_MEMORY_DIRECTIVE);

--- a/tests/orchestrator/cross-review-skills.test.ts
+++ b/tests/orchestrator/cross-review-skills.test.ts
@@ -1,0 +1,178 @@
+// tests/orchestrator/cross-review-skills.test.ts
+//
+// Issue #666: cross-review skill injection is severity-conditional on the
+// gossip_collect path. These tests pin the pure gate (findings[] → verdict) and
+// the single shared resolver that both DispatchPipeline and the collect handler
+// use to turn configured skills into prompt content.
+import {
+  crossReviewSkillGateSeverity,
+  shouldInjectCrossReviewSkills,
+  createAgentSkillsContentResolver,
+} from '../../packages/orchestrator/src/cross-review-skills';
+import { SkillIndex } from '../../packages/orchestrator/src/skill-index';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('crossReviewSkillGateSeverity', () => {
+  it('opens on a critical finding', () => {
+    expect(crossReviewSkillGateSeverity([{ severity: 'critical' }])).toBe('critical');
+  });
+
+  it('opens on a high finding', () => {
+    expect(crossReviewSkillGateSeverity([{ severity: 'high' }])).toBe('high');
+  });
+
+  it('reports critical when both critical and high are present, regardless of order', () => {
+    expect(crossReviewSkillGateSeverity([{ severity: 'high' }, { severity: 'critical' }])).toBe('critical');
+    expect(crossReviewSkillGateSeverity([{ severity: 'critical' }, { severity: 'high' }])).toBe('critical');
+  });
+
+  it('opens when a single critical/high hides among lower severities', () => {
+    expect(crossReviewSkillGateSeverity([
+      { severity: 'low' },
+      { severity: 'medium' },
+      { severity: undefined },
+      { severity: 'high' },
+      { severity: 'low' },
+    ])).toBe('high');
+  });
+
+  it('stays closed for medium, low, and absent severities', () => {
+    expect(crossReviewSkillGateSeverity([{ severity: 'medium' }])).toBeNull();
+    expect(crossReviewSkillGateSeverity([{ severity: 'low' }])).toBeNull();
+    expect(crossReviewSkillGateSeverity([{ severity: undefined }])).toBeNull();
+    expect(crossReviewSkillGateSeverity([{}])).toBeNull();
+    expect(crossReviewSkillGateSeverity([{ severity: 'medium' }, { severity: 'low' }, {}])).toBeNull();
+  });
+
+  it('stays closed on an empty findings list', () => {
+    expect(crossReviewSkillGateSeverity([])).toBeNull();
+  });
+
+  it('fails closed on malformed severities rather than coercing them', () => {
+    // Only the canonical lowercase enum from parseAgentFindingsStrict counts.
+    expect(crossReviewSkillGateSeverity([{ severity: 'HIGH' }])).toBeNull();
+    expect(crossReviewSkillGateSeverity([{ severity: 'Critical' }])).toBeNull();
+    expect(crossReviewSkillGateSeverity([{ severity: ' high' }])).toBeNull();
+    expect(crossReviewSkillGateSeverity([{ severity: 'sev:critical' }])).toBeNull();
+    expect(crossReviewSkillGateSeverity([{ severity: 1 }])).toBeNull();
+    expect(crossReviewSkillGateSeverity([{ severity: true }])).toBeNull();
+    expect(crossReviewSkillGateSeverity([{ severity: ['critical'] }])).toBeNull();
+    expect(crossReviewSkillGateSeverity([{ severity: null }])).toBeNull();
+  });
+
+  it('fails closed on malformed containers instead of throwing', () => {
+    expect(crossReviewSkillGateSeverity(null)).toBeNull();
+    expect(crossReviewSkillGateSeverity(undefined)).toBeNull();
+    expect(crossReviewSkillGateSeverity('critical' as unknown as never)).toBeNull();
+    expect(crossReviewSkillGateSeverity([null, undefined, 'critical'] as unknown as never)).toBeNull();
+  });
+
+  it('skips malformed entries without losing a later valid trigger', () => {
+    expect(crossReviewSkillGateSeverity(
+      [null, 'critical', { severity: 'critical' }] as unknown as never,
+    )).toBe('critical');
+  });
+});
+
+describe('shouldInjectCrossReviewSkills', () => {
+  it('is true exactly when the gate reports a triggering severity', () => {
+    expect(shouldInjectCrossReviewSkills([{ severity: 'critical' }])).toBe(true);
+    expect(shouldInjectCrossReviewSkills([{ severity: 'high' }])).toBe(true);
+    expect(shouldInjectCrossReviewSkills([{ severity: 'medium' }])).toBe(false);
+    expect(shouldInjectCrossReviewSkills([{ severity: 'low' }])).toBe(false);
+    expect(shouldInjectCrossReviewSkills([])).toBe(false);
+    expect(shouldInjectCrossReviewSkills(undefined)).toBe(false);
+  });
+});
+
+describe('createAgentSkillsContentResolver', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'xr-skills-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const writeAgentSkill = (agentId: string, name: string, body: string): void => {
+    const dir = join(tmp, '.gossip', 'agents', agentId, 'skills');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${name}.md`), body);
+  };
+
+  it('resolves the agent-local skill file for the configured skills', () => {
+    writeAgentSkill('agent-a', 'local-lens', '# Local Lens\nAGENT_LOCAL_SKILL_BODY');
+    const resolve = createAgentSkillsContentResolver({
+      registryGet: () => ({ skills: ['local-lens'] }),
+      projectRoot: tmp,
+    });
+    expect(resolve('agent-a', 'review the code')).toContain('AGENT_LOCAL_SKILL_BODY');
+  });
+
+  it('prefers the agent-local file over the project-wide one (resolution order)', () => {
+    writeAgentSkill('agent-a', 'shared-lens', 'AGENT_LOCAL_WINS');
+    const projectDir = join(tmp, '.gossip', 'skills');
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(join(projectDir, 'shared-lens.md'), 'PROJECT_WIDE_LOSES');
+
+    const resolve = createAgentSkillsContentResolver({
+      registryGet: () => ({ skills: ['shared-lens'] }),
+      projectRoot: tmp,
+    });
+    const content = resolve('agent-a', 'review the code');
+    expect(content).toContain('AGENT_LOCAL_WINS');
+    expect(content).not.toContain('PROJECT_WIDE_LOSES');
+  });
+
+  it('falls back to bundled default skills when no local override exists', () => {
+    const resolve = createAgentSkillsContentResolver({
+      registryGet: () => ({ skills: ['typescript'] }),
+      projectRoot: tmp,
+    });
+    expect(resolve('agent-a', 'review the code')).toContain('TypeScript');
+  });
+
+  it('returns undefined when the agent has no skills', () => {
+    const resolve = createAgentSkillsContentResolver({
+      registryGet: () => ({ skills: [] }),
+      projectRoot: tmp,
+    });
+    expect(resolve('agent-a', 'review the code')).toBeUndefined();
+  });
+
+  it('returns undefined when the agent is not in the registry', () => {
+    const resolve = createAgentSkillsContentResolver({
+      registryGet: () => undefined,
+      projectRoot: tmp,
+    });
+    expect(resolve('ghost-agent', 'review the code')).toBeUndefined();
+  });
+
+  it('swallows a registry throw instead of aborting the round', () => {
+    const resolve = createAgentSkillsContentResolver({
+      registryGet: () => { throw new Error('registry exploded'); },
+      projectRoot: tmp,
+    });
+    expect(resolve('agent-a', 'review the code')).toBeUndefined();
+  });
+
+  it('reads the skill index lazily so an index installed after construction is honored', () => {
+    writeAgentSkill('agent-a', 'late-lens', 'LATE_INDEX_SKILL');
+    let index: SkillIndex | null = null;
+    const resolve = createAgentSkillsContentResolver({
+      registryGet: () => ({ skills: [] }),
+      projectRoot: tmp,
+      getSkillIndex: () => index,
+    });
+    // No index and no configured skills → nothing resolves.
+    expect(resolve('agent-a', 'review the code')).toBeUndefined();
+
+    index = new SkillIndex(tmp);
+    index.bind('agent-a', 'late-lens', { mode: 'permanent' });
+    expect(resolve('agent-a', 'review the code')).toContain('LATE_INDEX_SKILL');
+  });
+});


### PR DESCRIPTION
Closes #666, per the operator decision recorded on the issue (2026-07-27): severity-conditional injection, not always-on.

## What

The production `gossip_collect` two-phase cross-review path constructed its `ConsensusEngine` with zero skills (premise grep-verified: exactly 5 production construction sites, only the `ConsensusCoordinator` one wired). Cross-reviewers now get their per-agent skill files ONLY when the Phase-1 findings under review contain at least one `critical` or `high` severity finding.

- **Pure gate** `crossReviewSkillGateSeverity(findings)` in `packages/orchestrator/src/cross-review-skills.ts` — fail-closed by construction: only canonical lowercase `critical`/`high` (the only values `parseAgentFindingsStrict` can emit) open the gate; `'HIGH'`, numbers, nulls, non-arrays all keep it closed.
- **Single injection mechanism preserved** (HANDBOOK invariant #7): a shared `createAgentSkillsContentResolver` adapter now backs both the pre-existing coordinator closure (behavior-identical refactor, lazy skill-index read kept) and the new gated collect wiring.
- **Ungated rounds are byte-identical to today**: the spread `...(gated ? { getAgentSkillsContent } : {})` omits the key entirely when closed — nothing grows in the ungated path.
- **Auditable**: one log line per round — `[consensus] cross-review skills_injected: true (severity_gate=critical, phase1_findings=2)`.

## Tests

24 new tests across `tests/orchestrator/cross-review-skills.test.ts` and `tests/cli/collect-cross-review-skill-gate.test.ts` (gate matrix incl. malformed-severity fail-closed; integration proving gated prompt contains skill content and ungated prompt is unchanged). Full suite green: **5119 tests / 369 suites**.

## Known residual gaps (flagged by the implementer, intentionally out of scope)

1. **All-relay rounds bypass the gate**: when a round has zero native agents, collect routes through `DispatchPipeline.runConsensus` → `ConsensusCoordinator`, which injects skills **unconditionally** (the pre-existing wired site). A medium/low all-relay round still pays ~43KB/agent. The cost decision is only half-enforced until that branch is gated too.
2. `synthesizeTimeoutRound` (`relay-cross-review.ts:53,65`) builds cross-review prompts skill-less — low impact (timeout-synthesis path) but a real prompt-building site.

The other two `relay-cross-review.ts` construction sites never build prompts (parse-only / synthesis-only), so they're correctly untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)