### PR TITLE
fix(deps): bump re2 to 1.26.1 to clear two published DoS advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4614,16 +4614,21 @@
       "license": "ISC"
     },
     "node_modules/install-artifact-from-github": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.6.0.tgz",
-      "integrity": "sha512-wKsuzN8fy8QK7iEUqyWTQmvZ1QFGPn1xyl3/1iIIDthDjS7Hn9HoPwHlNakZirWbCsbad0lZMkr6Xfbpe1pUzw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.7.0.tgz",
+      "integrity": "sha512-qAb91yAKVF9rFY4rVP21ZtYUyCScxAFt9udwzVWNLBE1pQcdQeB2gd1HlNPcQNYCzCDvJ/QJQPuWQ6aTmSlU8g==",
       "license": "BSD-3-Clause",
       "bin": {
+        "hash-github-cache": "bin/hash-github-cache.js",
         "install-from-cache": "bin/install-from-cache.js",
         "save-to-github-cache": "bin/save-to-github-cache.js"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/uhop"
       }
     },
     "node_modules/ip-address": {
@@ -6083,9 +6088,9 @@
       "license": "MIT"
     },
     "node_modules/nan": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
-      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6131,9 +6136,9 @@
       "license": "MIT"
     },
     "node_modules/node-gyp": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-13.0.0.tgz",
-      "integrity": "sha512-FYYyBDWdc+kzoyPd5PqHUgM9DGs1C/Z4jxBZAOnA2GRUVXPivKRREq5q+VVPXVr9aGVqGMaMqyFHbviy/yb7Hg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-13.0.1.tgz",
+      "integrity": "sha512-piOr0S10qy5THB+q5BdqkoOx65XL/tjTMUAit3vciPNp+snTOBnGunWH1Rz7XZUxf2T9uFrfT/Ty4+aC3yPeyg==",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
@@ -6144,7 +6149,7 @@
         "semver": "^7.3.5",
         "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
-        "undici": "^6.25.0",
+        "undici": "^8.4.1",
         "which": "^7.0.0"
       },
       "bin": {
@@ -6656,15 +6661,15 @@
       }
     },
     "node_modules/re2": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/re2/-/re2-1.25.0.tgz",
-      "integrity": "sha512-mtxKjWS+VYIt2ijgt6ohEdwzNlGPom1whyaEKJD40cBc/wqkO1vJoOyK539Qb8Xa9m4GA6hiPGDIbW/d3egSRQ==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/re2/-/re2-1.26.1.tgz",
+      "integrity": "sha512-oi79a4h6EO3PAwNsDMWgeCcsRGQEUa52DIgOiFTZGDEZocEXG9h+oXy0qZqndo47huUeJuVWSoOJIEhOupqOcg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "install-artifact-from-github": "^1.6.0",
-        "nan": "^2.27.0",
-        "node-gyp": "^13.0.0"
+        "install-artifact-from-github": "^1.7.0",
+        "nan": "^2.28.0",
+        "node-gyp": "^13.0.1"
       },
       "engines": {
         "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
@@ -7701,12 +7706,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {


### PR DESCRIPTION
## What

Bumps `re2` from **1.25.0 → 1.26.1** (lockfile-only) to clear the two open Dependabot alerts against `re2 <= 1.25.1`.

| Advisory | Severity | Bug |
|---|---|---|
| [GHSA-ff84-5f28-78qj](https://github.com/advisories/GHSA-ff84-5f28-78qj) | moderate | Out-of-bounds heap read in `exec`/`test`/`match` via attacker-influenced `lastIndex` on a **non-ASCII** subject → uncatchable process crash (DoS) |
| [GHSA-6hxr-mr5r-9836](https://github.com/advisories/GHSA-6hxr-mr5r-9836) | moderate | Global `String.prototype.match` with an empty-matchable pattern never advances → infinite loop, unbounded native memory (DoS) |

Both were patched upstream in re2 **1.25.2**; `npm update` resolved the latest in-range minor, **1.26.1**.

## Why lockfile-only

`package.json` already declares `"re2": "^1.25.0"` (root + `@gossip/tools`), which admits 1.26.1 — so there is no manifest change and no version-range decision to make. re2 backs the linear-time regex search in `packages/tools/src/file-tools.ts`.

## Verification (at repo root, not a worktree — native binary + dist-mcp discipline)

- `npm run build:mcp` clean (re2 is `--external`, loaded native at runtime).
- re2 1.26.1 loads and handles a non-ASCII subject without crashing (the GHSA-ff84 repro class).
- Full suite green: **381/381 suites, 5275 passed**, 29 skipped, 5 todo.
- `npm audit` shows no remaining re2 findings.

## Out of scope (follow-up)

`npm audit` still reports 2 moderate for `@hono/node-server` (`%5C` path traversal, Windows-only) pulled in transitively via `@modelcontextprotocol/sdk`. Fixing it requires bumping the MCP SDK — larger blast radius, dual-zod-sensitive — so it is deliberately left out of this security-scoped PR.

## Credit

Both advisories were reported by **@ataberk-xyz** (ASAN testing + pattern fuzzing of node-re2, disclosed 2026-07-07, published 2026-07-31). This PR closes the loop on gossipcat consuming its own then-unpatched dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)