### PR TITLE
fix(setup): stop resetting main_agent to google when main_provider is omitted (#724)

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -339,7 +339,7 @@ import { restorePendingConsensus } from './handlers/relay-cross-review';
 import { filterWatchEvents, WATCH_MAX_EVENTS } from './gossip-watch';
 import { persistRelayTasks, restoreRelayTasksAsFailed } from './handlers/relay-tasks';
 import { pickStickyPort, writeStickyPort, RELAY_STICKY_FILE, HTTP_MCP_STICKY_FILE } from './stickyPort';
-import { buildDashboardAdvisory, mergeSetupConfig, buildMalformedConfigHint, flushStagedAgentFileWrites } from './setup-response';
+import { buildDashboardAdvisory, mergeSetupConfig, resolveMainAgent, buildMalformedConfigHint, flushStagedAgentFileWrites } from './setup-response';
 import { refreshNativeAgentFromDisk } from './native-agent-cache';
 import { generateRulesContent } from './rules-content';
 import { formatDropReceipt } from './format-drop-receipt';
@@ -2744,10 +2744,10 @@ export function createMcpServer(): McpServer {
       // lens generator, gossip publisher all call createProvider on this value),
       // and createProvider has no 'native' branch. 'native' remains valid for
       // utility_model and per-agent overrides.
-      main_provider: z.enum(MCP_MAIN_PROVIDER_ENUM).default('google')
-        .describe('Provider for the orchestrator LLM. Use "none" when no API key is available — features degrade gracefully to profile-based. Note: "native" is not valid here (use it only for utility_model or per-agent overrides).'),
-      main_model: z.string().default('gemini-2.5-pro')
-        .describe('Model ID for orchestrator (e.g. gemini-2.5-pro, claude-sonnet-4-6, gpt-4o)'),
+      main_provider: z.enum(MCP_MAIN_PROVIDER_ENUM).optional()
+        .describe('OPTIONAL provider for the orchestrator LLM. Omit to keep the current orchestrator: the existing .gossip/config.json main_agent is preserved in BOTH merge and replace modes (replace replaces the team, not the orchestrator choice); on a fresh setup with nothing to preserve it resolves to "none" — the zero-config native-host orchestration state, not Google. Pass it explicitly (together with main_model) to change the orchestrator. Use "none" when no API key is available — features degrade gracefully to profile-based. Note: "native" is not valid here (use it only for utility_model or per-agent overrides).'),
+      main_model: z.string().optional()
+        .describe('OPTIONAL model ID for the orchestrator (e.g. gemini-2.5-pro, claude-sonnet-4-6, gpt-4o). Only honored alongside an explicit main_provider — main_model on its own is ignored and the preserved/default main_agent is kept. Omit it when omitting main_provider.'),
       mode: z.enum(['merge', 'replace', 'update_instructions']).default('merge')
         .describe('"merge" (default) keeps existing agents and adds/updates the ones specified. "replace" overwrites entire config. "update_instructions" updates agent instructions without touching the config.'),
       instruction_agent_ids: z.union([z.string(), z.array(z.string())]).optional().describe('Agent IDs for instruction update'),
@@ -3012,9 +3012,18 @@ export function createMcpServer(): McpServer {
       // is replaced); in merge mode existing agents are kept and updated. Other
       // top-level fields are preserved either way — replace replaces the team,
       // not the whole top-level config.
+      // #724: main_provider/main_model are optional. An omitted provider must
+      // preserve the on-disk main_agent (both modes) and fall back to the
+      // zero-config none/none only on a fresh setup — never to a hardcoded
+      // Google default. Resolution lives in setup-response.ts so it is unit
+      // testable without booting the MCP server; mergeSetupConfig stays dumb.
+      const resolvedMainAgent = resolveMainAgent(
+        { provider: main_provider, model: main_model },
+        existingConfig,
+      );
       const config = mergeSetupConfig({
         existingConfig,
-        mainAgent: { provider: main_provider, model: main_model },
+        mainAgent: { provider: resolvedMainAgent.provider, model: resolvedMainAgent.model },
         existingAgents,
         newAgents: configAgents,
       });
@@ -3208,7 +3217,11 @@ export function createMcpServer(): McpServer {
         lines.push(`Preserved from existing config (${preservedIds.length}):`);
         lines.push(...preservedIds.map(id => `  • ${id} → ${existingAgents[id].provider}/${existingAgents[id].model}`));
       }
+      if (resolvedMainAgent.warning) {
+        lines.push(`⚠ ${resolvedMainAgent.warning}`);
+      }
       lines.push(`\nMode: ${mode} | Config: .gossip/config.json (${Object.keys(config.agents).length} agents total)`);
+      lines.push(`Orchestrator: ${resolvedMainAgent.provider}/${resolvedMainAgent.model}`);
       lines.push(`Rules: ${env.rulesFile} (${env.host} will read this on next session)`);
       if (ctx.relay?.dashboardUrl) {
         lines.push(`Dashboard: ${dashboardClickableUrl(ctx.relay.dashboardUrl, ctx.relay.dashboardKey)}`);

--- a/apps/cli/src/setup-response.ts
+++ b/apps/cli/src/setup-response.ts
@@ -12,6 +12,8 @@
  *     anchor when cross-referencing with the Team page.
  */
 
+import { VALID_MAIN_PROVIDERS } from './config';
+
 export interface SyncResultSummary {
   ok: boolean;
   mergedAgentCount: number;
@@ -61,7 +63,10 @@ export function buildDashboardAdvisory(input: DashboardAdvisoryInput): string[] 
  * - `existingConfig` is spread first so any top-level field we don't manage
  *   (consensus.siblingRoots, autoDiscoverWorktrees, orchestratorOwnedGlobs,
  *   utility_model, …) survives a re-run in BOTH merge and replace modes.
- * - `main_agent` is always overwritten from the request.
+ * - `main_agent` is always overwritten from the value the caller passes in.
+ *   The caller resolves that value with `resolveMainAgent` first (#724), so an
+ *   omitted `main_provider` preserves the on-disk orchestrator instead of being
+ *   stomped by a schema default.
  * - `agents` is `{ ...existingAgents, ...newAgents }`. The caller passes an
  *   empty `existingAgents` in replace mode (team replaced) and the prior agent
  *   map in merge mode. Either way, OTHER top-level fields are preserved —
@@ -85,6 +90,100 @@ export function mergeSetupConfig(input: {
     main_agent: { provider: mainAgent.provider, model: mainAgent.model },
     agents: { ...existingAgents, ...newAgents },
   };
+}
+
+/**
+ * The zero-config orchestrator state: no API LLM, host classifies natively
+ * (Claude Code / Cursor). Used when a fresh setup has nothing to preserve.
+ */
+export const NATIVE_MAIN_AGENT: { provider: string; model: string } = { provider: 'none', model: 'none' };
+
+export interface MainAgentSelection {
+  provider: string;
+  model: string;
+  /** Set when a half-specified request pair was ignored — surfaced to the user. */
+  warning?: string;
+}
+
+function trimmed(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+/**
+ * Read a usable `main_agent` out of an existing config. Returns null when the
+ * field is absent, malformed, or names a provider validateConfig would reject —
+ * a corrupt orchestrator entry must not be preserved, otherwise gossip_setup
+ * would become unable to repair the very config it wrote.
+ */
+function readExistingMainAgent(
+  existingConfig: Record<string, unknown> | null | undefined,
+): { provider: string; model: string } | null {
+  const raw = (existingConfig ?? {})['main_agent'];
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const provider = trimmed((raw as Record<string, unknown>).provider);
+  const model = trimmed((raw as Record<string, unknown>).model);
+  if (!provider || !model) return null;
+  if (!VALID_MAIN_PROVIDERS.includes(provider)) return null;
+  return { provider, model };
+}
+
+/**
+ * Resolve the orchestrator LLM for a gossip_setup run (#724).
+ *
+ * Before this existed, `main_provider` / `main_model` carried Zod defaults of
+ * google / gemini-2.5-pro, so ANY gossip_setup call that omitted them silently
+ * reset a deliberately-configured `main_agent` (e.g. provider "none" for native
+ * orchestration) back to Google.
+ *
+ * Resolution order:
+ *  1. An explicit `provider` (with `model`) always wins.
+ *  2. Otherwise the existing on-disk `main_agent` is preserved — in BOTH merge
+ *     and replace modes. Replace replaces the team, not the orchestrator choice,
+ *     consistent with the f16 top-level field-preservation invariant above.
+ *  3. Otherwise (fresh setup, nothing to preserve) → `none`/`none`, the
+ *     documented zero-config native-orchestration state.
+ *
+ * The pair is atomic: only an explicit `provider` activates the request. A lone
+ * `model` is ignored (it cannot be attributed to a provider), and a lone
+ * `provider` is honored only when a model can be sourced without guessing —
+ * either the preserved entry already uses that same provider, or the provider is
+ * "none" (whose model is "none"). Anything else keeps the preserved/default pair
+ * and reports a warning rather than writing a provider/model mismatch.
+ */
+export function resolveMainAgent(
+  requested: { provider?: string; model?: string },
+  existingConfig: Record<string, unknown> | null | undefined,
+): MainAgentSelection {
+  const reqProvider = trimmed(requested.provider);
+  const reqModel = trimmed(requested.model);
+  const preserved = readExistingMainAgent(existingConfig);
+  const fallback = preserved ?? { ...NATIVE_MAIN_AGENT };
+
+  if (reqProvider && reqModel) return { provider: reqProvider, model: reqModel };
+
+  if (reqProvider) {
+    if (preserved && preserved.provider === reqProvider) {
+      return { provider: reqProvider, model: preserved.model };
+    }
+    if (reqProvider === NATIVE_MAIN_AGENT.provider) return { ...NATIVE_MAIN_AGENT };
+    return {
+      ...fallback,
+      warning:
+        `main_provider "${reqProvider}" ignored — main_model is required when switching the orchestrator provider. ` +
+        `Kept main_agent ${fallback.provider}/${fallback.model}.`,
+    };
+  }
+
+  if (reqModel && reqModel !== fallback.model) {
+    return {
+      ...fallback,
+      warning:
+        `main_model "${reqModel}" ignored — main_provider must be passed explicitly to change the orchestrator LLM. ` +
+        `Kept main_agent ${fallback.provider}/${fallback.model}.`,
+    };
+  }
+
+  return fallback;
 }
 
 /**

--- a/tests/cli/setup-config-preservation.test.ts
+++ b/tests/cli/setup-config-preservation.test.ts
@@ -22,6 +22,7 @@ import { resolve, join } from 'path';
 import { tmpdir } from 'os';
 import {
   mergeSetupConfig,
+  resolveMainAgent,
   buildMalformedConfigHint,
   flushStagedAgentFileWrites,
 } from '../../apps/cli/src/setup-response';
@@ -88,6 +89,112 @@ describe('mergeSetupConfig — top-level field preservation (f16)', () => {
       newAgents: {},
     });
     expect(() => validateConfig(merged)).not.toThrow();
+  });
+});
+
+describe('resolveMainAgent — orchestrator preservation (#724)', () => {
+  const existingNone = { main_agent: { provider: 'none', model: 'none' }, agents: {} };
+  const existingAnthropic = { main_agent: { provider: 'anthropic', model: 'claude-opus-4-6' }, agents: {} };
+
+  it('lets an explicit provider+model pair win over the existing config', () => {
+    expect(resolveMainAgent({ provider: 'openai', model: 'gpt-4o' }, existingAnthropic))
+      .toEqual({ provider: 'openai', model: 'gpt-4o' });
+  });
+
+  it('preserves the existing main_agent when both fields are omitted', () => {
+    // The #724 regression: an omitted main_provider used to reset a deliberate
+    // provider:"none" (native orchestration) back to google/gemini-2.5-pro.
+    expect(resolveMainAgent({}, existingNone)).toEqual({ provider: 'none', model: 'none' });
+    expect(resolveMainAgent({}, existingAnthropic)).toEqual({ provider: 'anthropic', model: 'claude-opus-4-6' });
+  });
+
+  it('preserves the existing main_agent in replace mode too', () => {
+    // replace mode replaces the team, not the orchestrator choice — the handler
+    // passes the same existingConfig in both modes (only existingAgents is
+    // mode-gated), so preservation is mode-independent by construction.
+    const replaceModeConfig = { ...existingAnthropic, agents: {} };
+    expect(resolveMainAgent({}, replaceModeConfig)).toEqual({ provider: 'anthropic', model: 'claude-opus-4-6' });
+  });
+
+  it('defaults to none/none on a fresh setup with nothing to preserve', () => {
+    expect(resolveMainAgent({}, {})).toEqual({ provider: 'none', model: 'none' });
+    expect(resolveMainAgent({}, undefined)).toEqual({ provider: 'none', model: 'none' });
+  });
+
+  it('never resolves to the old hardcoded google/gemini-2.5-pro default', () => {
+    for (const existing of [{}, existingNone, existingAnthropic]) {
+      const resolved = resolveMainAgent({}, existing);
+      expect(resolved.provider).not.toBe('google');
+      expect(resolved.model).not.toBe('gemini-2.5-pro');
+    }
+  });
+
+  it('ignores a malformed or invalid-provider main_agent and falls back to none/none', () => {
+    // A corrupt orchestrator entry must not be preserved — otherwise gossip_setup
+    // could never repair a config whose provider validateConfig rejects.
+    expect(resolveMainAgent({}, { main_agent: { provider: 'native', model: 'sonnet' } }))
+      .toEqual({ provider: 'none', model: 'none' });
+    expect(resolveMainAgent({}, { main_agent: { provider: 'anthropic' } }))
+      .toEqual({ provider: 'none', model: 'none' });
+    expect(resolveMainAgent({}, { main_agent: 'anthropic/claude-opus-4-6' }))
+      .toEqual({ provider: 'none', model: 'none' });
+  });
+
+  it('ignores a lone main_model and keeps the preserved pair, with a warning', () => {
+    const resolved = resolveMainAgent({ model: 'gpt-4o' }, existingAnthropic);
+    expect(resolved.provider).toBe('anthropic');
+    expect(resolved.model).toBe('claude-opus-4-6');
+    expect(resolved.warning).toContain('main_provider must be passed explicitly');
+  });
+
+  it('honors a lone main_provider when the preserved entry already uses it', () => {
+    const resolved = resolveMainAgent({ provider: 'anthropic' }, existingAnthropic);
+    expect(resolved).toEqual({ provider: 'anthropic', model: 'claude-opus-4-6' });
+  });
+
+  it('honors a lone main_provider "none" (its model is "none")', () => {
+    expect(resolveMainAgent({ provider: 'none' }, existingAnthropic))
+      .toEqual({ provider: 'none', model: 'none' });
+  });
+
+  it('refuses to guess a model when a lone main_provider switches provider', () => {
+    const resolved = resolveMainAgent({ provider: 'openai' }, existingAnthropic);
+    // No provider/model mismatch is written — the preserved pair is kept.
+    expect(resolved.provider).toBe('anthropic');
+    expect(resolved.model).toBe('claude-opus-4-6');
+    expect(resolved.warning).toContain('main_model is required');
+  });
+
+  it('produces a config that validateConfig accepts for every resolution branch', () => {
+    const cases = [
+      resolveMainAgent({ provider: 'openai', model: 'gpt-4o' }, existingAnthropic),
+      resolveMainAgent({}, existingAnthropic),
+      resolveMainAgent({}, {}),
+      resolveMainAgent({ model: 'gpt-4o' }, {}),
+    ];
+    for (const mainAgent of cases) {
+      const merged = mergeSetupConfig({
+        existingConfig: {},
+        mainAgent: { provider: mainAgent.provider, model: mainAgent.model },
+        existingAgents: {},
+        newAgents: {},
+      });
+      expect(() => validateConfig(merged)).not.toThrow();
+    }
+  });
+});
+
+describe('gossip_setup schema — no hardcoded orchestrator default (#724)', () => {
+  it('declares main_provider/main_model optional, not defaulted to google', () => {
+    const source = readFileSync(resolve(PROJECT_ROOT, 'apps', 'cli', 'src', 'mcp-server-sdk.ts'), 'utf-8');
+    expect(source).not.toContain(".default('google')");
+    expect(source).not.toContain(".default('gemini-2.5-pro')");
+    expect(source).toMatch(/main_provider: z\.enum\(MCP_MAIN_PROVIDER_ENUM\)\.optional\(\)/);
+    expect(source).toMatch(/main_model: z\.string\(\)\.optional\(\)/);
+    // The handler must route the request through the resolver, not straight
+    // into mergeSetupConfig.
+    expect(source).toContain('resolveMainAgent(');
+    expect(source).not.toMatch(/mainAgent: \{ provider: main_provider, model: main_model \}/);
   });
 });
 


### PR DESCRIPTION
Closes #724.

## Problem

Two compounding defects made `gossip_setup` silently reset the orchestrator LLM to Google:

1. The tool schema declared `main_provider: .default('google')` and `main_model: .default('gemini-2.5-pro')` — hardcoded defaults regardless of the user's keys or existing config.
2. `mergeSetupConfig` always overwrote `main_agent` from the request, so **any** merge-mode call that omitted `main_provider` (e.g. just adding one agent) stomped a deliberately-configured orchestrator — including `provider: "none"` (native orchestration) — back to google/gemini-2.5-pro.

Observed in the wild: a project ended up with a dead-quota Google orchestrator (125 consecutive 429s) that the operator never chose.

## Fix

- `main_provider` / `main_model` are now optional (no `.default()`), with `describe()` strings documenting the resolution order.
- New pure `resolveMainAgent(requested, existingConfig)` in `setup-response.ts`: explicit pair wins → else preserve the on-disk `main_agent` (both merge AND replace modes, per the f16 "replace replaces the team, not the whole top-level config" invariant) → else `none`/`none`, the zero-config native-orchestration state.
- The request pair is atomic: a lone `main_model` is ignored; a lone `main_provider` is honored only when a model can be sourced without guessing (same preserved provider, or "none"). Otherwise the preserved pair is kept and a ⚠ warning is surfaced in the setup response, so a mismatched provider/model combo can never be written.
- A malformed or invalid-provider `main_agent` on disk is deliberately NOT preserved (falls back to `none`/`none`) so `gossip_setup` can still repair a config `validateConfig` would reject.
- `mergeSetupConfig` stays dumb; the handler resolves. The setup response now prints the resolved `Orchestrator: <provider>/<model>` line.

## Tests

`tests/cli/setup-config-preservation.test.ts` — 10 new tests: explicit wins, omitted preserves (merge + replace), fresh → none/none, never-google guard, corrupt-entry fallback, half-specified pairs, plus a source-inspection guard that the `.default('google')` / `.default('gemini-2.5-pro')` defaults cannot return.

Full suite in the worktree: 392 suites / 5562 tests passed, 0 failures. `tsc --noEmit` clean.

## Out of scope (secondary half of #724)

`apps/cli/src/setup-wizard.ts` (CLI wizard) still forces `configuredProviders[0]` and never offers `none` — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)