### PR TITLE
fix(skills): ambient-noun stopword pass on CATEGORY_PATTERNS — the third category-vocabulary table (#706)

### DIFF
--- a/packages/orchestrator/src/category-extractor.ts
+++ b/packages/orchestrator/src/category-extractor.ts
@@ -9,7 +9,14 @@ const CATEGORY_PATTERNS: Record<string, RegExp[]> = {
   // origin-header are auth-boundary concerns and belong with the existing
   // authenticat/authoriz/credential keywords rather than a separate bucket.
   trust_boundaries: [/trust.?boundar/i, /authenticat/i, /authoriz/i, /impersonat/i, /identity/i, /credential/i, /\bcsrf\b/i, /sec.?fetch/i, /samesite/i, /origin.?header/i, /\bcors\b/i, /\bjwt\b/i, /session.?fixation/i],
-  injection_vectors: [/inject/i, /sanitiz/i, /escape/i, /\bxss\b/i, /sql.?inject/i, /prompt.?inject/i],
+  // #706 (ambient-noun pass on this table, following #700/PR#704 on the skill-
+  // keyword tables): bare /inject/i measured 89 corpus occurrences, ~84 of them
+  // skill/lesson/dependency injection ("injected structurally as skillResolver",
+  // "lesson auto-injection", "dependency-injected module") — the same 60/62
+  // split #700 found in DEFAULT_KEYWORDS. Genuine security-sense occurrences
+  // (header injection, argument injection, git-flag-injection, jsx HTML
+  // injection) are all multi-word and survive as qualified forms below.
+  injection_vectors: [/sanitiz/i, /escape/i, /\bxss\b/i, /sql.?inject/i, /prompt.?inject/i, /shell.?inject/i, /command.?inject/i, /header.?inject/i, /argument.?inject/i, /flag.?inject/i, /html.?inject/i],
   input_validation: [/validat/i, /input.?check/i, /type.?guard/i, /\bschema\b/i, /malform/i],
   concurrency: [/race.?condition/i, /deadlock/i, /\batomic\b/i, /concurrent/i, /\bmutex\b/i, /\btoctou\b/i],
   resource_exhaustion: [/\bdos\b/i, /unbounded/i, /memory.?leak/i, /exhaust/i, /\btimeout\b/i, /infinite.?loop/i],
@@ -23,10 +30,32 @@ const CATEGORY_PATTERNS: Record<string, RegExp[]> = {
   // Phase 1 dev-quality extensions (consensus 09693c51-184246e5). Vocabulary
   // disjoint from the security buckets above. Word boundaries on log/monitor
   // to avoid backlog/catalog/dialog/monitor-thread false-positives.
-  observability: [/observability/i, /\blog(ging)?\b/i, /\bmetric/i, /tracing/i, /telemetry/i, /\bmonitor(ing)?\b/i, /dashboard/i, /stderr/i],
-  cli_ergonomics: [/\bcli\b/i, /\bflag\b/i, /help text/i, /error message/i, /\busage\b/i, /\bprompt\b/i, /banner/i, /spinner/i],
+  // #706: /dashboard/i fired on 152/400 docs (38.0%) — in this repo "dashboard"
+  // means gossipcat's own dashboard product/UI (`feat(dashboard): ...`), never
+  // a generic observability dashboard; zero corpus hits for the genuine sense,
+  // so it is dropped outright rather than qualified (mirrors AMBIENT_STOPWORDS
+  // `dashboard` and the sense-dominance-alone precedent set by `scoped`).
+  // `\blog(ging)?\b` conflated ambient bare `log`/`logs` (16.6% DF, almost all
+  // `mcp.log` / `git log` / `Decisions Log`) with `logging`, which is not
+  // ambient (kept in AMBIENT_STOPWORDS at 1.5% DF); split so only `logging`
+  // fires.
+  observability: [/observability/i, /\blogging\b/i, /\bmetric/i, /tracing/i, /telemetry/i, /\bmonitor(ing)?\b/i, /stderr/i],
+  // #706: bare /\bprompt\b/i fired on 38/400 docs (9.5%), all LLM-prompt-
+  // assembly machinery (`prompt-assembler.ts`, warm prompt cache, system
+  // prompt) — the exact sense AMBIENT_STOPWORDS documents for `prompt`/
+  // `prompts` ("every brief is about prompts"). Zero corpus hits for the CLI
+  // UX sense (confirmation/interactive prompts); qualified forms kept for when
+  // it does appear.
+  cli_ergonomics: [/\bcli\b/i, /\bflag\b/i, /help text/i, /error message/i, /\busage\b/i, /confirmation.?prompt/i, /interactive.?prompt/i, /banner/i, /spinner/i],
   performance: [/\blatency/i, /slow/i, /performance/i, /\bn\+1\b/i, /uncached/i, /readFileSync/i, /synchronous/i, /hot path/i],
-  testing: [/\btest(s|ing)?\b/i, /coverage/i, /\bmock\b/i, /\bfixture\b/i, /\bunit test/i, /integration test/i, /\be2e\b/i, /test suite/i],
+  // #706: bare /\btest(s|ing)?\b/i fired on 232/400 docs (58.0%) — almost all
+  // gossipcat's own jest suite ("Full suite green, 351 suites, 4774 tests").
+  // `test suite` looked qualified but measured 13/14 occurrences as the same
+  // machinery chatter ("17-case test suite with injected stubs", "no test
+  // suite"), so it is dropped too rather than kept as a false discriminator.
+  // Genuine coverage-gap findings still fire via `coverage` / `unit test` /
+  // `integration test` / `e2e` / the new `untested`.
+  testing: [/coverage/i, /\bmock\b/i, /\bfixture\b/i, /\bunit test/i, /integration test/i, /\be2e\b/i, /\buntested\b/i],
 };
 
 /**

--- a/tests/orchestrator/category-extractor.test.ts
+++ b/tests/orchestrator/category-extractor.test.ts
@@ -15,7 +15,11 @@ describe('extractCategories', () => {
   });
 
   test('extracts multiple categories from compound finding', () => {
-    const cats = extractCategories('Missing type guard on LLM response allows injection');
+    // #706: bare "injection" no longer fires injection_vectors (89 corpus
+    // occurrences, ~94% skill/lesson/dependency injection chatter) — the
+    // finding must name the genuine sense concretely, as a real report would
+    // ("LLM response" without a type guard is a prompt-injection vector).
+    const cats = extractCategories('Missing type guard on LLM response allows prompt injection');
     expect(cats).toContain('type_safety');
     expect(cats).toContain('injection_vectors');
   });
@@ -56,10 +60,31 @@ describe('extractCategories', () => {
     expect(cats.length).toBe(unique.size);
   });
 
+  // #706: ambient-noun stopword pass on CATEGORY_PATTERNS, mirroring #700/PR#704
+  // on the skill-keyword tables. Bare /inject/i, /dashboard/i, /\bprompt\b/i and
+  // /\btest(s|ing)?\b/i measured as majority repo-machinery chatter over a
+  // 400-commit corpus (see category-extractor.ts inline comments for the
+  // per-pattern fire-rate breakdown) and were replaced with discriminative
+  // multi-word forms or dropped outright.
+  test('injection_vectors: repo-machinery injection (skill/lesson/dependency) does not fire', () => {
+    expect(extractCategories('Skill injection point injects the lesson card into the prompt')).not.toContain('injection_vectors');
+    expect(extractCategories('dependency-injected module orchestrator-preconditions.ts')).not.toContain('injection_vectors');
+    expect(extractCategories('lesson auto-injection (#669), cross-review memory directive')).not.toContain('injection_vectors');
+  });
+
+  test('injection_vectors: genuine multi-word injection senses still fire', () => {
+    expect(extractCategories('Header injection via unvalidated redirect target')).toContain('injection_vectors');
+    expect(extractCategories('Argument injection in the shell-out helper')).toContain('injection_vectors');
+    expect(extractCategories('git-flag-injection via unescaped ref name')).toContain('injection_vectors');
+    expect(extractCategories('jsx HTML injection in the rendered markdown')).toContain('injection_vectors');
+    expect(extractCategories('Command injection via a crafted filename argument')).toContain('injection_vectors');
+  });
+
   // Phase 1 dev-quality extensions
-  test('extracts observability from dashboard/telemetry findings', () => {
-    expect(extractCategories('Dashboard WebSocket broadcasts only log_lines')).toContain('observability');
+  test('extracts observability from telemetry/metric findings', () => {
     expect(extractCategories('telemetry gap: drop-gate bug hid for weeks')).toContain('observability');
+    expect(extractCategories('No observability into latency metrics on the hot path')).toContain('observability');
+    expect(extractCategories('Structured logging omits the request id')).toContain('observability');
   });
 
   test('observability \\blog\\b avoids backlog/catalog/dialog', () => {
@@ -68,8 +93,29 @@ describe('extractCategories', () => {
     expect(extractCategories('dialog box close handler')).not.toContain('observability');
   });
 
+  // #706: bare /dashboard/i dropped — in this repo "dashboard" means
+  // gossipcat's own dashboard product, never a generic observability surface.
+  test('observability: repo-machinery dashboard rendering does not fire', () => {
+    expect(extractCategories('feat(dashboard): redesign chat page — full-viewport fit')).not.toContain('observability');
+    expect(extractCategories('Dashboard WebSocket broadcasts only log_lines')).not.toContain('observability');
+    expect(extractCategories('mcp.log spam from getKeywords warnings')).not.toContain('observability');
+    expect(extractCategories('git log <sha>..HEAD walk for rotated files')).not.toContain('observability');
+  });
+
   test('extracts cli_ergonomics from UX findings', () => {
     expect(extractCategories('Banner alignment is off; spinner invisible during dispatch')).toContain('cli_ergonomics');
+  });
+
+  // #706: bare /\bprompt\b/i dropped — in this repo "prompt" means LLM-prompt
+  // assembly machinery, never CLI-facing prompt UX.
+  test('cli_ergonomics: repo-machinery prompt assembly does not fire', () => {
+    expect(extractCategories('assembled prompt cache warms the system prompt for native dispatch')).not.toContain('cli_ergonomics');
+    expect(extractCategories('prompt-assembler.ts wraps the skills block')).not.toContain('cli_ergonomics');
+  });
+
+  test('cli_ergonomics: genuine CLI prompt UX still fires', () => {
+    expect(extractCategories('Confirmation prompt missing before a destructive rm -rf')).toContain('cli_ergonomics');
+    expect(extractCategories('Interactive prompt hangs when stdin is not a TTY')).toContain('cli_ergonomics');
   });
 
   test('extracts performance from non-DoS perf findings', () => {
@@ -85,6 +131,33 @@ describe('extractCategories', () => {
   test('testing \\btest\\b avoids contest/protest/latest', () => {
     expect(extractCategories('the latest consensus round')).not.toContain('testing');
     expect(extractCategories('protest against unbounded growth')).not.toContain('testing');
+  });
+
+  // #706: bare /\btest(s|ing)?\b/i and the seemingly-qualified /test suite/i
+  // both measured majority repo-machinery ("Full suite green, 351 suites,
+  // 4774 tests"; "17-case test suite with injected git/fs stubs") rather than
+  // findings about test coverage, so both were dropped from the table.
+  test('testing: repo-machinery test-suite chatter does not fire', () => {
+    expect(extractCategories('Full test suite green (351 suites, 4774 tests); npm run build clean')).not.toContain('testing');
+    expect(extractCategories('17-case test suite with injected git/fs/emit stubs')).not.toContain('testing');
+    expect(extractCategories('all tests pass, 1270 total')).not.toContain('testing');
+  });
+
+  test('testing: genuine coverage-gap phrasing still fires', () => {
+    expect(extractCategories('Unit-test coverage gap on the retry path')).toContain('testing');
+    expect(extractCategories('This branch is completely untested')).toContain('testing');
+  });
+
+  // Regression guard: pins the #706 fix so re-adding a bare ambient pattern
+  // (/inject/i, /dashboard/i, /\bprompt\b/i, /\btest(s|ing)?\b/i) to
+  // CATEGORY_PATTERNS makes this test fail.
+  test('#706 regression guard: bare ambient patterns stay removed', () => {
+    const machinery = 'Skill injection point injects the lesson card into the assembled prompt for the feat(dashboard) redesign; full test suite green (353 suites, 4774 tests)';
+    const cats = extractCategories(machinery);
+    expect(cats).not.toContain('injection_vectors');
+    expect(cats).not.toContain('observability');
+    expect(cats).not.toContain('cli_ergonomics');
+    expect(cats).not.toContain('testing');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #706 (deferred from #700/PR #704 for blast radius — this table also drives finding categorization and `categoryStrengths`, per spec `2026-05-20-category-resolution-fix.md` PART F, so it required its own measurement pass).

Applies the #700 ambient-noun discipline to `CATEGORY_PATTERNS` in `category-extractor.ts`: the four cited bare ambient patterns dropped and replaced with discriminative qualified forms (`header/argument/flag/html.?inject`, `confirmation/interactive.?prompt`, `\buntested\b`); `/dashboard/i` dropped outright (zero genuine-sense corpus hits — the `scoped` sense-dominance precedent). The full-table audit found two more beyond the issue's list: `/\blog(ging)?\b/i` split to `/\blogging\b/i` (bare `log`/`logs` is 16.6% DF ambient: `mcp.log`, `git log`; `logging` is 1.5% and genuine), and `test suite` dropped from `testing` (13/14 ambient in this corpus for this table's purpose). All non-ambient patterns byte-identical.

## Measurement (400-doc commit corpus, per the keyword-stopwords.ts documented method; commits-only noted)

| category | before | after |
|---|---|---|
| injection_vectors | 18.0% | 11.5% |
| observability | **56.3%** | 19.8% |
| cli_ergonomics | 36.8% | 32.0% |
| testing | **59.8%** | 19.5% |

## Verification

- Machinery-negative tests (skill injection / dashboard rendering / prompt assembly / test-suite chatter must not fire) + genuine-sense positives per new pattern + a table pin against re-adding bare ambient patterns
- `npm test`: 391 suites green (2 pre-existing env skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)