### PR TITLE
fix(consensus): stop double-truncating verifier tool results

### DIFF
--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -10,6 +10,7 @@ function shortConsensusId(): string {
   return hex.slice(0, 8) + '-' + hex.slice(8, 16);
 }
 import { LLMMessage, ToolDefinition } from '@gossip/types';
+import { truncateToBytes, TRUNCATION_MARKER, SKILL_QUERY_MAX_BYTES } from '@gossip/tools';
 import { ILLMProvider } from './llm-client';
 import { AgentConfig, TaskEntry } from './types';
 import { ConsensusReport, ConsensusFinding, ConsensusNewFinding, ConsensusSignal, CrossReviewEntry, RelayWarningEntry } from './consensus-types';
@@ -62,6 +63,16 @@ const MIN_FINDINGS_PER_PEER = 2;
 const VALID_ACTIONS = new Set(['agree', 'disagree', 'unverified', 'new']);
 const ANCHOR_PATTERN = /(?:[a-zA-Z]:\/)?[\w./-]+\.(ts|js|tsx|jsx|py|go|rs|java|rb|md|json|yaml|yml|toml|sh):\d+/;
 const MAX_VERIFIER_TURNS = 7;
+/**
+ * Byte cap (not char cap) for a verifier tool-call result before it's appended
+ * to the cross-review conversation. Set to skill_query's own byte cap so a
+ * payload that tool already truncated to `SKILL_QUERY_MAX_BYTES` (with its own
+ * `TRUNCATION_MARKER`) passes through untouched instead of being re-sliced by
+ * a second, character-counting cut that can clip or duplicate that marker
+ * (#731). Byte-aware via `truncateToBytes` so multi-byte UTF-8 chars aren't
+ * split either.
+ */
+export const VERIFIER_TOOL_RESULT_MAX_BYTES = SKILL_QUERY_MAX_BYTES;
 /** Max roots named verbatim in an unresolved-citation annotation (issue #737). */
 const ANCHOR_ROOT_DISPLAY_LIMIT = 3;
 /** Per-root character cap in that annotation — bounds cross-review prompt growth. */
