### PR TITLE
fix(quota): classify zero-limit free-tier 429s as permanent no_quota (#732)

### DIFF
--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -340,6 +340,7 @@ import { filterWatchEvents, WATCH_MAX_EVENTS } from './gossip-watch';
 import { persistRelayTasks, restoreRelayTasksAsFailed } from './handlers/relay-tasks';
 import { pickStickyPort, writeStickyPort, RELAY_STICKY_FILE, HTTP_MCP_STICKY_FILE } from './stickyPort';
 import { buildDashboardAdvisory, mergeSetupConfig, resolveMainAgent, buildMalformedConfigHint, flushStagedAgentFileWrites } from './setup-response';
+import { formatQuotaLine } from './quota-banner';
 import { refreshNativeAgentFromDisk } from './native-agent-cache';
 import { generateRulesContent } from './rules-content';
 import { formatDropReceipt } from './format-drop-receipt';
@@ -2323,23 +2324,7 @@ export function createMcpServer(): McpServer {
         const quotaRaw = readFileSync(quotaPath, 'utf8');
         const quotaState: Record<string, { exhaustedUntil?: number; reason?: string; consecutive429s?: number }> = JSON.parse(quotaRaw);
         for (const [provider, state] of Object.entries(quotaState)) {
-          const now = Date.now();
-          const cooling = !!state.exhaustedUntil && state.exhaustedUntil > now;
-          const consecutive = state.consecutive429s ?? 0;
-          if (cooling && state.reason === 'spend_cap') {
-            // Monthly spend cap: a cooldown timer is meaningless to the user —
-            // it only recovers when they raise the cap or the month rolls over.
-            lines.push(`  Quota: ${provider} — EXHAUSTED (monthly spend cap — manage at https://ai.studio/spend)`);
-          } else if (cooling) {
-            const cooldownSec = Math.ceil((state.exhaustedUntil! - now) / 1000);
-            lines.push(`  Quota: ${provider} — EXHAUSTED (${cooldownSec}s cooldown)`);
-          } else if (consecutive >= 5) {
-            // Cooldown expired but a long run of 429s preceded it and no
-            // successful call has since reset the counter — do NOT claim OK.
-            lines.push(`  Quota: ${provider} — SUSPECT (${consecutive} consecutive 429s before cooldown expiry — verify with a real call)`);
-          } else {
-            lines.push(`  Quota: ${provider} — OK`);
-          }
+          lines.push(formatQuotaLine(provider, state));
         }
       } catch { /* quota-state.json not present — skip */ }
 

--- a/apps/cli/src/quota-banner.ts
+++ b/apps/cli/src/quota-banner.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure formatter for the `gossip_status` "Quota health" banner lines.
+ *
+ * Extracted out of mcp-server-sdk.ts (mirrors the setup-response.ts pattern)
+ * so the fall-through order between EXHAUSTED / SUSPECT / OK / NO QUOTA can
+ * be unit-tested directly instead of only through the full gossip_status
+ * handler. See issue #732.
+ */
+
+export interface QuotaProviderStateLike {
+  exhaustedUntil?: number;
+  reason?: string;
+  consecutive429s?: number;
+}
+
+/**
+ * Format a single "  Quota: <provider> — ..." banner line for one provider's
+ * persisted quota-state entry.
+ *
+ * Fall-through order (first match wins):
+ * 1. reason === 'no_quota' — a permanent zero-limit free-tier state (issue
+ *    #732). This is checked FIRST and unconditionally on `reason`, whether or
+ *    not the cooldown is still active — an EXPIRED no_quota cooldown must
+ *    NOT fall through to SUSPECT or OK, since waiting never fixes it and a
+ *    successful call (which would clear `reason`) hasn't happened.
+ * 2. cooling && reason === 'spend_cap' — monthly spend cap, same rationale.
+ * 3. cooling — ordinary short-lived rate-limit cooldown still active.
+ * 4. consecutive429s >= 5 — cooldown expired but a long 429 streak preceded
+ *    it with no successful call since; don't claim OK.
+ * 5. otherwise — OK.
+ */
+export function formatQuotaLine(
+  provider: string,
+  state: QuotaProviderStateLike,
+  now: number = Date.now(),
+): string {
+  const cooling = !!state.exhaustedUntil && state.exhaustedUntil > now;
+  const consecutive = state.consecutive429s ?? 0;
+
+  if (state.reason === 'no_quota') {
+    const base = `  Quota: ${provider} — NO QUOTA on current plan (free-tier limit is 0 — enable billing; waiting will not fix this)`;
+    return cooling ? base : `${base} — verify with a real call after enabling billing`;
+  }
+  if (cooling && state.reason === 'spend_cap') {
+    // Monthly spend cap: a cooldown timer is meaningless to the user —
+    // it only recovers when they raise the cap or the month rolls over.
+    return `  Quota: ${provider} — EXHAUSTED (monthly spend cap — manage at https://ai.studio/spend)`;
+  }
+  if (cooling) {
+    const cooldownSec = Math.ceil((state.exhaustedUntil! - now) / 1000);
+    return `  Quota: ${provider} — EXHAUSTED (${cooldownSec}s cooldown)`;
+  }
+  if (consecutive >= 5) {
+    // Cooldown expired but a long run of 429s preceded it and no
+    // successful call has since reset the counter — do NOT claim OK.
+    return `  Quota: ${provider} — SUSPECT (${consecutive} consecutive 429s before cooldown expiry — verify with a real call)`;
+  }
+  return `  Quota: ${provider} — OK`;
+}

--- a/packages/orchestrator/src/llm-client.ts
+++ b/packages/orchestrator/src/llm-client.ts
@@ -216,7 +216,7 @@ export class QuotaExhaustedException extends Error {
   }
 }
 
