### PR TITLE
fix(signals): stamp signal_class at synthesis, restore breaker coverage

### DIFF
--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -1296,6 +1296,12 @@ Return only valid JSON.${skillsBlock}`;
       }
       signals.push({
         type: 'consensus',
+        // Scoring-class stamp. Category resolution is allowed to fail here (a
+        // logged, expected condition when review vocabulary matches no
+        // CATEGORY_PATTERNS entry) — the stamp is what tells the circuit breaker
+        // an uncategorized row is still a REAL verdict, not a dispatch failure.
+        // See performance-reader.isOperationalDisagreement, consensus c2fb69d4-6a714a73.
+        signal_class: 'performance',
         taskId: getTaskId(entry.originalAgentId),
         consensusId,
         signal: 'hallucination_caught',
@@ -1358,6 +1364,7 @@ Return only valid JSON.${skillsBlock}`;
         });
         signals.push({
           type: 'consensus',
+          signal_class: 'performance',
           taskId: getTaskId(entry.agentId),
           consensusId,
           signal: 'new_finding',
@@ -1386,6 +1393,7 @@ Return only valid JSON.${skillsBlock}`;
           }
           signals.push({
             type: 'consensus',
+            signal_class: 'performance',
             taskId: getTaskId(entry.agentId),
             consensusId,
             signal: 'agreement',
@@ -1439,6 +1447,7 @@ Return only valid JSON.${skillsBlock}`;
             }
             signals.push({
               type: 'consensus',
+              signal_class: 'performance',
               taskId: getTaskId(entry.agentId),
               consensusId,
               signal: 'hallucination_caught',
@@ -1467,6 +1476,10 @@ Return only valid JSON.${skillsBlock}`;
             }
             signals.push({
               type: 'consensus',
+              // Load-bearing: without this stamp an uncategorized synthesis
+              // disagreement is indistinguishable from a collect.ts dispatch
+              // failure and the circuit breaker silently skips a real verdict.
+              signal_class: 'performance',
               taskId: getTaskId(entry.agentId),
               consensusId,
               signal: 'disagreement',
@@ -1502,6 +1515,7 @@ Return only valid JSON.${skillsBlock}`;
           }
           signals.push({
             type: 'consensus',
+            signal_class: 'performance',
             taskId: getTaskId(entry.agentId),
             consensusId,
             signal: 'unverified',
@@ -1581,6 +1595,7 @@ Return only valid JSON.${skillsBlock}`;
             type: 'consensus',
             taskId: getTaskId(entry.originalAgentId),
             consensusId,
+            signal_class: 'performance',
             signal: 'unique_unconfirmed',
             agentId: entry.originalAgentId,
             evidence: capEvidence(`Confirmed finding has unresolvable citation (stale?): "${entry.finding.slice(0, 200)}"`),
@@ -1609,6 +1624,7 @@ Return only valid JSON.${skillsBlock}`;
             type: 'consensus',
             taskId: getTaskId(entry.originalAgentId),
             consensusId,
+            signal_class: 'performance',
             signal: 'unique_confirmed',
             agentId: entry.originalAgentId,
             evidence: capEvidence(entry.finding),
@@ -1640,6 +1656,7 @@ Return only valid JSON.${skillsBlock}`;
         // FIX 5: resolve category via fallback so getCountersSince counts this signal
         signals.push({
           type: 'consensus',
+          signal_class: 'performance',
           taskId: getTaskId(entry.originalAgentId),
           consensusId,
           signal: 'unique_unconfirmed',
@@ -1662,6 +1679,7 @@ Return only valid JSON.${skillsBlock}`;
         // FIX 5: resolve category via fallback so getCountersSince counts this signal
         signals.push({
           type: 'consensus',
+          signal_class: 'performance',
           taskId: getTaskId(entry.originalAgentId),
           consensusId,
           signal: 'unique_unconfirmed',

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -143,7 +143,7 @@ export type { HookInstallResult, DisciplineHookInstallResult, BootstrapHookInsta
 export { OverlapDetector } from './overlap-detector';
 export { LensGenerator } from './lens-generator';
 export { PerformanceWriter, rotateJsonlIfNeeded, MAX_TELEMETRY_BYTES } from './performance-writer';
-export { PerformanceReader, readJsonlWithRotated } from './performance-reader';
+export { PerformanceReader, readJsonlWithRotated, isOperationalClassRow } from './performance-reader';
 export {
   loadOrRebuildAggregateIndex,
   rebuildAggregateIndex,

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -230,37 +230,76 @@ const NEGATIVE_IMPL_SIGNALS = new Set(['impl_test_fail', 'impl_peer_rejected']);
 const SIGNAL_EXPIRY_DAYS = 30;
 
 /**
+ * Explicit operational-class stamp test — the ONE shared exclusion used by every
+ * accuracy-counting surface (`getCountersSince`'s raw fallback, the signal
+ * aggregate index rebuild, and the dashboard skill-effectiveness index).
+ *
+ * Per docs/HANDBOOK.md invariant #14 an operational-class row is telemetry: it
+ * describes a transport / lifecycle event, not a finding-evaluation verdict, and
+ * must never move a score. Kept deliberately narrow — it tests only the explicit
+ * stamp, so callers that also need the legacy category-absence heuristic
+ * (the circuit breaker) layer it on top rather than duplicating this check.
+ *
+ * Accepts a loose row shape so untyped JSONL readers (packages/relay's
+ * dashboard/api-skills.ts) can call it without casting.
+ */
+export function isOperationalClassRow(row: { signal_class?: unknown }): boolean {
+  return row.signal_class === 'operational';
+}
+
+/**
  * Operational-class `disagreement` predicate — the single source of truth shared
  * by the accuracy loop and the circuit-breaker streak builder so the two cannot
  * drift apart.
  *
  * A failed dispatch (quota exhaustion, context overflow, model unavailable) is
  * auto-recorded as a `disagreement` by apps/cli/src/handlers/collect.ts, carrying
- * `signal_class: 'operational'` and NO `category` — it describes a transport /
- * lifecycle failure, not a finding-evaluation verdict. Per docs/HANDBOOK.md
- * invariant #14 these rows are telemetry and must never move a score: excluded
- * from accuracy arithmetic AND from the circuit-breaker streak.
+ * `signal_class: 'operational'` and NO `category` — telemetry, excluded from
+ * accuracy arithmetic AND from the circuit-breaker streak.
  *
- * The category-absence test is load-bearing (it matches the accuracy loop's
- * established semantics and covers historical rows written before `signal_class`
- * stamping existed); the `signal_class` test is a belt-and-braces second axis.
+ * The stamp is authoritative in BOTH directions. Consensus synthesis stamps every
+ * scoring-class signal `signal_class: 'performance'`, and category resolution is
+ * allowed to fail there (review vocabulary that matches no CATEGORY_PATTERNS entry
+ * is a logged, expected condition) — so an uncategorized `performance` row is a
+ * REAL verdict and must still feed the breaker. Only unstamped legacy rows fall
+ * back to the category-absence heuristic.
+ *
+ * Behavior matrix (see also `isScoringDisagreement`):
+ *
+ *   signal_class   category   circuit breaker   accuracy arm
+ *   -----------    --------   ---------------   ------------
+ *   operational    any        excluded          excluded
+ *   performance    present    counted           scored
+ *   performance    absent     counted           skipped (cannot be bucketed)
+ *   (none)         absent     excluded          excluded   ← legacy operational
+ *   (none)         present    counted           scored     ← legacy verdict
  */
 function isOperationalDisagreement(signal: ConsensusSignal): boolean {
   if (signal.signal !== 'disagreement') return false;
-  return !signal.category || signal.signal_class === 'operational';
+  if (isOperationalClassRow(signal)) return true;
+  return !signal.signal_class && !signal.category;
 }
 
 /** A `disagreement` row that participates in scoring — always carries a category. */
 type ScoringDisagreement = ConsensusSignal & { signal: 'disagreement'; category: string };
 
 /**
- * Exact inverse of `isOperationalDisagreement` for `disagreement` rows, as a
- * type predicate so the accuracy arm can index `categoryHallucinated` without a
- * non-null assertion. Defined in terms of the shared predicate — it cannot
- * disagree with it.
+ * The accuracy arm's admission test for `disagreement` rows, as a type predicate
+ * so the arm can index `categoryHallucinated` without a non-null assertion.
+ *
+ * Stricter than `!isOperationalDisagreement` by exactly one axis: a truthy
+ * `category`. A `performance`-stamped uncategorized row is a real verdict (the
+ * breaker counts it) but cannot be category-bucketed, so the accuracy arm keeps
+ * skipping it — preserving the PR 4 Part B contract that uncategorized rows never
+ * touch weightedTotal/disagreements/categoryHallucinated.
  */
 function isScoringDisagreement(signal: ConsensusSignal): signal is ScoringDisagreement {
-  return signal.signal === 'disagreement' && !isOperationalDisagreement(signal);
+  return (
+    signal.signal === 'disagreement' &&
+    !isOperationalDisagreement(signal) &&
+    typeof signal.category === 'string' &&
+    signal.category.length > 0
+  );
 }
 
 /** Known consensus signal types — used to filter valid signals in computeScores */
@@ -704,6 +743,10 @@ export class PerformanceReader {
       // categoryStrengths/categoryHallucinated) — an empty-string category
       // should never satisfy a category-specific counter query.
       if (!s.category) continue;
+      // Operational-class rows are telemetry — never accuracy counters. Shares
+      // `isOperationalClassRow` with the aggregate-index rebuild and the
+      // dashboard skill index so the three surfaces cannot drift.
+      if (isOperationalClassRow(s)) continue;
       if (normalizeSkillName(s.category) !== normalizedTarget) continue;
       const ts = s.timestamp ? new Date(s.timestamp).getTime() : 0;
       if (!isFinite(ts) || ts === 0 || ts < sinceMs) continue;

--- a/packages/orchestrator/src/signal-aggregate-index.ts
+++ b/packages/orchestrator/src/signal-aggregate-index.ts
@@ -44,7 +44,7 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { ConsensusSignal } from './consensus-types';
-import { readJsonlWithRotated } from './performance-reader';
+import { isOperationalClassRow, readJsonlWithRotated } from './performance-reader';
 import { SAFE_NAME } from './skill-engine';
 
 export const SIDECAR_VERSION = 1;
@@ -391,6 +391,10 @@ export function rebuildAggregateIndex(projectRoot: string): SignalAggregateIndex
   for (const row of rows) {
     if (row.agentId === '_system') continue;
     if (!row.category) continue;
+    // Operational-class rows are telemetry — never accuracy counters. Same
+    // exclusion the raw fallback in performance-reader.getCountersSince applies,
+    // so the sidecar and the fallback agree row-for-row.
+    if (isOperationalClassRow(row)) continue;
     if (classifyForAggregate(row.signal) === 'none') continue;
     const taskKey = row.taskId || row.timestamp;
     if (retractedScoped.has(`${row.agentId}:${taskKey}:${row.signal}`)) continue;

--- a/packages/relay/src/dashboard/api-skills.ts
+++ b/packages/relay/src/dashboard/api-skills.ts
@@ -1,5 +1,5 @@
 import { SkillIndex, SkillIndexData } from '@gossip/orchestrator/skill-index';
-import { readJsonlWithRotated, normalizeSkillName, resolveSkill } from '@gossip/orchestrator';
+import { readJsonlWithRotated, normalizeSkillName, resolveSkill, isOperationalClassRow } from '@gossip/orchestrator';
 import { existsSync, statSync } from 'fs';
 import { join } from 'path';
 import type { SkillVerdict, SkillCurvePoint, SkillEffectivenessEntry } from '@gossip/types';
@@ -164,6 +164,9 @@ function buildSignalIndex(projectRoot: string): SignalIndex {
     const signal = r.signal as string | undefined;
     if (!signal) continue;
     if (!CORRECT_SIGNALS.has(signal) && !HALLUC_SIGNALS.has(signal)) continue;
+    // Operational-class rows are telemetry — never skill-effectiveness counters.
+    // Same shared exclusion the orchestrator's accuracy surfaces apply.
+    if (isOperationalClassRow(r)) continue;
     const agentId = r.agentId as string | undefined;
     const category = r.category as string | undefined;
     const tsStr = r.timestamp as string | undefined;

--- a/tests/orchestrator/consensus-engine-signal-class-stamp.test.ts
+++ b/tests/orchestrator/consensus-engine-signal-class-stamp.test.ts
@@ -1,0 +1,155 @@
+/**
+ * consensus-engine synthesis stamps `signal_class: 'performance'` on every
+ * scoring-class signal it emits.
+ *
+ * Why this matters (consensus c2fb69d4-6a714a73, stacks on 7b5528b2):
+ * `resolveSignalCategory` is allowed to return null — review vocabulary that
+ * matches no CATEGORY_PATTERNS entry is a logged, expected condition, and the
+ * signal is deliberately recorded with `category: undefined` rather than
+ * dropped. Without the stamp, such a row is byte-identical to the
+ * category-less `disagreement` that apps/cli/src/handlers/collect.ts writes for
+ * a failed dispatch, so performance-reader's circuit breaker classified a REAL
+ * verdict as operational telemetry and skipped it. The stamp is the only thing
+ * that distinguishes the two.
+ *
+ * See performance-reader.isOperationalDisagreement and its sibling suite
+ * performance-reader-operational-disagreement-breaker.test.ts.
+ */
+
+import { testRound } from '../../packages/orchestrator/src/round-context';
+import { ConsensusEngine, CrossReviewEntry } from '../../packages/orchestrator/src/consensus-engine';
+import { TaskEntry } from '../../packages/orchestrator/src/types';
+
+const makeEngine = () => new ConsensusEngine({
+  llm: { generate: jest.fn() } as any,
+  registryGet: (id: string) => ({ id, provider: 'local', model: 'test', preset: `preset-${id}`, skills: [] }),
+  round: testRound(),
+} as any);
+
+const makeTask = (agentId: string, result: string): TaskEntry => ({
+  id: `task-${agentId}`,
+  agentId,
+  task: 'review',
+  status: 'completed',
+  result,
+  startedAt: Date.now(),
+  completedAt: Date.now(),
+  inputTokens: 0,
+  outputTokens: 0,
+});
+
+/** Every signal synthesis emits for finding-evaluation outcomes. */
+const SCORING_SIGNALS = new Set([
+  'agreement',
+  'disagreement',
+  'unverified',
+  'unique_confirmed',
+  'unique_unconfirmed',
+  'new_finding',
+  'hallucination_caught',
+]);
+
+describe('ConsensusEngine.synthesize — signal_class stamping', () => {
+  it("stamps every scoring-class signal with signal_class: 'performance'", async () => {
+    const engine = makeEngine();
+
+    const resultA = makeTask(
+      'agent-a',
+      `<agent_finding type="finding" severity="high" category="injection_vectors">SQL injection at db.ts:42</agent_finding>
+<agent_finding type="finding" severity="medium" category="type_safety">Unchecked cast at parse.ts:17</agent_finding>
+<agent_finding type="finding" severity="low" category="error_handling">Swallowed error at run.ts:88</agent_finding>
+<agent_finding type="finding" severity="low" category="concurrency">Unawaited promise at pool.ts:12</agent_finding>`,
+    );
+    const resultB = makeTask(
+      'agent-b',
+      `<agent_finding type="finding" severity="low" category="observability">Missing log at util.ts:10</agent_finding>`,
+    );
+
+    // Exercise every cross-review action so each push site in the synthesis
+    // block fires at least once. agent-a:f4 gets no entry → unique_unconfirmed.
+    const crossReview: CrossReviewEntry[] = [
+      {
+        action: 'agree',
+        agentId: 'agent-b',
+        peerAgentId: 'agent-a',
+        findingId: 'agent-a:f1',
+        finding: 'SQL injection at db.ts:42',
+        evidence: 'Confirmed — input unsanitised before query',
+        confidence: 5,
+      },
+      {
+        action: 'disagree',
+        agentId: 'agent-b',
+        peerAgentId: 'agent-a',
+        findingId: 'agent-a:f2',
+        finding: 'Unchecked cast at parse.ts:17',
+        evidence: 'The cast is guarded by a typeof check on the line above',
+        confidence: 4,
+      },
+      {
+        action: 'unverified',
+        agentId: 'agent-b',
+        peerAgentId: 'agent-a',
+        findingId: 'agent-a:f3',
+        finding: 'Swallowed error at run.ts:88',
+        evidence: 'Could not locate the cited line',
+        confidence: 2,
+      },
+      {
+        action: 'new',
+        agentId: 'agent-b',
+        peerAgentId: 'agent-a',
+        finding: 'Unvalidated path join at loader.ts:31',
+        evidence: 'Path segments are concatenated without a traversal check',
+        confidence: 4,
+      },
+    ];
+
+    const report = await engine.synthesize([resultA, resultB], crossReview);
+
+    const scoring = report.signals.filter(s => SCORING_SIGNALS.has(s.signal));
+    // Guard against a vacuous pass if synthesis stops emitting these.
+    expect(scoring.length).toBeGreaterThanOrEqual(4);
+    const unstamped = scoring.filter(s => s.signal_class !== 'performance');
+    expect(unstamped.map(s => `${s.signal}/${s.agentId}`)).toEqual([]);
+  });
+
+  it("stamps a disagreement whose category resolution failed — the breaker's admission key", async () => {
+    const engine = makeEngine();
+
+    // Deliberately category-free vocabulary on both the finding and the
+    // evidence so resolveSignalCategory returns null and the signal is
+    // recorded with `category: undefined`.
+    const resultA = makeTask(
+      'agent-a',
+      `<agent_finding type="finding" severity="medium">The wording of the summary paragraph reads oddly</agent_finding>`,
+    );
+    const resultB = makeTask(
+      'agent-b',
+      `<agent_finding type="finding" severity="low" category="observability">Missing log at util.ts:10</agent_finding>`,
+    );
+
+    const crossReview: CrossReviewEntry[] = [
+      {
+        action: 'disagree',
+        agentId: 'agent-b',
+        peerAgentId: 'agent-a',
+        findingId: 'agent-a:f1',
+        finding: 'The wording of the summary paragraph reads oddly',
+        evidence: 'The phrasing matches the surrounding prose',
+        confidence: 4,
+      },
+    ];
+
+    const report = await engine.synthesize([resultA, resultB], crossReview);
+
+    const disagreement = report.signals.find(
+      s => s.signal === 'disagreement' && s.agentId === 'agent-b',
+    );
+    expect(disagreement).toBeDefined();
+    expect(disagreement!.category).toBeUndefined();
+    // Uncategorized but stamped: performance-reader must read this as a real
+    // verdict, not as a collect.ts dispatch failure.
+    expect(disagreement!.signal_class).toBe('performance');
+  });
+});

--- a/tests/orchestrator/performance-reader-operational-disagreement-breaker.test.ts
+++ b/tests/orchestrator/performance-reader-operational-disagreement-breaker.test.ts
@@ -14,6 +14,14 @@
  *   - real (categorized) negatives still do;
  *   - an operational row does NOT rehabilitate an already-open streak —
  *     it is treated as absent, exactly like `transport_failure`.
+ *
+ * Follow-up (consensus c2fb69d4-6a714a73, stacks on 7b5528b2) pins the two axes
+ * the original suite left unmeasured:
+ *   - the `signal_class: 'operational'` axis on its own (a stamped row WITH a
+ *     category is still excluded — mutating that clause away used to pass);
+ *   - the `signal_class: 'performance'` axis on its own (a synthesis-stamped row
+ *     WITHOUT a category is a real verdict: it feeds the breaker, but stays out
+ *     of the accuracy arm because it cannot be category-bucketed).
  */
 
 import { PerformanceReader } from '../../packages/orchestrator/src/performance-reader';
@@ -59,6 +67,45 @@ function operationalDisagreement(taskId: string, timestamp: string): any {
     taskId,
     agentId: AGENT,
     evidence: 'Task failed: Context window exceeded',
+    timestamp,
+  };
+}
+
+/**
+ * An operational disagreement that DOES carry a category — e.g. a collect.ts
+ * failure row whose evidence happened to resolve to a category. The explicit
+ * stamp is authoritative: still telemetry, still excluded everywhere.
+ */
+function categorizedOperationalDisagreement(taskId: string, timestamp: string): any {
+  return {
+    type: 'consensus',
+    signal: 'disagreement',
+    signal_class: 'operational',
+    taskId,
+    agentId: AGENT,
+    counterpartId: 'gemini-reviewer',
+    category: 'testing',
+    severity: 'medium',
+    evidence: 'Task failed: model unavailable',
+    timestamp,
+  };
+}
+
+/**
+ * A consensus-synthesis disagreement whose category resolution failed — a REAL
+ * finding-evaluation verdict carrying the `performance` stamp but no category.
+ * consensus-engine.ts stamps every synthesis push this way.
+ */
+function uncategorizedPerformanceDisagreement(taskId: string, timestamp: string): any {
+  return {
+    type: 'consensus',
+    signal: 'disagreement',
+    signal_class: 'performance',
+    taskId,
+    agentId: AGENT,
+    counterpartId: 'gemini-reviewer',
+    severity: 'medium',
+    evidence: 'peer disproved the finding; category resolution failed',
     timestamp,
   };
 }
@@ -179,5 +226,55 @@ describe('PerformanceReader — operational disagreements and the circuit breake
     const score = scoreFor();
     expect(score.consecutiveFailures).toBe(0);
     expect(score.circuitOpen).toBe(false);
+  });
+
+  it('excludes an operational-stamped disagreement even when it carries a category', () => {
+    // Pins the `signal_class === 'operational'` axis in isolation: with a
+    // category present, the category-absence heuristic cannot do the work, so
+    // only the stamp keeps these rows out of the breaker and the accuracy arm.
+    writeSignals([
+      positive('t-0', ts(0)),
+      positive('t-1', ts(1)),
+      positive('t-2', ts(2)),
+      categorizedOperationalDisagreement('t-3', ts(3)),
+      categorizedOperationalDisagreement('t-4', ts(4)),
+      categorizedOperationalDisagreement('t-5', ts(5)),
+    ]);
+
+    const score = scoreFor();
+    expect(score.consecutiveFailures).toBe(0);
+    expect(score.circuitOpen).toBe(false);
+    // Accuracy arm untouched: scoringSignals increments in lockstep with
+    // weightedTotal for disagreement rows, so only the three positives count.
+    expect(score.scoringSignals).toBe(3);
+    expect(score.disagreements).toBe(0);
+    expect(score.categoryHallucinated.testing).toBeUndefined();
+    expect(dispatchWeightFor()).toBeGreaterThan(0.3);
+  });
+
+  it('opens the breaker on performance-stamped disagreements that failed category resolution', () => {
+    // The regression this follow-up repairs: consensus synthesis records real
+    // verdicts with an undefined category whenever review vocabulary matches no
+    // CATEGORY_PATTERNS entry. Pre-stamp, the category-absence heuristic read
+    // those as dispatch failures and the breaker skipped them entirely.
+    writeSignals([
+      positive('t-0', ts(0)),
+      positive('t-1', ts(1)),
+      positive('t-2', ts(2)),
+      uncategorizedPerformanceDisagreement('t-3', ts(3)),
+      uncategorizedPerformanceDisagreement('t-4', ts(4)),
+      uncategorizedPerformanceDisagreement('t-5', ts(5)),
+    ]);
+
+    const score = scoreFor();
+    expect(score.consecutiveFailures).toBe(3);
+    expect(score.circuitOpen).toBe(true);
+    expect(dispatchWeightFor()).toBe(0.3);
+    // ...while the accuracy arm still skips them — an uncategorized row cannot
+    // be category-bucketed, so weightedTotal/disagreements stay untouched
+    // (PR 4 Part B contract). Only the three positives are scoring signals.
+    expect(score.scoringSignals).toBe(3);
+    expect(score.disagreements).toBe(0);
+    expect(Object.keys(score.categoryHallucinated)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
> Replaces #691, which GitHub auto-closed when its base branch (`fix/circuit-breaker-operational-disagreements`, PR #690) was deleted on merge. Same commit content, rebased onto the squashed master. Review history lives on #691.

## Summary

Follow-up to consensus round `c2fb69d4-6a714a73` on #690. That fix was correct for the quota-benching incident but narrowed circuit-breaker coverage in one respect: a **real** cross-review verdict whose category resolution fails was also being treated as operational and skipped.

Root cause: the consensus-engine synthesis path never stamped `signal_class`, so the reader's only signal was category-absence, which cannot distinguish "infrastructure failure" from "real verdict with unmatched vocabulary."

## Change

1. **Stamp the synthesis path** — all **10** scoring-class `signals.push` sites in `synthesize()` now carry `signal_class: 'performance'`. (The consensus round cited 3; the implementer found the other 7.) The `_round` `consensus_coverage_degraded` signal and `collect.ts` operational writes are untouched.
2. **Split the predicate along the stamp:**

   | `signal_class` | `category` | breaker | accuracy |
   |---|---|---|---|
   | `operational` | any | excluded | excluded |
   | `performance` | present | counted | scored |
   | `performance` | absent | **counted** | excluded |
   | (none) | absent | excluded | excluded (legacy) |
   | (none) | present | counted | scored |

   `isScoringDisagreement` is deliberately no longer the exact inverse of `isOperationalDisagreement` — it additionally requires a truthy category, which is what lets a performance-stamped uncategorized row count toward the breaker while never touching `weightedTotal`/`disagreements`/`categoryHallucinated`. Narrowing stays type-sound via an explicit `typeof … === 'string' && length > 0` check (no `!` assertion).
3. **Consolidate three drift-risk surfaces** onto one barrel-exported `isOperationalClassRow` helper: `getCountersSince` raw fallback, the aggregate-index rebuild, and the dashboard's `api-skills.ts`.
4. **Tests** — 4 pre-existing breaker tests byte-unchanged; 2 added (operational-stamp axis pin, performance-stamped-uncategorized regression); new `consensus-engine-signal-class-stamp.test.ts` drives the real `synthesize()` path end-to-end.

## Verification

Full `npm run build` at the repo root on the rebased commit: **exit 0**. Full `npm test` pre-rebase: **374 suites / 5216 tests passed**; post-rebase spot-check of the three affected suites: 65/65 pass.

## Review

consensus-id: f0a881eb-756e4580

**9 confirmed, 0 disputed, 6 unique-confirmed.** Both reviewers independently verified the behavior matrix, all 10 stamp sites, the three-surface consolidation, type-predicate soundness, and reproduced the full suite.

Follow-ups (tracked, not blocking):

| Sev | Item |
|---|---|
| medium | The three consolidated exclusions have **no pinning tests** — all three guard-deletion mutants survive; `buildSignalIndex` has zero test references. |
| medium | Manual `gossip_signals` `record` / `bulk_from_consensus` paths still write **unstamped scoring rows**, leaving the same over-match live for hand-recorded uncategorized disagreements. |
| low | `unverified` is stamped `performance` while `OPERATIONAL_SIGNAL_NAMES` still lists it — `classifySignal` has zero non-test call sites, so impact is nil today. |
| low | `SIDECAR_VERSION` left at 1: self-healing on next append, cutover write-dependent rather than deterministic. |

`deepseek-challenger` emitted zero parseable finding tags this round — treat it as an effectively 2-agent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
