### PR TITLE
fix(relay): stop phantom task_timeout after MCP reconnect (#736)

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -231,6 +231,35 @@ export function isFindingAlreadySignaled(
   return alreadySignaled.has(composite) || alreadySignaled.has(finding.originalAgentId);
 }
 
+/**
+ * Given the taskIds a caller currently reports as `timed_out`, and the raw
+ * contents of `.gossip/agent-performance.jsonl`, return the subset that
+ * already have a `task_completed` signal on the ledger — i.e. phantom
+ * timeouts from a task that was restored as `timed_out` after an MCP
+ * reconnect/restart (`restoreRelayTasksAsFailed` / `restoreNativeTaskMap`)
+ * but had actually already finished, not real timeouts (#736).
+ *
+ * Pure and side-effect free so it's unit-testable without booting the full
+ * `handleCollect` context — the JSONL read/import stays at the call site.
+ */
+export function findPhantomTimeoutIds(
+  timedOutIds: ReadonlySet<string>,
+  perfJsonlRaw: string | undefined | null,
+): Set<string> {
+  const completed = new Set<string>();
+  if (!perfJsonlRaw || timedOutIds.size === 0) return completed;
+  for (const line of perfJsonlRaw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const row = JSON.parse(line);
+      if (row && row.signal === 'task_completed' && typeof row.taskId === 'string' && timedOutIds.has(row.taskId)) {
+        completed.add(row.taskId);
+      }
+    } catch { /* tolerate a torn/rotated line — skip it */ }
+  }
+  return completed;
+}
+
 export async function handleCollect(
   task_ids: string[],
   timeout_ms: number,
@@ -389,12 +418,37 @@ export async function handleCollect(
     const scopedResults = requestedIds
       ? allResults.filter((r: any) => requestedIds.includes(r.id))
       : allResults;
+    // #736: a task restored from relay-tasks.json / native-task-map after an
+    // MCP reconnect (restoreRelayTasksAsFailed / restoreNativeTaskMap) is
+    // unconditionally marked status:'timed_out', even when it actually
+    // completed before the restart and already has a `task_completed` signal
+    // on the ledger — pruneRelayTaskRecord narrows that race but can't close
+    // it entirely (a restart mid-write, or a native task, isn't covered).
+    // Cross-check the ledger before trusting 'timed_out' at face value so we
+    // don't record a `task_timeout` signal that contradicts a real
+    // `task_completed` already on disk. Scoped to 'timed_out' only — a
+    // 'completed' result with empty content legitimately gets task_empty
+    // alongside its own real task_completed, so this must not suppress that.
+    const timedOutIds = new Set(
+      scopedResults.filter((r: any) => r.status === 'timed_out').map((r: any) => r.id)
+    );
+    let completedTaskIds: Set<string> = new Set();
+    if (timedOutIds.size > 0) {
+      try {
+        const { readJsonlWithRotated } = await import('@gossip/orchestrator');
+        const perfPath = joinPath(process.cwd(), '.gossip', 'agent-performance.jsonl');
+        completedTaskIds = findPhantomTimeoutIds(timedOutIds, readJsonlWithRotated(perfPath));
+      } catch { /* best-effort — fail open: still emit task_timeout if the read fails */ }
+    }
     const failedResults = scopedResults.filter((r: any) =>
       !String(r.agentId || '').startsWith('_') &&
       (r.status === 'failed' ||
-        r.status === 'timed_out' ||
+        (r.status === 'timed_out' && !completedTaskIds.has(r.id)) ||
         (r.status === 'completed' && (!r.result || r.result.trim().length === 0 || r.result.includes('[No response from'))))
     );
+    if (completedTaskIds.size > 0) {
+      process.stderr.write(`[gossipcat] ↩️  Suppressed ${completedTaskIds.size} phantom task_timeout signal(s) — task_completed already on ledger (#736): ${[...completedTaskIds].join(', ')}\n`);
+    }
     if (failedResults.length > 0) {
       const { emitConsensusSignals } = await import('@gossip/orchestrator');
       const now = Date.now();

--- a/apps/cli/src/handlers/relay-tasks.ts
+++ b/apps/cli/src/handlers/relay-tasks.ts
@@ -130,13 +130,25 @@ export function restoreRelayTasksAsFailed(projectRoot: string): void {
         timeoutMs: r.timeoutMs,
       });
 
-      // Immediately mark as timed_out — we can't resume WebSocket streams
+      // Immediately mark as timed_out — we can't resume WebSocket streams.
+      //
+      // NOTE (#736): the record surviving on disk only proves the in-memory
+      // pipeline state was lost across an MCP reconnect/restart — it is
+      // equally consistent with "the task actually finished but hadn't been
+      // pruned from relay-tasks.json yet" (see dispatch-pipeline.ts's
+      // pruneRelayTaskRecord, which narrows but does not eliminate that
+      // window) as with a genuine mid-flight restart. Don't assert a cause
+      // we didn't observe, and don't unconditionally push re-dispatch —
+      // re-running a task that already completed just burns quota, and
+      // re-dispatch can't help at all if the underlying failure was e.g. an
+      // auth error. collect.ts cross-checks the signal ledger before it
+      // reports this as a timeout (see task_completed guard there).
       ctx.nativeResultMap.set(r.id, {
         id: r.id,
         agentId: r.agentId,
         task: r.task,
         status: 'timed_out',
-        error: `Relay task lost — MCP server restarted during execution. Re-dispatch with gossip_run to retry.`,
+        error: `Relay task state lost across an MCP reconnect/restart — the task may have already completed. Check task history before re-dispatching with gossip_run.`,
         startedAt: r.startedAt,
         completedAt: now,
       });

--- a/packages/orchestrator/src/dispatch-pipeline.ts
+++ b/packages/orchestrator/src/dispatch-pipeline.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { existsSync, readFileSync, mkdirSync, realpathSync, appendFileSync, statSync } from 'fs';
+import { existsSync, readFileSync, mkdirSync, realpathSync, appendFileSync, statSync, writeFileSync, renameSync } from 'fs';
 import { resolve as resolvePath, join } from 'path';
 import { AgentConfig, DispatchOptions, TaskEntry, TaskExecutionResult, PlanState, MIN_AGENTS_FOR_CONSENSUS } from './types';
 import { WorkerAgent } from './worker-agent';
@@ -586,6 +586,10 @@ export class DispatchPipeline {
                 timestamp: new Date().toISOString(),
               }) + '\n');
             } catch { /* best-effort visibility — never crash dispatch on log/write failure */ }
