### PR TITLE
fix(consensus): root Phase-2 verifier tools at resolutionRoots[0] — stop wrong-tree cross-review refutations (#710)

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -7,11 +7,12 @@ import { startConsensusTimeout, persistPendingConsensus } from './relay-cross-re
 import { persistRelayTasks } from './relay-tasks';
 import { seedRecentConsensusTaskIds } from './native-tasks';
 import { trackLifecycleTask } from '../lifecycle-tasks';
-import { FILE_TOOLS, FileTools, GitTools, Sandbox } from '@gossip/tools';
+import { FILE_TOOLS, FileTools, Sandbox } from '@gossip/tools';
 import { MemorySearcher } from '@gossip/orchestrator';
 import type { PromptFormat } from './dispatch';
 import { discoverVerifier, type VerifierBinding } from './auto-verify-discovery';
 import { buildGatedCrossReviewSkillsResolver } from './cross-review-skill-gate';
+import { buildVerifierFileAccess, buildVerifierToolRunner } from './verifier-tool-runner';
 import { makeRoundContext } from '@gossip/orchestrator';
 import type { RelayWarningEntry, RoundContext } from '@gossip/orchestrator';
 import { mkdirSync, appendFileSync } from 'node:fs';
@@ -558,36 +559,18 @@ export async function handleCollect(
       // Constructed AFTER effectiveRoots so fileSearch can prioritize matches under a
       // resolution root (e.g. sibling worktrees) instead of blindly taking the first hit.
       const verifierFs = new FileTools(new Sandbox(process.cwd()));
-      const verifierGit = new GitTools(process.cwd());
       const verifierMemory = new MemorySearcher(process.cwd());
 
-      // Resolve short file paths (e.g. "cross-reviewer-selection.ts") to full project-relative
-      // paths. LLMs often cite just the filename without the directory prefix.
-      // Disambiguation rules when multiple matches exist:
-      //   1. Prefer a match whose absolute path starts with any effectiveRoots entry
-      //   2. Else prefer paths inside process.cwd() over paths outside
-      //   3. On ambiguity, emit a stderr warning with the chosen + all candidates
-      const resolveToolPath = async (filePath: string): Promise<string> => {
-        if (!filePath) return filePath;
-        // Try as-is first — if Sandbox validates it, the file exists
-        try { new Sandbox(process.cwd()).validatePath(filePath); return filePath; } catch { /* not found */ }
-        // Search via file_search for the bare filename, passing resolutionRoots so
-        // fileSearch ranks matches inside a resolution root ahead of stray duplicates.
-        const fileName = filePath.split('/').pop() ?? filePath;
-        try {
-          const searchResult = await verifierFs.fileSearch({ pattern: fileName, resolutionRoots: effectiveRoots });
-          const candidates = searchResult.split('\n').map(s => s.trim()).filter(s => s && s !== 'No files found');
-          if (candidates.length === 0) return filePath;
-          const resolved = candidates[0];
-          if (candidates.length > 1) {
-            process.stderr.write(
-              `[consensus] ambiguous filename resolution for "${fileName}": chose "${resolved}" among [${candidates.join(', ')}]\n`,
-            );
-          }
-          return resolved;
-        } catch { /* search failed */ }
-        return filePath; // return original, let fileRead produce a clear error
-      };
+      // Issue #710: anchor Phase-2 verifier file access at the review worktree
+      // when resolutionRoots are declared, mirroring the Phase-1 relay dispatch
+      // plumbing (PR #328). Shared by BOTH Phase-2 tool loops — the engine-driven
+      // verifierToolRunner below and runOneRelayCrossReview's inline runToolCalls.
+      const verifierAccess = buildVerifierFileAccess({
+        fileTools: verifierFs,
+        projectRoot: process.cwd(),
+        effectiveRoots,
+      });
+      const resolveToolPath = verifierAccess.resolveToolPath;
 
       // Consensus auto-verify DI wiring (spec
       // docs/superpowers/specs/2026-05-21-consensus-auto-verify-design.md).
@@ -638,49 +621,13 @@ export async function handleCollect(
         round: effectiveRound,
         verifierDispatch: _autoVerifyDispatch,
         warningSink: _autoVerifyWarningSink,
-        verifierToolRunner: async (agentId: string, toolName: string, args: Record<string, unknown>): Promise<string> => {
-          const toolStart = Date.now();
-          try {
-            let result: string;
-            switch (toolName) {
-              case 'file_read': {
-                const resolvedPath = await resolveToolPath((args as any).path);
-                result = await verifierFs.fileRead({ ...args, path: resolvedPath } as any);
-                break;
-              }
-              case 'file_grep': {
-                const grepPath = (args as any).path ? await resolveToolPath((args as any).path) : undefined;
-                result = await verifierFs.fileGrep({ ...args, ...(grepPath ? { path: grepPath } : {}) } as any);
-                break;
-              }
-              case 'file_search':
-                result = await verifierFs.fileSearch({
-                  ...(args as any),
-                  resolutionRoots: effectiveRoots,
-                });
-                break;
-              case 'memory_query': {
-                const results = verifierMemory.search(agentId, (args as any).query ?? '', 5);
-                result = results.length ? results.map(r => `[${r.source}] ${r.name}: ${r.snippets.join(' | ')}`).join('\n---\n') : 'No memory results found.';
-                break;
-              }
-              case 'git_log': result = await verifierGit.gitLog(args as any); break;
-              default: result = `Unknown tool: ${toolName}`;
-            }
-            const argSummary = toolName === 'file_read' ? (args as any).path
-              : toolName === 'file_grep' ? `"${(args as any).pattern}" in ${(args as any).path ?? '.'}`
-              : toolName === 'file_search' ? (args as any).pattern
-              : toolName === 'memory_query' ? `"${(args as any).query}"`
-              : '';
-            const now = new Date(); const stamp = `${String(now.getHours()).padStart(2,'0')}:${String(now.getMinutes()).padStart(2,'0')}:${String(now.getSeconds()).padStart(2,'0')}.${String(now.getMilliseconds()).padStart(3,'0')}`;
-            process.stderr.write(`${stamp} 🤝 [consensus] 🔧 ${agentId} tool_call: ${toolName}(${argSummary}) → ${result.length}B (${Date.now() - toolStart}ms)\n`);
-            return result;
-          } catch (e) {
-            const now = new Date(); const stamp = `${String(now.getHours()).padStart(2,'0')}:${String(now.getMinutes()).padStart(2,'0')}:${String(now.getSeconds()).padStart(2,'0')}.${String(now.getMilliseconds()).padStart(3,'0')}`;
-            process.stderr.write(`${stamp} 🤝 [consensus] 🔧 ${agentId} tool_call: ${toolName}(${JSON.stringify(args).slice(0, 200)}) → ERROR: ${(e as Error).message} (${Date.now() - toolStart}ms)\n`);
-            return `Tool error: ${(e as Error).message}`;
-          }
-        },
+        verifierToolRunner: buildVerifierToolRunner({
+          access: verifierAccess,
+          fileTools: verifierFs,
+          memory: verifierMemory,
+          projectRoot: process.cwd(),
+          effectiveRoots,
+        }),
       });
 
       // Server-side Phase 2: engine selects cross-reviewers and runs internally.
@@ -760,11 +707,11 @@ export async function handleCollect(
               if (tc.name === 'file_read') {
                 const args = { ...(tc.arguments as any) };
                 if (args.path) args.path = await resolveToolPath(args.path);
-                out = await verifierFs.fileRead(args);
+                out = await verifierAccess.fileRead(args);
               } else if (tc.name === 'file_grep') {
                 const args = { ...(tc.arguments as any) };
                 if (args.path) args.path = await resolveToolPath(args.path);
-                out = await verifierFs.fileGrep(args);
+                out = await verifierAccess.fileGrep(args);
               } else {
                 out = `Tool ${tc.name} not available to cross-reviewers`;
               }

--- a/apps/cli/src/handlers/verifier-tool-runner.ts
+++ b/apps/cli/src/handlers/verifier-tool-runner.ts
@@ -1,0 +1,203 @@
+/**
+ * Verifier tool execution for consensus Phase-2 cross-review.
+ *
+ * Extracted from the inline closure in `collect.ts` so the rooting behavior is
+ * unit-testable (issue #710). Phase-1 relay dispatch already anchors agents at
+ * `resolutionRoots[0]` via `toolServer.assignRoot` (PR #328); Phase 2 did not,
+ * so cross-reviewers read the repo root while the findings under review
+ * described a sibling review worktree — producing confident-but-wrong
+ * refutations ("symbol does not exist", "file only has N lines").
+ *
+ * When `effectiveRoots` is empty every code path here is byte-identical to the
+ * pre-#710 behavior.
+ */
+import { FileTools, GitTools, Sandbox } from '@gossip/tools';
+import type { MemorySearcher } from '@gossip/orchestrator';
+import { existsSync, realpathSync } from 'node:fs';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+
+export type VerifierToolRunner = (
+  agentId: string,
+  toolName: string,
+  args: Record<string, unknown>,
+) => Promise<string>;
+
+/** Read-only file access for cross-reviewers, anchored at the review root. */
+export interface VerifierFileAccess {
+  /** Resolve an agent-cited path, preferring the review worktree copy. */
+  resolveToolPath(filePath: string): Promise<string>;
+  fileRead(args: Record<string, unknown>): Promise<string>;
+  fileGrep(args: Record<string, unknown>): Promise<string>;
+}
+
+export interface VerifierFileAccessOptions {
+  fileTools: FileTools;
+  projectRoot: string;
+  /** Validated resolution roots; `[0]` is the review worktree when present. */
+  effectiveRoots: readonly string[];
+  /** Defaults to stderr. Injected in tests to assert observability lines. */
+  log?: (line: string) => void;
+}
+
+export interface VerifierToolRunnerOptions extends VerifierFileAccessOptions {
+  memory: MemorySearcher;
+  /** Reuse an access built by the caller so both Phase-2 tool loops agree. */
+  access?: VerifierFileAccess;
+  /** Injection seam for tests — the ROOT choice is the behavior under test. */
+  makeGitTools?: (root: string) => GitTools;
+}
+
+/**
+ * Canonical form of a root for prefix comparison. Mirrors
+ * `FileTools.rankByResolutionRoots`: on darwin a `/tmp/...` root and a
+ * `/private/tmp/...` resolved path never match without this.
+ */
+function canonicalRoot(path: string): string {
+  const abs = resolve(path);
+  try {
+    return existsSync(abs) ? realpathSync(abs) : abs;
+  } catch {
+    return abs;
+  }
+}
+
+function isInsideRoot(absPath: string, root: string): boolean {
+  return absPath === root || absPath.startsWith(root.endsWith(sep) ? root : root + sep);
+}
+
+export function buildVerifierFileAccess(opts: VerifierFileAccessOptions): VerifierFileAccess {
+  const { fileTools } = opts;
+  const effectiveRoots = opts.effectiveRoots ?? [];
+  const log = opts.log ?? ((line: string) => { process.stderr.write(line); });
+  const projectRoot = canonicalRoot(opts.projectRoot);
+  const sandbox = new Sandbox(opts.projectRoot);
+  const declaredRoots = effectiveRoots.filter(Boolean).map(canonicalRoot);
+  const reviewRoot: string | undefined = declaredRoots[0];
+
+  /**
+   * Map a cited path onto the review worktree when that copy actually exists.
+   * Returns undefined when there is no review root, when the path already
+   * points inside a declared root, or when the worktree has no such file (the
+   * caller then falls back to project-root resolution).
+   */
+  const remapToReviewRoot = (filePath: string): string | undefined => {
+    if (!reviewRoot) return undefined;
+    let candidate: string;
+    if (isAbsolute(filePath)) {
+      const abs = canonicalRoot(filePath);
+      if (declaredRoots.some(r => isInsideRoot(abs, r))) return undefined;
+      const rel = relative(projectRoot, abs);
+      if (!rel || rel.startsWith('..') || isAbsolute(rel)) return undefined;
+      candidate = join(reviewRoot, rel);
+    } else {
+      candidate = join(reviewRoot, filePath);
+    }
+    return existsSync(candidate) ? candidate : undefined;
+  };
+
+  /**
+   * Project-root fallback. With a review root declared the tools are anchored
+   * at the worktree, so a project-root file must be handed over as an absolute
+   * path or it would re-resolve against the worktree and vanish.
+   */
+  const asProjectRootPath = (filePath: string): string =>
+    reviewRoot ? resolve(projectRoot, filePath) : filePath;
+
+  // Resolve short file paths (e.g. "cross-reviewer-selection.ts") to full
+  // project-relative paths. LLMs often cite just the filename without the
+  // directory prefix. Disambiguation rules when multiple matches exist:
+  //   1. Prefer the review worktree copy when the file exists there (#710)
+  //   2. Else prefer a match whose absolute path starts with any effectiveRoots entry
+  //   3. Else prefer paths inside projectRoot over paths outside
+  //   4. On ambiguity, emit a stderr warning with the chosen + all candidates
+  const resolveToolPath = async (filePath: string): Promise<string> => {
+    if (!filePath) return filePath;
+    const remapped = remapToReviewRoot(filePath);
+    if (remapped) return remapped;
+    // Try as-is next — if Sandbox validates it, the path is inside the project root.
+    try { sandbox.validatePath(filePath); return asProjectRootPath(filePath); } catch { /* outside root */ }
+    // Search via file_search for the bare filename, passing resolutionRoots so
+    // fileSearch ranks matches inside a resolution root ahead of stray duplicates.
+    const fileName = filePath.split('/').pop() ?? filePath;
+    try {
+      const searchResult = await fileTools.fileSearch({ pattern: fileName, resolutionRoots: effectiveRoots });
+      const candidates = searchResult.split('\n').map(s => s.trim()).filter(s => s && s !== 'No files found');
+      if (candidates.length === 0) return filePath;
+      const resolved = candidates[0];
+      if (candidates.length > 1) {
+        log(`[consensus] ambiguous filename resolution for "${fileName}": chose "${resolved}" among [${candidates.join(', ')}]\n`);
+      }
+      return remapToReviewRoot(resolved) ?? asProjectRootPath(resolved);
+    } catch { /* search failed */ }
+    return filePath; // return original, let fileRead produce a clear error
+  };
+
+  return {
+    resolveToolPath,
+    fileRead: (args) => fileTools.fileRead(args as any, reviewRoot),
+    fileGrep: (args) => fileTools.fileGrep(args as any, reviewRoot),
+  };
+}
+
+function timestamp(): string {
+  const now = new Date();
+  return `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}.${String(now.getMilliseconds()).padStart(3, '0')}`;
+}
+
+/**
+ * Build the `verifierToolRunner` callback handed to ConsensusEngine. Tools are
+ * anchored at `effectiveRoots[0]` when roots are declared: file_read/file_grep
+ * accept (and resolve against) the review worktree, and git_log reports the
+ * worktree's branch history rather than the project root's.
+ */
+export function buildVerifierToolRunner(opts: VerifierToolRunnerOptions): VerifierToolRunner {
+  const access = opts.access ?? buildVerifierFileAccess(opts);
+  const log = opts.log ?? ((line: string) => { process.stderr.write(line); });
+  const effectiveRoots = opts.effectiveRoots ?? [];
+  const gitRoot = effectiveRoots.length > 0 ? effectiveRoots[0] : opts.projectRoot;
+  const makeGitTools = opts.makeGitTools ?? ((root: string) => new GitTools(root));
+  const gitTools = makeGitTools(gitRoot);
+  const { fileTools, memory } = opts;
+
+  return async (agentId, toolName, args) => {
+    const toolStart = Date.now();
+    try {
+      let result: string;
+      switch (toolName) {
+        case 'file_read': {
+          const resolvedPath = await access.resolveToolPath((args as any).path);
+          result = await access.fileRead({ ...args, path: resolvedPath });
+          break;
+        }
+        case 'file_grep': {
+          const grepPath = (args as any).path ? await access.resolveToolPath((args as any).path) : undefined;
+          result = await access.fileGrep({ ...args, ...(grepPath ? { path: grepPath } : {}) });
+          break;
+        }
+        case 'file_search':
+          result = await fileTools.fileSearch({
+            ...(args as any),
+            resolutionRoots: effectiveRoots,
+          });
+          break;
+        case 'memory_query': {
+          const results = memory.search(agentId, (args as any).query ?? '', 5);
+          result = results.length ? results.map(r => `[${r.source}] ${r.name}: ${r.snippets.join(' | ')}`).join('\n---\n') : 'No memory results found.';
+          break;
+        }
+        case 'git_log': result = await gitTools.gitLog(args as any); break;
+        default: result = `Unknown tool: ${toolName}`;
+      }
+      const argSummary = toolName === 'file_read' ? (args as any).path
+        : toolName === 'file_grep' ? `"${(args as any).pattern}" in ${(args as any).path ?? '.'}`
+        : toolName === 'file_search' ? (args as any).pattern
+        : toolName === 'memory_query' ? `"${(args as any).query}"`
+        : '';
+      log(`${timestamp()} 🤝 [consensus] 🔧 ${agentId} tool_call: ${toolName}(${argSummary}) → ${result.length}B (${Date.now() - toolStart}ms)\n`);
+      return result;
+    } catch (e) {
+      log(`${timestamp()} 🤝 [consensus] 🔧 ${agentId} tool_call: ${toolName}(${JSON.stringify(args).slice(0, 200)}) → ERROR: ${(e as Error).message} (${Date.now() - toolStart}ms)\n`);
+      return `Tool error: ${(e as Error).message}`;
+    }
+  };
+}

--- a/apps/cli/src/handlers/verifier-tool-runner.ts
+++ b/apps/cli/src/handlers/verifier-tool-runner.ts
@@ -61,8 +61,21 @@ function canonicalRoot(path: string): string {
   }
 }
 
+/**
+ * Case-insensitive filesystems need case-folded path compares. Mirrors
+ * `Sandbox.validatePath` so this module and the terminal sandbox gate agree
+ * on what "inside a root" means.
+ */
+const CASE_INSENSITIVE_FS = process.platform === 'darwin' || process.platform === 'win32';
+
+function fold(p: string): string {
+  return CASE_INSENSITIVE_FS ? p.toLowerCase() : p;
+}
+
 function isInsideRoot(absPath: string, root: string): boolean {
-  return absPath === root || absPath.startsWith(root.endsWith(sep) ? root : root + sep);
+  const a = fold(absPath);
+  const r = fold(root);
+  return a === r || a.startsWith(r.endsWith(sep) ? r : r + sep);
 }
 
 export function buildVerifierFileAccess(opts: VerifierFileAccessOptions): VerifierFileAccess {
@@ -74,6 +87,13 @@ export function buildVerifierFileAccess(opts: VerifierFileAccessOptions): Verifi
   const declaredRoots = effectiveRoots.filter(Boolean).map(canonicalRoot);
   const reviewRoot: string | undefined = declaredRoots[0];
 
+  /** True when an absolute citation already points inside a declared root. */
+  const isInsideDeclaredRoot = (filePath: string): boolean => {
+    if (!isAbsolute(filePath)) return false;
+    const abs = canonicalRoot(filePath);
+    return declaredRoots.some(r => isInsideRoot(abs, r));
+  };
+
   /**
    * Map a cited path onto the review worktree when that copy actually exists.
    * Returns undefined when there is no review root, when the path already
@@ -84,8 +104,8 @@ export function buildVerifierFileAccess(opts: VerifierFileAccessOptions): Verifi
     if (!reviewRoot) return undefined;
     let candidate: string;
     if (isAbsolute(filePath)) {
+      if (isInsideDeclaredRoot(filePath)) return undefined;
       const abs = canonicalRoot(filePath);
-      if (declaredRoots.some(r => isInsideRoot(abs, r))) return undefined;
       const rel = relative(projectRoot, abs);
       if (!rel || rel.startsWith('..') || isAbsolute(rel)) return undefined;
       candidate = join(reviewRoot, rel);
@@ -112,6 +132,12 @@ export function buildVerifierFileAccess(opts: VerifierFileAccessOptions): Verifi
   //   4. On ambiguity, emit a stderr warning with the chosen + all candidates
   const resolveToolPath = async (filePath: string): Promise<string> => {
     if (!filePath) return filePath;
+    // A citation already inside a declared root is authoritative — return it
+    // untouched. Routing it onward would send a SIBLING review root through a
+    // projectRoot-only `validatePath` (which throws) and into the basename
+    // search below, silently substituting an unrelated same-basename file
+    // from the project root.
+    if (isInsideDeclaredRoot(filePath)) return filePath;
     const remapped = remapToReviewRoot(filePath);
     if (remapped) return remapped;
     // Try as-is next — if Sandbox validates it, the path is inside the project root.

--- a/tests/cli/verifier-tool-runner.test.ts
+++ b/tests/cli/verifier-tool-runner.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Issue #710 — Phase-2 cross-review verifier tools must read the review
+ * worktree when `resolutionRoots` are declared, not the repo root.
+ *
+ * Fixture shape: a fake project root and a fake review worktree that both
+ * contain `src/target.ts` with DIVERGENT content. A cross-reviewer citing that
+ * path must see the worktree copy; a path that only exists at the project root
+ * must still resolve.
+ */
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, realpathSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { FileTools, GitTools, Sandbox } from '@gossip/tools';
+import type { MemorySearcher } from '@gossip/orchestrator';
+import {
+  buildVerifierFileAccess,
+  buildVerifierToolRunner,
+} from '../../apps/cli/src/handlers/verifier-tool-runner';
+
+const ROOT_TARGET = ['export const a = 1;', 'export const b = 2;', 'export const c = 3;'].join('\n');
+const WORKTREE_TARGET = [
+  'export const a = 1;',
+  'export const b = 2;',
+  'export const c = 3;',
+  'export function resolveAutoBindMode() { return "MARKER_SYMBOL"; }',
+  'export const d = 4;',
+].join('\n');
+
+const noopLog = () => { /* silence observability in tests */ };
+const memoryStub = { search: () => [] } as unknown as MemorySearcher;
+
+describe('verifier tool runner — resolutionRoots anchoring (#710)', () => {
+  let projectRoot: string;
+  let worktree: string;
+  let fileTools: FileTools;
+
+  beforeEach(() => {
+    projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'gossip-vtr-root-')));
+    worktree = realpathSync(mkdtempSync(join(tmpdir(), 'gossip-vtr-wt-')));
+    mkdirSync(join(projectRoot, 'src'), { recursive: true });
+    mkdirSync(join(worktree, 'src'), { recursive: true });
+    writeFileSync(join(projectRoot, 'src/target.ts'), ROOT_TARGET);
+    writeFileSync(join(projectRoot, 'src/root-only.ts'), 'export const onlyAtRoot = true;');
+    writeFileSync(join(worktree, 'src/target.ts'), WORKTREE_TARGET);
+    fileTools = new FileTools(new Sandbox(projectRoot));
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+    rmSync(worktree, { recursive: true, force: true });
+  });
+
+  const makeRunner = (effectiveRoots: readonly string[], makeGitTools?: (root: string) => GitTools) =>
+    buildVerifierToolRunner({
+      fileTools,
+      memory: memoryStub,
+      projectRoot,
+      effectiveRoots,
+      log: noopLog,
+      ...(makeGitTools ? { makeGitTools } : {}),
+    });
+
+  describe('with a declared review root', () => {
+    it('file_read of a relative citation returns the WORKTREE copy', async () => {
+      const run = makeRunner([worktree]);
+      const out = await run('deepseek-challenger', 'file_read', { path: 'src/target.ts' });
+      expect(out).toContain('resolveAutoBindMode');
+      expect(out).toContain('5\texport const d = 4;');
+    });
+
+    it('file_read of an ABSOLUTE project-root citation is remapped to the worktree', async () => {
+      const run = makeRunner([worktree]);
+      const out = await run('deepseek-challenger', 'file_read', {
+        path: join(projectRoot, 'src/target.ts'),
+      });
+      expect(out).toContain('resolveAutoBindMode');
+    });
+
+    it('file_read of an absolute path ALREADY inside the review root is not remapped', async () => {
+      const run = makeRunner([worktree]);
+      const out = await run('deepseek-challenger', 'file_read', {
+        path: join(worktree, 'src/target.ts'),
+      });
+      expect(out).toContain('resolveAutoBindMode');
+    });
+
+    it('file_grep scoped to a cited directory finds the worktree-only marker symbol', async () => {
+      const run = makeRunner([worktree]);
+      const out = await run('deepseek-challenger', 'file_grep', {
+        pattern: 'MARKER_SYMBOL',
+        path: 'src',
+      });
+      expect(out).toContain('MARKER_SYMBOL');
+      expect(out).not.toBe('No matches found');
+    });
+
+    it('file_grep without a path searches the worktree, not the project root', async () => {
+      const run = makeRunner([worktree]);
+      const out = await run('deepseek-challenger', 'file_grep', { pattern: 'MARKER_SYMBOL' });
+      expect(out).toContain('MARKER_SYMBOL');
+    });
+
+    it('a file that exists ONLY at the project root still resolves', async () => {
+      const run = makeRunner([worktree]);
+      const out = await run('deepseek-challenger', 'file_read', { path: 'src/root-only.ts' });
+      expect(out).toContain('onlyAtRoot');
+    });
+
+    it('a path outside both roots is rejected', async () => {
+      const run = makeRunner([worktree]);
+      const out = await run('deepseek-challenger', 'file_read', { path: '/etc/hosts' });
+      expect(out).toMatch(/^Tool error: /);
+      expect(out).toContain('outside project root');
+    });
+
+    it('short-name resolution prefers the worktree copy', async () => {
+      const access = buildVerifierFileAccess({
+        fileTools,
+        projectRoot,
+        effectiveRoots: [worktree],
+        log: noopLog,
+      });
+      // Absolute + outside every root → falls through to the file_search branch.
+      const resolved = await access.resolveToolPath('/nowhere-at-all/target.ts');
+      expect(resolved).toBe(join(worktree, 'src/target.ts'));
+    });
+
+    it('git_log runs against the review root', async () => {
+      const gitLog = jest.fn().mockResolvedValue('abc123 worktree commit');
+      const makeGitTools = jest.fn(() => ({ gitLog } as unknown as GitTools));
+      const run = makeRunner([worktree], makeGitTools);
+      const out = await run('deepseek-challenger', 'git_log', { limit: 5 });
+      expect(makeGitTools).toHaveBeenCalledTimes(1);
+      expect(makeGitTools).toHaveBeenCalledWith(worktree);
+      expect(out).toBe('abc123 worktree commit');
+    });
+  });
+
+  describe('with NO declared roots (legacy behavior unchanged)', () => {
+    it('file_read of a relative citation returns the PROJECT ROOT copy', async () => {
+      const run = makeRunner([]);
+      const out = await run('deepseek-challenger', 'file_read', { path: 'src/target.ts' });
+      expect(out).not.toContain('resolveAutoBindMode');
+      expect(out).toContain('3\texport const c = 3;');
+    });
+
+    it('file_grep without a path searches the project root', async () => {
+      const run = makeRunner([]);
+      const out = await run('deepseek-challenger', 'file_grep', { pattern: 'MARKER_SYMBOL' });
+      expect(out).toBe('No matches found');
+    });
+
+    it('resolveToolPath returns in-root citations untouched', async () => {
+      const access = buildVerifierFileAccess({
+        fileTools,
+        projectRoot,
+        effectiveRoots: [],
+        log: noopLog,
+      });
+      expect(await access.resolveToolPath('src/target.ts')).toBe('src/target.ts');
+    });
+
+    it('short-name resolution still falls back to file_search', async () => {
+      const access = buildVerifierFileAccess({
+        fileTools,
+        projectRoot,
+        effectiveRoots: [],
+        log: noopLog,
+      });
+      const resolved = await access.resolveToolPath('/nowhere-at-all/target.ts');
+      expect(resolved).toBe('src/target.ts');
+    });
+
+    it('git_log runs against the project root', async () => {
+      const gitLog = jest.fn().mockResolvedValue('def456 root commit');
+      const makeGitTools = jest.fn(() => ({ gitLog } as unknown as GitTools));
+      const run = makeRunner([], makeGitTools);
+      await run('deepseek-challenger', 'git_log', {});
+      expect(makeGitTools).toHaveBeenCalledWith(projectRoot);
+    });
+  });
+
+  describe('runner plumbing', () => {
+    it('file_search still ranks by effectiveRoots and is not re-rooted', async () => {
+      const run = makeRunner([worktree]);
+      const out = await run('deepseek-challenger', 'file_search', { pattern: 'root-only.ts' });
+      expect(out).toBe('src/root-only.ts');
+    });
+
+    it('unknown tools report the tool name', async () => {
+      const run = makeRunner([worktree]);
+      expect(await run('deepseek-challenger', 'shell_exec', {})).toBe('Unknown tool: shell_exec');
+    });
+
+    it('emits one observability line per successful call', async () => {
+      const lines: string[] = [];
+      const run = buildVerifierToolRunner({
+        fileTools,
+        memory: memoryStub,
+        projectRoot,
+        effectiveRoots: [worktree],
+        log: (l) => { lines.push(l); },
+      });
+      await run('deepseek-challenger', 'file_read', { path: 'src/target.ts' });
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain('🤝 [consensus] 🔧 deepseek-challenger tool_call: file_read(');
+      expect(lines[0]).toMatch(/→ \d+B \(\d+ms\)\n$/);
+    });
+  });
+});

