### PR TITLE
fix(consensus): count timed-out arms in the coverage denominator (#738)

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -805,6 +805,17 @@ export async function handleCollect(
 
       // Phase 2c: Check if native agents need external dispatch
       const nativePrompts = prompts.filter((p: any) => p.isNative);
+      // #738 — every synthesis entry point below is handed a completed-only
+      // array. Capture the arms that were dispatched but never completed
+      // (timed out / failed / still running at collect time) so the engine's
+      // coverage denominator means "arms dispatched", not "arms that arrived".
+      // Mirrors the auto-signal hygiene above: synthetic `_`-prefixed buckets
+      // (e.g. `_utility`) are internal dispatches, not consensus arms.
+      const lostAgents: string[] = Array.from(new Set(
+        allResults
+          .filter((r: any) => r.status !== 'completed' && r.agentId && !String(r.agentId).startsWith('_'))
+          .map((r: any) => String(r.agentId)),
+      ));
       if (nativePrompts.length === 0) {
         // Edge case: all native agents had no completed results — synthesize immediately
         consensusReport = await engine.synthesizeWithCrossReview(
@@ -812,6 +823,7 @@ export async function handleCollect(
           relayEntries,
           consensusId,
           relayCrossReviewSkipped,
+          { lostAgents },
         );
       } else {
         // Store pending round for native agents to complete.
@@ -822,6 +834,10 @@ export async function handleCollect(
         ctx.pendingConsensusRounds.set(consensusId, {
           consensusId,
           allResults: allResults.filter((r: any) => r.status === 'completed'),
+          // #738 — carried alongside the completed-only snapshot so the
+          // deferred synthesis paths (native completion + timeout) can still
+          // report the full dispatched count.
+          lostAgents,
           relayCrossReviewEntries: relayEntries,
           relayCrossReviewSkipped,
           pendingNativeAgents: new Set(nativePrompts.map((p: any) => p.agentId)),

--- a/apps/cli/src/handlers/relay-cross-review.ts
+++ b/apps/cli/src/handlers/relay-cross-review.ts
@@ -20,6 +20,8 @@ import type {
  */
 export interface TimeoutSynthesisSnapshot {
   allResults: TaskEntry[];
+  /** #738 — arms dispatched but never completed. `allResults` is completed-only. */
+  lostAgents?: readonly string[];
   relayCrossReviewEntries: CrossReviewEntry[];
   relayCrossReviewSkipped?: Array<{ agentId: string; reason: string }>;
   nativeCrossReviewEntries: CrossReviewEntry[];
@@ -68,6 +70,7 @@ export async function synthesizeTimeoutRound(
     allEntries,
     consensusId,
     snapshot.relayCrossReviewSkipped,
+    { lostAgents: snapshot.lostAgents ?? [] },
   );
 
   // Persist report
@@ -125,7 +128,7 @@ export function startConsensusTimeout(consensusId: string): void {
     // FIX 1: read roundStartSha BEFORE delete so mid-flight check has it.
     const roundStartShaForMidFlight = current.roundStartSha;
     // Delete round BEFORE async work to prevent double-synthesis race with concurrent relay
-    const snapshot = { allResults: current.allResults, relayCrossReviewEntries: current.relayCrossReviewEntries, relayCrossReviewSkipped: current.relayCrossReviewSkipped, nativeCrossReviewEntries: [...current.nativeCrossReviewEntries], resolutionRoots: current.resolutionRoots, roundContext: current.roundContext };
+    const snapshot = { allResults: current.allResults, lostAgents: current.lostAgents, relayCrossReviewEntries: current.relayCrossReviewEntries, relayCrossReviewSkipped: current.relayCrossReviewSkipped, nativeCrossReviewEntries: [...current.nativeCrossReviewEntries], resolutionRoots: current.resolutionRoots, roundContext: current.roundContext };
     // PR #270 v3 review (HIGH): seed the agent-id fallback BEFORE delete from
     // the EXHAUSTIVE participation set, not just the still-pending agents.
     // Covers two cases: (1) agents that never relayed (still in
@@ -329,6 +332,9 @@ export async function handleRelayCrossReview(
   const completionRoundStartSha = round.roundStartSha;
   const synthSnapshot = {
     allResults: round.allResults,
+    // #738 — round.allResults is completed-only; carry the lost arms so the
+    // final synthesis can report the true dispatched count.
+    lostAgents: round.lostAgents,
     relayCrossReviewEntries: round.relayCrossReviewEntries,
     relayCrossReviewSkipped: round.relayCrossReviewSkipped,
     nativeCrossReviewEntries: [...round.nativeCrossReviewEntries],
@@ -380,6 +386,7 @@ export async function handleRelayCrossReview(
       allCrossReviewEntries,
       synthSnapshot.consensusId,
       synthSnapshot.relayCrossReviewSkipped,
+      { lostAgents: synthSnapshot.lostAgents ?? [] },
     );
 
     // Persist report for dashboard
@@ -565,6 +572,9 @@ export function persistPendingConsensus(): void {
           id: r.id, agentId: r.agentId, task: r.task?.slice(0, 5000),
           status: r.status, result: r.result?.slice(0, 10000),
         })),
+        // #738 — persist the lost-arm ids so a /mcp reconnect doesn't silently
+        // restore a round whose coverage denominator is back to arrivals-only.
+        lostAgents: round.lostAgents ? [...round.lostAgents] : undefined,
         relayCrossReviewEntries: round.relayCrossReviewEntries,
         relayCrossReviewSkipped: round.relayCrossReviewSkipped,
         pendingNativeAgents: [...round.pendingNativeAgents],
@@ -617,6 +627,8 @@ export function restorePendingConsensus(projectRoot: string): void {
       ctx.pendingConsensusRounds.set(id, {
         consensusId: data.consensusId,
         allResults: data.allResults,
+        // Back-compat: rounds persisted before #738 have no lostAgents key.
+        lostAgents: Array.isArray(data.lostAgents) ? data.lostAgents : undefined,
         relayCrossReviewEntries: data.relayCrossReviewEntries || [],
         relayCrossReviewSkipped: data.relayCrossReviewSkipped,
         pendingNativeAgents: new Set(data.pendingNativeAgents || []),

--- a/apps/cli/src/mcp-context.ts
+++ b/apps/cli/src/mcp-context.ts
@@ -22,6 +22,14 @@ export interface NativeCrossReviewPrompt {
 export interface PendingConsensusRound {
   consensusId: string;
   allResults: any[];  // TaskEntry[]
+  /**
+   * #738 — agent ids that were dispatched into this round but never produced a
+   * completed result (timed out / errored / cancelled). `allResults` above is
+   * pre-filtered to `status === 'completed'`, so without this list the
+   * consensus engine's coverage denominator cannot see a lost arm and
+   * `consensus_coverage_degraded` can never fire for one.
+   */
+  lostAgents?: string[];
   relayCrossReviewEntries: CrossReviewEntry[];
   /** Relay agents whose phase-2 cross-review failed (quota / parse / network). Surfaced in the final report. */
   relayCrossReviewSkipped?: Array<{ agentId: string; reason: string }>;

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -3221,12 +3221,20 @@ Return only valid JSON.${skillsBlock}`;
    * Synthesize a consensus report from externally-provided cross-review entries.
    * Used in the two-phase flow where native agents perform their own cross-review
    * and feed results back via gossip_relay_cross_review.
+   *
+   * `options.lostAgents` (#738) — ids of arms that WERE dispatched but never
+   * produced a completed result (timed out, errored, cancelled). Every caller
+   * pre-filters `results` to `status === 'completed'` before reaching here, so
+   * without this list the coverage denominator below can only ever count arms
+   * that arrived: a lost arm was never in `results` to begin with and
+   * `consensus_coverage_degraded` could never fire for it.
    */
   async synthesizeWithCrossReview(
     results: TaskEntry[],
     crossReviewEntries: CrossReviewEntry[],
     consensusId: string,
     relayCrossReviewSkipped?: Array<{ agentId: string; reason: string }>,
+    options?: { lostAgents?: readonly string[] },
   ): Promise<ConsensusReport> {
     const report = await this.synthesize(results, crossReviewEntries, consensusId);
 
@@ -3279,15 +3287,32 @@ Return only valid JSON.${skillsBlock}`;
     // (non-empty, ~50 chars, zero analytical content) is also treated as dropped.
     const isDropped = (r: { result?: string }): boolean =>
       !r.result || r.result.trim().length === 0 || r.result.includes('[No response from');
-    const droppedAgents = results.filter(isDropped).map(r => r.agentId);
-    const received = results.length - droppedAgents.length;
-    if (results.length > 0 && droppedAgents.length > 0) {
-      const evidence = buildCoverageDegradedMessage({ received, expected: results.length, droppedAgents });
+    const emptyAgents = results.filter(isDropped).map(r => r.agentId);
+    // #738 — an arm that never arrived (timed out / errored) is dropped just as
+    // surely as one that arrived with zero content, but the caller filtered it
+    // out of `results` upstream. Fold the caller-supplied ids back in, deduped
+    // against the arms that DID arrive so a double-reporting caller cannot
+    // inflate the denominator.
+    const arrived = new Set(results.map(r => r.agentId));
+    const lostAgents = Array.from(new Set(options?.lostAgents ?? [])).filter(id => !arrived.has(id));
+    const droppedAgents = [...emptyAgents, ...lostAgents];
+    const expected = results.length + lostAgents.length;
+    const received = results.length - emptyAgents.length;
+    if (expected > 0 && droppedAgents.length > 0) {
+      const evidence = buildCoverageDegradedMessage({ received, expected, droppedAgents });
       report.signals.push({
         type: 'consensus', taskId: '', consensusId, signal: 'consensus_coverage_degraded',
         signal_class: 'operational', agentId: '_round', evidence, timestamp: new Date().toISOString(),
       });
       report.summary += `\n⚠️  ${evidence}\n`;
+      if (lostAgents.length > 0) {
+        // #738 direction 3, conservative form: do NOT rewrite tag semantics for
+        // the arms that did arrive — the tagging loop has no expected-participant
+        // denominator, so a lost arm's would-be dissent is simply absent from the
+        // tally and a finding a full round would have DISPUTED can surface as
+        // confirmed/unique. Say so instead of silently presenting full coverage.
+        report.summary += `   ↳ finding tags reflect only the ${received} arm(s) that returned — dissent from ${lostAgents.join(', ')} is absent from every confirmed/disputed tally.\n`;
+      }
       // Spec §4 — warnings channel subsumes the legacy report.coverageDegraded
       // field (deleted in PR-C). The structured drop count + dropped-agent list
       // travel in the warning message. Fires after synthesize()'s drain, so

--- a/tests/cli/consensus-lost-arms-plumbing.test.ts
+++ b/tests/cli/consensus-lost-arms-plumbing.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Issue #738 — CLI-side plumbing for the lost-arm coverage denominator.
+ *
+ * The engine-level behavior is covered in
+ * tests/orchestrator/consensus-coverage-lost-arms.test.ts. This file drives the
+ * REAL CLI seams that feed it, because that is where the bug actually lived:
+ * every caller pre-filters `allResults` to `status === 'completed'`, so the
+ * dispatched-but-lost arm ids have to survive (a) the timeout-synthesis
+ * snapshot and (b) a /mcp reconnect round-trip, or the denominator silently
+ * falls back to arrivals-only.
+ */
+import { mkdtempSync, rmSync, mkdirSync, realpathSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  synthesizeTimeoutRound,
+  persistPendingConsensus,
+  restorePendingConsensus,
+  type TimeoutSynthesisSnapshot,
+} from '../../apps/cli/src/handlers/relay-cross-review';
+import { ctx } from '../../apps/cli/src/mcp-context';
+import { parseCoverageDegradedMessage } from '../../packages/orchestrator/src/coverage-degraded';
+import type { TaskEntry } from '@gossip/orchestrator';
+
+const makeLlm = (): any => ({
+  generate: jest.fn(async () => ({ text: '[]', usage: { inputTokens: 0, outputTokens: 0 } })),
+});
+
+const completed = (agentId: string, result: string): TaskEntry => ({
+  id: `t-${agentId}`, agentId, task: 'review X', status: 'completed', result, startedAt: Date.now(),
+}) as TaskEntry;
+
+const finding = (text: string) =>
+  `<agent_finding type="finding" severity="high" category="data_integrity">${text}</agent_finding>`;
+
+describe('#738 — synthesizeTimeoutRound carries lostAgents into the coverage denominator', () => {
+  let tmp: string;
+  let origMainAgent: any;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'lost-arm-'));
+    origMainAgent = (ctx as any).mainAgent;
+    (ctx as any).mainAgent = { getAgentConfig: () => undefined } as any;
+  });
+
+  afterEach(() => {
+    (ctx as any).mainAgent = origMainAgent;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('a 3-arm round with 1 timed-out arm reports 2/3, not 2/2', async () => {
+    const proj = realpathSync(mkdtempSync(join(tmp, 'proj')));
+    const snapshot: TimeoutSynthesisSnapshot = {
+      allResults: [
+        completed('agent-a', finding('Missing token validation in auth.ts:10 allows bypass')),
+        completed('agent-b', finding('Missing input validation in router.ts:22 for user query')),
+      ],
+      // agent-c was dispatched into the round and never came back — it is
+      // absent from allResults by construction (completed-only snapshot).
+      lostAgents: ['agent-c'],
+      relayCrossReviewEntries: [],
+      nativeCrossReviewEntries: [],
+    };
+
+    const { report } = await synthesizeTimeoutRound(
+      snapshot, 'aaaabbbb-ccccdddd', ['agent-c'], makeLlm(), proj,
+    );
+
+    const signal = report.signals.find((s: any) => s.signal === 'consensus_coverage_degraded');
+    expect(signal).toBeDefined();
+    expect(parseCoverageDegradedMessage(signal!.evidence!)).toEqual({
+      received: 2, expected: 3, droppedAgents: ['agent-c'],
+    });
+  });
+
+  it('an all-arrived round still reports no degradation through the same seam', async () => {
+    const proj = realpathSync(mkdtempSync(join(tmp, 'proj2')));
+    const snapshot: TimeoutSynthesisSnapshot = {
+      allResults: [
+        completed('agent-a', finding('Missing token validation in auth.ts:10 allows bypass')),
+        completed('agent-b', finding('Missing input validation in router.ts:22 for user query')),
+      ],
+      lostAgents: [],
+      relayCrossReviewEntries: [],
+      nativeCrossReviewEntries: [],
+    };
+
+    const { report } = await synthesizeTimeoutRound(
+      snapshot, 'eeeeffff-00001111', [], makeLlm(), proj,
+    );
+
+    expect(report.signals.find((s: any) => s.signal === 'consensus_coverage_degraded')).toBeUndefined();
+  });
+});
+
+describe('#738 — PendingConsensusRound.lostAgents survives a reconnect round-trip', () => {
+  let tmp: string;
+  let origMainAgent: any;
+
+  // NOTE: deliberately no process.chdir here. Both functions take their root
+  // explicitly (persist via ctx.mainAgent.projectRoot, restore via argument),
+  // and chdir mutates worker-global state that sibling suites reading relative
+  // paths in the same jest worker can observe.
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'lost-arm-persist-'));
+    mkdirSync(join(tmp, '.gossip'), { recursive: true });
+    origMainAgent = (ctx as any).mainAgent;
+    (ctx as any).mainAgent = { projectRoot: tmp } as any;
+  });
+
+  afterEach(() => {
+    ctx.pendingConsensusRounds.clear();
+    (ctx as any).mainAgent = origMainAgent;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const baseRound = (id: string, lostAgents?: string[]) => ({
+    consensusId: id,
+    allResults: [],
+    ...(lostAgents !== undefined ? { lostAgents } : {}),
+    relayCrossReviewEntries: [],
+    pendingNativeAgents: new Set(['sonnet']),
+    participatingNativeAgents: new Set(['sonnet']),
+    nativeCrossReviewEntries: [],
+    deadline: Date.now() + 600_000,
+    createdAt: Date.now(),
+  }) as any;
+
+  it('persists and restores the lost-arm ids', () => {
+    const roundId = '11112222-33334444';
+    ctx.pendingConsensusRounds.set(roundId, baseRound(roundId, ['agent-c', 'agent-d']));
+    persistPendingConsensus();
+
+    ctx.pendingConsensusRounds.clear();
+    restorePendingConsensus(tmp);
+
+    expect(ctx.pendingConsensusRounds.get(roundId)!.lostAgents).toEqual(['agent-c', 'agent-d']);
+  });
+
+  it('restores undefined for a round persisted before #738 (back-compat)', () => {
+    const roundId = '55556666-77778888';
+    ctx.pendingConsensusRounds.set(roundId, baseRound(roundId));
+    persistPendingConsensus();
+
+    ctx.pendingConsensusRounds.clear();
+    restorePendingConsensus(tmp);
+
+    expect(ctx.pendingConsensusRounds.get(roundId)!.lostAgents).toBeUndefined();
+  });
+});

--- a/tests/orchestrator/consensus-coverage-lost-arms.test.ts
+++ b/tests/orchestrator/consensus-coverage-lost-arms.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Issue #738 — `consensus_coverage_degraded` could never fire for a timed-out arm.
+ *
+ * Every caller of `synthesizeWithCrossReview` pre-filters its results to
+ * `status === 'completed'` before the engine sees them (collect.ts round-proceeds
+ * gate + round snapshot, relay-cross-review.ts completion/timeout snapshots), and
+ * the detector then computed `expected` as `results.length` — i.e. the number of
+ * arms that ARRIVED. A 3-arm round where 1 arm timed out reached the engine as a
+ * 2-entry array, `expected` read 2, and the round looked like full coverage.
+ *
+ * The fix carries the dispatched-but-lost agent ids through as
+ * `options.lostAgents` so `expected` means "arms dispatched".
+ */
+import { ConsensusEngine, ConsensusEngineConfig } from '../../packages/orchestrator/src/consensus-engine';
+import { parseCoverageDegradedMessage } from '../../packages/orchestrator/src/coverage-degraded';
+import { testRound } from '../../packages/orchestrator/src/round-context';
+import { TaskEntry } from '../../packages/orchestrator/src/types';
+import { ILLMProvider } from '../../packages/orchestrator/src/llm-client';
+
+describe('#738 — coverage degradation counts arms that never arrived', () => {
+  const mockLlm: jest.Mocked<ILLMProvider> = { generate: jest.fn() };
+  const baseConfig = (): ConsensusEngineConfig => ({
+    llm: mockLlm,
+    registryGet: (id: string) => ({
+      id, provider: 'local' as const, model: 'test', preset: 'reviewer', skills: [] as string[],
+    }),
+    round: testRound(),
+  });
+
+  const completed = (agentId: string, result: string): TaskEntry => ({
+    id: `task-${agentId}`, agentId, task: 'review', status: 'completed' as const,
+    result, startedAt: Date.now(), completedAt: Date.now(),
+    inputTokens: 100, outputTokens: 200,
+  }) as TaskEntry;
+
+  const finding = (text: string) =>
+    `## Consensus Summary\n<agent_finding type="finding" severity="high">${text}</agent_finding>`;
+
+  /** The two arms that DID return in a nominally-3-arm round. */
+  const arrivedPair = (): TaskEntry[] => [
+    completed('agent-a', finding('Missing token validation in auth.ts:10 allows bypass')),
+    completed('agent-b', finding('Missing input validation in router.ts:22 for user query')),
+  ];
+
+  const coverageSignal = (report: { signals: Array<{ signal: string; evidence?: string; agentId?: string }> }) =>
+    report.signals.find(s => s.signal === 'consensus_coverage_degraded');
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('fires for a 3-arm round where 1 arm timed out — the lost arm is counted as dropped', async () => {
+    const engine = new ConsensusEngine(baseConfig());
+
+    // Exactly the shape collect.ts hands over: completed-only results, plus the
+    // id of the arm that was dispatched but never came back.
+    const report = await engine.synthesizeWithCrossReview(
+      arrivedPair(), [], 'lost0001-lost0001', undefined,
+      { lostAgents: ['agent-c'] },
+    );
+
+    const signal = coverageSignal(report);
+    expect(signal).toBeDefined();
+    expect(signal!.agentId).toBe('_round');
+
+    const parsed = parseCoverageDegradedMessage(signal!.evidence!);
+    expect(parsed).toEqual({ received: 2, expected: 3, droppedAgents: ['agent-c'] });
+
+    // Mirrored into the warnings channel + the human-readable summary.
+    const warn = (report.warnings ?? []).filter(w => w.code === 'coverage_degraded');
+    expect(warn).toHaveLength(1);
+    expect(warn[0].message).toContain('2/3');
+    expect(report.summary).toContain('Coverage degraded: 2/3');
+    expect(report.summary).toContain('agent-c');
+  });
+
+  it('does NOT fire when every dispatched arm arrived with content (no regression)', async () => {
+    const engine = new ConsensusEngine(baseConfig());
+    const results = [
+      ...arrivedPair(),
+      completed('agent-c', finding('Unbounded retry loop in queue.ts:88 exhausts the pool')),
+    ];
+
+    const report = await engine.synthesizeWithCrossReview(results, [], 'ok000001-ok000001', undefined, { lostAgents: [] });
+
+    expect(coverageSignal(report)).toBeUndefined();
+    expect((report.warnings ?? []).some(w => w.code === 'coverage_degraded')).toBe(false);
+  });
+
+  it('preserves the pre-existing empty-content detector when no arm was lost', async () => {
+    const engine = new ConsensusEngine(baseConfig());
+    const results = [...arrivedPair(), completed('agent-c', '')];
+
+    const report = await engine.synthesizeWithCrossReview(results, [], 'empt0001-empt0001');
+
+    const parsed = parseCoverageDegradedMessage(coverageSignal(report)!.evidence!);
+    expect(parsed).toEqual({ received: 2, expected: 3, droppedAgents: ['agent-c'] });
+  });
+
+  it('counts an empty-content arrival AND a lost arm together in one 4-arm round', async () => {
+    const engine = new ConsensusEngine(baseConfig());
+    const results = [...arrivedPair(), completed('agent-c', '   ')];
+
+    const report = await engine.synthesizeWithCrossReview(
+      results, [], 'both0001-both0001', undefined,
+      { lostAgents: ['agent-d'] },
+    );
+
+    const parsed = parseCoverageDegradedMessage(coverageSignal(report)!.evidence!);
+    expect(parsed!.received).toBe(2);
+    expect(parsed!.expected).toBe(4);
+    expect(parsed!.droppedAgents.sort()).toEqual(['agent-c', 'agent-d']);
+  });
+
+  it('does not inflate the denominator when a caller reports an arm that actually arrived', async () => {
+    const engine = new ConsensusEngine(baseConfig());
+
+    // Defensive: a buggy/duplicating caller lists an id that IS present in
+    // `results`. It must be ignored, not double-counted.
+    const report = await engine.synthesizeWithCrossReview(
+      arrivedPair(), [], 'dup00001-dup00001', undefined,
+      { lostAgents: ['agent-b', 'agent-c', 'agent-c'] },
+    );
+
+    const parsed = parseCoverageDegradedMessage(coverageSignal(report)!.evidence!);
+    expect(parsed).toEqual({ received: 2, expected: 3, droppedAgents: ['agent-c'] });
+  });
+
+  it('behaves exactly as before when the options argument is omitted', async () => {
+    const engine = new ConsensusEngine(baseConfig());
+    const report = await engine.synthesizeWithCrossReview(arrivedPair(), [], 'none0001-none0001');
+    expect(coverageSignal(report)).toBeUndefined();
+  });
+
+  it('warns that finding tags reflect only the arms that returned', async () => {
+    // Conservative form of issue direction 3: the tagging loop still has no
+    // expected-participant denominator, so a lost arm's would-be dissent is
+    // absent from every confirmed/disputed tally. Say so rather than presenting
+    // the tags as full-coverage.
+    const engine = new ConsensusEngine(baseConfig());
+    const report = await engine.synthesizeWithCrossReview(
+      arrivedPair(), [], 'tags0001-tags0001', undefined,
+      { lostAgents: ['agent-c'] },
+    );
+
+    expect(report.summary).toContain('finding tags reflect only the 2 arm(s) that returned');
+    expect(report.summary).toContain('agent-c');
+  });
+
+  it('omits the tag-coverage caveat when the only dropout arrived empty', async () => {
+    const engine = new ConsensusEngine(baseConfig());
+    const report = await engine.synthesizeWithCrossReview(
+      [...arrivedPair(), completed('agent-c', '')], [], 'noct0001-noct0001',
+    );
+
+    expect(report.summary).toContain('Coverage degraded: 2/3');
+    expect(report.summary).not.toContain('finding tags reflect only');
+  });
+});


### PR DESCRIPTION
Fixes #738

## The bug

`consensus_coverage_degraded` could never fire for an arm that timed out — the detector's expected-count denominator is computed *after* lost arms have already been filtered out.

Every caller of `synthesizeWithCrossReview` hands it a completed-only array:

- `apps/cli/src/handlers/collect.ts:455` — the round-proceeds gate is `allResults.filter(r => r.status === 'completed').length >= 2`, so a 3-arm round with 1 timed-out arm still proceeds.
- `apps/cli/src/handlers/collect.ts:811` / `:824` — both the immediate synthesis call and the pending-round snapshot pass `allResults.filter(r => r.status === 'completed')`.
- `apps/cli/src/handlers/relay-cross-review.ts:331` / `:379` — the two-phase relay paths read `round.allResults`, carrying the same pre-filtered shape through.

By the time `consensus-engine.ts:3280-3285` ran `expected: results.length`, a timed-out arm had never been in `results` to begin with. `expected` undercounted by exactly the number of lost arms, so the round looked like full coverage. The detector only ever caught agents that *arrived and returned empty content* (the Gemini `MALFORMED_FUNCTION_CALL` / `[No response from ...]` class), never agents that never arrived.

Reported by @GravyaDev; independently verified against the TS source before this fix.

## The fix

Carry the dispatched-but-lost agent ids alongside the completed-only array so `expected` means "arms dispatched" rather than "arms that arrived" — issue directions 1 and 2, which collapse into one change.

- **`collect.ts`** computes `lostAgents` once from the non-completed arms, skipping synthetic `_`-prefixed buckets (`_utility`) to mirror the auto-signal hygiene directly above it. Passed to the immediate synthesis call and stored on the pending round.
- **`relay-cross-review.ts`** threads it through both deferred synthesis paths (native completion + timeout watcher) and persists/restores it, so a `/mcp` reconnect does not silently revert a round to an arrivals-only denominator. Restore is back-compatible: rounds persisted before this change simply have no `lostAgents` key.
- **`consensus-engine.ts`** takes an optional `options.lostAgents`, dedupes it against the arms that *did* arrive so a double-reporting caller cannot inflate the count, and folds it into both `droppedAgents` and `expected`. Omitting the argument reproduces the previous behavior exactly.

The message format is untouched, so the `buildCoverageDegradedMessage` / `parseCoverageDegradedMessage` round-trip contract and the dashboard chip keep working — a 3-arm round with 1 lost arm now emits `Coverage degraded: 2/3 agents returned content (dropped: agent-c)` where it previously emitted nothing.

### On direction 3 (tagging loop)

Scoped conservatively. The per-finding tagging loop at `consensus-engine.ts:1566-1580` still has no expected-participant denominator — a lost arm's would-be dissent is simply absent from the tally, so a finding a complete round would have marked `disputed` can surface as `confirmed` or `unique`. Rather than invert tag semantics for the normal all-arms-arrived case, the summary now *says so* when an arm was lost:

```
⚠️  Coverage degraded: 2/3 agents returned content (dropped: agent-c)
   ↳ finding tags reflect only the 2 arm(s) that returned — dissent from agent-c is absent from every confirmed/disputed tally.
```

A real expected-participant denominator inside the tagging loop is a larger change to tag semantics and belongs in its own PR.

## Tests

`tests/orchestrator/consensus-coverage-lost-arms.test.ts` (8) — engine behavior, including the exact reported scenario: a 3-arm round with 1 timed-out arm now fires `consensus_coverage_degraded` with `{ received: 2, expected: 3, droppedAgents: ['agent-c'] }`. Also covers the all-arrived no-regression case, the pre-existing empty-content detector, empty-content and lost arms combined in one round, the caller-dedupe guard, and byte-identical behavior when `options` is omitted.

`tests/cli/consensus-lost-arms-plumbing.test.ts` (4) — drives the real CLI seams, since that is where the bug lived: `synthesizeTimeoutRound` reporting 2/3 rather than 2/2, and the persist/restore round-trip across a reconnect (including back-compat for pre-#738 records).

Verified at repo root: `npm run build`, `npm run build:mcp`, full `npm test` — 398 suites / 5621 passed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