-type CooldownReason = 'quota' | 'unavailable' | 'spend_cap';
+type CooldownReason = 'quota' | 'unavailable' | 'spend_cap' | 'no_quota';
 
 // A monthly spend cap (Google) cannot recover via a short rate-limit cooldown —
 // it clears only when the user raises the cap or the billing month rolls over.
@@ -224,6 +224,19 @@ type CooldownReason = 'quota' | 'unavailable' | 'spend_cap';
 // stops lying about "OK" the instant a short cooldown would have expired.
 const SPEND_CAP_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 const SPEND_CAP_RE = /spend(?:ing)?\s+cap/i;
+
+// A free-tier key with a zero request/token limit for the model (issue #732)
+// is a PERMANENT no-quota state, not a transient rate limit — waiting never
+// clears it, only enabling billing does. Detect it from the structured
+// violation text Google embeds in the error body: a "Quota exceeded ...
+// limit: 0" line on the SAME line (bounded by `[^\n]*` so it can't match
+// across unrelated content), or a `"quotaId"` field whose value carries
+// Google's "-FreeTier" suffix. Both anchors require the zero-limit / FreeTier
+// signal to sit next to the quota-violation vocabulary, so ordinary 429s with
+// non-zero limits (e.g. "limit: 100") or unrelated zeros elsewhere in the
+// body never match. Same 24h re-armed cooldown pattern as spend_cap.
+const NO_QUOTA_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+const NO_QUOTA_RE = /Quota exceeded[^\n]*\blimit:\s*0\b|"quotaId"\s*:\s*"[^"]*-FreeTier"/i;
 
 interface QuotaProviderState {
   exhaustedUntil: number;
@@ -280,6 +293,7 @@ class QuotaTracker {
       const label =
         this.reason === 'unavailable' ? 'service unavailable'
         : this.reason === 'spend_cap' ? 'monthly spend cap reached'
+        : this.reason === 'no_quota' ? 'no quota on current plan'
         : 'quota exhausted';
       _log(this.provider, `${label}, ${Math.round(remainingMs / 1000)}s cooldown remaining`);
       throw new QuotaExhaustedException({
@@ -307,6 +321,24 @@ class QuotaTracker {
       _log(this.provider, `429 monthly spend cap (${this.consecutive429s}x) — cooling down ${cooldownMs / 1000}s`);
       throw new QuotaExhaustedException({
         message: `${this.provider} monthly spend cap reached (429 #${this.consecutive429s}): ${errBody}`,
+        provider: this.provider,
+        retryAfterMs: cooldownMs,
+      });
+    }
+    // A zero-limit free-tier 429 (issue #732) is checked AFTER spend_cap
+    // (spend_cap implies billing is already enabled, so the two are mutually
+    // exclusive in practice) and BEFORE the ordinary quota path — it must not
+    // fall through to the short exponential-backoff cooldown, since waiting
+    // never clears a zero-limit plan.
+    const isNoQuota = NO_QUOTA_RE.test(errBody);
+    if (isNoQuota) {
+      this.reason = 'no_quota';
+      const cooldownMs = NO_QUOTA_COOLDOWN_MS;
+      this.exhaustedUntil = Date.now() + cooldownMs;
+      this.persist();
+      _log(this.provider, `429 zero quota on current plan (${this.consecutive429s}x) — cooling down ${cooldownMs / 1000}s`);
+      throw new QuotaExhaustedException({
+        message: `${this.provider} has zero quota for this model on the current (free-tier) plan (429 #${this.consecutive429s}): enabling billing is the only fix, waiting will not help: ${errBody}`,
         provider: this.provider,
         retryAfterMs: cooldownMs,
       });

--- a/tests/cli/quota-banner.test.ts
+++ b/tests/cli/quota-banner.test.ts
@@ -1,0 +1,59 @@
+import { formatQuotaLine } from '../../apps/cli/src/quota-banner';
+
+describe('formatQuotaLine (issue #732)', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('OK when no cooldown and no consecutive429s', () => {
+    expect(formatQuotaLine('google', {}, NOW)).toBe('  Quota: google — OK');
+  });
+
+  it('EXHAUSTED with a cooldown countdown for an ordinary quota reason while cooling', () => {
+    const line = formatQuotaLine('google', { exhaustedUntil: NOW + 30_000, reason: 'quota' }, NOW);
+    expect(line).toBe('  Quota: google — EXHAUSTED (30s cooldown)');
+  });
+
+  it('SUSPECT when cooldown expired but consecutive429s >= 5', () => {
+    const line = formatQuotaLine('google', { exhaustedUntil: NOW - 1, consecutive429s: 5, reason: 'quota' }, NOW);
+    expect(line).toBe('  Quota: google — SUSPECT (5 consecutive 429s before cooldown expiry — verify with a real call)');
+  });
+
+  it('EXHAUSTED (monthly spend cap) while cooling with reason spend_cap', () => {
+    const line = formatQuotaLine('google', { exhaustedUntil: NOW + 60_000, reason: 'spend_cap' }, NOW);
+    expect(line).toBe('  Quota: google — EXHAUSTED (monthly spend cap — manage at https://ai.studio/spend)');
+  });
+
+  it('an EXPIRED spend_cap cooldown falls through to the ordinary cooling/SUSPECT/OK branches (reason check is cooling-gated)', () => {
+    // spend_cap's branch requires `cooling` — once expired it is NOT
+    // re-checked against reason, unlike no_quota (see next test).
+    const line = formatQuotaLine('google', { exhaustedUntil: NOW - 1, reason: 'spend_cap', consecutive429s: 1 }, NOW);
+    expect(line).toBe('  Quota: google — OK');
+  });
+
+  it('NO QUOTA while cooling with reason no_quota', () => {
+    const line = formatQuotaLine('google', { exhaustedUntil: NOW + 60_000, reason: 'no_quota' }, NOW);
+    expect(line).toBe(
+      '  Quota: google — NO QUOTA on current plan (free-tier limit is 0 — enable billing; waiting will not fix this)',
+    );
+  });
+
+  it('an EXPIRED no_quota cooldown still shows NO QUOTA — must NOT fall through to SUSPECT or OK', () => {
+    const line = formatQuotaLine('google', { exhaustedUntil: NOW - 1, reason: 'no_quota', consecutive429s: 12 }, NOW);
+    expect(line).toContain('NO QUOTA on current plan');
+    expect(line).toContain('verify with a real call after enabling billing');
+    expect(line).not.toContain('SUSPECT');
+    expect(line).not.toContain('OK');
+  });
+
+  it('an EXPIRED no_quota cooldown with a LOW consecutive429s count (would be OK for ordinary reasons) still shows NO QUOTA', () => {
+    // Regression guard: no_quota must win over the "otherwise OK" branch
+    // even when the consecutive429s count is below the SUSPECT threshold.
+    const line = formatQuotaLine('google', { exhaustedUntil: NOW - 1, reason: 'no_quota', consecutive429s: 1 }, NOW);
+    expect(line).toContain('NO QUOTA on current plan');
+    expect(line).not.toBe('  Quota: google — OK');
+  });
+
+  it('reason defaults treat missing/undefined reason as ordinary quota', () => {
+    const line = formatQuotaLine('google', { exhaustedUntil: NOW + 10_000 }, NOW);
+    expect(line).toBe('  Quota: google — EXHAUSTED (10s cooldown)');
+  });
+});

--- a/tests/orchestrator/llm-client.test.ts
+++ b/tests/orchestrator/llm-client.test.ts
@@ -1130,3 +1130,193 @@ describe('QuotaTracker spend-cap detection (429)', () => {
     expect(Number.isNaN(state.consecutive429s)).toBe(false);
   });
 });
+
+describe('QuotaTracker no-quota detection (429, issue #732)', () => {
+  let projectRoot: string;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'quota-no-quota-'));
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  const read429State = () =>
+    JSON.parse(readFileSync(join(projectRoot, '.gossip', 'quota-state.json'), 'utf-8')).google;
+
+  // Realistic shape of a Google free-tier zero-limit 429: the "message" field
+  // itself carries "Quota exceeded for metric: ..., limit: 0, model: ..."
+  // violation lines, and the structured `details` array carries a `quotaId`
+  // ending in "-FreeTier".
+  const ZERO_LIMIT_BODY = JSON.stringify({
+    error: {
+      code: 429,
+      message:
+        'You exceeded your current quota. * Quota exceeded for metric: ' +
+        'generativelanguage.googleapis.com/generate_content_free_tier_requests, ' +
+        'limit: 0, model: gemini-2.5-pro',
+      status: 'RESOURCE_EXHAUSTED',
+      details: [
+        {
+          '@type': 'type.googleapis.com/google.rpc.QuotaFailure',
+          violations: [
+            {
+              quotaMetric: 'generativelanguage.googleapis.com/generate_content_free_tier_requests',
+              quotaId: 'GenerateRequestsPerDayPerProjectPerModel-FreeTier',
+              quotaDimensions: { model: 'gemini-2.5-pro', location: 'global' },
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  it('a zero-limit free-tier 429 persists reason "no_quota" with a 24h cooldown and a billing-focused message', async () => {
+    const before = Date.now();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Map([['retry-after', '30']]) as any, // short header must be IGNORED, same as spend_cap
+      text: async () => ZERO_LIMIT_BODY,
+    }) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider('ai-test', 'gemini-2.5-pro', projectRoot);
+    await expect(provider.generate([{ role: 'user', content: 'hi' }]))
+      .rejects.toThrow(/zero quota.*free-tier.*enabling billing is the only fix/is);
+
+    const state = read429State();
+    expect(state.reason).toBe('no_quota');
+    expect(state.consecutive429s).toBe(1);
+    const remaining = state.exhaustedUntil - before;
+    expect(remaining).toBeGreaterThan(23 * 60 * 60 * 1000);
+    expect(remaining).toBeLessThanOrEqual(24 * 60 * 60 * 1000 + 5_000);
+  });
+
+  it('an ordinary 429 with a NON-zero limit does not match no_quota — stays on the exponential quota path (regression guard)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Map([['retry-after', '45']]) as any,
+      text: async () =>
+        JSON.stringify({
+          error: {
+            code: 429,
+            message: 'Quota exceeded for metric: generate_requests_per_minute, limit: 100, model: gemini-2.5-pro',
+            status: 'RESOURCE_EXHAUSTED',
+          },
+        }),
+    }) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider('ai-test', 'gemini-2.5-pro', projectRoot);
+    await expect(provider.generate([{ role: 'user', content: 'hi' }]))
+      .rejects.toThrow(/quota exhausted/i);
+
+    expect(read429State().reason).toBe('quota');
+  });
+
+  it('a plain ordinary 429 with an unrelated zero elsewhere in the body does not false-positive (regression guard)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Map([['retry-after', '20']]) as any,
+      text: async () => 'Resource has been exhausted (e.g. check quota). retryDelay: 0s',
+    }) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider('ai-test', 'gemini-2.5-pro', projectRoot);
+    await expect(provider.generate([{ role: 'user', content: 'hi' }]))
+      .rejects.toThrow(/quota exhausted/i);
+
+    expect(read429State().reason).toBe('quota');
+  });
+
+  it('a body matching BOTH spend_cap and the zero-limit shape resolves to spend_cap (pins precedence: spend_cap checked first)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Map() as any,
+      text: async () =>
+        'You exceeded your monthly spending cap. Quota exceeded for metric: ' +
+        'generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 0, model: gemini-2.5-pro',
+    }) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider('ai-test', 'gemini-2.5-pro', projectRoot);
+    await expect(provider.generate([{ role: 'user', content: 'hi' }]))
+      .rejects.toThrow(/monthly spend cap/i);
+
+    expect(read429State().reason).toBe('spend_cap');
+  });
+
+  it('re-arm: a second no_quota 429 after partial elapse re-arms the full 24h window from now', async () => {
+    // Simulate a prior no_quota cooldown that has ALREADY expired (so
+    // checkBeforeRequest lets the next request through), with a
+    // consecutive429s count carried over from before.
+    mkdirSync(join(projectRoot, '.gossip'), { recursive: true });
+    writeFileSync(
+      join(projectRoot, '.gossip', 'quota-state.json'),
+      JSON.stringify({ google: { exhaustedUntil: Date.now() - 1000, consecutive429s: 3, reason: 'no_quota' } }),
+    );
+
+    const before = Date.now();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Map() as any,
+      text: async () => ZERO_LIMIT_BODY,
+    }) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider('ai-test', 'gemini-2.5-pro', projectRoot);
+    await expect(provider.generate([{ role: 'user', content: 'hi' }]))
+      .rejects.toThrow(/zero quota/i);
+
+    const state = read429State();
+    expect(state.reason).toBe('no_quota');
+    expect(state.consecutive429s).toBe(4); // carried-over 3 + this one
+    const remaining = state.exhaustedUntil - before;
+    // Freshly re-armed to a full 24h window from NOW, not extended off the
+    // stale (already-expired) prior deadline.
+    expect(remaining).toBeGreaterThan(23 * 60 * 60 * 1000);
+    expect(remaining).toBeLessThanOrEqual(24 * 60 * 60 * 1000 + 5_000);
+  });
+
+  it('checkBeforeRequest labels a cooling no_quota state as "no quota on current plan"', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Map() as any,
+      text: async () => ZERO_LIMIT_BODY,
+    }) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider('ai-test', 'gemini-2.5-pro', projectRoot);
+    await expect(provider.generate([{ role: 'user', content: 'hi' }])).rejects.toThrow();
+
+    // Second call while still cooling hits checkBeforeRequest, not handle429.
+    await expect(provider.generate([{ role: 'user', content: 'hi again' }]))
+      .rejects.toThrow(/no quota on current plan/i);
+  });
+
+  it('a successful call after a no_quota cooldown resets reason to "quota" and clears the cooldown', async () => {
+    mkdirSync(join(projectRoot, '.gossip'), { recursive: true });
+    writeFileSync(
+      join(projectRoot, '.gossip', 'quota-state.json'),
+      JSON.stringify({ google: { exhaustedUntil: Date.now() - 1000, consecutive429s: 2, reason: 'no_quota' } }),
+    );
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ candidates: [{ content: { parts: [{ text: 'hi' }] }, finishReason: 'STOP' }] }),
+    }) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider('ai-test', 'gemini-2.5-pro', projectRoot);
+    await provider.generate([{ role: 'user', content: 'hi' }]);
+
+    const state = read429State();
+    expect(state.reason).toBe('quota');
+    expect(state.consecutive429s).toBe(0);
+    expect(state.exhaustedUntil).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #732.

