### PR TITLE
fix(scoring): exclude operational disagreements from the circuit-breaker streak

### DIFF
--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -229,6 +229,40 @@ const NEGATIVE_SIGNALS = new Set(['hallucination_caught', 'disagreement']);
 const NEGATIVE_IMPL_SIGNALS = new Set(['impl_test_fail', 'impl_peer_rejected']);
 const SIGNAL_EXPIRY_DAYS = 30;
 
+/**
+ * Operational-class `disagreement` predicate — the single source of truth shared
+ * by the accuracy loop and the circuit-breaker streak builder so the two cannot
+ * drift apart.
+ *
+ * A failed dispatch (quota exhaustion, context overflow, model unavailable) is
+ * auto-recorded as a `disagreement` by apps/cli/src/handlers/collect.ts, carrying
+ * `signal_class: 'operational'` and NO `category` — it describes a transport /
+ * lifecycle failure, not a finding-evaluation verdict. Per docs/HANDBOOK.md
+ * invariant #14 these rows are telemetry and must never move a score: excluded
+ * from accuracy arithmetic AND from the circuit-breaker streak.
+ *
+ * The category-absence test is load-bearing (it matches the accuracy loop's
+ * established semantics and covers historical rows written before `signal_class`
+ * stamping existed); the `signal_class` test is a belt-and-braces second axis.
+ */
+function isOperationalDisagreement(signal: ConsensusSignal): boolean {
+  if (signal.signal !== 'disagreement') return false;
+  return !signal.category || signal.signal_class === 'operational';
+}
+
+/** A `disagreement` row that participates in scoring — always carries a category. */
+type ScoringDisagreement = ConsensusSignal & { signal: 'disagreement'; category: string };
+
+/**
+ * Exact inverse of `isOperationalDisagreement` for `disagreement` rows, as a
+ * type predicate so the accuracy arm can index `categoryHallucinated` without a
+ * non-null assertion. Defined in terms of the shared predicate — it cannot
+ * disagree with it.
+ */
+function isScoringDisagreement(signal: ConsensusSignal): signal is ScoringDisagreement {
+  return signal.signal === 'disagreement' && !isOperationalDisagreement(signal);
+}
+
 /** Known consensus signal types — used to filter valid signals in computeScores */
 const KNOWN_SIGNALS: Record<ConsensusSignal['signal'], true> = {
   agreement: true,
@@ -1057,7 +1091,11 @@ export class PerformanceReader {
           // still arriving uncategorized is operational and must not touch
           // weightedTotal/disagreements. Mirrors the task_timeout/task_empty
           // no-op pattern below at :669-673.
-          if (!signal.category) {
+          //
+          // Shares `isOperationalDisagreement` with the circuit-breaker streak
+          // builder below so the accuracy path and the breaker path cannot
+          // diverge on what counts as operational.
+          if (!isScoringDisagreement(signal)) {
             break;
           }
           a.scoringSignals++;
@@ -1232,6 +1270,18 @@ export class PerformanceReader {
       // (would reset a real failure streak). Treat it as if absent so a relay
       // cwd outage neither benches nor rehabilitates the agent.
       if (signal.signal === 'transport_failure') continue;
+      // Same exclusion for operational-class disagreements — a dispatch that
+      // died on quota exhaustion / context overflow / model-unavailable is
+      // auto-recorded as a category-less `disagreement` by
+      // apps/cli/src/handlers/collect.ts. `NEGATIVE_SIGNALS` contains
+      // 'disagreement', so without this guard a run of infrastructure failures
+      // opens the breaker and benches a healthy agent (observed 2026-07-27:
+      // six consecutive quota failures floored sonnet-reviewer's dispatch
+      // weight at 0.30). The accuracy loop already excludes these rows via the
+      // shared `isOperationalDisagreement` predicate; treating them as absent
+      // here keeps the two paths consistent. "Absent" is exact: they neither
+      // count as a negative NOR rehabilitate a real failure streak.
+      if (isOperationalDisagreement(signal)) continue;
       const list = signalsByAgent.get(signal.agentId) || [];
       list.push(signal);
       signalsByAgent.set(signal.agentId, list);

--- a/tests/orchestrator/performance-reader-operational-disagreement-breaker.test.ts
+++ b/tests/orchestrator/performance-reader-operational-disagreement-breaker.test.ts
@@ -1,0 +1,183 @@
+/**
+ * performance-reader circuit-breaker exclusion for OPERATIONAL disagreements.
+ *
+ * Failed dispatches (quota exhaustion, context overflow, model unavailable) are
+ * auto-recorded by apps/cli/src/handlers/collect.ts as
+ * `{ signal: 'disagreement', signal_class: 'operational' }` with NO `category`.
+ * `NEGATIVE_SIGNALS` contains 'disagreement', so before this fix a run of
+ * infrastructure failures at an agent's tail opened its circuit breaker and
+ * floored dispatch weight — contradicting docs/HANDBOOK.md invariant #14
+ * (operational signals are telemetry, never score movement).
+ *
+ * Verifies:
+ *   - trailing operational disagreements never open the breaker;
+ *   - real (categorized) negatives still do;
+ *   - an operational row does NOT rehabilitate an already-open streak —
+ *     it is treated as absent, exactly like `transport_failure`.
+ */
+
+import { PerformanceReader } from '../../packages/orchestrator/src/performance-reader';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const TEST_DIR = join(__dirname, '..', '..', '.test-perf-reader-operational-disagreement');
+const AGENT = 'sonnet-reviewer';
+
+function writeSignals(signals: any[]): void {
+  mkdirSync(join(TEST_DIR, '.gossip'), { recursive: true });
+  writeFileSync(
+    join(TEST_DIR, '.gossip', 'agent-performance.jsonl'),
+    signals.map(s => JSON.stringify(s)).join('\n') + '\n',
+  );
+}
+
+/** Timestamps ascending from oldest → newest, spaced 1s apart. */
+function ts(indexFromOldest: number): string {
+  return new Date(Date.now() - 60_000 + indexFromOldest * 1000).toISOString();
+}
+
+/** A positive performance signal — resets any prior streak. */
+function positive(taskId: string, timestamp: string): any {
+  return {
+    type: 'consensus',
+    signal: 'unique_confirmed',
+    taskId,
+    agentId: AGENT,
+    category: 'trust_boundaries',
+    severity: 'medium',
+    evidence: 'confirmed unique finding',
+    timestamp,
+  };
+}
+
+/** An operational disagreement — a failed dispatch, not a review verdict. */
+function operationalDisagreement(taskId: string, timestamp: string): any {
+  return {
+    type: 'consensus',
+    signal: 'disagreement',
+    signal_class: 'operational',
+    taskId,
+    agentId: AGENT,
+    evidence: 'Task failed: Context window exceeded',
+    timestamp,
+  };
+}
+
+/** A real, finding-evaluation negative — must feed the breaker. */
+function realNegative(
+  taskId: string,
+  timestamp: string,
+  signal: 'disagreement' | 'hallucination_caught',
+): any {
+  return {
+    type: 'consensus',
+    signal,
+    taskId,
+    agentId: AGENT,
+    counterpartId: 'gemini-reviewer',
+    category: 'trust_boundaries',
+    severity: 'medium',
+    evidence: 'peer disproved the finding',
+    timestamp,
+  };
+}
+
+function scoreFor(agentId = AGENT) {
+  const score = new PerformanceReader(TEST_DIR).getScores().get(agentId);
+  expect(score).toBeDefined();
+  return score!;
+}
+
+function dispatchWeightFor(agentId = AGENT): number {
+  return new PerformanceReader(TEST_DIR).getDispatchWeight(agentId);
+}
+
+beforeEach(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterAll(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('PerformanceReader — operational disagreements and the circuit breaker', () => {
+  it('keeps the breaker closed when the tail is operational disagreements after a positive', () => {
+    writeSignals([
+      // Three positives so scoringSignals >= 3 and getDispatchWeight leaves its
+      // "not enough data, neutral" short-circuit — otherwise the weight
+      // assertion below would pass vacuously.
+      positive('t-0', ts(0)),
+      positive('t-1', ts(1)),
+      positive('t-2', ts(2)),
+      operationalDisagreement('t-3', ts(3)),
+      operationalDisagreement('t-4', ts(4)),
+      operationalDisagreement('t-5', ts(5)),
+      operationalDisagreement('t-6', ts(6)),
+    ]);
+
+    const score = scoreFor();
+    expect(score.consecutiveFailures).toBe(0);
+    expect(score.circuitOpen).toBe(false);
+    // The operational rows must not have moved accuracy either — only the
+    // three positives are scoring signals.
+    expect(score.scoringSignals).toBe(3);
+    expect(score.disagreements).toBe(0);
+    // Circuit-breaker flooring is what benched the agent; weight must not be
+    // pinned to the 0.3 open-circuit floor.
+    expect(dispatchWeightFor()).toBeGreaterThan(0.3);
+  });
+
+  it('still opens the breaker on three real trailing negatives', () => {
+    writeSignals([
+      positive('t-0', ts(0)),
+      realNegative('t-1', ts(1), 'disagreement'),
+      realNegative('t-2', ts(2), 'hallucination_caught'),
+      realNegative('t-3', ts(3), 'disagreement'),
+    ]);
+
+    const score = scoreFor();
+    expect(score.consecutiveFailures).toBe(3);
+    expect(score.circuitOpen).toBe(true);
+    expect(dispatchWeightFor()).toBe(0.3);
+  });
+
+  it('does not let a later operational disagreement rehabilitate an open streak', () => {
+    writeSignals([
+      positive('t-0', ts(0)),
+      realNegative('t-1', ts(1), 'disagreement'),
+      realNegative('t-2', ts(2), 'hallucination_caught'),
+      realNegative('t-3', ts(3), 'disagreement'),
+      // Arrives AFTER the three real negatives: skipped, not a streak-breaker.
+      operationalDisagreement('t-4', ts(4)),
+    ]);
+
+    const score = scoreFor();
+    expect(score.consecutiveFailures).toBe(3);
+    expect(score.circuitOpen).toBe(true);
+  });
+
+  it('excludes category-less disagreements even without signal_class stamping', () => {
+    // Historical rows predate `signal_class`; the category-absence test is the
+    // load-bearing predicate and must hold on its own.
+    const legacyOperational = (taskId: string, timestamp: string) => ({
+      type: 'consensus',
+      signal: 'disagreement',
+      taskId,
+      agentId: AGENT,
+      evidence: 'Task failed: quota exhausted',
+      timestamp,
+    });
+
+    writeSignals([
+      positive('t-0', ts(0)),
+      legacyOperational('t-1', ts(1)),
+      legacyOperational('t-2', ts(2)),
+      legacyOperational('t-3', ts(3)),
+    ]);
+
+    const score = scoreFor();
+    expect(score.consecutiveFailures).toBe(0);
+    expect(score.circuitOpen).toBe(false);
+  });
+});

--- a/tests/orchestrator/performance-reader.test.ts
+++ b/tests/orchestrator/performance-reader.test.ts
@@ -442,6 +442,12 @@ describe('PerformanceReader — circuit breaker chronology (signal-timestamp-fro
   // determine the tail. The reader was always correct in intent — these tests
   // pin its behavior so a future regression to "single batch timestamp"
   // recording immediately fails.
+  //
+  // Every `disagreement` below carries `category` on purpose: a category-less
+  // disagreement is OPERATIONAL (a failed dispatch, see the "disagreement no-op
+  // guard (PR 4 Part B)" suite above) and is excluded from both the accuracy
+  // arithmetic and the circuit-breaker streak. These fixtures model real
+  // finding-evaluation verdicts, so they must be categorized to be negatives.
 
   function ts(daysAgo: number, ms = 0): string {
     return new Date(Date.now() - daysAgo * 86400000 + ms).toISOString();
@@ -455,7 +461,7 @@ describe('PerformanceReader — circuit breaker chronology (signal-timestamp-fro
       { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', taskId: 't3', evidence: 'x', timestamp: ts(3) },
       // 3 negatives more recent (unique_unconfirmed removed from NEGATIVE_SIGNALS — use hallucination instead)
       { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', counterpartId: 'p', taskId: 't4', evidence: 'bad', timestamp: ts(2) },
-      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', taskId: 't5', evidence: 'bad', timestamp: ts(1) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', category: 'testing', taskId: 't5', evidence: 'bad', timestamp: ts(1) },
       { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', counterpartId: 'p', taskId: 't6', evidence: 'bad', timestamp: ts(0) },
     ]);
     const reader = new PerformanceReader(TEST_DIR);
@@ -466,7 +472,7 @@ describe('PerformanceReader — circuit breaker chronology (signal-timestamp-fro
     writeSignals([
       // 3 negatives in the past
       { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', counterpartId: 'p', taskId: 't1', evidence: 'bad', timestamp: ts(5) },
-      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', taskId: 't2', evidence: 'bad', timestamp: ts(4) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', category: 'testing', taskId: 't2', evidence: 'bad', timestamp: ts(4) },
       { type: 'consensus', signal: 'unique_unconfirmed', agentId: 'rev', taskId: 't3', evidence: 'bad', timestamp: ts(3) },
       // Newest is positive — must break the streak
       { type: 'consensus', signal: 'agreement', agentId: 'rev', counterpartId: 'p', taskId: 't4', evidence: 'x', timestamp: ts(0) },
@@ -486,8 +492,8 @@ describe('PerformanceReader — circuit breaker chronology (signal-timestamp-fro
       { type: 'consensus', signal: 'unique_confirmed', agentId: 'rev', taskId: 'newer', evidence: 'x', timestamp: ts(1) },
       { type: 'consensus', signal: 'agreement', agentId: 'rev', counterpartId: 'p', taskId: 'mid', evidence: 'x', timestamp: ts(2) },
       { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', counterpartId: 'p', taskId: 'old', evidence: 'bad', timestamp: ts(3) },
-      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', taskId: 'oldest1', evidence: 'bad', timestamp: ts(4) },
-      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', taskId: 'oldest2', evidence: 'bad', timestamp: ts(5) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', category: 'testing', taskId: 'oldest1', evidence: 'bad', timestamp: ts(4) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', category: 'testing', taskId: 'oldest2', evidence: 'bad', timestamp: ts(5) },
     ]);
     const reader = new PerformanceReader(TEST_DIR);
     // True chronology: 3 negatives (oldest) → 3 positives (newest). Tail is positive.
@@ -498,10 +504,10 @@ describe('PerformanceReader — circuit breaker chronology (signal-timestamp-fro
     // The exact incident: even though file order looks "good then bad",
     // the bad signals are CHRONOLOGICALLY NEWER and must trip the breaker.
     writeSignals([
-      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', taskId: 'oldest', evidence: 'bad', timestamp: ts(2) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', category: 'testing', taskId: 'oldest', evidence: 'bad', timestamp: ts(2) },
       { type: 'consensus', signal: 'agreement', agentId: 'rev', counterpartId: 'p', taskId: 'mid', evidence: 'x', timestamp: ts(5) },
       { type: 'consensus', signal: 'hallucination_caught', agentId: 'rev', counterpartId: 'p', taskId: 'newer', evidence: 'bad', timestamp: ts(1) },
-      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', taskId: 'newest', evidence: 'bad', timestamp: ts(0) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'rev', counterpartId: 'p', category: 'testing', taskId: 'newest', evidence: 'bad', timestamp: ts(0) },
     ]);
     const reader = new PerformanceReader(TEST_DIR);
     expect(reader.isCircuitOpen('rev')).toBe(true);
@@ -570,10 +576,12 @@ describe('PerformanceReader — circuit breaker: unique_unconfirmed removed from
   it('3 consecutive disagreement (loser) still bench: circuitOpen === true', () => {
     // disagreement remains in NEGATIVE_SIGNALS — agentId is the loser.
     // Only the loser gets a disagreement signal record; winner gets no streak tick.
+    // `category` is required for these to read as real verdicts rather than
+    // operational dispatch failures.
     writeSignals([
-      { type: 'consensus', signal: 'disagreement', agentId: 'agent-c', counterpartId: 'winner', taskId: 't1', evidence: 'bad', timestamp: ts(2) },
-      { type: 'consensus', signal: 'disagreement', agentId: 'agent-c', counterpartId: 'winner', taskId: 't2', evidence: 'bad', timestamp: ts(1) },
-      { type: 'consensus', signal: 'disagreement', agentId: 'agent-c', counterpartId: 'winner', taskId: 't3', evidence: 'bad', timestamp: ts(0) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'agent-c', counterpartId: 'winner', category: 'testing', taskId: 't1', evidence: 'bad', timestamp: ts(2) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'agent-c', counterpartId: 'winner', category: 'testing', taskId: 't2', evidence: 'bad', timestamp: ts(1) },
+      { type: 'consensus', signal: 'disagreement', agentId: 'agent-c', counterpartId: 'winner', category: 'testing', taskId: 't3', evidence: 'bad', timestamp: ts(0) },
     ]);
     const reader = new PerformanceReader(TEST_DIR);
     const score = reader.getAgentScore('agent-c')!;


### PR DESCRIPTION
## Summary

Failed dispatches (quota exhaustion, context overflow, model unavailable) are auto-recorded as `disagreement` rows with `signal_class: 'operational'` and no `category`. The accuracy loop already excluded them (PR 4 Part B guard), but the circuit-breaker streak builder did not — a run of infrastructure failures at an agent's tail opened its breaker and floored dispatch weight to 0.30.

**Observed incident (2026-07-27):** six consecutive google-quota failures benched sonnet-reviewer (accuracy 0.53 over 149 signals, positive trailing performance signal) at 0.30 dispatch weight.

## Change

- New shared predicate `isOperationalDisagreement` + type-predicate inverse `isScoringDisagreement` (defined in terms of it, so the accuracy arm and streak arm cannot drift).
- Streak builder skips operational disagreements with exact treat-as-absent semantics, mirroring the existing `transport_failure` exemption.
- 4-test regression suite (`performance-reader-operational-disagreement-breaker.test.ts`), mutation-verified: guard removal fails 3/4, over-broad predicate fails 2/4 — every mutant killed.
- Pre-existing chronology fixtures categorized to conform to the Part A stamping convention (additive only, zero assertions removed).

`NEGATIVE_SIGNALS`, `CIRCUIT_BREAKER_THRESHOLD`, accuracy arithmetic, and `transport_failure` handling unchanged. Read-side fix: wrongly-benched agents recover on the next `getScores()` call; no data migration.

## Consensus review

consensus_id: c2fb69d4-6a714a73 (3 agents: sonnet-reviewer, fable-reviewer, deepseek-challenger; 2 rounds)

10 confirmed, 2 disputed (both resolved), 2 unique-confirmed. Committed code verdict: correct, well-pinned, invariant #14 conformant. Confirmed follow-ups (tracked separately, not blocking):

1. **[high]** Uncategorized *synthesis* disagreements (real cross-review verdicts whose category resolution fails) are now excluded from the breaker too — the synthesis path never stamps `signal_class` (`consensus-engine.ts:1468-1479`). Follow-up: stamp `signal_class: 'performance'` on synthesis scoring rows and decide whether stamped-but-uncategorized verdicts should count toward the breaker.
2. **[low]** The `signal_class === 'operational'` axis of the predicate is unpinned by tests (deleting it passes all 61) — add one fixture with `{category, signal_class: 'operational'}`.
3. **[medium]** Three other classification surfaces (`getCountersSince` raw fallback, `classifyForAggregate`, dashboard `api-skills.ts`) still use inline category-only logic — consolidate onto the shared predicate to remove drift risk.

Full test suite: 373 suites / 5212 tests green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)