### PR TITLE
fix(deps): patch 9 Dependabot advisories in transitive deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4131,9 +4131,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
-      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
       "funding": [
         {
           "type": "github",
@@ -4632,9 +4632,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5442,9 +5442,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -60,11 +60,11 @@
     "ws": "^8.20.1"
   },
   "overrides": {
-    "ip-address": "^10.1.1",
+    "ip-address": "^10.7.0",
     "hono": ">=4.12.27 <5",
-    "fast-uri": ">=3.1.4",
+    "fast-uri": "^4.1.4",
     "postcss": "^8.5.18",
-    "js-yaml": "^4.2.1",
+    "js-yaml": "^4.3.2",
     "brace-expansion": "^5.0.8",
     "@hono/node-server": "^2.0.5"
   }


### PR DESCRIPTION
## Summary

Fixes 9 open Dependabot security advisories on transitive (non-direct)
dependencies. None of `fast-uri`, `ip-address`, or `js-yaml` are direct
`package.json` dependencies, so npm can't be told to bump them directly —
the fix is a tightened `overrides` block forcing safe minimum versions,
followed by `npm install` to regenerate `package-lock.json`.

### fast-uri: 4.1.1 → `^4.1.4`
Pulled in via `@modelcontextprotocol/sdk@1.30.0` → `ajv@8.20.0` → `fast-uri`.
- GHSA-5jgf-p345-68v8
- GHSA-f65p-4m7j-42xc
- GHSA-fph4-wmhf-6fwf
- GHSA-jqff-g426-hqxp
- GHSA-7p8r-x3mc-p8w7

### ip-address: 10.2.0 → `^10.7.0`
Pulled in via `@modelcontextprotocol/sdk@1.30.0` → `express-rate-limit@8.5.2` → `ip-address`.
- GHSA-mwp4-54f8-5fhr
- GHSA-4xrf-jv44-h6hh
- GHSA-22jq-vg5j-6vgg

### js-yaml: 4.3.0 → `^4.3.2`
Pulled in via `ts-jest@29.4.12` → `@jest/transform@29.7.0` → `babel-plugin-istanbul@6.1.1` → `@istanbuljs/load-nyc-config@1.1.0` → `js-yaml`.
- GHSA-5p4m-2wfm-xmqj (CVE-2026-59870, quadratic CPU in `!!omap` resolution)

Stayed on the js-yaml 4.x line per instructions rather than jumping to 5.x
(major bump, different consumer expectations).

## Verification

- `npm ls fast-uri ip-address js-yaml --all` — confirmed every resolution
  site in the tree (there is exactly one per package) now points at the
  patched version, no stragglers.
- `npm run build` — full monorepo build, clean.
- `npm run build:mcp` — dist-mcp bundle rebuilt, required for the binary
  test suites.
- `npm test` — full suite green: 396 test suites, 5609 passed, 29 skipped,
  5 todo, 0 failed.
- `npm audit` post-fix shows only pre-existing, unrelated advisories
  (brace-expansion, browserslist, nanoid, qs) — none of the 9 GHSAs in
  scope remain against fast-uri/ip-address/js-yaml.

## Test plan
- [x] `npm install` regenerates `package-lock.json` with patched resolutions
- [x] `npm ls <pkg> --all` shows no unpatched resolution sites
- [x] `npm run build` passes
- [x] `npm run build:mcp` passes
- [x] `npm test` full suite passes (396/396 suites, 0 failures)


🤖 Generated with [Claude Code](https://claude.com/claude-code)