+            // Prune this task from relay-tasks.json now that it's actually done —
+            // stops it from looking "running" on disk if an MCP reconnect lands
+            // before the next dispatch/collect call rewrites the file (#736).
+            this.pruneRelayTaskRecord(entry.id);
             // Emit task_completed + task_tool_turns + format_compliance + finding_dropped_format
             // via shared helper — eliminates native/relay signal-pipeline drift.
             emitCompletionSignals(this.projectRoot, {
@@ -626,6 +630,10 @@ export class DispatchPipeline {
                 error: event.payload.error,
                 timestamp: new Date().toISOString(),
               }) + '\n');
+              // Prune this task from relay-tasks.json — symmetric with the
+              // FINAL_RESULT path above (#736): a failed task is equally "done",
+              // not "running", and should stop looking that way on disk.
+              this.pruneRelayTaskRecord(entry.id);
               // Emit task_completed with error:true so downstream scorers get failure-rate
               // and latency data from relay tasks (consensus bac850a6-eeb048e3, f2).
               emitCompletionSignals(this.projectRoot, {
@@ -669,6 +677,45 @@ export class DispatchPipeline {
         ...(t.resolutionRoots && t.resolutionRoots.length > 0 ? { resolutionRoots: t.resolutionRoots } : {}),
         ...(t.images && t.images.length > 0 ? { images: [...t.images] } : {}),
       }));
