### PR TITLE
feat(skills): read-only bridge from .claude/skills project skills into gossipcat resolution (#698 part 3)

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -4649,8 +4649,8 @@ export function createMcpServer(): McpServer {
 
         if (!resolved) {
           const searched = agent_id
-            ? `agent-local (.gossip/agents/${agent_id}/skills), project-wide (.gossip/skills), and bundled (default-skills)`
-            : `project-wide (.gossip/skills) and bundled (default-skills)`;
+            ? `agent-local (.gossip/agents/${agent_id}/skills), project-wide (.gossip/skills), Claude Code project skills (.claude/skills/<name>/SKILL.md), and bundled (default-skills)`
+            : `project-wide (.gossip/skills), Claude Code project skills (.claude/skills/<name>/SKILL.md), and bundled (default-skills)`;
           return { content: [{ type: 'text' as const, text: `Skill "${skill}" not found. Searched: ${searched}.` }] };
         }
 

--- a/packages/orchestrator/src/skill-loader.ts
+++ b/packages/orchestrator/src/skill-loader.ts
@@ -308,7 +308,14 @@ function categoryBoost(skillCategory: string | undefined, categories: string[]):
  * Resolution order per skill:
  * 1. Agent's local skills: .gossip/agents/<id>/skills/
  * 2. Project skills: .gossip/skills/
- * 3. Default skills: packages/orchestrator/src/default-skills/
+ * 3. Claude Code project skills: .claude/skills/<name>/SKILL.md (#698 part 3)
+ * 4. Default skills: packages/orchestrator/src/default-skills/
+ *
+ * Note that (3) is reachable from this function only for a skill that is
+ * already on the agent's roster — `effectiveSkills` below is the index-enabled
+ * set or the config.json list, never a filesystem walk. A `.claude/skills`
+ * entry has neither, so in practice the bridge serves the on-demand fetch
+ * paths (`resolveServableSkill`) rather than dispatch-time injection.
  *
  * Permanent skills are always loaded. Contextual skills require MIN_KEYWORD_HITS
  * (word-boundary match) against the task string, capped at MAX_CONTEXTUAL_SKILLS.
@@ -699,10 +706,11 @@ export function resolveSkill(
   // Sanitize agentId to prevent path traversal
   if (!SAFE_AGENT_ID.test(agentId)) return null;
 
-  const bases = [
-    resolve(projectRoot, '.gossip', 'agents', agentId, 'skills'),
-    resolve(projectRoot, '.gossip', 'skills'),
-    resolve(__dirname, 'default-skills'),
+  const bases: SkillBase[] = [
+    { dir: resolve(projectRoot, '.gossip', 'agents', agentId, 'skills'), layout: 'flat' },
+    { dir: resolve(projectRoot, '.gossip', 'skills'), layout: 'flat' },
+    claudeCodeSkillsBase(projectRoot),
+    { dir: resolve(__dirname, 'default-skills'), layout: 'flat' },
   ];
 
   return resolveSkillFromBases(bases, skill);
@@ -720,26 +728,76 @@ export function resolveSharedSkill(
   skill: string,
   projectRoot: string,
 ): { content: string; path: string } | null {
-  const bases = [
-    resolve(projectRoot, '.gossip', 'skills'),
-    resolve(__dirname, 'default-skills'),
+  const bases: SkillBase[] = [
+    { dir: resolve(projectRoot, '.gossip', 'skills'), layout: 'flat' },
+    claudeCodeSkillsBase(projectRoot),
+    { dir: resolve(__dirname, 'default-skills'), layout: 'flat' },
   ];
 
   return resolveSkillFromBases(bases, skill);
 }
 
+/**
+ * One entry in a resolution chain: a directory plus the on-disk layout of skill
+ * files inside it.
+ *
+ * - `flat` — `<dir>/<name>.md`. Every gossipcat-native base (agent-local,
+ *   project-wide `.gossip/skills`, bundled `default-skills`).
+ * - `directory` — `<dir>/<name>/SKILL.md`. The Claude Code project-skill layout
+ *   (`.claude/skills/<name>/SKILL.md`), which is a directory per skill so the
+ *   skill can ship supporting files alongside `SKILL.md`.
+ *
+ * Carrying the layout on the base descriptor (rather than special-casing the
+ * `.claude` path inside the walk) keeps ONE containment check and ONE read
+ * path for every base — the traversal guard cannot drift between layouts.
+ */
+interface SkillBase {
+  dir: string;
+  layout: 'flat' | 'directory';
+}
+
+/**
+ * Read-only bridge to Claude Code project skills (issue #698 part 3).
+ *
+ * A user-authored `.claude/skills/<name>/SKILL.md` becomes fetchable by
+ * gossipcat agents (`gossip_skills(action: "get")`, `skill_query`,
+ * `gossip_skill_query`) without hand-duplicating it into `.gossip/skills`.
+ *
+ * PRECEDENCE: this base sits AFTER project-wide `.gossip/skills` and BEFORE
+ * bundled `default-skills`. So a name present in both `.gossip/skills/<n>.md`
+ * and `.claude/skills/<n>/SKILL.md` resolves to the `.gossip` copy — gossipcat-
+ * native content stays authoritative, and a Claude Code skill can never shadow
+ * a skill the effectiveness pipeline manages. It CAN shadow a bundled default,
+ * which is the same override power `.gossip/skills` already has.
+ *
+ * PULL-ONLY: these skills have no skill-index slot and no config.json roster
+ * entry, so `loadSkills` never iterates them (it walks `resolveEffectiveSkills`,
+ * i.e. the index-enabled set or the config list — never the filesystem). The
+ * bridge therefore changes on-demand resolution only, never dispatch-time
+ * injection eligibility.
+ */
+function claudeCodeSkillsBase(projectRoot: string): SkillBase {
+  return { dir: resolve(projectRoot, '.claude', 'skills'), layout: 'directory' };
+}
+
 /** Shared resolution walk used by {@link resolveSkill} and {@link resolveSharedSkill}. */
 function resolveSkillFromBases(
-  bases: string[],
+  bases: SkillBase[],
   skill: string,
 ): { content: string; path: string } | null {
   // Use canonical normalization for skill name (consistent with SkillIndex)
   const normalized = normalizeSkillName(skill);
   if (!normalized) return null;
-  const filename = `${normalized}.md`;
 
-  for (const base of bases) {
-    const candidate = resolve(base, filename);
+  for (const { dir: base, layout } of bases) {
+    // `normalized` is [a-z0-9-] only (normalizeSkillName strips everything
+    // else, `.` and `/` included), so neither layout can synthesize a `..`
+    // segment. The containment check below is the second, structural gate and
+    // is deliberately IDENTICAL for both layouts.
+    const relative = layout === 'directory'
+      ? `${normalized}${sep}SKILL.md`
+      : `${normalized}.md`;
+    const candidate = resolve(base, relative);
     // Validate resolved path stays within base directory
     if (!candidate.startsWith(base + sep)) continue;
     if (existsSync(candidate)) {
@@ -917,6 +975,18 @@ export function listAvailableSkills(agentId: string, projectRoot: string): strin
   if (existsSync(projectDir)) {
     for (const f of readdirSync(projectDir)) {
       if (f.endsWith('.md')) skills.add(f.replace('.md', ''));
+    }
+  }
+
+  // Claude Code project skills (#698 part 3). Directory-per-skill layout, so a
+  // name counts only when `<name>/SKILL.md` exists — that single probe also
+  // filters loose files and empty subdirectories, and unlike a Dirent type test
+  // it still sees a symlinked skill directory. Names are reported as authored;
+  // resolveSkill normalizes on lookup.
+  const claudeDir = claudeCodeSkillsBase(projectRoot).dir;
+  if (existsSync(claudeDir)) {
+    for (const entry of readdirSync(claudeDir)) {
+      if (existsSync(resolve(claudeDir, entry, 'SKILL.md'))) skills.add(entry);
     }
   }
 

--- a/packages/tools/src/skill-query.ts
+++ b/packages/tools/src/skill-query.ts
@@ -84,5 +84,5 @@ export function formatSkillPayload(canonicalName: string, resolved: ResolvedSkil
  */
 export function formatSkillNotFound(canonicalName: string, agentId: string): string {
   const shown = canonicalName || '<invalid>';
-  return `Skill "${shown}" not found. Searched: agent-local (.gossip/agents/${agentId}/skills), project-wide (.gossip/skills), and bundled (default-skills).`;
+  return `Skill "${shown}" not found. Searched: agent-local (.gossip/agents/${agentId}/skills), project-wide (.gossip/skills), Claude Code project skills (.claude/skills/<name>/SKILL.md), and bundled (default-skills).`;
 }

--- a/tests/orchestrator/skill-loader-claude-skills.test.ts
+++ b/tests/orchestrator/skill-loader-claude-skills.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Issue #698 part 3 — read-only bridge from Claude Code project skills
+ * (`.claude/skills/<name>/SKILL.md`) into gossipcat skill resolution.
+ *
+ * The bridge adds ONE base to the resolution chain, ordered AFTER project-wide
+ * `.gossip/skills` and BEFORE bundled `default-skills`. It is directory-per-
+ * skill rather than flat, so these tests pin:
+ *   1. resolution actually reaches the new layout (resolveSkill / resolveSharedSkill)
+ *   2. precedence in both directions (loses to .gossip, beats bundled defaults)
+ *   3. containment survives the extra path segment
+ *   4. the shared quarantine predicate applies here too
+ *   5. dispatch-time injection eligibility is UNCHANGED — pull-only
+ */
+import {
+  resolveSkill,
+  resolveSharedSkill,
+  resolveServableSkill,
+  listAvailableSkills,
+  loadSkills,
+} from '../../packages/orchestrator/src/skill-loader';
+import { SkillIndex } from '../../packages/orchestrator/src/skill-index';
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync, realpathSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = realpathSync(mkdtempSync(join(tmpdir(), 'gossip-claude-skills-')));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Write `.claude/skills/<name>/SKILL.md` — the Claude Code project-skill layout. */
+function writeClaudeSkill(name: string, body: string): string {
+  const dir = join(tmpDir, '.claude', 'skills', name);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, 'SKILL.md');
+  writeFileSync(path, body);
+  return path;
+}
+
+/** Write `.gossip/skills/<name>.md` — the project-wide gossipcat base. */
+function writeGossipSkill(name: string, body: string): string {
+  const dir = join(tmpDir, '.gossip', 'skills');
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `${name}.md`);
+  writeFileSync(path, body);
+  return path;
+}
+
+/** Write `.gossip/agents/<agent>/skills/<name>.md` — the agent-local base. */
+function writeAgentSkill(agent: string, name: string, body: string): string {
+  const dir = join(tmpDir, '.gossip', 'agents', agent, 'skills');
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `${name}.md`);
+  writeFileSync(path, body);
+  return path;
+}
+
+/** A realistic Claude Code SKILL.md: name + description frontmatter, NO status. */
+function claudeFrontmatter(name: string, body: string): string {
+  return `---\nname: ${name}\ndescription: A user-authored Claude Code skill\n---\n\n${body}\n`;
+}
+
+describe('resolution reaches .claude/skills/<name>/SKILL.md', () => {
+  it('resolveSkill resolves a Claude Code project skill', () => {
+    const path = writeClaudeSkill('deploy-runbook', claudeFrontmatter('deploy-runbook', 'CLAUDE CODE BODY'));
+    const resolved = resolveSkill('agent-a', 'deploy-runbook', tmpDir);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.content).toContain('CLAUDE CODE BODY');
+    expect(resolved!.path).toBe(path);
+  });
+
+  it('resolveSharedSkill (no agent_id) resolves it too', () => {
+    writeClaudeSkill('deploy-runbook', claudeFrontmatter('deploy-runbook', 'CLAUDE CODE BODY'));
+    const resolved = resolveSharedSkill('deploy-runbook', tmpDir);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.content).toContain('CLAUDE CODE BODY');
+  });
+
+  it('normalizes the requested name before probing the directory segment', () => {
+    writeClaudeSkill('deploy-runbook', claudeFrontmatter('deploy-runbook', 'CLAUDE CODE BODY'));
+    expect(resolveSkill('agent-a', 'Deploy_Runbook', tmpDir)).not.toBeNull();
+    expect(resolveServableSkill('agent-a', 'Deploy_Runbook', tmpDir).canonicalName).toBe('deploy-runbook');
+  });
+
+  it('a directory without SKILL.md does not resolve', () => {
+    mkdirSync(join(tmpDir, '.claude', 'skills', 'empty-dir'), { recursive: true });
+    expect(resolveSkill('agent-a', 'empty-dir', tmpDir)).toBeNull();
+  });
+
+  it('a flat .claude/skills/<name>.md is NOT the supported layout', () => {
+    mkdirSync(join(tmpDir, '.claude', 'skills'), { recursive: true });
+    writeFileSync(join(tmpDir, '.claude', 'skills', 'flat-one.md'), 'FLAT BODY');
+    expect(resolveSkill('agent-a', 'flat-one', tmpDir)).toBeNull();
+  });
+
+  it('not-found is unchanged when the skill exists in no base at all', () => {
+    expect(resolveSkill('agent-a', 'nothing-anywhere-xyz', tmpDir)).toBeNull();
+    expect(resolveSharedSkill('nothing-anywhere-xyz', tmpDir)).toBeNull();
+    expect(resolveServableSkill('agent-a', 'nothing-anywhere-xyz', tmpDir)).toEqual({
+      canonicalName: 'nothing-anywhere-xyz',
+      skill: null,
+    });
+  });
+});
+
+describe('precedence', () => {
+  it('.gossip/skills wins over .claude/skills for the same name', () => {
+    const gossipPath = writeGossipSkill('shared-name', 'GOSSIP NATIVE BODY');
+    writeClaudeSkill('shared-name', claudeFrontmatter('shared-name', 'CLAUDE CODE BODY'));
+
+    for (const resolved of [resolveSkill('agent-a', 'shared-name', tmpDir), resolveSharedSkill('shared-name', tmpDir)]) {
+      expect(resolved!.path).toBe(gossipPath);
+      expect(resolved!.content).toContain('GOSSIP NATIVE BODY');
+      expect(resolved!.content).not.toContain('CLAUDE CODE BODY');
+    }
+  });
+
+  it('agent-local wins over both .gossip/skills and .claude/skills', () => {
+    const agentPath = writeAgentSkill('agent-a', 'shared-name', 'AGENT LOCAL BODY');
+    writeGossipSkill('shared-name', 'GOSSIP NATIVE BODY');
+    writeClaudeSkill('shared-name', claudeFrontmatter('shared-name', 'CLAUDE CODE BODY'));
+
+    const resolved = resolveSkill('agent-a', 'shared-name', tmpDir);
+    expect(resolved!.path).toBe(agentPath);
+    expect(resolved!.content).toContain('AGENT LOCAL BODY');
+  });
+
+  it('.claude/skills wins over a bundled default of the same name', () => {
+    // `typescript` ships in packages/orchestrator/src/default-skills/.
+    const bundled = resolveSkill('agent-a', 'typescript', tmpDir);
+    expect(bundled).not.toBeNull();
+    expect(bundled!.path).toContain('default-skills');
+
+    const claudePath = writeClaudeSkill('typescript', claudeFrontmatter('typescript', 'CLAUDE CODE OVERRIDE'));
+    const overridden = resolveSkill('agent-a', 'typescript', tmpDir);
+    expect(overridden!.path).toBe(claudePath);
+    expect(overridden!.content).toContain('CLAUDE CODE OVERRIDE');
+  });
+});
+
+describe('containment holds for the directory-per-skill layout', () => {
+  it.each([
+    ['../evil', 'parent escape'],
+    ['../../etc/passwd', 'deep parent escape'],
+    ['foo/../../bar', 'mid-name escape'],
+    ['/etc/passwd', 'absolute path'],
+    ['.', 'dot'],
+    ['..', 'dot dot'],
+    ['', 'empty'],
+  ])('rejects %s (%s) without escaping the base', (name) => {
+    // Plant a file that a naive join would reach from `.claude/skills`.
+    mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+    writeFileSync(join(tmpDir, '.claude', 'SKILL.md'), 'ESCAPED CONTENT');
+    mkdirSync(join(tmpDir, '.claude', 'skills'), { recursive: true });
+
+    const resolved = resolveSkill('agent-a', name, tmpDir);
+    if (resolved) expect(resolved.content).not.toContain('ESCAPED CONTENT');
+    expect(resolveServableSkill('agent-a', name, tmpDir).skill).toBeNull();
+  });
+
+  it('a traversal-shaped name normalizes to an inert in-base name, never an escape', () => {
+    // `../evil` normalizes to `evil` — so it can only ever reach
+    // `.claude/skills/evil/SKILL.md`, which is inside the base.
+    writeClaudeSkill('evil', claudeFrontmatter('evil', 'IN BASE BODY'));
+    const resolved = resolveSkill('agent-a', '../evil', tmpDir);
+    expect(resolved!.path).toBe(join(tmpDir, '.claude', 'skills', 'evil', 'SKILL.md'));
+    expect(resolved!.content).toContain('IN BASE BODY');
+  });
+});
+
+describe('quarantine applies to the .claude/skills base', () => {
+  it('a plain Claude Code skill (name/description, no status) is servable', () => {
+    writeClaudeSkill('runbook', claudeFrontmatter('runbook', 'SERVABLE BODY'));
+    const result = resolveServableSkill('agent-a', 'runbook', tmpDir);
+    expect(result.skill).not.toBeNull();
+    expect(result.skill!.content).toContain('SERVABLE BODY');
+  });
+
+  it('withholds a status: failed Claude Code skill', () => {
+    writeClaudeSkill('burned', '---\nname: burned\nstatus: failed\n---\nSECRET\n');
+    // Sanity: the bare resolver WOULD have served it — the gate is what stops it.
+    expect(resolveSkill('agent-a', 'burned', tmpDir)).not.toBeNull();
+    expect(resolveServableSkill('agent-a', 'burned', tmpDir).skill).toBeNull();
+  });
+
+  it('withholds a status: silent_skill Claude Code skill', () => {
+    writeClaudeSkill('quiet', '---\nname: quiet\nstatus: silent_skill\n---\nSECRET\n');
+    expect(resolveServableSkill('agent-a', 'quiet', tmpDir).skill).toBeNull();
+  });
+
+  it('the kill-switch applies — propagated skill under bundledMemories.enabled=false', () => {
+    writeClaudeSkill('bundled', '---\nname: bundled\npropagated: true\n---\nSECRET\n');
+    mkdirSync(join(tmpDir, '.gossip'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.gossip', 'memory-config.json'),
+      JSON.stringify({ bundledMemories: { enabled: false, exclude: [] } }),
+    );
+    expect(resolveServableSkill('agent-a', 'bundled', tmpDir).skill).toBeNull();
+  });
+
+  it('the exclude list applies — propagated skill named in bundledMemories.exclude', () => {
+    writeClaudeSkill('excluded-one', '---\nname: excluded-one\npropagated: true\n---\nSECRET\n');
+    writeClaudeSkill('kept-one', '---\nname: kept-one\npropagated: true\n---\nKEPT BODY\n');
+    mkdirSync(join(tmpDir, '.gossip'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.gossip', 'memory-config.json'),
+      JSON.stringify({ bundledMemories: { enabled: true, exclude: ['excluded-one'] } }),
+    );
+    expect(resolveServableSkill('agent-a', 'excluded-one', tmpDir).skill).toBeNull();
+    expect(resolveServableSkill('agent-a', 'kept-one', tmpDir).skill).not.toBeNull();
+  });
+});
+
+describe('pull-only — dispatch-time injection eligibility is unchanged', () => {
+  it('a .claude/skills entry is never injected on its own (no index slot, no roster entry)', () => {
+    writeClaudeSkill('ambient-one', claudeFrontmatter('ambient-one', 'CLAUDE CODE BODY'));
+    const index = new SkillIndex(tmpDir);
+
+    // Empty roster + empty index: injection walks the roster, not the filesystem.
+    const result = loadSkills('agent-a', [], tmpDir, index, 'a task mentioning ambient-one');
+    expect(result.loaded).toEqual([]);
+    expect(result.content).toBe('');
+    expect(result.dropped).toEqual([]);
+
+    // ...but the pull path serves it.
+    expect(resolveServableSkill('agent-a', 'ambient-one', tmpDir).skill).not.toBeNull();
+  });
+});
+
+describe('listAvailableSkills', () => {
+  it('includes .claude/skills names that carry a SKILL.md', () => {
+    writeClaudeSkill('deploy-runbook', claudeFrontmatter('deploy-runbook', 'BODY'));
+    expect(listAvailableSkills('agent-a', tmpDir)).toContain('deploy-runbook');
+  });
+
+  it('excludes a subdirectory with no SKILL.md and a loose .md file', () => {
+    writeClaudeSkill('real-one', claudeFrontmatter('real-one', 'BODY'));
+    mkdirSync(join(tmpDir, '.claude', 'skills', 'no-skill-md'), { recursive: true });
+    writeFileSync(join(tmpDir, '.claude', 'skills', 'loose.md'), 'not a skill dir');
+
+    const skills = listAvailableSkills('agent-a', tmpDir);
+    expect(skills).toContain('real-one');
+    expect(skills).not.toContain('no-skill-md');
+    expect(skills).not.toContain('loose');
+  });
+
+  it('still lists bundled defaults when no .claude/skills dir exists', () => {
+    expect(listAvailableSkills('agent-a', tmpDir)).toContain('typescript');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #698 (final part; parts 1–2 shipped in PRs #702 and #718). A user-authored Claude Code project skill (`.claude/skills/<name>/SKILL.md`) is now fetchable by gossipcat agents — via `gossip_skills(action:"get")`, relay `skill_query`, and native `gossip_skill_query` — without hand-duplicating it into `.gossip/skills/`.

- One new resolution base, ordered **after** project `.gossip/skills` and **before** bundled defaults, carried on a `SkillBase` descriptor (`{dir, layout: 'flat'|'directory'}`) so both layouts share the single existing containment gate. Traversal is doubly blocked (name normalization strips `./`; containment check is structural).
- **Pull-only by architecture**: `loadSkills` iterates the index/roster, never a filesystem walk — a `.claude` skill can never be auto-injected at dispatch (pinned by test).
- **Quarantine holds by construction**: `resolveServableSkill` applies the base-agnostic `checkSkillQuarantine` to whichever base wins — `status: failed`/`silent_skill`, kill-switch, and exclude-list all enforced for bridged skills (tested); Claude Code frontmatter (no `status`) is servable per the no-explicit-quarantine default.
- Precedence documented and tested in all three directions: agent-local > `.gossip/skills` > `.claude/skills` > bundled.
- Both `resolveSkill` and `resolveSharedSkill` gained the base (the `get` action routes to either); `listAvailableSkills` enumerates bridged names; not-found messages name the fourth scope.

## Verification

- 26 new tests (`tests/orchestrator/skill-loader-claude-skills.test.ts`); full `npm test`: 392 suites, **5539 passed, 0 failed**
- dist-mcp binary suites validated **at repo root** on this branch (worktree bundles are known-broken): 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)