@@ -1003,7 +1014,19 @@ Return only valid JSON.${skillsBlock}`;
             } catch (e) {
               out = `Error: ${(e as Error).message}`;
             }
-            if (out.length > 8000) out = out.slice(0, 8000) + '\n…[truncated]';
+            if (Buffer.byteLength(out, 'utf8') > VERIFIER_TOOL_RESULT_MAX_BYTES) {
+              // If the tool already truncated its own output (e.g. skill_query
+              // at SKILL_QUERY_MAX_BYTES, ending in TRUNCATION_MARKER), strip
+              // that marker before re-cutting so the result carries exactly
+              // one truncation notice instead of a clipped/duplicated one
+              // (#731). This branch is a defensive fallback: since
+              // VERIFIER_TOOL_RESULT_MAX_BYTES == SKILL_QUERY_MAX_BYTES, a
+              // skill_query payload never exceeds the cap here in the first
+              // place and passes through untouched.
+              const base = out.endsWith(TRUNCATION_MARKER) ? out.slice(0, -TRUNCATION_MARKER.length) : out;
+              const budget = VERIFIER_TOOL_RESULT_MAX_BYTES - Buffer.byteLength(TRUNCATION_MARKER, 'utf8');
+              out = budget > 0 ? truncateToBytes(base, budget) + TRUNCATION_MARKER : TRUNCATION_MARKER;
+            }
             messages.push({ role: 'tool', toolCallId: tc.id, name: tc.name, content: out } as LLMMessage);
           }
         };

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -15,7 +15,7 @@ export { recordSkillPull, SKILL_PULL_LOG, MAX_SKILL_PULL_LOG_BYTES } from './ski
 export type { SkillPullEntry } from './skill-pull-audit';
 export { formatSkillPayload, formatSkillNotFound, SKILL_QUERY_MAX_BYTES } from './skill-query';
 export type { SkillResolverLike, ResolvedSkillLike } from './skill-query';
-export { truncateToBytes } from './truncate';
+export { truncateToBytes, TRUNCATION_MARKER } from './truncate';
 export { canonicalizeForBoundary, validatePathInScope, CASE_INSENSITIVE_FS } from './scope';
 export { SkillTools } from './skill-tools';
 export type { SuggestSkillArgs, GapSuggestion, GapResolution, GapEntry } from './skill-tools';

--- a/packages/tools/src/skill-query.ts
+++ b/packages/tools/src/skill-query.ts
@@ -19,7 +19,7 @@
  * Everything echoed is the CANONICAL normalized name.
  */
 
-import { truncateToBytes } from './truncate';
+import { truncateToBytes, TRUNCATION_MARKER } from './truncate';
 
 /**
  * Byte cap on the TOTAL returned payload — header + body + truncation marker.
@@ -28,8 +28,6 @@ import { truncateToBytes } from './truncate';
  * matches the verifier-tool convention in consensus-engine.ts.
  */
 export const SKILL_QUERY_MAX_BYTES = 16 * 1024;
-
-const TRUNCATION_MARKER = '\n…[truncated]';
 
 /** Resolution result shape returned by `resolveServableSkill`. */
 export interface ResolvedSkillLike {

--- a/packages/tools/src/truncate.ts
+++ b/packages/tools/src/truncate.ts
@@ -7,6 +7,15 @@
  */
 
 /**
+ * Single source of truth for the "this payload was cut" marker. Any path that
+ * truncates tool output (skill_query, the consensus-engine verifier tool-call
+ * loop) should append exactly this string so a downstream re-truncation can
+ * detect an already-truncated payload instead of blindly re-slicing it and
+ * mangling the marker (#731).
+ */
+export const TRUNCATION_MARKER = '\n…[truncated]';
+
+/**
  * Truncate text so its UTF-8 byte length stays <= maxBytes, without splitting
  * a multi-byte character. Prefers cutting at the last newline in the second
  * half of the slice so the returned string ends at a clean line boundary.

--- a/tests/orchestrator/consensus-engine-verifier-tools.test.ts
+++ b/tests/orchestrator/consensus-engine-verifier-tools.test.ts
@@ -9,10 +9,11 @@
 //   - summaries: Map<string, string> with at least 2 agents
 //   - engine config: { llm, registryGet, verifierToolRunner? }
 
-import { ConsensusEngine, ConsensusEngineConfig, VERIFIER_TOOLS } from '../../packages/orchestrator/src/consensus-engine';
+import { ConsensusEngine, ConsensusEngineConfig, VERIFIER_TOOLS, VERIFIER_TOOL_RESULT_MAX_BYTES } from '../../packages/orchestrator/src/consensus-engine';
 import { testRound } from '../../packages/orchestrator/src/round-context';
 import { TaskEntry, LLMResponse } from '../../packages/orchestrator/src/types';
 import { ILLMProvider } from '../../packages/orchestrator/src/llm-client';
+import { TRUNCATION_MARKER } from '../../packages/tools/src/truncate';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -394,8 +395,8 @@ describe('crossReviewForAgent — tool output truncation', () => {
     engine = new ConsensusEngine(config);
   });
 
-  it('truncates tool output > 8000 chars with "…[truncated]" suffix', async () => {
-    const bigOutput = 'x'.repeat(9000);
+  it(`truncates tool output > ${VERIFIER_TOOL_RESULT_MAX_BYTES} bytes with the shared truncation marker`, async () => {
+    const bigOutput = 'x'.repeat(VERIFIER_TOOL_RESULT_MAX_BYTES + 1000);
     const toolCallResponse: LLMResponse = {
       text: '',
       toolCalls: [{ id: 'tc-big', name: 'file_read', arguments: { path: 'big.ts' } }],
@@ -413,12 +414,14 @@ describe('crossReviewForAgent — tool output truncation', () => {
     const secondCallMessages = mockLlm.generate.mock.calls[1][0];
     const toolResultMsg = secondCallMessages.find((m: any) => m.role === 'tool');
     expect(toolResultMsg).toBeDefined();
-    expect(toolResultMsg!.content).toHaveLength(8000 + '\n…[truncated]'.length);
-    expect(String(toolResultMsg!.content).endsWith('\n…[truncated]')).toBe(true);
+    expect(Buffer.byteLength(String(toolResultMsg!.content), 'utf8')).toBeLessThanOrEqual(VERIFIER_TOOL_RESULT_MAX_BYTES);
+    expect(String(toolResultMsg!.content).endsWith(TRUNCATION_MARKER)).toBe(true);
+    // Exactly one marker occurrence — not clipped, not duplicated.
+    expect(String(toolResultMsg!.content).split(TRUNCATION_MARKER)).toHaveLength(2);
   });
 
-  it('does NOT truncate tool output of exactly 8000 chars', async () => {
-    const exactOutput = 'y'.repeat(8000);
+  it(`does NOT truncate tool output of exactly ${VERIFIER_TOOL_RESULT_MAX_BYTES} bytes`, async () => {
+    const exactOutput = 'y'.repeat(VERIFIER_TOOL_RESULT_MAX_BYTES);
     const toolCallResponse: LLMResponse = {
       text: '',
       toolCalls: [{ id: 'tc-exact', name: 'file_read', arguments: { path: 'exact.ts' } }],
@@ -438,6 +441,40 @@ describe('crossReviewForAgent — tool output truncation', () => {
     expect(toolResultMsg).toBeDefined();
     expect(toolResultMsg!.content).toBe(exactOutput);
     expect(toolResultMsg!.content).not.toContain('[truncated]');
+  });
+
+  it('preserves an already-truncated tool payload (e.g. skill_query at its own byte cap) intact, without double-truncating it (#731)', async () => {
+    // Simulate exactly what skill_query's formatSkillPayload returns once it
+    // hits SKILL_QUERY_MAX_BYTES: content truncated to its own budget, with
+    // TRUNCATION_MARKER already appended, and the WHOLE payload sitting right
+    // at (not over) VERIFIER_TOOL_RESULT_MAX_BYTES.
+    const header = '# skill: huge-skill  (resolved: .gossip/skills/huge-skill/SKILL.md)\n\n';
+    const budget = VERIFIER_TOOL_RESULT_MAX_BYTES - Buffer.byteLength(header, 'utf8') - Buffer.byteLength(TRUNCATION_MARKER, 'utf8');
+    const alreadyTruncated = header + 'z'.repeat(budget) + TRUNCATION_MARKER;
+    expect(Buffer.byteLength(alreadyTruncated, 'utf8')).toBeLessThanOrEqual(VERIFIER_TOOL_RESULT_MAX_BYTES);
+
+    const toolCallResponse: LLMResponse = {
+      text: '',
+      toolCalls: [{ id: 'tc-skill', name: 'skill_query', arguments: { skill: 'huge-skill' } }],
+    };
+    mockLlm.generate
+      .mockResolvedValueOnce(toolCallResponse)
+      .mockResolvedValueOnce({ text: VALID_CROSS_REVIEW_JSON });
+    verifierToolRunner.mockResolvedValue(alreadyTruncated);
+
+    const reviewer = makeAgent('reviewer-agent');
+    const summaries = makeSummaries('reviewer-agent', 'peer-agent');
+
+    await (engine as any).crossReviewForAgent(reviewer, summaries);
+
+    const secondCallMessages = mockLlm.generate.mock.calls[1][0];
+    const toolResultMsg = secondCallMessages.find((m: any) => m.role === 'tool');
+    expect(toolResultMsg).toBeDefined();
+    // Passed through byte-for-byte — the engine must not re-slice a payload
+    // the tool itself already truncated to the shared cap.
+    expect(toolResultMsg!.content).toBe(alreadyTruncated);
+    // Exactly one marker occurrence, not a second one stacked on top.
+    expect(String(toolResultMsg!.content).split(TRUNCATION_MARKER)).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
Fixes #731

## Problem

`ConsensusEngine.crossReviewForAgent`'s `runToolCalls` blanket-truncated every verifier tool result with a raw char-length slice:

```ts
if (out.length > 8000) out = out.slice(0, 8000) + '\n…[truncated]';
```

This is unaware of UTF-8 byte boundaries and unaware that some tools already truncate their own output. `skill_query` in particular caps its payload at `SKILL_QUERY_MAX_BYTES` (16KB) and appends its own `TRUNCATION_MARKER` when it truncates (`packages/tools/src/skill-query.ts`). Since 16KB routinely exceeds 8000 chars, an already-truncated `skill_query` result frequently got sliced *again* by the engine's blanket cut — clipping or duplicating the tool's own truncation marker and leaving the model with a confusingly double-marked (or marker-less) payload.

## Fix

- `packages/tools/src/truncate.ts` now exports `TRUNCATION_MARKER` as the single source of truth for the marker string (previously duplicated as a local const in `skill-query.ts`).
- `consensus-engine.ts`'s `runToolCalls` now cuts on UTF-8 byte boundaries via the existing shared `truncateToBytes` helper, at a byte cap (`VERIFIER_TOOL_RESULT_MAX_BYTES`) equal to `SKILL_QUERY_MAX_BYTES`. A `skill_query` payload — already bounded to that same cap — now always passes through untouched, so its own marker survives intact.
- As a defensive fallback (in case some other/future tool exceeds the cap while already carrying `TRUNCATION_MARKER`), the engine strips any pre-existing marker before re-cutting, so at most one marker is ever emitted rather than two stacked or a clipped one.

## Tests

Updated `tests/orchestrator/consensus-engine-verifier-tools.test.ts`:
- The two existing truncation tests now assert against the new byte-based cap instead of the old hardcoded 8000-char boundary.
- Added a new regression test that reproduces the reported case directly: a tool result shaped exactly like `skill_query`'s own output at its byte cap (header + truncated body + `TRUNCATION_MARKER`) is passed through byte-for-byte by the engine, with exactly one marker occurrence — not clipped, not duplicated.

## Verification

- `npm run build`, `npm run build:mcp` — clean.
- `npm test` — full suite passes except one pre-existing, unrelated flake (`tests/cli/mcp-server-code-dispatch.test.ts`, a `child_process.spawn`-based PATH-resolution test) that reproduces identically on a clean `git stash` of `master` before this change, confirming it's an environment characteristic of this sandbox, not a regression introduced here.

This is a low-priority fix — no correctness impact today (the model still received a truncated payload either way), just a confusing doubly-marked one in a fairly narrow case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)