### PR TITLE
fix(consensus): catch a WRONG project root, not just a missing one (#747)

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -120,8 +120,50 @@ export function __resetProjectRootWarnings(): void {
 }
 
 /**
+ * Registered agent IDs declared by a gossipcat config file, or `null` when that
+ * cannot be determined cheaply and safely (unreadable file, non-JSON legacy
+ * form, malformed JSON, or no `agents` object). `null` means "no evidence" —
+ * every caller must fail OPEN on it, never treat it as "zero agents". Issue #747.
+ */
+function readRegisteredAgentIds(configPath: string): readonly string[] | null {
+  try {
+    // Only the JSON forms are parsed here. The YAML variants are handled by the
+    // full loader and are not worth a parser dependency for a warning heuristic.
+    if (!configPath.endsWith('.json')) return null;
+    const parsed = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const agents = parsed?.agents;
+    if (!agents || typeof agents !== 'object' || Array.isArray(agents)) return null;
+    const ids = Object.keys(agents);
+    return ids.length > 0 ? ids : null;
+  } catch {
+    // Fail open: a warning heuristic must never turn a bad config file into an
+    // error on a path whose only job is to print advice.
+    return null;
+  }
+}
+
+/**
+ * True when the config found under the root is strong evidence of a DIFFERENT
+ * project than the round being synthesized: it registers agents, and not one of
+ * them is participating in this round. Issue #747.
+ *
+ * Fails open (returns false) whenever the evidence is incomplete — no expected
+ * IDs supplied, or the config's agent registry could not be read.
+ */
+function isForeignProjectConfig(
+  configPath: string,
+  expectedAgentIds?: readonly string[],
+): boolean {
+  if (!expectedAgentIds || expectedAgentIds.length === 0) return false;
+  const registered = readRegisteredAgentIds(configPath);
+  if (registered === null) return false;
+  const registeredSet = new Set(registered);
+  return !expectedAgentIds.some((id) => registeredSet.has(id));
+}
+
+/**
  * Sanity-check the directory a citation-bearing ConsensusEngine is about to
- * treat as the project root (issue #737 direction 3).
+ * treat as the project root (issue #737 direction 3, extended by issue #747).
  *
  * Every `ConsensusEngine` is handed `process.cwd()` as its project root. When a
  * single relay process serves more than one repository, that cwd can be some
@@ -131,19 +173,40 @@ export function __resetProjectRootWarnings(): void {
  * for "this is not a gossipcat project root" — so we say so up front, at
  * dispatch time, instead of leaving it to be discovered by investigation.
  *
+ * Config-presence alone only catches "no project", never "the WRONG project"
+ * (#747): a relay whose cwd is project A silently passed the check while
+ * synthesizing a round that is actually about project B. When the caller can
+ * name the agents actually in the round, a config whose registered `agents`
+ * keys share ZERO overlap with them is strong evidence of exactly that case,
+ * and is reported the same way. Callers that cannot supply the round's agent
+ * IDs keep the original config-exists-only behavior.
+ *
  * Deliberately warn-only: dispatch must still proceed. Anchor resolution is a
  * review-quality enhancement, not a precondition for running consensus, and a
  * throw here would break legitimate config-less invocations.
  *
- * @returns true when the root looks like a real project root.
+ * @param expectedAgentIds Agent IDs participating in the round being
+ *   synthesized. Optional; omitting it (or passing an empty list) disables the
+ *   wrong-project heuristic rather than failing the check.
+ * @returns true when the root looks like the right project root.
  */
-export function warnIfNotProjectRoot(projectRoot: string, context = 'consensus'): boolean {
-  if (findConfigPath(projectRoot) !== null) return true;
+export function warnIfNotProjectRoot(
+  projectRoot: string,
+  context = 'consensus',
+  expectedAgentIds?: readonly string[],
+): boolean {
+  const configPath = findConfigPath(projectRoot);
+  const foreign = configPath !== null && isForeignProjectConfig(configPath, expectedAgentIds);
+  if (configPath !== null && !foreign) return true;
+
   if (!warnedNonProjectRoots.has(projectRoot)) {
     warnedNonProjectRoots.add(projectRoot);
+    const cause = foreign
+      ? `the gossipcat config found there ("${configPath}") registers no agent from this round` +
+        ` (round agents: ${(expectedAgentIds ?? []).join(', ')}), so it belongs to a different project`
+      : `no gossipcat config (.gossip/config.json or gossip.agents.json) found under "${projectRoot}"`;
     console.warn(
-      `[gossipcat] ⚠ project-root sanity check failed for ${context}: no gossipcat config` +
-      ` (.gossip/config.json or gossip.agents.json) found under "${projectRoot}".` +
+      `[gossipcat] ⚠ project-root sanity check failed for ${context}: ${cause}.` +
       ` Citation anchors will be resolved against this directory anyway, so cited files that` +
       ` live in a different repository will be reported to cross-reviewers as "file not found".` +
       ` If this relay serves multiple projects, start it from the project root you are reviewing.`,

--- a/apps/cli/src/handlers/collect.ts
+++ b/apps/cli/src/handlers/collect.ts
@@ -665,7 +665,15 @@ export async function handleCollect(
       // Flag a cwd that isn't a gossipcat project root NOW, at dispatch time —
       // otherwise every unresolved citation downstream is indistinguishable from
       // a fabricated one. Warn-only: consensus still runs.
-      warnIfNotProjectRoot(process.cwd(), 'gossip_collect cross-review');
+      // Issue #747: the round's own agent IDs make the check catch a cwd that is
+      // some OTHER gossipcat project's root — config-presence alone passes there.
+      warnIfNotProjectRoot(
+        process.cwd(),
+        'gossip_collect cross-review',
+        allResults
+          .map((r: any) => r.agentId)
+          .filter((id: any): id is string => typeof id === 'string' && id.length > 0),
+      );
 
       const engine = new ConsensusEngine({
         llm: mainLlm,

--- a/apps/cli/src/handlers/relay-cross-review.ts
+++ b/apps/cli/src/handlers/relay-cross-review.ts
@@ -53,8 +53,15 @@ export async function synthesizeTimeoutRound(
   // Issue #737: timeout synthesis builds cross-review prompts, so this engine is
   // citation-bearing. Surface a non-project-root before its anchors start
   // failing. Warn-only — synthesis must not be blocked by the check.
+  // Issue #747: also pass the round's own agent IDs (completed arms plus any
+  // dispatched-but-lost ones), so a cwd holding a DIFFERENT project's config is
+  // caught too, not only a cwd holding no config at all.
   const { warnIfNotProjectRoot } = await import('../config');
-  warnIfNotProjectRoot(projectRoot, 'consensus timeout synthesis');
+  const roundAgentIds = [
+    ...snapshot.allResults.map((r) => r.agentId),
+    ...(snapshot.lostAgents ?? []),
+  ].filter((id): id is string => typeof id === 'string' && id.length > 0);
+  warnIfNotProjectRoot(projectRoot, 'consensus timeout synthesis', roundAgentIds);
   const round: RoundContext =
     snapshot.roundContext ?? makeRoundContext({ resolutionRoots: snapshot.resolutionRoots ?? [] });
   const engine: ConsensusEngineType = new ConsensusEngine({

--- a/tests/cli/project-root-sanity-warning.test.ts
+++ b/tests/cli/project-root-sanity-warning.test.ts
@@ -85,6 +85,83 @@ describe('warnIfNotProjectRoot (#737)', () => {
     expect(warnings()).toHaveLength(1);
   });
 
+  // ---------------------------------------------------------------------
+  // Issue #747 — config-presence alone only rules out "no project", never
+  // "the WRONG project". A relay sitting in project A's real root passed the
+  // check silently while synthesizing a round that belongs to project B.
+  // ---------------------------------------------------------------------
+
+  const makeProject = (name: string, agentIds: string[]): string => {
+    const dir = join(root, name);
+    mkdirSync(join(dir, '.gossip'), { recursive: true });
+    writeFileSync(
+      join(dir, '.gossip', 'config.json'),
+      JSON.stringify({
+        main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+        agents: Object.fromEntries(
+          agentIds.map((id) => [id, { provider: 'anthropic', model: 'claude-sonnet-4-6', skills: [] }]),
+        ),
+      }),
+    );
+    return dir;
+  };
+
+  it('warns when the root IS a gossipcat project but a different one than the round', () => {
+    // Project A is a perfectly real gossipcat root — findConfigPath succeeds.
+    const otherProject = makeProject('project-a', ['a-reviewer', 'a-researcher']);
+    expect(findConfigPath(otherProject)).not.toBeNull();
+
+    // ...but the round being synthesized belongs to project B entirely.
+    expect(
+      warnIfNotProjectRoot(otherProject, 'gossip_collect cross-review', ['b-reviewer', 'b-implementer']),
+    ).toBe(false);
+
+    const msgs = warnings();
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toContain(otherProject);
+    expect(msgs[0]).toContain('different project');
+    expect(msgs[0]).toContain('b-reviewer');
+    // Same downstream consequence as the no-config case, so the operator can
+    // connect it to the "file not found" citations they will see later.
+    expect(msgs[0]).toContain('file not found');
+  });
+
+  it('stays silent when even one round agent is registered in the found config', () => {
+    const project = makeProject('project-overlap', ['a-reviewer', 'a-researcher']);
+
+    expect(warnIfNotProjectRoot(project, 'consensus', ['a-researcher', 'guest-agent'])).toBe(true);
+    expect(warnings()).toHaveLength(0);
+  });
+
+  it('keeps the pre-#747 behavior when no round agent IDs are supplied', () => {
+    const project = makeProject('project-legacy-caller', ['a-reviewer']);
+
+    expect(warnIfNotProjectRoot(project)).toBe(true);
+    expect(warnIfNotProjectRoot(project, 'consensus', [])).toBe(true);
+    expect(warnings()).toHaveLength(0);
+  });
+
+  it('fails open (silent) when the found config declares no agents at all', () => {
+    // `{}` is the shape the pre-existing tests above use. Absent evidence must
+    // never be read as "zero overlap" — that would warn on every fresh install.
+    const bare = join(root, 'project-no-agents');
+    mkdirSync(join(bare, '.gossip'), { recursive: true });
+    writeFileSync(join(bare, '.gossip', 'config.json'), '{}');
+
+    expect(warnIfNotProjectRoot(bare, 'consensus', ['b-reviewer'])).toBe(true);
+    expect(warnings()).toHaveLength(0);
+  });
+
+  it('fails open (silent) when the found config is unparseable', () => {
+    const broken = join(root, 'project-broken-config');
+    mkdirSync(join(broken, '.gossip'), { recursive: true });
+    writeFileSync(join(broken, '.gossip', 'config.json'), '{ this is not json');
+
+    expect(() => warnIfNotProjectRoot(broken, 'consensus', ['b-reviewer'])).not.toThrow();
+    expect(warnIfNotProjectRoot(broken, 'consensus', ['b-reviewer'])).toBe(true);
+    expect(warnings()).toHaveLength(0);
+  });
+
   it('reports each distinct bad root separately', () => {
     const a = join(root, 'bad-a');
     const b = join(root, 'bad-b');
@@ -188,5 +265,43 @@ describe('citation-bearing round anchored at the wrong project root (#737)', () 
     expect(all).toContain(wrongRoot);
     expect(all).toContain('anchored to the wrong project');
     expect(all).not.toContain(realRepo);
+  });
+
+  // Issue #747: the reported shape. The relay's cwd is a REAL gossipcat project
+  // root, so the #737 config-presence check passed silently — but it is some
+  // other project's root, and the round under synthesis knows nothing about the
+  // agents it registers.
+  it('warns when the synthesis root is another real gossipcat project', async () => {
+    const otherProject = realpathSync(mkdtempSync(join(tmp, 'other-project')));
+    mkdirSync(join(otherProject, '.gossip'), { recursive: true });
+    writeFileSync(
+      join(otherProject, '.gossip', 'config.json'),
+      JSON.stringify({
+        main_agent: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+        agents: {
+          'unrelated-reviewer': { provider: 'anthropic', model: 'claude-sonnet-4-6', skills: [] },
+        },
+      }),
+    );
+
+    const snapshot: TimeoutSynthesisSnapshot = {
+      allResults: [
+        completed('agent-a', '<agent_finding type="finding" severity="high">Rate bug at src/billing.ts:1</agent_finding>'),
+        completed('agent-b', '<agent_finding type="finding" severity="high">Same rate bug at src/billing.ts:1</agent_finding>'),
+      ],
+      relayCrossReviewEntries: [],
+      nativeCrossReviewEntries: [],
+      roundContext: makeRoundContext({ resolutionRoots: [], consensusId: 'deadbeef-0badf00d' }),
+    };
+
+    await synthesizeTimeoutRound(snapshot, 'deadbeef-0badf00d', [], makeLlm(), otherProject);
+
+    const sanity = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('project-root sanity check'));
+    expect(sanity).toHaveLength(1);
+    expect(sanity[0]).toContain(otherProject);
+    expect(sanity[0]).toContain('different project');
+    expect(sanity[0]).toContain('agent-a');
   });
 });


### PR DESCRIPTION
Fixes #747

## The bug

`warnIfNotProjectRoot` (shipped in #737 as a cheap "is this cwd a project root?" guard) short-circuits on the *existence* of a config:

```ts
if (findConfigPath(projectRoot) !== null) return true;
```

`findConfigPath` only checks for `.gossip/config.json` / `gossip.agents.{json,yaml,yml}` **directly under the given root** — no upward walk, no identity check. So the guard rules out "no project" but never "the **wrong** project": a relay whose cwd is project A's real root passes silently while synthesizing a round that is actually about project B. Every citation then fails as `file not found`, indistinguishable from a fabricated citation — the exact failure mode #737 set out to make loud.

Existing coverage missed it because `tests/cli/project-root-sanity-warning.test.ts` built its wrong-root fixture as a bare `mkdtempSync` directory with no config at all — the one shape where the check already fired.

## The fix

Both call sites already know which agents are in the round. If the config that *was* found registers agents and **not one of them** is in this round, that is strong evidence it belongs to a different project.

- `warnIfNotProjectRoot(projectRoot, context, expectedAgentIds?)` — new optional third parameter.
- Zero overlap between the config's registered `agents` keys and `expectedAgentIds` ⇒ warn, same as "no config", with a message naming the offending config path and the round's agents.
- **Not a breaking change.** Omitted or empty `expectedAgentIds` keeps today's config-exists-only behavior for any caller that can't supply the round's agents.
- **Fails open on every incomplete signal**, so a fresh install never gets a spurious warning: unparseable config, non-JSON legacy form, or a config with no `agents` object all stay silent. Absent evidence is never read as "zero overlap".
- **Still warn-only.** Nothing throws, nothing blocks dispatch — anchor resolution remains a review-quality enhancement, not a precondition.

Wired at both real call sites:

| Call site | Round agents passed |
|---|---|
| `apps/cli/src/handlers/relay-cross-review.ts` (timeout synthesis) | completed arms + `snapshot.lostAgents` |
| `apps/cli/src/handlers/collect.ts` (`gossip_collect` cross-review) | `allResults.map(r => r.agentId)` |

## Explicitly NOT implemented

The deferred "accept a caller-supplied project root" direction is **not** in this PR. That was scoped out of #737 as needing separate design sign-off, since it changes the MCP tool schema. This is a better *heuristic* built from information already in scope at the call sites — no schema change, no new parameter on any MCP tool.

## Tests

`tests/cli/project-root-sanity-warning.test.ts` extended, not rewritten — all pre-existing assertions still pass unchanged. New cases:

- projectRoot is a **real** gossipcat project whose registered agents are disjoint from the round's → warning now fires (the reported scenario).
- End-to-end through the real `synthesizeTimeoutRound` with a genuine foreign-project root → warning fires and names the round's agents.
- Overlap present, `expectedAgentIds` omitted, and `expectedAgentIds: []` → silent (back-compat).
- Config with no `agents` object, and unparseable config → silent, no throw (fail-open).

Verified at repo root: `npm run build`, `npm run build:mcp`, full `npm test` (402 suites, 5657 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
