### PR TITLE
feat(skills): opt-in trailing-* stem match for keyword activation (#681)

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -3638,13 +3638,16 @@ export function createMcpServer(): McpServer {
             }
           } catch { /* file may not exist yet */ }
 
-          const { emitConsensusSignals: emitBulkConsensusSignals, PerformanceReader, DEFAULT_KEYWORDS: BULK_DK } = await import('@gossip/orchestrator');
+          const { emitConsensusSignals: emitBulkConsensusSignals, PerformanceReader, DEFAULT_KEYWORDS: BULK_DK, keywordStem: bulkKeywordStem } = await import('@gossip/orchestrator');
           const bulkInferCategory = (text: string): string | undefined => {
             if (!text.trim()) return undefined;
             let bestCategory = '';
             let bestHits = 0;
             for (const [category, keywords] of Object.entries(BULK_DK)) {
-              const hits = (keywords as string[]).filter(kw => text.includes(kw)).length;
+              // keywordStem strips the trailing `*` stem marker (#681). This is a
+              // literal-substring matcher, not getPattern's regex — a raw `cite*`
+              // occurs in no real prose and would silently go dead here.
+              const hits = (keywords as string[]).filter(kw => text.includes(bulkKeywordStem(kw))).length;
               if (hits > bestHits) { bestHits = hits; bestCategory = category; }
             }
             return bestHits >= 1 ? bestCategory : undefined;
@@ -3791,14 +3794,16 @@ export function createMcpServer(): McpServer {
         // bound skill stays pending forever because post-bind counters only match exact
         // category strings. Uses the same DEFAULT_KEYWORDS table the skill-gap tracker
         // uses below, so category assignment is consistent across both pipelines.
-        const { DEFAULT_KEYWORDS: DK } = await import('@gossip/orchestrator');
+        const { DEFAULT_KEYWORDS: DK, keywordStem: inferKeywordStem } = await import('@gossip/orchestrator');
         const inferCategory = (s: { finding?: string; evidence?: string; agent_id?: string }): string | undefined => {
           const text = `${s.finding || ''} ${s.evidence || ''}`.toLowerCase();
           if (!text.trim()) return undefined;
           let bestCategory = '';
           let bestHits = 0;
           for (const [category, keywords] of Object.entries(DK)) {
-            const hits = keywords.filter(kw => text.includes(kw)).length;
+            // Stem marker stripped before substring matching — see #681 and the
+            // identical guard in the bulk_from_consensus path above.
+            const hits = keywords.filter(kw => text.includes(inferKeywordStem(kw))).length;
             if (hits > bestHits) { bestHits = hits; bestCategory = category; }
           }
           return bestHits >= 1 ? bestCategory : undefined;

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -2,7 +2,7 @@ export { MainAgent } from './main-agent';
 export { seedMemoryHygiene } from './memory-hygiene-seed';
 export type { MemoryHygieneSeedResult } from './memory-hygiene-seed';
 export { detectFormatCompliance, MAX_COMPLIANCE_INPUT } from './dispatch-pipeline';
-export { loadSkills, resolveEffectiveSkills, DEFAULT_KEYWORDS, resolveSkillExists, resolveSkill } from './skill-loader';
+export { loadSkills, resolveEffectiveSkills, DEFAULT_KEYWORDS, keywordStem, resolveSkillExists, resolveSkill } from './skill-loader';
 export type { LoadSkillsResult, DroppedSkill } from './skill-loader';
 export { crossReviewSkillGateSeverity, shouldInjectCrossReviewSkills, createAgentSkillsContentResolver } from './cross-review-skills';
 export type { CrossReviewSkillGateSeverity, SeverityBearingFinding, AgentSkillsContentResolverConfig } from './cross-review-skills';

--- a/packages/orchestrator/src/skill-engine.ts
+++ b/packages/orchestrator/src/skill-engine.ts
@@ -116,16 +116,29 @@ const KNOWN_CATEGORIES = new Set([
   'severity_calibration', 'citation_grounding',
 ]);
 
-/** Default keywords per category for contextual skill activation */
-const CATEGORY_KEYWORDS: Record<string, string[]> = {
+/**
+ * Default keywords per category for contextual skill activation.
+ *
+ * Mirror of `DEFAULT_KEYWORDS` in skill-loader.ts for every category the two
+ * tables share — `tests/orchestrator/keyword-stem-matching.test.ts` asserts they
+ * agree, so edit both or neither. This table additionally seeds the `keywords:`
+ * frontmatter of generated skills (see the prompt below); skill-loader's table
+ * does not.
+ *
+ * Trailing `*` = opt-in stem match (issue #681). The full convention, and the
+ * per-stem over-match audit behind each `*` below, is documented on
+ * `DEFAULT_KEYWORDS` in skill-loader.ts. Do not add one here without doing that
+ * audit — `getPattern()` compiles these for every skill of every agent.
+ */
+export const CATEGORY_KEYWORDS: Record<string, string[]> = {
   trust_boundaries: ['auth', 'authentication', 'authorization', 'session', 'cookie', 'token', 'path', 'traversal', 'injection', 'middleware', 'permission', 'role', 'privilege', 'acl'],
-  injection_vectors: ['injection', 'xss', 'sql', 'sanitize', 'escape', 'template', 'eval', 'exec', 'html', 'uri', 'command'],
-  input_validation: ['validation', 'schema', 'zod', 'parse', 'sanitize', 'input', 'form', 'request', 'coerce', 'transform'],
+  injection_vectors: ['injection', 'xss', 'sql', 'sanitiz*', 'escape', 'template', 'eval', 'exec', 'html', 'uri', 'command'],
+  input_validation: ['validation', 'schema', 'zod', 'parse', 'sanitiz*', 'input', 'form', 'request', 'coerce', 'transform'],
   concurrency: ['race condition', 'concurrent', 'mutex', 'lock', 'atomic', 'parallel', 'deadlock', 'semaphore'],
   resource_exhaustion: ['memory', 'leak', 'unbounded', 'growth', 'limit', 'cap', 'timeout', 'pool', 'cache', 'backpressure', 'buffer', 'queue', 'throttle'],
   type_safety: ['type guard', 'generic', 'cast', 'assertion', 'narrowing', 'discriminated', 'satisfies'],
-  error_handling: ['error handling', 'catch', 'throw', 'exception', 'retry', 'fallback', 'recovery', 'graceful'],
-  data_integrity: ['data integrity', 'migration', 'serialize', 'deserialize', 'corrupt', 'consistency', 'invariant', 'transaction', 'rollback', 'idempotent'],
+  error_handling: ['error handling', 'catch', 'throw', 'exception', 'retry*', 'retries', 'retried', 'fallback', 'recovery', 'graceful'],
+  data_integrity: ['data integrity', 'migration', 'serializ*', 'deserializ*', 'corrupt*', 'consistency', 'invariant', 'transaction', 'rollback', 'idempotent'],
   severity_calibration: ['severity', 'critical', 'high', 'medium', 'low', 'impact', 'risk', 'priority', 'triage', 'cvss'],
   // Citation grounding — fabrication-class failures: cited file/line/symbol does not match repo state.
   // Gate for this is a skill bind + signal category, not the consensus-engine verifyCitations AND-gate
@@ -138,7 +151,10 @@ const CATEGORY_KEYWORDS: Record<string, string[]> = {
   // Issue #679 adds the present participles (`fabricating` / `hallucinating`) —
   // the most natural phrasing in a brief, and unreachable from any other
   // inflection under \b-anchored matching.
-  citation_grounding: ['cite', 'citation', 'line number', 'anchor', 'file path', 'reference', 'fabricate', 'fabricates', 'fabricated', 'fabricating', 'fabrication', 'hallucinate', 'hallucinates', 'hallucinated', 'hallucinating', 'hallucination', 'verify', 'does not exist', 'no such'],
+  // Issue #681 adds the stem markers. Because this table seeds generated skill
+  // frontmatter, every skill generated from here inherits the wildcards — which
+  // is how the fix reaches new agent-local skills without a backfill pass.
+  citation_grounding: ['cite*', 'citing', 'citation*', 'line number*', 'anchor*', 'file path*', 'referenc*', 'fabricate', 'fabricates', 'fabricated', 'fabricating', 'fabrication', 'hallucinate', 'hallucinates', 'hallucinated', 'hallucinating', 'hallucination', 'verif*', 'does not exist', "doesn't exist", 'no such'],
 };
 
 const REQUIRED_SECTIONS = ['## Iron Law', '## When This Skill Activates', '## Methodology', '## Key Patterns', '## Anti-Patterns', '## Quality Gate'];

--- a/packages/orchestrator/src/skill-loader.ts
+++ b/packages/orchestrator/src/skill-loader.ts
@@ -28,16 +28,49 @@ const CATEGORY_BOOST = 0.5;
 // to stronger ones and only fill the remaining slots when nothing else wins.
 const MIN_KEYWORD_HITS = 1;
 
-/** Default keyword sets by category — used when skill frontmatter has no explicit keywords */
+/**
+ * Default keyword sets by category — used when skill frontmatter has no explicit keywords.
+ *
+ * KEYWORD CONVENTION (issue #681, option 2, operator-approved). A trailing `*`
+ * opts that single keyword into stem matching: `verif*` compiles to the
+ * case-insensitive `\bverif[a-z]` star, reaching verifies / verified /
+ * verifying / verification.
+ * A bare keyword keeps exact `\b…\b` word matching, byte-identical to pre-#681.
+ * See `getPattern()` for the compiler and why the anchor is NOT relaxed globally.
+ *
+ * Adding a `*` is a deliberate act: audit the stem for off-domain over-match
+ * first. Stems rejected here for that reason, with the colliding words:
+ *   `cit*`   → city, citizen            (use `cite*` + `citing` + `citation*`)
+ *   `retr*`  → retreat, retrieve        (use `retry*` + explicit retries/retried)
+ *   `retrie*`→ retrieve, retrieval      (same)
+ *   `cast*`  → castle, caster, castigate (left bare below)
+ *   `auth*`  → author, authored          (left bare; the #676 case)
+ *   `log*`   → login, logic, logistics   (left bare)
+ *   `exec*`  → execution is in-domain, but `executive`/`executor` are not (left bare)
+ */
 export const DEFAULT_KEYWORDS: Record<string, string[]> = {
   trust_boundaries: ['auth', 'authentication', 'authorization', 'session', 'cookie', 'token', 'path', 'traversal', 'injection', 'middleware', 'permission', 'role', 'privilege', 'acl'],
-  injection_vectors: ['injection', 'xss', 'sql', 'sanitize', 'escape', 'template', 'eval', 'exec', 'html', 'uri', 'command'],
-  input_validation: ['validation', 'schema', 'zod', 'parse', 'sanitize', 'input', 'form', 'request', 'coerce', 'transform'],
+  // `sanitiz*` → sanitize/sanitized/sanitizes/sanitizing/sanitization/sanitizer.
+  // No English word outside that family begins `sanitiz`. (The British `sanitis*`
+  // spelling is still uncovered — same gap as the pre-#681 bare `sanitize`.)
+  // `exec` stays bare: `exec*` would reach executive/executor, which are not
+  // injection vocabulary.
+  injection_vectors: ['injection', 'xss', 'sql', 'sanitiz*', 'escape', 'template', 'eval', 'exec', 'html', 'uri', 'command'],
+  input_validation: ['validation', 'schema', 'zod', 'parse', 'sanitiz*', 'input', 'form', 'request', 'coerce', 'transform'],
   concurrency: ['race condition', 'concurrent', 'mutex', 'lock', 'atomic', 'parallel', 'deadlock', 'semaphore'],
   resource_exhaustion: ['memory', 'leak', 'unbounded', 'growth', 'limit', 'cap', 'timeout', 'pool', 'cache', 'backpressure', 'buffer', 'queue', 'throttle'],
+  // `cast` deliberately stays bare — `cast*` reaches castle/caster/castigate, and
+  // the trailing \b is what keeps it out of `broadcast` (#676). `casting` is
+  // therefore still unreachable; that is the accepted trade.
   type_safety: ['type guard', 'generic', 'cast', 'assertion', 'narrowing', 'discriminated', 'satisfies'],
-  error_handling: ['error handling', 'catch', 'throw', 'exception', 'retry', 'fallback', 'recovery', 'graceful'],
-  data_integrity: ['data integrity', 'migration', 'serialize', 'deserialize', 'corrupt', 'consistency', 'invariant', 'transaction', 'rollback', 'idempotent'],
+  // `retry*` → retry/retrying. retries/retried need a different stem (`retri*`
+  // collides with retrieve/retrieval, `retr*` also with retreat), so they are
+  // enumerated instead.
+  error_handling: ['error handling', 'catch', 'throw', 'exception', 'retry*', 'retries', 'retried', 'fallback', 'recovery', 'graceful'],
+  // `serializ*` / `deserializ*` → the -s/-d/-ing/-ation/-er forms. Both are needed:
+  // the leading \b means `serializ*` does NOT match inside `deserialization`.
+  // `corrupt*` → corrupts/corrupted/corruption/corruptible; no off-domain collisions.
+  data_integrity: ['data integrity', 'migration', 'serializ*', 'deserializ*', 'corrupt*', 'consistency', 'invariant', 'transaction', 'rollback', 'idempotent'],
   // Fabrication-class failures: agent cites code that does not match repo state.
   // Kept in sync with CATEGORY_KEYWORDS in skill-engine.ts — both tables drive contextual activation
   // and auto-inference in gossip_signals, so they must agree.
@@ -52,7 +85,26 @@ export const DEFAULT_KEYWORDS: Record<string, string[]> = {
   // participle is the most natural phrasing in a task brief ("the agent is
   // fabricating citations"), and \b-anchored matching means no other inflection
   // covers it.
-  citation_grounding: ['cite', 'citation', 'line number', 'anchor', 'file path', 'reference', 'fabricate', 'fabricates', 'fabricated', 'fabricating', 'fabrication', 'hallucinate', 'hallucinates', 'hallucinated', 'hallucinating', 'hallucination', 'verify', 'does not exist', 'no such'],
+  // Issue #681: 12 of 16 realistic phrasings fired NO keyword here, because
+  // every entry was a base form under \b…\b. The base forms below now carry the
+  // stem marker. Per-stem over-match audit:
+  //   `cite*`      cite/cites/cited. Not city/citizen (no `y`/`i` after `cite`),
+  //                not excite (leading \b). `citing` needs its own entry — the
+  //                `e` drops, so it is not reachable from the `cite` stem, and
+  //                `cit*` was rejected above.
+  //   `citation*`  citation/citations.
+  //   `line number*` / `file path*`  plural only; wildcarding mid-phrase is
+  //                awkward, and the trailing noun is the one that inflects.
+  //   `anchor*`    anchor/anchors/anchored/anchoring.
+  //   `referenc*`  reference(s|d)/referencing. Deliberately NOT `refer*`, which
+  //                reaches referral/referee/deference-adjacent prose.
+  //   `verif*`     verify/verifies/verified/verifying/verification/verifiable.
+  //                No word outside the verify family begins `verif`.
+  // The fabricate/hallucinate enumerations from #676/#679 are left as-is: they
+  // already cover their full inflection set, so restating them as `fabricat*` /
+  // `hallucinat*` would churn a working, test-pinned list for zero coverage gain.
+  // `doesn't exist` is a contraction, not an inflection — no stem reaches it.
+  citation_grounding: ['cite*', 'citing', 'citation*', 'line number*', 'anchor*', 'file path*', 'referenc*', 'fabricate', 'fabricates', 'fabricated', 'fabricating', 'fabrication', 'hallucinate', 'hallucinates', 'hallucinated', 'hallucinating', 'hallucination', 'verif*', 'does not exist', "doesn't exist", 'no such'],
   // Phase 1 dev-quality extensions (consensus 09693c51-184246e5).
   observability: ['log', 'logging', 'metric', 'tracing', 'telemetry', 'monitor', 'dashboard', 'stderr', 'observability'],
   cli_ergonomics: ['cli', 'flag', 'help text', 'error message', 'usage', 'prompt', 'banner', 'spinner'],
@@ -442,6 +494,48 @@ const patternCache = new Map<string, RegExp>();
 const MAX_PATTERN_CACHE = 500;
 const MAX_KEYWORD_LENGTH = 100;
 
+/**
+ * Strip the opt-in trailing `*` stem marker from a keyword, yielding the text a
+ * literal-substring consumer should match on.
+ *
+ * `getPattern()` is not the only consumer of the keyword tables: the signal
+ * category-inference paths in `mcp-server-sdk.ts` match with `text.includes(kw)`.
+ * A raw `cite*` is never a substring of real prose, so those consumers must strip
+ * the marker or the keyword goes dead for them — the exact failure mode #676
+ * fixed for `fabricat`/`hallucin`.
+ *
+ * A keyword of nothing but asterisks has no stem; returning the original (rather
+ * than `''`) keeps `includes()` from matching every string.
+ */
+export function keywordStem(keyword: string): string {
+  const stem = keyword.replace(/\*+$/, '');
+  return stem.length > 0 ? stem : keyword;
+}
+
+/**
+ * Compile one keyword into its matcher.
+ *
+ * **Bare keyword** — `/\b<escaped>\b/i`, exact word match. Unchanged, byte for
+ * byte, from the pre-#681 compiler.
+ *
+ * **Trailing `*` (issue #681, option 2, operator-approved)** — opts that ONE
+ * keyword into stem matching: case-insensitive `\b<escaped-stem>[a-z]` star.
+ * The leading `\b` is kept; only the trailing `\b` is dropped, so `verif*`
+ * reaches verifies / verified / verifying / verification while `\bverif` still
+ * cannot start mid-word.
+ *
+ * Opt-in is the whole point. Relaxing the trailing `\b` for EVERY keyword was
+ * considered and rejected in #676: `auth` would match `author`, `log` `login`,
+ * `cast` `broadcast`, `exec` `execution`. Those keywords stay bare and keep
+ * their anchor; only keywords whose author has audited the stem for over-match
+ * carry the marker.
+ *
+ * Only a TRAILING `*` is a wildcard. Anywhere else it stays a literal asterisk
+ * via the escape step, so `a*b` still means the three characters `a*b`. A
+ * keyword that is nothing but asterisks has no stem and falls back to the
+ * exact-match compile — `\b[a-z]*` would match every task string, so this fails
+ * closed rather than open.
+ */
 function getPattern(keyword: string): RegExp {
   const capped = keyword.slice(0, MAX_KEYWORD_LENGTH);
   const cached = patternCache.get(capped);
@@ -458,8 +552,10 @@ function getPattern(keyword: string): RegExp {
     const first = patternCache.keys().next().value;
     if (first !== undefined) patternCache.delete(first);
   }
-  const escaped = capped.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const pattern = new RegExp(`\\b${escaped}\\b`, 'i');
+  const stem = keywordStem(capped);
+  const isWildcard = stem !== capped;
+  const escaped = (isWildcard ? stem : capped).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(isWildcard ? `\\b${escaped}[a-z]*` : `\\b${escaped}\\b`, 'i');
   patternCache.set(capped, pattern);
   return pattern;
 }

--- a/tests/cli/mcp-signals-validation.test.ts
+++ b/tests/cli/mcp-signals-validation.test.ts
@@ -13,7 +13,7 @@
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { PerformanceWriter, SkillGapTracker, DEFAULT_KEYWORDS } from '@gossip/orchestrator';
+import { PerformanceWriter, SkillGapTracker, DEFAULT_KEYWORDS, keywordStem } from '@gossip/orchestrator';
 // Test-exemption: WRITER_INTERNAL gates appendSignal(s) access. Tests use it directly
 // to exercise validation/rejection behavior that helpers swallow via try/catch.
 // This import is outside the Step 4 parity-test scan scope (tests/ not scanned).
@@ -47,7 +47,9 @@ function runGapPipeline(
   let bestCategory = '';
   let bestHits = 0;
   for (const [category, keywords] of Object.entries(DEFAULT_KEYWORDS)) {
-    const hits = keywords.filter(kw => text.includes(kw)).length;
+    // Mirrors the production matcher: keywordStem strips the #681 trailing-`*`
+    // stem marker before substring matching.
+    const hits = keywords.filter(kw => text.includes(keywordStem(kw))).length;
     if (hits > bestHits) {
       bestHits = hits;
       bestCategory = category;
@@ -540,7 +542,7 @@ function bulkInferCategory(text: string): string | undefined {
   let bestCategory = '';
   let bestHits = 0;
   for (const [category, keywords] of Object.entries(DEFAULT_KEYWORDS)) {
-    const hits = (keywords as string[]).filter(kw => text.includes(kw)).length;
+    const hits = (keywords as string[]).filter(kw => text.includes(keywordStem(kw))).length;
     if (hits > bestHits) { bestHits = hits; bestCategory = category; }
   }
   return bestHits >= 1 ? bestCategory : undefined;

--- a/tests/orchestrator/keyword-stem-matching.test.ts
+++ b/tests/orchestrator/keyword-stem-matching.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Issue #681 — opt-in suffix-wildcard convention in the keyword tables.
+ *
+ * `getPattern()` compiles every keyword of every skill. Pre-#681 it emitted
+ * `/\b<escaped>\b/i` unconditionally, so only base forms matched: 12 of 16
+ * realistic `citation_grounding` phrasings fired NO keyword. Relaxing the
+ * trailing `\b` globally was rejected in #676 (auth→author, log→login,
+ * cast→broadcast, exec→execution).
+ *
+ * The landed design (option 2, operator-approved): a keyword ending in `*` opts
+ * into stem matching — `\b<stem>[a-z]*`, leading anchor kept, trailing anchor
+ * dropped. Bare keywords are untouched.
+ *
+ * This suite pins three things:
+ *   1. the compiler contract, by PATTERN SOURCE, so a stem accidentally compiled
+ *      with a trailing `\b` fails here and not just downstream;
+ *   2. the 16 measured phrasings from the issue, asserting the RIGHT keyword
+ *      fires — the pre-#681 pass rate flattered itself, because the 4 phrasings
+ *      that did fire all fired via a keyword unrelated to the phrasing;
+ *   3. the over-match control class, which must stay dead.
+ */
+import { DEFAULT_KEYWORDS, keywordStem, __lruInternals } from '../../packages/orchestrator/src/skill-loader';
+import { CATEGORY_KEYWORDS } from '../../packages/orchestrator/src/skill-engine';
+
+const { getPattern } = __lruInternals;
+
+/** Which keywords of a category fire on `text` — not just whether any does. */
+const firingKeywords = (category: string, text: string): string[] =>
+  DEFAULT_KEYWORDS[category].filter(k => getPattern(k).test(text));
+
+const categoryFires = (category: string, text: string): boolean =>
+  firingKeywords(category, text).length > 0;
+
+describe('#681 — getPattern compiler contract', () => {
+  it('a BARE keyword compiles byte-identically to the pre-#681 pattern', () => {
+    // The literal expected sources are spelled out rather than derived, so a
+    // regression in the escape/anchor logic cannot be masked by a shared helper.
+    expect(getPattern('auth').source).toBe('\\bauth\\b');
+    expect(getPattern('cite').source).toBe('\\bcite\\b');
+    expect(getPattern('line number').source).toBe('\\bline number\\b');
+    expect(getPattern('n+1').source).toBe('\\bn\\+1\\b');
+    expect(getPattern('auth').flags).toBe('i');
+  });
+
+  it('a TRAILING `*` compiles to a stem match with the leading anchor kept', () => {
+    // If the trailing \b survives here, every inflection test below dies — that
+    // is the mutation this assertion exists to catch.
+    expect(getPattern('verif*').source).toBe('\\bverif[a-z]*');
+    expect(getPattern('cite*').source).toBe('\\bcite[a-z]*');
+    expect(getPattern('line number*').source).toBe('\\bline number[a-z]*');
+    expect(getPattern('verif*').flags).toBe('i');
+    expect(getPattern('verif*').source).not.toContain('\\b[a-z]');
+    expect(getPattern('verif*').source.endsWith('\\b')).toBe(false);
+  });
+
+  it('case-insensitivity survives stem matching', () => {
+    expect(getPattern('verif*').test('VERIFIED the claim')).toBe(true);
+    expect(getPattern('verif*').test('Verification failed')).toBe(true);
+    expect(getPattern('corrupt*').test('CORRUPTION detected')).toBe(true);
+  });
+
+  it('the leading \\b still holds — a stem cannot match mid-word', () => {
+    // `\bcite[a-z]*` must not fire inside "excite"; dropping the LEADING anchor
+    // as well would be a far worse regression than the one being fixed.
+    expect(getPattern('cite*').test('excited about it')).toBe(false);
+    expect(getPattern('serializ*').test('deserialization failed')).toBe(false);
+    expect(getPattern('anchor*').test('unanchored')).toBe(false);
+  });
+
+  it('`*` is a wildcard ONLY as the trailing character', () => {
+    // Mid-word and leading asterisks stay literal via the escape step, exactly
+    // as before #681.
+    expect(getPattern('a*b').source).toBe('\\ba\\*b\\b');
+    expect(getPattern('a*b').test('a*b')).toBe(true);
+    expect(getPattern('a*b').test('ab')).toBe(false);
+    expect(getPattern('a*b').test('axb')).toBe(false);
+    expect(getPattern('*cite').source).toBe('\\b\\*cite\\b');
+    expect(getPattern('*cite').test('cited')).toBe(false);
+  });
+
+  it('an all-asterisk keyword fails CLOSED, not open', () => {
+    // `\b[a-z]*` would match every task string and activate every skill. The
+    // stem is empty, so the compiler must fall back to the exact-match branch.
+    expect(getPattern('*').source).toBe('\\b\\*\\b');
+    expect(getPattern('*').test('an ordinary task description')).toBe(false);
+    expect(getPattern('***').source).toBe('\\b\\*\\*\\*\\b');
+    expect(getPattern('***').test('an ordinary task description')).toBe(false);
+  });
+
+  it('repeated trailing asterisks collapse to one stem marker', () => {
+    expect(getPattern('verif**').source).toBe('\\bverif[a-z]*');
+    expect(getPattern('verif**').test('verified')).toBe(true);
+  });
+
+  it('keywordStem strips the marker for literal-substring consumers', () => {
+    // The signal category-inference paths in mcp-server-sdk.ts match with
+    // text.includes(); a raw `cite*` is a substring of nothing.
+    expect(keywordStem('cite*')).toBe('cite');
+    expect(keywordStem('verif**')).toBe('verif');
+    expect(keywordStem('cite')).toBe('cite');
+    expect(keywordStem('line number*')).toBe('line number');
+    // Empty stem → return the original, so includes() cannot match everything.
+    expect(keywordStem('*')).toBe('*');
+    expect(keywordStem('**')).toBe('**');
+  });
+
+  it('no keyword in any table is dead — every one matches its own stem', () => {
+    // The #676 failure class, restated for the wildcard era: a keyword that
+    // cannot match the text it is made of can never fire.
+    for (const [category, keywords] of Object.entries(DEFAULT_KEYWORDS)) {
+      for (const k of keywords) {
+        expect(`${category}:${k}:${getPattern(k).test(keywordStem(k))}`).toBe(`${category}:${k}:true`);
+      }
+    }
+  });
+});
+
+/**
+ * The 16 phrasings measured in issue #681, verbatim. `expected` names the
+ * keyword that SHOULD carry each phrasing — asserting only "something fired"
+ * would have passed pre-#681 for four of these via unrelated keywords.
+ */
+const ISSUE_681_PHRASINGS: ReadonlyArray<{ text: string; expected: string; wasDead: boolean }> = [
+  { text: 'cites the wrong line', expected: 'cite*', wasDead: true },
+  { text: 'cited the file', expected: 'cite*', wasDead: true },
+  { text: 'citing a stale anchor', expected: 'citing', wasDead: false },
+  { text: 'three citations', expected: 'citation*', wasDead: true },
+  { text: 'the line numbers are wrong', expected: 'line number*', wasDead: true },
+  { text: 'two anchors', expected: 'anchor*', wasDead: true },
+  { text: 'anchored to master', expected: 'anchor*', wasDead: true },
+  { text: 'several file paths', expected: 'file path*', wasDead: true },
+  { text: 'references are stale', expected: 'referenc*', wasDead: true },
+  { text: 'referenced the wrong file', expected: 'referenc*', wasDead: true },
+  { text: 'referencing a dead line', expected: 'referenc*', wasDead: true },
+  { text: 'verifies the claim', expected: 'verif*', wasDead: true },
+  { text: 'I verified the citation', expected: 'verif*', wasDead: false },
+  { text: 'verifying the anchor', expected: 'verif*', wasDead: false },
+  { text: 'citation verification failed', expected: 'citation*', wasDead: false },
+  { text: "doesn't exist", expected: "doesn't exist", wasDead: true },
+];
+
+describe('#681 — the 16 measured phrasings', () => {
+  it('the fixture matches the issue: 12 were DEAD, 4 fired', () => {
+    // Guards the guard — if someone trims the table, the reason is unambiguous.
+    expect(ISSUE_681_PHRASINGS).toHaveLength(16);
+    expect(ISSUE_681_PHRASINGS.filter(p => p.wasDead)).toHaveLength(12);
+  });
+
+  it.each(ISSUE_681_PHRASINGS.map(p => [p.text, p.expected] as const))(
+    'fires via the RIGHT keyword: "%s" → %s',
+    (text, expected) => {
+      expect(firingKeywords('citation_grounding', text)).toContain(expected);
+    },
+  );
+
+  it('all 16 fire the category (0 dead, was 12)', () => {
+    const dead = ISSUE_681_PHRASINGS.filter(p => !categoryFires('citation_grounding', p.text));
+    expect(dead.map(p => p.text)).toEqual([]);
+  });
+});
+
+/**
+ * Over-match control class. Every stem introduced by #681 was picked over a
+ * shorter one precisely because the shorter one collided with these words. If a
+ * future edit shortens a stem, this suite is what fails.
+ */
+describe('#681 — over-match control class stays dead', () => {
+  it.each([
+    // [category, text, why]
+    ['trust_boundaries', 'the author of the commit', 'auth must not reach author (#676)'],
+    ['observability', 'the login screen', 'log must not reach login'],
+    ['observability', 'business logic bug', 'log must not reach logic'],
+    ['type_safety', 'a broadcast listener', 'cast must not reach broadcast'],
+    ['type_safety', 'the castle metaphor', 'cast stays bare — cast* would reach castle'],
+    ['injection_vectors', 'the executive summary', 'exec stays bare — exec* would reach executive'],
+    ['citation_grounding', 'the city of Ankara', 'cite* must not reach city (cit* was rejected)'],
+    ['citation_grounding', 'a citizen report', 'cite* must not reach citizen'],
+    ['citation_grounding', 'a referral to another team', 'referenc* must not reach referral'],
+    ['citation_grounding', 'very fabric-like texture', 'fabricate entries must not reach fabric'],
+    ['error_handling', 'retrieve the record', 'retry* must not reach retrieve'],
+    ['error_handling', 'a hasty retreat', 'retry* must not reach retreat'],
+    ['data_integrity', 'a corral for the horses', 'corrupt* must not reach unrelated cor- words'],
+  ])('%s does not fire on "%s" (%s)', (category, text) => {
+    expect(firingKeywords(category as string, text as string)).toEqual([]);
+  });
+
+  it('serializ* and deserializ* do not cross-match', () => {
+    // The leading \b is what separates them; both entries are therefore needed.
+    expect(getPattern('serializ*').test('deserialize the payload')).toBe(false);
+    expect(getPattern('deserializ*').test('serialize the payload')).toBe(false);
+    expect(getPattern('serializ*').test('serialization is lossy')).toBe(true);
+    expect(getPattern('deserializ*').test('deserialization is lossy')).toBe(true);
+  });
+
+  it('the widened categories still fire on their own inflections', () => {
+    expect(categoryFires('data_integrity', 'the record was corrupted')).toBe(true);
+    expect(categoryFires('data_integrity', 'silent corruption on write')).toBe(true);
+    expect(categoryFires('injection_vectors', 'the value is sanitized twice')).toBe(true);
+    expect(categoryFires('injection_vectors', 'sanitization is the sole defense')).toBe(true);
+    expect(categoryFires('input_validation', 'sanitizing user input')).toBe(true);
+    expect(categoryFires('error_handling', 'retrying the request')).toBe(true);
+    expect(categoryFires('error_handling', 'three retries then give up')).toBe(true);
+    expect(categoryFires('error_handling', 'it retried and failed')).toBe(true);
+  });
+});
+
+describe('#681 — the two keyword tables agree', () => {
+  const shared = Object.keys(DEFAULT_KEYWORDS).filter(c => c in CATEGORY_KEYWORDS);
+
+  it('there are shared categories to compare (guards a vacuous pass)', () => {
+    expect(shared.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it.each(shared)('DEFAULT_KEYWORDS.%s === CATEGORY_KEYWORDS equivalent', category => {
+    // #675 noted drift between these two tables. They feed different pipelines
+    // (contextual activation vs. generated-skill frontmatter), so drift means a
+    // generated skill inherits keywords the loader never intended.
+    expect(CATEGORY_KEYWORDS[category]).toEqual(DEFAULT_KEYWORDS[category]);
+  });
+
+  it('the categories that legitimately differ are only these', () => {
+    // skill-engine seeds generated skills and carries severity_calibration, a
+    // category with no loader-side default. skill-loader carries the Phase 1
+    // dev-quality categories, which are never auto-generated. Documented, not
+    // accidental — a NEW asymmetry should fail this test.
+    const engineOnly = Object.keys(CATEGORY_KEYWORDS).filter(c => !(c in DEFAULT_KEYWORDS));
+    const loaderOnly = Object.keys(DEFAULT_KEYWORDS).filter(c => !(c in CATEGORY_KEYWORDS));
+    expect(engineOnly.sort()).toEqual(['severity_calibration']);
+    expect(loaderOnly.sort()).toEqual(['cli_ergonomics', 'observability', 'performance', 'testing']);
+  });
+});

--- a/tests/orchestrator/skills-delimiter-and-keywords.test.ts
+++ b/tests/orchestrator/skills-delimiter-and-keywords.test.ts
@@ -24,7 +24,7 @@
  * The fixtures here are adversarial by construction — see the comment on
  * ESCAPE_FIXTURE.
  */
-import { loadSkills, DEFAULT_KEYWORDS } from '../../packages/orchestrator/src/skill-loader';
+import { loadSkills, DEFAULT_KEYWORDS, __lruInternals } from '../../packages/orchestrator/src/skill-loader';
 import {
   assemblePrompt,
   wrapSkillsBlock,
@@ -39,12 +39,19 @@ const countOpen = (s: string) => (s.match(/---\s*SKILLS\s*---/g) || []).length;
 const countClose = (s: string) => (s.match(/---\s*END SKILLS\s*---/g) || []).length;
 
 /**
- * Mirror of `getPattern()` in skill-loader — keywords are escaped, then
- * anchored with \b on both sides. Reproduced here (rather than exported) so
- * the test fails loudly if the compiler's contract changes.
+ * Mirror of `getPattern()` in skill-loader. Reproduced here (rather than
+ * exported) so the test fails loudly if the compiler's contract changes.
+ *
+ * Issue #681 added the trailing-`*` stem convention: a keyword ending in `*`
+ * drops the trailing anchor and matches inflections. Bare keywords are escaped
+ * and anchored with \b on both sides, exactly as before.
  */
-const keywordPattern = (keyword: string) =>
-  new RegExp(`\\b${keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i');
+const keywordPattern = (keyword: string) => {
+  const stem = keyword.replace(/\*+$/, '');
+  const isWildcard = stem.length > 0 && stem !== keyword;
+  const escaped = (isWildcard ? stem : keyword).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(isWildcard ? `\\b${escaped}[a-z]*` : `\\b${escaped}\\b`, 'i');
+};
 
 const categoryFires = (category: string, text: string) =>
   DEFAULT_KEYWORDS[category].some(k => keywordPattern(k).test(text));
@@ -304,6 +311,16 @@ describe('#676/#679 — citation_grounding keywords match real inflections', () 
     expect(categoryFires('citation_grounding', text)).toBe(true);
   });
 
+  it('the local mirror still matches the real compiler', () => {
+    // The mirror above only guards the contract if it cannot silently drift from
+    // getPattern(). Under mutation testing, a change to the real compiler left
+    // every assertion in this file green because they all ran on the mirror.
+    for (const k of [...DEFAULT_KEYWORDS.citation_grounding, 'auth', 'a*b', '*', 'n+1']) {
+      expect(`${k} → ${keywordPattern(k).source}`)
+        .toBe(`${k} → ${__lruInternals.getPattern(k).source}`);
+    }
+  });
+
   it('has no permanently-dead stem entries left', () => {
     expect(DEFAULT_KEYWORDS.citation_grounding).not.toContain('fabricat');
     expect(DEFAULT_KEYWORDS.citation_grounding).not.toContain('hallucin');
@@ -314,21 +331,38 @@ describe('#676/#679 — citation_grounding keywords match real inflections', () 
     }
   });
 
-  it('REGRESSION: exact-match keywords keep their current behaviour', () => {
-    // `cite` is word-anchored and must NOT start matching plurals/derivatives.
+  /**
+   * CONTRACT CHANGE — issue #681, option 2, operator-approved.
+   *
+   * These assertions were added in #679 to prove that fix did not widen
+   * matching. #681 deliberately widens it, but ONLY for keywords that opt in
+   * with a trailing `*`. So the guard is not deleted — it is re-pointed at the
+   * property that still has to hold: a BARE keyword is still exactly anchored,
+   * and nothing stems by accident. The widening is asserted separately in
+   * tests/orchestrator/keyword-stem-matching.test.ts.
+   */
+  it('REGRESSION: BARE keywords keep their exact-match behaviour', () => {
+    // Bare `cite`/`anchor`/`verify` — the pre-#681 entries — must still refuse
+    // to match plurals and derivatives when written without the marker.
     expect(keywordPattern('cite').test('cite the line')).toBe(true);
     expect(keywordPattern('cite').test('citations')).toBe(false);
     expect(keywordPattern('anchor').test('anchor block')).toBe(true);
     expect(keywordPattern('anchor').test('anchors')).toBe(false);
     expect(keywordPattern('verify').test('verify the claim')).toBe(true);
     expect(keywordPattern('verify').test('verified')).toBe(false);
+    // The keyword the whole anchor exists for (#676): never `author`.
+    expect(keywordPattern('auth').test('the author of the file')).toBe(false);
+    expect(keywordPattern('auth').test('auth token')).toBe(true);
     // Multi-word keywords still work.
     expect(keywordPattern('does not exist').test('the file does not exist')).toBe(true);
   });
 
-  it('the 9 pre-existing keywords are all still present', () => {
+  it('the 9 pre-existing keywords are still reachable (as stems where widened)', () => {
+    // #681 replaced 7 of these base forms with stem-marked equivalents. The
+    // contract that survives is REACHABILITY, not literal list membership: each
+    // original base form must still be matched by some keyword in the category.
     for (const k of ['cite', 'citation', 'line number', 'anchor', 'file path', 'reference', 'verify', 'does not exist', 'no such']) {
-      expect(DEFAULT_KEYWORDS.citation_grounding).toContain(k);
+      expect(categoryFires('citation_grounding', k)).toBe(true);
     }
   });
 });


### PR DESCRIPTION
Closes #681, per the operator decision: **option 2** — an opt-in suffix-wildcard convention, not enumeration and not a global anchor relaxation.

## What

`getPattern()` now compiles a keyword ending in `*` as a stem match (`\b<stem>[a-z]*`); bare keywords compile byte-identically to before (`\b…\b`). The #676-rejected global `\b` relaxation stays rejected — auth→author etc. remain impossible, and the over-match guards are pinned in tests.

- Both keyword tables (`DEFAULT_KEYWORDS` in skill-loader, `CATEGORY_KEYWORDS` in skill-engine) updated in one category-wide pass, with per-stem over-match audits in comments (`cite*`+`citation*` not `cit*`; `retry*` with retries/retried enumerated; `cast`/`auth`/`log`/`exec` deliberately left bare). Table-agreement test added.
- **Adjacent defect found and fixed**: two CLI signal category-inference sites matched with `text.includes(kw)` — a raw `cite*` is a substring of nothing, so wildcarded keywords would have gone silently dead there (the exact #676 `fabricat`/`hallucin` failure class). Both now stem via `keywordStem()`.
- #679 pinning assertions re-pointed as a **documented contract change**, and a new test asserts the suite's local pattern mirror equals the real `getPattern` so the mirror can't drift silently (mutation testing revealed it had been drifting-capable).

## Verification

- Full suite **5208 tests / 372 suites** green (worktree); at repo root: orchestrator dist rebuilt, dist-mcp rebuilt, 201/201 across the stem/signals/binary suites.
- **Before/after activation diff** (the #679 method) over the real `loadSkills` path, 58 briefs: **26 activations gained, 0 lost**, identical under the contextual budget; all 12 formerly-DEAD phrasings fire via the *right* keyword; all 15 over-match controls absent from the diff.
- Probe hardened after a first false-negative run: the harness now asserts a known-positive control and dies loudly (`PROBE IS DEAD`) if it can't detect activations at all.
- Mutation-tested: dropping `*` handling → 21 failures; mis-compiling the stem with a trailing `\b` → 2 source-level failures.

## Follow-ups flagged, not fixed

- `category-extractor.ts:22` — a **third** keyword table (`CATEGORY_PATTERNS`) with the same inflection gap; different semantics, out of scope here.
- Curly-apostrophe `doesn't exist` (smart quote) uncovered; straight-quote form added per the issue's measurement.
- Backfilling `keywords:` frontmatter in the ~34 already-generated skill files (newly generated skills inherit the wildcards automatically; existing files don't) — this is the re-measurement path toward #675.

🤖 Generated with [Claude Code](https://claude.com/claude-code)