### PR TITLE
feat(consensus): let Phase-2 cross-reviewers pull skills on demand (#728)

### DIFF
--- a/apps/cli/src/handlers/verifier-tool-runner.ts
+++ b/apps/cli/src/handlers/verifier-tool-runner.ts
@@ -11,8 +11,9 @@
  * When `effectiveRoots` is empty every code path here is byte-identical to the
  * pre-#710 behavior.
  */
-import { FileTools, GitTools, Sandbox } from '@gossip/tools';
-import type { MemorySearcher } from '@gossip/orchestrator';
+import { FileTools, GitTools, Sandbox, formatSkillNotFound, formatSkillPayload, recordSkillPull } from '@gossip/tools';
+import { resolveServableSkill } from '@gossip/orchestrator';
+import type { MemorySearcher, SkillQueryResult } from '@gossip/orchestrator';
 import { existsSync, realpathSync } from 'node:fs';
 import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 
@@ -21,6 +22,27 @@ export type VerifierToolRunner = (
   toolName: string,
   args: Record<string, unknown>,
 ) => Promise<string>;
+
+/**
+ * Per-reviewer, per-round cap on `skill_query` (issue #728). Mirrors the relay
+ * value in `WorkerAgent.TOOL_CALL_BUDGETS.skill_query` — the prompt advertises
+ * at most a handful of on-demand names, so two pulls covers the realistic case
+ * while a confused reviewer cannot burn its 7 verification turns on skill
+ * fetches. Over-budget calls return an error STRING (never throw) so the
+ * remaining turns stay available for file evidence.
+ */
+export const VERIFIER_SKILL_QUERY_BUDGET = 2;
+
+/**
+ * Raw-argument length cap, mirroring the relay `skill_query` zod schema
+ * (`packages/tools/src/tool-schemas.ts`). The engine-driven path has no zod
+ * gate in front of it — the arguments come straight off an LLM tool call — so
+ * the bound is enforced here before the string reaches `normalizeSkillName`.
+ */
+export const MAX_SKILL_QUERY_NAME_LENGTH = 256;
+
+/** Resolve one on-demand skill for a cross-reviewer. */
+export type VerifierSkillResolver = (agentId: string, skill: string) => SkillQueryResult;
 
 /** Read-only file access for cross-reviewers, anchored at the review root. */
 export interface VerifierFileAccess {
@@ -45,6 +67,13 @@ export interface VerifierToolRunnerOptions extends VerifierFileAccessOptions {
   access?: VerifierFileAccess;
   /** Injection seam for tests — the ROOT choice is the behavior under test. */
   makeGitTools?: (root: string) => GitTools;
+  /**
+   * On-demand skill resolution for `skill_query`. Defaults to
+   * `resolveServableSkill` against `projectRoot` — the SAME resolver +
+   * quarantine predicate the relay tool uses. Injected only in tests; a caller
+   * must not substitute a resolver with different advertisement semantics.
+   */
+  skillResolver?: VerifierSkillResolver;
 }
 
 /**
@@ -193,6 +222,58 @@ export function buildVerifierToolRunner(opts: VerifierToolRunnerOptions): Verifi
   const makeGitTools = opts.makeGitTools ?? ((root: string) => new GitTools(root));
   const gitTools = makeGitTools(gitRoot);
   const { fileTools, memory } = opts;
+  const skillResolver: VerifierSkillResolver =
+    opts.skillResolver ?? ((agentId, skill) => resolveServableSkill(agentId, skill, opts.projectRoot));
+  // One runner is built per collect round, so this map IS the per-reviewer,
+  // per-round budget ledger.
+  const skillQueryCalls = new Map<string, number>();
+
+  /**
+   * `skill_query` — hand a cross-reviewer the raw markdown of one of its own
+   * bound skills (issue #728). The agentId comes from the engine's TaskEntry,
+   * never from the tool arguments, so an agent cannot pull a peer's local
+   * skill. Unknown and quarantined resolve to the SAME not-found message so a
+   * reviewer cannot probe which of its skills the effectiveness pipeline
+   * suppressed.
+   */
+  const runSkillQuery = (agentId: string, args: Record<string, unknown>): string => {
+    const used = skillQueryCalls.get(agentId) ?? 0;
+    if (used >= VERIFIER_SKILL_QUERY_BUDGET) {
+      return `Error: skill_query per-round budget exhausted (${VERIFIER_SKILL_QUERY_BUDGET} calls). The markdown from your earlier skill_query call is in this conversation — re-read it instead of calling again.`;
+    }
+    // Charged before validation, mirroring the relay budget gate: a malformed
+    // call still consumes a slot so a broken loop cannot retry for free.
+    skillQueryCalls.set(agentId, used + 1);
+
+    const raw = typeof args.skill === 'string' ? args.skill : '';
+    if (!raw.trim()) return 'skill_query requires a non-empty skill name.';
+    if (raw.length > MAX_SKILL_QUERY_NAME_LENGTH) {
+      return `skill_query skill name exceeds ${MAX_SKILL_QUERY_NAME_LENGTH} characters.`;
+    }
+
+    let resolution: SkillQueryResult;
+    try {
+      resolution = skillResolver(agentId, raw);
+    } catch {
+      // A resolver failure is a not-found from the reviewer's point of view;
+      // never surface an internal stack into the tool response.
+      resolution = { canonicalName: '', skill: null };
+    }
+    if (!resolution.skill) return formatSkillNotFound(resolution.canonicalName, agentId);
+
+    // Observability: successful pulls only. The audit schema has no phase
+    // field, so the row reuses `runtime: 'relay'` — this IS the relay/LLM
+    // reviewer path. `attributed` is true because the identity is the engine's,
+    // not a self-attested argument.
+    recordSkillPull(opts.projectRoot, {
+      agentId,
+      skill: resolution.canonicalName,
+      resolvedPath: resolution.skill.path,
+      runtime: 'relay',
+      attributed: true,
+    });
+    return formatSkillPayload(resolution.canonicalName, resolution.skill);
+  };
 
   return async (agentId, toolName, args) => {
     const toolStart = Date.now();
@@ -221,12 +302,17 @@ export function buildVerifierToolRunner(opts: VerifierToolRunnerOptions): Verifi
           break;
         }
         case 'git_log': result = await gitTools.gitLog(args as any); break;
+        case 'skill_query': result = runSkillQuery(agentId, args); break;
         default: result = `Unknown tool: ${toolName}`;
       }
       const argSummary = toolName === 'file_read' ? (args as any).path
         : toolName === 'file_grep' ? `"${(args as any).pattern}" in ${(args as any).path ?? '.'}`
         : toolName === 'file_search' ? (args as any).pattern
         : toolName === 'memory_query' ? `"${(args as any).query}"`
+        // The raw skill argument is model-controlled: strip everything outside
+        // the normalized alphabet so it cannot forge a second observability
+        // line, and bound its length.
+        : toolName === 'skill_query' ? String((args as any).skill ?? '').replace(/[^\w.-]/g, '').slice(0, 64)
         : '';
       log(`${timestamp()} 🤝 [consensus] 🔧 ${agentId} tool_call: ${toolName}(${argSummary}) → ${result.length}B (${Date.now() - toolStart}ms)\n`);
       return result;

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -86,12 +86,23 @@ export const CROSS_REVIEW_MEMORY_DIRECTIVE = `MEMORY (optional, verification-sco
 - FORBIDDEN: substituting a recalled verdict for fresh verification against the code. A recalled verdict is NOT evidence — "I confirmed this last cycle" must NEVER produce an AGREE. Re-verify every round.
 - If memory informed your verdict, make it traceable: cite \`per gossip_remember finding <id>\` inline.`;
 
-const VERIFIER_TOOLS: ToolDefinition[] = [
+/**
+ * Read-only tools offered to engine-driven Phase-2 cross-reviewers.
+ *
+ * `skill_query` (issue #728) is the Phase-2 twin of the relay worker tool of
+ * the same name: without it a reviewer keeps whatever skills the #666 gate
+ * injected and can pull nothing else, so an agent loses its specialty the
+ * moment it switches into cross-review. Resolution, quarantine and the byte
+ * cap all live in the runner (`buildVerifierToolRunner`), which routes through
+ * the SAME `resolveServableSkill` predicate the relay tool uses.
+ */
+export const VERIFIER_TOOLS: ToolDefinition[] = [
   { name: 'file_read', description: 'Read file contents', parameters: { type: 'object', properties: { path: { type: 'string', description: 'Absolute or project-relative file path' }, startLine: { type: 'number', description: 'First line to read (1-based)' }, endLine: { type: 'number', description: 'Last line to read (inclusive)' } }, required: ['path'] } },
   { name: 'file_grep', description: 'Search file contents by regex', parameters: { type: 'object', properties: { pattern: { type: 'string', description: 'Regex pattern to search for' }, path: { type: 'string', description: 'Directory or file to search in' }, maxResults: { type: 'number', description: 'Maximum number of results to return' } }, required: ['pattern'] } },
   { name: 'file_search', description: 'Find files by glob pattern', parameters: { type: 'object', properties: { pattern: { type: 'string', description: 'Glob pattern to match files' }, path: { type: 'string', description: 'Root directory to search from' } }, required: ['pattern'] } },
   { name: 'memory_query', description: 'Search agent memory by keyword', parameters: { type: 'object', properties: { query: { type: 'string', description: 'Keyword or phrase to search memory' } }, required: ['query'] } },
   { name: 'git_log', description: 'Show git log for a file or path', parameters: { type: 'object', properties: { path: { type: 'string', description: 'File or directory to show history for' }, maxCount: { type: 'number', description: 'Maximum number of commits to return' } }, required: [] } },
+  { name: 'skill_query', description: 'Fetch the full markdown of ONE of YOUR OWN bound skills that was not injected into this cross-review. Read-only — it never binds, unbinds, or changes your skill set. Budget: 2 calls per cross-review round.', parameters: { type: 'object', properties: { skill: { type: 'string', description: 'Exact skill name (e.g. "trust-boundaries"). Underscores and casing are normalized.' } }, required: ['skill'] } },
 ];
 
 /**

--- a/tests/cli/verifier-tool-runner.test.ts
+++ b/tests/cli/verifier-tool-runner.test.ts
@@ -7,14 +7,16 @@
  * path must see the worktree copy; a path that only exists at the project root
  * must still resolve.
  */
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, realpathSync } from 'fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, realpathSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { FileTools, GitTools, Sandbox } from '@gossip/tools';
+import { FileTools, GitTools, Sandbox, SKILL_QUERY_MAX_BYTES } from '@gossip/tools';
 import type { MemorySearcher } from '@gossip/orchestrator';
 import {
   buildVerifierFileAccess,
   buildVerifierToolRunner,
+  VERIFIER_SKILL_QUERY_BUDGET,
+  MAX_SKILL_QUERY_NAME_LENGTH,
 } from '../../apps/cli/src/handlers/verifier-tool-runner';
 
 const ROOT_TARGET = ['export const a = 1;', 'export const b = 2;', 'export const c = 3;'].join('\n');
@@ -263,5 +265,189 @@ describe('verifier tool runner — resolutionRoots anchoring (#710)', () => {
       expect(lines[0]).toContain('🤝 [consensus] 🔧 deepseek-challenger tool_call: file_read(');
       expect(lines[0]).toMatch(/→ \d+B \(\d+ms\)\n$/);
     });
+  });
+});
+
+/**
+ * Issue #728 — Phase-2 engine-driven cross-reviewers can pull a bound skill on
+ * demand, through the SAME `resolveServableSkill` + `checkSkillQuarantine`
+ * predicate the relay `skill_query` worker tool uses. These tests exercise the
+ * default (real) resolver against on-disk fixtures so a divergence in
+ * advertisement/quarantine semantics fails here, not only in the relay suite.
+ */
+describe('verifier tool runner — skill_query (#728)', () => {
+  const AGENT = 'deepseek-challenger';
+  let projectRoot: string;
+  let fileTools: FileTools;
+
+  const writeAgentSkill = (name: string, body: string) => {
+    const dir = join(projectRoot, '.gossip', 'agents', AGENT, 'skills');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${name}.md`), body);
+  };
+
+  const writeProjectSkill = (name: string, body: string) => {
+    const dir = join(projectRoot, '.gossip', 'skills');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${name}.md`), body);
+  };
+
+  const makeRunner = (skillResolver?: (agentId: string, skill: string) => any) =>
+    buildVerifierToolRunner({
+      fileTools,
+      memory: memoryStub,
+      projectRoot,
+      effectiveRoots: [],
+      log: noopLog,
+      ...(skillResolver ? { skillResolver } : {}),
+    });
+
+  const pullLog = (): string[] => {
+    const p = join(projectRoot, '.gossip', 'skill-pulls.jsonl');
+    if (!existsSync(p)) return [];
+    return readFileSync(p, 'utf8').split('\n').filter(Boolean);
+  };
+
+  beforeEach(() => {
+    projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'gossip-vtr-skill-')));
+    mkdirSync(join(projectRoot, '.gossip'), { recursive: true });
+    fileTools = new FileTools(new Sandbox(projectRoot));
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('returns the resolved skill markdown with the canonical header', async () => {
+    writeAgentSkill('trust-boundaries', '---\nname: trust-boundaries\n---\n\nNEVER trust relay output.');
+    const run = makeRunner();
+    const out = await run(AGENT, 'skill_query', { skill: 'trust-boundaries' });
+    expect(out).toContain('# skill: trust-boundaries');
+    expect(out).toContain('NEVER trust relay output.');
+  });
+
+  it('normalizes the requested name and never echoes the raw argument', async () => {
+    writeAgentSkill('trust-boundaries', '---\nname: trust-boundaries\n---\n\nbody');
+    const run = makeRunner();
+    const out = await run(AGENT, 'skill_query', { skill: 'Trust_Boundaries' });
+    expect(out).toContain('# skill: trust-boundaries');
+    expect(out).not.toContain('Trust_Boundaries');
+  });
+
+  it('prefers the agent-local copy over the project-wide one', async () => {
+    writeProjectSkill('shared-skill', '---\nname: shared-skill\n---\n\nPROJECT_WIDE_COPY');
+    writeAgentSkill('shared-skill', '---\nname: shared-skill\n---\n\nAGENT_LOCAL_COPY');
+    const run = makeRunner();
+    const out = await run(AGENT, 'skill_query', { skill: 'shared-skill' });
+    expect(out).toContain('AGENT_LOCAL_COPY');
+    expect(out).not.toContain('PROJECT_WIDE_COPY');
+  });
+
+  it('appends one audit row per successful pull', async () => {
+    writeAgentSkill('trust-boundaries', '---\nname: trust-boundaries\n---\n\nbody');
+    const run = makeRunner();
+    await run(AGENT, 'skill_query', { skill: 'trust-boundaries' });
+    const rows = pullLog().map(l => JSON.parse(l));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      agent_id: AGENT,
+      skill: 'trust-boundaries',
+      runtime: 'relay',
+      attributed: true,
+    });
+    expect(rows[0].resolved_path).toContain('trust-boundaries.md');
+  });
+
+  it('reports an unservable name as not found, naming the searched scopes', async () => {
+    const run = makeRunner();
+    const out = await run(AGENT, 'skill_query', { skill: 'no-such-skill-anywhere' });
+    expect(out).toContain('Skill "no-such-skill-anywhere" not found.');
+    expect(out).toContain(`.gossip/agents/${AGENT}/skills`);
+    expect(pullLog()).toHaveLength(0);
+  });
+
+  it('refuses a quarantined skill with the SAME message as unknown, and logs no pull', async () => {
+    writeAgentSkill(
+      'failed-skill',
+      '---\nname: failed-skill\nstatus: failed\n---\n\nQUARANTINED_BODY',
+    );
+    const run = makeRunner();
+    const out = await run(AGENT, 'skill_query', { skill: 'failed-skill' });
+    expect(out).not.toContain('QUARANTINED_BODY');
+    expect(out).toContain('Skill "failed-skill" not found.');
+    expect(pullLog()).toHaveLength(0);
+  });
+
+  it('rejects an empty skill name without touching the resolver', async () => {
+    const resolver = jest.fn();
+    const run = makeRunner(resolver);
+    expect(await run(AGENT, 'skill_query', { skill: '   ' })).toBe(
+      'skill_query requires a non-empty skill name.',
+    );
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('rejects an oversized raw name before it reaches the normalizer', async () => {
+    const resolver = jest.fn();
+    const run = makeRunner(resolver);
+    const out = await run(AGENT, 'skill_query', { skill: 'a'.repeat(MAX_SKILL_QUERY_NAME_LENGTH + 1) });
+    expect(out).toContain(`exceeds ${MAX_SKILL_QUERY_NAME_LENGTH} characters`);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('returns an error STRING once the per-round budget is exhausted, without throwing', async () => {
+    writeAgentSkill('a-skill', '---\nname: a-skill\n---\n\nbody');
+    const run = makeRunner();
+    for (let i = 0; i < VERIFIER_SKILL_QUERY_BUDGET; i++) {
+      expect(await run(AGENT, 'skill_query', { skill: 'a-skill' })).toContain('# skill: a-skill');
+    }
+    const out = await run(AGENT, 'skill_query', { skill: 'a-skill' });
+    expect(out).toContain('per-round budget exhausted');
+    expect(out).toContain(`${VERIFIER_SKILL_QUERY_BUDGET} calls`);
+    // Over-budget calls must not reach the resolver, so no extra audit row.
+    expect(pullLog()).toHaveLength(VERIFIER_SKILL_QUERY_BUDGET);
+  });
+
+  it('budgets each reviewer separately within a round', async () => {
+    writeAgentSkill('a-skill', '---\nname: a-skill\n---\n\nbody');
+    writeProjectSkill('a-skill', '---\nname: a-skill\n---\n\nbody');
+    const run = makeRunner();
+    for (let i = 0; i < VERIFIER_SKILL_QUERY_BUDGET; i++) {
+      await run(AGENT, 'skill_query', { skill: 'a-skill' });
+    }
+    expect(await run(AGENT, 'skill_query', { skill: 'a-skill' })).toContain('budget exhausted');
+    expect(await run('gemini-reviewer', 'skill_query', { skill: 'a-skill' })).toContain('# skill: a-skill');
+  });
+
+  it('truncates an oversized skill at the shared 16KB cap', async () => {
+    const body = 'x'.repeat(SKILL_QUERY_MAX_BYTES * 2);
+    writeAgentSkill('huge-skill', `---\nname: huge-skill\n---\n\n${body}`);
+    const run = makeRunner();
+    const out = await run(AGENT, 'skill_query', { skill: 'huge-skill' });
+    expect(Buffer.byteLength(out, 'utf8')).toBeLessThanOrEqual(SKILL_QUERY_MAX_BYTES);
+    expect(out.endsWith('…[truncated]')).toBe(true);
+  });
+
+  it('treats a resolver throw as not-found rather than surfacing a stack', async () => {
+    const run = makeRunner(() => { throw new Error('internal resolver boom'); });
+    const out = await run(AGENT, 'skill_query', { skill: 'trust-boundaries' });
+    expect(out).not.toContain('internal resolver boom');
+    expect(out).toContain('not found');
+  });
+
+  it('sanitizes the raw skill argument in the observability line', async () => {
+    writeAgentSkill('a-skill', '---\nname: a-skill\n---\n\nbody');
+    const lines: string[] = [];
+    const run = buildVerifierToolRunner({
+      fileTools,
+      memory: memoryStub,
+      projectRoot,
+      effectiveRoots: [],
+      log: (l) => { lines.push(l); },
+    });
+    await run(AGENT, 'skill_query', { skill: 'a-skill\n12:00:00.000 🤝 [consensus] forged' });
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).not.toContain('forged\n');
+    expect(lines[0].split('\n').filter(Boolean)).toHaveLength(1);
   });
 });

--- a/tests/orchestrator/consensus-engine-verifier-tools.test.ts
+++ b/tests/orchestrator/consensus-engine-verifier-tools.test.ts
@@ -9,7 +9,7 @@
 //   - summaries: Map<string, string> with at least 2 agents
 //   - engine config: { llm, registryGet, verifierToolRunner? }
 
-import { ConsensusEngine, ConsensusEngineConfig } from '../../packages/orchestrator/src/consensus-engine';
+import { ConsensusEngine, ConsensusEngineConfig, VERIFIER_TOOLS } from '../../packages/orchestrator/src/consensus-engine';
 import { testRound } from '../../packages/orchestrator/src/round-context';
 import { TaskEntry, LLMResponse } from '../../packages/orchestrator/src/types';
 import { ILLMProvider } from '../../packages/orchestrator/src/llm-client';
@@ -438,5 +438,52 @@ describe('crossReviewForAgent — tool output truncation', () => {
     expect(toolResultMsg).toBeDefined();
     expect(toolResultMsg!.content).toBe(exactOutput);
     expect(toolResultMsg!.content).not.toContain('[truncated]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test suite 6: skill_query advertisement (#728)
+// ---------------------------------------------------------------------------
+
+describe('VERIFIER_TOOLS — skill_query advertisement (#728)', () => {
+  it('advertises skill_query alongside the read-only evidence tools', () => {
+    expect(VERIFIER_TOOLS.map(t => t.name)).toEqual(
+      expect.arrayContaining(['file_read', 'file_grep', 'file_search', 'memory_query', 'git_log', 'skill_query']),
+    );
+  });
+
+  it('declares skill_query with a single required `skill` string parameter', () => {
+    const def = VERIFIER_TOOLS.find(t => t.name === 'skill_query');
+    expect(def).toBeDefined();
+    expect(def!.parameters.required).toEqual(['skill']);
+    expect((def!.parameters.properties as any).skill).toMatchObject({ type: 'string' });
+    // Exactly the relay tool's contract — no extra knobs the runner ignores.
+    expect(Object.keys(def!.parameters.properties)).toEqual(['skill']);
+  });
+
+  it('states the per-round budget in the description so the model self-limits', () => {
+    const def = VERIFIER_TOOLS.find(t => t.name === 'skill_query');
+    expect(def!.description).toContain('2 calls');
+  });
+
+  it('routes skill_query through the verifierToolRunner like any other tool', async () => {
+    const mockLlm: jest.Mocked<ILLMProvider> = { generate: jest.fn() };
+    const verifierToolRunner = jest.fn().mockResolvedValue('# skill: trust-boundaries  (resolved: /x/y.md)\n\nbody');
+    const engine = new ConsensusEngine({
+      llm: mockLlm,
+      registryGet: makeMockRegistryGet(),
+      verifierToolRunner,
+      round: testRound(),
+    } as ConsensusEngineConfig);
+
+    mockLlm.generate
+      .mockResolvedValueOnce({ text: '', toolCalls: [{ id: 'tc1', name: 'skill_query', arguments: { skill: 'trust-boundaries' } }] } as LLMResponse)
+      .mockResolvedValueOnce({ text: VALID_CROSS_REVIEW_JSON } as LLMResponse);
+
+    await (engine as any).crossReviewForAgent(makeAgent('reviewer-agent'), makeSummaries('reviewer-agent', 'peer-agent'));
+
+    expect(verifierToolRunner).toHaveBeenCalledWith('reviewer-agent', 'skill_query', { skill: 'trust-boundaries' });
+    const toolMsg = mockLlm.generate.mock.calls[1][0].find((m: any) => m.role === 'tool');
+    expect(toolMsg!.content).toContain('# skill: trust-boundaries');
   });
 });


### PR DESCRIPTION
Closes #728.

## Problem

Since v0.8, Phase-1 agents can pull skills mid-task (relay `skill_query` tool / native `gossip_skill_query`), but Phase-2 engine-driven cross-reviewers only had `VERIFIER_TOOLS` = file_read, file_grep, file_search, memory_query, git_log — an agent lost its specialty the moment it switched into cross-review.

## Fix

- `consensus-engine.ts`: `skill_query` added to `VERIFIER_TOOLS` (parameter shape mirrors the relay tool — one required `skill` string); array exported so the advertisement is testable.
- `verifier-tool-runner.ts`: new `skill_query` route through the **same** `resolveServableSkill` + quarantine predicate the relay tool uses — no new resolution semantics. Identity is the engine's reviewer agentId (never from tool args), so a reviewer can't pull a peer's agent-local skill.
- **Budget:** 2 pulls per reviewer per round (mirrors `TOOL_CALL_BUDGETS.skill_query`), charged before validation like the relay gate; over-budget returns an error string so the 7 verification turns stay usable.
- **Size:** shared `formatSkillPayload` 16KB cap + truncation marker.
- **Non-probeable:** unknown and quarantined skills return the identical not-found message and log no audit row.
- **Audit:** successful pulls append to `.gossip/skill-pulls.jsonl` via the existing writer (schema reused as-is; it has no phase field — extending it is a deliberate follow-up if Phase-1/Phase-2 analytics split is ever needed).
- Scope: engine-driven verifier path only; native cross-reviewer dispatch and the MCP handler untouched.

## Tests

17 new jest cases extending existing files: `tests/cli/verifier-tool-runner.test.ts` (13 — real resolver + on-disk fixtures: happy path, normalization, precedence, audit shape, not-found, quarantine, arg validation, budget exhaustion + per-agent isolation, 16KB truncation, resolver-throw, log sanitization) and `tests/orchestrator/consensus-engine-verifier-tools.test.ts` (4 — advertisement + end-to-end route).

Worktree full suite: 5583 tests passed, 0 failures. `tsc --noEmit` clean for both touched packages.

Known pre-existing (not a regression, left out of scope): the engine's `runToolCalls` also truncates every tool result at 8000 chars after the 16KB byte cap, so a very large skill gets cut twice with two different markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)