### PR TITLE
fix(skills): harden SkillIndex against cross-process lost updates, non-atomic saves, and silent corruption (#714)

### DIFF
--- a/packages/orchestrator/src/skill-index.ts
+++ b/packages/orchestrator/src/skill-index.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync, statSync, renameSync, unlinkSync } from 'fs';
 import { join, dirname } from 'path';
 import { normalizeSkillName } from './skill-name';
 
@@ -27,12 +27,23 @@ export type SkillIndexData = Record<string, Record<string, SkillSlot>>;
  * - Shared skills, per-agent binding
  *
  * Persists to `.gossip/skill-index.json`.
+ *
+ * **Cross-process safety.** The MCP server holds one long-lived instance while
+ * the dashboard and migration scripts write the same file from other processes.
+ * Every public read/mutate re-reads the file when its `mtimeMs`/`size` changed
+ * since our last load or save, and every write lands via temp-file + rename.
+ * Mutators are fully synchronous from refresh through save, so the lost-update
+ * window is closed for this single-machine system. No locking, by design.
  */
 export class SkillIndex {
   private data: SkillIndexData = {};
   private readonly filePath: string;
   private dirty = false;
   private _exists = false;
+  private _corrupt = false;
+  /** File identity as of our last successful load or save; -1 when unknown. */
+  private seenMtimeMs = -1;
+  private seenSize = -1;
 
   constructor(projectRoot: string) {
     this.filePath = join(projectRoot, '.gossip', 'skill-index.json');
@@ -41,6 +52,7 @@ export class SkillIndex {
 
   /** Bind a skill to an agent (creates or updates the slot) */
   bind(agentId: string, skill: string, options?: { enabled?: boolean; source?: SkillSlot['source']; mode?: SkillSlot['mode'] }): SkillSlot {
+    this.refreshIfChanged();
     this.validateAgentId(agentId);
     const name = this.validateSkillName(skill);
     if (!this.data[agentId]) this.data[agentId] = Object.create(null);
@@ -64,6 +76,7 @@ export class SkillIndex {
 
   /** Unbind a skill from an agent (removes the slot entirely) */
   unbind(agentId: string, skill: string): boolean {
+    this.refreshIfChanged();
     this.validateAgentId(agentId);
     const name = normalizeSkillName(skill);
     if (!this.data[agentId]?.[name]) return false;
@@ -77,6 +90,7 @@ export class SkillIndex {
 
   /** Enable a previously disabled skill slot */
   enable(agentId: string, skill: string): boolean {
+    this.refreshIfChanged();
     this.validateAgentId(agentId);
     const slot = this.resolveSlot(agentId, skill);
     if (!slot) return false;
@@ -89,6 +103,7 @@ export class SkillIndex {
 
   /** Disable a skill slot without removing it */
   disable(agentId: string, skill: string): boolean {
+    this.refreshIfChanged();
     this.validateAgentId(agentId);
     const slot = this.resolveSlot(agentId, skill);
     if (!slot) return false;
@@ -117,6 +132,7 @@ export class SkillIndex {
 
   /** Get all enabled skill names for an agent */
   getEnabledSkills(agentId: string): string[] {
+    this.refreshIfChanged();
     const agentSlots = this.data[agentId];
     if (!agentSlots) return [];
     return Object.values(agentSlots)
@@ -126,6 +142,7 @@ export class SkillIndex {
 
   /** Get all slots for an agent (enabled and disabled) — returns copies */
   getAgentSlots(agentId: string): SkillSlot[] {
+    this.refreshIfChanged();
     const agentSlots = this.data[agentId];
     if (!agentSlots) return [];
     return Object.values(agentSlots).map(s => ({ ...s }));
@@ -133,23 +150,29 @@ export class SkillIndex {
 
   /** Get a specific slot — returns a copy */
   getSlot(agentId: string, skill: string): SkillSlot | undefined {
+    this.refreshIfChanged();
     const slot = this.data[agentId]?.[normalizeSkillName(skill)];
     return slot ? { ...slot } : undefined;
   }
 
   /** Get the full index data — returns a deep copy */
   getIndex(): SkillIndexData {
+    this.refreshIfChanged();
     return JSON.parse(JSON.stringify(this.data));
   }
 
   /** Get the mode for a specific skill slot */
   getSkillMode(agentId: string, skill: string): 'permanent' | 'contextual' {
+    this.refreshIfChanged();
     const slot = this.data[agentId]?.[normalizeSkillName(skill)];
     return slot?.mode ?? 'permanent';
   }
 
   /** Get all agent IDs in the index */
-  getAgentIds(): string[] { return Object.keys(this.data); }
+  getAgentIds(): string[] {
+    this.refreshIfChanged();
+    return Object.keys(this.data);
+  }
 
   /**
    * Drop entries for agents not in `validAgentIds`. Returns the list of
@@ -165,6 +188,7 @@ export class SkillIndex {
    * `.gossip/skill-index.json` file.
    */
   prune(validAgentIds: string[]): string[] {
+    this.refreshIfChanged();
     const valid = new Set<string>();
     for (const id of validAgentIds) {
       if (typeof id === 'string' && id.length > 0 && !DANGEROUS_KEYS.has(id)) {
@@ -186,13 +210,28 @@ export class SkillIndex {
   }
 
   /** Check if an index file exists (for backward compat detection) */
-  exists(): boolean { return this._exists; }
+  exists(): boolean {
+    this.refreshIfChanged();
+    return this._exists;
+  }
+
+  /**
+   * True when an index file was found on disk but could not be used — invalid
+   * JSON (now quarantined) or a non-object shape. Callers that would otherwise
+   * overwrite the file can refuse and surface the problem instead. Cleared once
+   * a good index is loaded or written.
+   */
+  isCorrupt(): boolean {
+    this.refreshIfChanged();
+    return this._corrupt;
+  }
 
   /**
    * Seed index from agent configs — call once on first load when no index file exists.
    * Imports existing config.skills[] as 'config' source slots.
    */
   seedFromConfigs(agents: Array<{ id: string; skills: string[] }>): void {
+    this.refreshIfChanged();
     for (const agent of agents) {
       if (DANGEROUS_KEYS.has(agent.id) || !agent.id) continue;
       if (!this.data[agent.id]) this.data[agent.id] = Object.create(null);
@@ -243,6 +282,7 @@ export class SkillIndex {
     agentIds: string[],
     mode: 'permanent' | 'contextual',
   ): void {
+    this.refreshIfChanged();
     let changed = false;
     for (const agentId of agentIds) {
       if (DANGEROUS_KEYS.has(agentId) || !agentId) continue;
@@ -282,38 +322,122 @@ export class SkillIndex {
     return name;
   }
 
-  private load(): void {
+  /** File identity, or null when the file is absent/unreadable. */
+  private statFile(): { mtimeMs: number; size: number } | null {
     try {
-      const raw = readFileSync(this.filePath, 'utf-8');
-      const parsed = JSON.parse(raw);
-      // Structural validation: must be a non-null, non-array object
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        // Sanitize: remove prototype-polluting keys from disk JSON
-        for (const key of Object.keys(parsed)) {
-          if (DANGEROUS_KEYS.has(key)) delete parsed[key];
-        }
-        // Backfill mode for existing slots that don't have it
-        for (const agentSlots of Object.values(parsed)) {
-          if (!agentSlots || typeof agentSlots !== 'object') continue;
-          for (const slot of Object.values(agentSlots) as any[]) {
-            if (slot && !slot.mode) {
-              slot.mode = (slot.source === 'auto' || slot.source === 'imported')
-                ? 'contextual' : 'permanent';
-            }
-          }
-        }
-        this.data = parsed as SkillIndexData;
-        this._exists = true;
-      }
-    } catch { /* file doesn't exist or corrupted — start fresh */ }
+      const st = statSync(this.filePath);
+      return { mtimeMs: st.mtimeMs, size: st.size };
+    } catch {
+      return null;
+    }
   }
 
+  private markSeen(): void {
+    const st = this.statFile();
+    this.seenMtimeMs = st ? st.mtimeMs : -1;
+    this.seenSize = st ? st.size : -1;
+  }
+
+  /**
+   * Re-read the file if another process changed it since our last load or save.
+   * A missing file leaves in-memory state alone — same as a fresh construction
+   * against a project that has no index yet.
+   *
+   * Safe to call before any mutation: every mutator saves within the same
+   * synchronous turn it sets `dirty`, so there is never an unsaved edit for a
+   * reload to discard.
+   */
+  private refreshIfChanged(): void {
+    const st = this.statFile();
+    if (!st) return;
+    if (st.mtimeMs === this.seenMtimeMs && st.size === this.seenSize) return;
+    this.load();
+  }
+
+  /**
+   * Move an unparseable index aside so the bad bytes survive for diagnosis,
+   * and say so on stderr. Never throws — a corrupt file must not brick boot.
+   */
+  private quarantineCorruptFile(): void {
+    const backup = `${this.filePath}.corrupt-${Date.now()}`;
+    try {
+      renameSync(this.filePath, backup);
+      process.stderr.write(
+        `[gossipcat] ⚠️  skill-index.json is not valid JSON — moved to ${backup}, starting from an empty index\n`,
+      );
+    } catch {
+      process.stderr.write(
+        `[gossipcat] ⚠️  skill-index.json is not valid JSON and could not be moved aside — starting from an empty index\n`,
+      );
+    }
+  }
+
+  private load(): void {
+    let raw: string;
+    try {
+      raw = readFileSync(this.filePath, 'utf-8');
+    } catch {
+      return; // no file yet — start fresh
+    }
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      this.quarantineCorruptFile();
+      this.data = {};
+      this._exists = false;
+      this._corrupt = true;
+      this.markSeen();
+      return;
+    }
+
+    this.markSeen();
+    // Structural validation: must be a non-null, non-array object
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      this._corrupt = true;
+      return;
+    }
+
+    // Sanitize: remove prototype-polluting keys from disk JSON
+    for (const key of Object.keys(parsed)) {
+      if (DANGEROUS_KEYS.has(key)) delete parsed[key];
+    }
+    // Backfill mode for existing slots that don't have it
+    for (const agentSlots of Object.values(parsed)) {
+      if (!agentSlots || typeof agentSlots !== 'object') continue;
+      for (const slot of Object.values(agentSlots) as any[]) {
+        if (slot && !slot.mode) {
+          slot.mode = (slot.source === 'auto' || slot.source === 'imported')
+            ? 'contextual' : 'permanent';
+        }
+      }
+    }
+    this.data = parsed as SkillIndexData;
+    this._exists = true;
+    this._corrupt = false;
+  }
+
+  /**
+   * Atomic write: serialize to a sibling temp file, then rename over the
+   * target. A reader in another process sees either the old file or the new
+   * one, never a half-written index.
+   */
   private save(): void {
     if (!this.dirty) return;
     const dir = dirname(this.filePath);
     mkdirSync(dir, { recursive: true }); // idempotent, no TOCTOU
-    writeFileSync(this.filePath, JSON.stringify(this.data, null, 2) + '\n');
+    const tmp = join(dir, `.skill-index.json.${process.pid}.tmp`);
+    writeFileSync(tmp, JSON.stringify(this.data, null, 2) + '\n');
+    try {
+      renameSync(tmp, this.filePath);
+    } catch (err) {
+      try { unlinkSync(tmp); } catch { /* best-effort cleanup */ }
+      throw err;
+    }
     this._exists = true;
+    this._corrupt = false;
     this.dirty = false;
+    this.markSeen();
   }
 }

--- a/packages/relay/src/dashboard/api-skills.ts
+++ b/packages/relay/src/dashboard/api-skills.ts
@@ -38,10 +38,6 @@ const DEFAULT_THRESHOLD = 0.7;
  *  amortize the jsonl scan across the 5s dashboard poll. */
 const CACHE_TTL_MS = 60_000;
 
-function isCorrupt(projectRoot: string, index: SkillIndex): boolean {
-  return existsSync(join(projectRoot, '.gossip', 'skill-index.json')) && !index.exists();
-}
-
 /* ── frontmatter (status + bound_at + passed_baseline_rate + provenance) ── */
 
 interface SkillFrontmatter {
@@ -352,7 +348,7 @@ export async function skillsBindHandler(projectRoot: string, body: SkillsBindReq
   if (!body.skill || typeof body.skill !== 'string' || !AGENT_ID_RE.test(body.skill)) return { success: false, error: 'Invalid skill name' };
   try {
     const index = new SkillIndex(projectRoot);
-    if (isCorrupt(projectRoot, index)) {
+    if (index.isCorrupt()) {
       return { success: false, error: 'Could not parse skill-index.json' };
     }
     if (body.enabled) {

--- a/tests/orchestrator/skill-index-concurrency.test.ts
+++ b/tests/orchestrator/skill-index-concurrency.test.ts
@@ -1,0 +1,224 @@
+import { SkillIndex } from '@gossip/orchestrator';
+import { existsSync, mkdirSync, rmSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * Regression suite for #714 — the long-lived MCP-server SkillIndex clobbering
+ * writes made by other processes (dashboard binds, migration scripts).
+ */
+describe('SkillIndex cross-process safety', () => {
+  let testDir: string;
+  let indexPath: string;
+  let seq = 0;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `gossip-skill-index-concurrency-${Date.now()}-${seq++}`);
+    mkdirSync(join(testDir, '.gossip'), { recursive: true });
+    indexPath = join(testDir, '.gossip', 'skill-index.json');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  const readIndex = () => JSON.parse(readFileSync(indexPath, 'utf-8'));
+
+  describe('lost update', () => {
+    it('keeps both bindings when two instances write the same file', () => {
+      const a = new SkillIndex(testDir);
+      const b = new SkillIndex(testDir);
+
+      a.bind('agent-a', 'typescript');
+      b.bind('agent-b', 'security-audit');
+
+      const onDisk = readIndex();
+      expect(onDisk['agent-a']?.typescript).toBeDefined();
+      expect(onDisk['agent-b']?.['security-audit']).toBeDefined();
+    });
+
+    it('keeps both bindings when the two instances target the same agent', () => {
+      const a = new SkillIndex(testDir);
+      const b = new SkillIndex(testDir);
+
+      a.bind('agent-a', 'typescript');
+      b.bind('agent-a', 'security-audit');
+
+      const onDisk = readIndex();
+      expect(Object.keys(onDisk['agent-a']).sort()).toEqual(['security-audit', 'typescript']);
+    });
+
+    it('serves a later external bind through the read accessors', () => {
+      const longLived = new SkillIndex(testDir);
+      longLived.bind('agent-a', 'typescript');
+
+      new SkillIndex(testDir).bind('agent-a', 'security-audit');
+
+      expect(longLived.getEnabledSkills('agent-a').sort()).toEqual(['security-audit', 'typescript']);
+      expect(longLived.getSlot('agent-a', 'security-audit')).toBeDefined();
+      expect(longLived.getAgentIds()).toEqual(['agent-a']);
+    });
+  });
+
+  describe('external edit preservation', () => {
+    /** Simulates the #709 migration flipping an auto slot to contextual mode. */
+    const flipModeExternally = (agentId: string, skill: string) => {
+      const data = readIndex();
+      data[agentId][skill].mode = 'contextual';
+      data[agentId][skill].version += 1;
+      writeFileSync(indexPath, JSON.stringify(data, null, 2) + '\n');
+      return data[agentId][skill].boundAt as string;
+    };
+
+    it('preserves an externally flipped mode across an unrelated bind', () => {
+      const longLived = new SkillIndex(testDir);
+      longLived.bind('agent-a', 'typescript', { source: 'auto', mode: 'permanent' });
+
+      flipModeExternally('agent-a', 'typescript');
+      longLived.bind('agent-b', 'security-audit');
+
+      const onDisk = readIndex();
+      expect(onDisk['agent-a'].typescript.mode).toBe('contextual');
+      expect(onDisk['agent-b']?.['security-audit']).toBeDefined();
+    });
+
+    it('does not rotate boundAt on slots a refresh merely re-reads', () => {
+      const longLived = new SkillIndex(testDir);
+      longLived.bind('agent-a', 'typescript', { source: 'auto', mode: 'permanent' });
+
+      const boundAtBefore = flipModeExternally('agent-a', 'typescript');
+      longLived.bind('agent-b', 'security-audit');
+
+      expect(readIndex()['agent-a'].typescript.boundAt).toBe(boundAtBefore);
+      expect(longLived.getSlot('agent-a', 'typescript')?.boundAt).toBe(boundAtBefore);
+    });
+
+    it('reports the externally flipped mode from getSkillMode', () => {
+      const longLived = new SkillIndex(testDir);
+      longLived.bind('agent-a', 'typescript', { source: 'auto', mode: 'permanent' });
+      expect(longLived.getSkillMode('agent-a', 'typescript')).toBe('permanent');
+
+      flipModeExternally('agent-a', 'typescript');
+
+      expect(longLived.getSkillMode('agent-a', 'typescript')).toBe('contextual');
+    });
+
+    it('versions a re-bind from the on-disk version, not the stale one', () => {
+      const longLived = new SkillIndex(testDir);
+      longLived.bind('agent-a', 'typescript', { source: 'auto', mode: 'permanent' });
+
+      flipModeExternally('agent-a', 'typescript'); // version 1 → 2
+
+      expect(longLived.bind('agent-a', 'typescript').version).toBe(3);
+    });
+
+    it('leaves in-memory state intact when the file is deleted externally', () => {
+      const longLived = new SkillIndex(testDir);
+      longLived.bind('agent-a', 'typescript');
+
+      rmSync(indexPath);
+
+      expect(longLived.getEnabledSkills('agent-a')).toEqual(['typescript']);
+    });
+  });
+
+  describe('atomic save', () => {
+    it('leaves no temp file behind', () => {
+      const index = new SkillIndex(testDir);
+      index.bind('agent-a', 'typescript');
+      index.bind('agent-b', 'security-audit');
+      index.unbind('agent-b', 'security-audit');
+
+      expect(readdirSync(join(testDir, '.gossip'))).toEqual(['skill-index.json']);
+    });
+
+    it('writes pretty-printed JSON with a trailing newline', () => {
+      const index = new SkillIndex(testDir);
+      index.bind('agent-a', 'typescript');
+
+      const raw = readFileSync(indexPath, 'utf-8');
+      expect(raw.endsWith('\n')).toBe(true);
+      expect(raw).toBe(JSON.stringify(JSON.parse(raw), null, 2) + '\n');
+      expect(new SkillIndex(testDir).getIndex()).toEqual(index.getIndex());
+    });
+  });
+
+  describe('corrupt index handling', () => {
+    let stderrSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    });
+
+    afterEach(() => {
+      stderrSpy.mockRestore();
+    });
+
+    const corruptFiles = () =>
+      readdirSync(join(testDir, '.gossip')).filter(f => f.includes('.corrupt-'));
+
+    it('starts empty, backs the file up, and warns on stderr', () => {
+      writeFileSync(indexPath, '{ this is not json');
+
+      const index = new SkillIndex(testDir);
+
+      expect(index.getIndex()).toEqual({});
+      expect(corruptFiles()).toHaveLength(1);
+      expect(existsSync(indexPath)).toBe(false);
+      const warning = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(warning).toContain('not valid JSON');
+      expect(warning).toContain('.corrupt-');
+    });
+
+    it('preserves the corrupt bytes in the backup', () => {
+      writeFileSync(indexPath, '{ this is not json');
+
+      new SkillIndex(testDir);
+
+      const backup = corruptFiles()[0];
+      expect(readFileSync(join(testDir, '.gossip', backup), 'utf-8')).toBe('{ this is not json');
+    });
+
+    it('does not throw from the constructor', () => {
+      writeFileSync(indexPath, 'not json at all');
+
+      expect(() => new SkillIndex(testDir)).not.toThrow();
+    });
+
+    it('recovers into a usable index after quarantine', () => {
+      writeFileSync(indexPath, '<<<garbage>>>');
+
+      const index = new SkillIndex(testDir);
+      index.bind('agent-a', 'typescript');
+
+      expect(readIndex()['agent-a'].typescript.enabled).toBe(true);
+    });
+
+    describe('isCorrupt()', () => {
+      it('reports unparseable JSON so callers can refuse to overwrite', () => {
+        writeFileSync(indexPath, '{"foo":');
+        expect(new SkillIndex(testDir).isCorrupt()).toBe(true);
+      });
+
+      it('reports a non-object index shape', () => {
+        writeFileSync(indexPath, '[1,2,3]');
+        expect(new SkillIndex(testDir).isCorrupt()).toBe(true);
+      });
+
+      it('is false for a healthy or absent index', () => {
+        expect(new SkillIndex(testDir).isCorrupt()).toBe(false);
+        new SkillIndex(testDir).bind('agent-a', 'typescript');
+        expect(new SkillIndex(testDir).isCorrupt()).toBe(false);
+      });
+
+      it('clears once a good index is written over the quarantined one', () => {
+        writeFileSync(indexPath, '{"foo":');
+        const index = new SkillIndex(testDir);
+
+        index.bind('agent-a', 'typescript');
+
+        expect(index.isCorrupt()).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #714 — the bug that **twice silently reverted the #709 index migration in production**: the long-lived server `SkillIndex` held the whole index in memory and its next `save()` (hourly skill-graduation pass) blind-overwrote any external write. Independently confirmed at code level by review task 4d4c5bec, which also identified dashboard per-request instances as a second everyday clobber vector.

- **Refresh-if-stale**: `refreshIfChanged()` (mtimeMs+size stat) runs as the first statement of **every** public read/mutate method — verified exhaustively in review (15 entry points, no unguarded entry). Mutators are fully synchronous refresh→mutate→save, closing the cross-process window to the sync gap.
- **Atomic save**: pid-scoped temp file + rename (matching the migration script's convention), unlink-on-failure; target file untouched until a successful rename. Repo-wide there are exactly two writers and both are now atomic.
- **Loud corruption handling**: parse failure quarantines the file to `skill-index.json.corrupt-<epoch-ms>` with a stderr warning — never throws from the constructor. New authoritative `SkillIndex.isCorrupt()` replaces the dashboard's `existsSync && !exists()` heuristic in `api-skills.ts`, which the quarantine rename would otherwise have defeated (caught by the full suite; also now covers valid-JSON-wrong-shape).
- `boundAt` discipline preserved: refresh is a plain reload; the mode backfill in `load()` is in-memory only and never marks dirty (HANDBOOK invariant #6).

## Review trail

- Implementer premise-verified all claims; proved the new tests genuine by reverting the source (8 of 22 red on unpatched code); full `npm test` 5434 green.
- sonnet-reviewer verified guard coverage line-by-line, atomicity, corruption path, boundAt discipline, and the dashboard swap; re-ran 208 suites/3142 tests. Three low-severity notes, all judged shippable, tracked as optional follow-ups:
  1. mtime+size gate blind spot for same-size writes within mtime resolution (acceptable on APFS/ext4 single-machine; a content hash would close it — candidate one-line follow-up).
  2. Temp-file litter if `writeFileSync` itself throws (self-limiting via pid-scoped name).
  3. A `loadSkills()`-level end-to-end test would pin the regression at the layer where #709's loss actually manifested.

## Verification

- `npx jest tests/orchestrator/` — 206 suites, 3062 passed; full `npm test` — 387 suites, **5434 passed, 0 failed**
- Reviewer independently: 208 suites / 3142 passed; `tsc --noEmit` clean for orchestrator
- Note: `npm run build` **inside a worktree** shows a phantom relay TS2339 (module resolution walks up to the main repo's stale orchestrator dist — same family as the dist-mcp worktree lesson); verified false-negative via paths-override typecheck (exit 0). Root `build:all` builds orchestrator before relay, so CI is unaffected.

## Operational note

After this merges, external edits to `.gossip/skill-index.json` (e.g. re-running `scripts/migrate-skill-index-modes.mjs`) survive a running server — the original #714 incident becomes structurally impossible for these writers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)