### PR TITLE
fix(deps): clear @hono/node-server path-traversal advisory via SDK 1.30.0 + override (#703)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "dependencies": {
         "@clack/prompts": "^1.1.0",
-        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "re2": "^1.25.0",
         "tsconfig-paths": "^4.2.0",
         "ws": "^8.20.1"
@@ -1235,12 +1235,12 @@
       "link": true
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.15",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
-      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1628,12 +1628,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -4452,9 +4452,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.1.0",
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "re2": "^1.25.0",
     "tsconfig-paths": "^4.2.0",
     "ws": "^8.20.1"
@@ -65,6 +65,7 @@
     "fast-uri": ">=3.1.4",
     "postcss": "^8.5.18",
     "js-yaml": "^4.2.1",
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.8",
+    "@hono/node-server": "^2.0.5"
   }
 }


### PR DESCRIPTION
## Summary

Fixes #703. Clears GHSA-frvp-7c67-39w9 (`@hono/node-server` < 2.0.5 path traversal via encoded `%5C` on Windows), which reached us transitively under `@modelcontextprotocol/sdk`.

- SDK `^1.27.1` → `^1.30.0` (minor; 1.30.0's hono constraint is `^1.19.9 || ^2.0.5`)
- `overrides: { "@hono/node-server": "^2.0.5" }` forces resolution onto the fixed line — installed: **2.0.12**
- `npm audit`: **0 vulnerabilities**

## Verification (all at repo root, per the issue's requirements)

- **Dual-zod geometry intact** — `npm ls zod` before and after shows the identical load-bearing shape: `zod@4.4.3` (cli + SDK) and nested `zod@3.25.76` under `packages/tools`; nothing deduped (invariant per PR #648 / `project_dual_zod_geometry_load_bearing`)
- Full `npm test`: 393 suites, **5523 passed, 0 failed**
- `npm run build` + `npm run build:mcp` clean
- dist-mcp binary suites (`mcp-server-argv-dispatch`, `mcp-server-code-dispatch`, `install-packaging`): **26/26**

🤖 Generated with [Claude Code](https://claude.com/claude-code)