## Problem

A Google free-tier key whose plan has a hard **zero** request/token limit for the model returns 429 `RESOURCE_EXHAUSTED` with `limit: 0` violation lines on every call. `QuotaTracker.handle429` treated this as an ordinary transient rate limit (short exponential cooldown, max 5 min), producing an endless EXHAUSTED→SUSPECT loop — 125 consecutive 429s observed live on 2026-08-03. Waiting can never clear a zero-limit plan; only enabling billing does.

## Fix

Mirrors the existing `spend_cap` precedent:

- `packages/orchestrator/src/llm-client.ts`: new `no_quota` `CooldownReason`, detected in `handle429` via `NO_QUOTA_RE` — a same-line `Quota exceeded … limit: 0` match or a `"quotaId"` ending in `-FreeTier`. Bounded so ordinary 429s with non-zero limits (`limit: 100`) or unrelated zeros never match. Precedence: spend_cap → no_quota → ordinary quota (spend_cap implies billing is on; mutually exclusive in practice). 24h re-armed cooldown, persisted reason, distinct `checkBeforeRequest` label, exception message says enabling billing is the only fix. `onSuccess` needed no change — the generic reset already clears it.
- `apps/cli/src/quota-banner.ts` (new): the gossip_status "Quota health" fall-through extracted into pure `formatQuotaLine` (mirrors the setup-response.ts testability pattern). `no_quota` is checked first and **unconditionally on reason** — an expired no_quota cooldown shows `NO QUOTA on current plan (… enable billing; waiting will not fix this) — verify with a real call after enabling billing`, never falling through to SUSPECT/OK.
- `apps/cli/src/mcp-server-sdk.ts`: banner loop body replaced with the helper call.

## Tests

16 new jest cases: 7 in `tests/orchestrator/llm-client.test.ts` (zero-limit detection + 24h + billing message, non-zero-limit and unrelated-zero regression guards, spend_cap precedence pin, re-arm, checkBeforeRequest label, success reset) and 9 in new `tests/cli/quota-banner.test.ts` (every branch + the two expired-no_quota-stays-NO-QUOTA guards).

Worktree full suite: 394 suites / 5599 tests passed, 0 failures. `tsc --noEmit` + full `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)