### PR TITLE
feat(skills): effectiveness-aware contextual budget tiebreaker (#675 P2)

### DIFF
--- a/packages/orchestrator/src/skill-loader.ts
+++ b/packages/orchestrator/src/skill-loader.ts
@@ -277,6 +277,10 @@ function categoryBoost(skillCategory: string | undefined, categories: string[]):
  * MIN_KEYWORD_HITS=1 gate (effective 0.5 < 1). A 1-hit skill with boost gets
  * 1.5 effective hits — enough to outrank a non-category 1-hit but not a
  * non-category 2-hit. See consensus f2ff0fac-fb384daa.
+ *
+ * Candidates that tie on effective hits are ranked by their frontmatter
+ * `effectiveness` (descending; absent = 0), with the skill name as the final
+ * deterministic tiebreaker. See issue #675 precondition 2.
  */
 export function loadSkills(
   agentId: string,
@@ -307,7 +311,7 @@ export function loadSkills(
 
   const permanent: Array<{ name: string; content: string; path: string }> = [];
   const scoped: Array<{ name: string; content: string; path: string }> = [];
-  const contextualCandidates: Array<{ name: string; content: string; path: string; hits: number; rawHits: number; boost: number }> = [];
+  const contextualCandidates: Array<{ name: string; content: string; path: string; hits: number; rawHits: number; boost: number; effectiveness: number }> = [];
   const loaded: string[] = [];
   const paths: string[] = [];
   const dropped: DroppedSkill[] = [];
@@ -449,7 +453,18 @@ export function loadSkills(
       // but a 1-hit skill with boost passes (1.5 >= 1) and outranks plain
       // 1-hit candidates during the descending sort below.
       if (effectiveHits >= MIN_KEYWORD_HITS) {
-        contextualCandidates.push({ name: skill, content, path: resolvedPath, hits: effectiveHits, rawHits, boost });
+        // Unmeasured skills rank as 0.0 — neutral, so they lose a tie to a
+        // positive-effectiveness peer and win one against a negative-
+        // effectiveness peer that survived the status filter.
+        contextualCandidates.push({
+          name: skill,
+          content,
+          path: resolvedPath,
+          hits: effectiveHits,
+          rawHits,
+          boost,
+          effectiveness: frontmatter?.effectiveness ?? 0,
+        });
       } else {
         // Report raw hits so operators see the real keyword-match count; boost
         // already failed to rescue, so recording effective hits would hide the
@@ -463,13 +478,24 @@ export function loadSkills(
     }
   }
 
-  // Sort contextual by effective hit count (descending), with alphabetical
-  // name as a deterministic tiebreaker. Node's Array.sort has been stable
-  // since v12, but relying on input order here would leak skill-index
-  // iteration order into activation decisions — the name tiebreaker makes
-  // ties deterministic regardless of discovery order.
+  // Sort contextual by effective hit count (descending), then by measured
+  // effectiveness (descending), then alphabetically by name.
+  //
+  // The effectiveness tier is issue #675 precondition 2: hit counts are coarse
+  // integers (plus the 0.5 category boost), so a 1-1-1 tie for the last budget
+  // slot was previously decided alphabetically — which evicted
+  // `input-validation` (+0.416) in favour of `concurrency` on measured briefs.
+  // Ranking by hits alone turns that tie into a coin flip on a skill the RL
+  // loop has shown to work. Hit count stays the PRIMARY key: this only
+  // reorders candidates that the existing ranking already considered equal.
+  //
+  // Alphabetical name remains the final tiebreaker. Node's Array.sort has been
+  // stable since v12, but relying on input order here would leak skill-index
+  // iteration order into activation decisions — the name tiebreaker makes ties
+  // deterministic regardless of discovery order.
   contextualCandidates.sort((a, b) => {
     if (b.hits !== a.hits) return b.hits - a.hits;
+    if (b.effectiveness !== a.effectiveness) return b.effectiveness - a.effectiveness;
     return a.name.localeCompare(b.name);
   });
   const accepted = contextualCandidates.slice(0, MAX_CONTEXTUAL_SKILLS);

--- a/packages/orchestrator/src/skill-parser.ts
+++ b/packages/orchestrator/src/skill-parser.ts
@@ -62,6 +62,15 @@ export interface SkillFrontmatter {
    */
   regressed_from_passed_at?: string;
   /**
+   * Measured effectiveness delta written by `checkEffectiveness()` (positive =
+   * the skill improved the agent's outcomes, negative = it hurt). Absent on
+   * hand-authored skills and on generated files that have not been evaluated
+   * yet. Read by the skill-loader as the contextual-budget tiebreaker, so a
+   * missing value MUST be treated as 0 by callers rather than defaulted here —
+   * `undefined` distinguishes "never measured" from "measured at zero".
+   */
+  effectiveness?: number;
+  /**
    * Dispatch scope. Default 'any' preserves backwards-compatibility with skills
    * authored before this axis was introduced — they activate for all dispatches.
    * Explicit values ('review'|'implement'|'research') hard-reject on mismatch in
@@ -255,6 +264,15 @@ export function parseSkillFrontmatter(content: string, sourceLabel?: string): Sk
     if (valid.length > 0) scope = valid;
   }
 
+  // Numeric coercion is fail-soft in the same spirit as task_type/scope: a
+  // malformed value (`effectiveness: high`) collapses to undefined rather than
+  // rejecting the skill. NaN must never reach the loader's comparator — an
+  // NaN-producing sort key makes the ranking non-deterministic.
+  // An empty value (`effectiveness:` with nothing after the colon) is absent,
+  // not zero — `Number('')` is 0, so the emptiness check has to come first.
+  const rawEffectiveness = fields.effectiveness ? Number(fields.effectiveness) : NaN;
+  const effectiveness = Number.isFinite(rawEffectiveness) ? rawEffectiveness : undefined;
+
   return {
     name: normalizeSkillName(fields.name),
     description: fields.description,
@@ -265,6 +283,7 @@ export function parseSkillFrontmatter(content: string, sourceLabel?: string): Sk
     sources: fields.sources,
     status: fields.status as SkillStatus,
     regressed_from_passed_at: fields.regressed_from_passed_at || undefined,
+    effectiveness,
     task_type,
     scope,
   };

--- a/tests/orchestrator/skill-loader-effectiveness-tiebreak.test.ts
+++ b/tests/orchestrator/skill-loader-effectiveness-tiebreak.test.ts
@@ -1,0 +1,167 @@
+import { loadSkills } from '../../packages/orchestrator/src/skill-loader';
+import { SkillIndex } from '../../packages/orchestrator/src/skill-index';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * Issue #675 precondition 2 — the MAX_CONTEXTUAL_SKILLS budget must be
+ * effectiveness-aware.
+ *
+ * Contract:
+ *   - PRIMARY key is unchanged: effective hit count, descending.
+ *   - Ties on hits are broken by frontmatter `effectiveness`, descending.
+ *   - Absent/malformed `effectiveness` ranks as 0.0, so it loses to a positive
+ *     peer and beats a negative one.
+ *   - Name localeCompare remains the FINAL tiebreaker when hits AND
+ *     effectiveness are equal.
+ *
+ * The measured regression this pins: on a 1-1-1 hit tie, `input-validation`
+ * (+0.416) was evicted in favour of `concurrency` (0.0 at the time) purely by
+ * alphabetical order.
+ */
+describe('Skill loader — effectiveness-aware contextual budget (#675 P2)', () => {
+  let tmpDir: string;
+  let index: SkillIndex;
+
+  /**
+   * Write a contextual skill whose keywords all match the shared probe task.
+   * `effectiveness` is omitted from the frontmatter entirely when undefined,
+   * which is the shape of a hand-authored or never-evaluated skill file.
+   */
+  function writeSkill(
+    name: string,
+    keywords: string[],
+    effectiveness?: number | string,
+  ): void {
+    const skillsDir = join(tmpDir, '.gossip', 'agents', 'test-agent', 'skills');
+    const effLine = effectiveness === undefined ? '' : `effectiveness: ${effectiveness}\n`;
+    writeFileSync(
+      join(skillsDir, `${name}.md`),
+      `---
+name: ${name}
+description: ${name} skill
+keywords: [${keywords.join(', ')}]
+mode: contextual
+status: active
+${effLine}---
+
+## ${name} body
+Content for ${name}.
+`,
+    );
+    index.bind('test-agent', name, { source: 'auto', mode: 'contextual' });
+  }
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `gossip-eff-tiebreak-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    mkdirSync(join(tmpDir, '.gossip', 'agents', 'test-agent', 'skills'), { recursive: true });
+    mkdirSync(join(tmpDir, '.gossip', 'skills'), { recursive: true });
+    index = new SkillIndex(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ─── 1: equal hits, tie broken by effectiveness ───────────────────────────
+  it('equal hits: higher effectiveness wins the last budget slot over an alphabetically earlier skill', () => {
+    // Four candidates, 1 raw hit each, budget is 3. Alphabetically the loser
+    // would be `zulu-probe`; by effectiveness the loser must be `alpha-probe`.
+    writeSkill('alpha-probe', ['refactor'], -0.192);
+    writeSkill('bravo-probe', ['refactor'], 0.416);
+    writeSkill('charlie-probe', ['refactor'], 0.582);
+    writeSkill('zulu-probe', ['refactor'], 0.455);
+
+    const result = loadSkills('test-agent', [], tmpDir, index, 'please refactor this module', []);
+
+    // Ranked purely by effectiveness because all four tie at 1.0 hits.
+    expect(result.activatedContextual).toEqual(['charlie-probe', 'zulu-probe', 'bravo-probe']);
+    const drop = result.dropped.find(d => d.skill === 'alpha-probe');
+    expect(drop?.reason).toBe('budget-exceeded');
+  });
+
+  // ─── 2: missing effectiveness treated as 0 ────────────────────────────────
+  it('missing effectiveness ranks as 0.0 and loses a tie to a positive-effectiveness skill', () => {
+    // `alpha-unmeasured` has no effectiveness line at all and would win the
+    // alphabetical tiebreaker; the measured +0.416 skill must outrank it.
+    writeSkill('alpha-unmeasured', ['refactor']);
+    writeSkill('zulu-measured', ['refactor'], 0.416);
+    // A third candidate keeps the budget from hiding the ordering.
+    writeSkill('mike-negative', ['refactor'], -0.192);
+
+    const result = loadSkills('test-agent', [], tmpDir, index, 'please refactor this module', []);
+
+    // Unmeasured (0.0) sits between the positive and the negative skill.
+    expect(result.activatedContextual).toEqual(['zulu-measured', 'alpha-unmeasured', 'mike-negative']);
+  });
+
+  it('malformed effectiveness ranks as 0.0 rather than poisoning the comparator', () => {
+    // `Number('high')` is NaN; an NaN sort key would make ordering
+    // non-deterministic, so the parser must coerce it to absent.
+    writeSkill('alpha-malformed', ['refactor'], 'high');
+    writeSkill('zulu-measured', ['refactor'], 0.416);
+
+    const result = loadSkills('test-agent', [], tmpDir, index, 'please refactor this module', []);
+
+    expect(result.activatedContextual).toEqual(['zulu-measured', 'alpha-malformed']);
+  });
+
+  // ─── 3: alphabetical fallback preserved ───────────────────────────────────
+  it('equal hits AND equal effectiveness: alphabetical order is still the final tiebreaker', () => {
+    writeSkill('zulu-probe', ['refactor'], 0.416);
+    writeSkill('alpha-probe', ['refactor'], 0.416);
+
+    const r1 = loadSkills('test-agent', [], tmpDir, index, 'please refactor this module', []);
+    const r2 = loadSkills('test-agent', [], tmpDir, index, 'please refactor this module', []);
+
+    expect(r1.activatedContextual).toEqual(['alpha-probe', 'zulu-probe']);
+    expect(r2.activatedContextual).toEqual(r1.activatedContextual);
+  });
+
+  it('two unmeasured skills fall back to alphabetical order (both rank 0.0)', () => {
+    writeSkill('zulu-probe', ['refactor']);
+    writeSkill('alpha-probe', ['refactor']);
+
+    const result = loadSkills('test-agent', [], tmpDir, index, 'please refactor this module', []);
+
+    expect(result.activatedContextual).toEqual(['alpha-probe', 'zulu-probe']);
+  });
+
+  // ─── 4: primary hit ordering unchanged ────────────────────────────────────
+  it('hit count remains the primary key: a 2-hit skill outranks a 1-hit skill with far better effectiveness', () => {
+    writeSkill('alpha-twohit', ['refactor', 'migration'], -0.192);
+    writeSkill('zulu-onehit', ['refactor'], 0.582);
+
+    const result = loadSkills(
+      'test-agent',
+      [],
+      tmpDir,
+      index,
+      'please refactor this module during the migration',
+      [],
+    );
+
+    expect(result.activatedContextual).toEqual(['alpha-twohit', 'zulu-onehit']);
+  });
+
+  it('hit count remains the primary key under budget pressure: the 1-hit high-effectiveness skill is still evicted', () => {
+    writeSkill('two-a', ['refactor', 'migration'], 0);
+    writeSkill('two-b', ['refactor', 'migration'], 0);
+    writeSkill('two-c', ['refactor', 'migration'], 0);
+    writeSkill('one-best', ['refactor'], 0.9);
+
+    const result = loadSkills(
+      'test-agent',
+      [],
+      tmpDir,
+      index,
+      'please refactor this module during the migration',
+      [],
+    );
+
+    expect(result.activatedContextual).toEqual(['two-a', 'two-b', 'two-c']);
+    const drop = result.dropped.find(d => d.skill === 'one-best');
+    expect(drop?.reason).toBe('budget-exceeded');
+  });
+});


### PR DESCRIPTION
Part of #675 (precondition P2). Does NOT close it — the mode-flip (stage 2) stays blocked pending the remaining P3 gate items (see measurement comment on #675).

## Change

The `MAX_CONTEXTUAL_SKILLS` ranking in `skill-loader.ts` broke effective-hit ties alphabetically and never read the persisted `effectiveness` frontmatter — on the measured 1-1-1 tie this evicted `input-validation` (+0.416) in favour of `concurrency` purely by name. The comparator is now three-tier: effective hits desc (unchanged primary), then frontmatter `effectiveness` desc (absent → 0), then name. `MIN_KEYWORD_HITS`, `CATEGORY_BOOST`, and the single status-filter site are untouched (HANDBOOK invariant #7 — no second filter site).

`skill-parser.ts` adds `effectiveness?: number` to `SkillFrontmatter` with fail-soft coercion: empty values are absent (`Number('')` is 0, so the emptiness check comes first) and non-finite values collapse to `undefined` so an NaN sort key can never make the ranking non-deterministic.

## Measured impact

On 8 real dispatch briefs against post-#700 keywords, the tiebreaker changes **nothing** — accepted skill sets are byte-identical, because post-#700 keyword sparsity leaves the 3-slot budget rarely contended. This is a correctness safety net for the eviction case #675's measurement documented, not a behaviour change on the current corpus.

## Verification

- 7 new tests in `tests/orchestrator/skill-loader-effectiveness-tiebreak.test.ts` (tie broken by effectiveness; missing-as-0; alphabetical fallback; primary hit ordering preserved; malformed values).
- Full suite: 5,349 passed; one pre-existing worktree-only dist-mcp failure confirmed identical on unmodified base via git stash.
- Orchestrator re-verified the diff and re-ran the new suite (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)