### PR TITLE
feat(signals): add design_split — record an unresolved design disagreement without debiting either agent

### DIFF
--- a/apps/cli/src/handlers/operational-lesson-id.ts
+++ b/apps/cli/src/handlers/operational-lesson-id.ts
@@ -1,6 +1,6 @@
 /**
  * Operational (session-scoped) `finding_id` grammar for `gossip_signals`.
- * Issue #668.
+ * Issue #668, extended for `design_split` by issue #678.
  *
  * ## Why a second shape exists
  *
@@ -52,6 +52,25 @@
  * lesson-less operational signal is a row that can never be read back by
  * `gossip_remember` and never affects anything. That is noise, and the contract
  * rejects it up front rather than persisting it.
+ *
+ * ## `design_split` — the one signal that accepts BOTH grammars
+ *
+ * Issue #678. An unresolved design disagreement can arise in two places, and
+ * both are legitimate:
+ *
+ *  - inside a consensus round, where the split has a real consensus id and the
+ *    consensus-scoped shape is the accurate anchor; or
+ *  - in a PARALLEL (non-consensus) dispatch, which produces no consensus id at
+ *    all. Recording that split today required minting a synthetic
+ *    `<taskA>-<taskB>` pair purely to satisfy the regex — the same "fake an
+ *    audit trail" failure the session-scoped shape was introduced to end.
+ *
+ * So `design_split` accepts EITHER shape, unlike `operational_lesson` which is
+ * session-only. That does not soften either grammar: each is still parsed by
+ * its own validator and a value matching NEITHER is still rejected. It only
+ * means the disjointness rule is stated per-signal — the shapes themselves stay
+ * disjoint (a consensus id can never start with the literal `session:`), so
+ * there is never ambiguity about which grammar a given id used.
  */
 
 import { SAFE_NAME } from '@gossip/orchestrator';
@@ -59,8 +78,29 @@ import { SAFE_NAME } from '@gossip/orchestrator';
 /** The one signal name that carries an operator-authored process lesson. */
 export const OPERATIONAL_LESSON_SIGNAL = 'operational_lesson';
 
+/** Unresolved, defensible design disagreement between two agents (issue #678). */
+export const DESIGN_SPLIT_SIGNAL = 'design_split';
+
 /** Literal keyword that opens a session-scoped finding_id. */
 export const OPERATIONAL_ID_PREFIX = 'session:';
+
+/**
+ * Record-surface signal names that are operational-class: `gossip_signals`
+ * stamps `signal_class: 'operational'` on them and `performance-reader.ts`
+ * drops them before every scoring pass, so they move no score for anyone.
+ *
+ * Deliberately a hand-listed set rather than a `classifySignal()` call. That
+ * classifier also returns `'operational'` for auto-fired rows (`task_timeout`,
+ * `transport_failure`, …) which the record surface does not accept, and
+ * returns `'performance'` for the eight scoring names — stamping those would
+ * flip previously-unstamped manual rows from the legacy category-absence
+ * heuristic onto the explicit-stamp path and change circuit-breaker behaviour.
+ * The narrow set keeps this PR's blast radius to the two names it adds.
+ */
+export const OPERATIONAL_RECORD_SIGNALS: ReadonlySet<string> = new Set([
+  OPERATIONAL_LESSON_SIGNAL,
+  DESIGN_SPLIT_SIGNAL,
+]);
 
 /** Human-readable description of BOTH accepted finding_id shapes. */
 export const FINDING_ID_FORMS_HELP =
@@ -68,7 +108,9 @@ export const FINDING_ID_FORMS_HELP =
   '(e.g. "b81956b2-e0fa4ea4:sonnet-reviewer:f1") for consensus signals, or ' +
   '(b) a session-scoped id session:<sessionId>:<slug> ' +
   '(e.g. "session:2026-07-26-a38286c2:relay-window-expired") for signal ' +
