### PR TITLE
fix(consensus): surface tried roots on anchor miss, flag non-project cwd (#737)

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -106,6 +106,52 @@ export function findConfigPath(projectRoot?: string): string | null {
   return null;
 }
 
+/**
+ * Roots already reported by {@link warnIfNotProjectRoot}. Keeps the warning to
+ * one line per distinct root for the process lifetime instead of one per
+ * dispatch — the condition is a static property of the directory, so repeating
+ * it adds noise without adding information.
+ */
+const warnedNonProjectRoots = new Set<string>();
+
+/** Test-only: clear the {@link warnIfNotProjectRoot} dedup latch. */
+export function __resetProjectRootWarnings(): void {
+  warnedNonProjectRoots.clear();
+}
+
+/**
+ * Sanity-check the directory a citation-bearing ConsensusEngine is about to
+ * treat as the project root (issue #737 direction 3).
+ *
+ * Every `ConsensusEngine` is handed `process.cwd()` as its project root. When a
+ * single relay process serves more than one repository, that cwd can be some
+ * other project (or no project at all), and the resolver then fails every
+ * citation with a message indistinguishable from "the agent made the citation
+ * up". A missing gossipcat config under the root is a cheap, high-signal proxy
+ * for "this is not a gossipcat project root" — so we say so up front, at
+ * dispatch time, instead of leaving it to be discovered by investigation.
+ *
+ * Deliberately warn-only: dispatch must still proceed. Anchor resolution is a
+ * review-quality enhancement, not a precondition for running consensus, and a
+ * throw here would break legitimate config-less invocations.
+ *
+ * @returns true when the root looks like a real project root.
+ */
+export function warnIfNotProjectRoot(projectRoot: string, context = 'consensus'): boolean {
+  if (findConfigPath(projectRoot) !== null) return true;
+  if (!warnedNonProjectRoots.has(projectRoot)) {
+    warnedNonProjectRoots.add(projectRoot);
+    console.warn(
+      `[gossipcat] ⚠ project-root sanity check failed for ${context}: no gossipcat config` +
+      ` (.gossip/config.json or gossip.agents.json) found under "${projectRoot}".` +
+      ` Citation anchors will be resolved against this directory anyway, so cited files that` +
+      ` live in a different repository will be reported to cross-reviewers as "file not found".` +
+      ` If this relay serves multiple projects, start it from the project root you are reviewing.`,
+    );
+  }
+  return false;
+}
+
 export function loadConfig(configPath: string): GossipConfig {
   const raw = readFileSync(configPath, 'utf-8');
 

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -18,6 +18,7 @@ import type { RelayWarningEntry, RoundContext } from '@gossip/orchestrator';
 import { mkdirSync, appendFileSync } from 'node:fs';
 import { join as joinPath } from 'node:path';
 import { captureHeadSha } from './orchestrator-precondition-runner';
+import { warnIfNotProjectRoot } from '../config';
 
 /**
  * Schedule the per-skill checkEffectiveness runner as a detached, tracked
@@ -605,6 +606,12 @@ export async function handleCollect(
         projectRoot: process.cwd(),
         getSkillIndex: () => ctx.mainAgent.getSkillIndex(),
       });
+
+      // Issue #737: this engine resolves citation anchors against process.cwd().
+      // Flag a cwd that isn't a gossipcat project root NOW, at dispatch time —
+      // otherwise every unresolved citation downstream is indistinguishable from
+      // a fabricated one. Warn-only: consensus still runs.
+      warnIfNotProjectRoot(process.cwd(), 'gossip_collect cross-review');
 
       const engine = new ConsensusEngine({
         llm: mainLlm,

--- a/apps/cli/src/handlers/relay-cross-review.ts
+++ b/apps/cli/src/handlers/relay-cross-review.ts
@@ -48,6 +48,11 @@ export async function synthesizeTimeoutRound(
   projectRoot: string = process.cwd(),
 ): Promise<{ report: ConsensusReport; prompts: Array<{ system: string; user: string }> }> {
   const { ConsensusEngine, makeRoundContext } = await import('@gossip/orchestrator');
+  // Issue #737: timeout synthesis builds cross-review prompts, so this engine is
+  // citation-bearing. Surface a non-project-root before its anchors start
+  // failing. Warn-only — synthesis must not be blocked by the check.
+  const { warnIfNotProjectRoot } = await import('../config');
+  warnIfNotProjectRoot(projectRoot, 'consensus timeout synthesis');
   const round: RoundContext =
     snapshot.roundContext ?? makeRoundContext({ resolutionRoots: snapshot.resolutionRoots ?? [] });
   const engine: ConsensusEngineType = new ConsensusEngine({

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -62,6 +62,10 @@ const MIN_FINDINGS_PER_PEER = 2;
 const VALID_ACTIONS = new Set(['agree', 'disagree', 'unverified', 'new']);
 const ANCHOR_PATTERN = /(?:[a-zA-Z]:\/)?[\w./-]+\.(ts|js|tsx|jsx|py|go|rs|java|rb|md|json|yaml|yml|toml|sh):\d+/;
 const MAX_VERIFIER_TURNS = 7;
+/** Max roots named verbatim in an unresolved-citation annotation (issue #737). */
+const ANCHOR_ROOT_DISPLAY_LIMIT = 3;
+/** Per-root character cap in that annotation — bounds cross-review prompt growth. */
+const ANCHOR_ROOT_PATH_MAX_CHARS = 120;
 
 /**
  * Verification-scoped memory directive for the Phase-2 cross-review system
@@ -193,6 +197,14 @@ export class ConsensusEngine {
    * anchorPathCache in updateWorktreeRoots.
    */
   private anchorWarnedRefs = new Set<string>();
+  /**
+   * One-shot latch for the per-round "these are the roots I am resolving
+   * against" log line (issue #737 direction 2). Emitted lazily on the first
+   * anchor resolution of the round rather than in the constructor, so rounds
+   * with no citations stay silent. Reset in updateWorktreeRoots when the root
+   * set actually changes, so the logged roots always match the set in use.
+   */
+  private anchorRootsLogged = false;
   /**
    * Per-task worktree paths discovered from TaskEntry.worktreeInfo. Used as
    * additional file-resolution roots so consensus auto-anchor can find files
@@ -394,6 +406,9 @@ export class ConsensusEngine {
       this.fileCache.clear();
       this.anchorPathCache.clear();
       this.anchorWarnedRefs.clear();
+      // The root set changed — re-arm the one-shot root log so the next anchor
+      // resolution reports the roots actually in use (issue #737).
+      this.anchorRootsLogged = false;
     }
   }
 
@@ -436,6 +451,58 @@ export class ConsensusEngine {
     return roots;
   }
 
+  /**
+   * Prompt-safe, length-capped rendering of the roots the anchor resolver
+   * searches. Root paths are already validated (absolute, containment-checked)
+   * before they reach the engine, but this string is spliced into a
+   * cross-reviewer PROMPT, so it is sanitized the same way `safeRef` is:
+   * markup/quote/newline characters stripped so a pathological path cannot
+   * forge an `<anchor>` boundary. (issue #737)
+   */
+  private describeAnchorRoots(roots: string[], maxShown = ANCHOR_ROOT_DISPLAY_LIMIT): string {
+    if (roots.length === 0) return '(none)';
+    const shown = roots
+      .slice(0, maxShown)
+      .map((r) => r.replace(/[<>"`\r\n]/g, '').slice(0, ANCHOR_ROOT_PATH_MAX_CHARS));
+    const extra = roots.length - shown.length;
+    return extra > 0 ? `${shown.join(', ')} (+${extra} more)` : shown.join(', ');
+  }
+
+  /**
+   * Reviewer-facing annotation for an unresolvable citation.
+   *
+   * Before issue #737 this was a bare "but file not found", which is
+   * indistinguishable from "the resolver was anchored at the wrong project
+   * root" — the exact failure mode when one relay process serves several
+   * repos. Naming the tried roots lets the reviewer tell a fabricated citation
+   * apart from a misconfigured resolver instead of defaulting to UNVERIFIED.
+   */
+  private anchorMissAnnotation(safeRef: string, lineNum: number): string {
+    const roots = this.getAnchorPriorityRoots();
+    return (
+      `⚠ Agent cited \`${safeRef}:${lineNum}\` but file not found` +
+      ` — resolver searched ${roots.length} root(s): ${this.describeAnchorRoots(roots)}.` +
+      ` If the file exists outside those roots the resolver is anchored to the wrong project` +
+      ` (the citation may still be correct); otherwise the citation itself is wrong.`
+    );
+  }
+
+  /**
+   * Emit the resolver's own root list exactly once per round (issue #737
+   * direction 2). Answers "which directory did the resolver think was the
+   * project root?" from a single log line, instead of requiring per-citation
+   * forensics. Goes to stderr via console.warn — stdout is the MCP transport.
+   */
+  private logAnchorRootsOnce(roots: string[]): void {
+    if (this.anchorRootsLogged) return;
+    this.anchorRootsLogged = true;
+    console.warn(
+      `[consensus-engine] anchor resolution roots for this round` +
+      ` (projectRoot=${this.config.projectRoot ?? '(unset)'}):` +
+      ` [${roots.join(', ') || '(none)'}]`,
+    );
+  }
+
   private async cachedResolve(fileRef: string): Promise<string | null> {
     if (this.pathCache.has(fileRef)) return this.pathCache.get(fileRef)!;
     const resolved = await this.resolveFilePath(fileRef);
@@ -454,6 +521,7 @@ export class ConsensusEngine {
     // Cache hit: return immediately — no warning on cache-replay (memoized null).
     if (this.anchorPathCache.has(fileRef)) return this.anchorPathCache.get(fileRef)!;
     const priorityRoots = this.getAnchorPriorityRoots();
+    this.logAnchorRootsOnce(priorityRoots);
     const resolved = await this.resolveFilePath(fileRef, { priorityRoots });
     this.anchorPathCache.set(fileRef, resolved);
     // Emit a one-time warning only on the first genuine miss (not cache-replay).
@@ -1770,7 +1838,7 @@ Return only valid JSON.${skillsBlock}`;
         // BEFORE projectRoot so reviewers see the branch version of modified files.
         const filePath = await this.cachedResolveForAnchor(fullRef) ?? await this.cachedResolveForAnchor(bareFile);
         if (!filePath) {
-          anchors.push(`⚠ Agent cited \`${safeRef}:${lineNum}\` but file not found`);
+          anchors.push(this.anchorMissAnnotation(safeRef, lineNum));
           continue;
         }
         // Defense-in-depth: warn when the resolved path falls back to projectRoot

--- a/tests/cli/project-root-sanity-warning.test.ts
+++ b/tests/cli/project-root-sanity-warning.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Issue #737 direction 3 — flag a cwd that is not a real project root BEFORE a
+ * citation-bearing ConsensusEngine starts resolving anchors against it.
+ *
+ * `projectRoot: process.cwd()` is threaded into every ConsensusEngine with no
+ * check that the cwd is actually the project under review. When one relay
+ * process serves several repos, the resolver silently anchors at whichever repo
+ * happened to be cwd at startup and the failure surfaces much later as a wall
+ * of "file not found" citations. `warnIfNotProjectRoot` makes that condition
+ * loud at dispatch time — and deliberately does NOT throw, because anchor
+ * resolution is a review-quality enhancement, not a precondition for consensus.
+ */
+import { warnIfNotProjectRoot, findConfigPath, __resetProjectRootWarnings } from '../../apps/cli/src/config';
+import { synthesizeTimeoutRound, type TimeoutSynthesisSnapshot } from '../../apps/cli/src/handlers/relay-cross-review';
+import { ctx } from '../../apps/cli/src/mcp-context';
+import { makeRoundContext } from '@gossip/orchestrator';
+import type { TaskEntry } from '@gossip/orchestrator';
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('warnIfNotProjectRoot (#737)', () => {
+  let tmp: string;
+  let root: string;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'prs-'));
+    root = realpathSync(tmp);
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    __resetProjectRootWarnings();
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    __resetProjectRootWarnings();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const warnings = (): string[] =>
+    warnSpy.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('project-root sanity check'));
+
+  it('warns loudly (and does not throw) when the root holds no gossipcat config', () => {
+    const notARoot = join(root, 'random-dir');
+    mkdirSync(notARoot);
+    expect(findConfigPath(notARoot)).toBeNull();
+
+    expect(warnIfNotProjectRoot(notARoot, 'gossip_collect cross-review')).toBe(false);
+
+    const msgs = warnings();
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toContain(notARoot);
+    expect(msgs[0]).toContain('gossip_collect cross-review');
+    // The message must explain the downstream consequence, so the operator can
+    // connect it to the "file not found" citations they will see later.
+    expect(msgs[0]).toContain('file not found');
+  });
+
+  it('stays silent for a real project root (.gossip/config.json)', () => {
+    const realRoot = join(root, 'project');
+    mkdirSync(join(realRoot, '.gossip'), { recursive: true });
+    writeFileSync(join(realRoot, '.gossip', 'config.json'), '{}');
+
+    expect(warnIfNotProjectRoot(realRoot)).toBe(true);
+    expect(warnings()).toHaveLength(0);
+  });
+
+  it('accepts the legacy gossip.agents.json root form', () => {
+    const legacyRoot = join(root, 'legacy');
+    mkdirSync(legacyRoot);
+    writeFileSync(join(legacyRoot, 'gossip.agents.json'), '{}');
+
+    expect(warnIfNotProjectRoot(legacyRoot)).toBe(true);
+    expect(warnings()).toHaveLength(0);
+  });
+
+  it('reports a given bad root once, not once per dispatch', () => {
+    const notARoot = join(root, 'noisy');
+    mkdirSync(notARoot);
+
+    warnIfNotProjectRoot(notARoot);
+    warnIfNotProjectRoot(notARoot);
+    warnIfNotProjectRoot(notARoot);
+
+    expect(warnings()).toHaveLength(1);
+  });
+
+  it('reports each distinct bad root separately', () => {
+    const a = join(root, 'bad-a');
+    const b = join(root, 'bad-b');
+    mkdirSync(a);
+    mkdirSync(b);
+
+    warnIfNotProjectRoot(a);
+    warnIfNotProjectRoot(b);
+
+    const msgs = warnings();
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]).toContain(a);
+    expect(msgs[1]).toContain(b);
+  });
+});
+
+/**
+ * The reported scenario end-to-end, through the REAL exported timeout-synthesis
+ * core: a citation-bearing round whose projectRoot is some other directory.
+ * Both halves of the fix must be observable in one pass — the dispatch-time
+ * sanity warning AND the reviewer-facing annotation that names the searched
+ * roots.
+ */
+describe('citation-bearing round anchored at the wrong project root (#737)', () => {
+  let tmp: string;
+  let origMainAgent: any;
+  let warnSpy: jest.SpyInstance;
+
+  const makeLlm = (): any => ({
+    generate: jest.fn(async () => ({ text: '[]', usage: { inputTokens: 0, outputTokens: 0 } })),
+  });
+
+  const completed = (agentId: string, result: string): TaskEntry => ({
+    id: `t-${agentId}`,
+    agentId,
+    task: 'review billing',
+    status: 'completed',
+    result,
+    startedAt: Date.now(),
+  }) as TaskEntry;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'prs-e2e-'));
+    origMainAgent = (ctx as any).mainAgent;
+    (ctx as any).mainAgent = { getAgentConfig: () => undefined } as any;
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    __resetProjectRootWarnings();
+  });
+
+  afterEach(() => {
+    (ctx as any).mainAgent = origMainAgent;
+    warnSpy.mockRestore();
+    __resetProjectRootWarnings();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('warns about the bad root once and names it in the cross-review annotation', async () => {
+    // The relay's cwd-equivalent: a directory with no gossipcat config that does
+    // NOT contain the cited file.
+    const wrongRoot = realpathSync(mkdtempSync(join(tmp, 'other-repo')));
+    // The repo the citation actually belongs to — never searched.
+    const realRepo = realpathSync(mkdtempSync(join(tmp, 'real-repo')));
+    mkdirSync(join(realRepo, 'src'), { recursive: true });
+    writeFileSync(join(realRepo, 'src', 'billing.ts'), 'export const rate = 1;');
+
+    const snapshot: TimeoutSynthesisSnapshot = {
+      allResults: [
+        completed('agent-a', '<agent_finding type="finding" severity="high">Rate bug <cite tag="file">src/billing.ts:1</cite> and src/billing.ts:1</agent_finding>'),
+        completed('agent-b', '<agent_finding type="finding" severity="high">Same rate bug at src/billing.ts:1</agent_finding>'),
+      ],
+      relayCrossReviewEntries: [],
+      nativeCrossReviewEntries: [],
+      roundContext: makeRoundContext({ resolutionRoots: [], consensusId: 'deadbeef-0badf00d' }),
+    };
+
+    const { prompts } = await synthesizeTimeoutRound(
+      snapshot,
+      'deadbeef-0badf00d',
+      [],
+      makeLlm(),
+      wrongRoot,
+    );
+
+    // (3) dispatch-time sanity warning fired exactly once for the bad root.
+    const sanity = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('project-root sanity check'));
+    expect(sanity).toHaveLength(1);
+    expect(sanity[0]).toContain(wrongRoot);
+
+    // (2) the resolver's own root list is visible once, not per citation.
+    const rootLogs = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('anchor resolution roots for this round'));
+    expect(rootLogs).toHaveLength(1);
+    expect(rootLogs[0]).toContain(`projectRoot=${wrongRoot}`);
+
+    // (1) the reviewer-facing prompt distinguishes "wrong root" from "bad citation".
+    const all = prompts.map((p) => `${p.system}\n${p.user}`).join('\n');
+    expect(all).toContain('but file not found');
+    expect(all).toContain(wrongRoot);
+    expect(all).toContain('anchored to the wrong project');
+    expect(all).not.toContain(realRepo);
+  });
+});

