### PR TITLE
fix: close two verifier-tool false-negative gaps — unreachable short-name fallback (#711), fileGrep on file paths (#712)

### DIFF
--- a/apps/cli/src/handlers/verifier-tool-runner.ts
+++ b/apps/cli/src/handlers/verifier-tool-runner.ts
@@ -140,8 +140,17 @@ export function buildVerifierFileAccess(opts: VerifierFileAccessOptions): Verifi
     if (isInsideDeclaredRoot(filePath)) return filePath;
     const remapped = remapToReviewRoot(filePath);
     if (remapped) return remapped;
-    // Try as-is next — if Sandbox validates it, the path is inside the project root.
-    try { sandbox.validatePath(filePath); return asProjectRootPath(filePath); } catch { /* outside root */ }
+    // Try as-is next — if Sandbox validates it AND the resolved file actually
+    // exists, the citation is a usable project-root path. The existence check is
+    // load-bearing (#711): `Sandbox.validatePath` walks up to the deepest EXISTING
+    // ancestor, so it succeeds for ANY non-escaping relative path whether or not
+    // the file is there. Without it a bare-filename citation short-circuits here,
+    // file_read reports "File not found", and the short-name search below is
+    // unreachable for in-root relative citations.
+    try {
+      const validated = sandbox.validatePath(filePath);
+      if (existsSync(validated)) return asProjectRootPath(filePath);
+    } catch { /* outside root */ }
     // Search via file_search for the bare filename, passing resolutionRoots so
     // fileSearch ranks matches inside a resolution root ahead of stray duplicates.
     const fileName = filePath.split('/').pop() ?? filePath;

--- a/packages/tools/src/file-tools.ts
+++ b/packages/tools/src/file-tools.ts
@@ -131,7 +131,21 @@ export class FileTools {
       return `Invalid regex pattern: ${error instanceof Error ? error.message : 'Unknown error'}`;
     }
     const state: GrepState = { matches: [], filesScanned: 0, truncated: false };
-    await this.grepDir(searchRoot, regex, state, 0, 10);
+    // Dispatch on the target's type (#712). `grepDir` calls `readdir`, whose
+    // ENOTDIR is swallowed by its bare catch — so grepping a cited FILE used to
+    // return "No matches found" regardless of content, a false-negative
+    // generator for cross-reviewers verifying a specific file. A target that
+    // cannot be stat'd (e.g. a non-existent in-root path) falls through to the
+    // walk, preserving the previous error behavior exactly.
+    let targetInfo;
+    try {
+      targetInfo = await stat(searchRoot);
+    } catch { /* unreadable target — keep the pre-existing walk behavior */ }
+    if (targetInfo?.isFile()) {
+      await this.grepFile(searchRoot, targetInfo.size, regex, state);
+    } else {
+      await this.grepDir(searchRoot, regex, state, 0, 10);
+    }
     let output = state.matches.join('\n') || 'No matches found';
     if (state.truncated) {
       output += '\n... (truncated — result or scan limit reached; narrow your pattern/path)';
@@ -216,34 +230,46 @@ export class FileTools {
       if (info.isDirectory()) {
         await this.grepDir(fullPath, regex, state, depth + 1, maxDepth);
       } else {
-        if (info.size > MAX_GREP_FILE_BYTES) {
-          // Size-skipped files count toward the file cap but mark truncated
-          // only when the file cap is exceeded; size-skip alone is silent
-          // (caller sees no matches for that file, which is correct behavior).
-          continue;
-        }
-        state.filesScanned++;
-        if (state.filesScanned > MAX_GREP_FILES) {
+        await this.grepFile(fullPath, info.size, regex, state);
+        // grepFile sets `truncated` on file-cap exhaustion; the loop head above
+        // returns on the next iteration, matching the previous early return.
+      }
+    }
+  }
+
+  /**
+   * Grep a single file into `state`, honoring MAX_GREP_FILE_BYTES /
+   * MAX_GREP_FILES / MAX_GREP_MATCHES and the `path:line: content` output
+   * format. Shared by the directory walk and the single-file `fileGrep`
+   * target (#712) so both obey identical cap semantics.
+   */
+  private async grepFile(fullPath: string, size: number, regex: RegExp, state: GrepState): Promise<void> {
+    if (size > MAX_GREP_FILE_BYTES) {
+      // Size-skipped files count toward the file cap but mark truncated
+      // only when the file cap is exceeded; size-skip alone is silent
+      // (caller sees no matches for that file, which is correct behavior).
+      return;
+    }
+    state.filesScanned++;
+    if (state.filesScanned > MAX_GREP_FILES) {
+      state.truncated = true;
+      return;
+    }
+    try {
+      const content = await readFile(fullPath, 'utf-8');
+      const lines = content.split('\n');
+      const relPath = relative(this.sandbox.projectRoot, fullPath);
+      for (let idx = 0; idx < lines.length; idx++) {
+        if (state.matches.length >= MAX_GREP_MATCHES) {
           state.truncated = true;
-          return;
+          break;
         }
-        try {
-          const content = await readFile(fullPath, 'utf-8');
-          const lines = content.split('\n');
-          const relPath = relative(this.sandbox.projectRoot, fullPath);
-          for (let idx = 0; idx < lines.length; idx++) {
-            if (state.matches.length >= MAX_GREP_MATCHES) {
-              state.truncated = true;
-              break;
-            }
-            if (regex.test(lines[idx])) {
-              state.matches.push(`${relPath}:${idx + 1}: ${lines[idx]}`);
-            }
-          }
-        } catch {
-          // Skip binary or unreadable files
+        if (regex.test(lines[idx])) {
+          state.matches.push(`${relPath}:${idx + 1}: ${lines[idx]}`);
         }
       }
+    } catch {
+      // Skip binary or unreadable files
     }
   }
 

--- a/tests/cli/verifier-tool-runner.test.ts
+++ b/tests/cli/verifier-tool-runner.test.ts
@@ -176,7 +176,13 @@ describe('verifier tool runner — resolutionRoots anchoring (#710)', () => {
       expect(out).toBe('No matches found');
     });
 
-    it('resolveToolPath returns in-root citations untouched', async () => {
+    // #711 — the as-is short-circuit must require the resolved file to EXIST.
+    // `Sandbox.validatePath` walks up to the deepest existing ancestor, so it
+    // succeeds for any non-escaping relative path; without an existence check a
+    // bare-filename citation returned as-is and the search branch below was
+    // unreachable for in-root relative citations.
+    it('resolveToolPath returns an EXISTING in-root citation untouched, without hitting file_search', async () => {
+      const searchSpy = jest.spyOn(fileTools, 'fileSearch');
       const access = buildVerifierFileAccess({
         fileTools,
         projectRoot,
@@ -184,6 +190,31 @@ describe('verifier tool runner — resolutionRoots anchoring (#710)', () => {
         log: noopLog,
       });
       expect(await access.resolveToolPath('src/target.ts')).toBe('src/target.ts');
+      expect(searchSpy).not.toHaveBeenCalled();
+      searchSpy.mockRestore();
+    });
+
+    it('resolveToolPath resolves a bare filename of a nested file via file_search (#711)', async () => {
+      const access = buildVerifierFileAccess({
+        fileTools,
+        projectRoot,
+        effectiveRoots: [],
+        log: noopLog,
+      });
+      // `target.ts` does NOT exist at the project root — only at `src/target.ts`.
+      expect(await access.resolveToolPath('target.ts')).toBe('src/target.ts');
+    });
+
+    it('resolveToolPath returns the original when a bare filename matches nothing (#711)', async () => {
+      const access = buildVerifierFileAccess({
+        fileTools,
+        projectRoot,
+        effectiveRoots: [],
+        log: noopLog,
+      });
+      // No match anywhere → hand the citation back so file_read emits its own
+      // clear "File not found" error rather than a silent substitution.
+      expect(await access.resolveToolPath('no-such-file-anywhere.ts')).toBe('no-such-file-anywhere.ts');
     });
 
     it('short-name resolution still falls back to file_search', async () => {

--- a/tests/tools/file-tools.test.ts
+++ b/tests/tools/file-tools.test.ts
@@ -233,6 +233,52 @@ describe('FileTools', () => {
       expect(result).toBe('No matches found');
     });
 
+    // #712 — a `path` pointing at a FILE used to hit `grepDir`, whose `readdir`
+    // ENOTDIR was swallowed by a bare catch, so every such call returned
+    // "No matches found" regardless of content — a false negative for
+    // cross-reviewers grepping a specific cited file.
+    it('greps a single file when path points at a file (#712)', async () => {
+      const result = await fileTools.fileGrep({ pattern: 'hello', path: 'src/index.ts' });
+      expect(result).not.toBe('No matches found');
+      expect(result).toContain('index.ts');
+      expect(result).toContain('hello');
+      expect(result).toMatch(/index\.ts:1: /);
+    });
+
+    it('does not leak matches from sibling files when path is a single file (#712)', async () => {
+      // `export` appears in both src/index.ts and src/utils.ts — targeting one
+      // file must report only that file.
+      const result = await fileTools.fileGrep({ pattern: 'export', path: 'src/index.ts' });
+      expect(result).toContain('index.ts');
+      expect(result).not.toContain('utils.ts');
+    });
+
+    it('returns no matches message for a file path with no match (#712)', async () => {
+      const result = await fileTools.fileGrep({
+        pattern: 'NONEXISTENT_UNIQUE_STRING_XYZ',
+        path: 'src/index.ts',
+      });
+      expect(result).toBe('No matches found');
+    });
+
+    it('leaves directory-path behavior unchanged (#712)', async () => {
+      const result = await fileTools.fileGrep({ pattern: 'export', path: 'src' });
+      expect(result).toContain('index.ts');
+      expect(result).toContain('utils.ts');
+    });
+
+    it('preserves existing behavior for a nonexistent in-root path (#712)', async () => {
+      // validatePath resolves via the deepest-existing-ancestor walk, so this
+      // does not throw; the target simply cannot be stat'd and yields no matches.
+      const result = await fileTools.fileGrep({ pattern: 'export', path: 'src/no-such-file.ts' });
+      expect(result).toBe('No matches found');
+    });
+
+    it('preserves the outside-root error for a path escaping the sandbox (#712)', async () => {
+      await expect(fileTools.fileGrep({ pattern: 'export', path: '/etc' }))
+        .rejects.toThrow(/outside project root/);
+    });
+
     it('completes promptly for a pathological ReDoS pattern against a long line', async () => {
       // (a+)+$ causes catastrophic backtracking in JS RegExp against a long non-matching
       // string. With RE2's linear-time engine this resolves in microseconds.
@@ -329,6 +375,26 @@ describe('FileTools', () => {
       // Pattern ^x+$ would match if the file were read — but it's skipped due to size.
       const result = await bigOnlyTools.fileGrep({ pattern: '^x+$' });
       expect(result).toBe('No matches found');
+    }, 10_000);
+
+    it('(b-file-target) an over-size file targeted DIRECTLY is still size-skipped (#712)', async () => {
+      // Single-file targeting must honor MAX_GREP_FILE_BYTES exactly as the walk
+      // does — the cap is a resource guard, not a walk-only artifact.
+      const result = await capTools.fileGrep({ pattern: '^x+$', path: 'data/big-file.txt' });
+      expect(result).toBe('No matches found');
+    }, 10_000);
+
+    it('(b-file-target-under) an under-size file targeted DIRECTLY is scanned (#712)', async () => {
+      const result = await capTools.fileGrep({ pattern: '^x+$', path: 'data/under-size.txt' });
+      expect(result).toContain('under-size.txt');
+      expect(result).not.toContain('truncated');
+    }, 10_000);
+
+    it('(a-file-target) match cap + truncation notice apply to a single-file target (#712)', async () => {
+      const result = await capTools.fileGrep({ pattern: '^LINE', path: 'data/many-lines.txt' });
+      const lines = result.split('\n');
+      expect(lines[lines.length - 1]).toContain('truncated');
+      expect(lines).toHaveLength(MAX_GREP_MATCHES + 1);
     }, 10_000);
 
     it('(b-walk) size-skip does not break the broader walk', async () => {


### PR DESCRIPTION
## Summary

Fixes #711. Fixes #712. Two false-negative generators in the cross-review tool path, both found during the #710/#713 work and both empirically premise-verified before editing (temporary jest probes, deleted after).

- **#711** — `resolveToolPath`'s "try as-is" step short-circuited on `Sandbox.validatePath` alone, which walks up to the deepest *existing* ancestor and therefore succeeds for nonexistent in-root relative paths. Bare-filename citations (the exact case the `file_search` fallback was written for) returned as-is, `file_read` errored, and the fallback was unreachable. Fix: require `existsSync(validated)` before short-circuiting. The #713 semantics are untouched: the `isInsideDeclaredRoot` short-circuit stays first and unconditional; the prefer-worktree remap already checked existence.
- **#712** — `fileGrep` with `path` pointing at a **file** passed it to `grepDir`, whose `readdir` ENOTDIR was swallowed by a bare catch → `"No matches found"` for every file-scoped grep — the same "confident empty result from the wrong operation" class as #710. Fix: stat-based target-type dispatch; per-file matching extracted to a shared `grepFile()` used by both the walk and the single-file path, so caps (`MAX_GREP_FILE_BYTES`/`MAX_GREP_MATCHES`) and output format are identical either way. The walk's per-entry error handling is unchanged.

## Test honesty note

The pre-existing test `resolveToolPath returns in-root citations untouched` did not actually pin the buggy behavior (its fixture existed at root, so it passed before and after) — it's kept as the existing-path case and hardened with a `fileSearch` spy asserting the search branch is not reached. The genuine regression-prover is the new bare-filename test, verified red against pre-fix code by temporarily reverting the guard (1 failed / 20 passed, then restored).

## Verification

- `npx jest tests/cli/ tests/tools/` green (1523 + 123)
- Full `npm test` — 387 suites, **5445 passed, 0 failed** (+12 new tests)
- `tsc --noEmit` clean for `packages/tools`; the only worktree tsc output is the known phantom TS2339 class (stale main-repo dist, untouched files — see #716 PR body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)