-  '"operational_lesson". Both <sessionId> and <slug> must match ' +
+  '"operational_lesson" (session form REQUIRED) or "design_split" (either form ' +
+  'accepted — use (b) for splits from a parallel, non-consensus dispatch). ' +
+  'Both <sessionId> and <slug> must match ' +
   `${SAFE_NAME.source} (lowercase alphanumerics plus _ and -, max 63 chars).`;
 
 /**
@@ -111,6 +153,29 @@ export function isOperationalLessonSignal(signal: string): boolean {
   return signal === OPERATIONAL_LESSON_SIGNAL;
 }
 
+/** True when this signal name records an unresolved design split. */
+export function isDesignSplitSignal(signal: string): boolean {
+  return signal === DESIGN_SPLIT_SIGNAL;
+}
+
+/** True when `gossip_signals` should stamp `signal_class: 'operational'`. */
+export function isOperationalRecordSignal(signal: string): boolean {
+  return OPERATIONAL_RECORD_SIGNALS.has(signal);
+}
+
+/**
+ * True when this signal name may carry a session-scoped `finding_id`.
+ *
+ * Coincides with `OPERATIONAL_RECORD_SIGNALS` today, but is a SEPARATE
+ * predicate on purpose: "is unscored" and "may use the session grammar" are
+ * independent contracts that happen to hold for the same two names right now.
+ * A future unscored signal that is always consensus-anchored would change one
+ * and not the other.
+ */
+export function acceptsSessionScopedFindingId(signal: string): boolean {
+  return isOperationalLessonSignal(signal) || isDesignSplitSignal(signal);
+}
+
 /** Minimal shape `validateOperationalLessonSignal` needs from a signal input. */
 export interface OperationalLessonInput {
   signal: string;
@@ -124,10 +189,12 @@ export interface OperationalLessonInput {
  *
  * Returns an error string to return verbatim to the caller, or `null` when the
  * signal is fine to continue validating on the consensus path. Fail-closed in
- * both directions:
+ * every direction:
  *  - an `operational_lesson` MUST carry a valid session-scoped id and a lesson;
- *  - a NON-operational signal must NOT carry a session-scoped id, so the two
- *    shapes cannot be used interchangeably to dodge either gate.
+ *  - a `design_split` MAY carry either shape, but a MALFORMED session-scoped id
+ *    is still rejected — "accepts either" never means "accepts anything";
+ *  - any other signal must NOT carry a session-scoped id, so the two shapes
+ *    cannot be used interchangeably to dodge either gate.
  *
  * The consensus-scoped shape is deliberately untouched by this function — it is
  * still validated by `FINDING_ID_PREFIX` in the handler, exactly as before.
@@ -138,8 +205,14 @@ export function validateOperationalLessonSignal(s: OperationalLessonInput): stri
     : parseOperationalFindingId(s.finding_id);
 
   if (!isOperationalLessonSignal(s.signal)) {
-    if (parsed.kind !== 'not_operational') {
-      return `Error: finding_id "${s.finding_id}" uses the session-scoped form, which is only valid for signal "${OPERATIONAL_LESSON_SIGNAL}" (received "${s.signal}", agent: ${s.agent_id}). ${FINDING_ID_FORMS_HELP}`;
+    if (parsed.kind === 'invalid' && acceptsSessionScopedFindingId(s.signal)) {
+      // Opted into the session grammar and got it wrong. Report the parse
+      // reason rather than falling through to the consensus-prefix check,
+      // whose message ("expected <8hex>-<8hex>") would misdiagnose it.
+      return `Error: malformed finding_id "${s.finding_id}" (agent: ${s.agent_id}) — ${parsed.reason}. ${FINDING_ID_FORMS_HELP}`;
+    }
+    if (parsed.kind !== 'not_operational' && !acceptsSessionScopedFindingId(s.signal)) {
+      return `Error: finding_id "${s.finding_id}" uses the session-scoped form, which is only valid for signals "${OPERATIONAL_LESSON_SIGNAL}" and "${DESIGN_SPLIT_SIGNAL}" (received "${s.signal}", agent: ${s.agent_id}). ${FINDING_ID_FORMS_HELP}`;
     }
     return null;
   }

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -325,6 +325,10 @@ import { handleCollect } from './handlers/collect';
 import {
   validateOperationalLessonSignal,
   isOperationalLessonSignal,
+  isDesignSplitSignal,
+  isOperationalRecordSignal,
+  acceptsSessionScopedFindingId,
+  parseOperationalFindingId,
   FINDING_ID_FORMS_HELP,
 } from './handlers/operational-lesson-id';
 import { restorePendingConsensus } from './handlers/relay-cross-review';
@@ -3426,13 +3430,13 @@ export function createMcpServer(): McpServer {
       task_id: z.string().optional().describe('Task ID to link signals to. For record: optional (synthetic ID if omitted). For per-signal retract: required.'),
       task_start_time: z.string().optional().describe('ISO-8601 timestamp of the underlying task/consensus round. Used as the per-batch fallback timestamp so bulk-recording from a backlog preserves true chronology. Falls back to wall-clock if omitted.'),
       signals: z.array(z.object({
-        signal: z.enum(['agreement', 'disagreement', 'unique_confirmed', 'unique_unconfirmed', 'new_finding', 'hallucination_caught', 'impl_test_pass', 'impl_test_fail', 'impl_peer_approved', 'impl_peer_rejected', 'operational_lesson'])
-          .describe('Signal type: agreement (both agree), disagreement (one wrong), unique_confirmed (only one found it + verified), unique_unconfirmed (only one found it, unverified), new_finding (discovered during cross-review), hallucination_caught (fabricated finding), impl_test_pass/fail (write-mode task outcome), impl_peer_approved/rejected (peer code review verdict), operational_lesson (operator-authored PROCESS failure — no consensus round; requires finding_id "session:<sessionId>:<slug>" and a non-empty lesson; never affects accuracy scoring)'),
+        signal: z.enum(['agreement', 'disagreement', 'unique_confirmed', 'unique_unconfirmed', 'new_finding', 'hallucination_caught', 'impl_test_pass', 'impl_test_fail', 'impl_peer_approved', 'impl_peer_rejected', 'operational_lesson', 'design_split'])
+          .describe('Signal type: agreement (both agree), disagreement (one wrong), unique_confirmed (only one found it + verified), unique_unconfirmed (only one found it, unverified), new_finding (discovered during cross-review), hallucination_caught (fabricated finding), impl_test_pass/fail (write-mode task outcome), impl_peer_approved/rejected (peer code review verdict), operational_lesson (operator-authored PROCESS failure — no consensus round; requires finding_id "session:<sessionId>:<slug>" and a non-empty lesson; never affects accuracy scoring), design_split (two agents reached OPPOSED but DEFENSIBLE conclusions on a trade-off that reading code cannot settle — records BOTH sides and scores NEITHER. counterpart_id is REQUIRED; `finding` must state BOTH positions, not just one; category is optional. Accepts either finding_id shape, so a split from a parallel non-consensus dispatch can use "session:<sessionId>:<slug>". Use this INSTEAD of disagreement whenever no side has been shown wrong — "disagreement" means "one wrong" and debits accuracy. RESOLUTION IS A SEPARATE, LATER SIGNAL: if one side is subsequently shown wrong, record a normal scoring disagreement/hallucination_caught against the SAME finding_id; the split row stays as the audit trail of what was unresolved at the time)'),
         agent_id: z.string().describe('Agent being evaluated'),
         counterpart_id: z.string().optional().describe('The other agent involved (e.g., who won the disagreement)'),
         finding: z.string().describe('Brief description of the finding'),
         lesson: z.string().optional().describe('Root-cause narrative for a terminal correction signal — 1-2 sentences on why it failed and the check that would have caught it. Written verbatim into the discovering agent\'s lesson card (issue #642 A).'),
-        finding_id: z.string().optional().describe('Finding ID. Two accepted shapes: (a) consensus-scoped "<8hex>-<8hex>:<agent>:fN" — links this signal to a specific finding in a consensus report, enabling the dashboard to resolve UNVERIFIED findings; (b) session-scoped "session:<sessionId>:<slug>" — REQUIRED and only valid for signal "operational_lesson". Both <sessionId> and <slug> must be safe path segments; a path-unsafe value is rejected, never sanitized.'),
+        finding_id: z.string().optional().describe('Finding ID. Two accepted shapes: (a) consensus-scoped "<8hex>-<8hex>:<agent>:fN" — links this signal to a specific finding in a consensus report, enabling the dashboard to resolve UNVERIFIED findings; (b) session-scoped "session:<sessionId>:<slug>" — REQUIRED for signal "operational_lesson", OPTIONAL for "design_split" (which accepts either shape, so splits from parallel non-consensus dispatches need no synthetic consensus id), and rejected on every other signal. Both <sessionId> and <slug> must be safe path segments; a path-unsafe value is rejected, never sanitized.'),
         cross_cutting: z.boolean().optional().describe('Explicit opt-in (no heuristic), VALID ONLY on signal "operational_lesson": file this signal\'s lesson card in the shared .gossip/agents/_project/memory/knowledge/ instead of the recording agent\'s own knowledge dir. Use for lessons every contributor needs (e.g. "a dist-mcp bundle built inside a git worktree is always broken"). Ignored (with a log line) on consensus verdict signals such as hallucination_caught — those are per-agent findings and must not be published as shared blame cards. The signal row itself stays attributed to agent_id; only the card moves, and it records origin_agent in frontmatter.'),
         severity: z.enum(['critical', 'high', 'medium', 'low']).optional().describe('Finding severity for impact scoring. If omitted, defaults to medium.'),
         category: z.string().optional().describe('Finding category for ATI competency profiles (e.g., concurrency, trust_boundaries, injection_vectors, resource_exhaustion, type_safety, error_handling, data_integrity, input_validation)'),
@@ -3740,7 +3744,11 @@ export function createMcpServer(): McpServer {
         const batchFallback = task_start_time || wallClock;
         const MAX_EVIDENCE_LENGTH = 2000;
         const PUNITIVE_SIGNALS = new Set(['hallucination_caught', 'disagreement']);
-        const COUNTERPART_REQUIRED = new Set(['agreement', 'disagreement', 'impl_peer_approved', 'impl_peer_rejected']);
+        // `design_split` is in this set because naming both sides is the whole
+        // point: a split with one side recorded is indistinguishable from a
+        // verdict, and the second agent would silently vanish from the audit
+        // trail of a disagreement it was half of. Issue #678.
+        const COUNTERPART_REQUIRED = new Set(['agreement', 'disagreement', 'impl_peer_approved', 'impl_peer_rejected', 'design_split']);
 
         // finding_id schema gate. TWO shapes are accepted, and only two:
         //
@@ -3751,9 +3759,12 @@ export function createMcpServer(): McpServer {
         //       unchanged: a malformed value silently breaks round-retraction
         //       prefix-match (performance-reader.ts) and resolve scoping.
         //   (b) session-scoped — `session:<sessionId>:<slug>`, valid ONLY for
-        //       signal "operational_lesson" (issue #668). Process failures have
-        //       no consensus round, so requiring (a) forced operators to invent
-        //       filler consensus ids. See handlers/operational-lesson-id.ts.
+        //       signal "operational_lesson" (issue #668, session form REQUIRED)
+        //       and "design_split" (issue #678, EITHER form accepted). Process
+        //       failures have no consensus round, and neither do splits that
+        //       surface in a parallel dispatch, so requiring (a) forced
+        //       operators to invent filler consensus ids. See
+        //       handlers/operational-lesson-id.ts.
         //
         // Anything else is rejected loudly rather than persisted as an
         // unauditable signal — fail-closed, never sanitize-and-continue.
@@ -3764,6 +3775,14 @@ export function createMcpServer(): McpServer {
           // Operational lessons were fully validated above (shape (b)); skip the
           // consensus-prefix check so the two grammars stay disjoint.
           if (isOperationalLessonSignal(s.signal)) continue;
+          // `design_split` may use EITHER shape. When it actually used (b) the
+          // validator above already accepted it, so skip (a)'s check; when it
+          // used anything else, fall through and hold it to (a).
+          if (
+            s.finding_id !== undefined &&
+            acceptsSessionScopedFindingId(s.signal) &&
+            parseOperationalFindingId(s.finding_id).kind === 'valid'
+          ) continue;
           if (s.finding_id !== undefined && !FINDING_ID_PREFIX.test(s.finding_id)) {
             return { content: [{ type: 'text' as const, text: `Error: malformed finding_id "${s.finding_id}" (agent: ${s.agent_id}). ${FINDING_ID_FORMS_HELP} See CLAUDE.md signal contract.` }] };
           }
@@ -3819,12 +3838,13 @@ export function createMcpServer(): McpServer {
           if (task_start_time) return new Date(new Date(task_start_time).getTime() + i).toISOString();
           return new Date(wallClockMs + i).toISOString();
         };
-        // `signal_class` is stamped only for operator-authored process lessons
-        // (issue #668) so dashboards can partition them without re-deriving the
-        // class from the signal name. Scoring exclusion does NOT depend on this
-        // field — performance-reader.ts drops `operational_lesson` from
-        // `consensusSignals` outright — it is display metadata, matching the
-        // write-forward-only contract documented on `SignalClass`.
+        // `signal_class` is stamped only for the operational record signals
+        // (`operational_lesson`, issue #668; `design_split`, issue #678) so
+        // dashboards can partition them without re-deriving the class from the
+        // signal name. Scoring exclusion does NOT depend on this field —
+        // performance-reader.ts drops both from `consensusSignals` outright —
+        // it is display metadata, matching the write-forward-only contract
+        // documented on `SignalClass`.
         const formatted: PS[] = signals.map((s, i): PS => {
           const ts = resolveTs(s, i);
           const taskId = task_id || `manual-${batchFallback.replace(/[:.]/g, '')}-${i}`;
@@ -3843,7 +3863,7 @@ export function createMcpServer(): McpServer {
           return {
             type: 'consensus',
             signal: s.signal as Exclude<typeof s.signal, 'impl_test_pass' | 'impl_test_fail' | 'impl_peer_approved' | 'impl_peer_rejected'>,
-            signal_class: isOperationalLessonSignal(s.signal) ? 'operational' : undefined,
+            signal_class: isOperationalRecordSignal(s.signal) ? 'operational' : undefined,
             agentId: s.agent_id,
             taskId,
             counterpartId: s.counterpart_id,
@@ -4209,6 +4229,13 @@ export function createMcpServer(): McpServer {
         // score at all (performance-reader drops them before every scoring pass), so
         // showing one as "-1" would tell an operator recording their own process mistake
         // that they had just penalized an agent. Issue #668.
+        //
+        // `design_split` gets the same separate treatment for the same reason, and is
+        // ALSO credited to the counterpart (issue #678). The `-1` that issue reports is
+        // exactly this line: rendering an unresolved trade-off as a negative told the
+        // operator they had penalized deepseek-challenger for arguing a defensible
+        // position. Both sides are named, so both sides must show up as unscored — a
+        // split attributed to one agent reads as a verdict against the other.
         const POSITIVE_SIGNALS = new Set([
           'agreement',
           'unique_confirmed',
@@ -4216,28 +4243,44 @@ export function createMcpServer(): McpServer {
           'impl_test_pass',
           'impl_peer_approved',
         ]);
-        const byAgent = new Map<string, { pos: number; neg: number; lessons: number }>();
+        type SummaryEntry = { pos: number; neg: number; lessons: number; splits: number };
+        const byAgent = new Map<string, SummaryEntry>();
+        const ensureEntry = (id: string): SummaryEntry => {
+          const entry = byAgent.get(id) || { pos: 0, neg: 0, lessons: 0, splits: 0 };
+          byAgent.set(id, entry);
+          return entry;
+        };
         for (const s of deduped) {
-          const entry = byAgent.get(s.agentId) || { pos: 0, neg: 0, lessons: 0 };
+          const entry = ensureEntry(s.agentId);
           if (isOperationalLessonSignal(s.signal)) entry.lessons++;
+          else if (isDesignSplitSignal(s.signal)) {
+            entry.splits++;
+            const counterpart = s.type === 'consensus' ? s.counterpartId : undefined;
+            if (counterpart && counterpart !== s.agentId) ensureEntry(counterpart).splits++;
+          }
           else if (POSITIVE_SIGNALS.has(s.signal)) entry.pos++;
           else entry.neg++;
-          byAgent.set(s.agentId, entry);
         }
 
         const summary = Array.from(byAgent.entries())
-          .map(([id, { pos, neg, lessons }]) =>
-            `  ${id}: +${pos} / -${neg}${lessons > 0 ? ` (${lessons} lesson${lessons === 1 ? '' : 's'}, unscored)` : ''}`)
+          .map(([id, { pos, neg, lessons, splits }]) => {
+            const notes: string[] = [];
+            if (lessons > 0) notes.push(`${lessons} lesson${lessons === 1 ? '' : 's'}, unscored`);
+            if (splits > 0) notes.push(`${splits} design split${splits === 1 ? '' : 's'}, unscored`);
+            return `  ${id}: +${pos} / -${neg}${notes.length > 0 ? ` (${notes.join('; ')})` : ''}`;
+          })
           .join('\n');
 
         const taskIdList = deduped.map(f => `  ${f.agentId}: ${f.taskId}`).join('\n');
         // Only claim dispatch-weight impact when something recorded can actually
-        // move it. An all-lessons batch influences nothing — saying otherwise
-        // contradicts the contract the operator just relied on.
-        const scoringCount = deduped.filter(s => !isOperationalLessonSignal(s.signal)).length;
+        // move it. An all-lessons / all-splits batch influences nothing — saying
+        // otherwise contradicts the contract the operator just relied on.
+        const scoringCount = deduped.filter(
+          s => !isOperationalLessonSignal(s.signal) && !isDesignSplitSignal(s.signal),
+        ).length;
         const effectLine = scoringCount > 0
           ? 'These will influence future agent selection via dispatch weighting.'
-          : 'Recorded for recall only — operational lessons never influence dispatch weighting.';
+          : 'Recorded for recall only — operational lessons and design splits never influence dispatch weighting.';
         let baseReceipt = `Recorded ${deduped.length} consensus signals:\n${summary}\n\nTask IDs (for retraction):\n${taskIdList}\n\n${effectLine}`;
         if (missingFindingIdCount > 0) {
           baseReceipt += `\n\n⚠ ${missingFindingIdCount} signal(s) recorded without finding_id — unauditable, see CLAUDE.md contract`;

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -179,6 +179,15 @@ session:<sessionId>:<slug>
 
 Set `cross_cutting: true` to file the resulting lesson card in `.gossip/agents/_project/memory/knowledge/` instead of the recording agent's own dir. Use it for lessons every contributor needs (e.g. *a dist-mcp bundle built inside a git worktree is always broken, because the nested `packages/tools/node_modules/zod` is unreachable from a worktree*), since an agent-scoped card is only reachable by a query carrying that agent's id. It is an explicit opt-in — nothing infers it from the lesson text — and the card records `origin_agent` so provenance survives the move.
 
+**Unresolved design splits (`design_split`, issue #678).** `disagreement` means *one side was wrong* and debits that agent's accuracy. When two agents reach **opposed but defensible** conclusions on a trade-off that reading code cannot settle, recording a `disagreement` penalises an accuracy nothing has falsified — and, because dispatch weight derives from accuracy, pushes the fleet toward agents that agree. That is backwards for a design whose value is independent perspectives. Record `design_split` instead:
+
+- `counterpart_id` is **REQUIRED** and `finding` must state **both** positions — a one-sided split reads as a verdict against the absent agent.
+- **Neither side is scored.** It is in `OPERATIONAL_SIGNAL_NAMES`, and `performance-reader.ts` drops it from `consensusSignals` before every pass, so it moves no accuracy, no uniqueness, and no circuit-breaker streak for either agent. (Filtering, not a no-op switch arm: a merely-unscored row would still advance the per-agent task index for *both* ids, re-weighting decay, and would break a real failure streak.)
+- It accepts **either** `finding_id` grammar — consensus-scoped in a round, session-scoped (`session:<sessionId>:<slug>`) in a **parallel** dispatch that has no consensus id. `operational_lesson` stays session-only. The dashboard renders it as *Design split (unresolved)* in `--info` teal, never the rose `disputed` bucket.
+- **Resolution is a later, separate signal — not a state transition.** If one side is subsequently shown wrong, record a normal scoring `disagreement` / `hallucination_caught` against the **same `finding_id`**. The split row stays as the audit trail of what was genuinely unresolved at the time; the penalty lands at resolution, where the evidence is.
+
+**Historical `disagreement` rows are deliberately NOT migrated.** They were recorded under the old contract, where `disagreement` was the only way to record any disagreement at all — so the class of each one (real verdict vs. unresolved split) is not recoverable from the row. A blanket rewrite would either erase real penalties or fabricate exonerations; a heuristic rewrite would do both silently. The taxonomy change is **forward-only**: old rows keep the semantics they were recorded with, and the hallucination decay half-life (20 tasks) retires mis-classed penalties on its own.
+
 ---
 
 ## Operator playbook (for orchestrator LLMs)

--- a/packages/dashboard-v2/src/components/AgentActivityTimeline.tsx
+++ b/packages/dashboard-v2/src/components/AgentActivityTimeline.tsx
@@ -25,6 +25,10 @@ const SIGNAL_TAG_CLS: Record<string, string> = {
   disagreement: 'text-disputed bg-disputed/10',
   hallucination_caught: 'text-disputed bg-disputed/10',
   unverified: 'text-unverified bg-unverified/10',
+  // Issue #678 — unresolved design split. `unverified` classes resolve to
+  // --color-unverified, which globals.css unifies with --info teal, so this is
+  // the informational token, deliberately not the rose `disputed` one.
+  design_split: 'text-unverified bg-unverified/10',
 };
 
 export function AgentActivityTimeline({ agentId }: Props) {

--- a/packages/dashboard-v2/src/components/RecentSignalsPeek.tsx
+++ b/packages/dashboard-v2/src/components/RecentSignalsPeek.tsx
@@ -17,6 +17,8 @@ const LABELS: Record<string, string> = {
   unique_confirmed: 'unique',
   unique_unconfirmed: 'unique?',
   disagreement: 'disputed',
+  // Issue #678 — "split" reads as unresolved; "disputed" would read as settled.
+  design_split: 'split',
   hallucination_caught: 'hallucination',
   new_finding: 'new',
   unverified: 'unverified',
@@ -27,6 +29,7 @@ const VERDICT_COLOR: Record<string, string> = {
   agreement: 'var(--ok)',
   consensus_verified: 'var(--ok)',
   disagreement: 'var(--bad)',
+  design_split: 'var(--info)',
   hallucination_caught: 'var(--bad)',
   unique_confirmed: 'var(--unique)',
   unique_unconfirmed: 'var(--warn)',

--- a/packages/dashboard-v2/src/components/SignalTimeline.tsx
+++ b/packages/dashboard-v2/src/components/SignalTimeline.tsx
@@ -20,6 +20,11 @@ const SIGNAL_COLORS: Record<string, string> = {
   hallucination_caught: 'bg-disputed',
   new_finding: 'bg-unique',
   unverified: 'bg-unverified',
+  // Issue #678 — the --info teal family, at a reduced opacity so it stays
+  // distinguishable from `unverified` while sharing the informational token.
+  // Same idiom as `unique_unconfirmed` shading off `unique`. Deliberately NOT
+  // `bg-disputed`: nothing about a split has been shown wrong.
+  design_split: 'bg-unverified/60',
   // Amber/orange — fabricated citations are write-time warnings, not consensus
   // errors; keep visually distinct from the red disputed bucket.
   citation_fabricated: 'bg-amber-500',
@@ -35,6 +40,7 @@ const SIGNAL_LABELS: Record<string, string> = {
   hallucination_caught: 'Hallucination',
   new_finding: 'New finding',
   unverified: 'Unverified',
+  design_split: 'Design split (unresolved)',
   citation_fabricated: 'Fabricated citation',
   boundary_escape: 'Process violation',
 };
@@ -92,13 +98,16 @@ export function SignalTimeline({ agentId }: { agentId: string }) {
   // `total` population). With a capped window the counts still reflect only
   // the most recent slice. Label explicitly says "Last N" so users don't
   // divide counts by total and get a wrong ratio.
-  const counts = { confirmed: 0, disputed: 0, unique: 0, unverified: 0, fabricated: 0 };
+  const counts = { confirmed: 0, disputed: 0, unique: 0, unverified: 0, fabricated: 0, splits: 0 };
   for (const s of signals) {
     if (s.signal === 'agreement' || s.signal === 'consensus_verified') counts.confirmed++;
     // The "disputed" bucket covers both disagreement AND hallucination_caught
     // — both render as the same red `bg-disputed` color. Legend label below
     // matches "Disputed" so the counts row and legend tell one story.
+    // `design_split` is its OWN bucket and must never join this one: "disputed"
+    // here means a side was shown wrong, which is precisely what a split is not.
     else if (s.signal === 'disagreement' || s.signal === 'hallucination_caught') counts.disputed++;
+    else if (s.signal === 'design_split') counts.splits++;
     else if (s.signal === 'unique_confirmed' || s.signal === 'unique_unconfirmed' || s.signal === 'new_finding') counts.unique++;
     else if (s.signal === 'unverified') counts.unverified++;
     // Separate bucket from consensus-UNVERIFIED: fabricated citations are
@@ -137,6 +146,7 @@ export function SignalTimeline({ agentId }: { agentId: string }) {
           {counts.disputed > 0 && <span className="text-disputed">{counts.disputed} disputed</span>}
           {counts.unique > 0 && <span className="text-unique">{counts.unique} unique</span>}
           {counts.unverified > 0 && <span className="text-unverified">{counts.unverified} unverified</span>}
+          {counts.splits > 0 && <span className="text-unverified">{counts.splits} unresolved split{counts.splits === 1 ? '' : 's'}</span>}
           {counts.fabricated > 0 && <span className="text-amber-500">{counts.fabricated} fabricated</span>}
         </div>
       </div>
@@ -177,6 +187,7 @@ export function SignalTimeline({ agentId }: { agentId: string }) {
           { color: 'bg-unique', label: 'Unique (confirmed)' },
           { color: 'bg-unique/50', label: 'Unique (unconfirmed)' },
           { color: 'bg-unverified', label: 'Unverified' },
+          { color: 'bg-unverified/60', label: 'Design split (unresolved)' },
           { color: 'bg-amber-500', label: 'Fabricated citation' },
         ].map((l) => (
           <div key={l.label} className="flex items-center gap-1">

--- a/packages/dashboard-v2/src/components/SignalsPage.tsx
+++ b/packages/dashboard-v2/src/components/SignalsPage.tsx
@@ -24,6 +24,7 @@ const SIGNAL_TYPES = [
   'unique_confirmed',
   'unique_unconfirmed',
   'disagreement',
+  'design_split',
   'hallucination_caught',
   'new_finding',
   'unverified',
@@ -42,6 +43,9 @@ const SIGNAL_LABELS: Record<string, string> = {
   unique_confirmed: 'Unique (confirmed)',
   unique_unconfirmed: 'Unique (unconfirmed)',
   disagreement: 'Disagreement',
+  // Issue #678 — reads as "they disagreed and it is still open", explicitly NOT
+  // "one of them was wrong". The wording carries the whole distinction here.
+  design_split: 'Design split (unresolved)',
   hallucination_caught: 'Hallucination',
   new_finding: 'New finding',
   unverified: 'Unverified',
@@ -60,6 +64,11 @@ const SIGNAL_LABELS: Record<string, string> = {
 // hallucination = --bad rose, unique/new_finding = --unique purple, unverified = --info teal.
 // Operational pass/fail signals (impl_test_*, impl_typecheck_*) map onto the
 // same ok/bad axis. boundary_escape = --bad (security violation).
+// design_split = --info teal, NOT --bad rose: per DESIGN.md the status palette is
+// semantic, and --bad means "disputed/critical". An unresolved trade-off between
+// two defensible positions is informational — nothing has been shown wrong yet.
+// Sharing rose with `disagreement` would re-create the exact conflation issue
+// #678 exists to remove, this time in the operator's eyes rather than the score.
 const VERDICT_COLOR: Record<string, string> = {
   agreement: 'var(--ok)',
   consensus_verified: 'var(--ok)',
@@ -76,6 +85,7 @@ const VERDICT_COLOR: Record<string, string> = {
   unique_unconfirmed: 'var(--unique)',
   new_finding: 'var(--unique)',
   unverified: 'var(--info)',
+  design_split: 'var(--info)',
 };
 
 // DESIGN.md Step 8 — severity-tick semantic palette. Single color per severity

--- a/packages/orchestrator/src/consensus-types.ts
+++ b/packages/orchestrator/src/consensus-types.ts
@@ -242,7 +242,28 @@ export interface ConsensusSignal {
      * circuit-breaker arithmetic. Its payload is the `lesson` text, which is
      * fanned into a recallable lesson card by `writeLessonCardsForSignals`.
      */
-    | 'operational_lesson';
+    | 'operational_lesson'
+    /**
+     * Unresolved design disagreement between two agents (issue #678). Records
+     * that `agentId` and `counterpartId` reached OPPOSED, DEFENSIBLE conclusions
+     * on a trade-off that reading code cannot settle — not that either was
+     * wrong. `disagreement` already means "one side was wrong", so recording a
+     * genuine split as one debits an accuracy that nothing has falsified, and
+     * pushes dispatch weight toward agents that agree.
+     *
+     * Both sides are named (`counterpartId` is REQUIRED at the record surface)
+     * and NEITHER is scored: like `operational_lesson`, it is dropped from
+     * `consensusSignals` before any scoring pass. It accepts EITHER finding_id
+     * grammar — a split can arise inside a consensus round or in a parallel
+     * dispatch that has no consensus id.
+     *
+     * Resolution is a SEPARATE, later signal, not a state transition on this
+     * row: when one side is subsequently shown wrong, the orchestrator records
+     * a normal scoring `disagreement` / `hallucination_caught` against the SAME
+     * `findingId`. The split row stays as the audit trail of what was unresolved
+     * at the time. See HANDBOOK.md invariant #14.
+     */
+    | 'design_split';
   agentId: string;
   counterpartId?: string;
   skill?: string;
@@ -446,6 +467,13 @@ export const OPERATIONAL_SIGNAL_NAMES: ReadonlySet<string> = new Set([
    * than the pipeline emitting it. Never affects accuracy scoring.
    */
   'operational_lesson',
+  /**
+   * Unresolved design disagreement between two agents (issue #678). Operational
+   * for the same reason as the dispatch-hygiene signals above: it is an
+   * observation about the DECISION SPACE, not a verdict on a finding's
+   * correctness. Neither the recorded agent nor its counterpart is scored.
+   */
+  'design_split',
 ]);
 
 /**

--- a/packages/orchestrator/src/performance-reader.ts
+++ b/packages/orchestrator/src/performance-reader.ts
@@ -343,7 +343,29 @@ const KNOWN_SIGNALS: Record<ConsensusSignal['signal'], true> = {
   // no-op. "Score preconditions, not decisions": an operator recording their
   // own process mistake must never dent an agent's accuracy.
   operational_lesson: true,
+  // Unresolved design disagreement between two agents (issue #678). Same
+  // treatment as `operational_lesson` for the same reason: a defensible
+  // trade-off that reading code cannot settle is a decision-space observation,
+  // not a correctness failure by either side.
+  design_split: true,
 };
+
+/**
+ * Consensus-shaped signals that must contribute NOTHING to any score —
+ * dropped from `consensusSignals` before the first scoring pass, not merely
+ * given a no-op switch arm (see the comment at the filter site for why the
+ * distinction matters).
+ *
+ * Both members are operator-recorded rather than pipeline-derived, and both are
+ * registered in `OPERATIONAL_SIGNAL_NAMES`. They stay a distinct set here
+ * because that classifier also covers auto-fired rows (`transport_failure`,
+ * `task_timeout`) which DO need to reach the switch — the ones below must not
+ * reach it at all.
+ */
+const SCORING_EXEMPT_SIGNALS: ReadonlySet<ConsensusSignal['signal']> = new Set([
+  'operational_lesson',
+  'design_split',
+]);
 
 const SEVERITY_MULTIPLIER: Record<string, number> = {
   critical: 4,
@@ -918,8 +940,9 @@ export class PerformanceReader {
     // consensusSignals → scoring + streak building.
     // implSignals      → streak building only (scoring is handled separately by getImplScore).
     //
-    // `operational_lesson` (issue #668) is dropped HERE, before any other pass
-    // sees it. A no-op switch arm further down is NOT sufficient: the loops
+    // `SCORING_EXEMPT_SIGNALS` — `operational_lesson` (issue #668) and
+    // `design_split` (issue #678) — are dropped HERE, before any other pass
+    // sees them. A no-op switch arm further down is NOT sufficient: the loops
     // between here and there have side effects that a merely-unscored signal
     // would still trigger —
     //   1. the task-order index at :888 would advance `taskCounter`, shifting
@@ -929,9 +952,13 @@ export class PerformanceReader {
     //      signal as a streak-breaker, so recording a process lesson would
     //      REHABILITATE an agent sitting on 3 consecutive hallucinations.
     // Both are score movement, and "score preconditions, not decisions" means
-    // an operator logging their own mistake must move nothing at all.
+    // neither an operator logging their own mistake NOR a recorded design split
+    // may move anything at all — in either direction, for either side. Note
+    // `design_split` also names a `counterpartId`, which the task-order index
+    // indexes too, so a switch-arm-only exemption would move the counterpart's
+    // decay as well as the subject's.
     const consensusSignals = signals.filter(
-      (s): s is ConsensusSignal => s.type === 'consensus' && s.signal !== 'operational_lesson',
+      (s): s is ConsensusSignal => s.type === 'consensus' && !SCORING_EXEMPT_SIGNALS.has(s.signal),
     );
     const implSignals = signals.filter((s): s is ImplSignal => s.type === 'impl');
 
@@ -1284,10 +1311,12 @@ export class PerformanceReader {
         case 'auto_verify_skipped_misconfigured':
           break;
         case 'operational_lesson':
-          // Unreachable: filtered out of `consensusSignals` at the split above,
-          // because a no-op arm here would still be too late (see the comment
-          // there). This arm exists only to satisfy the exhaustiveness check
-          // below, and to fail loudly in review if the filter is ever removed.
+        case 'design_split':
+          // Unreachable: both are in `SCORING_EXEMPT_SIGNALS` and filtered out
+          // of `consensusSignals` at the split above, because a no-op arm here
+          // would still be too late (see the comment there). These arms exist
+          // only to satisfy the exhaustiveness check below, and to fail loudly
+          // in review if the filter is ever removed.
           break;
         default: {
           // Exhaustiveness: any new ConsensusSignal['signal'] member added to

--- a/packages/orchestrator/src/performance-writer.ts
+++ b/packages/orchestrator/src/performance-writer.ts
@@ -16,6 +16,7 @@ import {
   type SignalAggregateIndexData,
 } from './signal-aggregate-index';
 import { readSkillFreshness } from './skill-freshness';
+import { isOperationalClassRow } from './performance-reader';
 
 /**
  * Fix 5 (spec 2026-04-27-self-telemetry-remediation §Fix 5): rate-limited
@@ -86,6 +87,11 @@ export const VALID_CONSENSUS_SIGNALS = new Set([
   // `consensusSignals` entirely, so it moves no score. Must be listed here or
   // validateSignal drops every emit (the PR #329 failure mode).
   'operational_lesson',
+  // Unresolved design disagreement between two agents (issue #678) — both sides
+  // named, neither scored. Same operational treatment as `operational_lesson`:
+  // performance-reader.ts filters it out of `consensusSignals` entirely. Must be
+  // listed here or validateSignal drops every emit (the PR #329 failure mode).
+  'design_split',
 ]);
 
 export const VALID_IMPL_SIGNALS = new Set([
@@ -234,9 +240,22 @@ const INTERNAL = Symbol('performance-writer-internal');
 /**
  * Resolve a (boundAtMs, signalForAggregate) pair for a consensus signal that
  * should contribute to the sidecar. Returns null when:
- *   - the signal is not a per-agent accuracy signal (operational / unknown), OR
+ *   - the signal's agent is the `_system` sentinel (round-level tombstone), OR
  *   - the signal carries no `category` (sidecar partitions by category), OR
- *   - the signal's agent is the `_system` sentinel (round-level tombstone).
+ *   - the row is operational-class (telemetry, never an accuracy counter), OR
+ *   - the signal is not a per-agent accuracy signal (`classifyForAggregate`).
+ *
+ * The `isOperationalClassRow` guard is the WRITE-side half of a pair — the
+ * rebuild path (`signal-aggregate-index.rebuildAggregateIndex`) has applied the
+ * same guard since the operational-class work landed, but this incremental
+ * fold-in did not. `classifyForAggregate` alone does not cover it: it keys off
+ * the signal NAME, so a categorized `disagreement` stamped
+ * `signal_class: 'operational'` (a failed dispatch auto-recorded by
+ * handlers/collect.ts) classified as `hallucinated` and folded in here, while a
+ * later rebuild dropped it. Sidecar and rebuild then disagreed for the same
+ * jsonl — the sidecar reporting hallucinations the reader's raw fallback never
+ * counts. Issue #678 ledger item; pinned by
+ * tests/orchestrator/aggregate-key-operational-exclusion.test.ts.
  */
 function deriveAggregateKey(
   signal: PerformanceSignal,
@@ -247,6 +266,7 @@ function deriveAggregateKey(
   const cs = signal as ConsensusSignal;
   if (cs.agentId === '_system') return null;
   if (!cs.category) return null;
+  if (isOperationalClassRow(cs)) return null;
   if (classifyForAggregate(cs.signal) === 'none') return null;
   const ts = cs.timestamp ? new Date(cs.timestamp).getTime() : 0;
   if (!isFinite(ts) || ts === 0) return null;

--- a/packages/relay/src/dashboard/api-fleet-trend.ts
+++ b/packages/relay/src/dashboard/api-fleet-trend.ts
@@ -1,6 +1,6 @@
 import { existsSync, statSync } from 'fs';
 import { join } from 'path';
-import { readJsonlWithRotated } from '@gossip/orchestrator';
+import { readJsonlWithRotated, isOperationalClassRow } from '@gossip/orchestrator';
 
 export interface FleetTrendPoint {
   day: string; // ISO date YYYY-MM-DD
@@ -62,6 +62,15 @@ export async function fleetTrendHandler(projectRoot: string, query?: URLSearchPa
       try {
         const rec = JSON.parse(line);
         if (rec.type !== 'consensus' || !rec.agentId || rec.agentId === '_system' || !rec.timestamp) continue;
+        // Operational-class rows are telemetry, never accuracy. This chart's
+        // `total` is the accuracy DENOMINATOR, so an unfiltered operational row
+        // is scored here even though every scoring surface excludes it: it can
+        // never increment `good`, so it silently drags the plotted accuracy
+        // down. That would make `design_split` (issue #678) debit a displayed
+        // accuracy for both named agents — the exact outcome the signal exists
+        // to prevent. Same guard, same helper, as api-skills.ts:175,
+        // signal-aggregate-index rebuild, and performance-reader.getCountersSince.
+        if (isOperationalClassRow(rec)) continue;
         const t = Date.parse(rec.timestamp);
         if (!Number.isFinite(t) || t < cutoff) continue;
         const day = new Date(t).toISOString().slice(0, 10);

--- a/tests/cli/design-split-finding-id.test.ts
+++ b/tests/cli/design-split-finding-id.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Issue #678 — `design_split` is the one signal that accepts BOTH `finding_id`
+ * grammars.
+ *
+ * Contract under test:
+ *   (a) consensus-scoped `<8hex>-<8hex>:...` — a split found inside a round;
+ *   (b) session-scoped `session:<sessionId>:<slug>` — a split found in a
+ *       PARALLEL dispatch, which has no consensus id (the issue notes this round
+ *       had to mint a synthetic `<taskA>-<taskB>` pair to satisfy the validator);
+ *   (c) anything matching NEITHER is still rejected — "accepts either" is not
+ *       "accepts anything", and a malformed session id is rejected with the
+ *       SESSION parse reason, not misdiagnosed as a bad consensus prefix;
+ *   (d) `operational_lesson` stays session-ONLY — widening one signal must not
+ *       widen the other.
+ *
+ * Imports the real validator, so handler logic changes cannot pass here while
+ * breaking in production. Source-grep guards at the bottom pin the wiring that
+ * unit tests cannot reach (zod enum, counterpart requirement, class stamp).
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  parseOperationalFindingId,
+  validateOperationalLessonSignal,
+  isOperationalLessonSignal,
+  isDesignSplitSignal,
+  isOperationalRecordSignal,
+  acceptsSessionScopedFindingId,
+  FINDING_ID_FORMS_HELP,
+  DESIGN_SPLIT_SIGNAL,
+  OPERATIONAL_LESSON_SIGNAL,
+} from '../../apps/cli/src/handlers/operational-lesson-id';
+
+const HANDLER_SRC = join(__dirname, '..', '..', 'apps', 'cli', 'src', 'mcp-server-sdk.ts');
+const FINDING_ID_PREFIX = /^[0-9a-f]{8}-[0-9a-f]{8}:/;
+
+/** Replica of the handler's two-stage gate, including the #678 branch. */
+function gate(s: { signal: string; agent_id: string; finding_id?: string; lesson?: string }): string | null {
+  const opErr = validateOperationalLessonSignal(s);
+  if (opErr) return opErr;
+  if (isOperationalLessonSignal(s.signal)) return null;
+  if (
+    s.finding_id !== undefined &&
+    acceptsSessionScopedFindingId(s.signal) &&
+    parseOperationalFindingId(s.finding_id).kind === 'valid'
+  ) return null;
+  if (s.finding_id !== undefined && !FINDING_ID_PREFIX.test(s.finding_id)) {
+    return `Error: malformed finding_id "${s.finding_id}" (agent: ${s.agent_id}). ${FINDING_ID_FORMS_HELP} See CLAUDE.md signal contract.`;
+  }
+  return null;
+}
+
+const split = (finding_id?: string) => ({
+  signal: DESIGN_SPLIT_SIGNAL,
+  agent_id: 'fable-reviewer',
+  ...(finding_id === undefined ? {} : { finding_id }),
+});
+
+describe('design_split predicates', () => {
+  it('identifies itself and is an operational record signal', () => {
+    expect(isDesignSplitSignal(DESIGN_SPLIT_SIGNAL)).toBe(true);
+    expect(isOperationalRecordSignal(DESIGN_SPLIT_SIGNAL)).toBe(true);
+    expect(isOperationalRecordSignal(OPERATIONAL_LESSON_SIGNAL)).toBe(true);
+  });
+
+  it('does not bleed into the scoring signal names', () => {
+    for (const name of ['agreement', 'disagreement', 'hallucination_caught', 'unique_confirmed']) {
+      expect(isDesignSplitSignal(name)).toBe(false);
+      expect(isOperationalRecordSignal(name)).toBe(false);
+      expect(acceptsSessionScopedFindingId(name)).toBe(false);
+    }
+  });
+});
+
+describe('design_split accepts BOTH finding_id grammars', () => {
+  it.each([
+    ['b81956b2-e0fa4ea4:fable-reviewer:f1'],
+    ['b81956b2-e0fa4ea4:f3'],
+  ])('accepts the consensus-scoped %s', (findingId) => {
+    expect(gate(split(findingId))).toBeNull();
+  });
+
+  it.each([
+    ['session:2026-07-27-c0ffee01:conditioning-vs-independence'],
+    ['session:b2a68971-28f7-4465-a6a8-1e270bac6f34:phase2-block-scope'],
+  ])('accepts the session-scoped %s (parallel dispatch, no consensus id)', (findingId) => {
+    expect(gate(split(findingId))).toBeNull();
+  });
+
+  it('accepts an absent finding_id (optional, same as other consensus signals)', () => {
+    expect(gate(split())).toBeNull();
+  });
+
+  it('needs no lesson, unlike operational_lesson', () => {
+    // The lesson requirement exists because a lesson card is the lesson
+    // signal's entire payload. A split's payload is the two positions in
+    // `finding`, so requiring `lesson` here would be cargo-culted.
+    expect(gate(split('session:s1:tradeoff'))).toBeNull();
+  });
+});
+
+describe('design_split still rejects malformed ids (fail-closed both ways)', () => {
+  it.each([
+    ['garbage'],
+    ['f1'],
+    ['deadbeef:f1'],
+    ['zzzzzzzz-e0fa4ea4:f1'],
+  ])('rejects %s — matches neither grammar', (findingId) => {
+    const err = gate(split(findingId));
+    expect(err).not.toBeNull();
+    expect(err).toContain('malformed finding_id');
+  });
+
+  it.each([
+    ['session:only-one'],
+    ['session:s1:slug:extra'],
+  ])('rejects the malformed session-scoped %s with the SESSION parse reason', (findingId) => {
+    const err = gate(split(findingId));
+    expect(err).not.toBeNull();
+    expect(err).toContain('malformed finding_id');
+    // Misdiagnosis guard: falling through to the consensus gate would say
+    // "expected <8hex>-<8hex>", which sends the operator to fix the wrong half.
+    expect(err).toMatch(/exactly 2 components|not a safe path segment/);
+  });
+
+  it.each([
+    ['session:../etc:slug'],
+    ['session:s1:../../escape'],
+    ['session:S1:UPPER'],
+  ])('rejects the path-unsafe %s — never sanitized', (findingId) => {
+    expect(parseOperationalFindingId(findingId).kind).toBe('invalid');
+    expect(gate(split(findingId))).toContain('not a safe path segment');
+  });
+});
+
+describe('widening design_split does not widen anything else', () => {
+  it('operational_lesson still REJECTS a consensus-scoped id', () => {
+    const err = gate({
+      signal: OPERATIONAL_LESSON_SIGNAL,
+      agent_id: 'orchestrator',
+      finding_id: 'a38286c2-11111111:orchestrator:f2',
+      lesson: 'x',
+    });
+    expect(err).toContain('requires a session-scoped finding_id');
+  });
+
+  it('a scoring signal still REJECTS a session-scoped id', () => {
+    const err = gate({ signal: 'hallucination_caught', agent_id: 'a', finding_id: 'session:s1:x' });
+    expect(err).not.toBeNull();
+    expect(err).toContain('only valid for signals');
+  });
+
+  it('the two grammars stay disjoint by first token', () => {
+    // `session` is not 8 hex chars, so no consensus id can ever open with it.
+    expect(FINDING_ID_PREFIX.test('session:s1:x')).toBe(false);
+    expect(parseOperationalFindingId('b81956b2-e0fa4ea4:a:f1').kind).toBe('not_operational');
+  });
+});
+
+// ── Source-grep guards for wiring unit tests cannot reach ───────────────────
+
+describe('gossip_signals handler wiring', () => {
+  const src = readFileSync(HANDLER_SRC, 'utf8');
+
+  it('exposes design_split on the record zod enum', () => {
+    expect(src).toContain("'operational_lesson', 'design_split'");
+  });
+
+  it('documents that it records both sides and scores neither', () => {
+    expect(src).toContain('records BOTH sides and scores NEITHER');
+    expect(src).toContain('counterpart_id is REQUIRED');
+  });
+
+  it('documents the resolution-time contract in the tool description', () => {
+    // Without this the operator has no way to learn that resolving a split is a
+    // second signal on the same finding_id rather than an edit to this row.
+    expect(src).toContain('RESOLUTION IS A SEPARATE, LATER SIGNAL');
+    expect(src).toContain('against the SAME finding_id');
+  });
+
+  it('requires counterpart_id — a one-sided split reads as a verdict', () => {
+    expect(src).toContain("'impl_peer_rejected', 'design_split'");
+  });
+
+  it('stamps signal_class operational via the shared predicate', () => {
+    expect(src).toContain("isOperationalRecordSignal(s.signal) ? 'operational' : undefined");
+  });
+
+  it('skips the consensus prefix gate only for a VALID session-scoped id', () => {
+    expect(src).toContain('acceptsSessionScopedFindingId(s.signal) &&');
+    expect(src).toContain("parseOperationalFindingId(s.finding_id).kind === 'valid'");
+  });
+
+  it('counts splits separately in the receipt, never as negative', () => {
+    expect(src).toContain('else if (isDesignSplitSignal(s.signal)) {');
+    // The split branch must precede the positive/negative classification, or
+    // the conservative else-branch reclaims it as the "-1" from the issue.
+    const splitIdx = src.indexOf('else if (isDesignSplitSignal(s.signal)) {');
+    const posIdx = src.indexOf('else if (POSITIVE_SIGNALS.has(s.signal)) entry.pos++;');
+    expect(splitIdx).toBeGreaterThan(-1);
+    expect(posIdx).toBeGreaterThan(splitIdx);
+    expect(src).toContain('design split${splits === 1 ? \'\' : \'s\'}, unscored');
+  });
+
+  it('credits the counterpart as unscored too', () => {
+    expect(src).toContain('if (counterpart && counterpart !== s.agentId) ensureEntry(counterpart).splits++;');
+  });
+});

--- a/tests/cli/operational-lesson-id.test.ts
+++ b/tests/cli/operational-lesson-id.test.ts
@@ -20,6 +20,7 @@ import {
   parseOperationalFindingId,
   validateOperationalLessonSignal,
   isOperationalLessonSignal,
+  acceptsSessionScopedFindingId,
   FINDING_ID_FORMS_HELP,
   OPERATIONAL_LESSON_SIGNAL,
 } from '../../apps/cli/src/handlers/operational-lesson-id';
@@ -37,6 +38,13 @@ function gate(s: { signal: string; agent_id: string; finding_id?: string; lesson
   const opErr = validateOperationalLessonSignal(s);
   if (opErr) return opErr;
   if (isOperationalLessonSignal(s.signal)) return null;
+  // Issue #678 — `design_split` may use either grammar; skip the consensus
+  // prefix check only when it actually used the session form.
+  if (
+    s.finding_id !== undefined &&
+    acceptsSessionScopedFindingId(s.signal) &&
+    parseOperationalFindingId(s.finding_id).kind === 'valid'
+  ) return null;
   if (s.finding_id !== undefined && !FINDING_ID_PREFIX.test(s.finding_id)) {
     return `Error: malformed finding_id "${s.finding_id}" (agent: ${s.agent_id}). ${FINDING_ID_FORMS_HELP} See CLAUDE.md signal contract.`;
   }
@@ -88,7 +96,8 @@ describe('consensus finding_id — unchanged primary contract', () => {
   it('rejects the session-scoped form on a NON-operational signal', () => {
     const err = gate({ signal: 'agreement', agent_id: 'a', finding_id: 'session:s1:lesson' });
     expect(err).not.toBeNull();
-    expect(err).toContain('only valid for signal "operational_lesson"');
+    // Issue #678 widened this to the two signals that accept the session form.
+    expect(err).toContain('only valid for signals "operational_lesson" and "design_split"');
   });
 });
 
@@ -232,12 +241,14 @@ describe('gossip_signals handler wiring', () => {
     const posIdx = src.indexOf('else if (POSITIVE_SIGNALS.has(s.signal)) entry.pos++;');
     expect(lessonIdx).toBeGreaterThan(-1);
     expect(posIdx).toBeGreaterThan(lessonIdx);
-    expect(src).toContain('lesson${lessons === 1 ? \'\' : \'s\'}, unscored)');
+    // Issue #678 moved the trailing ")" out of this template — the note list is
+    // now joined so `design_split` can add a second parenthetical clause.
+    expect(src).toContain('lesson${lessons === 1 ? \'\' : \'s\'}, unscored');
   });
 
   it('does not claim dispatch-weight impact for an all-lessons batch', () => {
-    expect(src).toContain('const scoringCount = deduped.filter(s => !isOperationalLessonSignal(s.signal)).length;');
-    expect(src).toContain('operational lessons never influence dispatch weighting.');
+    expect(src).toContain('!isOperationalLessonSignal(s.signal) && !isDesignSplitSignal(s.signal),');
+    expect(src).toContain('operational lessons and design splits never influence dispatch weighting.');
     // The unconditional claim must be gone — it is now behind scoringCount > 0.
     expect(src).not.toContain('${taskIdList}\\n\\nThese will influence future agent selection');
   });

--- a/tests/orchestrator/aggregate-key-operational-exclusion.test.ts
+++ b/tests/orchestrator/aggregate-key-operational-exclusion.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Issue #678 ledger item — the FOURTH operational-class exclusion surface.
+ *
+ * Three surfaces already excluded `signal_class: 'operational'` rows from
+ * accuracy math (PRs #690/#692/#695): the accuracy arm, the circuit-breaker
+ * streak, and `rebuildAggregateIndex`. The incremental sidecar fold-in
+ * (`deriveAggregateKey` in performance-writer.ts) did not — it gated only on
+ * `classifyForAggregate(signal)`, which keys off the signal NAME.
+ *
+ * That leaves one row shape divergent: a `disagreement` (name → 'hallucinated')
+ * WITH a category (sidecar partitions by category) AND
+ * `signal_class: 'operational'`. That is not hypothetical — it is exactly what a
+ * failed dispatch produces once synthesis stamps the class. The write path
+ * counted it as a hallucination; a later rebuild dropped it. Two readers of the
+ * same jsonl then disagreed, and which answer you got depended on whether the
+ * sidecar happened to be stale.
+ *
+ * These tests pin CONVERGENCE — incremental fold-in must equal a from-scratch
+ * rebuild — rather than asserting a particular bucket shape, so they keep
+ * holding if the bucket layout is ever changed.
+ */
+
+import { PerformanceWriter } from '../../packages/orchestrator/src/performance-writer';
+import {
+  rebuildAggregateIndex,
+  readAggregateIndex,
+} from '../../packages/orchestrator/src/signal-aggregate-index';
+import type { PerformanceSignal } from '../../packages/orchestrator/src/consensus-types';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const TEST_DIR = join(__dirname, '..', '..', '.test-aggregate-key-operational');
+const SIGNALS_PATH = join(TEST_DIR, '.gossip', 'agent-performance.jsonl');
+const AGENT = 'sonnet-reviewer';
+const CATEGORY = 'trust_boundaries';
+const now = new Date().toISOString();
+
+function writeJsonl(signals: PerformanceSignal[]): void {
+  mkdirSync(join(TEST_DIR, '.gossip'), { recursive: true });
+  writeFileSync(SIGNALS_PATH, signals.map(s => JSON.stringify(s)).join('\n') + '\n');
+}
+
+/** A real verdict — must be counted by both paths. */
+function scoringAgreement(): PerformanceSignal {
+  return {
+    type: 'consensus', signal: 'agreement', taskId: 'real-1', agentId: AGENT,
+    counterpartId: 'gemini-reviewer', category: CATEGORY, signal_class: 'performance',
+    findingId: `b81956b2-e0fa4ea4:${AGENT}:f1`, source: 'manual',
+    evidence: 'confirmed peer finding', timestamp: now,
+  } as PerformanceSignal;
+}
+
+/**
+ * The divergent shape: a scoring signal NAME, a category, and an operational
+ * class stamp. Auto-recorded by handlers/collect.ts when a dispatch dies on
+ * quota exhaustion / context overflow.
+ */
+function operationalDisagreement(taskId: string): PerformanceSignal {
+  return {
+    type: 'consensus', signal: 'disagreement', taskId, agentId: AGENT,
+    counterpartId: 'gemini-reviewer', category: CATEGORY, signal_class: 'operational',
+    findingId: `b81956b2-e0fa4ea4:${AGENT}:f2`, source: 'auto',
+    evidence: 'Task failed: Context low - stopping', timestamp: now,
+  } as PerformanceSignal;
+}
+
+/** A `design_split`, which also carries a category in this fixture. */
+function categorizedDesignSplit(): PerformanceSignal {
+  return {
+    type: 'consensus', signal: 'design_split', taskId: 'split-1', agentId: AGENT,
+    counterpartId: 'deepseek-challenger', category: CATEGORY, signal_class: 'operational',
+    findingId: 'session:2026-07-27-c0ffee01:conditioning-vs-independence', source: 'manual',
+    evidence: 'both positions stated', timestamp: now,
+  } as PerformanceSignal;
+}
+
+function bucketsFor(root: string) {
+  const data = readAggregateIndex(root);
+  return data?.agents[AGENT]?.[CATEGORY] ?? {};
+}
+
+/** Sum every bucket so the comparison is layout-independent. */
+function totals(root: string): { correct: number; hallucinated: number; total: number } {
+  const out = { correct: 0, hallucinated: 0, total: 0 };
+  for (const b of Object.values(bucketsFor(root))) {
+    out.correct += b.correct;
+    out.hallucinated += b.hallucinated;
+    out.total += b.total;
+  }
+  return out;
+}
+
+beforeEach(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterAll(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('deriveAggregateKey excludes operational-class rows', () => {
+  it('does not fold a categorized operational disagreement into the sidecar', () => {
+    const rows = [scoringAgreement(), operationalDisagreement('failed-1')];
+    writeJsonl(rows);
+    new PerformanceWriter(TEST_DIR).__updateAggregateSidecar(rows);
+
+    // Only the real agreement lands. Pre-fix this read `hallucinated: 1`.
+    expect(totals(TEST_DIR)).toEqual({ correct: 1, hallucinated: 0, total: 1 });
+  });
+
+  it('agrees with rebuildAggregateIndex row-for-row', () => {
+    const rows = [
+      scoringAgreement(),
+      operationalDisagreement('failed-1'),
+      operationalDisagreement('failed-2'),
+      operationalDisagreement('failed-3'),
+    ];
+    writeJsonl(rows);
+
+    new PerformanceWriter(TEST_DIR).__updateAggregateSidecar(rows);
+    const incremental = totals(TEST_DIR);
+
+    rebuildAggregateIndex(TEST_DIR);
+    const rebuilt = totals(TEST_DIR);
+
+    // The whole point: whether you read a freshly-folded sidecar or one rebuilt
+    // from raw must not change the answer. Pre-fix these were 3 apart.
+    expect(incremental).toEqual(rebuilt);
+    expect(incremental.hallucinated).toBe(0);
+  });
+
+  it('does not fold a categorized design_split either', () => {
+    const rows = [scoringAgreement(), categorizedDesignSplit()];
+    writeJsonl(rows);
+    new PerformanceWriter(TEST_DIR).__updateAggregateSidecar(rows);
+
+    // Belt and braces: `classifyForAggregate('design_split')` already returns
+    // 'none', so this passes on the name gate alone. Pinned anyway so adding
+    // design_split to that switch later cannot silently start scoring it.
+    expect(totals(TEST_DIR)).toEqual({ correct: 1, hallucinated: 0, total: 1 });
+    rebuildAggregateIndex(TEST_DIR);
+    expect(totals(TEST_DIR)).toEqual({ correct: 1, hallucinated: 0, total: 1 });
+  });
+
+  it('still folds a REAL categorized disagreement (guard is not over-broad)', () => {
+    const realVerdict = {
+      ...(operationalDisagreement('real-verdict') as unknown as Record<string, unknown>),
+      signal_class: 'performance',
+      source: 'manual',
+      evidence: 'the cited line does not contain the claimed call',
+    } as unknown as PerformanceSignal;
+
+    const rows = [scoringAgreement(), realVerdict];
+    writeJsonl(rows);
+    new PerformanceWriter(TEST_DIR).__updateAggregateSidecar(rows);
+
+    expect(totals(TEST_DIR)).toEqual({ correct: 1, hallucinated: 1, total: 2 });
+  });
+});

--- a/tests/orchestrator/design-split-scoring.test.ts
+++ b/tests/orchestrator/design-split-scoring.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Issue #678 — a `design_split` records that two agents reached opposed but
+ * DEFENSIBLE conclusions. It must move NO score, for EITHER side.
+ *
+ * The two-sided part is what makes this different from `operational_lesson`
+ * (#668): a split names a `counterpartId`, and `computeScores` indexes task
+ * order for the counterpart as well as the subject. So a switch-arm-only
+ * exemption would still shift decay weighting for the OTHER agent — the one
+ * that was never even the subject of the row. These tests therefore fingerprint
+ * both agents, not just the recorded one.
+ *
+ * Like the #668 suite, they deliberately do not assert on `signal_class`:
+ * labelling the row correctly proves nothing about whether the scoring switch
+ * counts it. Each test computes a real baseline, appends splits, recomputes, and
+ * compares the numbers.
+ */
+
+import { PerformanceReader } from '../../packages/orchestrator/src/performance-reader';
+import { classifySignal, OPERATIONAL_SIGNAL_NAMES } from '../../packages/orchestrator/src/consensus-types';
+import { VALID_CONSENSUS_SIGNALS } from '../../packages/orchestrator/src/performance-writer';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const TEST_DIR = join(__dirname, '..', '..', '.test-design-split-scoring');
+const SIGNALS_PATH = join(TEST_DIR, '.gossip', 'agent-performance.jsonl');
+const AGENT = 'fable-reviewer';
+const PEER = 'deepseek-challenger';
+const now = new Date().toISOString();
+
+function writeSignals(signals: unknown[]): void {
+  mkdirSync(join(TEST_DIR, '.gossip'), { recursive: true });
+  writeFileSync(SIGNALS_PATH, signals.map(s => JSON.stringify(s)).join('\n') + '\n');
+}
+
+function agreement(taskId: string, agentId: string): Record<string, unknown> {
+  return {
+    type: 'consensus', signal: 'agreement', taskId, agentId,
+    counterpartId: 'gemini-reviewer', category: 'trust_boundaries', severity: 'medium',
+    findingId: `b81956b2-e0fa4ea4:${agentId}:f1`, evidence: 'confirmed peer finding', timestamp: now,
+  };
+}
+
+function hallucination(taskId: string, agentId: string): Record<string, unknown> {
+  return {
+    type: 'consensus', signal: 'hallucination_caught', taskId, agentId,
+    category: 'trust_boundaries', severity: 'high', outcome: 'fabricated_citation',
+    findingId: `b81956b2-e0fa4ea4:${agentId}:f9`, evidence: 'cited a line that does not exist', timestamp: now,
+  };
+}
+
+/** The #666-round case from the issue, in row form. */
+function designSplit(slug: string, opts: { category?: string } = {}): Record<string, unknown> {
+  return {
+    type: 'consensus', signal: 'design_split', taskId: `manual-${slug}`, agentId: AGENT,
+    counterpartId: PEER, signal_class: 'operational',
+    findingId: `session:2026-07-27-c0ffee01:${slug}`, source: 'manual',
+    ...(opts.category ? { category: opts.category } : {}),
+    evidence:
+      'fable: inject per-agent failure-pattern content into Phase-2 cross-review. ' +
+      'deepseek: the block must be agent-independent or claimant and verifier correlate.',
+    timestamp: now,
+  };
+}
+
+function scoreFingerprint(reader: PerformanceReader, agentId: string) {
+  const s = reader.getScores().get(agentId)!;
+  return {
+    accuracy: s.accuracy,
+    uniqueness: s.uniqueness,
+    reliability: s.reliability,
+    impactScore: s.impactScore,
+    scoringSignals: s.scoringSignals,
+    agreements: s.agreements,
+    disagreements: s.disagreements,
+    hallucinations: s.hallucinations,
+    weightedHallucinations: s.weightedHallucinations,
+    uniqueFindings: s.uniqueFindings,
+    consecutiveFailures: s.consecutiveFailures,
+    circuitOpen: s.circuitOpen,
+  };
+}
+
+// `reliability` folds in a wall-clock recency term — freeze Date.now() so any
+// delta between `before` and `after` is attributable to the appended rows.
+const FIXED_NOW = new Date(now).getTime();
+let nowSpy: jest.SpyInstance<number, []>;
+
+beforeEach(() => {
+  nowSpy = jest.spyOn(Date, 'now').mockReturnValue(FIXED_NOW);
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  nowSpy.mockRestore();
+});
+
+afterAll(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('design_split taxonomy registration', () => {
+  it('classifies as operational, not performance', () => {
+    expect(OPERATIONAL_SIGNAL_NAMES.has('design_split')).toBe(true);
+    expect(classifySignal('design_split')).toBe('operational');
+  });
+
+  it('is accepted by validateSignal (else every emit is silently dropped)', () => {
+    // The PR #329 failure mode: classified but not on the writer allowlist.
+    expect(VALID_CONSENSUS_SIGNALS.has('design_split')).toBe(true);
+  });
+});
+
+describe('design_split debits neither side', () => {
+  it('leaves the recorded agent\'s score bit-identical', () => {
+    const baseSignals = [agreement('t1', AGENT), agreement('t2', AGENT), hallucination('t3', AGENT)];
+
+    writeSignals(baseSignals);
+    const before = scoreFingerprint(new PerformanceReader(TEST_DIR), AGENT);
+
+    writeSignals([
+      ...baseSignals,
+      designSplit('phase2-conditioning-vs-independence'),
+      designSplit('another-open-tradeoff'),
+    ]);
+    const after = scoreFingerprint(new PerformanceReader(TEST_DIR), AGENT);
+
+    expect(after).toEqual(before);
+    // Sanity: a real, non-degenerate baseline — otherwise equality is trivial.
+    expect(before.accuracy).toBeGreaterThan(0);
+    expect(before.accuracy).toBeLessThan(1);
+    expect(before.scoringSignals).toBe(3);
+  });
+
+  it('leaves the COUNTERPART\'s score bit-identical too', () => {
+    // The issue's actual complaint: `deepseek-challenger: +2 / -1`. The peer is
+    // named on the row, so a no-op switch arm alone would still index its task
+    // order and re-weight its decay.
+    const baseSignals = [agreement('p1', PEER), agreement('p2', PEER), hallucination('p3', PEER)];
+
+    writeSignals(baseSignals);
+    const before = scoreFingerprint(new PerformanceReader(TEST_DIR), PEER);
+
+    writeSignals([...baseSignals, designSplit('opposed-but-defensible')]);
+    const after = scoreFingerprint(new PerformanceReader(TEST_DIR), PEER);
+
+    expect(after).toEqual(before);
+    expect(before.scoringSignals).toBe(3);
+  });
+
+  it('is excluded even when it carries a category', () => {
+    // `category` is optional on a split but permitted. A categorized row must
+    // not sneak into the accuracy arm the way a categorized operational
+    // `disagreement` would if its signal_class were ignored.
+    const baseSignals = [agreement('t1', AGENT), hallucination('t2', AGENT)];
+
+    writeSignals(baseSignals);
+    const before = scoreFingerprint(new PerformanceReader(TEST_DIR), AGENT);
+
+    writeSignals([...baseSignals, designSplit('categorized', { category: 'trust_boundaries' })]);
+    expect(scoreFingerprint(new PerformanceReader(TEST_DIR), AGENT)).toEqual(before);
+  });
+
+  it('cannot manufacture a score for an agent that has only splits', () => {
+    writeSignals([designSplit('only-split')]);
+    const scores = new PerformanceReader(TEST_DIR).getScores();
+    expect(scores.get(AGENT)).toBeUndefined();
+    expect(scores.get(PEER)).toBeUndefined();
+  });
+});
+
+describe('design_split and the circuit-breaker streak', () => {
+  it('cannot open the breaker no matter how many are recorded', () => {
+    writeSignals(Array.from({ length: 12 }, (_, i) => designSplit(`split-${i}`)));
+    expect(new PerformanceReader(TEST_DIR).getScores().get(AGENT)).toBeUndefined();
+  });
+
+  it('does not RESET a real hallucination streak either (pure no-op, not a positive)', () => {
+    // The inverse failure: `design_split` is not in NEGATIVE_SIGNALS, so a row
+    // that reached the streak builder would count as a streak-BREAKER and
+    // rehabilitate an agent sitting on three consecutive hallucinations.
+    const streak = [hallucination('h1', AGENT), hallucination('h2', AGENT), hallucination('h3', AGENT)];
+
+    writeSignals(streak);
+    const before = scoreFingerprint(new PerformanceReader(TEST_DIR), AGENT);
+    expect(before.circuitOpen).toBe(true);
+
+    writeSignals([...streak, designSplit('appended-after-streak')]);
+    const after = scoreFingerprint(new PerformanceReader(TEST_DIR), AGENT);
+
+    expect(after).toEqual(before);
+    expect(after.circuitOpen).toBe(true);
+  });
+});
+
+describe('resolution is a later scoring signal on the same finding_id', () => {
+  it('a follow-up disagreement on the split\'s finding_id DOES score', () => {
+    // Documents the resolution contract: the split itself never scores, but the
+    // orchestrator resolving it later against the SAME finding_id does. If this
+    // ever stops scoring, resolution has become unrecordable and the taxonomy
+    // has silently turned into "disagreements are free".
+    const splitFindingId = 'session:2026-07-27-c0ffee01:resolved-later';
+    const split = { ...designSplit('resolved-later'), findingId: splitFindingId };
+    const resolution = {
+      type: 'consensus', signal: 'disagreement', taskId: 'manual-resolution', agentId: AGENT,
+      counterpartId: PEER, category: 'trust_boundaries', severity: 'medium',
+      signal_class: 'performance', findingId: splitFindingId, source: 'manual',
+      evidence: 'the independence argument was shown correct by the correlation measurement',
+      timestamp: now,
+    };
+
+    writeSignals([agreement('t1', AGENT), split]);
+    const unresolved = scoreFingerprint(new PerformanceReader(TEST_DIR), AGENT);
+
+    writeSignals([agreement('t1', AGENT), split, resolution]);
+    const resolved = scoreFingerprint(new PerformanceReader(TEST_DIR), AGENT);
+
+    expect(resolved.disagreements).toBe(unresolved.disagreements + 1);
+    expect(resolved.accuracy).toBeLessThan(unresolved.accuracy);
+  });
+});

--- a/tests/relay/api-fleet-trend.test.ts
+++ b/tests/relay/api-fleet-trend.test.ts
@@ -55,4 +55,44 @@ describe('fleetTrendHandler', () => {
     expect(res.points.some(p => p.agentId === '_system')).toBe(false);
     expect(res.points.some(p => p.agentId === 'alice')).toBe(true);
   });
+
+  // Issue #678. `total` here is the accuracy DENOMINATOR, and an operational
+  // row can never increment `good` — so leaving it in silently drags the
+  // plotted accuracy down. For `design_split` that means both named agents
+  // visibly lose accuracy for holding a defensible position, which is the
+  // outcome the signal exists to prevent.
+  it('excludes operational-class rows from the accuracy denominator', async () => {
+    const now = new Date().toISOString();
+    const root = makeRoot([
+      { type: 'consensus', signal: 'agreement', agentId: 'alice', timestamp: now },
+      {
+        type: 'consensus', signal: 'design_split', agentId: 'alice',
+        counterpartId: 'bob', signal_class: 'operational', timestamp: now,
+      },
+      {
+        type: 'consensus', signal: 'operational_lesson', agentId: 'alice',
+        signal_class: 'operational', timestamp: now,
+      },
+    ]);
+    const res = await fleetTrendHandler(root);
+    const alice = res.points.find(p => p.agentId === 'alice');
+    expect(alice).toBeDefined();
+    expect(alice!.signals).toBe(1);
+    expect(alice!.accuracy).toBe(1);
+  });
+
+  it('still counts a real (performance-class) verdict against accuracy', async () => {
+    const now = new Date().toISOString();
+    const root = makeRoot([
+      { type: 'consensus', signal: 'agreement', agentId: 'alice', timestamp: now },
+      {
+        type: 'consensus', signal: 'disagreement', agentId: 'alice',
+        signal_class: 'performance', category: 'trust_boundaries', timestamp: now,
+      },
+    ]);
+    const res = await fleetTrendHandler(root);
+    const alice = res.points.find(p => p.agentId === 'alice');
+    expect(alice!.signals).toBe(2);
+    expect(alice!.accuracy).toBe(0.5);
+  });
 });


### PR DESCRIPTION
Closes #678.

**Consensus round:** consensus-id: 5928db5e-6e614012 — 7 confirmed, 2 disputed (both citation-grounding miscites by a reviewer, verified and signal-recorded; the underlying claims held), 1 unique (verified by orchestrator). Reviewers: sonnet-reviewer (scoring-pipeline correctness), haiku-researcher (docs/tests/DESIGN.md), deepseek-challenger (dispatched for the adversarial lens but exhausted its turn budget — the orchestrator covered that lens manually, see below).

## What

A `disagreement` signal means *one side was wrong* and debits accuracy. When two agents reach opposed but defensible conclusions on a trade-off that reading code cannot settle, there was no way to record that without penalising someone — which pushes the fleet toward agents that agree (issue #678's deepseek `+2 / -1` case). This adds `design_split`:

- Records **both** sides (`counterpart_id` required, `finding` must state both positions), scores **neither**.
- **Resolution-time semantics without a state machine:** if one side is later shown wrong, record a normal scoring `disagreement`/`hallucination_caught` against the **same `finding_id`**; the split row remains the audit trail.
- Accepts **either** `finding_id` grammar — consensus-scoped, or `session:<sessionId>:<slug>` for splits arising in parallel (non-consensus) dispatches, closing the grammar gap noted in the issue.
- Dashboard renders it as "Design split (unresolved)" in `--info` teal on all four signal surfaces — never the rose `disputed` bucket.

## Why `SCORING_EXEMPT_SIGNALS` instead of just `OPERATIONAL_SIGNAL_NAMES`

The dispatch premise assumed registry membership was enough. The implementer's premise-verification disproved it: `isOperationalDisagreement` is name-gated on `'disagreement'`, so a new signal name never reaches the shipped exclusion machinery. A registry-only version would have (a) **reset real hallucination streaks** (`design_split` is non-negative, so the streak builder's `else break` treats it as a streak-breaker) and (b) **shifted the counterpart's decay** (the task-order index keys both `agentId` and `counterpartId`). The fix mirrors the `operational_lesson` pattern — drop from `consensusSignals` before every pass — and both failure modes are pinned as tests.

## Also in this PR (exclusion surfaces)

- `deriveAggregateKey` (performance-writer.ts:269) now carries the same `isOperationalClassRow` guard as `rebuildAggregateIndex` — previously a categorized operational `disagreement` folded into the incremental sidecar as `hallucinated` while a rebuild dropped it (proved by reverting the guard: sidecar read 3, rebuild read 0). Pinned by `tests/orchestrator/aggregate-key-operational-exclusion.test.ts`.
- `api-fleet-trend.ts:64` gets the same filter — its `total` is the accuracy denominator, so operational rows visibly dragged plotted accuracy for both named agents, failing acceptance criterion 1 on a user-visible surface. Implementer-discovered beyond spec; kept deliberately.

## Migration

Historical `disagreement` rows are **deliberately not migrated** — whether each one was a real verdict or an unresolved split is not recoverable from the row; a blanket or heuristic rewrite would erase real penalties or fabricate exonerations. Forward-only; the 20-task hallucination decay half-life retires mis-classed penalties on its own. Documented in HANDBOOK.md.

## Verification

- Full jest suite in the implementation worktree: 379 suites / 5265 tests green; cross-review re-ran the three new suites (41/41) plus 310 suites / 4473 tests at root.
- At repo root on the branch commit: `npm run build:mcp` + `tests/cli/mcp-server-code-dispatch.test.ts` (4/4), dashboard vitest (70/70), `tsc --noEmit` clean, `rulebook-coverage-gate.mjs` OK (19 signals: 7 documented, 12 exempted).
- Orchestrator adversarial pass on the record path (covering the failed deepseek lens): missing/empty `counterpart_id` rejected; the two `finding_id` grammars stay disjoint and fail closed; `signal_class` is not caller-suppliable (server-stamped at mcp-server-sdk.ts:3866).

## Known follow-ups (out of scope)

- `peer-relationships.ts` skips `design_split` (fourth bucket needs a `PeerRelationship` type change + renderer updates).
- A self-split (`agent_id === counterpart_id`) is not rejected — same pre-existing behavior as `agreement`/`disagreement`; harmless (scores nothing) but worth a shared guard someday.
- HANDBOOK.md is at 519 lines (was 510 before this PR; the addition was compressed to +9). Needs a dedicated curation pass to get back under 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