--- a/tests/orchestrator/anchor-miss-root-diagnostics.test.ts
+++ b/tests/orchestrator/anchor-miss-root-diagnostics.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Issue #737 — an unresolvable citation must tell the cross-reviewer WHICH
+ * roots were searched.
+ *
+ * Reported scenario: one relay process serves several repos, so `projectRoot`
+ * (always `process.cwd()`) points at a directory that does not contain the
+ * cited file. The resolver knew the tried-roots list but sent it only to
+ * `console.warn`; the reviewer-facing annotation said a bare
+ * "but file not found", which is byte-identical to the message a genuinely
+ * fabricated citation produces. The reviewer has no way to tell the two apart
+ * and defaults to UNVERIFIED.
+ *
+ * These tests pin (1) the tried-roots list reaching the prompt annotation and
+ * (2) the once-per-round root log that makes the resolver's own notion of the
+ * project root visible without per-citation forensics.
+ */
+import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engine';
+import { testRound } from '../../packages/orchestrator/src/round-context';
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const makeLlm = (): any => ({
+  generate: jest.fn(async () => ({ text: '[]', usage: { inputTokens: 0, outputTokens: 0 } })),
+});
+
+const makeEngine = (projectRoot: string, resolutionRoots: string[] = []): any =>
+  new ConsensusEngine({
+    llm: makeLlm(),
+    registryGet: () => undefined,
+    projectRoot,
+    round: testRound({ resolutionRoots }),
+  });
+
+describe('anchor miss diagnostics (#737)', () => {
+  let tmp: string;
+  let root: string;
+  /** The repo the resolver is (wrongly) anchored at — does NOT hold the file. */
+  let wrongRepo: string;
+  /** The repo the citation actually refers to. */
+  let realRepo: string;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'amd-'));
+    root = realpathSync(tmp);
+    wrongRepo = join(root, 'other-project');
+    realRepo = join(root, 'real-project');
+    mkdirSync(wrongRepo, { recursive: true });
+    mkdirSync(join(realRepo, 'src'), { recursive: true });
+    writeFileSync(join(realRepo, 'src', 'billing.ts'), 'export const rate = 1;\n');
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('names the searched roots in the reviewer-facing annotation when the cwd is the wrong repo', async () => {
+    // Resolver anchored at a repo that does not contain the cited file — the
+    // citation itself is perfectly correct for `real-project`.
+    const engine = makeEngine(wrongRepo);
+
+    const out = await engine.snippetsForFinding('Rate is miscomputed at src/billing.ts:1');
+
+    expect(out).toContain('but file not found');
+    // The distinguishing information: what the resolver actually searched.
+    expect(out).toContain(wrongRepo);
+    expect(out).toContain('resolver searched 1 root(s)');
+    // And a hint that separates "wrong root" from "wrong citation".
+    expect(out).toMatch(/anchored to the wrong project/);
+    // The correct repo was never searched — that is the whole point.
+    expect(out).not.toContain(realRepo);
+  });
+
+  it('lists every priority root, worktree-first, so a reviewer sees the full search set', async () => {
+    const worktree = join(root, 'wt-feature');
+    mkdirSync(worktree, { recursive: true });
+    const engine = makeEngine(wrongRepo, [worktree]);
+
+    const out = await engine.snippetsForFinding('See src/billing.ts:1');
+
+    expect(out).toContain('resolver searched 2 root(s)');
+    // Worktree roots are checked before projectRoot (getAnchorPriorityRoots).
+    expect(out.indexOf(worktree)).toBeLessThan(out.indexOf(wrongRepo));
+  });
+
+  it('caps the rendered root list so a many-root round cannot bloat the prompt', async () => {
+    const worktrees = ['a', 'b', 'c', 'd', 'e'].map((n) => {
+      const p = join(root, `wt-${n}`);
+      mkdirSync(p, { recursive: true });
+      return p;
+    });
+    const engine = makeEngine(wrongRepo, worktrees);
+
+    const out = await engine.snippetsForFinding('See src/billing.ts:1');
+
+    expect(out).toContain('resolver searched 6 root(s)');
+    expect(out).toContain('(+3 more)');
+  });
+
+  it('still resolves normally when the root IS correct (no diagnostic noise)', async () => {
+    const engine = makeEngine(realRepo);
+
+    const out = await engine.snippetsForFinding('Rate is miscomputed at src/billing.ts:1');
+
+    expect(out).toContain('<anchor src="src/billing.ts:1"');
+    expect(out).not.toContain('but file not found');
+  });
+
+  it('emits the resolver root list exactly once per round, not once per citation', async () => {
+    const engine = makeEngine(wrongRepo);
+
+    await engine.snippetsForFinding('alpha.ts:1 and beta.ts:2 and gamma.ts:3');
+    await engine.snippetsForFinding('delta.ts:4');
+
+    const rootLogs = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('anchor resolution roots for this round'));
+
+    expect(rootLogs).toHaveLength(1);
+    expect(rootLogs[0]).toContain(`projectRoot=${wrongRepo}`);
+    expect(rootLogs[0]).toContain(wrongRepo);
+  });
+
+  it('re-arms the root log when the round changes its root set', async () => {
+    const engine = makeEngine(wrongRepo);
+    await engine.snippetsForFinding('alpha.ts:1');
+
+    const worktree = join(root, 'wt-late');
+    mkdirSync(worktree, { recursive: true });
+    // updateWorktreeRoots is the single place the root set can change.
+    engine.updateWorktreeRoots([], [worktree]);
+    await engine.snippetsForFinding('alpha.ts:1');
+
+    const rootLogs = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('anchor resolution roots for this round'));
+
+    expect(rootLogs).toHaveLength(2);
+    expect(rootLogs[1]).toContain(worktree);
+  });
+
+  it('sanitizes root paths before splicing them into the prompt annotation', async () => {
+    // A root whose name carries markup must not be able to forge an <anchor>
+    // boundary inside the cross-review prompt.
+    const nasty = join(root, 'we"ird<repo>');
+    mkdirSync(nasty, { recursive: true });
+    const engine = makeEngine(nasty);
+
+    const out = await engine.snippetsForFinding('See src/billing.ts:1');
+
+    expect(out).toContain('but file not found');
+    expect(out).toContain('weirdrepo');
+    expect(out).not.toContain('<repo>');
+    expect(out).not.toContain('we"ird');
+  });
+});


