### PR TITLE
fix(cli): offer native host orchestration ("none") in setup wizard (#726)

### DIFF
--- a/apps/cli/src/setup-wizard-options.ts
+++ b/apps/cli/src/setup-wizard-options.ts
@@ -1,0 +1,62 @@
+// ── Provider + Model catalog ────────────────────────────────────────────────
+// Extracted from setup-wizard.ts into its own module (no @clack/prompts
+// import) so pure helpers here stay unit-testable without an ESM-transform
+// jest config change. setup-wizard.ts imports PROVIDERS / ProviderKey /
+// buildOrchestratorOptions from here.
+export const PROVIDERS = {
+  anthropic: {
+    label: 'Anthropic (Claude)',
+    hint: 'claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5',
+    models: [
+      { value: 'claude-opus-4-6',   label: 'Claude Opus 4.6',   hint: 'Most capable, highest cost' },
+      { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6',  hint: 'Fast + smart — recommended' },
+      { value: 'claude-haiku-4-5',  label: 'Claude Haiku 4.5',   hint: 'Fastest, lowest cost' },
+    ],
+  },
+  openai: {
+    label: 'OpenAI (GPT)',
+    hint: 'gpt-5, gpt-4o, o3, o3-mini',
+    models: [
+      { value: 'gpt-5',      label: 'GPT-5',       hint: 'Most capable' },
+      { value: 'gpt-4o',     label: 'GPT-4o',      hint: 'Fast + smart — recommended' },
+      { value: 'gpt-4o-mini', label: 'GPT-4o Mini', hint: 'Fastest, lowest cost' },
+      { value: 'o3',         label: 'o3',           hint: 'Reasoning model' },
+      { value: 'o3-mini',    label: 'o3-mini',      hint: 'Fast reasoning' },
+    ],
+  },
+  google: {
+    label: 'Google (Gemini)',
+    hint: 'gemini-2.5-pro, gemini-2.5-flash',
+    models: [
+      { value: 'gemini-2.5-pro',   label: 'Gemini 2.5 Pro',   hint: 'Most capable' },
+      { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', hint: 'Fast — recommended' },
+      { value: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash', hint: 'Previous gen, stable' },
+    ],
+  },
+} as const;
+
+export type ProviderKey = keyof typeof PROVIDERS | 'local';
+
+/**
+ * Builds the Step 3 orchestrator select options: "none" (native host
+ * orchestration) always first, followed by one entry per configured
+ * provider. Pure helper — no prompt I/O — so it can be unit-tested directly.
+ */
+export function buildOrchestratorOptions(
+  configuredProviders: ProviderKey[]
+): Array<{ value: string; label: string; hint?: string }> {
+  const options: Array<{ value: string; label: string; hint?: string }> = [
+    {
+      value: 'none',
+      label: 'None — native host orchestration',
+      hint: 'no API key needed; recommended inside Claude Code / Cursor',
+    },
+  ];
+
+  for (const provider of configuredProviders) {
+    const label = provider === 'local' ? 'Local (Ollama)' : PROVIDERS[provider as keyof typeof PROVIDERS].label;
+    options.push({ value: provider, label });
+  }
+
+  return options;
+}

--- a/apps/cli/src/setup-wizard.ts
+++ b/apps/cli/src/setup-wizard.ts
@@ -2,41 +2,7 @@ import * as p from '@clack/prompts';
 import { writeFileSync, existsSync, mkdirSync } from 'fs';
 import { resolve } from 'path';
 import { Keychain } from './keychain';
-
-// ── Provider + Model catalog ────────────────────────────────────────────────
-const PROVIDERS = {
-  anthropic: {
-    label: 'Anthropic (Claude)',
-    hint: 'claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5',
-    models: [
-      { value: 'claude-opus-4-6',   label: 'Claude Opus 4.6',   hint: 'Most capable, highest cost' },
-      { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6',  hint: 'Fast + smart — recommended' },
-      { value: 'claude-haiku-4-5',  label: 'Claude Haiku 4.5',   hint: 'Fastest, lowest cost' },
-    ],
-  },
-  openai: {
-    label: 'OpenAI (GPT)',
-    hint: 'gpt-5, gpt-4o, o3, o3-mini',
-    models: [
-      { value: 'gpt-5',      label: 'GPT-5',       hint: 'Most capable' },
-      { value: 'gpt-4o',     label: 'GPT-4o',      hint: 'Fast + smart — recommended' },
-      { value: 'gpt-4o-mini', label: 'GPT-4o Mini', hint: 'Fastest, lowest cost' },
-      { value: 'o3',         label: 'o3',           hint: 'Reasoning model' },
-      { value: 'o3-mini',    label: 'o3-mini',      hint: 'Fast reasoning' },
-    ],
-  },
-  google: {
-    label: 'Google (Gemini)',
-    hint: 'gemini-2.5-pro, gemini-2.5-flash',
-    models: [
-      { value: 'gemini-2.5-pro',   label: 'Gemini 2.5 Pro',   hint: 'Most capable' },
-      { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', hint: 'Fast — recommended' },
-      { value: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash', hint: 'Previous gen, stable' },
-    ],
-  },
-} as const;
-
-type ProviderKey = keyof typeof PROVIDERS | 'local';
+import { PROVIDERS, buildOrchestratorOptions, type ProviderKey } from './setup-wizard-options';
 
 const PRESETS = [
   { value: 'architect',   label: 'Architect',   hint: 'System design, decomposition, trade-offs' },
@@ -156,23 +122,45 @@ export async function runSetupWizard(): Promise<void> {
   p.log.step('Choose your orchestrator — the main agent that routes tasks to your team.');
   p.log.info('Tip: Pick a fast model here. It only routes, not heavy lifting.');
 
-  const mainProvider = configuredProviders[0];
-  const mainModelOptions = mainProvider === 'local'
-    ? ollamaModels.slice(0, 10).map((m, i) => ({
-        value: m, label: m, hint: i === 0 ? 'Recommended' : undefined,
-      }))
-    : PROVIDERS[mainProvider as keyof typeof PROVIDERS].models.map(m => ({
-        value: m.value, label: m.label, hint: m.hint,
-      }));
+  const orchestratorOptions = buildOrchestratorOptions(configuredProviders);
 
-  const mainModel = await p.select({
-    message: `Orchestrator model (${mainProvider}):`,
-    options: mainModelOptions,
+  const orchestratorChoice = await p.select({
+    message: 'Orchestrator:',
+    options: orchestratorOptions,
   });
 
-  if (p.isCancel(mainModel)) {
+  if (p.isCancel(orchestratorChoice)) {
     p.cancel('Setup cancelled.');
     process.exit(0);
+  }
+
+  let mainProvider: ProviderKey | 'none';
+  let mainModel: string;
+
+  if (orchestratorChoice === 'none') {
+    mainProvider = 'none';
+    mainModel = 'none';
+  } else {
+    mainProvider = orchestratorChoice as ProviderKey;
+    const mainModelOptions = mainProvider === 'local'
+      ? ollamaModels.slice(0, 10).map((m, i) => ({
+          value: m, label: m, hint: i === 0 ? 'Recommended' : undefined,
+        }))
+      : PROVIDERS[mainProvider as keyof typeof PROVIDERS].models.map(m => ({
+          value: m.value, label: m.label, hint: m.hint,
+        }));
+
+    const selectedModel = await p.select({
+      message: `Orchestrator model (${mainProvider}):`,
+      options: mainModelOptions,
+    });
+
+    if (p.isCancel(selectedModel)) {
+      p.cancel('Setup cancelled.');
+      process.exit(0);
+    }
+
+    mainModel = selectedModel;
   }
 
   // ── Step 4: Configure agent team ────────────────────────────────────────
@@ -349,8 +337,12 @@ Then synthesize all results — cross-reference findings, deduplicate, resolve c
     .map(([id, a]: [string, any]) => `  ${id} → ${a.model} (${a.preset})`)
     .join('\n');
 
+  const orchestratorSummary = mainProvider === 'none'
+    ? 'native host (no API LLM)'
+    : `${mainModel} (${mainProvider})`;
+
   p.note(
-    `Orchestrator: ${mainModel} (${mainProvider})\n\nTeam (${agentCount} agent${agentCount > 1 ? 's' : ''}):\n${summary}`,
+    `Orchestrator: ${orchestratorSummary}\n\nTeam (${agentCount} agent${agentCount > 1 ? 's' : ''}):\n${summary}`,
     'Your Setup'
   );
 

--- a/tests/cli/setup-wizard-orchestrator-options.test.ts
+++ b/tests/cli/setup-wizard-orchestrator-options.test.ts
@@ -1,0 +1,38 @@
+import { buildOrchestratorOptions } from '../../apps/cli/src/setup-wizard-options';
+
+describe('buildOrchestratorOptions', () => {
+  it('always puts "none" (native host orchestration) first', () => {
+    const options = buildOrchestratorOptions(['anthropic', 'openai']);
+    expect(options[0]).toEqual({
+      value: 'none',
+      label: 'None — native host orchestration',
+      hint: 'no API key needed; recommended inside Claude Code / Cursor',
+    });
+  });
+
+  it('appends one entry per configured provider, using PROVIDERS labels', () => {
+    const options = buildOrchestratorOptions(['anthropic', 'openai', 'google']);
+    expect(options.map(o => o.value)).toEqual(['none', 'anthropic', 'openai', 'google']);
+    expect(options.find(o => o.value === 'anthropic')?.label).toBe('Anthropic (Claude)');
+    expect(options.find(o => o.value === 'openai')?.label).toBe('OpenAI (GPT)');
+    expect(options.find(o => o.value === 'google')?.label).toBe('Google (Gemini)');
+  });
+
+  it('labels the "local" provider as "Local (Ollama)"', () => {
+    const options = buildOrchestratorOptions(['local']);
+    expect(options).toEqual([
+      {
+        value: 'none',
+        label: 'None — native host orchestration',
+        hint: 'no API key needed; recommended inside Claude Code / Cursor',
+      },
+      { value: 'local', label: 'Local (Ollama)' },
+    ]);
+  });
+
+  it('returns only the "none" option when no providers are configured', () => {
+    const options = buildOrchestratorOptions([]);
+    expect(options).toHaveLength(1);
+    expect(options[0].value).toBe('none');
+  });
+});


### PR DESCRIPTION
Fixes #726. Completes the secondary half of #724 (the MCP-tool half shipped in #725).

## Problem

The CLI setup wizard's Step 3 hardcoded the orchestrator to `configuredProviders[0]` and only asked which model — there was no way to choose `none`/`none` (native host orchestration), the documented zero-config state everywhere else since #725.

## Fix

- Step 3 now asks which orchestrator to use: **"None — native host orchestration"** first (hint: "no API key needed; recommended inside Claude Code / Cursor"), followed by each configured provider.
- Picking "none" skips the model select and writes `main_agent: { provider: "none", model: "none" }`; picking a keyed provider keeps today's model-select flow unchanged (ollama list for `local`).
- Final summary renders `native host (no API LLM)` for the none case.
- `buildOrchestratorOptions` (+ the `PROVIDERS` catalog and `ProviderKey` type) extracted to new `apps/cli/src/setup-wizard-options.ts` — a module with no `@clack/prompts` import, so the pure helper is unit-testable without adding an ESM jest transform for `@clack/prompts`.
- Steps 1/2, agent-team setup, config shape, `setup-response.ts`, and `mcp-server-sdk.ts` untouched.

## Tests

New `tests/cli/setup-wizard-orchestrator-options.test.ts` (none-first ordering, provider labels, `local` labeling, empty-providers). Prior wizard coverage: none (verified by grep — interactive `@clack/prompts` CLI with no test seam).

Worktree full suite: 5566 tests passed, 0 failures. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)