### PR TITLE
fix(observability): distinguish Phase-1 vs Phase-2 skill-pull audit rows (#730)

### DIFF
--- a/apps/cli/src/handlers/verifier-tool-runner.ts
+++ b/apps/cli/src/handlers/verifier-tool-runner.ts
@@ -261,9 +261,10 @@ export function buildVerifierToolRunner(opts: VerifierToolRunnerOptions): Verifi
     }
     if (!resolution.skill) return formatSkillNotFound(resolution.canonicalName, agentId);
 
-    // Observability: successful pulls only. The audit schema has no phase
-    // field, so the row reuses `runtime: 'relay'` — this IS the relay/LLM
-    // reviewer path. `attributed` is true because the identity is the engine's,
+    // Observability: successful pulls only. `runtime: 'relay'` still applies —
+    // this IS the relay/LLM reviewer path — but `phase: 'cross_review'` (issue
+    // #730) now distinguishes it from Phase-1 task pulls that share the same
+    // runtime tag. `attributed` is true because the identity is the engine's,
     // not a self-attested argument.
     recordSkillPull(opts.projectRoot, {
       agentId,
@@ -271,6 +272,7 @@ export function buildVerifierToolRunner(opts: VerifierToolRunnerOptions): Verifi
       resolvedPath: resolution.skill.path,
       runtime: 'relay',
       attributed: true,
+      phase: 'cross_review',
     });
     return formatSkillPayload(resolution.canonicalName, resolution.skill);
   };

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -5637,12 +5637,15 @@ export function createMcpServer(): McpServer {
 
       // agent_id here is self-attested (the caller's own argument), unlike the
       // relay path's envelope-authenticated sid — tag the row accordingly.
+      // This is a Phase-1 (normal task execution) pull, not a Phase-2
+      // cross-review pull.
       recordSkillPull(projectRoot, {
         agentId: agent_id,
         skill: canonicalName,
         resolvedPath: resolved.path,
         runtime: 'native',
         attributed: false,
+        phase: 'task',
       });
 
       return { content: [{ type: 'text' as const, text: formatSkillPayload(canonicalName, resolved) }] };

--- a/packages/tools/src/skill-pull-audit.ts
+++ b/packages/tools/src/skill-pull-audit.ts
@@ -17,7 +17,12 @@
  *   runtime: 'relay' | 'native',
  *   attributed: boolean,             // true when identity is relay-authenticated
  *   _audit?: 'untrusted_caller',     // set when agent_id is self-attested
- *   task_id?: string                 // only when the call site has one cheaply
+ *   task_id?: string,                // only when the call site has one cheaply
+ *   phase?: 'task' | 'cross_review'  // issue #730 — Phase-1 task pull vs Phase-2
+ *                                    // verifier cross-review pull. Optional and
+ *                                    // additive: absent on rows written before
+ *                                    // this field existed, and readers MUST
+ *                                    // treat a missing phase as 'task'.
  * }
  *
  * `attributed` mirrors the gossip_remember / memory_query convention in