### PR DESCRIPTION
Fixes #737

## The problem

When the anchor resolver cannot find a cited file, the cross-reviewer sees:

```
⚠ Agent cited `src/billing.ts:42` but file not found
```

That message is byte-identical whether the agent fabricated the citation or the resolver was simply looking in the wrong repository. The reviewer has no way to tell the two apart, so the finding gets tagged UNVERIFIED and a correct citation is discarded.

The resolver already computed the exact list of roots it searched — it just sent that list to `console.warn` and dropped it before building the reviewer's prompt. Separately, `projectRoot` is `process.cwd()` at every `ConsensusEngine` construction, with no check that the cwd is actually a project root. In any deployment where one relay process serves more than one repo (a single user-scoped MCP registration across several projects), the resolver silently anchors to whichever repo happened to be cwd at startup.

Verified against `master` before changing anything: `packages/orchestrator/src/consensus-engine.ts` had the `rootList` in `cachedResolveForAnchor`'s `console.warn` and a bare, root-free annotation in `snippetsForFinding`. No existing test asserted either string.

## The fix

**1. The tried-roots list reaches the reviewer.** A new `anchorMissAnnotation` builds the miss message from `getAnchorPriorityRoots()`:

```
⚠ Agent cited `src/billing.ts:42` but file not found — resolver searched 2 root(s):
/repos/other-project, /repos/other-project/.claude/worktrees/wt-1. If the file exists
outside those roots the resolver is anchored to the wrong project (the citation may
still be correct); otherwise the citation itself is wrong.
```

