### PR TITLE
fix(consensus): fire consensus_coverage_degraded on the server-side Phase-2 path (#746)

### DIFF
--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -706,9 +706,25 @@ export async function handleCollect(
       // for natives so the orchestrator can dispatch them externally.
       const completedResults = allResults.filter((r: any) => r.status === 'completed');
       const hasNative = completedResults.some((r: any) => nativeAgentIds.has(r.agentId));
+      // #738 — every synthesis entry point below is handed a completed-only
+      // array. Capture the arms that were dispatched but never completed
+      // (timed out / failed / still running at collect time) so the engine's
+      // coverage denominator means "arms dispatched", not "arms that arrived".
+      // Mirrors the auto-signal hygiene above: synthetic `_`-prefixed buckets
+      // (e.g. `_utility`) are internal dispatches, not consensus arms.
+      //
+      // #746 — computed HERE, before the server-side/legacy fork, because both
+      // branches finalize a round and both need the same denominator. It used
+      // to be computed inside the legacy branch only, which is why an all-relay
+      // round (server-side Phase 2) could never report a lost arm.
+      const lostAgents: string[] = Array.from(new Set(
+        allResults
+          .filter((r: any) => r.status !== 'completed' && r.agentId && !String(r.agentId).startsWith('_'))
+          .map((r: any) => String(r.agentId)),
+      ));
       if (engine.hasPerformanceReader && !hasNative) {
         try {
-          consensusReport = await engine.runSelectedCrossReview(completedResults);
+          consensusReport = await engine.runSelectedCrossReview(completedResults, undefined, { lostAgents });
           // Success — skip legacy relay + native dispatch paths
         } catch (err) {
           process.stderr.write(`[consensus] Server-side Phase 2 failed: ${(err as Error).message} — falling back\n`);
@@ -866,17 +882,9 @@ export async function handleCollect(
 
       // Phase 2c: Check if native agents need external dispatch
       const nativePrompts = prompts.filter((p: any) => p.isNative);
-      // #738 — every synthesis entry point below is handed a completed-only
-      // array. Capture the arms that were dispatched but never completed
-      // (timed out / failed / still running at collect time) so the engine's
-      // coverage denominator means "arms dispatched", not "arms that arrived".
-      // Mirrors the auto-signal hygiene above: synthetic `_`-prefixed buckets
-      // (e.g. `_utility`) are internal dispatches, not consensus arms.
-      const lostAgents: string[] = Array.from(new Set(
-        allResults
-          .filter((r: any) => r.status !== 'completed' && r.agentId && !String(r.agentId).startsWith('_'))
-          .map((r: any) => String(r.agentId)),
-      ));
+      // #746 — `lostAgents` is now hoisted above the server-side/legacy fork
+      // (see its definition near the runSelectedCrossReview branch) so both
+      // finalization paths share one denominator. Still in scope here.
       if (nativePrompts.length === 0) {
         // Edge case: all native agents had no completed results — synthesize immediately
         consensusReport = await engine.synthesizeWithCrossReview(

--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -3146,10 +3146,17 @@ Return only valid JSON.${skillsBlock}`;
    * Requires `config.performanceReader` — throws if not set.
    * Emits a `partial_review` RoundWarning on the report if any finding received
    * fewer than K cross-reviewers (K = 3 for critical, 2 for all others).
+   *
+   * `options.lostAgents` (#746) — ids of arms dispatched into this round that
+   * never produced a completed result. Same contract as
+   * `synthesizeWithCrossReview`'s option of the same name: the caller hands
+   * `results` in completed-only form, so the lost ids have to travel separately
+   * or `consensus_coverage_degraded` can never fire on this path.
    */
   async runSelectedCrossReview(
     results: TaskEntry[],
     externalConsensusId?: string,
+    options?: { lostAgents?: readonly string[] },
   ): Promise<ConsensusReport> {
     const { performanceReader } = this.config;
     // Generate (or accept caller-provided) consensusId ONCE and thread it
@@ -3208,6 +3215,7 @@ Return only valid JSON.${skillsBlock}`;
       // No structured findings — fall back to synthesize with no cross-review entries
       _log('consensus', 'runSelectedCrossReview: no structured findings extracted; synthesizing without cross-review');
       const report = await this.synthesize(results, [], consensusId);
+      this.surfaceCoverageDegraded(report, results, consensusId, options?.lostAgents);
       this.surfaceZeroTagBanner(report);
       return report;
     }
@@ -3224,6 +3232,7 @@ Return only valid JSON.${skillsBlock}`;
       // Spec §4 — the warnings channel SUBSUMES the legacy report.partialReview
       // field (deleted in PR-C). Fires after synthesize()'s drain.
       this.appendReportWarning(report, 'partial_review', 'no cross-reviewers selected — every finding is under-reviewed (0 of target K)');
+      this.surfaceCoverageDegraded(report, results, consensusId, options?.lostAgents);
       this.surfaceZeroTagBanner(report);
       return report;
     }
@@ -3287,6 +3296,7 @@ Return only valid JSON.${skillsBlock}`;
     );
 
     const report = await this.synthesize(results, allCrossReviewEntries, consensusId);
+    this.surfaceCoverageDegraded(report, results, consensusId, options?.lostAgents);
     if (partialReview) {
       // Spec §4 — warnings channel subsumes the legacy report.partialReview
       // field (deleted in PR-C). At least one finding got fewer than its
@@ -3306,6 +3316,71 @@ Return only valid JSON.${skillsBlock}`;
 
     this.surfaceZeroTagBanner(report);
     return report;
+  }
+
+  /**
+   * Surface round-level coverage degradation (0-char dropouts, e.g. Gemini
+   * MALFORMED_FUNCTION_CALL, plus arms that never arrived at all). Adds ONE
+   * round-level `consensus_coverage_degraded` signal alongside the per-task
+   * auto-signal at collect.ts:178.
+   *
+   * #746 — this MUST be shared by every Phase-2 finalization path. It used to
+   * live inline in `synthesizeWithCrossReview`, which is only reached when at
+   * least one arm is native; the server-side path
+   * (`hasPerformanceReader && !hasNative`, collect.ts) finalizes through
+   * `runSelectedCrossReview` → `synthesize` and therefore could never fire the
+   * detector — the exact #738 failure class on a second call path. Both paths
+   * now call this method, so an all-relay round with a lost arm degrades
+   * identically to a native one.
+   *
+   * `lostAgentIds` — ids of arms that WERE dispatched but never produced a
+   * completed result (timed out, errored, cancelled). Every caller pre-filters
+   * `results` to `status === 'completed'` before reaching synthesis, so without
+   * this list the coverage denominator can only ever count arms that arrived.
+   */
+  private surfaceCoverageDegraded(
+    report: ConsensusReport,
+    results: TaskEntry[],
+    consensusId: string,
+    lostAgentIds?: readonly string[],
+  ): void {
+    // The substring match mirrors collect.ts:178 so the Gemini sentinel
+    // "[No response from Gemini: ...]" (non-empty, ~50 chars, zero analytical
+    // content) is also treated as dropped.
+    const isDropped = (r: { result?: string }): boolean =>
+      !r.result || r.result.trim().length === 0 || r.result.includes('[No response from');
+    const emptyAgents = results.filter(isDropped).map(r => r.agentId);
+    // #738 — an arm that never arrived (timed out / errored) is dropped just as
+    // surely as one that arrived with zero content, but the caller filtered it
+    // out of `results` upstream. Fold the caller-supplied ids back in, deduped
+    // against the arms that DID arrive so a double-reporting caller cannot
+    // inflate the denominator.
+    const arrived = new Set(results.map(r => r.agentId));
+    const lostAgents = Array.from(new Set(lostAgentIds ?? [])).filter(id => !arrived.has(id));
+    const droppedAgents = [...emptyAgents, ...lostAgents];
+    const expected = results.length + lostAgents.length;
+    const received = results.length - emptyAgents.length;
+    if (expected === 0 || droppedAgents.length === 0) return;
+
+    const evidence = buildCoverageDegradedMessage({ received, expected, droppedAgents });
+    report.signals.push({
+      type: 'consensus', taskId: '', consensusId, signal: 'consensus_coverage_degraded',
+      signal_class: 'operational', agentId: '_round', evidence, timestamp: new Date().toISOString(),
+    });
+    report.summary += `\n⚠️  ${evidence}\n`;
+    if (lostAgents.length > 0) {
+      // #738 direction 3, conservative form: do NOT rewrite tag semantics for
+      // the arms that did arrive — the tagging loop has no expected-participant
+      // denominator, so a lost arm's would-be dissent is simply absent from the
+      // tally and a finding a full round would have DISPUTED can surface as
+      // confirmed/unique. Say so instead of silently presenting full coverage.
+      report.summary += `   ↳ finding tags reflect only the ${received} arm(s) that returned — dissent from ${lostAgents.join(', ')} is absent from every confirmed/disputed tally.\n`;
+    }
+    // Spec §4 — warnings channel subsumes the legacy report.coverageDegraded
+    // field (deleted in PR-C). The structured drop count + dropped-agent list
+    // travel in the warning message. Callers invoke this AFTER synthesize()'s
+    // drain, so it writes to both round + report.
+    this.appendReportWarning(report, 'coverage_degraded', evidence);
   }
 
   /**
@@ -3371,45 +3446,7 @@ Return only valid JSON.${skillsBlock}`;
       report.summary = report.summary.split(`${internalConsensusId}:`).join(`${consensusId}:`);
     }
 
-    // Surface round-level coverage degradation (0-char dropouts, e.g. Gemini
-    // MALFORMED_FUNCTION_CALL). Adds ONE round-level signal alongside the
-    // per-task auto-signal at collect.ts:178. The substring match mirrors
-    // collect.ts:178 so the Gemini sentinel "[No response from Gemini: ...]"
-    // (non-empty, ~50 chars, zero analytical content) is also treated as dropped.
-    const isDropped = (r: { result?: string }): boolean =>
-      !r.result || r.result.trim().length === 0 || r.result.includes('[No response from');
-    const emptyAgents = results.filter(isDropped).map(r => r.agentId);
-    // #738 — an arm that never arrived (timed out / errored) is dropped just as
-    // surely as one that arrived with zero content, but the caller filtered it
-    // out of `results` upstream. Fold the caller-supplied ids back in, deduped
-    // against the arms that DID arrive so a double-reporting caller cannot
-    // inflate the denominator.
-    const arrived = new Set(results.map(r => r.agentId));
-    const lostAgents = Array.from(new Set(options?.lostAgents ?? [])).filter(id => !arrived.has(id));
-    const droppedAgents = [...emptyAgents, ...lostAgents];
-    const expected = results.length + lostAgents.length;
-    const received = results.length - emptyAgents.length;
-    if (expected > 0 && droppedAgents.length > 0) {
-      const evidence = buildCoverageDegradedMessage({ received, expected, droppedAgents });
-      report.signals.push({
-        type: 'consensus', taskId: '', consensusId, signal: 'consensus_coverage_degraded',
-        signal_class: 'operational', agentId: '_round', evidence, timestamp: new Date().toISOString(),
-      });
-      report.summary += `\n⚠️  ${evidence}\n`;
-      if (lostAgents.length > 0) {
-        // #738 direction 3, conservative form: do NOT rewrite tag semantics for
-        // the arms that did arrive — the tagging loop has no expected-participant
-        // denominator, so a lost arm's would-be dissent is simply absent from the
-        // tally and a finding a full round would have DISPUTED can surface as
-        // confirmed/unique. Say so instead of silently presenting full coverage.
-        report.summary += `   ↳ finding tags reflect only the ${received} arm(s) that returned — dissent from ${lostAgents.join(', ')} is absent from every confirmed/disputed tally.\n`;
-      }
-      // Spec §4 — warnings channel subsumes the legacy report.coverageDegraded
-      // field (deleted in PR-C). The structured drop count + dropped-agent list
-      // travel in the warning message. Fires after synthesize()'s drain, so
-      // write to both round + report.
-      this.appendReportWarning(report, 'coverage_degraded', evidence);
-    }
+    this.surfaceCoverageDegraded(report, results, consensusId, options?.lostAgents);
 
     // Surface zero-tag agents via the shared idempotent helper (deduplicated from
     // the inline block that previously lived here). Mirrors the coverage_degraded

--- a/tests/orchestrator/consensus-coverage-lost-arms-selected.test.ts
+++ b/tests/orchestrator/consensus-coverage-lost-arms-selected.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Issue #746 — `consensus_coverage_degraded` never fired on the server-side
+ * Phase-2 path (all-relay rounds).
+ *
+ * `handleCollect` routes to `engine.runSelectedCrossReview` whenever
+ * `engine.hasPerformanceReader && !hasNative` (apps/cli/src/handlers/collect.ts).
+ * `performanceReader` is supplied unconditionally, so that branch is taken for
+ * every all-relay round. All of `runSelectedCrossReview`'s synthesis exits called
+ * `synthesize()`, and the coverage detector added by #738 lived exclusively inside
+ * `synthesizeWithCrossReview()` — so a timed-out arm in an all-relay round was
+ * invisible to the detector. Same failure class as #738, different call path.
+ *
+ * The fix extracts the detector into a shared `surfaceCoverageDegraded` helper
+ * invoked by BOTH paths, and gives `runSelectedCrossReview` the same
+ * `options.lostAgents` contract `synthesizeWithCrossReview` already had.
+ *
+ * Assertions mirror tests/orchestrator/consensus-coverage-lost-arms.test.ts
+ * (the native path) so both paths are held to one shape.
+ */
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ConsensusEngine, ConsensusEngineConfig } from '../../packages/orchestrator/src/consensus-engine';
+import { parseCoverageDegradedMessage } from '../../packages/orchestrator/src/coverage-degraded';
+import { PerformanceReader } from '../../packages/orchestrator/src/performance-reader';
+import { testRound } from '../../packages/orchestrator/src/round-context';
+import { TaskEntry } from '../../packages/orchestrator/src/types';
+import { ILLMProvider } from '../../packages/orchestrator/src/llm-client';
+
+describe('#746 — server-side Phase 2 counts arms that never arrived', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'lost-arm-selected-'));
+    mkdirSync(join(root, '.gossip'), { recursive: true });
+    // Empty performance file — fresh pool, same as the selected-review suite.
+    writeFileSync(join(root, '.gossip', 'agent-performance.jsonl'), '');
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  /** Cross-review returns no entries; synthesis still runs. */
+  const makeLlm = (): ILLMProvider => ({
+    generate: jest.fn().mockResolvedValue({
+      text: '[]', inputTokens: 10, outputTokens: 10, toolCalls: [],
+    }),
+  }) as unknown as ILLMProvider;
+
+  const baseConfig = (): ConsensusEngineConfig => ({
+    llm: makeLlm(),
+    registryGet: (id: string) => ({
+      id, provider: 'local' as const, model: 'test', preset: 'reviewer', skills: [] as string[],
+    }),
+    projectRoot: root,
+    // The exact precondition for the server-side branch in collect.ts.
+    performanceReader: new PerformanceReader(root),
+    round: testRound(),
+  });
+
+  const completed = (agentId: string, result: string): TaskEntry => ({
+    id: `task-${agentId}`, agentId, task: 'review', status: 'completed' as const,
+    result, startedAt: Date.now(), completedAt: Date.now(),
+    inputTokens: 100, outputTokens: 200,
+  }) as TaskEntry;
+
+  const finding = (text: string) =>
+    `## Consensus Summary\n<agent_finding type="finding" severity="high">${text}</agent_finding>`;
+
+  /** The two relay arms that DID return in a nominally-3-arm all-relay round. */
+  const arrivedPair = (): TaskEntry[] => [
+    completed('relay-a', finding('Missing token validation in auth.ts:10 allows bypass')),
+    completed('relay-b', finding('Missing input validation in router.ts:22 for user query')),
+  ];
+
+  const coverageSignal = (
+    report: { signals: Array<{ signal: string; evidence?: string; agentId?: string; consensusId?: string }> },
+  ) => report.signals.find(s => s.signal === 'consensus_coverage_degraded');
+
+  it('fires for a 3-arm all-relay round where 1 relay arm timed out', async () => {
+    const engine = new ConsensusEngine(baseConfig());
+    expect(engine.hasPerformanceReader).toBe(true); // collect.ts routing precondition
+
+    // Exactly the shape collect.ts hands over on the server-side path:
+    // completed-only results, plus the id of the arm that never came back.
+    const report = await engine.runSelectedCrossReview(
+      arrivedPair(), 'lost0746-lost0746', { lostAgents: ['relay-c'] },
+    );
+
+    const signal = coverageSignal(report);
+    expect(signal).toBeDefined();
+    expect(signal!.agentId).toBe('_round');
+    expect(signal!.consensusId).toBe('lost0746-lost0746');
+
+    expect(parseCoverageDegradedMessage(signal!.evidence!)).toEqual({
+      received: 2, expected: 3, droppedAgents: ['relay-c'],
+    });
+
+    // Mirrored into the warnings channel + the human-readable summary.
+    const warn = (report.warnings ?? []).filter(w => w.code === 'coverage_degraded');
+    expect(warn).toHaveLength(1);
+    expect(warn[0].message).toContain('2/3');
+    expect(report.summary).toContain('Coverage degraded: 2/3');
+    expect(report.summary).toContain('relay-c');
+    expect(report.summary).toContain('finding tags reflect only the 2 arm(s) that returned');
+  });
+
+  it('fires on the no-structured-findings synthesis exit too', async () => {
+    const engine = new ConsensusEngine(baseConfig());
+
+    // No <agent_finding> tags → runSelectedCrossReview short-circuits to
+    // synthesize() before any reviewer selection. That exit must degrade too.
+    const report = await engine.runSelectedCrossReview(
+      [
+        completed('relay-a', 'Plain prose with no structured findings at all.'),
+        completed('relay-b', 'More prose, still no finding tags anywhere.'),
+      ],
+      'nofi0746-nofi0746',
+      { lostAgents: ['relay-c'] },
+    );
+
+    expect(parseCoverageDegradedMessage(coverageSignal(report)!.evidence!)).toEqual({
+      received: 2, expected: 3, droppedAgents: ['relay-c'],
+    });
+  });
+
+  it('does NOT fire when every dispatched relay arm arrived with content', async () => {
+    const engine = new ConsensusEngine(baseConfig());
+    const report = await engine.runSelectedCrossReview(
+      [...arrivedPair(), completed('relay-c', finding('Unbounded retry loop in queue.ts:88 exhausts the pool'))],
+      'ok460000-ok460000',
+      { lostAgents: [] },
+    );
+
+    expect(coverageSignal(report)).toBeUndefined();
+    expect((report.warnings ?? []).some(w => w.code === 'coverage_degraded')).toBe(false);
+  });
+
+  it('behaves exactly as before when the options argument is omitted', async () => {
+    const engine = new ConsensusEngine(baseConfig());
+    const report = await engine.runSelectedCrossReview(arrivedPair(), 'none0746-none0746');
+    expect(coverageSignal(report)).toBeUndefined();
+  });
+
+  it('does not inflate the denominator when a caller reports an arm that actually arrived', async () => {
+    const engine = new ConsensusEngine(baseConfig());
+    const report = await engine.runSelectedCrossReview(
+      arrivedPair(), 'dup40746-dup40746',
+      { lostAgents: ['relay-b', 'relay-c', 'relay-c'] },
+    );
+
+    expect(parseCoverageDegradedMessage(coverageSignal(report)!.evidence!)).toEqual({
+      received: 2, expected: 3, droppedAgents: ['relay-c'],
+    });
+  });
+
+  it('counts an empty-content arrival AND a lost arm together', async () => {
+    const engine = new ConsensusEngine(baseConfig());
+    const report = await engine.runSelectedCrossReview(
+      [...arrivedPair(), completed('relay-c', '   ')],
+      'both0746-both0746',
+      { lostAgents: ['relay-d'] },
+    );
+
+    const parsed = parseCoverageDegradedMessage(coverageSignal(report)!.evidence!);
+    expect(parsed!.received).toBe(2);
+    expect(parsed!.expected).toBe(4);
+    expect(parsed!.droppedAgents.sort()).toEqual(['relay-c', 'relay-d']);
+  });
+});


### PR DESCRIPTION
Fixes #746

## The gap

`handleCollect` routes to the server-side Phase-2 path whenever
`engine.hasPerformanceReader && !hasNative` (`apps/cli/src/handlers/collect.ts`).
`performanceReader` is supplied to the engine unconditionally, so that branch is
taken for **every all-relay round** — i.e. any round where no completed arm is
native.

All three of `runSelectedCrossReview`'s synthesis exits called `this.synthesize(...)`:

- the no-structured-findings fallback,
- the no-reviewers-selected fallback,
- the main post-cross-review exit.

The lost-arm coverage detector added by #738 / PR #740 lived **exclusively inside
`synthesizeWithCrossReview()`**, which is only reached when at least one arm is
native. `consensus_coverage_degraded` is emitted from exactly one place in the
codebase, and that place was unreachable from the all-relay path.

Consequence: a timed-out/lost arm in an all-relay round was invisible to the
coverage-degraded detector — the exact #738 failure class, on a different call
path. Impact is latent in this repo today (the roster is all-native except one
relay agent, so a 2+-arm all-relay round can't currently form), but it silently
reproduces #738 the moment a second relay-type agent exists, or on any
relay-only gossipcat deployment.

## The fix

Smallest change that makes both paths share one detector, no control-flow
restructuring:

- **Extract**, not duplicate: the coverage block moves out of
  `synthesizeWithCrossReview` into a private
  `surfaceCoverageDegraded(report, results, consensusId, lostAgentIds)`. The
  logic is unchanged — empty/`[No response from` sentinel dropouts, dedupe of
  caller-supplied lost ids against arms that actually arrived, the
  `finding tags reflect only the N arm(s) that returned` caveat, and the
  `coverage_degraded` warnings-channel mirror.
- `runSelectedCrossReview` gains the same `options.lostAgents` contract
  `synthesizeWithCrossReview` already had, and calls the shared helper at all
  three synthesis exits (after `synthesize()`'s drain, matching the existing
  ordering contract for `appendReportWarning`).
- `collect.ts` hoists its `lostAgents` computation **above** the
  server-side/legacy fork. It previously sat inside the legacy branch only, which
  is the CLI-side half of why the server-side path could never see a lost arm.

The `successful.length < 2` early return is deliberately untouched — it returns a
`Consensus skipped: insufficient agents` stub without synthesizing, and changing
that report shape is out of scope for a bug fix.

## Tests

New `tests/orchestrator/consensus-coverage-lost-arms-selected.test.ts` drives the
server-side path directly (asserting `engine.hasPerformanceReader` as the
collect.ts routing precondition) with an all-relay 3-arm round where one relay
arm is lost. Assertions mirror the shape the native-path test
(`tests/orchestrator/consensus-coverage-lost-arms.test.ts`) already holds #738
to: signal presence, `agentId: '_round'`, `consensusId`, parsed
`{ received: 2, expected: 3, droppedAgents: ['relay-c'] }`, the warnings entry,
and the summary banner + tag-coverage caveat. Also covers the
no-structured-findings exit, denominator non-inflation on a double-reporting
caller, empty-arrival + lost-arm combined, and two no-regression cases.

Proven to be a real reproduction rather than a tautology: with the fix's three
calls removed, 4 of the 6 new cases fail. The 2 that still pass are exactly the
intentional no-regression cases (all arms arrived; `options` omitted).

## Verification

Run at repo root (not a worktree):

- `npm run build` — clean
- `npm run build:mcp` — clean
- `npm test` — 403 suites / 5657 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)