+  }
+
+  /**
+   * Prune a single relay task record from `.gossip/relay-tasks.json` the
+   * moment it finishes (completed or failed) — issue #736.
+   *
+   * `apps/cli/src/handlers/relay-tasks.ts:persistRelayTasks()` only ever
+   * *rewrites the whole file* from `getRunningTaskRecords()` above, and it is
+   * only called from dispatch/collect call sites, not from this completion
+   * path (this package cannot import apps/cli — that would be a package
+   * layering violation). So a relay task that finishes here stays "running"
+   * on disk until the next unrelated dispatch/collect happens to run
+   * `persistRelayTasks()` again. If an MCP reconnect/restart lands in that
+   * window, `restoreRelayTasksAsFailed()` resurrects the already-finished
+   * task as a phantom `timed_out` record, which `collect.ts` then reports as
+   * a false `task_timeout` signal even though the task genuinely completed.
+   *
+   * Uses the same raw-fs-via-`join(this.projectRoot, '.gossip', ...)` pattern
+   * as the `task-graph.jsonl` append above — the established way for this
+   * package to touch `.gossip/` without importing apps/cli. Mirrors
+   * `persistRelayTasks()`'s atomic tmp-then-rename write so a killed process
+   * never leaves a torn `relay-tasks.json` for the next boot to choke on.
+   * Best-effort: pruning is an optimization (narrows the race window to
+   * "mid-flight" tasks only), not a correctness requirement — collect.ts's
+   * own task_completed check is the correctness backstop for whatever slips
+   * through.
+   */
+  private pruneRelayTaskRecord(taskId: string): void {
+    try {
+      const relayTasksPath = join(this.projectRoot, '.gossip', 'relay-tasks.json');
+      if (!existsSync(relayTasksPath)) return;
+      const raw = JSON.parse(readFileSync(relayTasksPath, 'utf-8')) as { tasks?: Array<{ id: string }> };
+      const tasks = raw.tasks || [];
+      if (!tasks.some((t) => t.id === taskId)) return; // nothing to prune — avoid a needless write
+      const filtered = tasks.filter((t) => t.id !== taskId);
+      const tmp = `${relayTasksPath}.${process.pid}.tmp`;
+      writeFileSync(tmp, JSON.stringify({ tasks: filtered }));
+      renameSync(tmp, relayTasksPath);
+    } catch { /* best-effort — never crash dispatch on relay-tasks.json prune failure */ }
   }
 
   /** Get a health summary of all active tasks — for diagnostics when user asks "is it working?" */