@@ -45,6 +50,12 @@ export interface SkillPullEntry {
   /** True only when the agent id was authenticated (relay envelope.sid). */
   attributed: boolean;
   taskId?: string;
+  /**
+   * Phase-1 (normal task execution) vs Phase-2 (verifier cross-review) pull.
+   * Optional and additive — absence means the row predates this field and
+   * MUST be read as 'task' by any consumer.
+   */
+  phase?: 'task' | 'cross_review';
 }
 
 /**
@@ -76,6 +87,7 @@ export function recordSkillPull(projectRoot: string, entry: SkillPullEntry): voi
     };
     if (!entry.attributed) row._audit = 'untrusted_caller';
     if (entry.taskId) row.task_id = entry.taskId;
+    if (entry.phase) row.phase = entry.phase;
     appendFileSync(logPath, JSON.stringify(row) + '\n');
   } catch {
     // Best-effort — a logging failure must never break the tool call.

--- a/packages/tools/src/tool-server.ts
+++ b/packages/tools/src/tool-server.ts
@@ -505,13 +505,15 @@ export class ToolServer {
     if (!resolution.skill) return formatSkillNotFound(resolution.canonicalName, callerId);
 
     // Observability: successful pulls only — see skill-pull-audit.ts. Relay
-    // identity is envelope-authenticated, hence attributed: true.
+    // identity is envelope-authenticated, hence attributed: true. This is a
+    // Phase-1 (normal task execution) pull, not a Phase-2 cross-review pull.
     recordSkillPull(this.sandbox.projectRoot, {
       agentId: callerId,
       skill: resolution.canonicalName,
       resolvedPath: resolution.skill.path,
       runtime: 'relay',
       attributed: true,
+      phase: 'task',
     });
 
     return formatSkillPayload(resolution.canonicalName, resolution.skill);

--- a/tests/cli/mcp-skill-query.test.ts
+++ b/tests/cli/mcp-skill-query.test.ts
@@ -65,6 +65,11 @@ describe('gossip_skill_query registration', () => {
     expect(block).toContain("runtime: 'native'");
   });
 
+  it('tags the pull row phase: task — this is a Phase-1 pull, not Phase-2 cross-review (#730)', () => {
+    const block = skillQueryBlock();
+    expect(block).toContain("phase: 'task'");
+  });
+
   it('routes through resolveServableSkill — the quarantine-gated resolver, never the bare one', () => {
     const block = skillQueryBlock();
     expect(block).toContain('resolveServableSkill(agent_id, skill, projectRoot)');

--- a/tests/cli/verifier-tool-runner.test.ts
+++ b/tests/cli/verifier-tool-runner.test.ts
@@ -354,6 +354,9 @@ describe('verifier tool runner — skill_query (#728)', () => {
       skill: 'trust-boundaries',
       runtime: 'relay',
       attributed: true,
+      // Phase-2 cross-review pull, distinguishing it from Phase-1 task pulls
+      // that share the same `runtime: 'relay'` tag (#730).
+      phase: 'cross_review',
     });
     expect(rows[0].resolved_path).toContain('trust-boundaries.md');
   });

--- a/tests/tools/skill-pull-audit.test.ts
+++ b/tests/tools/skill-pull-audit.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit coverage for the optional `phase` field on SkillPullEntry (issue
+ * #730). Call-site-level coverage (tool-server, mcp-server-sdk,
+ * verifier-tool-runner) lives in their own test files — this file exercises
+ * `recordSkillPull` directly plus the legacy-row backward-compat contract.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { recordSkillPull, SKILL_PULL_LOG, type SkillPullEntry } from '../../packages/tools/src/skill-pull-audit';
+
+function readRows(root: string): Array<Record<string, unknown>> {
+  const logPath = path.join(root, '.gossip', SKILL_PULL_LOG);
+  if (!fs.existsSync(logPath)) return [];
+  return fs.readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean).map(l => JSON.parse(l));
+}
+
+describe('SkillPullEntry.phase (issue #730)', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-pull-phase-'));
+    fs.mkdirSync(path.join(projectRoot, '.gossip'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('writes phase: "task" when the caller passes it', () => {
+    recordSkillPull(projectRoot, {
+      agentId: 'agent-a',
+      skill: 'trust-boundaries',
+      resolvedPath: '/skills/trust-boundaries.md',
+      runtime: 'relay',
+      attributed: true,
+      phase: 'task',
+    });
+    const rows = readRows(projectRoot);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].phase).toBe('task');
+  });
+
+  it('writes phase: "cross_review" when the caller passes it', () => {
+    recordSkillPull(projectRoot, {
+      agentId: 'agent-b',
+      skill: 'implementation-discipline',
+      resolvedPath: '/skills/implementation-discipline.md',
+      runtime: 'relay',
+      attributed: true,
+      phase: 'cross_review',
+    });
+    const rows = readRows(projectRoot);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].phase).toBe('cross_review');
+  });
+
+  it('omits the phase key entirely when the caller does not pass it — stays purely additive', () => {
+    recordSkillPull(projectRoot, {
+      agentId: 'agent-c',
+      skill: 'testing',
+      resolvedPath: '/skills/testing.md',
+      runtime: 'native',
+      attributed: false,
+    });
+    const rows = readRows(projectRoot);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).not.toHaveProperty('phase');
+  });
+
+  it('a pre-existing row with no phase field (legacy record) still parses fine and reads as "task" by convention', () => {
+    // Simulate a row written before this field existed — appended directly,
+    // bypassing recordSkillPull, exactly as an old on-disk log would look.
+    const logPath = path.join(projectRoot, '.gossip', SKILL_PULL_LOG);
+    const legacyRow = {
+      timestamp: '2026-01-01T00:00:00.000Z',
+      agent_id: 'agent-legacy',
+      skill: 'old-skill',
+      resolved_path: '/skills/old-skill.md',
+      runtime: 'relay',
+      attributed: true,
+      // no `phase` key — this is the pre-#730 shape.
+    };
+    fs.appendFileSync(logPath, JSON.stringify(legacyRow) + '\n');
+
+    const rows = readRows(projectRoot);
+    expect(rows).toHaveLength(1);
+    expect(() => JSON.parse(JSON.stringify(rows[0]))).not.toThrow();
+    expect(rows[0]).not.toHaveProperty('phase');
+    // Reader-side convention: absence of `phase` means 'task' (per the
+    // SkillPullEntry doc comment) — assert the fallback a consumer would apply.
+    const phase = (rows[0].phase as SkillPullEntry['phase'] | undefined) ?? 'task';
+    expect(phase).toBe('task');
+  });
+});

--- a/tests/tools/tool-server-skill-query.test.ts
+++ b/tests/tools/tool-server-skill-query.test.ts
@@ -293,6 +293,8 @@ describe('ToolServer skill_query (issue #715 / #698 part 2)', () => {
         resolved_path: p,
         runtime: 'relay',
         attributed: true,
+        // Phase-1 (normal task execution) pull, not Phase-2 cross-review (#730).
+        phase: 'task',
       });
       expect(typeof rows[0].timestamp).toBe('string');
       // Relay identity is envelope-authenticated — no untrusted marker.


### PR DESCRIPTION
## Summary

Fixes #730. `.gossip/skill-pulls.jsonl` rows could not distinguish a normal
Phase-1 task-execution skill pull from a Phase-2 cross-review verifier pull —
both the relay tool-server path and the verifier path write `runtime: 'relay'`,
so they were indistinguishable in the audit log.

**Correction to the issue's own text**: the issue names two call sites
(`tool-server.ts` and a "relay worker gate in `worker-agent.ts`"). Verified by
grep that `worker-agent.ts` does **not** call `recordSkillPull` at all — it
only has an unrelated `skill_query: 2` keyword-gate weight. There are
**three** real call sites, confirmed by `grep -rn "recordSkillPull("`:

1. `packages/tools/src/tool-server.ts:509` — relay agent's `skill_query`
   handler during normal task execution (`runtime: 'relay', attributed: true`).
2. `apps/cli/src/mcp-server-sdk.ts:5640` — native agent's `gossip_skill_query`
   MCP tool handler during normal task execution (`runtime: 'native',
   attributed: false`).
3. `apps/cli/src/handlers/verifier-tool-runner.ts:268` — the Phase-2
   cross-review verifier's `skill_query` handler (`runtime: 'relay',
   attributed: true`). This is the one that actually collides with (1) — same
   `runtime` tag, no way to tell them apart.

## Fix

- `packages/tools/src/skill-pull-audit.ts`: add optional
  `phase?: 'task' | 'cross_review'` to `SkillPullEntry`, threaded into the
  written row only when present. Purely additive — omitted fields on old rows
  stay valid, readers are documented to treat a missing `phase` as `'task'`.
- Sites (1) and (2) now pass `phase: 'task'`.
- Site (3) now passes `phase: 'cross_review'`; the stale comment above the
  call ("the audit schema has no phase field") is updated to reflect the fix.

No runtime behavior change — this is an audit-log schema addition only.

## Test plan

- [x] Extended `tests/tools/tool-server-skill-query.test.ts` to assert
      `phase: 'task'` on the relay task-path pull row.
- [x] Extended `tests/cli/verifier-tool-runner.test.ts` to assert
      `phase: 'cross_review'` on the verifier pull row.
- [x] Extended `tests/cli/mcp-skill-query.test.ts` (source-inspection style,
      matching its existing pattern) to assert `phase: 'task'` appears in the
      native `gossip_skill_query` handler block.
- [x] New `tests/tools/skill-pull-audit.test.ts` unit-tests `recordSkillPull`
      directly: writes `phase` when passed, omits it when not passed, and
      confirms a legacy row with no `phase` key still parses/reads fine and
      falls back to `'task'` by the documented reader convention.
- [x] `npm run build` — passes (all workspaces).
- [x] `npm run build:mcp` — passes.
- [x] `npm test` — 402 suites, 5650 passed, 29 skipped, 5 todo (full green,
      matching pre-change baseline plus the new/updated assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)