### PR TITLE
fix(consensus): anchor-miss annotation leaks full filesystem paths to third-party providers

### DIFF
--- a/packages/orchestrator/src/consensus-engine.ts
+++ b/packages/orchestrator/src/consensus-engine.ts
@@ -1,7 +1,7 @@
 import { readFile, readdir, stat } from 'fs/promises';
 import { mkdirSync, writeFileSync, realpathSync } from 'fs';
 import { randomUUID } from 'crypto';
-import { join, resolve, dirname, relative, sep, isAbsolute } from 'path';
+import { join, resolve, dirname, relative, sep, isAbsolute, basename } from 'path';
 import { log as _log } from './log';
 
 /** Generate a short consensus round ID: xxxxxxxx-xxxxxxxx (17 chars from UUID) */
@@ -469,12 +469,24 @@ export class ConsensusEngine {
    * cross-reviewer PROMPT, so it is sanitized the same way `safeRef` is:
    * markup/quote/newline characters stripped so a pathological path cannot
    * forge an `<anchor>` boundary. (issue #737)
+   *
+   * Only the final path segment (basename) is rendered — never the full
+   * absolute path. `anchorMissAnnotation` reaches a cross-review PROMPT,
+   * which for relay-type reviewers is sent to a third-party LLM provider
+   * (google/openai/deepseek). The full path discloses the operator's home
+   * directory name, project directory names, and worktree temp-dir layout
+   * to that provider; the basename alone still tells a reviewer which root
+   * (of several) the resolver tried, which is the only diagnostic value
+   * this annotation needs. (issue #748 — this is distinct from the
+   * character-stripping above, which guards against prompt-boundary
+   * injection, not disclosure.) The local-only `logAnchorRootsOnce`
+   * console.warn path is unaffected and keeps full absolute paths.
    */
   private describeAnchorRoots(roots: string[], maxShown = ANCHOR_ROOT_DISPLAY_LIMIT): string {
     if (roots.length === 0) return '(none)';
     const shown = roots
       .slice(0, maxShown)
-      .map((r) => r.replace(/[<>"`\r\n]/g, '').slice(0, ANCHOR_ROOT_PATH_MAX_CHARS));
+      .map((r) => basename(r).replace(/[<>"`\r\n]/g, '').slice(0, ANCHOR_ROOT_PATH_MAX_CHARS));
     const extra = roots.length - shown.length;
     return extra > 0 ? `${shown.join(', ')} (+${extra} more)` : shown.join(', ');
   }

--- a/tests/cli/project-root-sanity-warning.test.ts
+++ b/tests/cli/project-root-sanity-warning.test.ts
@@ -17,7 +17,7 @@ import { makeRoundContext } from '@gossip/orchestrator';
 import type { TaskEntry } from '@gossip/orchestrator';
 import { mkdtempSync, mkdirSync, writeFileSync, realpathSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { join, basename } from 'path';
 
 describe('warnIfNotProjectRoot (#737)', () => {
   let tmp: string;
@@ -260,9 +260,14 @@ describe('citation-bearing round anchored at the wrong project root (#737)', () 
     expect(rootLogs[0]).toContain(`projectRoot=${wrongRoot}`);
 
     // (1) the reviewer-facing prompt distinguishes "wrong root" from "bad citation".
+    // The prompt reaches relay-type reviewers backed by a third-party LLM
+    // provider, so only the basename is disclosed there — never the full
+    // absolute path (issue #748). The full path is fine in (2)/(3) above,
+    // which are local-only console.warn output.
     const all = prompts.map((p) => `${p.system}\n${p.user}`).join('\n');
     expect(all).toContain('but file not found');
-    expect(all).toContain(wrongRoot);
+    expect(all).toContain(basename(wrongRoot));
+    expect(all).not.toContain(wrongRoot);
     expect(all).toContain('anchored to the wrong project');
     expect(all).not.toContain(realRepo);
   });

--- a/tests/orchestrator/anchor-miss-root-diagnostics.test.ts
+++ b/tests/orchestrator/anchor-miss-root-diagnostics.test.ts
@@ -18,7 +18,7 @@ import { ConsensusEngine } from '../../packages/orchestrator/src/consensus-engin
 import { testRound } from '../../packages/orchestrator/src/round-context';
 import { mkdtempSync, mkdirSync, writeFileSync, realpathSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { join, basename } from 'path';
 
 const makeLlm = (): any => ({
   generate: jest.fn(async () => ({ text: '[]', usage: { inputTokens: 0, outputTokens: 0 } })),
@@ -65,8 +65,12 @@ describe('anchor miss diagnostics (#737)', () => {
     const out = await engine.snippetsForFinding('Rate is miscomputed at src/billing.ts:1');
 
     expect(out).toContain('but file not found');
-    // The distinguishing information: what the resolver actually searched.
-    expect(out).toContain(wrongRepo);
+    // The distinguishing information: what the resolver actually searched —
+    // rendered as a basename, never the full absolute path (issue #748: the
+    // full path would disclose the operator's filesystem layout to
+    // relay-type reviewers backed by a third-party LLM provider).
+    expect(out).toContain(basename(wrongRepo));
+    expect(out).not.toContain(wrongRepo);
     expect(out).toContain('resolver searched 1 root(s)');
     // And a hint that separates "wrong root" from "wrong citation".
     expect(out).toMatch(/anchored to the wrong project/);
@@ -83,7 +87,10 @@ describe('anchor miss diagnostics (#737)', () => {
 
     expect(out).toContain('resolver searched 2 root(s)');
     // Worktree roots are checked before projectRoot (getAnchorPriorityRoots).
-    expect(out.indexOf(worktree)).toBeLessThan(out.indexOf(wrongRepo));
+    // Basenames only — full absolute paths never reach the prompt.
+    expect(out.indexOf(basename(worktree))).toBeLessThan(out.indexOf(basename(wrongRepo)));
+    expect(out).not.toContain(worktree);
+    expect(out).not.toContain(wrongRepo);
   });
 
   it('caps the rendered root list so a many-root round cannot bloat the prompt', async () => {
@@ -155,5 +162,26 @@ describe('anchor miss diagnostics (#737)', () => {
     expect(out).toContain('weirdrepo');
     expect(out).not.toContain('<repo>');
     expect(out).not.toContain('we"ird');
+  });
+
+  it('never discloses the operator filesystem layout above a project root to the prompt (#748)', async () => {
+    // Simulate an operator whose project lives several directories deep,
+    // e.g. under a home directory — the intermediate segments (home dir
+    // name, parent dirs) must never reach a cross-review prompt that a
+    // relay-type reviewer forwards to a third-party LLM provider.
+    const operatorTree = join(root, 'Users', 'someoperator', 'Desktop');
+    const secretProject = join(operatorTree, 'secret-project-name');
+    mkdirSync(secretProject, { recursive: true });
+    const engine = makeEngine(secretProject);
+
+    const out = await engine.snippetsForFinding('See src/billing.ts:1');
+
+    expect(out).toContain('but file not found');
+    // Only the basename is disclosed...
+    expect(out).toContain('secret-project-name');
+    // ...never the full absolute path or any parent segment.
+    expect(out).not.toContain(secretProject);
+    expect(out).not.toContain('someoperator');
+    expect(out).not.toContain(join('Users', 'someoperator'));
   });
 });


### PR DESCRIPTION
## Summary

Fixes #748.

`anchorMissAnnotation` in `packages/orchestrator/src/consensus-engine.ts` spliced `getAnchorPriorityRoots()` (`projectRoot` plus every worktree/resolutionRoot — all absolute filesystem paths) verbatim into the reviewer-facing annotation via `describeAnchorRoots`. That annotation is pushed into `anchors`, cached by `snippetsForFinding`, and becomes part of the cross-review prompt handed to `llm.generate` — reaching any relay-type reviewer's third-party provider (google/openai/deepseek per this project's own agent roster), not just the local process.

This was introduced in #737, which (correctly) fixed a real observability gap by moving the tried-roots list from `console.warn` (local-only) into the prompt, but did not account for the prompt-facing copy reaching an external LLM provider. It is a distinct issue from the existing `describeAnchorRoots` character-stripping sanitization, which prevents a malicious root name from forging an `<anchor>` prompt boundary (injection) — that sanitization is correct and unrelated to disclosure.

## Fix

- `describeAnchorRoots` now renders each root as `path.basename(root)` instead of the full absolute path, before applying the existing character-stripping/length-cap sanitization. This keeps the diagnostic value ("resolver tried the wrong root — here's which one") without exporting the operator's home directory name, project directory names, or worktree temp-dir layout to an external provider.
- `logAnchorRootsOnce` (the `console.warn`-only path used for local operator debugging) is untouched — it never leaves the local machine, so full absolute paths remain more useful there.
- If two roots (e.g. two worktrees) share a basename, that ambiguity is accepted for this low-severity diagnostic message rather than over-engineered.

## Tests

- Updated `tests/orchestrator/anchor-miss-root-diagnostics.test.ts` and `tests/cli/project-root-sanity-warning.test.ts`, which previously asserted the full absolute path reached the prompt — now assert the basename appears and the full path does not.
- Added a new regression test asserting a root like `/Users/someoperator/Desktop/secret-project-name` renders in the prompt only as `secret-project-name`, never with the home directory or intermediate path segments.
- `npm run build`, `npm run build:mcp`, and the full `npm test` suite (403 suites, 5664 passing, 0 failing) all pass at the repo root.

## Test plan

- [x] `npm run build`
- [x] `npm run build:mcp`
- [x] `npm test` (full suite, repo root, not a worktree)
- [x] Manually re-read `anchorMissAnnotation`, `describeAnchorRoots`, `getAnchorPriorityRoots`, `logAnchorRootsOnce` to confirm only the prompt-facing path was changed, not the local-only console.warn path

🤖 Generated with [Claude Code](https://claude.com/claude-code)