--- a/tests/cli/collect-phantom-timeout.test.ts
+++ b/tests/cli/collect-phantom-timeout.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for issue #736 — a relay/native task that actually completed before
+ * an MCP reconnect/restart gets restored as `timed_out`
+ * (restoreRelayTasksAsFailed / restoreNativeTaskMap), and collect.ts's
+ * auto-signal step (Step 3.5) then reports a phantom `task_timeout` even
+ * though a real `task_completed` signal is already on the ledger for the
+ * same taskId.
+ *
+ * `findPhantomTimeoutIds` is the pure guard collect.ts consults before
+ * deciding whether a `timed_out` result should actually emit `task_timeout`.
+ */
+import { findPhantomTimeoutIds } from '../../apps/cli/src/handlers/collect';
+
+function jsonl(rows: Array<Record<string, unknown>>): string {
+  return rows.map((r) => JSON.stringify(r)).join('\n') + '\n';
+}
+
+describe('findPhantomTimeoutIds — #736 phantom task_timeout guard', () => {
+  it('returns empty when there are no timed-out candidates, even with a matching ledger row', () => {
+    const raw = jsonl([{ signal: 'task_completed', taskId: 'abc123', agentId: 'agent-1' }]);
+    expect(findPhantomTimeoutIds(new Set(), raw)).toEqual(new Set());
+  });
+
+  it('returns empty when the ledger has no rows at all (real timeout, nothing on disk)', () => {
+    expect(findPhantomTimeoutIds(new Set(['abc123']), '')).toEqual(new Set());
+    expect(findPhantomTimeoutIds(new Set(['abc123']), undefined)).toEqual(new Set());
+    expect(findPhantomTimeoutIds(new Set(['abc123']), null)).toEqual(new Set());
+  });
+
+  it('flags a taskId as phantom when a task_completed row already exists for it', () => {
+    const raw = jsonl([
+      { signal: 'task_completed', taskId: 'abc123', agentId: 'agent-1' },
+      { signal: 'task_completed', taskId: 'other-task', agentId: 'agent-2' },
+    ]);
+    const result = findPhantomTimeoutIds(new Set(['abc123']), raw);
+    expect(result).toEqual(new Set(['abc123']));
+  });
+
+  it('does not flag a taskId with no matching task_completed row (a real timeout)', () => {
+    const raw = jsonl([{ signal: 'task_completed', taskId: 'unrelated-task', agentId: 'agent-1' }]);
+    expect(findPhantomTimeoutIds(new Set(['abc123']), raw)).toEqual(new Set());
+  });
+
+  it('ignores other signal types for the same taskId — only task_completed counts', () => {
+    const raw = jsonl([
+      { signal: 'disagreement', taskId: 'abc123', agentId: 'agent-1' },
+      { signal: 'hallucination_caught', taskId: 'abc123', agentId: 'agent-1' },
+    ]);
+    expect(findPhantomTimeoutIds(new Set(['abc123']), raw)).toEqual(new Set());
+  });
+
+  it('handles multiple timed-out candidates, flagging only the ones with a real completion', () => {
+    const raw = jsonl([
+      { signal: 'task_completed', taskId: 'task-a', agentId: 'agent-1' },
+    ]);
+    const result = findPhantomTimeoutIds(new Set(['task-a', 'task-b']), raw);
+    expect(result).toEqual(new Set(['task-a']));
+  });
+
+  it('tolerates a torn/unparseable line without throwing and still finds the valid rows', () => {
+    const raw = '{"signal": "task_completed", "taskId": "abc123", "agentId": "agent-1"}\n{not valid json\n';
+    expect(() => findPhantomTimeoutIds(new Set(['abc123']), raw)).not.toThrow();
+    expect(findPhantomTimeoutIds(new Set(['abc123']), raw)).toEqual(new Set(['abc123']));
+  });
+
+  it('ignores blank lines between rows', () => {
+    const raw = '\n{"signal": "task_completed", "taskId": "abc123", "agentId": "agent-1"}\n\n';
+    expect(findPhantomTimeoutIds(new Set(['abc123']), raw)).toEqual(new Set(['abc123']));
+  });
+});

--- a/tests/cli/relay-tasks.test.ts
+++ b/tests/cli/relay-tasks.test.ts
@@ -141,7 +141,10 @@ describe('relay-tasks', () => {
 
       const result = ctx.nativeResultMap.get(task.id);
       expect(result?.status).toBe('timed_out');
-      expect(result?.error).toContain('MCP server restarted');
+      // #736: message must describe what was actually observed (state lost
+      // across a reconnect), not assert an unverified restart cause.
+      expect(result?.error).toContain('state lost across an MCP reconnect');
+      expect(result?.error).not.toContain('MCP server restarted during execution');
 
       expect(stderrWriteSpy).toHaveBeenCalledWith(expect.stringContaining(`Restored 1 relay task(s)`));
       expect(fs.unlinkSync).toHaveBeenCalledWith(filePath);

--- a/tests/orchestrator/dispatch-pipeline.test.ts
+++ b/tests/orchestrator/dispatch-pipeline.test.ts
@@ -628,4 +628,91 @@ describe('DispatchPipeline', () => {
       expect(compliance.findingCount).toBe(0);
     });
   });
