### PR TITLE
fix(writer): escape the NUL map-key separator so the file stays greppable

### DIFF
--- a/packages/orchestrator/src/performance-writer.ts
+++ b/packages/orchestrator/src/performance-writer.ts
@@ -277,7 +277,7 @@ function resolveBoundAtMs(
   cache: Map<string, number>,
   fallbackMs: number,
 ): number {
-  const key = agentId + ' ' + category;
+  const key = agentId + '\u0000' + category;
   const cached = cache.get(key);
   if (cached !== undefined) {
     return cached === boundAtMissSentinel ? fallbackMs : cached;


### PR DESCRIPTION
## Problem

`packages/orchestrator/src/performance-writer.ts` contains a **literal NUL byte at offset 12059**, so `file` classifies the source as `data` and `grep -r` **silently skips it** — no match, no warning, exit 1.

```
$ file packages/orchestrator/src/performance-writer.ts
packages/orchestrator/src/performance-writer.ts: data

$ grep -rn "classifySignal" packages/orchestrator/src/ | wc -l
1

$ git grep -n "classifySignal" -- packages/orchestrator/src/ | wc -l
8
```

The NUL is **intentional** — a composite map-key separator in `resolveBoundAtMs` (line 280):

```ts
const key = agentId + '<literal NUL byte>' + category;
```

It was written as a raw byte instead of the escape `''`. Both forms are semantically identical at runtime; only the raw byte trips binary detection.

## Impact — this already caused two false consensus findings

In consensus round `f0a881eb-756e4580`, **two independent reviewers and the orchestrator** all reached wrong conclusions because the file was invisible to their greps:

1. **"The manual `gossip_signals` record/bulk paths write unstamped scoring rows."** False — `stampSignalClass` (`performance-writer.ts:137`, called at `:426`/`:504`) stamps `signal_class` at write time. Empirically: 528/528 manual-source scoring rows on disk carry `signal_class: 'performance'`.
2. **"`classifySignal` has zero non-test call sites."** False — it has 5 production call sites, all in this file (`:139`, `:446`, `:512`, `:541`, plus the import at `:4`).

Both findings were confirmed by cross-review before being caught by an implementer using `git grep`. Finding 1 required a signal retraction — and revealed a second bug: after retracting, the auto-dedup gate refuses to record the corrective `hallucination_caught` on the same `finding_id`, so a wrong verdict can be voided but never re-scored.

## Fix

Replace the raw byte with the escape sequence:

```ts
const key = agentId + '' + category;
```

Runtime behavior is unchanged; the file becomes text again and greppable by every tool.

## Suggested follow-ups

- Add a CI check rejecting NUL bytes in tracked `*.ts` sources.
- Prefer `git grep` over `grep -r` for premise verification in agent skills — it does not binary-skip tracked text. Worth adding to the `verify-the-premise` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
