### PR TITLE
fix(skills): stopword bare 'scoped' as ambient repo noun; use 'scoped write*' phrase (#675 P3 prereq)

### DIFF
--- a/packages/orchestrator/src/keyword-stopwords.ts
+++ b/packages/orchestrator/src/keyword-stopwords.ts
@@ -37,11 +37,23 @@
  * the DF bar but are the literal subject of `cli_ergonomics` and
  * `citation_grounding`, so they fail (b) and are kept.
  *
- * `injection` is the one entry admitted on (b) alone, at DF 7.4%: of its 62
- * corpus occurrences, 60 are skill/lesson/context injection ("injection point",
- * "injection time", "lesson injection poisons the cache") and 2 are the security
- * sense. The multi-word forms `prompt injection` / `shell injection` /
- * `command injection` survive stopwording and carry that sense precisely.
+ * Two entries are admitted on (b) alone.
+ *
+ * `injection`, at DF 7.4%: of its 62 corpus occurrences, 60 are skill/lesson/
+ * context injection ("injection point", "injection time", "lesson injection
+ * poisons the cache") and 2 are the security sense. The multi-word forms
+ * `prompt injection` / `shell injection` / `command injection` survive
+ * stopwording and carry that sense precisely.
+ *
+ * `scoped`, at DF 6.5% (26 of 400 documents, 45 occurrences, re-measured
+ * 2026-08-03) — and here the sense split is total rather than lopsided: all 45
+ * occurrences name gossipcat's own machinery (`write_mode: "scoped"`, scoped
+ * signal retraction, session-/consensus-/file-scoped identifiers, CSS-scoped
+ * tokens) and none carry a permissions sense. It was itself introduced by #700
+ * as replacement vocabulary for the removed `path` / `session` / `token`, which
+ * makes it this rule's own blind spot: a term can be the repo's trust-boundary
+ * jargon and an ambient repo noun at once. The phrase `scoped write*` (DF 0.2%)
+ * replaces it in `trust_boundaries` and survives stopwording.
  *
  * ## Scope of the filter
  *
@@ -102,6 +114,12 @@ export const AMBIENT_STOPWORDS: ReadonlySet<string> = new Set([
 
   // ── admitted on sense, not DF ────────────────────────────────────────────
   'injection',                  // 7.4%, but 60/62 occurrences are skill injection
+  'scoped',                     // 6.5%, but 45/45 occurrences are gossipcat's own
+                                // machinery: `write_mode: "scoped"`, scoped signal
+                                // retraction, session-/consensus-/file-scoped ids,
+                                // CSS-scoped tokens. Zero carry a permissions sense.
+                                // Ironically added by #700 itself as replacement
+                                // vocabulary; `scoped write*` carries the sense.
 ]);
 
 /**

--- a/packages/orchestrator/src/skill-engine.ts
+++ b/packages/orchestrator/src/skill-engine.ts
@@ -139,7 +139,7 @@ const KNOWN_CATEGORIES = new Set([
  * the per-entry rationale, which is written up on the skill-loader copy.
  */
 export const CATEGORY_KEYWORDS: Record<string, string[]> = {
-  trust_boundaries: ['auth', 'authentication', 'authorization', 'cookie', 'traversal', 'path traversal', 'middleware', 'permission', 'role', 'privilege', 'acl', 'trust boundary', 'boundary escape', 'sandbox', 'scoped', 'untrusted', 'allowlist', 'bypass*', 'escalat*', 'tamper*'],
+  trust_boundaries: ['auth', 'authentication', 'authorization', 'cookie', 'traversal', 'path traversal', 'middleware', 'permission', 'role', 'privilege', 'acl', 'trust boundary', 'boundary escape', 'sandbox', 'scoped write*', 'untrusted', 'allowlist', 'bypass*', 'escalat*', 'tamper*'],
   injection_vectors: ['xss', 'sql', 'sanitiz*', 'escape', 'template', 'eval', 'exec', 'html', 'uri', 'command', 'prompt injection', 'shell injection', 'command injection', 'argument injection'],
   input_validation: ['validation', 'schema', 'zod', 'parse', 'sanitiz*', 'input', 'form', 'request', 'coerce', 'transform'],
   concurrency: ['race', 'concurren*', 'mutex', 'lock', 'atomic', 'parallel', 'deadlock', 'semaphore', 'toctou', 'interleav*', 'in-flight'],

--- a/packages/orchestrator/src/skill-loader.ts
+++ b/packages/orchestrator/src/skill-loader.ts
@@ -52,7 +52,7 @@ const MIN_KEYWORD_HITS = 1;
  * AMBIENT-NOUN RULE (issue #700). No entry below may be a single ambient repo
  * noun — a word that names gossipcat's own machinery or the scaffolding every
  * dispatch brief shares (`path`, `session`, `token`, `memory`, `log`, `test`,
- * `dashboard`, `prompt`, `high`/`medium`/`low`, `injection`). Those terms
+ * `dashboard`, `prompt`, `high`/`medium`/`low`, `injection`, `scoped`). Those terms
  * measure vocabulary overlap with this repo, not task relevance, which is how
  * `trust_boundaries` reached a 59.4% brief fire rate at -0.19 effectiveness
  * while `concurrency` sat at 15.7% and +0.58. The list, its measured document
@@ -67,9 +67,14 @@ export const DEFAULT_KEYWORDS: Record<string, string[]> = {
   // brief they mean the orchestrator session, a context token, a file path and
   // skill injection, never the security concepts. `path` alone matched 42.7% of
   // briefs. Replaced with this repo's real trust-boundary vocabulary: the
-  // worktree `sandbox`, `scoped` write mode, `allowlist` checks, and the
-  // `path traversal` / `boundary escape` phrases (exempt from stopwording).
-  trust_boundaries: ['auth', 'authentication', 'authorization', 'cookie', 'traversal', 'path traversal', 'middleware', 'permission', 'role', 'privilege', 'acl', 'trust boundary', 'boundary escape', 'sandbox', 'scoped', 'untrusted', 'allowlist', 'bypass*', 'escalat*', 'tamper*'],
+  // worktree `sandbox`, the `scoped write*` mode phrase, `allowlist` checks, and
+  // the `path traversal` / `boundary escape` phrases (exempt from stopwording).
+  // #675 P3: that replacement first shipped as bare `scoped`, which was itself an
+  // ambient repo noun — 45/45 corpus occurrences are gossipcat machinery (scoped
+  // write mode, scoped retraction, session-/consensus-/file-scoped ids), none a
+  // permissions sense. It is now stopworded, and the `scoped write*` phrase (DF
+  // 0.2%) carries the sense: firing rarely and correctly is the goal.
+  trust_boundaries: ['auth', 'authentication', 'authorization', 'cookie', 'traversal', 'path traversal', 'middleware', 'permission', 'role', 'privilege', 'acl', 'trust boundary', 'boundary escape', 'sandbox', 'scoped write*', 'untrusted', 'allowlist', 'bypass*', 'escalat*', 'tamper*'],
   // `sanitiz*` → sanitize/sanitized/sanitizes/sanitizing/sanitization/sanitizer.
   // No English word outside that family begins `sanitiz`. (The British `sanitis*`
   // spelling is still uncovered — same gap as the pre-#681 bare `sanitize`.)

--- a/tests/orchestrator/keyword-stopwords.test.ts
+++ b/tests/orchestrator/keyword-stopwords.test.ts
@@ -81,9 +81,24 @@ describe('#700 — multi-word phrases are never stopwords', () => {
     ['prompt injection', 'injection_vectors'],
     ['command injection', 'injection_vectors'],
     ['trust boundary', 'trust_boundaries'],
+    ['scoped write*', 'trust_boundaries, #675 P3 replacement for bare `scoped`'],
   ])('%s survives (%s)', phrase => {
     expect(isAmbientStopword(phrase)).toBe(false);
     expect(stripAmbientStopwords([phrase])).toEqual([phrase]);
+  });
+
+  it('#675 P3 — bare `scoped` is ambient, but the `scoped write*` phrase is not', () => {
+    // `scoped` was added by #700 as replacement vocabulary and is itself an
+    // ambient repo noun: 45/45 corpus occurrences are gossipcat machinery
+    // (write_mode, scoped retraction, session-/consensus-/file-scoped ids).
+    expect(isAmbientStopword('scoped')).toBe(true);
+    expect(isAmbientStopword('scoped*')).toBe(true);
+    expect(isAmbientStopword('Scoped')).toBe(true);
+    expect(AMBIENT_STOPWORDS.has('scoped')).toBe(true);
+    expect(stripAmbientStopwords(['scoped', 'scoped write*'])).toEqual(['scoped write*']);
+    // The phrase must still compile to a matching pattern, not merely survive.
+    expect(getPattern('scoped write*').test('the scoped write contract forbids it')).toBe(true);
+    expect(getPattern('scoped write*').test('write_mode: "scoped" per task')).toBe(false);
   });
 
   it('#681 stem phrases still compile and match after surviving the filter', () => {
@@ -171,6 +186,12 @@ describe('#700 — TABLE HYGIENE: no ambient noun ships in either keyword table'
     expect(CATEGORY_KEYWORDS.severity_calibration).not.toContain('high');
     expect(CATEGORY_KEYWORDS.severity_calibration).not.toContain('medium');
     expect(CATEGORY_KEYWORDS.severity_calibration).not.toContain('low');
+    // #675 P3: bare `scoped` was #700's own replacement vocabulary; both tables
+    // now carry the phrase form instead, and they must agree.
+    expect(DEFAULT_KEYWORDS.trust_boundaries).not.toContain('scoped');
+    expect(CATEGORY_KEYWORDS.trust_boundaries).not.toContain('scoped');
+    expect(DEFAULT_KEYWORDS.trust_boundaries).toContain('scoped write*');
+    expect(CATEGORY_KEYWORDS.trust_boundaries).toContain('scoped write*');
   });
 
   it('DF-clearing terms that are their category subject are deliberately KEPT', () => {
@@ -197,11 +218,16 @@ describe('#700 — regenerated categories fire on the right vocabulary', () => {
     expect(fires('trust_boundaries', 'the relay drops resolutionRoots on consensus')).toBe(false);
     expect(fires('trust_boundaries', 'trim the context token budget for the dashboard')).toBe(false);
     expect(fires('trust_boundaries', 'skill injection happens after the cache warms')).toBe(false);
+    // #675 P3: bare `scoped` fired on gossipcat's own dispatch vocabulary.
+    expect(fires('trust_boundaries', 'the signal retraction is round-scoped')).toBe(false);
+    expect(fires('trust_boundaries', 'run this one scoped, not in a worktree')).toBe(false);
   });
 
   it('trust_boundaries still fires on real trust-boundary briefs', () => {
     expect(fires('trust_boundaries', 'the agent escaped the worktree sandbox')).toBe(true);
     expect(fires('trust_boundaries', 'absolute paths bypass the scoped write contract')).toBe(true);
+    // The phrase alone carries it — no `bypass*` in this one.
+    expect(fires('trust_boundaries', 'the scoped write mode let a file land outside')).toBe(true);
     expect(fires('trust_boundaries', 'validate against path traversal')).toBe(true);
     expect(fires('trust_boundaries', 'untrusted agent output is parsed directly')).toBe(true);
     expect(fires('trust_boundaries', 'the allowlist check is missing')).toBe(true);


### PR DESCRIPTION
## Summary

#700 removed `path` / `session` / `token` / `injection` from the `trust_boundaries` keyword list and seeded bare `scoped` as replacement vocabulary. That entry is itself an ambient repo noun — it names gossipcat's own `write_mode` machinery — so it reproduced the exact vocabulary-overlap failure #700 set out to remove, and blocked the #675 P3 anti-correlation gate re-measurement.

**Corpus evidence** (2026-08-03, per the method documented in `keyword-stopwords.ts`: all GitHub issue bodies + last 400 commit messages):
- `\bscoped\b` DF = 26/400 docs (6.5%), 45 occurrences — **all 45** are gossipcat machinery senses (`write_mode: "scoped"`, scoped signal retraction, session-/consensus-/file-scoped identifiers, CSS-scoped tokens). Zero security/permissions sense.
- Independently re-measured by the implementer on the commit-only corpus half (25/401 docs, 37/37 machinery-sense) — consistent.
- This is a stronger sense-dominance case than the existing `injection` precedent (60/62), which is the established basis for admission below the 10% DF bar.

## Changes

- `keyword-stopwords.ts` — `'scoped'` added to `AMBIENT_STOPWORDS` under "admitted on sense, not DF"; file-top doc now enumerates two sense-admitted entries and notes `scoped` as the rule's own blind spot.
- `skill-engine.ts` / `skill-loader.ts` — both duplicated `trust_boundaries` tables replace bare `'scoped'` with the phrase `'scoped write*'` (phrases are stopword-exempt by design; DF 0.2% — firing rarely and correctly is the goal, same rationale as the injection phrases). Entries byte-identical across tables.
- `tests/orchestrator/keyword-stopwords.test.ts` — stopword admission (`scoped`/`scoped*`/`Scoped`), phrase survival + pattern compilation both ways (`"the scoped write contract"` matches, `write_mode: "scoped"` does not), table-hygiene pins in both tables, and fire-rate cases (round-scoped/scoped-dispatch prose no longer fires; scoped-write-mode prose still does without `bypass*` help).

## Verification

- `npx jest tests/orchestrator/` — 204 suites, 3032 passed
- `npm test` — 383 suites, 5342 passed, 0 failed
- `npm run build -w @gossip/orchestrator` clean; `npx tsc --noEmit` shows only pre-existing dashboard-v2 JSX diagnostics (untouched files)

## Follow-up (out of scope here)

- Re-measure the #675 P3 fire-rate-vs-effectiveness gate now that the leak is fixed.
- Watch-item from the implementer: `'scoped write*'` will effectively almost never fire (it doesn't match the dominant corpus spelling `write_mode: "scoped"`), so `trust_boundaries` trades a noisy trigger for a near-silent one — intended, but worth keeping in view during the P3 measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)