+
+  describe('pruneRelayTaskRecord (#736 — prune on completion, not just next dispatch/collect)', () => {
+    const fs = require('fs');
+    const path = require('path');
+
+    function seedRelayTasksFile(tmpDir: string, records: Array<Record<string, unknown>>) {
+      const dir = path.join(tmpDir, '.gossip');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'relay-tasks.json'), JSON.stringify({ tasks: records }));
+    }
+
+    function readRelayTasksFile(tmpDir: string): { tasks: Array<{ id: string }> } {
+      return JSON.parse(fs.readFileSync(path.join(tmpDir, '.gossip', 'relay-tasks.json'), 'utf-8'));
+    }
+
+    it('removes the task record from relay-tasks.json the moment a relay task completes', async () => {
+      const tmpDir = '/tmp/gossip-prune-completed-' + Date.now();
+      const p = new DispatchPipeline({
+        projectRoot: tmpDir,
+        workers: new Map([['test-agent', mockWorker('ok')]]),
+        registryGet: () => mockRegistryGet(),
+      });
+
+      // Seed relay-tasks.json BEFORE the task resolves — simulating the record
+      // written by an earlier persistRelayTasks() call while this task was
+      // still running (dispatch.ts / collect.ts call sites).
+      const { taskId, finalResultPromise } = p.dispatch('test-agent', 'task 1');
+      seedRelayTasksFile(tmpDir, [
+        { id: taskId, agentId: 'test-agent', task: 'task 1', startedAt: Date.now(), timeoutMs: 300_000 },
+        { id: 'unrelated-task', agentId: 'other-agent', task: 'other', startedAt: Date.now(), timeoutMs: 300_000 },
+      ]);
+
+      await finalResultPromise;
+
+      const { tasks } = readRelayTasksFile(tmpDir);
+      expect(tasks.find((t) => t.id === taskId)).toBeUndefined();
+      // Unrelated in-flight records are left alone — this is a targeted prune,
+      // not a blanket rewrite from getRunningTaskRecords().
+      expect(tasks.find((t) => t.id === 'unrelated-task')).toBeDefined();
+
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('removes the task record from relay-tasks.json when a relay task fails', async () => {
+      const tmpDir = '/tmp/gossip-prune-failed-' + Date.now();
+      const failingWorker = {
+        executeTask: jest.fn().mockImplementation(async function* () {
+          yield { type: 'error', payload: { error: 'boom' }, timestamp: Date.now() };
+        }),
+        subscribeToBatch: jest.fn().mockResolvedValue(undefined),
+        unsubscribeFromBatch: jest.fn().mockResolvedValue(undefined),
+      };
+      const p = new DispatchPipeline({
+        projectRoot: tmpDir,
+        workers: new Map([['test-agent', failingWorker]]),
+        registryGet: () => mockRegistryGet(),
+      });
+
+      const { taskId, finalResultPromise } = p.dispatch('test-agent', 'task 1');
+      seedRelayTasksFile(tmpDir, [
+        { id: taskId, agentId: 'test-agent', task: 'task 1', startedAt: Date.now(), timeoutMs: 300_000 },
+      ]);
+
+      await expect(finalResultPromise).rejects.toThrow('boom');
+
+      const { tasks } = readRelayTasksFile(tmpDir);
+      expect(tasks.find((t) => t.id === taskId)).toBeUndefined();
+
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('is a no-op (does not throw) when relay-tasks.json does not exist', async () => {
+      const tmpDir = '/tmp/gossip-prune-missing-' + Date.now();
+      const p = new DispatchPipeline({
+        projectRoot: tmpDir,
+        workers: new Map([['test-agent', mockWorker('ok')]]),
+        registryGet: () => mockRegistryGet(),
+      });
+
+      const { finalResultPromise } = p.dispatch('test-agent', 'task 1');
+      await expect(finalResultPromise).resolves.toBeDefined();
+
+      expect(fs.existsSync(path.join(tmpDir, '.gossip', 'relay-tasks.json'))).toBe(false);
+
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #736

## Problem

Reported externally by @GravyaDev: a relay task that completes successfully can still show up as a `task_timeout` signal after an MCP reconnect/restart, misrepresenting a real completion as a failure.

## Root cause

`getRunningTaskRecords()` (`packages/orchestrator/src/dispatch-pipeline.ts`) only ever snapshots tasks with `status === 'running'`, and `.gossip/relay-tasks.json` is only rewritten from that snapshot by `persistRelayTasks()` (`apps/cli/src/handlers/relay-tasks.ts`), which runs at dispatch/collect call sites — never at the moment a relay task actually finishes. That completion/error transition happens entirely inside `packages/orchestrator`, which cannot import `apps/cli`'s `persistRelayTasks()` without a package-layering violation.

So a relay task that finishes stays marked "running" on disk until the next *unrelated* dispatch/collect call happens to rewrite the file. If an MCP reconnect/restart lands in that window, `restoreRelayTasksAsFailed()` resurrects the already-finished task as `timed_out`, and `collect()`'s auto-signal step then reports a `task_timeout` for a task that actually completed — with no check against whether a `task_completed` signal already exists for that `taskId`.

## Fix (3 parts)

1. **`dispatch-pipeline.ts`** — `pruneRelayTaskRecord()` removes the task's entry from `.gossip/relay-tasks.json` the moment it completes or fails (both the `FINAL_RESULT` and `ERROR` stream-event handlers), using the same raw-`fs` + `join(this.projectRoot, '.gossip', ...)` pattern already established for the `task-graph.jsonl` append at the same call sites, plus an atomic tmp-then-rename write mirroring `persistRelayTasks()`. This narrows the race window down to genuinely in-flight tasks.

2. **`relay-tasks.ts`** — `restoreRelayTasksAsFailed()` no longer asserts an unverified "MCP server restarted during execution" cause, or unconditionally recommend re-dispatch (which can't help for e.g. an auth failure). It now says state was lost across a reconnect and the task may have already completed.

3. **`collect.ts`** — before emitting `task_timeout` for a `'timed_out'` result, a new pure helper `findPhantomTimeoutIds` checks whether a `task_completed` signal already exists on `.gossip/agent-performance.jsonl` for that `taskId`, and skips emission if so. This is the correctness backstop for whatever slips through the narrowed race window in (1) — e.g. a restart that lands mid-write, or a native (non-relay) task. Scoped strictly to `'timed_out'` results so it doesn't touch the legitimate `task_empty` path for genuinely-completed-but-empty results.

`task_timeout` hits the explicit no-op `case 'task_timeout': case 'task_empty': break;` in `computeScores` and is absent from `NEGATIVE_SIGNALS` (it is NOT in `SCORING_EXEMPT_SIGNALS`, which only holds `operational_lesson` and `design_split`) — so this was a false audit-log entry rather than a scoring-manipulation bug, but it named the wrong cause, gave advice that couldn't help the actual failure, and could make specific agents' timeout history look worse than reality.

## Tests

- `tests/orchestrator/dispatch-pipeline.test.ts` — new `pruneRelayTaskRecord` suite: seeds a `relay-tasks.json` record for an in-flight task, completes/fails it, and asserts the record is removed (leaving unrelated records untouched) and that a missing file is a no-op.
- `tests/cli/relay-tasks.test.ts` — updated to assert the restored error message describes state loss rather than asserting a restart cause.
- `tests/cli/collect-phantom-timeout.test.ts` — new suite covering `findPhantomTimeoutIds` directly (no ledger match, matching `task_completed` row, other signal types ignored, torn/blank lines tolerated, multiple candidates).

## Verification

- `npm run build` — clean
- `npm run build:mcp` — clean
- `npm test` — 401/401 suites, 5645/5645 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