--- a/tests/cli/verifier-tool-runner.test.ts
+++ b/tests/cli/verifier-tool-runner.test.ts
@@ -42,6 +42,12 @@ describe('verifier tool runner — resolutionRoots anchoring (#710)', () => {
     writeFileSync(join(projectRoot, 'src/target.ts'), ROOT_TARGET);
     writeFileSync(join(projectRoot, 'src/root-only.ts'), 'export const onlyAtRoot = true;');
     writeFileSync(join(worktree, 'src/target.ts'), WORKTREE_TARGET);
+    // Basename-collision fixture: `worktree-only.ts` exists ONLY in the sibling
+    // review root, while an unrelated file of the same basename sits at a
+    // DIFFERENT relative path under the project root.
+    mkdirSync(join(projectRoot, 'vendor'), { recursive: true });
+    writeFileSync(join(projectRoot, 'vendor/worktree-only.ts'), 'export const decoy = "DECOY_COPY";');
+    writeFileSync(join(worktree, 'src/worktree-only.ts'), 'export const real = "WORKTREE_COPY";');
     fileTools = new FileTools(new Sandbox(projectRoot));
   });
 
@@ -82,6 +88,26 @@ describe('verifier tool runner — resolutionRoots anchoring (#710)', () => {
         path: join(worktree, 'src/target.ts'),
       });
       expect(out).toContain('resolveAutoBindMode');