Rendering is capped (3 roots named, 120 chars each, `(+N more)` beyond that) so a many-root round cannot bloat the cross-review prompt, and root paths are stripped of `< > " ` ` and newlines — the same sanitization `safeRef` already gets, since this string is spliced into a prompt and a pathological path must not be able to forge an `<anchor>` boundary.

**2. One root-list log line per round.** `logAnchorRootsOnce` prints the resolver's `projectRoot` and full priority root list, fired lazily on the first anchor resolution rather than in the constructor — rounds with no citations stay silent, and rounds with fifty citations still log once. The latch is re-armed in `updateWorktreeRoots` when the root set actually changes, so the logged roots always match the set in use. Goes to stderr via `console.warn`; stdout is the MCP transport.

**3. Non-project cwd is flagged at dispatch time.** `warnIfNotProjectRoot` (new, in `apps/cli/src/config.ts` next to `findConfigPath`) runs before the two citation-bearing `ConsensusEngine` constructions — `gossip_collect` cross-review and timeout synthesis — and warns once per distinct bad root, naming the downstream consequence so an operator can connect the warning to the "file not found" citations they will see later.

This is warn-only, never a throw. Anchor resolution is a review-quality enhancement, not a precondition for running consensus, and a throw would break legitimate config-less invocations. The other three `ConsensusEngine` sites are untouched: `relay-cross-review.ts:227` is parse-only and `:363` calls `synthesizeWithCrossReview`, neither of which reaches `snippetsForFinding`; `consensus-coordinator.ts` lives in `packages/orchestrator` and cannot import from `apps/cli`, and is covered by fix 2 regardless.

## Deliberately out of scope

**Direction 4 of the issue — accepting a caller-supplied project root — is not implemented here.** That means: no `projectRoot`/`cwd` parameter added to the `gossip_dispatch` or `gossip_collect` zod schemas, no change to where `validateResolutionRoot` anchors its check, and `validateResolutionRoot` itself untouched.

That is a breaking schema change and a real architecture decision about whether the relay should trust a caller-declared root at all — including what it means for the path-containment guarantees `resolutionRoots` currently provides. It wants separate human sign-off and its own PR, not a ride-along on a diagnostics fix. Directions 1-3 are independently valuable: they turn a silent, indistinguishable failure into a loud, self-describing one, which is most of the cost of the reported bug.

## Tests

`tests/orchestrator/anchor-miss-root-diagnostics.test.ts` (7) reproduces the reported scenario directly — `projectRoot` pointed at a repo that does not hold the cited file, while the file exists in a sibling repo that is never searched. Asserts the annotation names the searched roots and not the unsearched one, worktree-first ordering is visible, the cap engages at 6 roots, a correct root produces a clean `<anchor>` with no diagnostic noise, the root log fires exactly once across multiple `snippetsForFinding` calls, it re-arms on a root-set change, and markup in a root path is sanitized out.

`tests/cli/project-root-sanity-warning.test.ts` (6) covers `warnIfNotProjectRoot` (both config forms, dedup per root, distinct roots reported separately, no throw) plus an end-to-end pass through the real exported `synthesizeTimeoutRound` seam asserting all three fixes are observable together: the sanity warning fires once, the root log fires once, and the resulting cross-review prompt carries the wrong root by name.

Verified at repo root (not a worktree): `npm run build`, `npm run build:mcp`, full `npm test` — 398 suites, 5622 passed, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
