### PR TITLE
test(signals): pin the three consolidated operational-class exclusions

### DIFF
--- a/packages/orchestrator/src/consensus-auto-verify.ts
+++ b/packages/orchestrator/src/consensus-auto-verify.ts
@@ -155,7 +155,7 @@ function buildAttemptSignal(args: {
   return {
     type: 'consensus',
     // Telemetry, never a scoring verdict. Stamped explicitly for symmetry with
-    // the `consensus_coverage_degraded` sibling (completion-signals.ts) so the
+    // the `consensus_coverage_degraded` sibling (consensus-engine.ts) so the
     // row-level `isOperationalClassRow` surfaces see the class without having
     // to re-derive it from the signal name.
     signal_class: 'operational',

--- a/packages/orchestrator/src/consensus-auto-verify.ts
+++ b/packages/orchestrator/src/consensus-auto-verify.ts
@@ -154,6 +154,11 @@ function buildAttemptSignal(args: {
 }): ConsensusSignal {
   return {
     type: 'consensus',
+    // Telemetry, never a scoring verdict. Stamped explicitly for symmetry with
+    // the `consensus_coverage_degraded` sibling (completion-signals.ts) so the
+    // row-level `isOperationalClassRow` surfaces see the class without having
+    // to re-derive it from the signal name.
+    signal_class: 'operational',
     signal: 'auto_verify_attempted',
     taskId: `${args.utilityTaskIdSeed}:auto-verify:${args.finding.id}`,
     consensusId: args.consensusId,
@@ -178,6 +183,8 @@ export function buildSkipSignal(args: {
 }): ConsensusSignal {
   return {
     type: 'consensus',
+    /** Telemetry — see `buildAttemptSignal` for why this is stamped explicitly. */
+    signal_class: 'operational',
     signal: 'auto_verify_skipped_misconfigured',
     taskId: `${args.utilityTaskIdSeed}:auto-verify:skip`,
     consensusId: args.consensusId,

--- a/packages/relay/src/dashboard/api-skills.ts
+++ b/packages/relay/src/dashboard/api-skills.ts
@@ -106,12 +106,12 @@ function readSkillFrontmatter(
 
 /* ── signal index (per-agent, per-normalized-skill) ────────────────────── */
 
-interface SignalEvent {
+export interface SignalEvent {
   ts: number;
   signal: string;
 }
 
-interface SignalIndex {
+export interface SignalIndex {
   /** agentId → normalizedSkill → events (chronological order). */
   byAgentSkill: Map<string, Map<string, SignalEvent[]>>;
 }
@@ -124,7 +124,13 @@ const CORRECT_SIGNALS = new Set([
 ]);
 const HALLUC_SIGNALS = new Set(['disagreement', 'hallucination_caught']);
 
-function buildSignalIndex(projectRoot: string): SignalIndex {
+/**
+ * Exported for direct test coverage of the row-level exclusions (the
+ * `isOperationalClassRow` guard below). Driving this through
+ * `skillsGetHandler` would require a full SkillIndex + frontmatter fixture and
+ * would not isolate the guard.
+ */
+export function buildSignalIndex(projectRoot: string): SignalIndex {
   const idx: SignalIndex = { byAgentSkill: new Map() };
   const perfPath = join(projectRoot, '.gossip', 'agent-performance.jsonl');
   if (!existsSync(perfPath)) return idx;

--- a/tests/orchestrator/operational-class-row-exclusion.test.ts
+++ b/tests/orchestrator/operational-class-row-exclusion.test.ts
@@ -24,14 +24,22 @@
 // HOW WE KNOW EACH TEST FAILS IF ITS GUARD LINE IS DELETED (no source mutation
 // was performed — this is the mutation-equivalence argument):
 //
-//   1. The operational fixture row and its positive control differ in EXACTLY
-//      one field: `signal_class`. Every other axis the filters read (type,
-//      signal, agentId, taskId, category, timestamp, retraction keys) is
+//   1. The operational fixture row and its positive control differ in exactly
+//      one field that any filter READS as a discriminator: `signal_class`.
+//      (They also differ in `agentId` and the derived `taskId`, which is what
+//      separates the two populations — but each surface is queried per-agent
+//      and the control proves the counted path works for its own agent, so
+//      neither field can substitute for the guard.) Every other axis the
+//      filters read (type, signal, category, timestamp, retraction keys) is
 //      identical.
-//   2. `signal_class` is read in exactly two places in the whole orchestrator:
-//      `isOperationalClassRow` (performance-reader.ts:247) and
-//      `isOperationalDisagreement` (:280). Neither signal-aggregate-index.ts nor
-//      the reader's `readSignalsRaw` inspects the field on its own;
+//   2. `signal_class` is read in three places in the orchestrator:
+//      `isOperationalClassRow` (performance-reader.ts:247),
+//      `isOperationalDisagreement` (:280), and `stampSignalClass`
+//      (performance-writer.ts:138). The third is unreachable here: it runs only
+//      inside PerformanceWriter's append methods, and these fixtures write the
+//      ledger directly with `fs.writeFileSync`, bypassing the writer entirely.
+//      Neither signal-aggregate-index.ts nor the reader's `readSignalsRaw`
+//      inspects the field on its own;
 //      `isOperationalDisagreement` is reached only from `computeScores`, which
 //      neither surface under test calls.
 //   3. So on both paths the ONLY code that can distinguish the two rows is the

--- a/tests/orchestrator/operational-class-row-exclusion.test.ts
+++ b/tests/orchestrator/operational-class-row-exclusion.test.ts
@@ -1,0 +1,167 @@
+// tests/orchestrator/operational-class-row-exclusion.test.ts
+//
+// Pins the row-level `signal_class: 'operational'` exclusion on the two
+// orchestrator-side accuracy surfaces consolidated by PR #692:
+//
+//   a. PerformanceReader.getCountersSince  — performance-reader.ts raw fallback
+//   b. rebuildAggregateIndex               — signal-aggregate-index.ts rebuild loop
+//
+// (The third surface, packages/relay's dashboard `buildSignalIndex`, is pinned
+// by tests/relay/api-skills-operational-class-exclusion.test.ts.)
+//
+// WHY THIS FILE EXISTS: consensus f0a881eb-756e4580:f11 found that deleting any
+// of the three `isOperationalClassRow(...)` guards left the whole suite green.
+// The pre-existing signal-aggregate-index tests only feed operational SIGNAL
+// NAMES (task_timeout / transport_failure / boundary_escape), which
+// `classifyForAggregate` already maps to 'none' — so they short-circuit on the
+// NEXT line and cannot distinguish the guard's presence.
+//
+// The discriminating fixture is therefore a row that is operational by CLASS but
+// looks like a scoring verdict by every other axis: a scoring signal NAME
+// ('agreement' / 'hallucination_caught'), a truthy `category`, a live timestamp,
+// and no retraction. Only the class stamp keeps it out.
+//
+// HOW WE KNOW EACH TEST FAILS IF ITS GUARD LINE IS DELETED (no source mutation
+// was performed — this is the mutation-equivalence argument):
+//
+//   1. The operational fixture row and its positive control differ in EXACTLY
+//      one field: `signal_class`. Every other axis the filters read (type,
+//      signal, agentId, taskId, category, timestamp, retraction keys) is
+//      identical.
+//   2. `signal_class` is read in exactly two places in the whole orchestrator:
+//      `isOperationalClassRow` (performance-reader.ts:247) and
+//      `isOperationalDisagreement` (:280). Neither signal-aggregate-index.ts nor
+//      the reader's `readSignalsRaw` inspects the field on its own;
+//      `isOperationalDisagreement` is reached only from `computeScores`, which
+//      neither surface under test calls.
+//   3. So on both paths the ONLY code that can distinguish the two rows is the
+//      guard line under test.
+//   4. The control assertions below prove the control row IS counted / folded.
+//      Deleting the guard therefore makes the operational row take the control's
+//      path and produce the control's numbers, breaking the exclusion assertion.
+//
+// The control is thus the empirical half of the proof: if a fixture silently
+// stopped reaching the guard, the control would stop being counted too and fail
+// loudly instead of letting the exclusion test pass vacuously.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { PerformanceReader, rebuildAggregateIndex } from '@gossip/orchestrator';
+
+const CATEGORY = 'testing';
+const OPERATIONAL_AGENT = 'ops-agent';
+const CONTROL_AGENT = 'control-agent';
+
+/** Fixed clock so `sinceMs` windows and bucket keys are deterministic. */
+const NOW_MS = Date.UTC(2026, 6, 20, 12, 0, 0);
+const SINCE_MS = NOW_MS - 60 * 60 * 1000;
+
+interface RowOverrides {
+  agentId: string;
+  signal: 'agreement' | 'hallucination_caught';
+  signal_class?: 'operational' | 'performance';
+}
+
+function row(o: RowOverrides): Record<string, unknown> {
+  return {
+    type: 'consensus',
+    signal: o.signal,
+    signal_class: o.signal_class,
+    agentId: o.agentId,
+    taskId: `task-${o.agentId}-${o.signal}`,
+    category: CATEGORY,
+    severity: 'medium',
+    evidence: 'fixture row',
+    timestamp: new Date(NOW_MS).toISOString(),
+  };
+}
+
+/**
+ * Writes agent-performance.jsonl ONLY — deliberately no aggregate sidecar. See
+ * the note on the getCountersSince test for why that matters.
+ */
+function seedProjectRoot(prefix: string, rows: Array<Record<string, unknown>>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  fs.mkdirSync(path.join(root, '.gossip'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, '.gossip', 'agent-performance.jsonl'),
+    rows.map(r => JSON.stringify(r)).join('\n') + '\n',
+  );
+  return root;
+}
+
+const FIXTURE_ROWS = [
+  // Operational by class, scoring by every other axis.
+  row({ agentId: OPERATIONAL_AGENT, signal: 'agreement', signal_class: 'operational' }),
+  row({ agentId: OPERATIONAL_AGENT, signal: 'hallucination_caught', signal_class: 'operational' }),
+  // Positive control — identical shape, scoring class.
+  row({ agentId: CONTROL_AGENT, signal: 'agreement', signal_class: 'performance' }),
+  row({ agentId: CONTROL_AGENT, signal: 'hallucination_caught', signal_class: 'performance' }),
+];
+
+describe('operational-class row exclusion (consensus f0a881eb-756e4580:f11)', () => {
+  const roots: string[] = [];
+
+  afterAll(() => {
+    for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+  });
+
+  function makeRoot(prefix: string): string {
+    const root = seedProjectRoot(prefix, FIXTURE_ROWS);
+    roots.push(root);
+    return root;
+  }
+
+  describe('(a) PerformanceReader.getCountersSince', () => {
+    // Sidecar fast path: `getCountersSince` consults `readAggregateIndex` first
+    // and only falls through to the per-row raw scan when there is no usable
+    // sidecar. This fixture writes NO `.gossip/signal-aggregate-index.json`, so
+    // `readAggregateIndex` returns null and the raw fallback — the branch that
+    // holds the `isOperationalClassRow` guard — is the one under test.
+    //
+    // Deliberate choice: the guard lives ONLY on the raw fallback. Asserting
+    // through the sidecar would exercise `rebuildAggregateIndex`'s guard
+    // instead (covered separately below) and would pass even if the raw
+    // fallback's guard were deleted.
+
+    it('does not count operational-class rows even when they carry a category', () => {
+      const reader = new PerformanceReader(makeRoot('gossip-counters-op-'));
+      expect(reader.getCountersSince(OPERATIONAL_AGENT, CATEGORY, SINCE_MS)).toEqual({
+        correct: 0,
+        hallucinated: 0,
+      });
+    });
+
+    it('positive control — the same rows stamped performance ARE counted', () => {
+      const reader = new PerformanceReader(makeRoot('gossip-counters-ctl-'));
+      expect(reader.getCountersSince(CONTROL_AGENT, CATEGORY, SINCE_MS)).toEqual({
+        correct: 1,
+        hallucinated: 1,
+      });
+    });
+  });
+
+  describe('(b) rebuildAggregateIndex', () => {
+    it('folds no bucket for an agent whose only rows are operational-class', () => {
+      const data = rebuildAggregateIndex(makeRoot('gossip-rebuild-op-'));
+      const buckets = data.agents[OPERATIONAL_AGENT];
+      // Either the agent is absent entirely or it has no bucket for the category.
+      expect(buckets?.[CATEGORY]).toBeUndefined();
+    });
+
+    it('positive control — performance-class rows DO produce a bucket', () => {
+      const data = rebuildAggregateIndex(makeRoot('gossip-rebuild-ctl-'));
+      const categoryBuckets = data.agents[CONTROL_AGENT]?.[CATEGORY];
+      expect(categoryBuckets).toBeDefined();
+      const totals = Object.values(categoryBuckets ?? {}).reduce(
+        (acc, b) => ({
+          correct: acc.correct + b.correct,
+          hallucinated: acc.hallucinated + b.hallucinated,
+        }),
+        { correct: 0, hallucinated: 0 },
+      );
+      expect(totals).toEqual({ correct: 1, hallucinated: 1 });
+    });
+  });
+});

--- a/tests/relay/api-skills-operational-class-exclusion.test.ts
+++ b/tests/relay/api-skills-operational-class-exclusion.test.ts
@@ -1,0 +1,81 @@
+// tests/relay/api-skills-operational-class-exclusion.test.ts
+//
+// Pins the third `isOperationalClassRow` guard consolidated by PR #692 — the
+// one in packages/relay's dashboard skill-effectiveness index
+// (dashboard/api-skills.ts `buildSignalIndex`).
+//
+// Before this file, `buildSignalIndex` was imported by NO test anywhere; it was
+// module-private and only reachable through `skillsGetHandler`, which needs a
+// full SkillIndex + skill-frontmatter fixture and would not isolate the guard.
+// It is now exported (minimal change) so the exclusion can be asserted directly.
+//
+// HOW WE KNOW THIS FAILS IF THE GUARD IS DELETED (no source mutation was
+// performed): the operational fixture row and its positive control differ in
+// exactly one field, `signal_class`. `buildSignalIndex` reads that field only
+// via the imported `isOperationalClassRow` — `git grep signal_class -- api-skills.ts`
+// returns no other hit. So the guard is the sole discriminator between the two
+// rows; the control assertion proves the control row IS indexed, therefore
+// deleting the guard makes the operational row indexed too and the exclusion
+// assertion fails.
+//
+// Consensus f0a881eb-756e4580:f11.
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { buildSignalIndex } from '../../packages/relay/src/dashboard/api-skills';
+
+const CATEGORY = 'testing';
+const OPERATIONAL_AGENT = 'ops-agent';
+const CONTROL_AGENT = 'control-agent';
+const NOW_ISO = new Date(Date.UTC(2026, 6, 20, 12, 0, 0)).toISOString();
+
+function row(agentId: string, signal: string, signalClass: 'operational' | 'performance') {
+  return {
+    type: 'consensus',
+    signal,
+    signal_class: signalClass,
+    agentId,
+    taskId: `task-${agentId}-${signal}`,
+    category: CATEGORY,
+    timestamp: NOW_ISO,
+  };
+}
+
+function setupRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'gossip-skills-opclass-'));
+  mkdirSync(join(root, '.gossip'), { recursive: true });
+  const rows = [
+    // Operational by class, scoring by every other axis: a signal name in
+    // CORRECT_SIGNALS/HALLUC_SIGNALS, a truthy category, a live timestamp and
+    // no retraction. Only the class stamp keeps it out of the index.
+    row(OPERATIONAL_AGENT, 'agreement', 'operational'),
+    row(OPERATIONAL_AGENT, 'hallucination_caught', 'operational'),
+    // Positive control — identical shape, scoring class.
+    row(CONTROL_AGENT, 'agreement', 'performance'),
+    row(CONTROL_AGENT, 'hallucination_caught', 'performance'),
+  ];
+  writeFileSync(
+    join(root, '.gossip', 'agent-performance.jsonl'),
+    rows.map(r => JSON.stringify(r)).join('\n') + '\n',
+  );
+  return root;
+}
+
+describe('buildSignalIndex — operational-class row exclusion', () => {
+  let root: string;
+
+  beforeAll(() => { root = setupRoot(); });
+  afterAll(() => { rmSync(root, { recursive: true, force: true }); });
+
+  it('drops operational-class rows even when they carry a category', () => {
+    const idx = buildSignalIndex(root);
+    expect(idx.byAgentSkill.get(OPERATIONAL_AGENT)).toBeUndefined();
+  });
+
+  it('positive control — the same rows stamped performance ARE indexed', () => {
+    const idx = buildSignalIndex(root);
+    const events = idx.byAgentSkill.get(CONTROL_AGENT)?.get(CATEGORY);
+    expect(events?.map(e => e.signal).sort()).toEqual(['agreement', 'hallucination_caught']);
+  });
+});


### PR DESCRIPTION
consensus-id: 733aa54b-21ef4e67

> Stacked on #692 (`fix/signal-class-stamp-synthesis`, commit `664b6dff`). Merge #692 first — **without `--delete-branch`**, which auto-closes stacked children.

## Summary

Closes the confirmed test-coverage gap from consensus `f0a881eb-756e4580:f11`: the three `isOperationalClassRow` guards that #692 introduced had **zero** test coverage — deleting any of them left the entire suite green.

The pre-existing `signal-aggregate-index` fixtures could not catch this, because they use operational *signal names* (`task_timeout`, `transport_failure`, `boundary_escape`) which `classifyForAggregate` maps to `'none'` one line **after** the guard. This adds fixtures that are operational **by class stamp** while being scoring rows on every other axis — the only shape that discriminates.

## Changes

- `tests/orchestrator/operational-class-row-exclusion.test.ts` (new) — pins `getCountersSince`'s raw-scan fallback and `rebuildAggregateIndex`.
- `tests/relay/api-skills-operational-class-exclusion.test.ts` (new) — pins `buildSignalIndex`.
- `packages/relay/src/dashboard/api-skills.ts` — exports `buildSignalIndex` (+ `SignalIndex`/`SignalEvent`), which was module-private and imported by no test. Export-only; no logic change, not added to any package barrel.
- `packages/orchestrator/src/consensus-auto-verify.ts` — stamps `signal_class: 'operational'` on `buildAttemptSignal`/`buildSkipSignal` for symmetry with the already-stamped `consensus_coverage_degraded` sibling.

Each test carries a positive control asserting a non-operational row with the same category **is** counted, so it proves discrimination rather than universal exclusion.

## Verification

Full `npm run build` at the repo root: **exit 0**. Full `npm test`: **377 suites / 5231 tests** passing.

> Note for anyone reproducing locally: `npm run build` does not rebuild `dist-mcp`. If `tests/cli/mcp-server-code-dispatch.test.ts` fails, run `npm run build:mcp` first — that suite tests the built binary and a stale bundle fails it independently of any source change.

## Review — consensus `733aa54b-21ef4e67`

3 agents, 2 rounds. **7 confirmed, 4 disputed, 2 new.** No blocking findings; every dispute was citation precision with agreed substance.

Two comment corrections raised in review are already applied in `d9f2ba26`:
- The `consensus_coverage_degraded` sibling was misattributed to `completion-signals.ts`; it's emitted in `consensus-engine.ts`.
- The mutation-equivalence proof comment claimed "exactly two reads" of `signal_class` (there are three — `stampSignalClass` at `performance-writer.ts:138`) and "differ in exactly one field" (they also differ in `agentId`/`taskId`). The conclusion survives; the premises are now literally true.

### Follow-ups (not addressed here)

| Sev | Item |
|---|---|
| low | **Fourth exclusion surface unguarded.** `deriveAggregateKey` (`performance-writer.ts:241-251`) folds rows into the sidecar at write time filtering only on type / `_system` / category / `classifyForAggregate` / timestamp — it never reads `signal_class`. A row with a scoring name + category + `signal_class:'operational'` would be folded **in** while both read surfaces exclude it, so the sidecar fast path disagrees with the rebuild until the next full rebuild. Currently unreachable only because `collect.ts:399-414` emits such rows without a category; adding category inference there makes it live and silently defeats the "three surfaces cannot drift" invariant. |
| low | The proof would be airtight with a single-agent/single-category fixture (2 operational + 2 performance, differing only in `signal_class`): guard present → 1/1, deleted → 2/2. Removes the cross-agent correlation caveat entirely. |
| low | The relay test's hard-coded monorepo-relative import path is fragile if the package is ever extracted. Test-only. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
