### PR TITLE
fix(skills): align keyword-migration rewrite regex with the parser's item grammar (#705)

### DIFF
--- a/packages/orchestrator/src/skill-keyword-migration.ts
+++ b/packages/orchestrator/src/skill-keyword-migration.ts
@@ -110,7 +110,14 @@ export function rewriteKeywordsFrontmatter(raw: string, keywords: readonly strin
   }
 
   // Block sequence: `keywords:` on its own line followed by `- item` lines.
-  const seq = block.match(/^(\s*)keywords:[ \t]*\n((?:[ \t]*-[ \t]*.*\n?)+)/m);
+  // The item pattern must be no more permissive than the parser's
+  // (skill-parser.ts: `/^\s*-\s(.*)$/`), which requires whitespace after the
+  // dash and RESETS block context on the first line that fails. Hence
+  // `-[ \t]`, not `-[ \t]*`: a bare `-item` is not a sequence item, so it and
+  // everything after it are outside the region the parser read and must be
+  // left byte-identical. `.` never crosses a newline, so the `+` already stops
+  // at the first non-matching line — matching the parser's reset (#705).
+  const seq = block.match(/^(\s*)keywords:[ \t]*\n((?:[ \t]*-[ \t].*\n?)+)/m);
   if (seq) {
     const indent = seq[1];
     const itemIndent = seq[2].match(/^([ \t]*)-/)?.[1] ?? `${indent}  `;

--- a/tests/orchestrator/skill-keyword-migration.test.ts
+++ b/tests/orchestrator/skill-keyword-migration.test.ts
@@ -82,6 +82,34 @@ describe('#700 — rewriteKeywordsFrontmatter', () => {
     expect(fm?.status).toBe('active');
   });
 
+  // #705 — the rewrite's consumed region must equal the parser's. The parser
+  // (skill-parser.ts) requires `-` + whitespace for a sequence item and RESETS
+  // block context on the first line that fails, so anything at or after that
+  // line is NOT a keyword and must survive the rewrite byte-identical.
+  it('#705 — stops consuming at the first line the parser would reject', () => {
+    const raw = '---\nname: s\nkeywords:\n- path\n-broken\n- b\nstatus: active\n---\n\nbody\n';
+    // Ground the premise: `-broken` has no space after the dash, so the parser
+    // keeps `path` only — and having reset, it never resumes for `- b`.
+    expect(parseSkillFrontmatter(raw, 'test')?.keywords).toEqual(['path']);
+
+    const out = rewriteKeywordsFrontmatter(raw, ['gamma', 'delta']);
+    expect(out).toBe(
+      '---\nname: s\nkeywords:\n- gamma\n- delta\n-broken\n- b\nstatus: active\n---\n\nbody\n',
+    );
+  });
+
+  it('#705 — a clean all-valid block is still rewritten in full', () => {
+    const raw = '---\nname: s\nkeywords:\n  - alpha\n  - beta\n  - epsilon\nstatus: active\n---\n\nbody\n';
+    const out = rewriteKeywordsFrontmatter(raw, ['gamma', 'delta']);
+    expect(out).toBe('---\nname: s\nkeywords:\n  - gamma\n  - delta\nstatus: active\n---\n\nbody\n');
+  });
+
+  it('#705 — non-list content after the block is left byte-identical', () => {
+    const raw = "---\nname: s\nkeywords:\n  - alpha\ndescription: a - dash - laden line\n---\n\nbody\n";
+    const out = rewriteKeywordsFrontmatter(raw, ['gamma']);
+    expect(out).toBe("---\nname: s\nkeywords:\n  - gamma\ndescription: a - dash - laden line\n---\n\nbody\n");
+  });
+
   it('a $-sequence in a surviving keyword does not corrupt the block form', () => {
     const raw = "---\nname: s\nkeywords:\n  - alpha\n  - beta\nstatus: active\n---\n\nbody\n";
     const out = rewriteKeywordsFrontmatter(raw, ["$'", '$&', 'gamma']);


### PR DESCRIPTION
## Summary

Fixes #705 (deferred LOW from consensus `b416f60f-69ac47cb:f16`, verified by fable-reviewer + sonnet-reviewer at filing). The block-sequence rewrite in `rewriteKeywordsFrontmatter` consumed `-item` lines with no space after the dash, while the parser requires `-␣` and resets block context on the first non-matching line — so a strip rewrite could delete hand-edited lines the parser never counted as keywords, breaking the module's byte-identical-outside-the-edit promise.

One character of behavior change (`-[ \t]*` → `-[ \t]`) plus a comment coupling the two regexes. No stop-logic needed: each repetition consumes exactly one line, so `+` terminates at the first non-match — matching the parser's reset for free.

## Verification

- Reproduced red on the issue's exact fixture before fixing (parser yields `['path']`; old rewrite deleted `-broken` and `- b`)
- 3 new tests with whole-string `toBe` assertions (byte-identity enforced, not substring checks)
- `npm test`: 391 suites, 5516 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)