### PR TITLE
fix(session-save): converge after relay when _utility_task_id is dropped (#745)

### DIFF
--- a/apps/cli/src/handlers/session-save-reentry.ts
+++ b/apps/cli/src/handlers/session-save-reentry.ts
@@ -1,0 +1,90 @@
+/**
+ * Convergence resolver for the `gossip_session_save` native-utility loop
+ * (GH #745).
+ *
+ * The documented flow is:
+ *
+ *   1. `gossip_session_save()`                 → dispatch instruction + task_id
+ *   2. run the Agent, then `gossip_relay(task_id, result)`
+ *   3. `gossip_session_save(_utility_task_id: task_id)` → "Session saved."
+ *
+ * Step 3 is the ONLY thing that finalizes the save, and it is entirely
+ * dependent on the caller echoing back an opaque id. When that id is dropped,
+ * the handler used to fall straight through to the dispatch branch again:
+ * the utility task was no longer pending (it had been relayed), so the
+ * refuse-gate did not block, and both the stashed session data and the
+ * relayed summarizer output were silently ignored. The result was an
+ * unbounded dispatch→relay→dispatch loop that never reached "Session saved."
+ *
+ * This module gives the server its own memory of the in-flight save so
+ * convergence no longer depends on the client. It is a pure function over the
+ * three pieces of state the handler already keeps, so it can be unit-tested
+ * without booting the MCP server.
+ */
+
+/** Minimal shape of a `ctx.nativeResultMap` entry that this resolver reads. */
+export interface SessionSummaryResultLike {
+  status?: string;
+  result?: string;
+  completedAt?: number;
+}
+
+export interface SessionSummaryReentry {
+  /**
+   * Task id of a session_summary utility that was dispatched, relayed
+   * successfully, and never consumed by a re-entry call. The handler should
+   * finalize with this instead of dispatching a fresh summarizer.
+   */
+  adoptTaskId?: string;
+  /**
+   * Task id of a session_summary utility that was dispatched but whose relay
+   * has not landed yet. The handler should re-issue the instruction for THIS
+   * id rather than minting a second summarizer for the same save.
+   */
+  inFlightTaskId?: string;
+}
+
+/**
+ * Decide whether a `gossip_session_save` call that arrived WITHOUT
+ * `_utility_task_id` can be reconciled against an earlier dispatch.
+ *
+ * @param pendingTaskIds  keys of `_pendingSessionData` — one per dispatched,
+ *                        not-yet-finalized session_summary utility task.
+ * @param getResult       lookup into `ctx.nativeResultMap`.
+ * @param hasPendingTask  lookup into `ctx.nativeTaskMap` (task still awaiting relay).
+ *
+ * Adoption requires a genuinely completed relay carrying output: a
+ * failed/timed-out summarizer is left alone so the existing re-dispatch
+ * behaviour still applies to it. When several completed candidates exist the
+ * most recently completed one wins.
+ */
+export function resolveSessionSummaryReentry(args: {
+  pendingTaskIds: Iterable<string>;
+  getResult: (id: string) => SessionSummaryResultLike | undefined;
+  hasPendingTask: (id: string) => boolean;
+}): SessionSummaryReentry {
+  const { pendingTaskIds, getResult, hasPendingTask } = args;
+
+  let adoptTaskId: string | undefined;
+  let adoptCompletedAt = -Infinity;
+  let inFlightTaskId: string | undefined;
+
+  for (const id of pendingTaskIds) {
+    const result = getResult(id);
+    if (result?.status === 'completed' && result.result) {
+      const completedAt = typeof result.completedAt === 'number' ? result.completedAt : 0;
+      if (completedAt >= adoptCompletedAt) {
+        adoptCompletedAt = completedAt;
+        adoptTaskId = id;
+      }
+      continue;
+    }
+    // No result yet and the task is still armed → the relay is still coming.
+    if (!result && hasPendingTask(id) && !inFlightTaskId) inFlightTaskId = id;
+  }
+
+  return {
+    ...(adoptTaskId ? { adoptTaskId } : {}),
+    ...(inFlightTaskId ? { inFlightTaskId } : {}),
+  };
+}

--- a/apps/cli/src/mcp-server-sdk.ts
+++ b/apps/cli/src/mcp-server-sdk.ts
@@ -315,6 +315,7 @@ try {
   if (stalenessResult.stale) logStalenessToMcpLog(stalenessResult, process.cwd());
 } catch { /* never break boot */ }
 import { restoreNativeTaskMap, handleNativeRelay, spawnTimeoutWatcher, scheduleNativeTaskEviction, UTILITY_RESULT_TTL_MS } from './handlers/native-tasks';
+import { resolveSessionSummaryReentry, type SessionSummaryReentry } from './handlers/session-save-reentry';
 import { handleDispatchSingle, handleDispatchParallel, handleDispatchConsensus, detectLostDispatchWarnings } from './handlers/dispatch';
 import { buildIntrospectionPrompt, appendIntrospection } from './handlers/ask-back';
 import {
@@ -5148,20 +5149,40 @@ export function createMcpServer(): McpServer {
     async ({ notes, force, _utility_task_id }) => {
       await boot();
 
+      // #745 convergence guard: the re-entry call is the ONLY thing that
+      // finalizes the save, and it hinges on the caller echoing back an opaque
+      // id. When `_utility_task_id` is dropped, the already-relayed summarizer
+      // result is invisible to the code below and the handler mints a brand-new
+      // utility task instead — dispatch → relay → dispatch, forever. Reconcile
+      // against the server's own record of the in-flight save first so the loop
+      // terminates regardless of what the client remembers.
+      const _reentry: SessionSummaryReentry = _utility_task_id
+        ? {}
+        : resolveSessionSummaryReentry({
+            pendingTaskIds: _pendingSessionData.keys(),
+            getResult: (id) => ctx.nativeResultMap.get(id),
+            hasPendingTask: (id) => ctx.nativeTaskMap.has(id),
+          });
+      const _adoptedTaskId = _reentry.adoptTaskId;
+      const _resolvedTaskId = _utility_task_id || _adoptedTaskId;
+      if (_adoptedTaskId) {
+        process.stderr.write(`[gossipcat] session_save: adopting relayed summary [${_adoptedTaskId}] — _utility_task_id was not passed on the re-call\n`);
+      }
+
       // Re-entry fast path: retrieve stashed data, skip re-gathering
-      if (_utility_task_id) {
-        const stashed = _pendingSessionData.get(_utility_task_id);
-        _pendingSessionData.delete(_utility_task_id);
+      if (_resolvedTaskId) {
+        const stashed = _pendingSessionData.get(_resolvedTaskId);
+        _pendingSessionData.delete(_resolvedTaskId);
         const summaryData = stashed ?? { gossip: '', consensus: '', performance: '', gitLog: '', notes };
 
         // Utility-guard: detect prompt-injection drift in the sub-agent.
-        const _guardBefore = _utilityGuardSnapshots.get(_utility_task_id);
-        _utilityGuardSnapshots.delete(_utility_task_id);
+        const _guardBefore = _utilityGuardSnapshots.get(_resolvedTaskId);
+        _utilityGuardSnapshots.delete(_resolvedTaskId);
         if (_guardBefore !== undefined) {
-          checkUnexpectedChanges(_guardBefore, captureGitStatus(), 'session_summary', _utility_task_id);
+          checkUnexpectedChanges(_guardBefore, captureGitStatus(), 'session_summary', _resolvedTaskId);
         }
 
-        const utilityResult = ctx.nativeResultMap.get(_utility_task_id);
+        const utilityResult = ctx.nativeResultMap.get(_resolvedTaskId);
         const { MemoryWriter } = await import('@gossip/orchestrator');
         const writer = new MemoryWriter(process.cwd());
         try { if (ctx.mainAgent.getLLM()) writer.setSummaryLlm(ctx.mainAgent.getLLM()); } catch {}
@@ -5177,11 +5198,11 @@ export function createMcpServer(): McpServer {
             artifacts = await writer.prepareSessionArtifacts(summaryData);
           }
         } else {
-          process.stderr.write(`[gossipcat] Native session summary utility ${_utility_task_id} failed/timed out, falling back to LLM\n`);
+          process.stderr.write(`[gossipcat] Native session summary utility ${_resolvedTaskId} failed/timed out, falling back to LLM\n`);
           artifacts = await writer.prepareSessionArtifacts(summaryData);
         }
-        ctx.nativeResultMap.delete(_utility_task_id);
-        ctx.nativeTaskMap.delete(_utility_task_id);
+        ctx.nativeResultMap.delete(_resolvedTaskId);
+        ctx.nativeTaskMap.delete(_resolvedTaskId);
 
         const summary = await writeArtifactsInOrder(artifacts);
 
@@ -5250,7 +5271,10 @@ export function createMcpServer(): McpServer {
           wf(j(process.cwd(), '.gossip', 'agents', '_project', 'memory', 'session-gossip.jsonl'), '');
         } catch { /* best-effort */ }
 
-        return { content: [{ type: 'text' as const, text: `Session saved.\n\n${summary}` }] };
+        const adoptedNote = _adoptedTaskId
+          ? ` (adopted relayed summary [${_adoptedTaskId}] — the re-call omitted _utility_task_id)`
+          : '';
+        return { content: [{ type: 'text' as const, text: `Session saved.${adoptedNote}\n\n${summary}` }] };
       }
 
       // Refuse-gate: block session_save while native tasks or consensus rounds are still in flight.
@@ -5425,20 +5449,28 @@ export function createMcpServer(): McpServer {
       // Native utility branch: dispatch Agent() for session summary instead of calling LLM directly
       if (ctx.nativeUtilityConfig && !_utility_task_id) {
         const { system, user } = writer.getSessionSummaryPrompt(summaryData);
-        const taskId = randomUUID().slice(0, 8);
+        // #745: a save that reaches here while an earlier summarizer is still
+        // awaiting its relay (only possible via force: true — the refuse-gate
+        // blocks it otherwise) re-issues the ORIGINAL task id instead of
+        // minting a second summarizer, so a dropped `_utility_task_id` can
+        // never fan out an unbounded chain of orphaned _utility tasks.
+        const reusedTaskId = _reentry.inFlightTaskId;
+        const taskId = reusedTaskId ?? randomUUID().slice(0, 8);
         // Stash gathered data so re-entry doesn't need to re-gather
         _pendingSessionData.set(taskId, summaryData);
         _utilityGuardSnapshots.set(taskId, captureGitStatus());
         const UTILITY_TTL_MS = 120_000;
-        ctx.nativeTaskMap.set(taskId, {
-          agentId: '_utility',
-          task: 'session_summary',
-          startedAt: Date.now(),
-          timeoutMs: UTILITY_TTL_MS,
-          utilityType: 'session_summary',
-        });
-        try { ctx.mainAgent.recordNativeTask(taskId, '_utility', 'session_summary'); } catch { /* best-effort */ }
-        spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
+        if (!reusedTaskId) {
+          ctx.nativeTaskMap.set(taskId, {
+            agentId: '_utility',
+            task: 'session_summary',
+            startedAt: Date.now(),
+            timeoutMs: UTILITY_TTL_MS,
+            utilityType: 'session_summary',
+          });
+          try { ctx.mainAgent.recordNativeTask(taskId, '_utility', 'session_summary'); } catch { /* best-effort */ }
+          spawnTimeoutWatcher(taskId, ctx.nativeTaskMap.get(taskId)!);
+        }
         // Stash eviction: session_summary results go to ctx.nativeResultMap
         // (swept at NATIVE_TASK_TTL_MS, 2h) — align the stash lifetime to match.
         setTimeout(() => {

--- a/tests/cli/session-save-converge.test.ts
+++ b/tests/cli/session-save-converge.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Regression tests for GH #745 — `gossip_session_save` does not converge.
+ *
+ * Reported failure mode (maintainer, 4 consecutive attempts in one session):
+ *
+ *   gossip_session_save()                    → "Dispatching native utility…" [A]
+ *   gossip_relay(task_id: A, result: …)      → "relay: _utility [A] completed"
+ *   gossip_session_save(…)                   → "Dispatching native utility…" [B]   ← should have saved
+ *   gossip_relay(task_id: B, result: …)      → "relay: _utility [B] completed"
+ *   gossip_session_save(…)                   → "Dispatching native utility…" [C]   ← …forever
+ *
+ * Root cause: finalization was reachable ONLY through the `_utility_task_id`
+ * re-entry argument. Once the summarizer was relayed, its task left
+ * `ctx.nativeTaskMap`, so the refuse-gate no longer blocked; a save call that
+ * omitted the id then ignored both the stashed session data and the relayed
+ * summarizer output and minted a brand-new utility task. Nothing on the server
+ * remembered that a summarizer for this save had already run, so the cycle had
+ * no terminal state.
+ *
+ * Fix: `resolveSessionSummaryReentry` gives the handler its own record of the
+ * in-flight save. A save call without `_utility_task_id` adopts a completed,
+ * relayed-but-unconsumed session_summary result instead of re-dispatching.
+ *
+ * Suite layout:
+ *   1. unit tests over the pure resolver;
+ *   2. an end-to-end MCP-protocol test that replays the exact reported
+ *      sequence through the real tool registrations.
+ */
+process.env.GOSSIPCAT_MCP_NO_MAIN = '1';
+// mcp-server-sdk.ts runs an argv shim at import time and process.exit(2)s on an
+// unrecognised subcommand — jest's argv (the test path) would trip it.
+process.argv = [process.argv[0], 'gossipcat'];
+
+import { createServer as createNetServer, type Server as NetServer } from 'net';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { resolveSessionSummaryReentry } from '../../apps/cli/src/handlers/session-save-reentry';
+import { createMcpServer } from '../../apps/cli/src/mcp-server-sdk';
+import { ctx } from '../../apps/cli/src/mcp-context';
+
+describe('resolveSessionSummaryReentry', () => {
+  const completed = (completedAt: number) => ({ status: 'completed', result: '## Summary\n\nok', completedAt });
+
+  it('adopts a relayed, unconsumed session_summary result', () => {
+    const r = resolveSessionSummaryReentry({
+      pendingTaskIds: ['aaaa1111'],
+      getResult: (id) => (id === 'aaaa1111' ? completed(10) : undefined),
+      hasPendingTask: () => false,
+    });
+    expect(r.adoptTaskId).toBe('aaaa1111');
+    expect(r.inFlightTaskId).toBeUndefined();
+  });
+
+  it('adopts the most recently completed candidate when several are stashed', () => {
+    const results: Record<string, ReturnType<typeof completed>> = {
+      older: completed(100),
+      newer: completed(500),
+    };
+    const r = resolveSessionSummaryReentry({
+      pendingTaskIds: ['older', 'newer'],
+      getResult: (id) => results[id],
+      hasPendingTask: () => false,
+    });
+    expect(r.adoptTaskId).toBe('newer');
+  });
+
+  it('does not adopt a completed result with empty output', () => {
+    const r = resolveSessionSummaryReentry({
+      pendingTaskIds: ['aaaa1111'],
+      getResult: () => ({ status: 'completed', result: '', completedAt: 10 }),
+      hasPendingTask: () => false,
+    });
+    expect(r.adoptTaskId).toBeUndefined();
+  });
+
+  it('does not adopt a failed or timed-out summarizer', () => {
+    for (const status of ['failed', 'timed_out', 'superseded']) {
+      const r = resolveSessionSummaryReentry({
+        pendingTaskIds: ['aaaa1111'],
+        getResult: () => ({ status, result: 'partial', completedAt: 10 }),
+        hasPendingTask: () => false,
+      });
+      expect(r.adoptTaskId).toBeUndefined();
+    }
+  });
+
+  it('reports a still-armed dispatch as in-flight, never as adoptable', () => {
+    const r = resolveSessionSummaryReentry({
+      pendingTaskIds: ['aaaa1111'],
+      getResult: () => undefined,
+      hasPendingTask: (id) => id === 'aaaa1111',
+    });
+    expect(r.adoptTaskId).toBeUndefined();
+    expect(r.inFlightTaskId).toBe('aaaa1111');
+  });
+
+  it('ignores a stash whose task is gone and has no result (evicted)', () => {
+    const r = resolveSessionSummaryReentry({
+      pendingTaskIds: ['aaaa1111'],
+      getResult: () => undefined,
+      hasPendingTask: () => false,
+    });
+    expect(r).toEqual({});
+  });
+
+  it('returns nothing when no save is in flight', () => {
+    const r = resolveSessionSummaryReentry({
+      pendingTaskIds: [],
+      getResult: () => undefined,
+      hasPendingTask: () => false,
+    });
+    expect(r).toEqual({});
+  });
+});
+
+describe('gossip_session_save converges over the real MCP tool (#745)', () => {
+  let tmp: string;
+  let origCwd: string;
+  let origHttpPort: string | undefined;
+  let portBlocker: NetServer;
+  let client: Client;
+  let server: ReturnType<typeof createMcpServer>;
+
+  const textOf = (r: any): string => (r.content || []).map((c: any) => c.text).join('\n');
+  const taskIdOf = (text: string): string | undefined => /_utility_task_id: "([0-9a-f]+)"/.exec(text)?.[1];
+  const save = (args: Record<string, unknown> = {}) =>
+    client.callTool({ name: 'gossip_session_save', arguments: args });
+
+  beforeAll(async () => {
+    tmp = mkdtempSync(join(tmpdir(), 'ss745-'));
+    origCwd = process.cwd();
+    mkdirSync(join(tmp, '.gossip'), { recursive: true });
+    // utility_model.provider = 'native' is what puts the handler on the
+    // Agent()-dispatch path this bug lives on.
+    writeFileSync(
+      join(tmp, '.gossip', 'config.json'),
+      JSON.stringify({
+        main_agent: { provider: 'none', model: 'none' },
+        utility_model: { provider: 'native', model: 'sonnet' },
+        agents: {},
+      }),
+    );
+    process.chdir(tmp);
+
+    // boot() also starts an HTTP MCP transport whose server handle is not
+    // exported, which would keep jest's event loop open. Occupying its port
+    // makes listen() fail with EADDRINUSE, which boot already handles by
+    // skipping the transport — no stray handle, no --forceExit needed.
+    portBlocker = createNetServer();
+    await new Promise<void>((resolve) => portBlocker.listen(0, '127.0.0.1', resolve));
+    origHttpPort = process.env.GOSSIPCAT_HTTP_PORT;
+    process.env.GOSSIPCAT_HTTP_PORT = String((portBlocker.address() as { port: number }).port);
+
+    server = createMcpServer();
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: 'session-save-converge-test', version: '1.0.0' }, { capabilities: {} });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+  }, 60000);
+
+  afterAll(async () => {
+    await client?.close().catch(() => {});
+    await server?.close().catch(() => {});
+    // Disconnect relay clients BEFORE stopping the relay, otherwise their
+    // reconnect timers spin for the rest of the run.
+    try { await (ctx.mainAgent as any)?.orchestratorAgent?.disconnect?.(); } catch { /* best-effort */ }
+    try { await ctx.relay?.stop(); } catch { /* best-effort */ }
+    if (origHttpPort === undefined) delete process.env.GOSSIPCAT_HTTP_PORT;
+    else process.env.GOSSIPCAT_HTTP_PORT = origHttpPort;
+    await new Promise<void>((resolve) => portBlocker.close(() => resolve()));
+    process.chdir(origCwd);
+    rmSync(tmp, { recursive: true, force: true });
+  }, 60000);
+
+  it('advertises _utility_task_id on the tool schema', async () => {
+    const tools = await client.listTools();
+    const schema: any = tools.tools.find((t) => t.name === 'gossip_session_save')?.inputSchema;
+    expect(schema?.properties?._utility_task_id).toBeDefined();
+  });
+
+  it('finalizes when the re-call carries _utility_task_id (unchanged happy path)', async () => {
+    const dispatch = textOf(await save());
+    expect(dispatch).toContain('Dispatching native utility for summary');
+    const taskId = taskIdOf(dispatch);
+    expect(taskId).toBeDefined();
+
+    await client.callTool({
+      name: 'gossip_relay',
+      arguments: { task_id: taskId, result: '## Summary\n\nExplicit re-entry path.\n' },
+    });
+
+    const saved = textOf(await save({ notes: '', _utility_task_id: taskId }));
+    expect(saved).toContain('Session saved.');
+    expect(saved).not.toContain('Dispatching native utility');
+    // Explicit re-entry must not advertise the adoption fallback.
+    expect(saved).not.toContain('adopted relayed summary');
+    expect(saved).toContain('Explicit re-entry path.');
+  }, 60000);
+
+  it('converges when the re-call DROPS _utility_task_id — the #745 loop', async () => {
+    const dispatch = textOf(await save());
+    expect(dispatch).toContain('Dispatching native utility for summary');
+    const taskId = taskIdOf(dispatch);
+    expect(taskId).toBeDefined();
+
+    const relayed = textOf(
+      await client.callTool({
+        name: 'gossip_relay',
+        arguments: { task_id: taskId, result: '## Summary\n\nRelayed but id dropped.\n' },
+      }),
+    );
+    expect(relayed).toContain(`relay: _utility [${taskId}] completed`);
+
+    // Before the fix this returned "Session data gathered. Dispatching native
+    // utility for summary." plus a brand-new task_id, and did so on every
+    // subsequent call — the reported non-convergence.
+    const saved = textOf(await save());
+    expect(saved).toContain('Session saved.');
+    expect(saved).not.toContain('Dispatching native utility');
+    expect(saved).toContain(`adopted relayed summary [${taskId}]`);
+    // The adopted content is the relayed summarizer output, not a re-run.
+    expect(saved).toContain('Relayed but id dropped.');
+  }, 60000);
+
+  it('still dispatches a fresh summarizer once the previous save was consumed', async () => {
+    // Nothing outstanding after the previous test consumed its stash — a new
+    // save must start a new summarizer rather than re-adopting stale output.
+    const dispatch = textOf(await save());
+    expect(dispatch).toContain('Dispatching native utility for summary');
+    expect(taskIdOf(dispatch)).toBeDefined();
+    // Drain it so the suite leaves no armed utility task behind.
+    await client.callTool({
+      name: 'gossip_relay',
+      arguments: { task_id: taskIdOf(dispatch), result: '## Summary\n\nDrain.\n' },
+    });
+    expect(textOf(await save())).toContain('Session saved.');
+  }, 60000);
+});


### PR DESCRIPTION
Fixes #745

## Reported failure mode

`gossip_session_save` never reaches a terminal "saved" state. In the reported session the documented loop ran 4 times in a row:

```
gossip_session_save()               → "Dispatching native utility for summary" [A]
gossip_relay(task_id: A, result: …) → "relay: _utility [A] completed"
gossip_session_save(…)              → "Dispatching native utility for summary" [B]   ← should have saved
gossip_relay(task_id: B, result: …) → "relay: _utility [B] completed"
gossip_session_save(…)              → "Dispatching native utility for summary" [C]   ← …forever
```

## Root cause

Reproduced end-to-end against the real tool registrations (`createMcpServer()` + `InMemoryTransport`), not inferred from reading.

Finalization was reachable **only** through the `_utility_task_id` re-entry argument. That path is correct — the bug is that it is the *only* path, so convergence depends entirely on the client echoing back an opaque id. When the id is dropped:

1. The relayed summarizer task has already left `ctx.nativeTaskMap` (`handlers/native-tasks.ts` deletes it and stores the result in `ctx.nativeResultMap`), so the refuse-gate sees nothing in flight and does not block.
2. The re-entry fast path is gated on `if (_utility_task_id)`, so the stashed session data (`_pendingSessionData`) and the relayed summarizer output are both silently ignored.
3. Control falls through to `if (ctx.nativeUtilityConfig && !_utility_task_id)`, which mints a fresh task id and returns the dispatch instruction again.

Nothing on the server remembered that a summarizer for this save had already run and been relayed, so the cycle had no terminal state. Every subsequent call repeated it.

Ruled out during investigation: a duplicate/shadowing `server.tool('gossip_session_save', …)` registration (there is exactly one), `boot()` clearing state (it is memoised and mutates no task maps), a `_utility_task_id` × `force` interaction, TTL eviction (an evicted entry still finalizes via the `prepareSessionArtifacts` fallback — it can never produce the dispatch text), a `gossip_relay` namespace collision (`session_summary` results go to `ctx.nativeResultMap`, the same map the re-entry path reads; only `skill_develop` is routed to `nativeUtilityResultMap`), and MCP-reconnect state loss (utility *results* are persisted by `persistNativeTaskMap`, and a missing stash still finalizes). The MCP layer also delivers `_utility_task_id` correctly — verified against the advertised JSON schema and a live tool call.

## Fix

New `apps/cli/src/handlers/session-save-reentry.ts` exports `resolveSessionSummaryReentry()`, a pure function over the three pieces of state the handler already keeps. `gossip_session_save` now reconciles against the server's own record of the in-flight save:

- **Adopt** — a call without `_utility_task_id` finalizes using a completed, relayed-but-unconsumed `session_summary` result instead of dispatching a new summarizer. The response says so explicitly: `Session saved. (adopted relayed summary [<id>] — the re-call omitted _utility_task_id)`.
- **Reuse** — a call that reaches the dispatch branch while an earlier summarizer is still awaiting its relay (only possible via `force: true`) re-issues the original task id rather than fanning out orphaned `_utility` tasks.

Deliberately conservative: only genuinely completed relays carrying output are adopted, so a failed or timed-out summarizer keeps the existing re-dispatch behaviour. The explicit `_utility_task_id` re-entry path is byte-identical, and a save with nothing outstanding still dispatches normally.

## Tests

`tests/cli/session-save-converge.test.ts` (11 tests):

- 7 unit tests over the resolver — adoption, most-recent-wins, empty output, `failed`/`timed_out`/`superseded`, in-flight, evicted stash, nothing pending.
- 4 end-to-end tests driving the real `gossip_session_save` / `gossip_relay` tools over the MCP protocol, including a replay of the exact reported sequence. That test fails on master with `Dispatching native utility for summary` and passes here with `Session saved.`

Verified at repo root: `npm run build`, `npm run build:mcp`, full `npm test` — 406 suites, 5682 passed, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)