+    });
+
+    it('an absolute citation that exists ONLY in the sibling review root is not swapped for a same-basename decoy', async () => {
+      const run = makeRunner([worktree]);
+      const out = await run('deepseek-challenger', 'file_read', {
+        path: join(worktree, 'src/worktree-only.ts'),
+      });
+      expect(out).toContain('WORKTREE_COPY');
+      expect(out).not.toContain('DECOY_COPY');
+    });
+
+    it('resolveToolPath returns a review-root citation unchanged', async () => {
+      const access = buildVerifierFileAccess({
+        fileTools,
+        projectRoot,
+        effectiveRoots: [worktree],
+        log: noopLog,
+      });
+      const cited = join(worktree, 'src/worktree-only.ts');
+      expect(await access.resolveToolPath(cited)).toBe(cited);
     });
 
     it('file_grep scoped to a cited directory finds the worktree-only marker symbol', async () => {


### PR DESCRIPTION
## Summary

Fixes #710. Phase-2 cross-review file tools resolved citations against `process.cwd()` (master) instead of the declared `resolutionRoots` worktree, letting cross-reviewers confidently "refute" correct findings with measurements taken from the wrong tree. Two-provider evidence: gemini 2026-04-29 Phase 1 (fixed by #328) and deepseek 2026-08-03 Phase 2 (consensus `e8c1986b-65b64cfa`, disputing a correct finding with root-tree line counts).

- New `apps/cli/src/handlers/verifier-tool-runner.ts` extracts the verifier tool runner into a testable module: `file_read`/`file_grep` pass `effectiveRoots[0]` as `agentRoot` (FileTools/Sandbox already supported union-of-roots — no `packages/tools` changes), `resolveToolPath` gains a prefer-worktree remap (relative joins; absolute-inside-projectRoot re-based; citations already inside a declared root returned untouched), and `git_log` runs against the review root. Roots are realpath-canonicalized (darwin `/tmp` vs `/private/tmp`) and membership checks case-fold like the sandbox.
- **Critically, the fix covers BOTH Phase-2 tool loops.** Besides the engine-driven `verifierToolRunner`, `runOneRelayCrossReview` has its own inline `runToolCalls` — the loop mixed native+relay teams actually take (the engine path is skipped when any completed agent is native), and the one that produced the deepseek failure. It previously called `fileRead(args)` with no path resolution at all. Both now share one `verifierAccess`.
- With `effectiveRoots: []` behavior is byte-identical to the previous inline code, including stderr observability lines and the two loops' distinct error-string shapes.

## Review trail

- Implementer premise-verified all cited code claims, then found the second tool loop (scope expansion documented in the commit).
- sonnet-reviewer (native) review: confirmed no traversal hole (the terminal `Sandbox.validatePath(path, [reviewRoot])` inside FileTools is the real gate), git rooting, shared access, and empty-roots byte-identity — and caught one real defect: for **sibling** review roots, an absolute citation already inside the review root fell into the basename-search fallback and could silently substitute an unrelated same-basename file (the pinning test passed only by fixture coincidence).
- Second commit `933d1839` fixes it TDD-style (collision test written red against the first commit): `remapToReviewRoot` was overloading `undefined` for two opposite outcomes; an `isInsideDeclaredRoot` predicate now short-circuits authoritative citations before validation/search, with a genuinely-sibling fixture + decoy-basename test, plus the case-fold alignment.

Relay cross-review was deliberately not used for this PR — a relay cross-reviewer would exercise the very bug under review.

## Follow-ups filed (pre-existing, out of scope)

- #711 — `resolveToolPath` short-name fallback unreachable for in-root relative citations (`validatePath` succeeds on nonexistent paths)
- #712 — `FileTools.fileGrep` on a file path silently returns "No matches found" (ENOTDIR swallowed)

## Verification

- `npx jest tests/cli/` — 108 suites, 1521 passed
- `npm test` — 386 suites, **5416 passed, 0 failed**
- `npm run build` clean
- New suite `tests/cli/verifier-tool-runner.test.ts` (19 tests): divergent root/worktree content selection both ways, absolute-path remap, already-inside-declared-root short-circuit (sibling fixture + basename decoy), outside-all-roots rejection, single GitTools construction, empty-roots legacy behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)