### PR TITLE
feat(skills): add gossip_skills(action:"get") to fetch a skill's raw markdown (#698 part 1)

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -4549,12 +4549,12 @@ export function createMcpServer(): McpServer {
   // ── Unified skill management ─────────────────────────────────────────────
   server.tool(
     'gossip_skills',
-    'Manage agent skills. Actions: list (show skill index), bind (attach skill to agent), unbind (remove skill from agent), build (create skills from gap suggestions), develop (generate skill from ATI competency data), prune (drop skill-index entries for agents no longer in config.json).',
+    'Manage agent skills. Actions: list (show skill index), get (return a skill\'s raw markdown by name), bind (attach skill to agent), unbind (remove skill from agent), build (create skills from gap suggestions), develop (generate skill from ATI competency data), prune (drop skill-index entries for agents no longer in config.json).',
     {
-      action: z.enum(['list', 'bind', 'unbind', 'build', 'develop', 'prune']).describe('Action to perform'),
-      // bind/unbind/develop params
-      agent_id: z.string().optional().describe('Agent ID (required for bind, unbind, develop)'),
-      skill: z.string().optional().describe('Skill name (required for bind, unbind)'),
+      action: z.enum(['list', 'get', 'bind', 'unbind', 'build', 'develop', 'prune']).describe('Action to perform'),
+      // bind/unbind/develop/get params
+      agent_id: z.string().optional().describe('Agent ID (required for bind, unbind, develop; optional for get — when given, checks that agent\'s local skills dir first)'),
+      skill: z.string().optional().describe('Skill name (required for bind, unbind, get)'),
       // NOTE: no z.default() here — combining .default().optional() on a boolean
       // produces a malformed JSON schema emitted to MCP clients, which then
       // mis-serialize sibling complex fields (notably `skills: [...]`) as strings,
@@ -4595,6 +4595,25 @@ export function createMcpServer(): McpServer {
         });
 
         return { content: [{ type: 'text' as const, text: `Skill Index (${agentIds.length} agents):\n\n${sections.join('\n\n')}` }] };
+      }
+
+      // ── get ──
+      if (action === 'get') {
+        if (!skill) return { content: [{ type: 'text' as const, text: 'Error: skill is required for get.' }] };
+
+        const { resolveSkill: resolveSkillFn, resolveSharedSkill } = await import('@gossip/orchestrator');
+        const resolved = agent_id
+          ? resolveSkillFn(agent_id, skill, process.cwd())
+          : resolveSharedSkill(skill, process.cwd());
+
+        if (!resolved) {
+          const searched = agent_id
+            ? `agent-local (.gossip/agents/${agent_id}/skills), project-wide (.gossip/skills), and bundled (default-skills)`
+            : `project-wide (.gossip/skills) and bundled (default-skills)`;
+          return { content: [{ type: 'text' as const, text: `Skill "${skill}" not found. Searched: ${searched}.` }] };
+        }
+
+        return { content: [{ type: 'text' as const, text: `# skill: ${skill}  (resolved: ${resolved.path})\n\n${resolved.content}` }] };
       }
 
       // ── bind ──
@@ -5692,7 +5711,7 @@ export function createMcpServer(): McpServer {
         // Power-user (5)
         { name: 'gossip_plan', desc: 'Plan a task with write-mode suggestions. Returns dispatch-ready JSON for approval.' },
         { name: 'gossip_scores', desc: 'View agent performance scores and dispatch weights.' },
-        { name: 'gossip_skills', desc: 'Manage skills. action: list, bind, unbind, build, develop.' },
+        { name: 'gossip_skills', desc: 'Manage skills. action: list, get, bind, unbind, build, develop.' },
         { name: 'gossip_config', desc: 'Manage runtime feature-gate flags in .gossip/runtime-flags.json. action: list, get, set, unset, reload.' },
         { name: 'gossip_remember', desc: 'Search an agent\'s archived knowledge files by keyword query.' },
         { name: 'gossip_verify_memory', desc: 'On-demand staleness check for a memory file claim. Returns FRESH | STALE | CONTRADICTED | INCONCLUSIVE with file:line evidence.' },

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -2,7 +2,7 @@ export { MainAgent } from './main-agent';
 export { seedMemoryHygiene } from './memory-hygiene-seed';
 export type { MemoryHygieneSeedResult } from './memory-hygiene-seed';
 export { detectFormatCompliance, MAX_COMPLIANCE_INPUT } from './dispatch-pipeline';
-export { loadSkills, resolveEffectiveSkills, DEFAULT_KEYWORDS, keywordStem, resolveSkillExists, resolveSkill } from './skill-loader';
+export { loadSkills, resolveEffectiveSkills, DEFAULT_KEYWORDS, keywordStem, resolveSkillExists, resolveSkill, resolveSharedSkill } from './skill-loader';
 export type { LoadSkillsResult, DroppedSkill } from './skill-loader';
 export { crossReviewSkillGateSeverity, shouldInjectCrossReviewSkills, createAgentSkillsContentResolver } from './cross-review-skills';
 export type { CrossReviewSkillGateSeverity, SeverityBearingFinding, AgentSkillsContentResolverConfig } from './cross-review-skills';

--- a/packages/orchestrator/src/skill-loader.ts
+++ b/packages/orchestrator/src/skill-loader.ts
@@ -617,16 +617,44 @@ export function resolveSkill(
   // Sanitize agentId to prevent path traversal
   if (!SAFE_AGENT_ID.test(agentId)) return null;
 
-  // Use canonical normalization for skill name (consistent with SkillIndex)
-  const normalized = normalizeSkillName(skill);
-  if (!normalized) return null;
-  const filename = `${normalized}.md`;
-
   const bases = [
     resolve(projectRoot, '.gossip', 'agents', agentId, 'skills'),
     resolve(projectRoot, '.gossip', 'skills'),
     resolve(__dirname, 'default-skills'),
   ];
+
+  return resolveSkillFromBases(bases, skill);
+}
+
+/**
+ * Resolve a skill name against the agent-agnostic bases only (project-wide
+ * `.gossip/skills`, then bundled `default-skills`) — never an agent-local
+ * `.gossip/agents/<id>/skills` directory. For callers that have no specific
+ * agentId in hand (e.g. an ad-hoc `gossip_skills(action: "get")` lookup)
+ * and must not risk resolving into an unrelated agent's local skill dir.
+ * Shares the same path-traversal guard and safe-read behavior as {@link resolveSkill}.
+ */
+export function resolveSharedSkill(
+  skill: string,
+  projectRoot: string,
+): { content: string; path: string } | null {
+  const bases = [
+    resolve(projectRoot, '.gossip', 'skills'),
+    resolve(__dirname, 'default-skills'),
+  ];
+
+  return resolveSkillFromBases(bases, skill);
+}
+
+/** Shared resolution walk used by {@link resolveSkill} and {@link resolveSharedSkill}. */
+function resolveSkillFromBases(
+  bases: string[],
+  skill: string,
+): { content: string; path: string } | null {
+  // Use canonical normalization for skill name (consistent with SkillIndex)
+  const normalized = normalizeSkillName(skill);
+  if (!normalized) return null;
+  const filename = `${normalized}.md`;
 
   for (const base of bases) {
     const candidate = resolve(base, filename);

--- a/tests/cli/mcp-skills-validation.test.ts
+++ b/tests/cli/mcp-skills-validation.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { SkillIndex, SkillGapTracker, resolveSkillExists } from '@gossip/orchestrator';
+import { SkillIndex, SkillGapTracker, resolveSkillExists, resolveSkill, resolveSharedSkill } from '@gossip/orchestrator';
 
 function makeTmpDir(): string {
   const dir = join(tmpdir(), `gossip-skills-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -357,5 +357,97 @@ describe('build discovery reports pending gaps', () => {
     const result = tracker.checkThresholds();
     expect(result.count).toBe(0);
     expect(result.pending).not.toContain('error-handling');
+  });
+});
+
+// ── gossip_skills(action: "get") — issue #698 part 1 ──────────────────────
+//
+// The `get` handler (apps/cli/src/mcp-server-sdk.ts, action === 'get' branch)
+// is a thin wrapper over resolveSkill / resolveSharedSkill: it validates
+// `skill` is present, resolves via the appropriate function, and formats the
+// result. These tests exercise the resolution building blocks directly (the
+// handler itself is not exported — see mcp-skills-develop-throttle.test.ts
+// for the same "test the building blocks" convention used elsewhere in this
+// suite) plus a local mirror of the one-line `skill` presence guard.
+
+describe('resolveSkill / resolveSharedSkill power gossip_skills(action: "get")', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('(a) resolves a bundled default skill by name with no agent_id and no project override', () => {
+    // No .gossip/skills or .gossip/agents dir exists in tmpDir at all — the
+    // only place "implementation-discipline" can resolve from is the bundled
+    // default-skills/ directory shipped with @gossip/orchestrator.
+    const resolved = resolveSharedSkill('implementation-discipline', tmpDir);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.content).toContain('name: implementation-discipline');
+    expect(resolved!.path.endsWith(join('default-skills', 'implementation-discipline.md'))).toBe(true);
+  });
+
+  it('(a2) resolveSkill (agent_id path) also falls through to the bundled default when no local/project override exists', () => {
+    const resolved = resolveSkill('agent-a', 'implementation-discipline', tmpDir);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.content).toContain('name: implementation-discipline');
+  });
+
+  it('(b) returns null for a bogus skill name (not-found case for the handler to report)', () => {
+    expect(resolveSharedSkill('this-skill-does-not-exist-anywhere-xyz', tmpDir)).toBeNull();
+    expect(resolveSkill('agent-a', 'this-skill-does-not-exist-anywhere-xyz', tmpDir)).toBeNull();
+  });
+
+  it('(c) resolveSharedSkill prefers project-wide .gossip/skills over the bundled default', () => {
+    const projectSkillsDir = join(tmpDir, '.gossip', 'skills');
+    mkdirSync(projectSkillsDir, { recursive: true });
+    // Reuse a name that also exists in default-skills/ so precedence is meaningfully tested.
+    writeFileSync(join(projectSkillsDir, 'implementation-discipline.md'), '# PROJECT-WIDE OVERRIDE\n');
+
+    const resolved = resolveSharedSkill('implementation-discipline', tmpDir);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.content).toBe('# PROJECT-WIDE OVERRIDE\n');
+  });
+
+  it('(c) resolveSharedSkill never reads an agent-local skills dir, even when one exists for the same name', () => {
+    const agentSkillsDir = join(tmpDir, '.gossip', 'agents', 'some-agent', 'skills');
+    mkdirSync(agentSkillsDir, { recursive: true });
+    writeFileSync(join(agentSkillsDir, 'shared-priority-test.md'), '# AGENT LOCAL — SHOULD NEVER BE RETURNED\n');
+
+    const projectSkillsDir = join(tmpDir, '.gossip', 'skills');
+    mkdirSync(projectSkillsDir, { recursive: true });
+    writeFileSync(join(projectSkillsDir, 'shared-priority-test.md'), '# PROJECT WIDE\n');
+
+    const resolved = resolveSharedSkill('shared-priority-test', tmpDir);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.content).toBe('# PROJECT WIDE\n');
+  });
+
+  it('(c) resolveSharedSkill returns null for a skill that ONLY exists in an agent-local dir (no project/bundled copy)', () => {
+    const agentSkillsDir = join(tmpDir, '.gossip', 'agents', 'some-agent', 'skills');
+    mkdirSync(agentSkillsDir, { recursive: true });
+    writeFileSync(join(agentSkillsDir, 'agent-only-skill.md'), '# AGENT ONLY\n');
+
+    // resolveSkill (agent_id given) WOULD find it via the agent-local base...
+    expect(resolveSkill('some-agent', 'agent-only-skill', tmpDir)).not.toBeNull();
+    // ...but resolveSharedSkill (no agent_id / "get" without agent_id) must not.
+    expect(resolveSharedSkill('agent-only-skill', tmpDir)).toBeNull();
+  });
+
+  it('(d) the handler\'s "skill is required for get" guard rejects an empty/missing skill param', () => {
+    // Mirrors the exact one-line guard at the top of the `get` branch in
+    // apps/cli/src/mcp-server-sdk.ts: `if (!skill) return { ... 'Error: skill is required for get.' ... }`.
+    function simulateGetGuard(skill?: string): string | null {
+      if (!skill) return 'Error: skill is required for get.';
+      return null;
+    }
+
+    expect(simulateGetGuard(undefined)).toBe('Error: skill is required for get.');
+    expect(simulateGetGuard('')).toBe('Error: skill is required for get.');
+    expect(simulateGetGuard('implementation-discipline')).toBeNull();
   });
 });


### PR DESCRIPTION
Part 1 of #698 (the on-demand skill-fetch escape hatch). Parts 2–3 remain open on the issue.

## Problem

`gossip_skills` had no way to read a skill's content on demand — only roster operations (`list`/`bind`/`unbind`/`build`/`develop`/`prune`), with content reaching an agent solely via dispatch-time auto-injection. To reuse a skill's guidance in a one-off dispatch without permanently binding it, the orchestrator had to open `.gossip/skills/<name>.md` and hand-copy it: stale-copy-prone and undiscoverable.

## Change

Adds `action:"get"`:

```
gossip_skills(action: "get", skill: "<name>", agent_id?: "<id>")  →  raw markdown
```

Resolution reuses the existing `resolveSkill()`:
- **`agent_id` given** → agent-local → project-wide → bundled (that agent's chain).
- **`agent_id` omitted** → new `resolveSharedSkill()`: project-wide → bundled **only**.

`resolveSharedSkill` is a thin sibling in `skill-loader.ts`; both it and `resolveSkill` now delegate to a shared `resolveSkillFromBases` walk with the **unchanged** path-traversal guard (`candidate.startsWith(base + sep)`) and safe read. The "never touches an agent-local dir" guarantee is **structural** — the agent-local base is simply absent from its `bases` array — rather than passing a guessable sentinel agentId into `resolveSkill` (which could collide with a real agent's dir). `resolveSkill`'s signature/behavior are untouched for existing callers.

## Not in scope (tracked on #698)

- **Part 2**: an agent-facing self-serve skill-query tool (the `gossip_remember` analogue for skills).
- **Part 3**: a bridge to Claude Code `.claude/skills/*/SKILL.md`.

## Tests

7 new in `tests/cli/mcp-skills-validation.test.ts`: bundled resolution (with/without `agent_id`), project-over-bundled precedence, `resolveSharedSkill` **never** reading agent-local even when a same-named file exists there, agent-local-only resolving via `resolveSkill` but not `resolveSharedSkill`, bogus-name → null, and the `skill`-required guard. Mirrors the existing "test the building blocks, not the unexported handler" convention in the file.

Full suite **381/381 (5,282 passed)**; `tsc --noEmit` clean on `apps/cli` and `@gossip/orchestrator`. Build artifacts (`packages/orchestrator/dist`, `dist-mcp`) are gitignored and rebuilt by CI — not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)