### PR TITLE
feat(skills): honour declared contextual mode at all auto-bind sites + flip-only-measured index migration (#675 stage 3)

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -1404,7 +1404,7 @@ export async function handleCollect(
   try {
     const gaps = ctx.mainAgent.getSkillGapSuggestions();
     if (gaps.length > 0 && ctx.skillEngine) {
-      const { normalizeSkillName: nsn, readSkillFreshness: rsf } = await import('@gossip/orchestrator');
+      const { normalizeSkillName: nsn, readSkillFreshness: rsf, resolveAutoBindMode } = await import('@gossip/orchestrator');
       const { appendSkillDevelopAudit } = await import('./skill-develop-audit');
       const developed: string[] = [];
       const failed: string[] = [];
@@ -1412,10 +1412,15 @@ export async function handleCollect(
         // Capture pre-develop freshness for audit
         const freshnessSnapshot = rsf(gap.agentId, gap.category, process.cwd());
         try {
-          await ctx.skillEngine.generate(gap.agentId, gap.category);
+          const generated = await ctx.skillEngine.generate(gap.agentId, gap.category);
           const skillName = nsn(gap.category);
           const skillIndex = ctx.mainAgent.getSkillIndex();
-          if (skillIndex) skillIndex.bind(gap.agentId, skillName, { source: 'auto', mode: 'contextual' });
+          // Honour the mode declared in the generated skill's own frontmatter;
+          // default to permanent when absent (#675).
+          if (skillIndex) {
+            const declaredMode = resolveAutoBindMode(generated.content, generated.path);
+            skillIndex.bind(gap.agentId, skillName, { source: 'auto', mode: declaredMode });
+          }
           // Suppress AFTER successful generate — not before
           const pipeline = (ctx.mainAgent as any).pipeline;
           if (pipeline?.suppressSkillGapAlert) {

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -4816,14 +4816,17 @@ export function createMcpServer(): McpServer {
           if (utilityResult?.status === 'completed' && utilityResult.result && stashedMeta) {
             try {
               const result = ctx.skillEngine.saveFromRaw(agent_id, category, utilityResult.result, stashedMeta);
-              const { normalizeSkillName: nsn } = await import('@gossip/orchestrator');
+              const { normalizeSkillName: nsn, resolveAutoBindMode } = await import('@gossip/orchestrator');
               const skillName = nsn(category);
 
-              // Auto-bind to skill index so it's injected on next dispatch
+              // Auto-bind to skill index so it's injected on next dispatch.
+              // Honour a `mode: contextual` declared in the generated skill's
+              // own frontmatter; default to permanent when absent (#675).
               if (ctx.mainAgent) {
                 const skillIndex = ctx.mainAgent.getSkillIndex();
                 if (skillIndex) {
-                  skillIndex.bind(agent_id, skillName, { source: 'auto', mode: 'permanent' });
+                  const declaredMode = resolveAutoBindMode(result.content, result.path);
+                  skillIndex.bind(agent_id, skillName, { source: 'auto', mode: declaredMode });
                 }
 
                 // Also register on agent config for backwards compat
@@ -4912,14 +4915,17 @@ export function createMcpServer(): McpServer {
         // ── Direct path (no native utility config, or fallback) ──
         try {
           const result = await ctx.skillEngine.generate(agent_id, category);
-          const { normalizeSkillName: nsn } = await import('@gossip/orchestrator');
+          const { normalizeSkillName: nsn, resolveAutoBindMode } = await import('@gossip/orchestrator');
           const skillName = nsn(category);
 
-          // Auto-bind to skill index so it's injected on next dispatch
+          // Auto-bind to skill index so it's injected on next dispatch.
+          // Honour a `mode: contextual` declared in the generated skill's
+          // own frontmatter; default to permanent when absent (#675).
           if (ctx.mainAgent) {
             const skillIndex = ctx.mainAgent.getSkillIndex();
             if (skillIndex) {
-              skillIndex.bind(agent_id, skillName, { source: 'auto', mode: 'permanent' });
+              const declaredMode = resolveAutoBindMode(result.content, result.path);
+              skillIndex.bind(agent_id, skillName, { source: 'auto', mode: declaredMode });
             }
 
             // Also register on agent config for backwards compat

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -213,7 +213,7 @@ export type { ProjectInitializerConfig } from './project-initializer';
 export { TeamManager } from './team-manager';
 export type { TeamManagerConfig } from './team-manager';
 export { normalizeSkillName } from './skill-name';
-export { parseSkillFrontmatter } from './skill-parser';
+export { parseSkillFrontmatter, resolveAutoBindMode } from './skill-parser';
 export type { SkillFrontmatter, SkillScope } from './skill-parser';
 export { extractCategories, isValidCategory, VALID_CATEGORIES } from './category-extractor';
 export { logUncategorizedFinding, getUncategorizedStatusLine } from './uncategorized-logger';

--- a/packages/orchestrator/src/skill-parser.ts
+++ b/packages/orchestrator/src/skill-parser.ts
@@ -288,3 +288,21 @@ export function parseSkillFrontmatter(content: string, sourceLabel?: string): Sk
     scope,
   };
 }
+
+/**
+ * Decide the skill-index binding mode for an auto-bound (generated) skill.
+ *
+ * Issue #675: both auto-bind sites previously hardcoded `'permanent'`, so a
+ * generated skill declaring `mode: contextual` in its own frontmatter was
+ * still bound permanent and injected on every dispatch. The declared mode is
+ * now authoritative; `'permanent'` remains the default whenever the file has
+ * no frontmatter, or the frontmatter omits or misspells `mode`.
+ */
+export function resolveAutoBindMode(
+  content: string,
+  sourceLabel?: string,
+): 'permanent' | 'contextual' {
+  return parseSkillFrontmatter(content, sourceLabel)?.mode === 'contextual'
+    ? 'contextual'
+    : 'permanent';
+}

--- a/scripts/migrate-skill-index-modes.lib.cjs
+++ b/scripts/migrate-skill-index-modes.lib.cjs
@@ -1,0 +1,263 @@
+'use strict';
+// Pure logic for scripts/migrate-skill-index-modes.mjs (issue #675 stage 3).
+//
+// Migrates `.gossip/skill-index.json` auto-bound slots that are still recorded
+// as `mode: "permanent"` over to `mode: "contextual"` — but ONLY when the
+// agent-local skill file BOTH declares `mode: contextual` in its frontmatter
+// AND has a measured effectiveness verdict (`status` is not `pending` and not
+// `insufficient_evidence`). Slots still accumulating evidence keep their
+// permanent binding so the measurement window is not disturbed.
+//
+// The migration edits `mode` in place. It deliberately does NOT go through
+// SkillIndex.bind(), which rotates `boundAt` — `boundAt` anchors the skill
+// effectiveness windows (HANDBOOK invariant #6) and must survive byte-for-byte.
+//
+// CommonJS so ts-jest can require it without Jest's experimental ESM mode.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const HELP = `migrate-skill-index-modes — flip measured auto-bound skills to contextual mode
+
+Usage:
+  node scripts/migrate-skill-index-modes.mjs [--root <path>] [--dry-run] [--json] [--help]
+
+Options:
+  --root <path>   Project root containing .gossip/ (default: process.cwd())
+  --dry-run       Print the flip/keep plan without writing the index
+  --json          Emit the plan as JSON instead of a text report
+  --help          Show this message
+
+A slot is flipped only when ALL of the following hold:
+  * slot.source === "auto" and slot.mode === "permanent"
+  * .gossip/agents/<agent>/skills/<skill>.md declares mode: contextual
+  * that file's status is neither "pending" nor "insufficient_evidence"
+
+Flipped slots keep their original boundAt and get version + 1. Everything
+else is left untouched and reported by category. Re-running is a no-op.`;
+
+/** Statuses that mean "still accumulating evidence" — never flip these. */
+const STARVED_STATUSES = new Set(['pending', 'insufficient_evidence']);
+
+/**
+ * Path components are read from a persisted JSON file, so they are untrusted
+ * input for the purposes of building a filesystem path. Fail closed: a key
+ * that does not match is reported as `unsafe_name` and never joined.
+ */
+const SAFE_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+function isSafeName(value) {
+  return (
+    typeof value === 'string' &&
+    value.length <= 128 &&
+    SAFE_NAME.test(value) &&
+    value !== '.' &&
+    value !== '..'
+  );
+}
+
+function parseArgs(argv) {
+  const args = { help: false, dryRun: false, json: false, root: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') args.help = true;
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--json') args.json = true;
+    else if (a === '--root') args.root = argv[++i] ?? null;
+    else if (a.startsWith('--root=')) args.root = a.slice('--root='.length);
+    else throw new Error(`unknown argument: ${a}`);
+  }
+  return args;
+}
+
+/**
+ * Minimal leading-`---` frontmatter reader for the two scalar fields this
+ * migration cares about. Returns null when the file has no frontmatter block.
+ */
+function parseFrontmatterFields(content) {
+  const match = /^---\n([\s\S]*?)\n---/.exec(content);
+  if (!match) return null;
+  const fields = {};
+  for (const line of match[1].split('\n')) {
+    const colon = line.indexOf(':');
+    if (colon === -1) continue;
+    const key = line.slice(0, colon).trim();
+    if (key !== 'mode' && key !== 'status') continue;
+    fields[key] = stripQuotes(line.slice(colon + 1).trim());
+  }
+  return { mode: fields.mode ?? null, status: fields.status ?? null };
+}
+
+function stripQuotes(value) {
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value[value.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return value.slice(1, -1).trim();
+    }
+  }
+  return value;
+}
+
+function indexPath(root) {
+  return path.join(root, '.gossip', 'skill-index.json');
+}
+
+function skillFilePath(root, agentId, skill) {
+  return path.join(root, '.gossip', 'agents', agentId, 'skills', `${skill}.md`);
+}
+
+function readIndex(root) {
+  const file = indexPath(root);
+  if (!fs.existsSync(file)) {
+    throw new Error(`skill index not found: ${file}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (err) {
+    throw new Error(`skill index is not valid JSON (${file}): ${err.message}`);
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`skill index must be an object of agent → skill → slot (${file})`);
+  }
+  return parsed;
+}
+
+/**
+ * Classify a single slot. Returns one of:
+ *   flip | starved | not_declared_contextual | no_frontmatter | no_file
+ *   | already_contextual | not_auto | unsafe_name | malformed
+ */
+function classifySlot(root, agentId, skillKey, slot) {
+  const base = { agent: agentId, skill: skillKey };
+  if (!slot || typeof slot !== 'object') {
+    return { ...base, action: 'malformed', reason: 'slot is not an object' };
+  }
+  if (!isSafeName(agentId) || !isSafeName(skillKey)) {
+    return { ...base, action: 'unsafe_name', reason: 'agent or skill key is not a safe path segment' };
+  }
+  if (slot.source !== 'auto') {
+    return { ...base, action: 'not_auto', reason: `source=${String(slot.source)}` };
+  }
+  if (slot.mode === 'contextual') {
+    return { ...base, action: 'already_contextual', reason: 'mode is already contextual' };
+  }
+  if (slot.mode !== 'permanent') {
+    return { ...base, action: 'malformed', reason: `unexpected mode=${String(slot.mode)}` };
+  }
+
+  const file = skillFilePath(root, agentId, skillKey);
+  let content;
+  try {
+    content = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    return { ...base, action: 'no_file', reason: `unreadable: ${err.code ?? err.message}` };
+  }
+
+  const fm = parseFrontmatterFields(content);
+  if (!fm) {
+    return { ...base, action: 'no_frontmatter', reason: 'skill file has no frontmatter block' };
+  }
+  if (fm.mode !== 'contextual') {
+    return { ...base, action: 'not_declared_contextual', reason: `declared mode=${fm.mode ?? 'absent'}` };
+  }
+  if (fm.status === null || STARVED_STATUSES.has(fm.status)) {
+    return { ...base, action: 'starved', reason: `status=${fm.status ?? 'absent'}` };
+  }
+  return { ...base, action: 'flip', reason: `declared contextual, status=${fm.status}` };
+}
+
+/**
+ * Build the full migration plan by classifying every slot from disk.
+ * Returns `{ data, rows, flips, counts }` — `data` is the parsed index,
+ * unmodified.
+ */
+function planMigration(root) {
+  const data = readIndex(root);
+  const rows = [];
+  for (const agentId of Object.keys(data)) {
+    const slots = data[agentId];
+    if (!slots || typeof slots !== 'object' || Array.isArray(slots)) {
+      rows.push({ agent: agentId, skill: '*', action: 'malformed', reason: 'agent entry is not an object' });
+      continue;
+    }
+    for (const skillKey of Object.keys(slots)) {
+      rows.push(classifySlot(root, agentId, skillKey, slots[skillKey]));
+    }
+  }
+  const counts = {};
+  for (const row of rows) counts[row.action] = (counts[row.action] ?? 0) + 1;
+  return { data, rows, flips: rows.filter((r) => r.action === 'flip'), counts };
+}
+
+/**
+ * Apply the plan's flips to `plan.data` in memory. Mutates `mode` and
+ * `version` only; `boundAt` and every other field are untouched.
+ * Returns the number of slots changed.
+ */
+function applyFlips(plan) {
+  for (const row of plan.flips) {
+    const slot = plan.data[row.agent][row.skill];
+    slot.mode = 'contextual';
+    slot.version = typeof slot.version === 'number' ? slot.version + 1 : 1;
+  }
+  return plan.flips.length;
+}
+
+/** Write the index atomically: temp file in the same directory, then rename. */
+function writeIndex(root, data) {
+  const file = indexPath(root);
+  const tmp = path.join(path.dirname(file), `.skill-index.json.${process.pid}.tmp`);
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n');
+  try {
+    fs.renameSync(tmp, file);
+  } catch (err) {
+    try { fs.unlinkSync(tmp); } catch { /* best-effort cleanup */ }
+    throw err;
+  }
+}
+
+const ACTION_ORDER = [
+  'flip',
+  'starved',
+  'not_declared_contextual',
+  'no_frontmatter',
+  'no_file',
+  'already_contextual',
+  'not_auto',
+  'unsafe_name',
+  'malformed',
+];
+
+function renderReport(plan, { dryRun }) {
+  const lines = [];
+  lines.push(`# migrate-skill-index-modes — ${plan.rows.length} slot(s) inspected`);
+  lines.push(dryRun ? '# mode: DRY RUN (no write)' : '# mode: APPLY');
+  lines.push('');
+  for (const action of ACTION_ORDER) {
+    const rows = plan.rows.filter((r) => r.action === action);
+    if (rows.length === 0) continue;
+    lines.push(`## ${action} (${rows.length})`);
+    for (const r of rows) lines.push(`  ${r.agent}/${r.skill} — ${r.reason}`);
+    lines.push('');
+  }
+  lines.push(`flips: ${plan.flips.length}`);
+  return lines.join('\n');
+}
+
+module.exports = {
+  HELP,
+  STARVED_STATUSES,
+  applyFlips,
+  classifySlot,
+  indexPath,
+  isSafeName,
+  parseArgs,
+  parseFrontmatterFields,
+  planMigration,
+  readIndex,
+  renderReport,
+  skillFilePath,
+  writeIndex,
+};

--- a/scripts/migrate-skill-index-modes.mjs
+++ b/scripts/migrate-skill-index-modes.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Issue #675 stage 3 — flip-only-measured skill-index mode migration.
+//
+// Auto-bound skills were historically pinned to `mode: "permanent"` at both
+// bind sites regardless of what the generated skill file declared. Those bind
+// sites now honour the declared mode; this script migrates the slots already
+// written to `.gossip/skill-index.json`.
+//
+// Only slots whose skill file declares `mode: contextual` AND has a real
+// effectiveness verdict are flipped. Slots still accumulating evidence
+// (status pending / insufficient_evidence) stay permanent. `boundAt` is
+// preserved byte-for-byte — it anchors the effectiveness measurement window.
+//
+// Usage:
+//   node scripts/migrate-skill-index-modes.mjs [--root <path>] [--dry-run] [--json]
+//
+// Pure logic lives in ./migrate-skill-index-modes.lib.cjs so ts-jest can
+// require it without flipping on Jest's experimental ESM mode.
+
+import process from 'node:process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const lib = require('./migrate-skill-index-modes.lib.cjs');
+
+function main() {
+  let args;
+  try {
+    args = lib.parseArgs(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n\n${lib.HELP}\n`);
+    return 2;
+  }
+  if (args.help) {
+    process.stdout.write(lib.HELP + '\n');
+    return 0;
+  }
+
+  const root = args.root ?? process.cwd();
+  let plan;
+  try {
+    plan = lib.planMigration(root);
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n`);
+    return 1;
+  }
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify({ dryRun: args.dryRun, counts: plan.counts, rows: plan.rows }, null, 2) + '\n');
+  } else {
+    process.stdout.write(lib.renderReport(plan, { dryRun: args.dryRun }) + '\n');
+  }
+
+  if (args.dryRun) return 0;
+  if (plan.flips.length === 0) {
+    if (!args.json) process.stdout.write('nothing to migrate — index unchanged\n');
+    return 0;
+  }
+
+  lib.applyFlips(plan);
+  try {
+    lib.writeIndex(root, plan.data);
+  } catch (err) {
+    process.stderr.write(`error: failed to write skill index: ${err.message}\n`);
+    return 1;
+  }
+  if (!args.json) process.stdout.write(`wrote ${lib.indexPath(root)} (${plan.flips.length} flipped)\n`);
+  return 0;
+}
+
+process.exit(main());

--- a/tests/orchestrator/skill-auto-bind-mode.test.ts
+++ b/tests/orchestrator/skill-auto-bind-mode.test.ts
@@ -95,23 +95,42 @@ describe('auto-bind slot written from a declared mode', () => {
   });
 });
 
-describe('mcp-server-sdk auto-bind sites', () => {
-  const source = readFileSync(
-    join(__dirname, '..', '..', 'apps', 'cli', 'src', 'mcp-server-sdk.ts'),
-    'utf8',
-  );
+describe('auto-bind call sites', () => {
+  const cliSrc = join(__dirname, '..', '..', 'apps', 'cli', 'src');
+  const mcpServer = readFileSync(join(cliSrc, 'mcp-server-sdk.ts'), 'utf8');
+  const collect = readFileSync(join(cliSrc, 'handlers', 'collect.ts'), 'utf8');
+  const sources: Array<[string, string]> = [
+    ['mcp-server-sdk.ts', mcpServer],
+    ['collect.ts', collect],
+  ];
 
-  it('no auto bind site hardcodes a mode any more', () => {
-    expect(source).not.toContain("{ source: 'auto', mode: 'permanent' }");
+  it.each(sources)('%s hardcodes no mode literal at any auto bind site', (_name, source) => {
+    const hardcoded = source.match(/\.bind\([^)]*\{ source: 'auto', mode: '(permanent|contextual)' \}\)/g);
+    expect(hardcoded).toBeNull();
   });
 
-  it('both auto bind sites pass a resolved mode', () => {
-    const matches = source.match(/skillIndex\.bind\(agent_id, skillName, \{ source: 'auto', mode: declaredMode \}\)/g);
+  it.each(sources)('%s derives every auto bind mode via resolveAutoBindMode', (_name, source) => {
+    const binds = source.match(/skillIndex\.bind\([^)]*source: 'auto'[^)]*\)/g) ?? [];
+    expect(binds.length).toBeGreaterThan(0);
+    for (const bind of binds) expect(bind).toContain('mode: declaredMode');
+    expect(source.match(/const declaredMode = resolveAutoBindMode\(/g)).toHaveLength(binds.length);
+  });
+
+  it('the two mcp-server-sdk.ts sites resolve from the saved skill result', () => {
+    const matches = mcpServer.match(/const declaredMode = resolveAutoBindMode\(result\.content, result\.path\);/g);
     expect(matches).toHaveLength(2);
   });
 
-  it('both auto bind sites derive declaredMode via resolveAutoBindMode', () => {
-    const matches = source.match(/const declaredMode = resolveAutoBindMode\(result\.content, result\.path\);/g);
-    expect(matches).toHaveLength(2);
+  it('the collect.ts skill-gap site resolves from the generated skill result', () => {
+    expect(collect).toContain('const generated = await ctx.skillEngine.generate(gap.agentId, gap.category);');
+    expect(collect).toContain('const declaredMode = resolveAutoBindMode(generated.content, generated.path);');
+  });
+
+  it('covers every skillIndex.bind auto call site in apps/cli', () => {
+    const total = sources.reduce(
+      (n, [, source]) => n + (source.match(/skillIndex\.bind\([^)]*source: 'auto'[^)]*\)/g) ?? []).length,
+      0,
+    );
+    expect(total).toBe(3);
   });
 });

--- a/tests/orchestrator/skill-auto-bind-mode.test.ts
+++ b/tests/orchestrator/skill-auto-bind-mode.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Issue #675 stage 3 — auto-bind mode resolution.
+ *
+ * Both auto-bind sites in apps/cli/src/mcp-server-sdk.ts previously hardcoded
+ * `mode: 'permanent'`. They now delegate to resolveAutoBindMode() so a
+ * generated skill declaring `mode: contextual` is bound contextual, while a
+ * skill with no frontmatter (or no `mode:` key) still binds permanent.
+ *
+ * The develop handler itself is not exported, so — following the convention in
+ * tests/cli/mcp-skills-develop-throttle.test.ts — the semantics are asserted on
+ * the building-block function, plus a source assertion that both bind sites
+ * actually route through it and no longer hardcode a mode.
+ */
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { resolveAutoBindMode } from '../../packages/orchestrator/src/skill-parser';
+import { SkillIndex } from '../../packages/orchestrator/src/skill-index';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+
+function skillFile(fields: string[], body = '\n## Body\n\ntext\n'): string {
+  return ['---', ...fields, '---', body].join('\n');
+}
+
+describe('resolveAutoBindMode', () => {
+  it('returns contextual when the frontmatter declares mode: contextual', () => {
+    const content = skillFile(['name: trust-boundaries', 'mode: contextual', 'status: passed']);
+    expect(resolveAutoBindMode(content, 'trust-boundaries.md')).toBe('contextual');
+  });
+
+  it('returns contextual for a quoted declaration', () => {
+    const content = skillFile(['name: trust-boundaries', 'mode: "contextual"']);
+    expect(resolveAutoBindMode(content, 'trust-boundaries.md')).toBe('contextual');
+  });
+
+  it('returns permanent when mode is explicitly permanent', () => {
+    const content = skillFile(['name: trust-boundaries', 'mode: permanent']);
+    expect(resolveAutoBindMode(content)).toBe('permanent');
+  });
+
+  it('defaults to permanent when the frontmatter omits mode', () => {
+    const content = skillFile(['name: trust-boundaries', 'status: passed']);
+    expect(resolveAutoBindMode(content)).toBe('permanent');
+  });
+
+  it('defaults to permanent when the file has no frontmatter block', () => {
+    expect(resolveAutoBindMode('# memory-retrieval\n\nCall gossip_remember first.\n')).toBe('permanent');
+  });
+
+  it('defaults to permanent on an unknown mode token', () => {
+    const content = skillFile(['name: trust-boundaries', 'mode: sometimes']);
+    expect(resolveAutoBindMode(content)).toBe('permanent');
+  });
+
+  it('defaults to permanent on empty content', () => {
+    expect(resolveAutoBindMode('')).toBe('permanent');
+  });
+});
+
+describe('auto-bind slot written from a declared mode', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'skill-autobind-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('binds a generated skill declaring mode: contextual as a contextual slot', () => {
+    const index = new SkillIndex(root);
+    const content = skillFile(['name: trust-boundaries', 'mode: contextual', 'status: passed']);
+
+    const slot = index.bind('opus-implementer', 'trust-boundaries', {
+      source: 'auto',
+      mode: resolveAutoBindMode(content, 'trust-boundaries.md'),
+    });
+
+    expect(slot.mode).toBe('contextual');
+    expect(slot.source).toBe('auto');
+  });
+
+  it('binds a generated skill with no frontmatter as a permanent slot', () => {
+    const index = new SkillIndex(root);
+
+    const slot = index.bind('opus-implementer', 'memory-retrieval', {
+      source: 'auto',
+      mode: resolveAutoBindMode('# memory-retrieval\n\nbody\n', 'memory-retrieval.md'),
+    });
+
+    expect(slot.mode).toBe('permanent');
+    expect(slot.source).toBe('auto');
+  });
+});
+
+describe('mcp-server-sdk auto-bind sites', () => {
+  const source = readFileSync(
+    join(__dirname, '..', '..', 'apps', 'cli', 'src', 'mcp-server-sdk.ts'),
+    'utf8',
+  );
+
+  it('no auto bind site hardcodes a mode any more', () => {
+    expect(source).not.toContain("{ source: 'auto', mode: 'permanent' }");
+  });
+
+  it('both auto bind sites pass a resolved mode', () => {
+    const matches = source.match(/skillIndex\.bind\(agent_id, skillName, \{ source: 'auto', mode: declaredMode \}\)/g);
+    expect(matches).toHaveLength(2);
+  });
+
+  it('both auto bind sites derive declaredMode via resolveAutoBindMode', () => {
+    const matches = source.match(/const declaredMode = resolveAutoBindMode\(result\.content, result\.path\);/g);
+    expect(matches).toHaveLength(2);
+  });
+});

--- a/tests/scripts/migrate-skill-index-modes.test.ts
+++ b/tests/scripts/migrate-skill-index-modes.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for scripts/migrate-skill-index-modes.mjs (issue #675 stage 3).
+ *
+ * Pure logic lives in scripts/migrate-skill-index-modes.lib.cjs (CommonJS) so
+ * ts-jest can require it without flipping on Jest's experimental ESM mode.
+ * The .mjs is a thin CLI wrapper over the same library.
+ *
+ * Covers:
+ *   1. Measured contextual slots flip; boundAt preserved, version bumped
+ *   2. pending / insufficient_evidence slots stay permanent
+ *   3. no-frontmatter, non-auto, already-contextual, missing-file slots stay
+ *   4. --dry-run writes nothing
+ *   5. Second run is a no-op (idempotent)
+ *   6. Missing index errors with a clear message
+ *   7. Unsafe agent/skill keys are never path-joined and never flipped
+ */
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { execFileSync } from 'node:child_process';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const lib = require(path.resolve(__dirname, '..', '..', 'scripts', 'migrate-skill-index-modes.lib.cjs'));
+const SCRIPT_MJS = path.resolve(__dirname, '..', '..', 'scripts', 'migrate-skill-index-modes.mjs');
+
+const BOUND_AT = '2026-06-01T12:00:00.000Z';
+
+type Slot = {
+  skill: string;
+  enabled: boolean;
+  source: string;
+  mode: string;
+  version: number;
+  boundAt: string;
+};
+
+function slot(overrides: Partial<Slot> = {}): Slot {
+  return {
+    skill: 'trust-boundaries',
+    enabled: true,
+    source: 'auto',
+    mode: 'permanent',
+    version: 3,
+    boundAt: BOUND_AT,
+    ...overrides,
+  };
+}
+
+function skillMd(fields: string[]): string {
+  return ['---', ...fields, '---', '', '## Body', '', 'text', ''].join('\n');
+}
+
+let root: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-index-migrate-'));
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function writeIndex(data: unknown): void {
+  const dir = path.join(root, '.gossip');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'skill-index.json'), JSON.stringify(data, null, 2) + '\n');
+}
+
+function writeSkill(agent: string, name: string, content: string): void {
+  const dir = path.join(root, '.gossip', 'agents', agent, 'skills');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${name}.md`), content);
+}
+
+function readIndex(): Record<string, Record<string, Slot>> {
+  return JSON.parse(fs.readFileSync(path.join(root, '.gossip', 'skill-index.json'), 'utf8'));
+}
+
+function runScript(args: string[] = []): string {
+  return execFileSync('node', [SCRIPT_MJS, '--root', root, ...args], { encoding: 'utf8' });
+}
+
+// ── parseFrontmatterFields ────────────────────────────────────────────────
+
+describe('parseFrontmatterFields', () => {
+  it('reads mode and status from a leading frontmatter block', () => {
+    const fm = lib.parseFrontmatterFields(skillMd(['name: x', 'mode: contextual', 'status: passed']));
+    expect(fm).toEqual({ mode: 'contextual', status: 'passed' });
+  });
+
+  it('strips surrounding double and single quotes', () => {
+    const fm = lib.parseFrontmatterFields(skillMd(['mode: "contextual"', "status: 'failed'"]));
+    expect(fm).toEqual({ mode: 'contextual', status: 'failed' });
+  });
+
+  it('returns null when there is no frontmatter block', () => {
+    expect(lib.parseFrontmatterFields('# memory-retrieval\n\nbody\n')).toBeNull();
+  });
+
+  it('reports absent fields as null', () => {
+    expect(lib.parseFrontmatterFields(skillMd(['name: x']))).toEqual({ mode: null, status: null });
+  });
+});
+
+// ── isSafeName ────────────────────────────────────────────────────────────
+
+describe('isSafeName', () => {
+  it.each(['opus-implementer', 'trust_boundaries', 'a.b-c_1'])('accepts %s', (name) => {
+    expect(lib.isSafeName(name)).toBe(true);
+  });
+
+  it.each(['..', '.', '../escape', 'a/b', '', '__proto__/x', 'a\0b'])('rejects %j', (name) => {
+    expect(lib.isSafeName(name)).toBe(false);
+  });
+});
+
+// ── planMigration classification ──────────────────────────────────────────
+
+describe('planMigration', () => {
+  it('flips a measured contextual auto slot', () => {
+    writeIndex({ 'opus-implementer': { 'trust-boundaries': slot() } });
+    writeSkill('opus-implementer', 'trust-boundaries', skillMd(['mode: contextual', 'status: passed']));
+
+    const plan = lib.planMigration(root);
+    expect(plan.flips).toHaveLength(1);
+    expect(plan.rows[0].action).toBe('flip');
+  });
+
+  it.each(['pending', 'insufficient_evidence'])('keeps a %s slot permanent', (status) => {
+    writeIndex({ 'opus-implementer': { 'trust-boundaries': slot() } });
+    writeSkill('opus-implementer', 'trust-boundaries', skillMd(['mode: contextual', `status: ${status}`]));
+
+    const plan = lib.planMigration(root);
+    expect(plan.flips).toHaveLength(0);
+    expect(plan.rows[0].action).toBe('starved');
+  });
+
+  it.each(['passed', 'failed', 'silent_skill', 'inconclusive'])('treats %s as measured', (status) => {
+    writeIndex({ 'opus-implementer': { 'trust-boundaries': slot() } });
+    writeSkill('opus-implementer', 'trust-boundaries', skillMd(['mode: contextual', `status: ${status}`]));
+
+    expect(lib.planMigration(root).flips).toHaveLength(1);
+  });
+
+  it('keeps a slot whose file declares no mode', () => {
+    writeIndex({ 'opus-implementer': { 'trust-boundaries': slot() } });
+    writeSkill('opus-implementer', 'trust-boundaries', skillMd(['name: x', 'status: passed']));
+
+    const plan = lib.planMigration(root);
+    expect(plan.flips).toHaveLength(0);
+    expect(plan.rows[0].action).toBe('not_declared_contextual');
+  });
+
+  it('keeps a slot whose file has no frontmatter', () => {
+    writeIndex({ 'haiku-researcher': { 'memory-retrieval': slot({ skill: 'memory-retrieval' }) } });
+    writeSkill('haiku-researcher', 'memory-retrieval', '# memory-retrieval\n\nbody\n');
+
+    const plan = lib.planMigration(root);
+    expect(plan.flips).toHaveLength(0);
+    expect(plan.rows[0].action).toBe('no_frontmatter');
+  });
+
+  it('keeps a slot whose skill file is missing', () => {
+    writeIndex({ 'opus-implementer': { 'trust-boundaries': slot() } });
+
+    const plan = lib.planMigration(root);
+    expect(plan.flips).toHaveLength(0);
+    expect(plan.rows[0].action).toBe('no_file');
+  });
+
+  it('never touches non-auto slots even when the file declares contextual', () => {
+    writeIndex({ 'opus-implementer': { 'trust-boundaries': slot({ source: 'config' }) } });
+    writeSkill('opus-implementer', 'trust-boundaries', skillMd(['mode: contextual', 'status: passed']));
+
+    const plan = lib.planMigration(root);
+    expect(plan.flips).toHaveLength(0);
+    expect(plan.rows[0].action).toBe('not_auto');
+  });
+
+  it('reports already-contextual slots without flipping them', () => {
+    writeIndex({ 'opus-implementer': { 'trust-boundaries': slot({ mode: 'contextual' }) } });
+    writeSkill('opus-implementer', 'trust-boundaries', skillMd(['mode: contextual', 'status: passed']));
+
+    const plan = lib.planMigration(root);
+    expect(plan.flips).toHaveLength(0);
+    expect(plan.rows[0].action).toBe('already_contextual');
+  });
+
+  it('rejects an unsafe agent key without reading from disk', () => {
+    writeIndex({ '../escape': { 'trust-boundaries': slot() } });
+
+    const plan = lib.planMigration(root);
+    expect(plan.flips).toHaveLength(0);
+    expect(plan.rows[0].action).toBe('unsafe_name');
+  });
+
+  it('rejects an unsafe skill key', () => {
+    writeIndex({ 'opus-implementer': { '../../etc/passwd': slot() } });
+
+    const plan = lib.planMigration(root);
+    expect(plan.flips).toHaveLength(0);
+    expect(plan.rows[0].action).toBe('unsafe_name');
+  });
+
+  it('throws a clear error when the index is missing', () => {
+    expect(() => lib.planMigration(root)).toThrow(/skill index not found/);
+  });
+
+  it('throws a clear error when the index is not valid JSON', () => {
+    fs.mkdirSync(path.join(root, '.gossip'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.gossip', 'skill-index.json'), '{not json');
+    expect(() => lib.planMigration(root)).toThrow(/not valid JSON/);
+  });
+});
+
+// ── CLI behaviour ─────────────────────────────────────────────────────────
+
+describe('migrate-skill-index-modes.mjs', () => {
+  function seedMixedIndex(): void {
+    writeIndex({
+      'opus-implementer': {
+        'trust-boundaries': slot(),
+        'type-safety': slot({ skill: 'type-safety', version: 1 }),
+      },
+      'haiku-researcher': {
+        'memory-retrieval': slot({ skill: 'memory-retrieval', version: 7 }),
+      },
+    });
+    writeSkill('opus-implementer', 'trust-boundaries', skillMd(['mode: contextual', 'status: passed']));
+    writeSkill('opus-implementer', 'type-safety', skillMd(['mode: contextual', 'status: pending']));
+    writeSkill('haiku-researcher', 'memory-retrieval', '# memory-retrieval\n\nbody\n');
+  }
+
+  it('flips only the measured slot, preserving boundAt and bumping version', () => {
+    seedMixedIndex();
+    runScript();
+
+    const after = readIndex();
+    expect(after['opus-implementer']['trust-boundaries'].mode).toBe('contextual');
+    expect(after['opus-implementer']['trust-boundaries'].version).toBe(4);
+    expect(after['opus-implementer']['trust-boundaries'].boundAt).toBe(BOUND_AT);
+
+    expect(after['opus-implementer']['type-safety'].mode).toBe('permanent');
+    expect(after['opus-implementer']['type-safety'].version).toBe(1);
+    expect(after['haiku-researcher']['memory-retrieval'].mode).toBe('permanent');
+    expect(after['haiku-researcher']['memory-retrieval'].version).toBe(7);
+  });
+
+  it('preserves every other slot field verbatim', () => {
+    seedMixedIndex();
+    runScript();
+
+    const s = readIndex()['opus-implementer']['trust-boundaries'];
+    expect(s.skill).toBe('trust-boundaries');
+    expect(s.enabled).toBe(true);
+    expect(s.source).toBe('auto');
+  });
+
+  it('--dry-run writes nothing', () => {
+    seedMixedIndex();
+    const file = path.join(root, '.gossip', 'skill-index.json');
+    const before = fs.readFileSync(file, 'utf8');
+
+    const out = runScript(['--dry-run']);
+    expect(out).toMatch(/DRY RUN/);
+    expect(out).toMatch(/flips: 1/);
+    expect(fs.readFileSync(file, 'utf8')).toBe(before);
+  });
+
+  it('is idempotent — a second run flips nothing and leaves the file unchanged', () => {
+    seedMixedIndex();
+    runScript();
+    const file = path.join(root, '.gossip', 'skill-index.json');
+    const afterFirst = fs.readFileSync(file, 'utf8');
+
+    const out = runScript();
+    expect(out).toMatch(/nothing to migrate/);
+    expect(fs.readFileSync(file, 'utf8')).toBe(afterFirst);
+  });
+
+  it('leaves no temp file behind', () => {
+    seedMixedIndex();
+    runScript();
+    const leftovers = fs.readdirSync(path.join(root, '.gossip')).filter((f) => f.includes('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('--json emits counts and rows', () => {
+    seedMixedIndex();
+    const parsed = JSON.parse(runScript(['--dry-run', '--json']));
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.counts.flip).toBe(1);
+    expect(parsed.rows).toHaveLength(3);
+  });
+
+  it('exits non-zero with a clear error when the index is missing', () => {
+    let code = 0;
+    try {
+      execFileSync('node', [SCRIPT_MJS, '--root', root], { encoding: 'utf8', stdio: 'pipe' });
+    } catch (err: any) {
+      code = err.status;
+      expect(String(err.stderr)).toMatch(/skill index not found/);
+    }
+    expect(code).toBe(1);
+  });
+
+  it('--help documents --dry-run and --root', () => {
+    const out = execFileSync('node', [SCRIPT_MJS, '--help'], { encoding: 'utf8' });
+    expect(out).toMatch(/--dry-run/);
+    expect(out).toMatch(/--root/);
+  });
+
+  it('rejects an unknown argument', () => {
+    let code = 0;
+    try {
+      execFileSync('node', [SCRIPT_MJS, '--bogus'], { encoding: 'utf8', stdio: 'pipe' });
+    } catch (err: any) {
+      code = err.status;
+      expect(String(err.stderr)).toMatch(/unknown argument/);
+    }
+    expect(code).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the #675 bind-site gap: auto-developed skills declare `mode: "contextual"` with curated keywords in their own frontmatter, but every auto-bind site hardcoded a mode, so ~78% of reviewer prompt payload shipped unconditionally. This PR makes the declared mode authoritative at bind time and ships the explicit index migration for already-bound slots (future-binds-only was confirmed a no-op).

- **All three `source: 'auto'` bind sites** now resolve mode via a new `resolveAutoBindMode(content, sourceLabel?)` helper (`packages/orchestrator/src/skill-parser.ts`): `contextual` when the generated skill's frontmatter declares it, `permanent` otherwise (default-permanent-when-absent per the #675 acceptance criteria). Sites: the two `gossip_skills develop` paths in `apps/cli/src/mcp-server-sdk.ts`, plus a third in `apps/cli/src/handlers/collect.ts` (skill-gap auto-development) found in cross-review — that one hardcoded the *inverse* (`'contextual'`). A count assertion pins the total at 3 so a future fourth site fails the suite.
- **Migration** `scripts/migrate-skill-index-modes.mjs` (+`.lib.cjs`), **flip-only-measured policy**: an auto/permanent slot flips to contextual only when its agent-local skill file declares `mode: contextual` AND status is a real verdict (not `pending`/`insufficient_evidence`) — evidence-starved slots stay permanent so they keep accumulating toward MIN_EVIDENCE. Edits `mode` in place and **preserves `boundAt` byte-for-byte** (it anchors the effectiveness windows, HANDBOOK invariant #6; the migration deliberately bypasses `bind()`, which rotates it). Version bump matches `bind()`'s formula. Single atomic write (temp+rename), idempotent, `--dry-run`/`--root`/`--json`, SAFE_NAME fail-closed guard on index keys before any path join.
- Live counts at repo root today: 45 auto/permanent slots → 13 flip, 15 evidence-starved stay, 17 no-frontmatter untouched. The orchestrator runs the migration at repo root after merge.

## Consensus review

consensus-id: e8c1986b-65b64cfa

2-agent round (sonnet-reviewer correctness + deepseek-challenger adversarial) + cross-review. sonnet-reviewer independently verified default-permanent-on-absence, boundAt preservation, atomicity, idempotency, and the SAFE_NAME guard, re-ran all new tests (51/51), and caught the third bind site (`e8c1986b-65b64cfa:f1`) — fixed in the second commit with generalized source assertions. deepseek-challenger's dispute of f1 was a wrong-tree refutation (grepped repo root instead of the review worktree); recorded as a `disagreement` signal against it.

## Behaviour change worth noting

A gap-developed skill whose frontmatter does not declare `mode: contextual` now binds **permanent** at the collect.ts site, where it previously always bound contextual. That matches #675 semantics at the other two sites; the develop template always emits `mode: contextual`, so in practice this only affects malformed/hand-authored files.

## Verification

- `npm test` — 5397 passed, 0 failed (39 skipped, 5 todo)
- `npm run build` (build:all) clean; `npx tsc --noEmit` clean for all touched files
- New suites: `tests/orchestrator/skill-auto-bind-mode.test.ts`, `tests/scripts/migrate-skill-index-modes.test.ts` — mode resolution (quoted/unknown/absent tokens), all-sites source sweep + site count pin, migration flip/keep matrix, boundAt preservation, dry-run byte-identity, idempotency, unsafe-key rejection, error paths
- New test regexes were proven against the pre-fix code (both would have failed) before trusting the green run
- dist-mcp binary suites to be confirmed at repo root before release (not buildable in a worktree by design; this PR does not touch bundling)

## Post-merge steps (orchestrator)

1. Run `node scripts/migrate-skill-index-modes.mjs --dry-run` then live at repo root.
2. Measure per-reviewer prompt payload reduction and record on #675.

🤖 Generated with [Claude Code](https://claude.com/claude-code)